### PR TITLE
Fix Layer GetDeviceProcAddr behavior

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13147,6 +13147,9 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
     assert(device);
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
+    if (!ApiParentExtensionEnabled(funcName, device_data->extensions.device_extension_set)) {
+        return nullptr;
+    }
     // Is API to be intercepted by this layer?
     const auto &item = name_to_funcptr_map.find(funcName);
     if (item != name_to_funcptr_map.end()) {

--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "vk_loader_platform.h"
 #include "vulkan/vulkan.h"
@@ -40,6 +41,7 @@
 #include "vulkan/vk_layer.h"
 #include "vk_dispatch_table_helper.h"
 #include "vk_validation_error_messages.h"
+#include "vk_extension_helper.h"
 
 namespace object_tracker {
 
@@ -95,6 +97,7 @@ struct layer_data {
 
     uint64_t num_objects[kVulkanObjectTypeMax + 1];
     uint64_t num_total_objects;
+    std::unordered_set<std::string> device_extension_set;
 
     debug_report_data *report_data;
     std::vector<VkDebugReportCallbackEXT> logging_callback;

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -845,6 +845,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
     device_data->report_data = layer_debug_utils_create_device(phy_dev_data->report_data, *pDevice);
     layer_init_device_dispatch_table(*pDevice, &device_data->device_dispatch_table, fpGetDeviceProcAddr);
 
+    // Save pCreateInfo device extension list for GetDeviceProcAddr()
+    for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
+        device_data->device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);
+    }
+
     // Add link back to physDev
     device_data->physical_device = physicalDevice;
     device_data->instance = phy_dev_data->instance;
@@ -1392,11 +1397,14 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance in
 }
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char *funcName) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!ApiParentExtensionEnabled(funcName, device_data->device_extension_set)) {
+        return nullptr;
+    }
     const auto item = name_to_funcptr_map.find(funcName);
     if (item != name_to_funcptr_map.end()) {
         return reinterpret_cast<PFN_vkVoidFunction>(item->second);
     }
-    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!device_data->device_dispatch_table.GetDeviceProcAddr) return NULL;
     return device_data->device_dispatch_table.GetDeviceProcAddr(device, funcName);
 }

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2977,12 +2977,14 @@ bool pv_vkCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX,
 }
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char *funcName) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!ApiParentExtensionEnabled(funcName, device_data->extensions.device_extension_set)) {
+        return nullptr;
+    }
     const auto item = name_to_funcptr_map.find(funcName);
     if (item != name_to_funcptr_map.end()) {
         return reinterpret_cast<PFN_vkVoidFunction>(item->second);
     }
-
-    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     const auto &table = device_data->dispatch_table;
     if (!table.GetDeviceProcAddr) return nullptr;
     return table.GetDeviceProcAddr(device, funcName);

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -170,6 +170,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     // Setup device dispatch table
     my_device_data->device_dispatch_table = new VkLayerDispatchTable;
     layer_init_device_dispatch_table(*pDevice, my_device_data->device_dispatch_table, fpGetDeviceProcAddr);
+    // Save pCreateInfo device extension list for GetDeviceProcAddr()
+    for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
+        my_device_data->device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);
+    }
 
     my_device_data->report_data = layer_debug_utils_create_device(my_instance_data->report_data, *pDevice);
     return result;
@@ -258,12 +262,14 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance instance, const char *funcName);
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char *funcName) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!ApiParentExtensionEnabled(funcName, device_data->device_extension_set)) {
+        return nullptr;
+    }
     const auto item = name_to_funcptr_map.find(funcName);
     if (item != name_to_funcptr_map.end()) {
         return reinterpret_cast<PFN_vkVoidFunction>(item->second);
     }
-
-    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     auto &table = device_data->device_dispatch_table;
     if (!table->GetDeviceProcAddr) return nullptr;
     return table->GetDeviceProcAddr(device, funcName);

--- a/layers/threading.h
+++ b/layers/threading.h
@@ -23,6 +23,8 @@
 #include <condition_variable>
 #include <mutex>
 #include <vector>
+#include <unordered_set>
+#include <string>
 #include "vk_layer_config.h"
 #include "vk_layer_logging.h"
 
@@ -248,6 +250,7 @@ struct layer_data {
     std::vector<VkDebugUtilsMessengerEXT> logging_messenger;
     VkLayerDispatchTable *device_dispatch_table;
     VkLayerInstanceDispatchTable *instance_dispatch_table;
+    std::unordered_set<std::string> device_extension_set;
 
     // The following are for keeping track of the temporary callbacks that can
     // be used in vkCreateInstance and vkDestroyInstance:

--- a/layers/unique_objects.h
+++ b/layers/unique_objects.h
@@ -21,6 +21,7 @@
 
 #include "vulkan/vulkan.h"
 
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -71,6 +72,7 @@ struct layer_data {
     VkLayerDispatchTable dispatch_table = {};
 
     std::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
+    std::unordered_set<std::string> device_extension_set;
 
     bool wsi_enabled;
     VkPhysicalDevice gpu;

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -492,6 +492,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             '',
             '#ifndef VK_EXTENSION_HELPER_H_',
             '#define VK_EXTENSION_HELPER_H_',
+            '#include <unordered_set>',
             '#include <string>',
             '#include <unordered_map>',
             '#include <utility>',
@@ -532,6 +533,11 @@ class HelperFileOutputGenerator(OutputGenerator):
             # Output the data member list
             struct  = [struct_decl]
             struct.extend([ '    bool %s{false};' % field_name[ext_name] for ext_name, info in extension_items])
+
+            # Create struct entries for saving extension count and extension list from DeviceCreateInfo
+            struct.extend([
+                '',
+                '    std::unordered_set<std::string> device_extension_set;'])
 
             # Construct the extension information map -- mapping name to data member (field), and required extensions
             # The map is contained within a static function member for portability reasons.
@@ -595,7 +601,12 @@ class HelperFileOutputGenerator(OutputGenerator):
                     '                                      const VkDeviceCreateInfo *pCreateInfo) {',
                     '        // Initialize: this to defaults,  base class fields to input.',
                     '        assert(instance_extensions);',
-                    '        *this = %s(*instance_extensions);' % struct_type])
+                    '        *this = %s(*instance_extensions);' % struct_type,
+                    '',
+                    '        // Save pCreateInfo device extension list',
+                    '        for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {',
+                    '           device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);',
+                    '        }']),
 
             struct.extend([
                 '',


### PR DESCRIPTION
Per the Vulkan Specification, GetDeviceProcAddr() should behave as follows:

Given this as an API-Name | GDPA should return:
------------ | -----------------------
core device-level Vulkan command |  fp
enabled device extension commands  |  fp
*(any pName not covered above) |  NULL

However, the layers do not check for **enabled** device extension commands and return a valid fp regardless of which extensions were enabled.  This patch is to bring the layers up to spec in this regard.