### PR TITLE
Additional BufferViewCreateInfo validation

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3388,6 +3388,15 @@ bool PreCallValidateCreateBufferView(const layer_data *device_data, const VkBuff
                                          "VUID-VkBufferViewCreateInfo-buffer-00932", "vkCreateBufferView()",
                                          "VK_BUFFER_USAGE_[STORAGE|UNIFORM]_TEXEL_BUFFER_BIT");
 
+        // Buffer view offset must be less than the size of buffer
+        if (pCreateInfo->offset >= buffer_state->createInfo.size) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
+                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-offset-00925",
+                            "VkBufferViewCreateInfo offset (%" PRIuLEAST64
+                            ") must be less than the size of the buffer (%" PRIuLEAST64 ").",
+                            pCreateInfo->offset, buffer_state->createInfo.size);
+        }
+
         const VkPhysicalDeviceLimits *device_limits = &(GetPhysicalDeviceProperties(device_data)->limits);
         // Buffer view offset must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment
         if ((pCreateInfo->offset % device_limits->minTexelBufferOffsetAlignment) != 0) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4716,7 +4716,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(VkDevice device, const VkBufferV
 }
 
 // Access helper functions for external modules
-VkFormatProperties GetFormatProperties(core_validation::layer_data *device_data, VkFormat format) {
+VkFormatProperties GetFormatProperties(const core_validation::layer_data *device_data, const VkFormat format) {
     VkFormatProperties format_properties;
     instance_layer_data *instance_data =
         GetLayerDataPtr(get_dispatch_key(device_data->instance_data->instance), instance_layer_data_map);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1074,7 +1074,7 @@ bool ValidateCmdSubpassState(const layer_data *dev_data, const GLOBAL_CB_NODE *p
 bool ValidateCmd(layer_data *dev_data, const GLOBAL_CB_NODE *cb_state, const CMD_TYPE cmd, const char *caller_name);
 
 // Prototypes for layer_data accessor functions.  These should be in their own header file at some point
-VkFormatProperties GetFormatProperties(core_validation::layer_data *device_data, VkFormat format);
+VkFormatProperties GetFormatProperties(const core_validation::layer_data *device_data, const VkFormat format);
 VkResult GetImageFormatProperties(core_validation::layer_data *device_data, const VkImageCreateInfo *image_ci,
                                   VkImageFormatProperties *image_format_properties);
 const debug_report_data *GetReportData(const layer_data *);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -23860,6 +23860,16 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    // Verify VK_FORMAT_R8_UNORM supports VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT
+    const VkFormat format_texel_case = VK_FORMAT_R8_UNORM;
+    const char *format_texel_case_string = "VK_FORMAT_R8_UNORM";
+    VkFormatProperties format_properties;
+    vkGetPhysicalDeviceFormatProperties(gpu(), format_texel_case, &format_properties);
+    if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
+        printf("%s Test requires %s to support VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT\n", kSkipPrefix, format_texel_case_string);
+        return;
+    }
+
     // Image Case
     {
         m_errorMonitor->ExpectSuccess();
@@ -24008,7 +24018,7 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
         VkBufferViewCreateInfo buff_view_ci = {};
         buff_view_ci.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
         buff_view_ci.buffer = buffer;
-        buff_view_ci.format = VK_FORMAT_R8_UNORM;
+        buff_view_ci.format = format_texel_case;
         buff_view_ci.range = VK_WHOLE_SIZE;
         VkBufferView buffer_view;
         err = vkCreateBufferView(m_device->device(), &buff_view_ci, NULL, &buffer_view);


### PR DESCRIPTION
Extends validation coverage of the BufferViewCreateInfo  structure. The following checks are now in place and tested:

* `offset` must be less than the size of `buffer`
* If `range` is not equal to `VK_WHOLE_SIZE`, `range` must be greater than 0
* If `range` is not equal to `VK_WHOLE_SIZE`, `range` must be a multiple of the element size of `format`
* If `range` is not equal to `VK_WHOLE_SIZE`, `range` divided by the element size of `format` must be less than or equal to `VkPhysicalDeviceLimits::maxTexelBufferElements`
* If `range` is not equal to `VK_WHOLE_SIZE`, the sum of `offset` and `range` must be less than or equal to the size of `buffer`
* `buffer` must have been created with a `usage` value containing at least one of `VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT` or `VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT`
* If `buffer` was created with `usage` containing `VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT`, `format` must be supported for uniform texel buffers, as specified by the `VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT` flag in `VkFormatProperties::bufferFeatures` returned by `vkGetPhysicalDeviceFormatProperties`
* If `buffer` was created with `usage` containing `VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT`, format must be supported for storage texel buffers, as specified by the `VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT` flag in `VkFormatProperties::bufferFeatures` returned by `vkGetPhysicalDeviceFormatProperties`