### PR TITLE
Cmake fixes and upgrades for glslang, sdk locations

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -40,7 +40,8 @@ Windows 7+ with the following software packages:
 
 - Microsoft Visual Studio 2013 Update 4 Professional, VS2015 (any version), or VS2017 (any version).
 - [glslang](https://github.com/KhronosGroup/glslang)
-  - Ensure that the 'update_glslang_sources.py' script has been run, and the repository successfully built.
+  - Ensure that the 'update_glslang_sources.py' script has been run. Follow the build instructions in the
+    glslang README.md file, noting the location of the chosen install directory.
 - [CMake](http://www.cmake.org/download/)
   - Tell the installer to "Add CMake to the system PATH" environment variable.
 - [Python 3](https://www.python.org/downloads)
@@ -76,9 +77,9 @@ Windows 7+ with the following software packages:
 
 For example, for VS2017 (generators for other versions are [specified here](#cmake-visual-studio-generators)):
 
-    cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\VULKAN_LOADER -DGLSLANG_REPO_ROOT=c:\absolute_path_to\glslang -G "Visual Studio 15 2017 Win64" ..
+    cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\VULKAN_LOADER -DGLSLANG_INSTALL_DIR=c:\absolute_path_to\glslang\install -G "Visual Studio 15 2017 Win64" ..
 
-Both LOADER_REPO_ROOT and GLSLANG_REPO_ROOT each require absolute paths.
+Both LOADER_REPO_ROOT and GLSLANG_INSTALL_DIR each require absolute paths.
 This will create a Windows solution file named `Vulkan-ValidationLayers.sln` in the build directory.
 
 Launch Visual Studio and open the "Vulkan-ValidationLayers.sln" solution file in the build folder.
@@ -139,8 +140,12 @@ It should be straightforward to adapt this repository to other Linux distributio
 Vulkan Loader Library
   - Building the Layer Validation Tests requires linking to the Vulkan Loader Library (libvulkan-1.so).
       - The LOADER_REPO_ROOT environment variable should be used on the cmake command line to specify a vulkan loader library. Make sure to specify an absoute path, like so:
-      
+
           `cmake -DLOADER_REPO_ROOT=c:\development\Vulkan-Loader ....`
+
+- [glslang](https://github.com/KhronosGroup/glslang)
+  - Ensure that the 'update_glslang_sources.py' script has been run. Follow the build instructions in the
+    glslang README.md file, noting the location of the chosen install directory.
 
 ### Linux Build
 
@@ -154,7 +159,7 @@ See **Validation Layer Dependencies** (below) for more information and other opt
 
         mkdir build
         cd build
-        cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DGLSLANG_REPO_ROOT=/absolute_path_to_/glslang -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/location_of/install -DCMAKE_BUILD_TYPE=Debug ..
 
 4. Run `make -j8` to begin the build
 
@@ -496,11 +501,11 @@ After installing and building glslang, the location will be used to build the Vu
 
 1) Pass in the location of your glslang repository to cmake using absolute paths. From your build directory run:
     1) on Windows
-    
-        `cmake -DGLSLANG_REPO_ROOT=c:/absolute_path_to_your_installation_of/glslang -G "Visual Studio 15 Win64" ..`
+
+        `cmake -DGLSLANG_INSTALL_DIR=c:/absolute_path_to/glslang/location_of/install -G "Visual Studio 15 Win64" ..`
     1) or Linux
-    
-        `cmake -DGLSLANG_REPO_ROOT=/absolute_path_to_your_installation_of/glslang -DCMAKE_BUILD_TYPE=Debug ..`
+
+        `cmake -DGLSLANG_INSTALL_DIR=/absolute_path_to/glslang/location_of/install -DCMAKE_BUILD_TYPE=Debug ..`
 
 2) If building on Windows with MSVC, set `DISABLE_BUILDTGT_DIR_DECORATION` to _On_.
  If building on Windows, but without MSVC set `DISABLE_BUILD_PATH_DECORATION` to _On_

--- a/BUILD.md
+++ b/BUILD.md
@@ -41,7 +41,7 @@ Windows 7+ with the following software packages:
 - Microsoft Visual Studio 2013 Update 4 Professional, VS2015 (any version), or VS2017 (any version).
 - [glslang](https://github.com/KhronosGroup/glslang)
   - Ensure that the 'update_glslang_sources.py' script has been run. Follow the build instructions in the
-    glslang README.md file, noting the location of the chosen install directory.
+    glslang [README.md](https://github.com/KhronosGroup/glslang/blob/master/README.md) file, noting the location of the chosen install directory.
 - [CMake](http://www.cmake.org/download/)
   - Tell the installer to "Add CMake to the system PATH" environment variable.
 - [Python 3](https://www.python.org/downloads)
@@ -145,7 +145,7 @@ Vulkan Loader Library
 
 - [glslang](https://github.com/KhronosGroup/glslang)
   - Ensure that the 'update_glslang_sources.py' script has been run. Follow the build instructions in the
-    glslang README.md file, noting the location of the chosen install directory.
+    glslang [README.md](https://github.com/KhronosGroup/glslang/blob/master/README.md) file, noting the location of the chosen install directory.
 
 ### Linux Build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,70 +149,94 @@ option(BUILD_LAYERS "Build layers" ON)
 set(NOT_DEFINED "NOT_DEFINED")
 set(VULKAN_SDK $ENV{VULKAN_SDK})
 
-# Set GLSLANG_REPO_ROOT to define the path to the glslang binaries for this project
+# set GLSLANG_INSTALL_DIR to define locations of glslang includes, libs, and binaries.
+# This is the preferred method for building this repository.
+set(GLSLANG_INSTALL_DIR ${NOT_DEFINED} CACHE PATH "Absolute path to a glslang install directory")
+
+# Set GLSLANG_REPO_ROOT to locate glslang repository
+# This should be deprecated in lieu of GLSANG_INSTALL_DIR, remove once users have switched to preferred solution
 set(GLSLANG_REPO_ROOT ${NOT_DEFINED} CACHE PATH "Absolute path to glslang repository")
 
-if (${GLSLANG_REPO_ROOT} STREQUAL ${NOT_DEFINED})
-    message(FATAL_ERROR "Must define GLSLANG_REPO_ROOT -- see BUILD.md")
+# Repo requires glslang and that the update_glslang_sources.py script was run in the indicated glslang repo
+
+if (${GLSLANG_INSTALL_DIR} STREQUAL ${NOT_DEFINED} AND ${GLSLANG_REPO_ROOT} STREQUAL ${NOT_DEFINED})
+    message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
+endif()
+
+# Is user specifying a glslang install directory?
+if (NOT ${GLSLANG_INSTALL_DIR} STREQUAL ${NOT_DEFINED})
+    message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
+    set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
+    set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
+    set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to glslang spirv headers")
+    set(SPIRV_TOOLS_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
+
+    set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+    set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+    set (SPIRV_TOOLS_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+    set (SPIRV_TOOLS_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+    set (SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+    set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
 else()
     message(STATUS "Using glslang instance located at ${GLSLANG_REPO_ROOT}")
-endif()
 
-# These paths assume that the update_glslang_sources.py script was run in the indicated glslang repo and the repo was built
-set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source" CACHE STRING "User defined path to the SPIRV-Tools binaries for this project")
-set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source/opt" CACHE STRING "User defined path to the SPIRV-Tools-opt binaries for this project")
+    # These paths assume that the update_glslang_sources.py script was run in the indicated glslang repo and the repo was built
+    set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
+    set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source/opt" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
 
-if (WIN32)
-    set(GSLANG_FINAL_BINARY_PATH ${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR})
+    if(WIN32)
+        set(GSLANG_FINAL_BINARY_PATH ${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR})
 
-    if(DISABLE_BUILD_PATH_DECORATION)
-        set (DEBUG_DECORATION "")
-        set (RELEASE_DECORATION "")
+        if(DISABLE_BUILD_PATH_DECORATION)
+            set (DEBUG_DECORATION "")
+            set (RELEASE_DECORATION "")
+        else()
+            set (DEBUG_DECORATION "Debug")
+            set (RELEASE_DECORATION "Release")
+        endif()
+
+        # Take some steps to set up a variable pointing to the final glslang binaries given the variety of input options
+        set (GLSLANG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${RELEASE_DECORATION}"
+                                 "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${RELEASE_DECORATION}"
+                                 "${GSLANG_FINAL_BINARY_PATH}/hlsl/${RELEASE_DECORATION}"
+                                 "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${RELEASE_DECORATION}"
+                                 "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${RELEASE_DECORATION}" )
+
+        set (GLSLANG_DEBUG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${DEBUG_DECORATION}"
+                                       "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${DEBUG_DECORATION}"
+                                       "${GSLANG_FINAL_BINARY_PATH}/hlsl/${DEBUG_DECORATION}"
+                                       "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${DEBUG_DECORATION}"
+                                       "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${DEBUG_DECORATION}")
+
+        set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${RELEASE_DECORATION}")
+        set (SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${DEBUG_DECORATION}")
+        set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${RELEASE_DECORATION}")
+        set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${DEBUG_DECORATION}")
     else()
-        set (DEBUG_DECORATION "Debug")
-        set (RELEASE_DECORATION "Release")
+        # not WIN32
+        set (GLSLANG_SEARCH_PATH "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/install/lib"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang/OSDependent/Unix"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/OGLCompilersDLL"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/SPIRV"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/hlsl"
+                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/StandAlone")
+
+        set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}" )
+        set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}" )
     endif()
+    find_path(GLSLANG_SPIRV_INCLUDE_DIR SPIRV/spirv.hpp HINTS
+             "${GLSLANG_REPO_ROOT}"
+             "${CMAKE_SOURCE_DIR}/../glslang"
+             DOC "Path to SPIRV/spirv.hpp")
 
-    # Take some steps to set up a variable pointing to the final glslang binaries given the variety of input options
-    set (GLSLANG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${RELEASE_DECORATION}"
-                             "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${RELEASE_DECORATION}"
-                             "${GSLANG_FINAL_BINARY_PATH}/hlsl/${RELEASE_DECORATION}"
-                             "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${RELEASE_DECORATION}"
-                             "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${RELEASE_DECORATION}" )
-
-    set (GLSLANG_DEBUG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${DEBUG_DECORATION}"
-                                   "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${DEBUG_DECORATION}"
-                                   "${GSLANG_FINAL_BINARY_PATH}/hlsl/${DEBUG_DECORATION}"
-                                   "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${DEBUG_DECORATION}"
-                                   "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${DEBUG_DECORATION}")
-
-    set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${RELEASE_DECORATION}")
-    set (SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${DEBUG_DECORATION}")
-    set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${RELEASE_DECORATION}")
-    set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${DEBUG_DECORATION}")
-else()
-    # not WIN32
-    set (GLSLANG_SEARCH_PATH "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/install/lib"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang/OSDependent/Unix"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/OGLCompilersDLL"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/SPIRV"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/hlsl"
-                             "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/StandAlone")
-
-    set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}" )
-    set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}" )
+    find_path(SPIRV_TOOLS_INCLUDE_DIR spirv-tools/libspirv.h HINTS
+              "${GLSLANG_REPO_ROOT}/External/spirv-tools/include"
+              "${CMAKE_SOURCE_DIR}/../glslang/External/spirv-tools/include"
+              DOC "Path to spirv-tools/libspirv.h")
 endif()
 
-find_path(GLSLANG_SPIRV_INCLUDE_DIR SPIRV/spirv.hpp HINTS
-         "${GLSLANG_REPO_ROOT}"
-         "${CMAKE_SOURCE_DIR}/../glslang"
-         DOC "Path to SPIRV/spirv.hpp")
 
-find_path(SPIRV_TOOLS_INCLUDE_DIR spirv-tools/libspirv.h HINTS
-          "${GLSLANG_REPO_ROOT}/External/spirv-tools/include"
-          "${CMAKE_SOURCE_DIR}/../glslang/External/spirv-tools/include"
-          DOC "Path to spirv-tools/libspirv.h")
 
 find_library(GLSLANG_LIB NAMES glslang
              HINTS ${GLSLANG_SEARCH_PATH} )
@@ -265,7 +289,6 @@ if (WIN32)
                  HINTS ${SPIRV_TOOLS_DEBUG_SEARCH_PATH} )
     find_library(SPIRV_TOOLS_OPT_DLIB NAMES SPIRV-Tools-optd
                  HINTS ${SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH} )
-
     set_target_properties(glslang PROPERTIES
                          IMPORTED_LOCATION       "${GLSLANG_LIB}"
                          IMPORTED_LOCATION_DEBUG "${GLSLANG_DLIB}")
@@ -291,10 +314,12 @@ if (WIN32)
                          IMPORTED_LOCATION       "${SPIRV_TOOLS_OPT_LIB}"
                          IMPORTED_LOCATION_DEBUG "${SPIRV_TOOLS_OPT_DLIB}")
 
+endif()
+
+if(WIN32)
     set (SPIRV_TOOLS_LIBRARIES SPIRV-Tools-opt SPIRV-Tools)
     set (GLSLANG_LIBRARIES glslang OGLCompiler OSDependent HLSL SPIRV SPVRemapper ${SPIRV_TOOLS_LIBRARIES})
 else ()
-    # not WIN32
     set (SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
     set (GLSLANG_LIBRARIES ${GLSLANG_LIB} ${OGLCompiler_LIB} ${OSDependent_LIB} ${HLSL_LIB} ${SPIRV_LIB} ${SPIRV_REMAPPER_LIB} ${SPIRV_TOOLS_LIBRARIES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,14 +146,16 @@ endif()
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_LAYERS "Build layers" ON)
 
+set(NOT_DEFINED "NOT_DEFINED")
 set(VULKAN_SDK $ENV{VULKAN_SDK})
 
 # Set GLSLANG_REPO_ROOT to define the path to the glslang binaries for this project
+set(GLSLANG_REPO_ROOT ${NOT_DEFINED} CACHE PATH "Absolute path to glslang repository")
 
-if (NOT DEFINED GLSLANG_REPO_ROOT)
-    message(ERROR "Must define GLSLANG_REPO_ROOT -- see BUILD.md")
+if (${GLSLANG_REPO_ROOT} STREQUAL ${NOT_DEFINED})
+    message(FATAL_ERROR "Must define GLSLANG_REPO_ROOT -- see BUILD.md")
 else()
-    message("Using glslang instance located at ${GLSLANG_REPO_ROOT}")
+    message(STATUS "Using glslang instance located at ${GLSLANG_REPO_ROOT}")
 endif()
 
 # These paths assume that the update_glslang_sources.py script was run in the indicated glslang repo and the repo was built

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,25 +146,23 @@ endif()
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_LAYERS "Build layers" ON)
 
-set(NOT_DEFINED "NOT_DEFINED")
 set(VULKAN_SDK $ENV{VULKAN_SDK})
 
 # set GLSLANG_INSTALL_DIR to define locations of glslang includes, libs, and binaries.
 # This is the preferred method for building this repository.
-set(GLSLANG_INSTALL_DIR ${NOT_DEFINED} CACHE PATH "Absolute path to a glslang install directory")
+set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
 
 # Set GLSLANG_REPO_ROOT to locate glslang repository
 # This should be deprecated in lieu of GLSANG_INSTALL_DIR, remove once users have switched to preferred solution
-set(GLSLANG_REPO_ROOT ${NOT_DEFINED} CACHE PATH "Absolute path to glslang repository")
+set(GLSLANG_REPO_ROOT "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to glslang repository")
 
 # Repo requires glslang and that the update_glslang_sources.py script was run in the indicated glslang repo
-
-if (${GLSLANG_INSTALL_DIR} STREQUAL ${NOT_DEFINED} AND ${GLSLANG_REPO_ROOT} STREQUAL ${NOT_DEFINED})
+if (NOT GLSLANG_INSTALL_DIR AND NOT GLSLANG_REPO_ROOT)
     message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
 endif()
 
 # Is user specifying a glslang install directory?
-if (NOT ${GLSLANG_INSTALL_DIR} STREQUAL ${NOT_DEFINED})
+if (GLSLANG_INSTALL_DIR)
     message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
     set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
     set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
@@ -178,7 +176,7 @@ if (NOT ${GLSLANG_INSTALL_DIR} STREQUAL ${NOT_DEFINED})
     set (SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
     set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
 else()
-    message(STATUS "Using glslang instance located at ${GLSLANG_REPO_ROOT}")
+    message(STATUS "Using glslang built in repository located at ${GLSLANG_REPO_ROOT}")
 
     # These paths assume that the update_glslang_sources.py script was run in the indicated glslang repo and the repo was built
     set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
@@ -235,8 +233,6 @@ else()
               "${CMAKE_SOURCE_DIR}/../glslang/External/spirv-tools/include"
               DOC "Path to spirv-tools/libspirv.h")
 endif()
-
-
 
 find_library(GLSLANG_LIB NAMES glslang
              HINTS ${GLSLANG_SEARCH_PATH} )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,10 +92,12 @@ else()
         set (LOADER_SEARCH_PATHS
             "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${DEBUG_DECORATION}"
             "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${RELEASE_DECORATION}"
+            "${LOADER_REPO_ROOT}/Lib"
             )
     elseif(UNIX)
         set (LOADER_SEARCH_PATHS
             "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader"
+            "${LOADER_REPO_ROOT}/x86_64/lib"
             )
     endif()
     find_library(LIBVK NAMES vulkan vulkan-1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,13 @@ else()
     endif()
 endif()
 
-if(DEFINED LOADER_REPO_ROOT)
+set(LOADER_REPO_ROOT ${NOT_DEFINED} CACHE PATH "Absolute path to Vulkan-Loader repository")
+
+if(${LOADER_REPO_ROOT} STREQUAL ${NOT_DEFINED})
+    message(STATUS "LOADER_REPO_ROOT not set, using find_package to locate Vulkan")
+    find_package(Vulkan)
+    set (LIBVK "Vulkan::Vulkan")
+else()
     message(STATUS "Using user-supplied path to locate Vulkan")
     if(WIN32)
         set (LOADER_SEARCH_PATHS
@@ -96,10 +102,6 @@ if(DEFINED LOADER_REPO_ROOT)
         HINTS ${LOADER_SEARCH_PATHS}
         )
     message(STATUS "Found Vulkan: ${LIBVK}")
-else()
-    message(STATUS "Using find_package to locate Vulkan")
-    find_package(Vulkan)
-    set (LIBVK "Vulkan::Vulkan")
 endif()
 
 add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,9 +80,10 @@ else()
     endif()
 endif()
 
-set(LOADER_REPO_ROOT ${NOT_DEFINED} CACHE PATH "Absolute path to Vulkan-Loader repository")
+# Predefine loader root as a cmake cache variable for cmake-gui
+set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
 
-if(${LOADER_REPO_ROOT} STREQUAL ${NOT_DEFINED})
+if(NOT LOADER_REPO_ROOT)
     message(STATUS "LOADER_REPO_ROOT not set, using find_package to locate Vulkan")
     find_package(Vulkan)
     set (LIBVK "Vulkan::Vulkan")


### PR DESCRIPTION
Hopefully addresses three issues found by @danginsburg.  

- If an SDK is installed, setting LOADER_REPO_ROOT is not required.  However, setting it to point to an installed SDK uncovered a cmake deficiency.
- Pointing to a glslang repo caused a host of issues (build dir names, build decorations, etc).  Changed glslang location method to **require** building per the glslang instructions, meaning that  INSTALL_PREFIX is supplied and 'make install' gets run.  GLSLANG_REPO_ROOT will be phased out and the new hotness is "**GLSLANG_INSTALL_DIR**".  Both should work for the time being.
- The LOADER and GLSLSANG variables were not predefined, and so could not be manipulated with ccmake or cmake-gui.  

Updated BUILD.md to reflect changes.

Fixes #113.  

