### PR TITLE
Update object_tracker dispatch table handling

### DIFF
--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -111,7 +111,8 @@ struct layer_data {
     // Map of queue information structures, one per queue
     std::unordered_map<VkQueue, ObjTrackQueueInfo *> queue_info_map;
 
-    VkLayerDispatchTable dispatch_table;
+    VkLayerDispatchTable device_dispatch_table;
+    VkLayerInstanceDispatchTable instance_dispatch_table;
     // Default constructor
     layer_data()
         : instance(nullptr),
@@ -126,14 +127,13 @@ struct layer_data {
           tmp_messenger_create_infos(nullptr),
           tmp_debug_messengers(nullptr),
           object_map{},
-          dispatch_table{} {
+          device_dispatch_table{},
+          instance_dispatch_table{} {
         object_map.resize(kVulkanObjectTypeMax + 1);
     }
 };
 
 extern std::unordered_map<void *, layer_data *> layer_data_map;
-extern device_table_map ot_device_table_map;
-extern instance_table_map ot_instance_table_map;
 extern std::mutex global_lock;
 extern uint64_t object_track_index;
 extern uint32_t loader_layer_if_version;

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -973,9 +973,13 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             # Pull out the text for each of the parameters, separate them by commas in a list
             paramstext = ', '.join([str(param.text) for param in params])
             # Use correct dispatch table
-            disp_type = cmdinfo.elem.find('param/type').text
             disp_name = cmdinfo.elem.find('param/name').text
-            dispatch_table = 'get_dispatch_table(ot_%s_table_map, %s)->' % (self.GetDispType(disp_type), disp_name)
+            disp_type = cmdinfo.elem.find('param/type').text
+            if disp_type in ["VkInstance", "VkPhysicalDevice"] or cmdname == 'vkCreateInstance':
+                object_type = 'instance'
+            else:
+                object_type = 'device'
+            dispatch_table = 'GetLayerDataPtr(get_dispatch_key(%s), layer_data_map)->%s_dispatch_table.' % (disp_name, object_type)
             API = cmdinfo.elem.attrib.get('name').replace('vk', dispatch_table, 1)
             # Put all this together for the final down-chain call
             if assignresult != '':


### PR DESCRIPTION
OT was using old style dispatch table handling (and for some reason had multiple device dispatch tables!). Updated to be consistent with other validation layers.  

Next up, getting rid of vk_layer_table.*, and then fixing up the dispatch tables to null extension function pointers if they're disabled.
