### PR TITLE
tests: Get seven more tests running without skipping on device profiles

### DIFF
--- a/tests/device_profiles/geforce_1080_ti.json
+++ b/tests/device_profiles/geforce_1080_ti.json
@@ -1,0 +1,2190 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
+    "comments": {
+        "info": "Vulkan Hardware Report generated via https://vulkan.gpuinfo.org",
+        "desc": "https://vulkan.gpuinfo.org/displayreport.php?id=3292"
+    },
+    "environment": {
+        "architecture": "x86_64",
+        "comment": "",
+        "name": "windows",
+        "reportversion": "1.6",
+        "submitter": "eloj",
+        "version": "10"
+    },
+    "extended": {
+        "devicefeatures2": [
+            {
+                "extension": "VK_KHR_multiview",
+                "name": "multiview",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_multiview",
+                "name": "multiviewGeometryShader",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_multiview",
+                "name": "multiviewTessellationShader",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_variable_pointers",
+                "name": "variablePointersStorageBuffer",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_variable_pointers",
+                "name": "variablePointers",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_16bit_storage",
+                "name": "storageBuffer16BitAccess",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_16bit_storage",
+                "name": "uniformAndStorageBuffer16BitAccess",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_16bit_storage",
+                "name": "storagePushConstant16",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_16bit_storage",
+                "name": "storageInputOutput16",
+                "supported": false
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendCoherentOperations",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_sampler_ycbcr_conversion",
+                "name": "samplerYcbcrConversion",
+                "supported": true
+            },
+            {
+                "extension": "VK_KHR_shader_draw_parameters",
+                "name": "shaderDrawParameters",
+                "supported": true
+            }
+        ],
+        "deviceproperties2": [
+            {
+                "extension": "VK_KHR_multiview",
+                "name": "maxMultiviewViewCount",
+                "value": "32"
+            },
+            {
+                "extension": "VK_KHR_multiview",
+                "name": "maxMultiviewInstanceIndex",
+                "value": "134217727"
+            },
+            {
+                "extension": "VK_KHR_push_descriptor",
+                "name": "maxPushDescriptors",
+                "value": "32"
+            },
+            {
+                "extension": "VK_EXT_discard_rectangles",
+                "name": "maxDiscardRectangles",
+                "value": "8"
+            },
+            {
+                "extension": "VK_NVX_multiview_per_view_attributes",
+                "name": "perViewPositionAllComponents",
+                "value": "false"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "primitiveOverestimationSize",
+                "value": "0"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "maxExtraPrimitiveOverestimationSize",
+                "value": "0.75"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "extraPrimitiveOverestimationSizeGranularity",
+                "value": "0.25"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "primitiveUnderestimation",
+                "value": "false"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "conservativePointAndLineRasterization",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "degenerateTrianglesRasterized",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "degenerateLinesRasterized",
+                "value": "false"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "fullyCoveredFragmentShaderInputVariable",
+                "value": "false"
+            },
+            {
+                "extension": "VK_EXT_conservative_rasterization",
+                "name": "conservativeRasterizationPostDepthCoverage",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_sampler_filter_minmax",
+                "name": "filterMinmaxSingleComponentFormats",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_sampler_filter_minmax",
+                "name": "filterMinmaxImageComponentMapping",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "sampleLocationSampleCounts",
+                "value": "31"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "maxSampleLocationGridSize.width",
+                "value": "1"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "maxSampleLocationGridSize.height",
+                "value": "1"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "sampleLocationCoordinateRange[0]",
+                "value": "0"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "sampleLocationCoordinateRange[1]",
+                "value": "0.9375"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "sampleLocationSubPixelBits",
+                "value": "4"
+            },
+            {
+                "extension": "VK_EXT_sample_locations",
+                "name": "variableSampleLocations",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendMaxColorAttachments",
+                "value": "8"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendIndependentBlend",
+                "value": "false"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendNonPremultipliedSrcColor",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendNonPremultipliedDstColor",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendCorrelatedOverlap",
+                "value": "true"
+            },
+            {
+                "extension": "VK_EXT_blend_operation_advanced",
+                "name": "advancedBlendAllOperations",
+                "value": "true"
+            },
+            {
+                "extension": "VK_KHR_sampler_ycbcr_conversion",
+                "name": "combinedImageSamplerDescriptorCount",
+                "value": "0"
+            },
+            {
+                "extension": "VK_KHR_maintenance3",
+                "name": "maxPerSetDescriptors",
+                "value": "4294967295"
+            },
+            {
+                "extension": "VK_KHR_maintenance3",
+                "name": "maxMemoryAllocationSize",
+                "value": "4292870144"
+            }
+        ]
+    },
+    "instance": {
+        "extensions": [
+            {
+                "extensionName": "VK_EXT_debug_report",
+                "specVersion": 9
+            },
+            {
+                "extensionName": "VK_EXT_display_surface_counter",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_get_physical_device_properties2",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_get_surface_capabilities2",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_surface",
+                "specVersion": 25
+            },
+            {
+                "extensionName": "VK_KHR_win32_surface",
+                "specVersion": 6
+            },
+            {
+                "extensionName": "VK_KHR_device_group_creation",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_external_fence_capabilities",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_external_memory_capabilities",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_KHR_external_semaphore_capabilities",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_NV_external_memory_capabilities",
+                "specVersion": 1
+            },
+            {
+                "extensionName": "VK_EXT_debug_utils",
+                "specVersion": 1
+            }
+        ],
+        "layers": [
+            {
+                "description": "NVIDIA Optimus layer",
+                "extensions": [],
+                "implementationVersion": 1,
+                "layerName": "VK_LAYER_NV_optimus",
+                "specVersion": 4198470
+            },
+            {
+                "description": "Steam Overlay Layer",
+                "extensions": [],
+                "implementationVersion": 1,
+                "layerName": "VK_LAYER_VALVE_steam_overlay",
+                "specVersion": 4194307
+            },
+            {
+                "description": "LunarG Standard Validation Layer",
+                "extensions": [],
+                "implementationVersion": 1,
+                "layerName": "VK_LAYER_LUNARG_standard_validation",
+                "specVersion": 4194377
+            }
+        ]
+    },
+    "platformdetails": [],
+    "surfacecapabilites": {
+        "maxImageArrayLayers": 1,
+        "maxImageCount": 8,
+        "maxImageExtent": {
+            "height": 755,
+            "width": 927
+        },
+        "minImageCount": 2,
+        "minImageExtent": {
+            "height": 755,
+            "width": 927
+        },
+        "presentmodes": [
+            2,
+            3,
+            1
+        ],
+        "supportedCompositeAlpha": 1,
+        "supportedTransforms": 1,
+        "supportedUsageFlags": 159,
+        "surfaceExtension": "VK_KHR_win32_surface",
+        "surfaceformats": [
+            {
+                "colorSpace": 0,
+                "format": 44
+            },
+            {
+                "colorSpace": 0,
+                "format": 50
+            }
+        ],
+        "validSurface": true
+    },
+    "VkPhysicalDeviceFeatures": {
+        "alphaToOne": 1,
+        "depthBiasClamp": 1,
+        "depthBounds": 1,
+        "depthClamp": 1,
+        "drawIndirectFirstInstance": 1,
+        "dualSrcBlend": 1,
+        "fillModeNonSolid": 1,
+        "fragmentStoresAndAtomics": 1,
+        "fullDrawIndexUint32": 1,
+        "geometryShader": 1,
+        "imageCubeArray": 1,
+        "independentBlend": 1,
+        "inheritedQueries": 1,
+        "largePoints": 1,
+        "logicOp": 1,
+        "multiDrawIndirect": 1,
+        "multiViewport": 1,
+        "occlusionQueryPrecise": 1,
+        "pipelineStatisticsQuery": 1,
+        "robustBufferAccess": 1,
+        "sampleRateShading": 1,
+        "samplerAnisotropy": 1,
+        "shaderClipDistance": 1,
+        "shaderCullDistance": 1,
+        "shaderFloat64": 1,
+        "shaderImageGatherExtended": 1,
+        "shaderInt16": 1,
+        "shaderInt64": 1,
+        "shaderResourceMinLod": 1,
+        "shaderResourceResidency": 1,
+        "shaderSampledImageArrayDynamicIndexing": 1,
+        "shaderStorageBufferArrayDynamicIndexing": 1,
+        "shaderStorageImageArrayDynamicIndexing": 1,
+        "shaderStorageImageExtendedFormats": 1,
+        "shaderStorageImageMultisample": 1,
+        "shaderStorageImageReadWithoutFormat": 1,
+        "shaderStorageImageWriteWithoutFormat": 1,
+        "shaderTessellationAndGeometryPointSize": 1,
+        "shaderUniformBufferArrayDynamicIndexing": 1,
+        "sparseBinding": 1,
+        "sparseResidency16Samples": 1,
+        "sparseResidency2Samples": 1,
+        "sparseResidency4Samples": 1,
+        "sparseResidency8Samples": 1,
+        "sparseResidencyAliased": 1,
+        "sparseResidencyBuffer": 1,
+        "sparseResidencyImage2D": 1,
+        "sparseResidencyImage3D": 1,
+        "tessellationShader": 1,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 1,
+        "textureCompressionETC2": 0,
+        "variableMultisampleRate": 1,
+        "vertexPipelineStoresAndAtomics": 1,
+        "wideLines": 1
+    },
+    "VkPhysicalDeviceProperties": {
+        "apiVersion": 4198470,
+        "deviceID": 6918,
+        "deviceName": "GeForce GTX 1080 Ti",
+        "deviceType": 2,
+        "driverVersion": 1666662400,
+        "limits": {
+            "bufferImageGranularity": 1024,
+            "discreteQueuePriorities": 2,
+            "framebufferColorSampleCounts": 15,
+            "framebufferDepthSampleCounts": 15,
+            "framebufferNoAttachmentsSampleCounts": 31,
+            "framebufferStencilSampleCounts": 31,
+            "lineWidthGranularity": 0.125,
+            "lineWidthRange": [
+                0.5,
+                10
+            ],
+            "maxBoundDescriptorSets": 8,
+            "maxClipDistances": 8,
+            "maxColorAttachments": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "maxComputeSharedMemorySize": 49152,
+            "maxComputeWorkGroupCount": [
+                2147483647,
+                65535,
+                65535
+            ],
+            "maxComputeWorkGroupInvocations": 1536,
+            "maxComputeWorkGroupSize": [
+                1536,
+                1024,
+                64
+            ],
+            "maxCullDistances": 8,
+            "maxDescriptorSetInputAttachments": 1048576,
+            "maxDescriptorSetSampledImages": 1048576,
+            "maxDescriptorSetSamplers": 1048576,
+            "maxDescriptorSetStorageBuffers": 1048576,
+            "maxDescriptorSetStorageBuffersDynamic": 16,
+            "maxDescriptorSetStorageImages": 1048576,
+            "maxDescriptorSetUniformBuffers": 90,
+            "maxDescriptorSetUniformBuffersDynamic": 15,
+            "maxDrawIndexedIndexValue": 4294967295,
+            "maxDrawIndirectCount": 4294967295,
+            "maxFragmentCombinedOutputResources": 16,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentInputComponents": 128,
+            "maxFragmentOutputAttachments": 8,
+            "maxFramebufferHeight": 32768,
+            "maxFramebufferLayers": 2048,
+            "maxFramebufferWidth": 32768,
+            "maxGeometryInputComponents": 128,
+            "maxGeometryOutputComponents": 128,
+            "maxGeometryOutputVertices": 1024,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxImageArrayLayers": 2048,
+            "maxImageDimension1D": 32768,
+            "maxImageDimension2D": 32768,
+            "maxImageDimension3D": 16384,
+            "maxImageDimensionCube": 32768,
+            "maxInterpolationOffset": 0.4375,
+            "maxMemoryAllocationCount": 4096,
+            "maxPerStageDescriptorInputAttachments": 1048576,
+            "maxPerStageDescriptorSampledImages": 1048576,
+            "maxPerStageDescriptorSamplers": 1048576,
+            "maxPerStageDescriptorStorageBuffers": 1048576,
+            "maxPerStageDescriptorStorageImages": 1048576,
+            "maxPerStageDescriptorUniformBuffers": 15,
+            "maxPerStageResources": 4294967295,
+            "maxPushConstantsSize": 256,
+            "maxSampleMaskWords": 1,
+            "maxSamplerAllocationCount": 4000,
+            "maxSamplerAnisotropy": 16,
+            "maxSamplerLodBias": 15,
+            "maxStorageBufferRange": 4294967295,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlPerVertexInputComponents": 128,
+            "maxTessellationControlPerVertexOutputComponents": 128,
+            "maxTessellationControlTotalOutputComponents": 4216,
+            "maxTessellationEvaluationInputComponents": 128,
+            "maxTessellationEvaluationOutputComponents": 128,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTexelBufferElements": 134217728,
+            "maxTexelGatherOffset": 31,
+            "maxTexelOffset": 7,
+            "maxUniformBufferRange": 65536,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputAttributes": 32,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexInputBindings": 32,
+            "maxVertexOutputComponents": 128,
+            "maxViewportDimensions": [
+                32768,
+                32768
+            ],
+            "maxViewports": 16,
+            "minInterpolationOffset": -0.5,
+            "minMemoryMapAlignment": 64,
+            "minStorageBufferOffsetAlignment": 32,
+            "minTexelBufferOffsetAlignment": 16,
+            "minTexelGatherOffset": -32,
+            "minTexelOffset": -8,
+            "minUniformBufferOffsetAlignment": 256,
+            "mipmapPrecisionBits": 8,
+            "nonCoherentAtomSize": 64,
+            "optimalBufferCopyOffsetAlignment": 1,
+            "optimalBufferCopyRowPitchAlignment": 1,
+            "pointSizeGranularity": 0.125,
+            "pointSizeRange": [
+                1,
+                189.875
+            ],
+            "sampledImageColorSampleCounts": 15,
+            "sampledImageDepthSampleCounts": 15,
+            "sampledImageIntegerSampleCounts": 15,
+            "sampledImageStencilSampleCounts": 31,
+            "sparseAddressSpaceSize": -1,
+            "standardSampleLocations": 1,
+            "storageImageSampleCounts": 15,
+            "strictLines": 1,
+            "subPixelInterpolationOffsetBits": 4,
+            "subPixelPrecisionBits": 8,
+            "subTexelPrecisionBits": 8,
+            "timestampComputeAndGraphics": 1,
+            "timestampPeriod": 1,
+            "viewportBoundsRange": [
+                -65536,
+                65536
+            ],
+            "viewportSubPixelBits": 8
+        },
+        "pipelineCacheUUID": [
+            120,
+            132,
+            235,
+            50,
+            24,
+            166,
+            79,
+            35,
+            161,
+            144,
+            218,
+            111,
+            217,
+            132,
+            252,
+            96
+        ],
+        "sparseProperties": {
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 1,
+            "residencyStandard2DBlockShape": 1,
+            "residencyStandard2DMultisampleBlockShape": 1,
+            "residencyStandard3DBlockShape": 1
+        },
+        "subgroupProperties": {
+            "quadOperationsInAllStages": true,
+            "subgroupSize": 32,
+            "supportedOperations": 255,
+            "supportedStages": 63
+        },
+        "vendorID": 4318
+    },
+    "VkPhysicalDeviceMemoryProperties": {
+        "memoryHeaps": [
+            {
+                "flags": 1,
+                "size": 11667505152
+            },
+            {
+                "flags": 0,
+                "size": 68656562176
+            }
+        ],
+        "memoryTypes": [
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 0
+            },
+            {
+                "heapIndex": 0,
+                "propertyFlags": 1
+            },
+            {
+                "heapIndex": 0,
+                "propertyFlags": 1
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 6
+            },
+            {
+                "heapIndex": 1,
+                "propertyFlags": 14
+            }
+        ]
+    },
+    "ArrayOfVkExtensionProperties": [
+        {
+            "extensionName": "VK_KHR_swapchain",
+            "specVersion": 70
+        },
+        {
+            "extensionName": "VK_KHR_16bit_storage",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_bind_memory2",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_dedicated_allocation",
+            "specVersion": 3
+        },
+        {
+            "extensionName": "VK_KHR_descriptor_update_template",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_device_group",
+            "specVersion": 3
+        },
+        {
+            "extensionName": "VK_KHR_get_memory_requirements2",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_image_format_list",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_maintenance1",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_maintenance2",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_maintenance3",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_multiview",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_push_descriptor",
+            "specVersion": 2
+        },
+        {
+            "extensionName": "VK_KHR_relaxed_block_layout",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_sampler_mirror_clamp_to_edge",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_sampler_ycbcr_conversion",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_shader_draw_parameters",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_storage_buffer_storage_class",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_memory",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_memory_win32",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_semaphore",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_semaphore_win32",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_win32_keyed_mutex",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_fence",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_external_fence_win32",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHR_variable_pointers",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_KHX_device_group",
+            "specVersion": 2
+        },
+        {
+            "extensionName": "VK_KHX_multiview",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_blend_operation_advanced",
+            "specVersion": 2
+        },
+        {
+            "extensionName": "VK_EXT_conservative_rasterization",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_depth_range_unrestricted",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_discard_rectangles",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_post_depth_coverage",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_sample_locations",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_sampler_filter_minmax",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_shader_subgroup_ballot",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_shader_subgroup_vote",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_EXT_shader_viewport_index_layer",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_dedicated_allocation",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_external_memory",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_external_memory_win32",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_fill_rectangle",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_fragment_coverage_to_color",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_framebuffer_mixed_samples",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_glsl_shader",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_win32_keyed_mutex",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_clip_space_w_scaling",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_sample_mask_override_coverage",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_viewport_array2",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_viewport_swizzle",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NV_geometry_shader_passthrough",
+            "specVersion": 1
+        },
+        {
+            "extensionName": "VK_NVX_device_generated_commands",
+            "specVersion": 3
+        },
+        {
+            "extensionName": "VK_NVX_multiview_per_view_attributes",
+            "specVersion": 1
+        }
+    ],
+    "ArrayOfVkLayerProperties": [
+        {
+            "description": "NVIDIA Optimus layer",
+            "implementationVersion": 1,
+            "layerName": "VK_LAYER_NV_optimus",
+            "specVersion": 4198470
+        }
+    ],
+    "ArrayOfVkQueueFamilyProperties": [
+        {
+            "minImageTransferGranularity": {
+                "depth": 1,
+                "height": 1,
+                "width": 1
+            },
+            "queueCount": 16,
+            "queueFlags": 15,
+            "timestampValidBits": 64
+        },
+        {
+            "minImageTransferGranularity": {
+                "depth": 1,
+                "height": 1,
+                "width": 1
+            },
+            "queueCount": 1,
+            "queueFlags": 4,
+            "timestampValidBits": 64
+        },
+        {
+            "minImageTransferGranularity": {
+                "depth": 1,
+                "height": 1,
+                "width": 1
+            },
+            "queueCount": 8,
+            "queueFlags": 2,
+            "timestampValidBits": 64
+        }
+    ],
+    "ArrayOfVkFormatProperties": [
+        {
+            "formatID": 1,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 2,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 3,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 4,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 5,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 6,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 7,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 8,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 9,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 10,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 11,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 12,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 13,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 14,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 15,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 16,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 17,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 18,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 19,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 20,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 21,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 22,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 23,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 24,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 25,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 26,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 27,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 28,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 29,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 30,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 31,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 32,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 33,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 34,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 35,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 36,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 37,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 38,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 39,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 40,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 41,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 42,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 43,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 44,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 45,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 46,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 47,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 48,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 115713,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 49,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 115713,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 50,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 51,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 52,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 53,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 54,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 55,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 56,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 57,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 58,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122241,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 59,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 60,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 61,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 62,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 115713,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 63,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 64,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 65,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 66,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 67,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 68,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 69,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 70,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 71,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 72,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 73,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 74,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 75,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 76,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 77,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 78,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 79,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 80,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 81,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 82,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 83,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 84,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 85,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 86,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 87,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 88,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 89,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 90,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 91,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 92,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 93,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 94,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 95,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 96,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 97,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 98,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117895,
+            "bufferFeatures": 120
+        },
+        {
+            "formatID": 99,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117895,
+            "bufferFeatures": 120
+        },
+        {
+            "formatID": 100,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122247,
+            "bufferFeatures": 120
+        },
+        {
+            "formatID": 101,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 102,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 103,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 104,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 105,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 106,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 72
+        },
+        {
+            "formatID": 107,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 108,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 117891,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 109,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 110,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 111,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 112,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 113,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 114,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 115,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 116,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 117,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 118,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 119,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 120,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 121,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 64
+        },
+        {
+            "formatID": 122,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 122243,
+            "bufferFeatures": 88
+        },
+        {
+            "formatID": 123,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 8
+        },
+        {
+            "formatID": 124,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 120321,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 125,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 120321,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 126,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 120321,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 127,
+            "linearTilingFeatures": 115713,
+            "optimalTilingFeatures": 116225,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 128,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 129,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 120321,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 130,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 120321,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 131,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 132,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 133,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 134,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 135,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 136,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 137,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 138,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 139,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 140,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 141,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 142,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 143,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 144,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 145,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 146,
+            "linearTilingFeatures": 119809,
+            "optimalTilingFeatures": 119809,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 147,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 148,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 149,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 150,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 151,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 152,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 153,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 154,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 155,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 156,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 157,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 158,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 159,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 160,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 161,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 162,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 163,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 164,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 165,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 166,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 167,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 168,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 169,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 170,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 171,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 172,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 173,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 174,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 175,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 176,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 177,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 178,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 179,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 180,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 181,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 182,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 183,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 184,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156000,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156001,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156002,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156003,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156004,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156005,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156006,
+            "linearTilingFeatures": 5230593,
+            "optimalTilingFeatures": 5230593,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156007,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156008,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156009,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156010,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156011,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156012,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156013,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156014,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156015,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156016,
+            "linearTilingFeatures": 5230593,
+            "optimalTilingFeatures": 5230593,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156017,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156018,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156019,
+            "linearTilingFeatures": 1036289,
+            "optimalTilingFeatures": 1036289,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156020,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156021,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156022,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156023,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156024,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156025,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156026,
+            "linearTilingFeatures": 5230593,
+            "optimalTilingFeatures": 5230593,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156027,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156028,
+            "linearTilingFeatures": 9424897,
+            "optimalTilingFeatures": 9424897,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156029,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156030,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156031,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156032,
+            "linearTilingFeatures": 13619201,
+            "optimalTilingFeatures": 13619201,
+            "bufferFeatures": 0
+        }
+    ]
+}

