### PR TITLE
Remove *_REPO_ROOT, allow env var for glslang

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -582,16 +582,13 @@ Instructions to install an instance of the glslang repository follow here.
 
 After installing and building glslang, the location will be used to build the Vulkan-ValidationLayers repo:
 
-1) Pass in the location of your glslang repository to cmake using absolute paths. From your build directory run:
+  Pass in the location of your glslang repository to cmake using absolute paths. From your build directory run:
     1) on Windows
 
         `cmake -DGLSLANG_INSTALL_DIR=c:/absolute_path_to/glslang/location_of/install -G "Visual Studio 15 Win64" ..`
-    1) or Linux
+    2) or Linux
 
         `cmake -DGLSLANG_INSTALL_DIR=/absolute_path_to/glslang/location_of/install -DCMAKE_BUILD_TYPE=Debug ..`
-
-2) If building on Windows with MSVC, set `DISABLE_BUILDTGT_DIR_DECORATION` to _On_.
- If building on Windows, but without MSVC set `DISABLE_BUILD_PATH_DECORATION` to _On_
 
 ## Optional software packages
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,117 +117,29 @@ if(WIN32)
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34245>")
 endif()
 
-if(NOT WIN32)
-    set (BUILDTGT_DIR build)
-    set (BINDATA_DIR Bin)
-    set (LIBSOURCE_DIR Lib)
-else()
-    # For Windows, since 32-bit and 64-bit items can co-exist, we build each in its own build directory.
-    # 32-bit target data goes in build32, and 64-bit target data goes into build.  So, include/link the
-    # appropriate data at build time.
-    if (DISABLE_BUILDTGT_DIR_DECORATION)
-        set (BUILDTGT_DIR "")
-        set (BINDATA_DIR "")
-        set (LIBSOURCE_DIR "")
-    elseif (CMAKE_CL_64)
-        set (BUILDTGT_DIR build)
-        set (BINDATA_DIR Bin)
-        set (LIBSOURCE_DIR Lib)
-    else()
-        set (BUILDTGT_DIR build32)
-        set (BINDATA_DIR Bin32)
-        set (LIBSOURCE_DIR Lib32)
-    endif()
-endif()
-
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_LAYERS "Build layers" ON)
 
-# set GLSLANG_INSTALL_DIR to define locations of glslang includes, libs, and binaries.
-# This is the preferred method for building this repository.
 set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
-
-# Set GLSLANG_REPO_ROOT to locate glslang repository
-# This should be deprecated in lieu of GLSANG_INSTALL_DIR, remove once users have switched to preferred solution
-set(GLSLANG_REPO_ROOT "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to glslang repository")
-
-# Repo requires glslang and that the update_glslang_sources.py script was run in the indicated glslang repo
-if (NOT GLSLANG_INSTALL_DIR AND NOT GLSLANG_REPO_ROOT)
+if (NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR})
     message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
 endif()
 
-if(DISABLE_BUILD_PATH_DECORATION)
-    set (DEBUG_DECORATION "")
-    set (RELEASE_DECORATION "")
-else()
-    set (DEBUG_DECORATION "Debug")
-    set (RELEASE_DECORATION "Release")
+# Cmake command line option overrides environment variable
+if(NOT GLSLANG_INSTALL_DIR)
+    set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
 endif()
