### PR TITLE
layers: Validation of VK_WHOLE_SIZE in descriptor sets

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1858,7 +1858,8 @@ bool cvdescriptorset::DescriptorSet::ValidateBufferUpdate(VkDescriptorBufferInfo
         } else if (buffer_info->range == VK_WHOLE_SIZE && (buffer_node->createInfo.size - buffer_info->offset) > max_ub_range) {
             *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00332";
             std::stringstream error_str;
-            error_str << "VkDescriptorBufferInfo range is VK_WHOLE_SIZE but effective range is greater than this device's "
+            error_str << "VkDescriptorBufferInfo range is VK_WHOLE_SIZE but effective range "
+                      << "(" << (buffer_node->createInfo.size - buffer_info->offset) << ") is greater than this device's "
                       << "maxUniformBufferRange (" << max_ub_range << ")";
             *error_msg = error_str.str();
             return false;
@@ -1875,7 +1876,8 @@ bool cvdescriptorset::DescriptorSet::ValidateBufferUpdate(VkDescriptorBufferInfo
         } else if (buffer_info->range == VK_WHOLE_SIZE && (buffer_node->createInfo.size - buffer_info->offset) > max_sb_range) {
             *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00333";
             std::stringstream error_str;
-            error_str << "VkDescriptorBufferInfo range is VK_WHOLE_SIZE but effective range is greater than this device's "
+            error_str << "VkDescriptorBufferInfo range is VK_WHOLE_SIZE but effective range "
+                      << "(" << (buffer_node->createInfo.size - buffer_info->offset) << ") is greater than this device's "
                       << "maxStorageBufferRange (" << max_sb_range << ")";
             *error_msg = error_str.str();
             return false;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13782,8 +13782,10 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         "Test cases include:\n"
         "1. range of uniform buffer update exceeds maxUniformBufferRange\n"
         "2. offset of uniform buffer update is not multiple of minUniformBufferOffsetAlignment\n"
-        "3. range of storage buffer update exceeds maxStorageBufferRange\n"
-        "4. offset of storage buffer update is not multiple of minStorageBufferOffsetAlignment");
+        "3. using VK_WHOLE_SIZE with uniform buffer size exceeding maxUniformBufferRange\n"
+        "4. range of storage buffer update exceeds maxStorageBufferRange\n"
+        "5. offset of storage buffer update is not multiple of minStorageBufferOffsetAlignment\n"
+        "6. using VK_WHOLE_SIZE with storage buffer size exceeding maxStorageBufferRange");
     VkResult err;
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -13875,18 +13877,12 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
             m_errorMonitor->VerifyFound();
         }
 
-        // Exceed effictive range limit by using VK_WHOLE_SIZE
+        // Exceed effective range limit by using VK_WHOLE_SIZE
         buff_info.range = VK_WHOLE_SIZE;
         buff_info.offset = 0;
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, test_case.max_range_vu);
         vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
         m_errorMonitor->VerifyFound();
-
-        // Don't exceed effective range limit by using VK_WHOLE_SIZE and offset
-        buff_info.range = VK_WHOLE_SIZE;
-        buff_info.offset = test_case.min_align;
-        vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
-        m_errorMonitor->VerifyNotFound();
 
         // Cleanup
         vkFreeMemory(m_device->device(), mem, NULL);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13875,6 +13875,19 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
             m_errorMonitor->VerifyFound();
         }
 
+        // Exceed effictive range limit by using VK_WHOLE_SIZE
+        buff_info.range = VK_WHOLE_SIZE;
+        buff_info.offset = 0;
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, test_case.max_range_vu);
+        vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        m_errorMonitor->VerifyFound();
+
+        // Don't exceed effective range limit by using VK_WHOLE_SIZE and offset
+        buff_info.range = VK_WHOLE_SIZE;
+        buff_info.offset = test_case.min_align;
+        vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        m_errorMonitor->VerifyNotFound();
+
         // Cleanup
         vkFreeMemory(m_device->device(), mem, NULL);
         vkDestroyBuffer(m_device->device(), buffer, NULL);


### PR DESCRIPTION
Implements validation of effective range when VK_WHOLE_SIZE is used in
vkUpdateDescriptorSets with uniform or storage buffers.