### PR TITLE
Update known-good for 1.1.83 headers

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -16,13 +16,13 @@
       "name" : "Vulkan-Headers",
       "url" : "https://github.com/KhronosGroup/Vulkan-Headers.git",
       "sub_dir" : "Vulkan-Headers",
-      "commit" : "c4e056d365472174471a243dfefbfe66a03564af"
+      "commit" : "db09f95ac00e44149f3894bf82c918e58277cfdb"
     },
     {
       "name" : "Vulkan-Tools",
       "url" : "https://github.com/KhronosGroup/Vulkan-Tools.git",
       "sub_dir" : "Vulkan-Tools",
-      "commit" : "5caab21c8d228a94a2f897cbe9447de48736eed7"
+      "commit" : "ca05ec7c9706eb2949e489b4719fe499b0059d36"
     },
     {
       "name" : "SPIRV-Tools",

--- a/layers/linux/VkLayer_core_validation.json
+++ b/layers/linux/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_core_validation.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_object_tracker.json
+++ b/layers/linux/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_object_tracker.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_parameter_validation.json
+++ b/layers/linux/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_parameter_validation.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_standard_validation.json
+++ b/layers/linux/VkLayer_standard_validation.json
@@ -3,7 +3,7 @@
     "layer": {
         "name": "VK_LAYER_LUNARG_standard_validation",
         "type": "GLOBAL",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Standard Validation",
         "component_layers": [

--- a/layers/linux/VkLayer_threading.json
+++ b/layers/linux/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_threading.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_unique_objects.json
+++ b/layers/linux/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_unique_objects.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/layers/macos/VkLayer_core_validation.json
+++ b/layers/macos/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_core_validation.dylib",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/macos/VkLayer_object_tracker.json
+++ b/layers/macos/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_object_tracker.dylib",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/macos/VkLayer_parameter_validation.json
+++ b/layers/macos/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_parameter_validation.dylib",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/macos/VkLayer_standard_validation.json
+++ b/layers/macos/VkLayer_standard_validation.json
@@ -3,7 +3,7 @@
     "layer": {
         "name": "VK_LAYER_LUNARG_standard_validation",
         "type": "GLOBAL",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Standard Validation",
         "component_layers": [

--- a/layers/macos/VkLayer_threading.json
+++ b/layers/macos/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_threading.dylib",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/macos/VkLayer_unique_objects.json
+++ b/layers/macos/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_unique_objects.dylib",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/layers/windows/VkLayer_core_validation.json
+++ b/layers/windows/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_core_validation.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_object_tracker.json
+++ b/layers/windows/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_object_tracker.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_parameter_validation.json
+++ b/layers/windows/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_parameter_validation.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_standard_validation.json
+++ b/layers/windows/VkLayer_standard_validation.json
@@ -3,7 +3,7 @@
     "layer": {
         "name": "VK_LAYER_LUNARG_standard_validation",
         "type": "GLOBAL",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "LunarG Standard Validation",
         "component_layers": [

--- a/layers/windows/VkLayer_threading.json
+++ b/layers/windows/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_threading.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_unique_objects.json
+++ b/layers/windows/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_unique_objects.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "e99a26810f65314183163c07664a40e05647c15f",
+      "commit" : "1323bf8e39fa17da3e0901a4b1ab5dfd61ee5460",
       "prebuild" : [
         "python update_glslang_sources.py"
       ],
@@ -20,7 +20,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "c4e056d365472174471a243dfefbfe66a03564af"
+      "commit" : "db09f95ac00e44149f3894bf82c918e58277cfdb"
     },
     {
       "name" : "Vulkan-Loader",
@@ -28,7 +28,7 @@
       "sub_dir" : "Vulkan-Loader",
       "build_dir" : "Vulkan-Loader/build",
       "install_dir" : "Vulkan-Loader/build/install",
-      "commit" : "dbf8f2cd85190ac902f1da57482a6e340f05e860",
+      "commit" : "4573f327dd9a5e4114d5c56682892290affa46e5",
       "deps" : [
         {
           "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
@@ -45,7 +45,7 @@
       "sub_dir" : "VulkanTools",
       "build_dir" : "VulkanTools/build",
       "install_dir" : "VulkanTools/build/install",
-      "commit" : "7d5375ac509444ccdcbfbfd2b908b9751cea4997",
+      "commit" : "d878e6a3839ce97a59a28d40b465118c3deb5deb",
       "deps" : [
         {
           "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
@@ -83,7 +83,7 @@
       "sub_dir" : "Vulkan-Tools",
       "build_dir" : "Vulkan-Tools/build",
       "install_dir" : "Vulkan-Tools/build/install",
-      "commit" : "5caab21c8d228a94a2f897cbe9447de48736eed7",
+      "commit" : "ca05ec7c9706eb2949e489b4719fe499b0059d36",
       "deps" : [
         {
           "var_name" : "VULKAN_HEADERS_INSTALL_DIR",

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -559,7 +559,8 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         elif 'FlagBits' in groupName:
             bits = []
             for elem in groupElem.findall('enum'):
-                bits.append(elem.get('name'))
+                if elem.get('supported') != 'disabled':
+                    bits.append(elem.get('name'))
             if bits:
                 self.flagBits[groupName] = bits
         else:

--- a/tests/layers/linux/VkLayer_device_profile_api.json
+++ b/tests/layers/linux/VkLayer_device_profile_api.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_device_profile_api",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_profile_api.so",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "2",
         "description": "LunarG Device Profile Api Layer",
         "device_extensions": [

--- a/tests/layers/windows/VkLayer_device_profile_api.json
+++ b/tests/layers/windows/VkLayer_device_profile_api.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_device_profile_api",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_profile_api.dll",
-        "api_version": "1.1.82",
+        "api_version": "1.1.83",
         "implementation_version": "2",
         "description": "LunarG Device Profile Api Layer",
         "device_extensions": [


### PR DESCRIPTION
This PR updates the known-good SHAs and changes the `parameter_validation_generator.py` script to exclude disabled enums in `parameter_validation.cpp` which were causing errors after the header update.