### PR TITLE
layers: Add check and test for relax block layout

### DIFF
--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -773,3 +773,25 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
 
     return true;
 }
+
+//
+// Compile a given string containing SPIR-V assembly into SPV for use by VK
+// Return value of false means an error was encountered.
+//
+bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm,
+                               std::vector<unsigned int> &spv) {
+    spv_binary binary;
+    spv_diagnostic diagnostic = nullptr;
+    spv_context context = spvContextCreate(target_env);
+    spv_result_t error = spvTextToBinaryWithOptions(context, pasm, strlen(pasm), options, &binary, &diagnostic);
+    spvContextDestroy(context);
+    if (error) {
+        spvDiagnosticPrint(diagnostic);
+        spvDiagnosticDestroy(diagnostic);
+        return false;
+    }
+    spv.insert(spv.end(), binary->code, binary->code + binary->wordCount);
+    spvBinaryDestroy(binary);
+
+    return true;
+}

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -23,6 +23,7 @@
 #define VKTESTFRAMEWORK_H
 
 #include "SPIRV/GLSL.std.450.h"
+#include "spirv-tools/libspirv.h"
 #include "glslang/Public/ShaderLang.h"
 #include "icd-spv.h"
 #include "test_common.h"
@@ -67,6 +68,7 @@ class VkTestFramework : public ::testing::Test {
     static void Finish();
 
     bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv);
+    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_canonicalize_spv;
     static bool m_strip_spv;
     static bool m_do_everything_spv;

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -93,3 +93,25 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
 
     return true;
 }
+
+//
+// Compile a given string containing SPIR-V assembly into SPV for use by VK
+// Return value of false means an error was encountered.
+//
+bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm,
+                               std::vector<unsigned int> &spv) {
+    spv_binary binary;
+    spv_diagnostic diagnostic = nullptr;
+    spv_context context = spvContextCreate(target_env);
+    spv_result_t error = spvTextToBinaryWithOptions(context, pasm, strlen(pasm), options, &binary, &diagnostic);
+    spvContextDestroy(context);
+    if (error) {
+        __android_log_print(ANDROID_LOG_ERROR, "VkLayerValidationTest", "ASMtoSPV compilation failed");
+        spvDiagnosticDestroy(diagnostic);
+        return false;
+    }
+    spv.insert(spv.end(), binary->code, binary->code + binary->wordCount);
+    spvBinaryDestroy(binary);
+
+    return true;
+}

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -20,6 +20,7 @@
 #ifndef VKTESTFRAMEWORKANDROID_H
 #define VKTESTFRAMEWORKANDROID_H
 
+#include "spirv-tools/libspirv.h"
 #include "test_common.h"
 
 #if defined(NDEBUG)
@@ -43,6 +44,7 @@ class VkTestFramework : public ::testing::Test {
 
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
     bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv);
+    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_devsim_layer;
 };
 


### PR DESCRIPTION
Tell the SPIR-V validator to skip block layout checking if the
VK_KHR_relaxed_block_layout extension is enabled.
This prevents validation error messages for shaders with
non-compliant layouts when the extension is enabled.

The VK_KHR_relaxed_block_layout extension was promoted to core
in 1.1, so it is "enabled" for 1.1 and later apps all the time.

Since block layout checking is always relaxed in 1.1 or later,
there is really no way to write a negative test for 1.1 or later.
Therefore there is just a positive test that checks that no error
is generated for a shader with a non-compiliant layout.

Fixes #275