### PR TITLE
docs:Add Cloud CI section to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,10 @@ or you can run `run_all_tests.ps1` from a PowerShell window
 * Run tests that explicitly exercise your changes.
 * Feel free to subject your code changes to other tests as well!
 
+#### **GitHub Cloud CI Testing**
+Pull Requests to GitHub are tested in the cloud on Linux and Windows VMs. The Linux VMs use [Travis CI](https://travis-ci.org/KhronosGroup/Vulkan-ValidationLayers) with the sequence of commands driven by the [.travis.yml](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/.travis.yml) file. The Windows VMs use [AppVeyor](https://ci.appveyor.com/project/Khronoswebmaster/vulkan-validationlayers/branch/master) with the sequence of commands driven by the [.appveyor.yml](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/.appveyor.yml) file.
+
+The Linux testing includes iterating on all of the validation layer tests over multiple [different device](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/master/tests/device_profiles) profiles using the [devsim layer](https://github.com/LunarG/VulkanTools/tree/master/layersvt) in combination with the [mock icd](https://github.com/KhronosGroup/Vulkan-Tools/tree/master/icd). This is a fast way to simulate testing across different devices. Any new tests must pass across all device profiles.
 
 #### **Special Considerations for Validation Layers**
 * **Validation Tests**  If you are submitting a change that adds a new validation check, you should also construct a "negative" test function.


### PR DESCRIPTION
Give a brief overview of GitHub cloud CI testing including links for devsim and device profiles. This gives some starting info to people who hit CI fails with their PR.