### PR TITLE
Fix white_list() false positives

### DIFF
--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -74,11 +74,7 @@ VK_LAYER_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, cons
 }
 
 // Utility function for finding a text string in another string
-VK_LAYER_EXPORT bool white_list(const char *item, const char *list) {
-    std::string candidate(item);
-    std::string white_list(list);
-    return (white_list.find(candidate) != std::string::npos);
-}
+VK_LAYER_EXPORT bool white_list(const char *item, const std::set<std::string> &list) { return (list.find(item) != list.end()); }
 
 // Debug callbacks get created in three ways:
 //   o  Application-defined debug callbacks

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <string>
 #include <vector>
+#include <set>
 #include "vk_format_utils.h"
 #include "vk_layer_logging.h"
 
@@ -134,7 +135,7 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
                                                    const VkAllocationCallbacks *pAllocator, const char *layer_identifier);
 
 VK_LAYER_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
-VK_LAYER_EXPORT bool white_list(const char *item, const char *whitelist);
+VK_LAYER_EXPORT bool white_list(const char *item, const std::set<std::string> &whitelist);
 
 static inline int u_ffs(int val) {
 #ifdef WIN32

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -498,6 +498,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             '#include <string>',
             '#include <unordered_map>',
             '#include <utility>',
+            '#include <set>',
             '',
             '#include <vulkan/vulkan.h>',
             '']
@@ -638,9 +639,9 @@ class HelperFileOutputGenerator(OutputGenerator):
                 '};'])
 
             # Output reference lists of instance/device extension names
-            struct.extend(['', 'static const char * const k%sExtensionNames = ' % type])
-            struct.extend([guarded(info['ifdef'], '    %s' % info['define']) for ext_name, info in extension_items])
-            struct.extend([';', ''])
+            struct.extend(['', 'static const std::set<std::string> k%sExtensionNames = {' % type])
+            struct.extend([guarded(info['ifdef'], '    %s,' % info['define']) for ext_name, info in extension_items])
+            struct.extend(['};', ''])
             output.extend(struct)
 
         output.extend(['', '#endif // VK_EXTENSION_HELPER_H_'])


### PR DESCRIPTION
Existing extension name comparisons produced false positives in cases where extensions shared a common root. Moved to a set of explicit strings.

E.g., VK_KHR_external_memory is a device extension that is a substring of the VK_KHR_external_memory_capabilities instance extension.

Fixes #282.