-
-# Is user specifying a glslang install directory?
-if (GLSLANG_INSTALL_DIR)
-    message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
-    set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
-    set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
-    set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to glslang spirv headers")
-    set(SPIRV_TOOLS_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
-
-    set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set (SPIRV_TOOLS_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set (SPIRV_TOOLS_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set (SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-else()
-    message(STATUS "Using glslang built in repository located at ${GLSLANG_REPO_ROOT}")
-
-    # These paths assume that the update_glslang_sources.py script was run in the indicated glslang repo and the repo was built
-    set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
-    set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/External/spirv-tools/source/opt" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
-
-    if(WIN32)
-        set(GSLANG_FINAL_BINARY_PATH ${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR})
-
-        # Take some steps to set up a variable pointing to the final glslang binaries given the variety of input options
-        set (GLSLANG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${RELEASE_DECORATION}"
-                                 "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${RELEASE_DECORATION}"
-                                 "${GSLANG_FINAL_BINARY_PATH}/hlsl/${RELEASE_DECORATION}"
-                                 "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${RELEASE_DECORATION}"
-                                 "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${RELEASE_DECORATION}" )
-
-        set (GLSLANG_DEBUG_SEARCH_PATH "${GSLANG_FINAL_BINARY_PATH}/glslang/${DEBUG_DECORATION}"
-                                       "${GSLANG_FINAL_BINARY_PATH}/glslang/OSDependent/Windows/${DEBUG_DECORATION}"
-                                       "${GSLANG_FINAL_BINARY_PATH}/hlsl/${DEBUG_DECORATION}"
-                                       "${GSLANG_FINAL_BINARY_PATH}/OGLCompilersDLL/${DEBUG_DECORATION}"
-                                       "${GSLANG_FINAL_BINARY_PATH}/SPIRV/${DEBUG_DECORATION}")
-
-        set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${RELEASE_DECORATION}")
-        set (SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}/${DEBUG_DECORATION}")
-        set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${RELEASE_DECORATION}")
-        set (SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}/${DEBUG_DECORATION}")
-    else()
-        # not WIN32
-        set (GLSLANG_SEARCH_PATH "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/install/lib"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/glslang/OSDependent/Unix"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/OGLCompilersDLL"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/SPIRV"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/hlsl"
-                                 "${GLSLANG_REPO_ROOT}/${BUILDTGT_DIR}/StandAlone")
-
-        set (SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_BINARY_ROOT}" )
-        set (SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_OPT_BINARY_ROOT}" )
-    endif()
-    find_path(GLSLANG_SPIRV_INCLUDE_DIR SPIRV/spirv.hpp HINTS
-             "${GLSLANG_REPO_ROOT}"
-             "${CMAKE_SOURCE_DIR}/../glslang"
-             DOC "Path to SPIRV/spirv.hpp")
-
-    find_path(SPIRV_TOOLS_INCLUDE_DIR spirv-tools/libspirv.h HINTS
-              "${GLSLANG_REPO_ROOT}/External/spirv-tools/include"
-              "${CMAKE_SOURCE_DIR}/../glslang/External/spirv-tools/include"
-              DOC "Path to spirv-tools/libspirv.h")
-endif()
+message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
+set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
+set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib" CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
+set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to glslang spirv headers")
+set(SPIRV_TOOLS_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
+set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+set(SPIRV_TOOLS_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+set(SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
 
 find_library(GLSLANG_LIB NAMES glslang
              HINTS ${GLSLANG_SEARCH_PATH} )
@@ -304,7 +216,6 @@ if (WIN32)
     set_target_properties(SPIRV-Tools-opt PROPERTIES
                          IMPORTED_LOCATION       "${SPIRV_TOOLS_OPT_LIB}"
                          IMPORTED_LOCATION_DEBUG "${SPIRV_TOOLS_OPT_DLIB}")
-
 endif()
 
 if(WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,41 +88,14 @@ if (TARGET gtest_main)
     #     Default findVulkan operation if the VULKAN_SDK environment variable is defined
     set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
 
-    # TODO: Remove this option after all repos converted
-    set(LOADER_REPO_ROOT "LOADER-NOTFOUND" CACHE PATH "Absolute path to the root of the loader repository")
-
-    if(NOT LOADER_REPO_ROOT)
-        if (VULKAN_LOADER_INSTALL_DIR)
-            message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
-        elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
-            message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
-        endif()
-        set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR})
-        find_package(Vulkan)
-        set (LIBVK "Vulkan::Vulkan")
-    else()
-        # TODO: Delete this code block when we're done with REPO_ROOT
-        message(STATUS "Using user-supplied LOADER_REPO_ROOT to locate Vulkan")
-        message(STATUS "DO NOT USE LOADER_REPO_ROOT!  See BUILD.md for information on using VULKAN_LOADER_INSTALL_DIR.")
-        if(WIN32)
-            set (LOADER_SEARCH_PATHS
-                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${DEBUG_DECORATION}"
-                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader/${RELEASE_DECORATION}"
-                "${LOADER_REPO_ROOT}/Lib"
-                )
-        elseif(UNIX)
-            set (LOADER_SEARCH_PATHS
-                "${LOADER_REPO_ROOT}/${BUILDTGT_DIR}/loader"
-                "${LOADER_REPO_ROOT}/x86_64/lib"
-                )
-        endif()
-        find_library(LIBVK NAMES vulkan vulkan-1
-            HINTS ${LOADER_SEARCH_PATHS}
-            )
-        if (LIBVK)
-            message(STATUS "Found Vulkan: ${LIBVK}")
-        endif()
+    if (VULKAN_LOADER_INSTALL_DIR)
+        message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
+    elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
+        message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
     endif()
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR})
+    find_package(Vulkan)
+    set (LIBVK "Vulkan::Vulkan")
 
     add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
     set_target_properties(vk_layer_validation_tests


### PR DESCRIPTION
This allowed killing a bunch of cmake crud. Repo root is now gone, and setting VULKAN_HEADERS_INSTALL_DIR, VULKAN_LOADER_INSTALL_DIR, and GLSLANG_INSTALL_DIR can all be done via environment variables.