### PR TITLE
ci: Clean up AppVeyor config file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,33 +31,23 @@ before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo.
   - echo Starting build for %APPVEYOR_REPO_NAME% in %APPVEYOR_BUILD_FOLDER%
-  # Determine the appropriate CMake generator for the current version of Visual Studio
-  - echo Determining VS version
-  - python .\scripts\determine_vs_version.py > vsversion.tmp
-  - set /p VS_VERSION=< vsversion.tmp
-  - echo Detected Visual Studio Version as %VS_VERSION%
-  - del /Q /F vsversion.tmp
-  - if %PLATFORM% == Win32 (set GENERATOR="Visual Studio %VS_VERSION%")
-  - if %PLATFORM% == x64 (set GENERATOR="Visual Studio %VS_VERSION% Win64")
-  - if %PLATFORM% == Win32 (set BUILD_DIR="build32")
-  - if %PLATFORM% == x64 (set BUILD_DIR="build")
   # Build Vulkan-Headers
   - echo Building Vulkan-Headers for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - git clone https://github.com/KhronosGroup/Vulkan-Headers.git Vulkan-Headers
   - cd Vulkan-Headers
-  - mkdir %BUILD_DIR%
-  - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
+  - mkdir build
+  - cd build
+  - cmake -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Build Vulkan-Loader
   - echo Building Vulkan-Loader for %PLATFORM% %CONFIGURATION%
   - cd %APPVEYOR_BUILD_FOLDER%
   - git clone https://github.com/KhronosGroup/Vulkan-Loader.git
   - cd Vulkan-Loader
-  - mkdir %BUILD_DIR%
-  - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install ..
+  - mkdir build
+  - cd build
+  - cmake -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=install -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install ..
   - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Build glslang
   - echo Building glslang for %PLATFORM% %CONFIGURATION%
@@ -65,18 +55,18 @@ before_build:
   - git clone https://github.com/KhronosGroup/glslang.git
   - cd glslang
   - update_glslang_sources.py
-  - mkdir %BUILD_DIR%
-  - cd %BUILD_DIR%
-  - cmake -G %GENERATOR% -DCMAKE_INSTALL_PREFIX=install ..
+  - mkdir build
+  - cd build
+  - cmake -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% --target install -- /maxcpucount
   # Generate build files using CMake for the build step.
   - echo Fetching googletest external dependencies for building validation layer tests
+  - cd %APPVEYOR_BUILD_FOLDER%
   - git clone https://github.com/google/googletest.git external/googletest
   - echo Generating Vulkan-ValidationLayers CMake files for %PLATFORM% %CONFIGURATION%
-  - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/%BUILD_DIR%/install -DGLSLANG_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/glslang/%BUILD_DIR%/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/%BUILD_DIR%/install ..
+  - cmake -A %PLATFORM% -DVULKAN_HEADERS_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Headers/build/install -DGLSLANG_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/glslang/build/install -DVULKAN_LOADER_INSTALL_DIR=%APPVEYOR_BUILD_FOLDER%/Vulkan-Loader/build/install ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:


### PR DESCRIPTION
- Use -A CMake argument instead of creating a generator string
  based on the worker image and architecture. Instead, set the
  architecture (platform Win32 or x64) with -A and take whatever
  Visual Studio version is provided by the worker image.  The
  worker image is specified by the "os" config property.
- Fix likely bug with cloning googletest into the wrong place.