### PR TITLE
layers: Fix bugs of display queries in unique_objects

### DIFF
--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -163,7 +163,6 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             'vkGetDisplayPlaneSupportedDisplaysKHR',
             'vkGetDisplayModePropertiesKHR',
             'vkGetDisplayModeProperties2KHR',
-            'vkGetDisplayPlaneCapabilitiesKHR',
             ]
         # Commands shadowed by interface functions and are not implemented
         self.interface_functions = [


### PR DESCRIPTION
- remove duplicate include
- `currentDisplay` in `vkGetPhysicalDeviceDisplayPlaneProperties` may be `VK_NULL_HANDLE`
- `vkGetDisplayPlaneSupportedDisplays` did not account for `VK_INCOMPLETE`
-  `vkGetDisplayPlaneCapabilitiesKHR` can be handled by generated code