### PR TITLE
Remove googletest as a submodule and make it optional

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,6 +62,8 @@ before_build:
   - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% -- /maxcpucount
   # Generate build files using CMake for the build step.
+  - echo Fetching googletest external dependencies for building validation layer tests
+  - git clone https://github.com/google/googletest.git external/googletest
   - echo Generating Vulkan-ValidationLayers CMake files for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ CMakeFiles/
 cmake_install.cmake
 Makefile
 scripts/__pycache__
+external/googletest
 *.so
 *.so.*
 _out64

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "submodules/googletest"]
-	path = tests/googletest
-	url = https://github.com/google/googletest.git
 [submodule "Vulkan-Headers"]
 	path = Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,9 @@ script:
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
+      # Fetch googletest componenet to build validation layer tests
+      echo Fetching googletest external dependencies for building validation layer tests
+      git clone https://github.com/google/googletest.git external/googletest
       # Build Vulkan-ValidationLayers
       cd ${TRAVIS_BUILD_DIR}
       mkdir build

--- a/BUILD.md
+++ b/BUILD.md
@@ -55,6 +55,7 @@ Windows 7+ with the following software packages:
   - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
   - Install both the 32-bit and 64-bit versions, as the 64-bit installer does not install the
     32-bit libraries and tools.
+  - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
 - Vulkan Loader Library
   - Building the Layer Validation Tests requires linking to the Vulkan Loader Library (vulkan-1.dll).
     Locating the library for this repo can be done in two different ways:
@@ -66,7 +67,13 @@ Windows 7+ with the following software packages:
          and use absolute (not relative) paths, like so:
              cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader ....
          Currently, the build directory *must* be named either 'build' or 'build32'.
