### PR TITLE
Cleaned up unexpected errors in various tests

### DIFF
--- a/scripts/parse_test_results.py
+++ b/scripts/parse_test_results.py
@@ -128,7 +128,7 @@ class OutputStats(object):
             self.current_test_output = ""
 
     def skip_test_match(self, line):
-        if re.search(r'TEST_SKIPPED', line) != None:
+        if re.search(r'TEST SKIPPED', line) != None:
             self.test_results[self.current_test][self.current_profile] = "skip"
 
     def pass_test_match(self, line):

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -23687,9 +23687,19 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
 TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     TEST_DESCRIPTION("Exercise errors for updating a descriptor set after it is bound.");
 
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix,
+               VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        return;
+    }
+
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME) &&
+        DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE3_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+        m_device_extension_names.push_back(VK_KHR_MAINTENANCE3_EXTENSION_NAME);
     } else {
         printf("%s Descriptor Indexing or Maintenance3 Extension not supported, skipping tests\n", kSkipPrefix);
         return;
@@ -23704,6 +23714,10 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
 
     if (VK_FALSE == indexingFeatures.descriptorBindingStorageBufferUpdateAfterBind) {
         printf("%s Test requires (unsupported) descriptorBindingStorageBufferUpdateAfterBind, skipping\n", kSkipPrefix);
+        return;
+    }
+    if (VK_FALSE == features2.features.fragmentStoresAndAtomics) {
+        printf("%s Test requires (unsupported) fragmentStoresAndAtomics, skipping\n", kSkipPrefix);
         return;
     }
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5807,22 +5807,37 @@ TEST_F(VkLayerTest, IndexBufferNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferBadSizeOffset) {
-    TEST_DESCRIPTION("Run indexed draw calls with invalid index ranges.");
+TEST_F(VkLayerTest, IndexBufferBadSize) {
+    TEST_DESCRIPTION("Run indexed draw call with bad index buffer size.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "vkCmdDrawIndexed() index size ");
     VKTriangleTest(BsoFailIndexBufferBadSize);
     m_errorMonitor->VerifyFound();
+}
 
+TEST_F(VkLayerTest, IndexBufferBadOffset) {
+    TEST_DESCRIPTION("Run indexed draw call with bad index buffer offset.");
+
+    ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "vkCmdDrawIndexed() index size ");
     VKTriangleTest(BsoFailIndexBufferBadOffset);
     m_errorMonitor->VerifyFound();
+}
 
+TEST_F(VkLayerTest, IndexBufferBadBindSize) {
+    TEST_DESCRIPTION("Run bind index buffer with a size greater than the index buffer.");
+
+    ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "vkCmdDrawIndexed() index size ");
     VKTriangleTest(BsoFailIndexBufferBadMapSize);
     m_errorMonitor->VerifyFound();
+}
 
+TEST_F(VkLayerTest, IndexBufferBadBindOffset) {
+    TEST_DESCRIPTION("Run bind index buffer with an offset greater than the size of the index buffer.");
+
+    ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "vkCmdDrawIndexed() index size ");
     VKTriangleTest(BsoFailIndexBufferBadMapOffset);
     m_errorMonitor->VerifyFound();

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -6487,7 +6487,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                              "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01681");  // expect all-stages sum too
     }
-    if (dslb.descriptorCount > sum_storage_buffers) {
+    if (dslb_vec[0].descriptorCount + dslb_vec[2].descriptorCount > sum_storage_buffers) {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                              "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01680");  // expect all-stages sum too
     }
@@ -6519,7 +6519,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290");
-    if (max_combined + max_sampled_images > sum_sampled_images) {
+    if (max_combined + 2 * max_sampled_images > sum_sampled_images) {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                              "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01682");  // expect all-stages sum too
     }
@@ -6648,8 +6648,19 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01677");
     if (dslb.descriptorCount > max_samplers) {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                             "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00287");  // expect max-per-stage too
+        m_errorMonitor->SetDesiredFailureMsg(
+            VK_DEBUG_REPORT_ERROR_BIT_EXT,
+            "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00287");  // Expect max-per-stage samplers exceeds limits
+    }
+    if (dslb.descriptorCount > sum_sampled_images) {
+        m_errorMonitor->SetDesiredFailureMsg(
+            VK_DEBUG_REPORT_ERROR_BIT_EXT,
+            "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01682");  // Expect max overall sampled image count exceeds limits
+    }
+    if (dslb.descriptorCount > max_sampled_images) {
+        m_errorMonitor->SetDesiredFailureMsg(
+            VK_DEBUG_REPORT_ERROR_BIT_EXT,
+            "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290");  // Expect max per-stage sampled image count exceeds limits
     }
     err = vkCreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
     m_errorMonitor->VerifyFound();