--- a/tests/device_profiles/geforce_1080_ti.json
+++ b/tests/device_profiles/geforce_1080_ti.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
     "comments": {
-        "info": "Vulkan Hardware Report generated via https://vulkan.gpuinfo.org",
-        "desc": "https://vulkan.gpuinfo.org/displayreport.php?id=3292"
+        "info": "Modified version of Vulkan Hardware Report generated via https://vulkan.gpuinfo.org",
+        "desc": "Removed subgroup properties from https://vulkan.gpuinfo.org/displayreport.php?id=3292"
     },
     "environment": {
         "architecture": "x86_64",
@@ -562,12 +562,6 @@
             "residencyStandard2DBlockShape": 1,
             "residencyStandard2DMultisampleBlockShape": 1,
             "residencyStandard3DBlockShape": 1
-        },
-        "subgroupProperties": {
-            "quadOperationsInAllStages": true,
-            "subgroupSize": 32,
-            "supportedOperations": 255,
-            "supportedStages": 63
         },
         "vendorID": 4318
     },

--- a/tests/device_profiles/mobile_chip.json
+++ b/tests/device_profiles/mobile_chip.json
@@ -2,25 +2,25 @@
     "$schema": "https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
     "comments": {
         "info": "Vulkan Hardware Report generated via https://vulkan.gpuinfo.org",
-        "desc": "https://vulkan.gpuinfo.org/displayreport.php?id=2001"
+        "desc": ""
     },
     "environment": {
-        "architecture": "arm",
+        "architecture": "",
         "comment": "",
-        "name": "android",
+        "name": "",
         "reportversion": "1.4",
-        "submitter": "Iwandi",
-        "version": "7.1.2"
+        "submitter": "",
+        "version": ""
     },
     "extended": {
         "devicefeatures2": [],
         "deviceproperties2": []
     },
     "platformdetails": {
-        "android.BuildID": "NHG47K",
-        "android.BuildVersionIncremental": "eng.root.20170901.232851",
-        "android.ProductManufacturer": "rockchip",
-        "android.ProductModel": "rk3288"
+        "android.BuildID": "",
+        "android.BuildVersionIncremental": "",
+        "android.ProductManufacturer": "",
+        "android.ProductModel": ""
     },
     "surfacecapabilites": {
         "maxImageArrayLayers": 1,
@@ -314,6 +314,16 @@
             },
             "queueCount": 2,
             "queueFlags": 7,
