### PR TITLE
tests: layer tests should depend on layer builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,7 +126,16 @@ if (TARGET gtest_main)
         ${PROJECT_BINARY_DIR}
         ${PROJECT_BINARY_DIR}/layers
         )
-    add_dependencies(vk_layer_validation_tests VkLayer_utils)
+    add_dependencies(vk_layer_validation_tests
+        VkLayer_utils
+        VkLayer_core_validation-json
+        VkLayer_device_profile_api-json
+        VkLayer_object_tracker-json
+        VkLayer_parameter_validation-json
+        VkLayer_standard_validation-json
+        VkLayer_threading-json
+        VkLayer_unique_objects-json
+        )
 
     if(NOT WIN32)
         set_target_properties(vk_layer_validation_tests


### PR DESCRIPTION
This is mainly to ensure that in a Visual Studio workflow, running the `vk_layers_validation_tests` project in the IDE triggers the individual layers to build if they're out of date.

(...no *YOU* just spent an hour "debugging" a test failure you'd already fixed because your layers binaries were stale.)