### PR TITLE
layers: Rework include dependencies

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -45,6 +45,7 @@
 #include "vk_layer_logging.h"
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
+#include "vk_layer_dispatch_table.h"
 
 #include "parameter_name.h"
 #include "parameter_validation.h"

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -30,6 +30,7 @@
 #include "vulkan/vk_layer.h"
 #include "vk_object_types.h"
 #include "vk_validation_error_messages.h"
+#include "vk_layer_dispatch_table.h"
 #include <signal.h>
 #include <cinttypes>
 #include <stdarg.h>

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -115,6 +115,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         preamble += '#include <string>\n'
         preamble += '#include <unordered_set>\n'
         preamble += '#include <unordered_map>\n'
+        preamble += '#include "vk_layer_dispatch_table.h"\n'
 
         write(copyright, file=self.outFile)
         write(preamble, file=self.outFile)


### PR DESCRIPTION
This change removes the assumption that `vk_layer.h` will include `vk_layer_dispatch_table.h`, since it will be removed from `vk_layer.h` in the near future. The change to remove the extra include is KhronosGroup/Vulkan-Headers#11.

This PR is needed to ensure that merging the Vulkan-Headers PR doesn't break anything in this repo.