### PR TITLE
Update LG-VT known-good and build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Install the appropriate Linux packages.
       sudo apt-get -qq update
-      sudo apt-get -y install libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev libx11-xcb-dev
+      sudo apt-get -y install libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
@@ -90,15 +90,31 @@ script:
       cd ${TRAVIS_BUILD_DIR}
       mkdir build
       cd build
-      cmake -C ${TRAVIS_BUILD_DIR}/external/helper.cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_CCACHE=ON ..
-      cmake --build . -- -j$core_count
+      cmake -C ${TRAVIS_BUILD_DIR}/external/helper.cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/install -DUSE_CCACHE=ON ..
+      cmake --build . --target install -- -j$core_count
       ccache --show-stats
+    fi
+  - |
+    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
+      # Build VulkanTools
+      # Note: VulkanTools has a build dependency on Vulkan-ValidationLayers so it must be built after V-VL is built
+      pushd ${TRAVIS_BUILD_DIR}/external/VulkanTools
+      ./update_external_sources.sh
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Headers/build/install \
+            -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install \
+            -DVULKAN_VALIDATIONLAYERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/build/install \
+            ..
+      cmake --build . -- -j $core_count
+      popd
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Run Tests
       cd ${TRAVIS_BUILD_DIR}
-      export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/loader:$LD_LIBRARY_PATH
+      export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/install/lib:${LD_LIBRARY_PATH}
       export VK_LAYER_PATH=${TRAVIS_BUILD_DIR}/external/VulkanTools/build/layersvt:${TRAVIS_BUILD_DIR}/build/layers
       export VK_ICD_FILENAMES=${TRAVIS_BUILD_DIR}/external/Vulkan-Tools/build/icd/VkICD_mock_icd.json
       build/tests/vk_layer_validation_tests

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -42,15 +42,19 @@
       "sub_dir" : "VulkanTools",
       "build_dir" : "VulkanTools/build",
       "install_dir" : "VulkanTools/build/install",
-      "commit" : "188cad536064d05db9c7affca5bb66aed77b07ad",
+      "commit" : "7d5375ac509444ccdcbfbfd2b908b9751cea4997",
       "deps" : [
         {
           "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
           "repo_name" : "Vulkan-Headers"
         },
         {
-          "var_name" : "GLSLANG_INSTALL_DIR",
-          "repo_name" : "glslang"
+          "var_name" : "VULKAN_LOADER_INSTALL_DIR",
+          "repo_name" : "Vulkan-Loader"
+        },
+        {
+          "var_name" : "VULKAN_VALIDATIONLAYERS_INSTALL_DIR",
+          "repo_name" : "Vulkan-ValidationLayers"
         }
       ],
       "prebuild_linux" : [
@@ -67,7 +71,8 @@
       ],
       "ci_only" : [
         "TRAVIS"
-      ]
+      ],
+      "build_step" : "skip"
     },
     {
       "name" : "Vulkan-Tools",

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -107,7 +107,7 @@ $ cmake --build .
 JSON File Schema
 ----------------
 
-There's no formal schema for the "known-good" JSON file, but here is 
+There's no formal schema for the "known-good" JSON file, but here is
 a description of its elements.  All elements are required except those
 marked as optional.  Please see the "known_good.json" file for
 examples of all of these elements.
@@ -190,6 +190,12 @@ each of these CI systems sets an environment variable with its own
 name to "true".  Note that this could also be (ab)used to control
 the processing of the repo with any environment variable.  The default
 is an empty list, which means that the repo is always processed.
+
+- build_step (optional)
+
+Specifies if the dependent repository should be built or not. This can
+have a value of 'build' or 'skip'. The dependent repositories are
+built by default.
 
 Note
 ----
@@ -281,6 +287,7 @@ class GoodRepo(object):
         self.cmake_options = json['cmake_options'] if (
             'cmake_options' in json) else []
         self.ci_only = json['ci_only'] if ('ci_only' in json) else []
+        self.build_step = json['build_step'] if ('build_step' in json) else 'build'
         # Absolute paths for a repo's directories
         dir_top = os.path.abspath(args.dir)
         self.repo_dir = os.path.join(dir_top, self.sub_dir)
@@ -564,7 +571,7 @@ def main():
         repo.Checkout()
 
         # Build the repository
-        if args.do_build:
+        if args.do_build and repo.build_step == 'build':
             repo.Build(repos)
 
     # Need to restore original cwd in order for CreateHelper to find json file


### PR DESCRIPTION
The new LunarG-VulkanTools build process results in failure when using VulkanTools tip-of-tree. This commit updates everything necessary for build success.

`update_deps.py` was modified to no longer build LunarG/VulkanTools due to the VulkanTools build now requiring the VVL install directory. The VulkanTools build step is now kicked off in the `.travis.yml` file.