### PR TITLE
Disable test when needed format not avail

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13954,7 +13954,10 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
     // Create an image to be used for invalid updates
     VkImageObj image_obj(m_device);
     image_obj.Init(64, 64, 1, depth_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image_obj.initialized());
+    if (!image_obj.initialized()) {
+        printf("%s Depth + Stencil format cannot be sampled. Skipped.\n", kSkipPrefix);
+        return;
+    }
     VkImage image = image_obj.image();
 
     // Now create view for image

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -957,6 +957,8 @@ void VkImageObj::Init(uint32_t const width, uint32_t const height, uint32_t cons
                       const std::vector<uint32_t> *queue_families) {
     InitNoLayout(width, height, mipLevels, format, usage, requested_tiling, reqs, queue_families);
 
+    if (!initialized()) return;  // We don't have a valid handle from early stage init, and thus SetLayout will fail
+
     VkImageLayout newLayout;
     if (usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
         newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;


### PR DESCRIPTION
Fixes #263

VkLayerTest.DSAspectBitsErrors was failing as the depth stencil formats
on certain platforms did not support VK_IMAGE_USAGE_SAMPLED_BIT.

This test is now skipped for these platforms.

Change-Id: I5ac270e976a3e1e2163a6111da6d66c8c7352a89