### PR TITLE
build: Activate ccache for glslang in Travis-CI

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -9,6 +9,9 @@
       "commit" : "e99a26810f65314183163c07664a40e05647c15f",
       "prebuild" : [
         "python update_glslang_sources.py"
+      ],
+      "cmake_options" : [
+        "-DUSE_CCACHE=ON"
       ]
     },
     {


### PR DESCRIPTION
glslang build now supports ccache in CMake via the USE_CCACHE option.
This is necessary to allow ccache to work in CMake-generated makefiles.