### PR TITLE
layers: Make validation error maps non-static

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -35,6 +35,7 @@
 
 // Allow use of STL min and max functions in Windows
 #define NOMINMAX
+#define VALIDATION_ERROR_MAP_IMPL
 
 #include <algorithm>
 #include <array>

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -20,6 +20,8 @@
  * Author: Tobin Ehlis <tobin@lunarg.com>
  */
 
+#define VALIDATION_ERROR_MAP_IMPL
+
 #include "object_tracker.h"
 
 namespace object_tracker {

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -19,6 +19,7 @@
  */
 
 #define NOMINMAX
+#define VALIDATION_ERROR_MAP_IMPL
 
 #include <limits.h>
 #include <math.h>

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -22,6 +22,8 @@
 #include <unordered_map>
 #include <list>
 
+#define VALIDATION_ERROR_MAP_IMPL
+
 #include "vk_loader_platform.h"
 #include "vulkan/vk_layer.h"
 #include "vk_layer_config.h"

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -21,6 +21,7 @@
  */
 
 #define NOMINMAX
+#define VALIDATION_ERROR_MAP_IMPL
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/layers/vk_validation_error_messages.h
+++ b/layers/vk_validation_error_messages.h
@@ -3965,7 +3965,8 @@ enum UNIQUE_VALIDATION_ERROR_CODE {
 };
 
 // Mapping from unique validation error enum to the corresponding spec text
-static std::unordered_map<int, char const *const> validation_error_map{
+#ifdef VALIDATION_ERROR_MAP_IMPL
+std::unordered_map<int, char const *const> validation_error_map {
     {VALIDATION_ERROR_00000009, "The spec valid usage text states 'Each of fence, semaphore, and swapchain that are valid handles must have been created, allocated, or retrieved from the same VkInstance' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VUID-VkAcquireNextImageInfoKHR-commonparent)"},
     {VALIDATION_ERROR_00000a10, "The spec valid usage text states 'If semaphore is not VK_NULL_HANDLE it must be unsignaled' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VUID-VkAcquireNextImageInfoKHR-semaphore-01288)"},
     {VALIDATION_ERROR_00000a12, "The spec valid usage text states 'If fence is not VK_NULL_HANDLE it must be unsignaled and must not be associated with any other queue command that has not yet completed execution on that queue' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VUID-VkAcquireNextImageInfoKHR-fence-01289)"},
@@ -7893,10 +7894,14 @@ static std::unordered_map<int, char const *const> validation_error_map{
     {VALIDATION_ERROR_47600e9c, "The spec valid usage text states 'divisor must be a value between 0 and VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT::maxVertexAttribDivisor, inclusive.' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VUID-VkVertexInputBindingDivisorDescriptionEXT-divisor-01870)"},
     {VALIDATION_ERROR_47600e9e, "The spec valid usage text states 'VkVertexInputBindingDescription::inputRate must be of type VK_VERTEX_INPUT_RATE_INSTANCE for this binding.' (https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#VUID-VkVertexInputBindingDivisorDescriptionEXT-inputRate-01871)"},
 };
+#else
+extern std::unordered_map<int, char const *const> validation_error_map;
+#endif
 
 
 // Mapping from spec validation error text string to unique validation error enum
-static std::unordered_map<std::string, int> validation_error_text_map{
+#ifdef VALIDATION_ERROR_MAP_IMPL
+std::unordered_map<std::string, int> validation_error_text_map {
     {"VUID-VkAcquireNextImageInfoKHR-commonparent", VALIDATION_ERROR_00000009},
     {"VUID-VkAcquireNextImageInfoKHR-semaphore-01288", VALIDATION_ERROR_00000a10},
     {"VUID-VkAcquireNextImageInfoKHR-fence-01289", VALIDATION_ERROR_00000a12},
@@ -11824,3 +11829,6 @@ static std::unordered_map<std::string, int> validation_error_text_map{
     {"VUID-VkVertexInputBindingDivisorDescriptionEXT-divisor-01870", VALIDATION_ERROR_47600e9c},
     {"VUID-VkVertexInputBindingDivisorDescriptionEXT-inputRate-01871", VALIDATION_ERROR_47600e9e},
 };
+#else
+extern std::unordered_map<std::string, int> validation_error_text_map;
+#endif

--- a/scripts/spec.py
+++ b/scripts/spec.py
@@ -202,8 +202,10 @@ class Specification:
         file_contents.append('//  When a given error occurs, these enum values should be passed to the as the messageCode')
         file_contents.append('//  parameter to the PFN_vkDebugReportCallbackEXT function')
         enum_decl = ['enum UNIQUE_VALIDATION_ERROR_CODE {\n    VALIDATION_ERROR_UNDEFINED = -1,']
-        vuid_int_to_error_map = ['static std::unordered_map<int, char const *const> validation_error_map{']
-        vuid_string_to_error_map = ['static std::unordered_map<std::string, int> validation_error_text_map{']
+        vuid_int_to_error_map_decl = 'std::unordered_map<int, char const *const> validation_error_map'
+        vuid_int_to_error_map = [ '#ifdef VALIDATION_ERROR_MAP_IMPL', vuid_int_to_error_map_decl + ' {']
+        vuid_string_to_error_map_decl = 'std::unordered_map<std::string, int> validation_error_text_map'
+        vuid_string_to_error_map = [ '#ifdef VALIDATION_ERROR_MAP_IMPL', vuid_string_to_error_map_decl + ' {']
         enum_value = 0
         max_enum_val = 0
         for enum in sorted(self.error_db_dict):
@@ -214,8 +216,16 @@ class Specification:
             max_enum_val = max(max_enum_val, enum_value)
         enum_decl.append('    %sMAX_ENUM = %d,' % (validation_error_enum_name, max_enum_val + 1))
         enum_decl.append('};')
-        vuid_int_to_error_map.append('};\n')
-        vuid_string_to_error_map.append('};\n')
+        vuid_int_to_error_map.extend([
+            '};',
+            '#else',
+            'extern ' + vuid_int_to_error_map_decl + ';',
+            '#endif\n'])
+        vuid_string_to_error_map.extend([
+            '};',
+            '#else',
+            'extern ' + vuid_string_to_error_map_decl + ';',
+            '#endif\n'])
         file_contents.extend(enum_decl)
         file_contents.append('\n// Mapping from unique validation error enum to the corresponding spec text')
         file_contents.extend(vuid_int_to_error_map)

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -23,6 +23,8 @@
 #include <assert.h>
 #include <unordered_map>
 
+#define VALIDATION_ERROR_MAP_IMPL
+
 #include "vk_dispatch_table_helper.h"
 #include "vk_lunarg_device_profile_api_layer.h"
 #include "vk_device_profile_api_layer.h"


### PR DESCRIPTION
In order to address compile/runtime issues, the large validation tables
are now generated such that the declaration and implementation are
separate.

