### PR TITLE
build: Improve googletest handling

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -141,7 +141,7 @@ on/off options currently supported by this repository:
 | ------ | -------- | ------- | ----------- |
 | BUILD_LAYERS | All | `ON` | Controls whether or not the validation layers are built. |
 | BUILD_LAYER_SUPPORT_FILES | All | `OFF` | Controls whether or not layer support files are built if the layers are not built. |
-| BUILD_TESTS | All | `ON` | Controls whether or not the validation layer tests are built. This option is only available when a copy of Google Test is available in the "external" directory. |
+| BUILD_TESTS | All | `???` | Controls whether or not the validation layer tests are built. The default is `ON` when the Google Test repository is cloned into the `external` directory.  Otherwise, the default is `OFF`. |
 | INSTALL_TESTS | All | `OFF` | Controls whether or not the validation layer tests are installed. This option is only available when a copy of Google Test is available
 | BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the components with XCB support. |
 | BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the components with Xlib support. |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,11 @@ if(WIN32)
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34245>")
 endif()
 
-option(BUILD_TESTS "Build tests" ON)
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
+    option(BUILD_TESTS "Build tests" ON)
+else()
+    option(BUILD_TESTS "Build tests" OFF)
+endif()
 option(INSTALL_TESTS "Install tests" OFF)
 option(BUILD_LAYERS "Build layers" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Generate layer files" OFF) # For generating files when not building layers
@@ -255,8 +259,8 @@ endif()
 
 add_definitions(-DAPI_NAME="${API_NAME}")
 
+add_subdirectory(external)
 if(BUILD_TESTS)
-    add_subdirectory(external)
     add_subdirectory(tests)
 endif()
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,19 +1,26 @@
-# googletest is an external dependency for the tests in the ValidationLayers
-# repo. Check for its presence before trying to build tests.
+if(BUILD_TESTS)
+    # googletest is an external dependency for the tests in the ValidationLayers
+    # repo. Add googletest to the project if present and not already defined.
 
-# Suppress all warnings from external projects.
-set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
+    # Suppress all warnings from external projects.
+    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
 
-if(TARGET gtest_main)
-    message(STATUS "Google Test (googletest) already configured - use it")
-elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
-    SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-    SET(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-    SET(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
-    SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-    # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/googletest EXCLUDE_FROM_ALL)
-else()
-    message(STATUS
-        "Google Test was not found - tests based on that will not build")
+    if(TARGET gtest_main)
+        # It is possible that a project enclosing this one has defined the gtest target
+        message(STATUS "Vulkan-ValidationLayers/external: "
+            "Google Test (googletest) already configured - use it")
+    elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
+        message(STATUS "Vulkan-ValidationLayers/external: "
+            "googletests found - configuring it for tests")
+        SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
+        SET(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
+        SET(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
+        SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+        # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/googletest EXCLUDE_FROM_ALL)
+    else()
+        message(SEND_ERROR
+            "Vulkan-ValidationLayers/external: Google Test was not found.  "
+            "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
+    endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,158 +1,152 @@
-cmake_minimum_required(VERSION 2.8.11)
+set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
 
-if (TARGET gtest_main)
-    message(STATUS "Vulkan-ValidationLayers/tests: googletests found - building tests")
-
-    set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
-
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
-        # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
-        add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-        set(DisplayServer Win32)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
-        add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        if (BUILD_WSI_XCB_SUPPORT)
-            add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
-        endif()
-
-        if (BUILD_WSI_XLIB_SUPPORT)
-           add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
-        endif()
-
-        if (BUILD_WSI_WAYLAND_SUPPORT)
-           add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
-        endif()
-
-        if (BUILD_WSI_MIR_SUPPORT)
-            add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
-            include_directories(${MIR_INCLUDE_DIR})
-        endif()
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
-    else()
-        message(FATAL_ERROR "Unsupported Platform!")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
+    # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
+    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    set(DisplayServer Win32)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (BUILD_WSI_XCB_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
 
-    if (WIN32)
-       file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
+    if (BUILD_WSI_XLIB_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
     endif()
 
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-
-    if(WIN32)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-
-        # If MSVC, disable some signed/unsigned mismatch warnings.
-        if (MSVC)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
-        endif()
-
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    if (BUILD_WSI_WAYLAND_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
     endif()
 
-    set (LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
+    if (BUILD_WSI_MIR_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
+        include_directories(${MIR_INCLUDE_DIR})
+    endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+else()
+    message(FATAL_ERROR "Unsupported Platform!")
+endif()
 
-    set(COMMON_CPP
-        vkrenderframework.cpp
-        vktestbinding.cpp
-        vktestframework.cpp
-        test_environment.cpp
-       )
+if (WIN32)
+    file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
+endif()
 
-    if (NOT WIN32)
-        # extra setup for out-of-tree builds
-        if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-            add_custom_target(binary-dir-symlinks ALL
-                COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh
-                VERBATIM
-                )
-        endif()
-    else()
-        if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-            FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_run_all_tests.ps1 RUN_ALL)
-            add_custom_target(binary-dir-symlinks ALL
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RUN_ALL} run_all_tests.ps1
-                VERBATIM
-                )
-            set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-        endif()
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+
+if(WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+
+    # If MSVC, disable some signed/unsigned mismatch warnings.
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
     endif()
 
-    # The vulkan loader search is:
-    #     User-supplied setting of CMAKE_PREFIX_PATH
-    #     VULKAN_LOADER_INSTALL_DIR defined via cmake option
-    #     VULKAN_LOADER_INSTALL_DIR defined via environment variable
-    #     Default findVulkan operation if the VULKAN_SDK environment variable is defined
-    set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
-    if (VULKAN_LOADER_INSTALL_DIR)
-        message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
-    elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
-        message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
+set (LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
+
+set(COMMON_CPP
+    vkrenderframework.cpp
+    vktestbinding.cpp
+    vktestframework.cpp
+    test_environment.cpp
+    )
+
+if (NOT WIN32)
+    # extra setup for out-of-tree builds
+    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
+        add_custom_target(binary-dir-symlinks ALL
+            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh
+            VERBATIM
+            )
     endif()
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR})
-    find_package(Vulkan)
-    set (LIBVK "Vulkan::Vulkan")
+else()
+    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
+        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_run_all_tests.ps1 RUN_ALL)
+        add_custom_target(binary-dir-symlinks ALL
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${RUN_ALL} run_all_tests.ps1
+            VERBATIM
+            )
+        set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+    endif()
+endif()
 
-    add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
+# The vulkan loader search is:
+#     User-supplied setting of CMAKE_PREFIX_PATH
+#     VULKAN_LOADER_INSTALL_DIR defined via cmake option
+#     VULKAN_LOADER_INSTALL_DIR defined via environment variable
+#     Default findVulkan operation if the VULKAN_SDK environment variable is defined
+set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
+
+if (VULKAN_LOADER_INSTALL_DIR)
+    message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
+elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
+    message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
+endif()
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR})
+find_package(Vulkan)
+set (LIBVK "Vulkan::Vulkan")
+
+add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
+set_target_properties(vk_layer_validation_tests
+    PROPERTIES
+    COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+target_include_directories(vk_layer_validation_tests PUBLIC
+    ${VulkanHeaders_INCLUDE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${GTEST_LOCATION}/googletest/include
+    ${PROJECT_SOURCE_DIR}/layers
+    ${GLSLANG_SPIRV_INCLUDE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}/layers
+    )
+add_dependencies(vk_layer_validation_tests
+    VkLayer_utils
+    VkLayer_core_validation-json
+    VkLayer_device_profile_api-json
+    VkLayer_object_tracker-json
+    VkLayer_parameter_validation-json
+    VkLayer_standard_validation-json
+    VkLayer_threading-json
+    VkLayer_unique_objects-json
+    )
+
+if(NOT WIN32)
     set_target_properties(vk_layer_validation_tests
-       PROPERTIES
-       COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
-    target_include_directories(vk_layer_validation_tests PUBLIC
-        ${VulkanHeaders_INCLUDE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${GTEST_LOCATION}/googletest/include
-        ${PROJECT_SOURCE_DIR}/layers
-        ${GLSLANG_SPIRV_INCLUDE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}
-        ${PROJECT_BINARY_DIR}
-        ${PROJECT_BINARY_DIR}/layers
-        )
-    add_dependencies(vk_layer_validation_tests
-        VkLayer_utils
-        VkLayer_core_validation-json
-        VkLayer_device_profile_api-json
-        VkLayer_object_tracker-json
-        VkLayer_parameter_validation-json
-        VkLayer_standard_validation-json
-        VkLayer_threading-json
-        VkLayer_unique_objects-json
-        )
-
-    if(NOT WIN32)
-        set_target_properties(vk_layer_validation_tests
-            PROPERTIES
-            COMPILE_FLAGS "-Wno-sign-compare")
-        if (BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
-            target_link_libraries(vk_layer_validation_tests ${LIBVK} ${XCB_LIBRARIES} ${X11_LIBRARIES} gtest gtest_main ${GLSLANG_LIBRARIES})
-        else()
-            target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
-        endif()
-    endif()
-    if(WIN32)
+        PROPERTIES
+        COMPILE_FLAGS "-Wno-sign-compare")
+    if (BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
+        target_link_libraries(vk_layer_validation_tests ${LIBVK} ${XCB_LIBRARIES} ${X11_LIBRARIES} gtest gtest_main ${GLSLANG_LIBRARIES})
+    else()
         target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
     endif()
-
-    if (WIN32)
-        # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
-        FILE(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIGURATION>/*.dll SRC_GTEST_DLLS)
-        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
-        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
-            COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
-        # Copy the loader shared lib (if supplied) to the test application directory so the test app finds it.
-        if(VULKAN_LOADER_INSTALL_DIR)
-            add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy ${VULKAN_LOADER_INSTALL_DIR}/bin/vulkan-1.dll $<TARGET_FILE_DIR:vk_layer_validation_tests>)
-        endif()
-    endif()
-
-    if(INSTALL_TESTS)
-        install(TARGETS vk_layer_validation_tests DESTINATION ${CMAKE_INSTALL_BINDIR})
-    endif()
-
-    add_subdirectory(layers)
 endif()
+if(WIN32)
+    target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
+endif()
+
+if (WIN32)
+    # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
+    FILE(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIGURATION>/*.dll SRC_GTEST_DLLS)
+    FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
+    add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+        COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
+    # Copy the loader shared lib (if supplied) to the test application directory so the test app finds it.
+    if(VULKAN_LOADER_INSTALL_DIR)
+        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy ${VULKAN_LOADER_INSTALL_DIR}/bin/vulkan-1.dll $<TARGET_FILE_DIR:vk_layer_validation_tests>)
+    endif()
+endif()
+
+if(INSTALL_TESTS)
+    install(TARGETS vk_layer_validation_tests DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+add_subdirectory(layers)


### PR DESCRIPTION
Behavior is largely unchanged except that specifying BUILD_TESTS=ON
with googletest not present no longer quietly skips building the tests.

- Make inclusion of external directory unconditional.  We may someday
  put something there is not related to testing.
- Make default for BUILD_TEST dependent on googletest presence.
- Remove if() around entire contents of tests CMake file.
- Add CMake messaging to clarify googletest activity.
- Throw a CMake error if googletest not present and BUILD_TESTS=ON