@@ -6783,10 +6794,10 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01682");
-    if (dslb.descriptorCount > max_sampled_images) {
-        // revisit: not robust to `remaining` being small.
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                             "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290");  // expect max-per-stage too
+    if (std::max(dslb_vec[0].descriptorCount, dslb_vec[1].descriptorCount) > max_sampled_images) {
+        m_errorMonitor->SetDesiredFailureMsg(
+            VK_DEBUG_REPORT_ERROR_BIT_EXT,
+            "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290");  // Expect max-per-stage sampled images to exceed limits
     }
     err = vkCreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
     m_errorMonitor->VerifyFound();

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1930,6 +1930,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedSamples) {
     // Determine which device feature are available
     VkPhysicalDeviceFeatures device_features = {};
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&device_features));
 
     // These tests require that the device support sparse residency for 2D images
     if (VK_TRUE != device_features.sparseResidencyImage2D) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -22790,22 +22790,6 @@ TEST_F(VkLayerTest, SetDynViewportParamMaintenance1Tests) {
     NegHeightViewportTests(m_device, m_commandBuffer, m_errorMonitor);
 }
 
-TEST_F(VkLayerTest, SetDynViewportParamAmdNegHeightTests) {
-    TEST_DESCRIPTION("Verify errors are detected on misuse of SetViewport with AMD negative viewport extension enabled.");
-
-    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
-
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME);
-    } else {
-        printf("%s VK_AMD_negative_viewport_height extension not supported -- skipping test\n", kSkipPrefix);
-        return;
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState());
-
-    NegHeightViewportTests(m_device, m_commandBuffer, m_errorMonitor);
-}
-
 TEST_F(VkLayerTest, SetDynViewportParamMultiviewportTests) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetViewport with multiViewport feature enabled");
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -20961,12 +20961,23 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatchMaintenance1) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
+    VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;
+    VkFormatProperties format_props;
+    // TODO: Remove this check if or when devsim handles extensions.
+    // The chosen format has mandatory support the transfer src and dst format features when Maitenance1 is enabled. However, our
+    // use of devsim and the mock ICD violate this guarantee.
+    vkGetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_format, &format_props);
+    if (!(format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+        printf("%s Maintenance1 extension is not supported.\n", kSkipPrefix);
+        return;
+    }
+
     VkImageCreateInfo ci;
     ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     ci.pNext = NULL;
     ci.flags = 0;
     ci.imageType = VK_IMAGE_TYPE_1D;
-    ci.format = VK_FORMAT_R8G8B8A8_UNORM;
+    ci.format = image_format;
     ci.extent = {32, 1, 1};
     ci.mipLevels = 1;
     ci.arrayLayers = 1;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13101,7 +13101,7 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
 
         VkMemoryAllocateInfo alloc_info = {};
         alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        alloc_info.allocationSize = 1024;
+        alloc_info.allocationSize = mem_reqs.size;
         bool pass = false;
         pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
         if (!pass) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -7013,7 +7013,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
     char const *fsSource =
         "#version 450\n"
         "\n"
-        "layout(set=0, binding=0, r32f) uniform imageBuffer s;\n"
+        "layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;\n"
         "layout(location=0) out vec4 x;\n"
         "void main(){\n"
         "   x = imageLoad(s, 0);\n"
@@ -15975,7 +15975,7 @@ TEST_F(VkLayerTest, BufferViewInUseDestroyedSignaled) {
     char const *fsSource =
         "#version 450\n"
         "\n"
-        "layout(set=0, binding=0, r32f) uniform imageBuffer s;\n"
+        "layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;\n"
         "layout(location=0) out vec4 x;\n"
         "void main(){\n"
         "   x = imageLoad(s, 0);\n"


### PR DESCRIPTION
Went through and fixed several small bugs in tests that were causing unexpected errors to be printed.

The following test with unexpected errors were fixed:

CreatePipelineLayoutExcessPerStageDescriptors 
IndexBufferBadSizeOffset 
InvalidQueueFamilyIndex 
SetDynViewportParamAmdNegHeightTests 
CopyImageTypeExtentMismatchMaintenance1 
InvalidBarrierQueueFamilyWithMemExt 
DescriptorIndexingUpdateAfterBind 
BufferViewInUseDestroyedSignaled 
CreatePipelineLayoutExcessDescriptorsOverall 
InvalidCmdBufferBufferViewDestroyed 
InvalidBarrierQueueFamily