### PR TITLE
ci: Turn on ccache for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,9 @@ script:
       cd ${TRAVIS_BUILD_DIR}
       mkdir build
       cd build
-      cmake -C ${TRAVIS_BUILD_DIR}/external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+      cmake -C ${TRAVIS_BUILD_DIR}/external/helper.cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_CCACHE=ON ..
       cmake --build . -- -j$core_count
+      ccache --show-stats
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ if(USE_CCACHE)
     find_program(CCACHE_FOUND ccache)
     if(CCACHE_FOUND)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
     endif(CCACHE_FOUND)
 endif()
 

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -364,7 +364,9 @@ class HelperFileOutputGenerator(OutputGenerator):
         outstring += '{\n'
         outstring += '    switch ((%s)input_value)\n' % groupName
         outstring += '    {\n'
-        for item in value_list:
+        # Emit these in a repeatable order so file is generated with the same contents each time.
+        # This helps compiler caching systems like ccache.
+        for item in sorted(value_list):
             outstring += '        case %s:\n' % item
             outstring += '            return "%s";\n' % item
         outstring += '        default:\n'


### PR DESCRIPTION
- Although ccache is turned on in the Travis config file, additional
steps are needed to turn it on for CMake-based builds.  Set USE_CCACHE=ON
in the Travis config for this repo to cause CMake to "wrap" (prepend)
compiler invocations with "ccache".
- Turn off ccache linker wrapping in CMake code to enable ccache.
It doesn't work.
- Modify the helper generator script to sort the enums when generating
the enum-to-string functions.  This causes the header file to be generated
with the same content each time the script is run, which greatly improves
ccache effectiveness.  For local ccache-assisted builds of this repo,
the build time can be cut in half.