### PR TITLE
scripts: Fix processing of -text arg [skip ci]

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -558,7 +558,7 @@ def main(argv):
             i = i + 1
         elif (arg == '-todo'):
             report_unimplemented = True
-        elif (arg == '-txt'):
+        elif (arg == '-text'):
             txt_out = True
             # Set filename if supplied, else use default
             if i < len(argv) and not argv[i].startswith('-'):


### PR DESCRIPTION
Make the sought-for argument match the help text.
(Look for -text instead of -txt)