### PR TITLE
Add 'LOADER_INSTALL_DIR' option to Vulkan-ValidationLayers

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -64,12 +64,11 @@ Windows 7+ with the following software packages:
     Locating the library for this repo can be done in two different ways:
       -  The Vulkan SDK can be installed. In this case, cmake should be able to locate the loader repo through the VulkanSDK
          environment variable
-      -  The library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository.
+      -  The library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository. This can be done by setting 'CMAKE_INSTALL_PREFIX' and building 'install' target from within the Vulkan-Loader repo, noting the install location.
          In this case, the following option should be used on the cmake command line:
-             LOADER_REPO_ROOT=c:\developement\Vulkan-Loader
-         and use absolute (not relative) paths, like so:
-             cmake -DLOADER_REPO_ROOT=c:\absolute_path_to\Vulkan-Loader ....
-         Currently, the build directory *must* be named either 'build' or 'build32'.
+
+             cmake -DVULKAN_LOADER_INSTALL_DIR=c:\absolute_path_to\Vulkan-Loader\install
+
 - [googletest](https://github.com/google/googletest.git)
   - This is an optional component, but required for building the validation layer tests. To install,
 
@@ -88,9 +87,9 @@ Windows 7+ with the following software packages:
 
 For example, for VS2017 (generators for other versions are [specified here](#cmake-visual-studio-generators)):
 
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=c:\absolute_path_to\Vulkan-Headers\install -DLOADER_REPO_ROOT=c:\absolute_path_to\VULKAN_LOADER -DGLSLANG_INSTALL_DIR=c:\absolute_path_to\glslang\install -G "Visual Studio 15 2017 Win64" ..
+    cmake -DVULKAN_HEADERS_INSTALL_DIR=c:\absolute_path_to\Vulkan-Headers\install -DVULKAN_LOADER_INSTALL_DIR=c:\absolute_path_to\VULKAN_LOADER\install -DGLSLANG_INSTALL_DIR=c:\absolute_path_to\glslang\install -G "Visual Studio 15 2017 Win64" ..
 
-LOADER_REPO_ROOT, VULKAN_HEADERS_INSTALL_DIR, and GLSLANG_INSTALL_DIR each require absolute paths.
+VULKAN_LOADER_INSTALL_DIR, VULKAN_HEADERS_INSTALL_DIR, and GLSLANG_INSTALL_DIR each require absolute paths.
 This will create a Windows solution file named `Vulkan-ValidationLayers.sln` in the build directory.
 
 Launch Visual Studio and open the "Vulkan-ValidationLayers.sln" solution file in the build folder.
@@ -148,13 +147,11 @@ It should be straightforward to adapt this repository to other Linux distributio
 
     sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev
 
-Vulkan Loader Library
-  - Building the Layer Validation Tests requires linking to the Vulkan Loader Library (libvulkan-1.so).
-      - The LOADER_REPO_ROOT environment variable should be used on the cmake command line to specify a vulkan loader library. Make sure to specify an absoute path, like so:
+- [Vulkan-Loader](https://github.com/Khronosgroup/Vulkan-Loader.git)
+  - Building the Layer Validation Tests requires linking to the Vulkan Loader Library (libvulkan-1.so). This can be done by setting 'CMAKE_INSTALL_PREFIX' and building 'install' target from within the Vulkan-Loader repo, noting the install location.
+      - The VULKAN_LOADER_INSTALL_DIR environment variable should be used on the cmake command line to specify a vulkan loader library, like so:
 
-          `cmake -DLOADER_REPO_ROOT=c:\development\Vulkan-Loader ....`
-
-    Currently, the build directory *must* be named either 'build' or 'build32'.
+          `cmake -DVULKAN_LOADER_INSTALL_DIR=c:\absolute_path_to\Vulkan-Loader\install ....`
 
 - [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers.git)
   - This repo should be built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
@@ -183,7 +180,7 @@ See **Validation Layer Dependencies** (below) for more information and other opt
 
         mkdir build
         cd build
-        cmake -DVULKAN_HEADERS_INSTALL_DIR=/absolute_path_to/Vulkan-Headers/install -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/location_of/install -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DVULKAN_HEADERS_INSTALL_DIR=/absolute_path_to/Vulkan-Headers/install -DVULKAN_LOADER_INSTALL_DIR=/absolute_path_to/Vulkan-Loader/install -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/location_of/install -DCMAKE_BUILD_TYPE=Debug ..
 
 3. Run `make -j8` to begin the build
 
@@ -447,16 +444,13 @@ Also clone the following repos:
 
 - [glslang](https://github.com/KhronosGroup/glslang)
   - Ensure that the 'update_glslang_sources.py' script has been run, and the repository successfully built.
-- Vulkan Loader Library
+- [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git)
   - Building the Layer Validation Tests requires linking to the Vulkan Loader Library (libvulkan.1.dylib).
     Locating the library for this repo can be done in two different ways:
       -  The Vulkan SDK can be installed. In this case, cmake should be able to locate the loader repo through the VulkanSDK
          environment variable
-      -  The library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository.
-         In this case, the following option should be used on the cmake command line:
-             LOADER_REPO_ROOT=/absolute_path_to_/Vulkan-Loader
-         and use absolute (not relative) paths, like so:
-             cmake -DLOADER_REPO_ROOT=/absolute_path_to_/Vulkan-Loader ....
+      -  The library can be built from the [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader.git) repository. This can be done by setting 'CMAKE_INSTALL_PREFIX' and building 'install' target from within the Vulkan-Loader repo, noting the location.
+             cmake -DVULKAN_LOADER_INSTALL_DIR=/absolute_path_to_/Vulkan-Loader/install ....
 - [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers.git)
   - This repo should be built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
     and building the "install" target from within the Vulkan-Headers repository.
@@ -487,7 +481,7 @@ build is:
 
         mkdir build
         cd build
-        cmake -DVULKAN_HEADERS_INSTALL_DIR=/absolute_path_to/Vulkan-Headers/install -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/build/install -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DVULKAN_HEADERS_INSTALL_DIR=/absolute_path_to/Vulkan-Headers/install -DVULKAN_LOADER_INSTALL_DIR=/absolute_path_to/Vulkan-Loader/install -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/build/install -DCMAKE_BUILD_TYPE=Debug ..
         make
 
 To speed up the build on a multi-core machine, use the `-j` option for `make`
@@ -502,7 +496,7 @@ To create and open an Xcode project:
 
         mkdir build-xcode
         cd build-xcode
-        cmake -DLOADER_REPO_ROOT=/absolute_path_to/Vulkan-Loader -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/build/install -GXcode ..
+        cmake -DVULKAN_LOADER_INSTALL_DIR=/absolute_path_to/Vulkan-Loader/install -DGLSLANG_INSTALL_DIR=/absolute_path_to_/glslang/build/install -GXcode ..
         open VULKAN.xcodeproj
 
 Within Xcode, you can select Debug or Release builds in the Build Settings of the project.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,15 +84,29 @@ if (TARGET gtest_main)
         endif()
     endif()
 
-    # Predefine loader root as a cmake cache variable for cmake-gui
+    # The vulkan loader search is:
+    #     User-supplied setting of CMAKE_PREFIX_PATH
+    #     VULKAN_LOADER_INSTALL_DIR defined via cmake option
+    #     VULKAN_LOADER_INSTALL_DIR defined via environment variable
+    #     Default findVulkan operation if the VULKAN_SDK environment variable is defined
+    set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
+
+    # TODO: Remove this option after all repos converted
     set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
 
     if(NOT LOADER_REPO_ROOT)
-        message(STATUS "LOADER_REPO_ROOT not set, using find_package to locate Vulkan")
+        if ({VULKAN_LOADER_INSTALL_DIR)
+            message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
+        elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
+            message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
+        endif()
+        set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR})
         find_package(Vulkan)
         set (LIBVK "Vulkan::Vulkan")
     else()
-        message(STATUS "Using user-supplied path to locate Vulkan")
+        # TODO: Delete this code block when we're done with REPO_ROOT
+        message(STATUS "Using user-supplied LOADER_REPO_ROOT to locate Vulkan")
+        message(STATUS "DO NOT USE LOADER_REPO_ROOT!  See BUILD.md for information on using VULKAN_LOADER_INSTALL_DIR.")
         if(WIN32)
             set (LOADER_SEARCH_PATHS
                 "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${DEBUG_DECORATION}"
@@ -108,7 +122,9 @@ if (TARGET gtest_main)
         find_library(LIBVK NAMES vulkan vulkan-1
             HINTS ${LOADER_SEARCH_PATHS}
             )
-        message(STATUS "Found Vulkan: ${LIBVK}")
+        if (LIBVK)
+            message(STATUS "Found Vulkan: ${LIBVK}")
+        endif()
     endif()
 
     add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})


### PR DESCRIPTION
To replace 'LOADER_REPO_ROOT', which will be left in place until the dependent repos are scrubbed.