### PR TITLE
ci: Reduce AppVeyor jobs to two

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,6 +87,16 @@ configuration:
   - Release
   - Debug
 
+# Build only x64 Release and Win32(x86) Debug to reduce build time.
+# This should still provide adequate 32-bit vs 64-bit and
+# Release vs Debug coverage.
+matrix:
+  exclude:
+    - configuration: Release
+      platform: Win32
+    - configuration: Debug
+      platform: x64
+
 build:
   parallel: true                              # enable MSBuild parallel builds
   project: build/Vulkan-ValidationLayers.sln  # path to Visual Studio solution or project


### PR DESCRIPTION
Build only x64 Release and Win32 Debug to improve
turnaround time.