### PR TITLE
Update appveyor/travis for INSTALL_DIR builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,6 @@ before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo.
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
-  - git submodule update --init --recursive
   # Determine the appropriate CMake generator for the current version of Visual Studio
   - echo Determining VS version
   - python .\scripts\determine_vs_version.py > vsversion.tmp
@@ -54,12 +53,12 @@ before_build:
   # Build Vulkan-Loader
   - echo Building Vulkan-Loader for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
-  - git clone --recurse-submodules https://github.com/KhronosGroup/Vulkan-Loader.git
+  - git clone https://github.com/KhronosGroup/Vulkan-Loader.git
   - cd Vulkan-Loader
   - mkdir %BUILD_DIR%
   - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install ..
-  - cmake --build . --config %CONFIGURATION% -- /maxcpucount
+  - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install ..
+  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Build glslang
   - echo Building glslang for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -69,7 +68,7 @@ before_build:
   - mkdir %BUILD_DIR%
   - cd %BUILD_DIR%
   - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
-  - cmake --build . --config %CONFIGURATION% -- /maxcpucount
+  - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Generate build files using CMake for the build step.
   - echo Fetching googletest external dependencies for building validation layer tests
   - git clone https://github.com/google/googletest.git external/googletest
@@ -77,7 +76,7 @@ before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DGLSLANG_REPO_ROOT=%APPVEYOR_BUILD_FOLDER%\glslang -DLOADER_REPO_ROOT=%APPVEYOR_BUILD_FOLDER%\Vulkan-Loader ..
+  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DGLSLANG_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/glslang/%BUILD_DIR%/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/%BUILD_DIR%/install ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ script:
       ./update_glslang_sources.py
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug ..
-      make -j $core_count
+      cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Debug ..
+      make install -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi
   - |
@@ -112,23 +112,23 @@ script:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build Vulkan-Loader for Vulkan-ValidationLayers
       cd ${TRAVIS_BUILD_DIR}
-      git clone --recurse-submodules https://github.com/KhronosGroup/Vulkan-Loader.git
+      git clone https://github.com/KhronosGroup/Vulkan-Loader.git
       cd Vulkan-Loader
       mkdir build
       cd build
-      cmake -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DCMAKE_BUILD_TYPE=Debug ..
-      make -j $core_count
+      cmake -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Debug ..
+      make install -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Build Vulkan-Tools for Vulkan-ValidationLayers
       cd ${TRAVIS_BUILD_DIR}
-      git clone --recurse-submodules https://github.com/KhronosGroup/Vulkan-Tools.git
+      git clone https://github.com/KhronosGroup/Vulkan-Tools.git
       cd Vulkan-Tools
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_CUBE=OFF -DBUILD_VULKANINFO=OFF ..
+      cmake -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Loader/build/install -DCMAKE_BUILD_TYPE=Debug -DBUILD_CUBE=OFF -DBUILD_VULKANINFO=OFF ..
       make -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi
@@ -141,7 +141,7 @@ script:
       cd ${TRAVIS_BUILD_DIR}
       mkdir build
       cd build
-      cmake -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DGLSLANG_REPO_ROOT=${TRAVIS_BUILD_DIR}/glslang -DLOADER_REPO_ROOT=${TRAVIS_BUILD_DIR}/Vulkan-Loader -DCMAKE_BUILD_TYPE=Debug ..
+      cmake -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Headers/build/install -DGLSLANG_INSTALL_DIR=${TRAVIS_BUILD_DIR}/glslang/build/install -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/Vulkan-Loader/build/install -DCMAKE_BUILD_TYPE=Debug ..
       make -j $core_count
       cd ${TRAVIS_BUILD_DIR}
     fi
@@ -149,7 +149,6 @@ script:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Run Tests
       cd ${TRAVIS_BUILD_DIR}
-      #(cd build/tests; ./vkvalidatelayerdoc.sh)
       export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/Vulkan-Loader/build/loader:$LD_LIBRARY_PATH
       export VK_LAYER_PATH=${TRAVIS_BUILD_DIR}/external/VulkanTools/build/layersvt:${TRAVIS_BUILD_DIR}/build/layers
       export VK_ICD_FILENAMES=${TRAVIS_BUILD_DIR}/Vulkan-Tools/build/icd/VkICD_mock_icd.json


### PR DESCRIPTION
Removed submodule cruft, removed *_REPO_ROOT references, changed to new install targets for loader, headers, and glslang. 