-  - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
+- [googletest](https://github.com/google/googletest.git)
+  - This is an optional component, but required for building the validation layer tests. To install,
+
+        cd <the root directory of your copy of the Vulkan-ValidationLayers repository, "external" will be a subdirectory>
+        git clone https://github.com/google/googletest.git external/googletest
+
+  - The gtest libraries will be built as part of the main project cmake/build process
 
 ### Windows Build - Microsoft Visual Studio
 
@@ -149,6 +156,14 @@ Vulkan Loader Library
 - [glslang](https://github.com/KhronosGroup/glslang)
   - Ensure that the 'update_glslang_sources.py' script has been run. Follow the build instructions in the
     glslang [README.md](https://github.com/KhronosGroup/glslang/blob/master/README.md) file, noting the location of the chosen install directory.
+
+- [googletest](https://github.com/google/googletest.git)
+  - This is an optional component, but required for building the validation layer tests. To install,
+
+        cd <the root directory of your copy of the Vulkan-ValidationLayers repository, "external" will be a subdirectory>
+        git clone https://github.com/google/googletest.git external/googletest
+
+  - The gtest libraries will be built as part of the main project cmake/build process
 
 ### Linux Build
 
@@ -442,6 +457,14 @@ Also clone the following repos:
              LOADER_REPO_ROOT=/absolute_path_to_/Vulkan-Loader
          and use absolute (not relative) paths, like so:
              cmake -DLOADER_REPO_ROOT=/absolute_path_to_/Vulkan-Loader ....
+- [googletest](https://github.com/google/googletest.git)
+  - This is an optional component, but required for building the validation layer tests. To install,
+
+        cd <the root directory of your copy of the Vulkan-ValidationLayers repository, "external" will be a subdirectory>
+        git clone https://github.com/google/googletest.git external/googletest
+
+  - The gtest libraries will be built as part of the main project cmake/build process
+
 
 ### MacOS build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,10 +348,7 @@ add_custom_target(uninstall
 add_definitions(-DAPI_NAME="${API_NAME}")
 
 if(BUILD_TESTS)
-    # Output warning if googletest submodule contents are not present
-    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/googletest/googletest/include/gtest/gtest.h")
-        message(FATAL_ERROR "Please run 'git submodule update --init' before running cmake")
-    endif()
+    add_subdirectory(external)
     add_subdirectory(tests)
 endif()
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,19 @@
+# googletest is an external dependency for the tests in the ValidationLayers
+# repo. Check for its presence before trying to build tests.
+
+# Suppress all warnings from external projects.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
+
+if(TARGET gtest_main)
+    message(STATUS "Google Test (googletest) already configured - use it")
+elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
+    SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
+    SET(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
+    SET(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
+    SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+    # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/googletest EXCLUDE_FROM_ALL)
+else()
+    message(STATUS
+        "Google Test was not found - tests based on that will not build")
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,157 +1,154 @@
 cmake_minimum_required(VERSION 2.8.11)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
-    # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
-    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    set(DisplayServer Win32)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if (BUILD_WSI_XCB_SUPPORT)
-        add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
-    endif()
+if (TARGET gtest_main)
+    message(STATUS "Vulkan-ValidationLayers/tests: googletests found - building tests")
 
-    if (BUILD_WSI_XLIB_SUPPORT)
-       add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
-    endif()
+    set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
 
-    if (BUILD_WSI_WAYLAND_SUPPORT)
-       add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
-    endif()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
+        # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
+        add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        set(DisplayServer Win32)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+        add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        if (BUILD_WSI_XCB_SUPPORT)
+            add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
+        endif()
 
-    if (BUILD_WSI_MIR_SUPPORT)
-        add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
-        include_directories(${MIR_INCLUDE_DIR})
-    endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
-else()
-    message(FATAL_ERROR "Unsupported Platform!")
-endif()
+        if (BUILD_WSI_XLIB_SUPPORT)
+           add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
+        endif()
 
-if (WIN32)
-   file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
-endif()
+        if (BUILD_WSI_WAYLAND_SUPPORT)
+           add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
+        endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-
-    # If MSVC, disable some signed/unsigned mismatch warnings.
-    if (MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
-    endif()
-
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
-
-set (LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
-
-set(COMMON_CPP
-    vkrenderframework.cpp
-    vktestbinding.cpp
-    vktestframework.cpp
-    test_environment.cpp
-   )
-
-
-if (NOT WIN32)
-    # extra setup for out-of-tree builds
-    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        add_custom_target(binary-dir-symlinks ALL
-            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh
-            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/vkvalidatelayerdoc.sh
-            VERBATIM
-            )
-    endif()
-else()
-    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_run_all_tests.ps1 RUN_ALL)
-        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_vkvalidatelayerdoc.ps1 VALIDATE_DOC)
-        add_custom_target(binary-dir-symlinks ALL
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RUN_ALL} run_all_tests.ps1
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VALIDATE_DOC} vkvalidatelayerdoc.ps1
-            VERBATIM
-            )
-        set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${VVL_TARGET_FOLDER})
-    endif()
-endif()
-
-# Predefine loader root as a cmake cache variable for cmake-gui
-set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
-
-if(NOT LOADER_REPO_ROOT)
-    message(STATUS "LOADER_REPO_ROOT not set, using find_package to locate Vulkan")
-    find_package(Vulkan)
-    set (LIBVK "Vulkan::Vulkan")
-else()
-    message(STATUS "Using user-supplied path to locate Vulkan")
-    if(WIN32)
-        set (LOADER_SEARCH_PATHS
-            "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${DEBUG_DECORATION}"
-            "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${RELEASE_DECORATION}"
-            "${LOADER_REPO_ROOT}/Lib"
-            )
-    elseif(UNIX)
-        set (LOADER_SEARCH_PATHS
-            "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader"
-            "${LOADER_REPO_ROOT}/x86_64/lib"
-            )
-    endif()
-    find_library(LIBVK NAMES vulkan vulkan-1
-        HINTS ${LOADER_SEARCH_PATHS}
-        )
-    message(STATUS "Found Vulkan: ${LIBVK}")
-endif()
-
-add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
-set_target_properties(vk_layer_validation_tests
-   PROPERTIES
-   COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
-target_include_directories(vk_layer_validation_tests PUBLIC
-    ${VULKAN_HEADERS_LOCATION}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest/include
-    ${PROJECT_SOURCE_DIR}/layers
-    ${GLSLANG_SPIRV_INCLUDE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}
-    ${PROJECT_BINARY_DIR}
-    ${PROJECT_BINARY_DIR}/layers
-    )
-add_dependencies(vk_layer_validation_tests VkLayer_utils)
-
-if(NOT WIN32)
-    set_target_properties(vk_layer_validation_tests
-        PROPERTIES
-        COMPILE_FLAGS "-Wno-sign-compare")
-    if (BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
-        target_link_libraries(vk_layer_validation_tests ${LIBVK} ${XCB_LIBRARIES} ${X11_LIBRARIES} gtest gtest_main ${GLSLANG_LIBRARIES})
+        if (BUILD_WSI_MIR_SUPPORT)
+            add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
+            include_directories(${MIR_INCLUDE_DIR})
+        endif()
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
     else()
+        message(FATAL_ERROR "Unsupported Platform!")
+    endif()
+
+    if (WIN32)
+       file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
+    endif()
+
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+
+    if(WIN32)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+
+        # If MSVC, disable some signed/unsigned mismatch warnings.
+        if (MSVC)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
+        endif()
+
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+
+    set (LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
+
+    set(COMMON_CPP
+        vkrenderframework.cpp
+        vktestbinding.cpp
+        vktestframework.cpp
+        test_environment.cpp
+       )
+
+    if (NOT WIN32)
+        # extra setup for out-of-tree builds
+        if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
+            add_custom_target(binary-dir-symlinks ALL
+                COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh
+                COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/vkvalidatelayerdoc.sh
+                VERBATIM
+                )
+        endif()
+    else()
+        if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
+            FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_run_all_tests.ps1 RUN_ALL)
+            FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_vkvalidatelayerdoc.ps1 VALIDATE_DOC)
+            add_custom_target(binary-dir-symlinks ALL
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RUN_ALL} run_all_tests.ps1
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VALIDATE_DOC} vkvalidatelayerdoc.ps1
+                VERBATIM
+                )
+            set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${VVL_TARGET_FOLDER})
+        endif()
+    endif()
+
+    # Predefine loader root as a cmake cache variable for cmake-gui
+    set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
+
+    if(NOT LOADER_REPO_ROOT)
+        message(STATUS "LOADER_REPO_ROOT not set, using find_package to locate Vulkan")
+        find_package(Vulkan)
+        set (LIBVK "Vulkan::Vulkan")
+    else()
+        message(STATUS "Using user-supplied path to locate Vulkan")
+        if(WIN32)
+            set (LOADER_SEARCH_PATHS
+                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${DEBUG_DECORATION}"
+                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${RELEASE_DECORATION}"
+                "${LOADER_REPO_ROOT}/Lib"
+                )
+        elseif(UNIX)
+            set (LOADER_SEARCH_PATHS
+                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader"
+                "${LOADER_REPO_ROOT}/x86_64/lib"
+                )
+        endif()
+        find_library(LIBVK NAMES vulkan vulkan-1
+            HINTS ${LOADER_SEARCH_PATHS}
+            )
+        message(STATUS "Found Vulkan: ${LIBVK}")
+    endif()
+
+    add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
+    set_target_properties(vk_layer_validation_tests
+       PROPERTIES
+       COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+    target_include_directories(vk_layer_validation_tests PUBLIC
+        ${VULKAN_HEADERS_LOCATION}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${GTEST_LOCATION}/googletest/include
+        ${PROJECT_SOURCE_DIR}/layers
+        ${GLSLANG_SPIRV_INCLUDE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}
+        ${PROJECT_BINARY_DIR}
+        ${PROJECT_BINARY_DIR}/layers
+        )
+    add_dependencies(vk_layer_validation_tests VkLayer_utils)
+
+    if(NOT WIN32)
+        set_target_properties(vk_layer_validation_tests
+            PROPERTIES
+            COMPILE_FLAGS "-Wno-sign-compare")
+        if (BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
+            target_link_libraries(vk_layer_validation_tests ${LIBVK} ${XCB_LIBRARIES} ${X11_LIBRARIES} gtest gtest_main ${GLSLANG_LIBRARIES})
+        else()
+            target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
+        endif()
+    endif()
+    if(WIN32)
         target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
     endif()
-endif()
-if(WIN32)
-    target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
-endif()
 
-if (WIN32)
-    # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
-    FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/googletest/googletest/$<CONFIGURATION>/*.dll SRC_GTEST_DLLS)
-    FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
-    add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
-        COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
+    if (WIN32)
+        # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
+        FILE(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIGURATION>/*.dll SRC_GTEST_DLLS)
+        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
+        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+            COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
+    endif()
+
+    add_subdirectory(layers)
 endif()
-
-set (GTEST_RELATIVE_LOCATION googletest)
-SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-SET(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-SET(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
-SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-# EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
-add_subdirectory(${GTEST_RELATIVE_LOCATION} ${CMAKE_CURRENT_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
-
-add_subdirectory(layers)

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -64,7 +64,7 @@
 
 // Use the NDK's header on Android
 #ifndef __ANDROID__
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 #else
 #include "gtest/gtest.h"
 #endif


### PR DESCRIPTION
Removed this component as a submodule and made it an optional component of the tests portion of the repo.  If googletests is present in the External folder, tests will build (if enabled).  Otherwise, building of tests will be skipped.  This step has no other dependencies.