+            "timestampValidBits": 0
+        },
+        {
+            "minImageTransferGranularity": {
+                "depth": 1,
+                "height": 1,
+                "width": 1
+            },
+            "queueCount": 2,
+            "queueFlags": 1,
             "timestampValidBits": 0
         }
     ],

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -23570,22 +23570,23 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayoutWithoutExtension) {
 TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
     TEST_DESCRIPTION("Exercise various create/allocate-time errors related to VK_EXT_descriptor_indexing.");
 
-    std::array<const char *, 2> reqd_instance_extensions = {
-        {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, VK_KHR_MAINTENANCE3_EXTENSION_NAME}};
-    for (auto instance_ext : reqd_instance_extensions) {
-        if (InstanceExtensionSupported(instance_ext)) {
-            m_instance_extension_names.push_back(instance_ext);
-        } else {
-            printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix, instance_ext);
-            return;
-        }
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix,
+               VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        return;
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-    } else {
-        printf("%s %s Extension not supported.\n", kSkipPrefix, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-        return;
+    std::array<const char *, 2> required_device_extensions = {
+        {VK_KHR_MAINTENANCE3_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME}};
+    for (auto device_extension : required_device_extensions) {
+        if (DeviceExtensionSupported(gpu(), nullptr, device_extension)) {
+            m_device_extension_names.push_back(device_extension);
+        } else {
+            printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, device_extension);
+            return;
+        }
     }
 
     // Create a device that enables all supported indexing features except descriptorBindingUniformBufferUpdateAfterBind

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -249,6 +249,7 @@ void Device::init(std::vector<const char *> &extensions, VkPhysicalDeviceFeature
     for (uint32_t i = 0; i < (uint32_t)queue_props.size(); i++) {
         if (queue_props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
             graphics_queue_node_index_ = i;
+            break;
         }
     }
     // Only request creation with queuefamilies that have at least one queue


### PR DESCRIPTION
Made fixes to two tests and added a high end device profile to get seven more tests running without being skipped.

The tests now no longer being skipped are:
VkPositiveLayerTest.MultiplaneImageTests
VkPositiveLayerTest.MultiplaneGetImageSubresourceLayout
VkLayerTest.CopyImageSinglePlane422Alignment
VkLayerTest.DescriptorIndexingSetLayout
VkLayerTest.MultiplaneImageLayoutBadAspectFlags
VkLayerTest.CopyImageMultiplaneAspectBits
VkLayerTest.InvalidBarriers