### PR TITLE
Add queue transfer ownership validation

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -121,6 +121,21 @@ bool ValidateBarrierLayoutToImageUsage(layer_data *device_data, const VkImageMem
 bool ValidateBarriersToImages(layer_data *device_data, GLOBAL_CB_NODE const *cb_state, uint32_t imageMemoryBarrierCount,
                               const VkImageMemoryBarrier *pImageMemoryBarriers, const char *func_name);
 
+bool ValidateBarriersQFOTransferUniqueness(layer_data *device_data, const char *func_name, GLOBAL_CB_NODE *cb_state,
+                                           uint32_t bufferBarrierCount, const VkBufferMemoryBarrier *pBufferMemBarriers,
+                                           uint32_t imageMemBarrierCount, const VkImageMemoryBarrier *pImageMemBarriers);
+
+void RecordBarriersQFOTransfers(layer_data *device_data, const char *func_name, GLOBAL_CB_NODE *cb_state,
+                                uint32_t bufferBarrierCount, const VkBufferMemoryBarrier *pBufferMemBarriers,
+                                uint32_t imageMemBarrierCount, const VkImageMemoryBarrier *pImageMemBarriers);
+
+bool ValidateQueuedQFOTransfers(layer_data *dev_data, GLOBAL_CB_NODE *pCB,
+                                QFOTransferCBScoreboards<VkImageMemoryBarrier> *qfo_image_scoreboards,
+                                QFOTransferCBScoreboards<VkBufferMemoryBarrier> *qfo_buffer_scoreboards);
+
+void RecordQueuedQFOTransfers(layer_data *dev_data, GLOBAL_CB_NODE *pCB);
+void EraseQFOImageRelaseBarriers(layer_data *device_data, const VkImage &image);
+
 void TransitionImageLayouts(layer_data *device_data, GLOBAL_CB_NODE *cb_state, uint32_t memBarrierCount,
                             const VkImageMemoryBarrier *pImgMemBarriers);
 

--- a/layers/hash_vk_types.h
+++ b/layers/hash_vk_types.h
@@ -83,4 +83,20 @@ template <>
 struct hash<PushConstantRanges> : public hash_util::IsOrderedContainer<PushConstantRanges> {};
 }  // namespace std
 
+// VkImageSubresourceRange
+static bool operator==(const VkImageSubresourceRange &lhs, const VkImageSubresourceRange &rhs) {
+    return (lhs.aspectMask == rhs.aspectMask) && (lhs.baseMipLevel == rhs.baseMipLevel) && (lhs.levelCount == rhs.levelCount) &&
+           (lhs.baseArrayLayer == lhs.baseArrayLayer) && (lhs.layerCount == lhs.layerCount);
+}
+namespace std {
+template <>
+struct hash<VkImageSubresourceRange> {
+    size_t operator()(const VkImageSubresourceRange &value) const {
+        hash_util::HashCombiner hc;
+        hc << value.aspectMask << value.baseMipLevel << value.levelCount << value.baseArrayLayer << value.layerCount;
+        return hc.Value();
+    }
+};
+}  // namespace std
+
 #endif  // HASH_VK_TYPES_H_


### PR DESCRIPTION
Added tracking and validation and test of queue family ownership transfer barriers.  Validation will warn on duplicated transfers and error on acquire operations without matching release operations. Fixes #39.

Adds new valid usage placeholders:

- UNASSIGNED-VkImageMemoryBarrier-image-00001 QFO transfer image barrier must not duplicate QFO recorded in command buffer
- UNASSIGNED-VkImageMemoryBarrier-image-00002 QFO transfer image barrier must not duplicate QFO submitted in batch
- UNASSIGNED-VkImageMemoryBarrier-image-00003 QFO transfer image barrier must not duplicate QFO submitted previously
- UNASSIGNED-VkImageMemoryBarrier-image-00004 QFO acquire image barrier must have matching QFO release submitted previously
- UNASSIGNED-VkImageMemoryBarrier-buffer-00001 QFO transfer buffer barrier must not duplicate QFO recorded in command buffer
- UNASSIGNED-VkBufferMemoryBarrier-buffer-00002 QFO transfer buffer barrier must not duplicate QFO submitted in batch
- UNASSIGNED-VkBufferMemoryBarrier-buffer-00003 QFO transfer buffer barrier must not duplicate QFO submitted previously
- UNASSIGNED-VkBufferMemoryBarrier-buffer-00004 QFO acquire buffer barrier must have matching QFO release submitted previously
