### PR TITLE
Copy loader dll to bin dir for LVTs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,14 @@ if (TARGET gtest_main)
         FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
         add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
             COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
+        # Copy the loader shared lib to the test application directory so the test app finds it.
+        set(default_find_library_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+        get_filename_component(lib_name ${Vulkan_LIBRARY} NAME_WE)
+        find_library(vulkan_dll NAMES ${lib_name} HINTS ${Vulkan_LIBRARY} PATH_SUFFIXES "bin")
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ${default_find_library_suffixes})
+        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy ${vulkan_dll} $<TARGET_FILE_DIR:vk_layer_validation_tests>)
     endif()
 
     add_subdirectory(layers)


### PR DESCRIPTION
Even though INSTALL_DIR was used to indicate the loader libs to link against, due to Windows DLL search order rules there was no telling which, if any, vulkan loader was getting used. Copy the indicated loader binary to the app dir to make sure.

This is a cmake post-build step that runs ONLY on windows.