### PR TITLE
Provide Vulkan_1_1 environment to SPIR-V tools, when appropriate

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1710,7 +1710,11 @@ bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreat
         }
 
         // Use SPIRV-Tools validator to try and catch any issues with the module itself
-        spv_context ctx = spvContextCreate(SPV_ENV_VULKAN_1_0);
+        spv_target_env spirv_environment = SPV_ENV_VULKAN_1_0;
+        if (GetApiVersion(dev_data) >= VK_API_VERSION_1_1) {
+            spirv_environment = SPV_ENV_VULKAN_1_1;
+        }
+        spv_context ctx = spvContextCreate(spirv_environment);
         spv_const_binary_t binary{pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)};
         spv_diagnostic diag = nullptr;
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "806af25f749b4d7cd861eaebc32474b3a7d102c0",
+      "commit" : "3f05beddc8f69466894468efd661826d15c4d90b",
       "prebuild" : [
         "python update_glslang_sources.py"
       ]


### PR DESCRIPTION
spirv-tools now [supports the Vulkan 1.1 environment qualifier](https://github.com/KhronosGroup/SPIRV-Tools/pull/1629) and that fix was recently incorporated into the glslang [known_good](https://github.com/KhronosGroup/glslang/pull/1453) tag. This seems like an opportune time to start using the 1.1 environment variable in shader validation, and close a few lingering issues.
 
Fixes #158 
Fixes #101 
Fixes #74 

Note that this PR requires a refresh of the glslang repo (via `update_glslang_sources.py`) to work correctly. Prior to that refresh, validation will fail to detect any illegal SPIRV capabilities within a shader when run in a Vulkan 1.1 environment. 
