### PR TITLE
layers: Export negotiate functions on Windows

### DIFF
--- a/layers/VkLayer_core_validation.def
+++ b/layers/VkLayer_core_validation.def
@@ -27,3 +27,4 @@ vkGetInstanceProcAddr
 vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/VkLayer_object_tracker.def
+++ b/layers/VkLayer_object_tracker.def
@@ -27,3 +27,4 @@ vkGetInstanceProcAddr
 vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/VkLayer_parameter_validation.def
+++ b/layers/VkLayer_parameter_validation.def
@@ -27,3 +27,4 @@ vkGetInstanceProcAddr
 vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/VkLayer_threading.def
+++ b/layers/VkLayer_threading.def
@@ -27,3 +27,4 @@ vkGetInstanceProcAddr
 vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/VkLayer_unique_objects.def
+++ b/layers/VkLayer_unique_objects.def
@@ -27,3 +27,4 @@ vkGetInstanceProcAddr
 vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -3073,7 +3073,8 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDevi
     return parameter_validation::vkGetPhysicalDeviceProcAddr(instance, funcName);
 }
 
-VK_LAYER_EXPORT bool pv_vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pVersionStruct) {
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL VKAPI_CALL
+vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pVersionStruct) {
     assert(pVersionStruct != NULL);
     assert(pVersionStruct->sType == LAYER_NEGOTIATE_INTERFACE_STRUCT);
 


### PR DESCRIPTION
On Windows the `vkNegotiateLoaderLayerInterfaceVersion` entry points are not included in the def files. As a result, the loader is unable to find these functions and they never get used. On top of that, the negotiate function in parameter validation has the wrong name and protoype. This change gets the negotiate functions working in the validation layers.