### PR TITLE
Track initial and final layout only for render pass attachments referenced by at least one subpass.

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -421,16 +421,13 @@ void TransitionBeginRenderPassLayouts(layer_data *device_data, GLOBAL_CB_NODE *c
         for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
             const VkSubpassDescription &subpass = rpci->pSubpasses[i];
             for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
-                if (subpass.pInputAttachments[j].attachment == attachment)
-                    referencedBySubpass = true;
+                if (subpass.pInputAttachments[j].attachment == attachment) referencedBySubpass = true;
             }
             for (uint32_t j = 0; j < subpass.colorAttachmentCount; ++j) {
-                if (subpass.pColorAttachments[j].attachment == attachment)
-                    referencedBySubpass = true;
+                if (subpass.pColorAttachments[j].attachment == attachment) referencedBySubpass = true;
             }
             if (subpass.pDepthStencilAttachment) {
-                if (subpass.pDepthStencilAttachment->attachment == attachment)
-                    referencedBySubpass = true;
+                if (subpass.pDepthStencilAttachment->attachment == attachment) referencedBySubpass = true;
             }
         }
         if (referencedBySubpass) {
@@ -970,16 +967,13 @@ void TransitionFinalSubpassLayouts(layer_data *device_data, GLOBAL_CB_NODE *pCB,
             for (uint32_t i = 0; i < pRenderPassInfo->subpassCount; ++i) {
                 const VkSubpassDescription &subpass = pRenderPassInfo->pSubpasses[i];
                 for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
-                    if (subpass.pInputAttachments[j].attachment == attachment)
-                        referencedBySubpass = true;
+                    if (subpass.pInputAttachments[j].attachment == attachment) referencedBySubpass = true;
                 }
                 for (uint32_t j = 0; j < subpass.colorAttachmentCount; ++j) {
-                    if (subpass.pColorAttachments[j].attachment == attachment)
-                        referencedBySubpass = true;
+                    if (subpass.pColorAttachments[j].attachment == attachment) referencedBySubpass = true;
                 }
                 if (subpass.pDepthStencilAttachment) {
-                    if (subpass.pDepthStencilAttachment->attachment == attachment)
-                        referencedBySubpass = true;
+                    if (subpass.pDepthStencilAttachment->attachment == attachment) referencedBySubpass = true;
                 }
             }
             if (referencedBySubpass) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -31552,7 +31552,8 @@ TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
 }
 
 TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
-    TEST_DESCRIPTION("Create render pass with attachement not referenced by any subpasses. The initial and final layout should be ignored.");
+    TEST_DESCRIPTION(
+        "Create render pass with attachement not referenced by any subpasses. The initial and final layout should be ignored.");
 
     m_errorMonitor->ExpectSuccess();
 
@@ -31585,8 +31586,8 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
     attach_desc[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attach_desc[1].format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; // Expected to be ignored
-    attach_desc[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL; // Expected to be ignored
+    attach_desc[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;               // Expected to be ignored
+    attach_desc[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;  // Expected to be ignored
     attach_desc[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     rpci.pAttachments = attach_desc;
     rpci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -31630,7 +31631,8 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
 
     // Image which is not referenced by any subpass. Initialized to layout VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL.
     VkImageObj unreferencedImage(m_device);
-    unreferencedImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    unreferencedImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     unreferencedImage.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     VkImageView unreferencedImageView = unreferencedImage.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
@@ -31640,7 +31642,7 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
     dstImage.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     // Create frame buffer
-    VkImageView imageViews[] = { imageView, unreferencedImageView };
+    VkImageView imageViews[] = {imageView, unreferencedImageView};
     VkFramebufferCreateInfo fbci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp, 2, imageViews, 32, 32, 1};
     VkFramebuffer fb;
     vkCreateFramebuffer(m_device->device(), &fbci, nullptr, &fb);
@@ -31648,7 +31650,17 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
     m_commandBuffer->begin();
 
     // Render
-    VkRenderPassBeginInfo rpbi = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, nullptr, rp, fb, {{ 0, 0, }, {32, 32}}, 0, nullptr};
+    VkRenderPassBeginInfo rpbi = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+                                  nullptr,
+                                  rp,
+                                  fb,
+                                  {{
+                                       0,
+                                       0,
+                                   },
+                                   {32, 32}},
+                                  0,
+                                  nullptr};
     vkCmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vkCmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
@@ -31675,7 +31687,8 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
     copy_region.extent.depth = 1;
 
     // No error should be produced as the image layout was not expected to change during render pass.
-    m_commandBuffer->CopyImage(unreferencedImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+    m_commandBuffer->CopyImage(unreferencedImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage.handle(),
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
     m_commandBuffer->end();
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -31551,6 +31551,140 @@ TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
     vkFreeMemory(m_device->device(), index_buffer_memory, 0);
 }
 
+TEST_F(VkPositiveLayerTest, CreateRenderPassWithIgnoredFinalLayout) {
+    TEST_DESCRIPTION("Create render pass with attachement not referenced by any subpasses. The initial and final layout should be ignored.");
+
+    m_errorMonitor->ExpectSuccess();
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Create descriptor set
+    VkDescriptorSetObj descriptorSet(m_device);
+    descriptorSet.AppendDummy();
+    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+    // Create a subpass which only references the first attachment
+    VkAttachmentReference attachment = {};
+    attachment.layout = VK_IMAGE_LAYOUT_GENERAL;
+    VkSubpassDescription subpass = {};
+    subpass.pColorAttachments = &attachment;
+    subpass.colorAttachmentCount = 1;
+
+    // Render pass references two images, but only the first one is referenced by subpass.
+    VkRenderPass rp;
+    VkRenderPassCreateInfo rpci = {};
+    rpci.subpassCount = 1;
+    rpci.pSubpasses = &subpass;
+    rpci.attachmentCount = 2;
+    VkAttachmentDescription attach_desc[2] = {};
+    attach_desc[0].format = VK_FORMAT_R8G8B8A8_UNORM;
+    attach_desc[0].samples = VK_SAMPLE_COUNT_1_BIT;
+    attach_desc[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attach_desc[0].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attach_desc[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attach_desc[1].format = VK_FORMAT_R8G8B8A8_UNORM;
+    attach_desc[1].samples = VK_SAMPLE_COUNT_1_BIT;
+    attach_desc[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; // Expected to be ignored
+    attach_desc[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL; // Expected to be ignored
+    attach_desc[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    rpci.pAttachments = attach_desc;
+    rpci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    vkCreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+
+    // Create pipeline
+    VkPipelineObj pipe(m_device);
+    char const *vsSource =
+        "#version 450\n"
+        "\n"
+        "void main(){\n"
+        "   gl_Position = vec4(1);\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "\n"
+        "layout(location=0) out vec4 color;\n"
+        "void main(){\n"
+        "   color = vec4(1);\n"
+        "}\n";
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+    VkViewport viewport = {0.0f, 0.0f, 32.0f, 32.0f, 0.0f, 1.0f};
+    m_viewports.push_back(viewport);
+    pipe.SetViewport(m_viewports);
+    VkRect2D rect = {};
+    m_scissors.push_back(rect);
+    pipe.SetScissor(m_scissors);
+    VkPipelineColorBlendAttachmentState att_state = {};
+    att_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    att_state.blendEnable = VK_FALSE;
+    pipe.AddColorAttachment(0, att_state);
+    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), rp);
+
+    // Framebuffer output image
+    VkImageObj image(m_device);
+    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
+    // Image which is not referenced by any subpass. Initialized to layout VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL.
+    VkImageObj unreferencedImage(m_device);
+    unreferencedImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    unreferencedImage.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    VkImageView unreferencedImageView = unreferencedImage.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
+    // Destination image for copy operation
+    VkImageObj dstImage(m_device);
+    dstImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    dstImage.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+    // Create frame buffer
+    VkImageView imageViews[] = { imageView, unreferencedImageView };
+    VkFramebufferCreateInfo fbci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp, 2, imageViews, 32, 32, 1};
+    VkFramebuffer fb;
+    vkCreateFramebuffer(m_device->device(), &fbci, nullptr, &fb);
+
+    m_commandBuffer->begin();
+
+    // Render
+    VkRenderPassBeginInfo rpbi = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, nullptr, rp, fb, {{ 0, 0, }, {32, 32}}, 0, nullptr};
+    vkCmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    vkCmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    vkCmdEndRenderPass(m_commandBuffer->handle());
+
+    // Do an image copy. The layout of unreferenced image should still be VK_LAYOUT_TRANSFER_SRC_OPTIMAL.
+    VkImageCopy copy_region;
+    copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    copy_region.srcSubresource.mipLevel = 0;
+    copy_region.srcSubresource.baseArrayLayer = 0;
+    copy_region.srcSubresource.layerCount = 1;
+    copy_region.srcOffset.x = 0;
+    copy_region.srcOffset.y = 0;
+    copy_region.srcOffset.z = 0;
+    copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    copy_region.dstSubresource.mipLevel = 0;
+    copy_region.dstSubresource.baseArrayLayer = 0;
+    copy_region.dstSubresource.layerCount = 1;
+    copy_region.dstOffset.x = 0;
+    copy_region.dstOffset.y = 0;
+    copy_region.dstOffset.z = 0;
+    copy_region.extent.width = 1;
+    copy_region.extent.height = 1;
+    copy_region.extent.depth = 1;
+
+    // No error should be produced as the image layout was not expected to change during render pass.
+    m_commandBuffer->CopyImage(unreferencedImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+
+    m_commandBuffer->end();
+
+    vkDestroyFramebuffer(m_device->device(), fb, nullptr);
+    vkDestroyRenderPass(m_device->device(), rp, nullptr);
+
+    m_errorMonitor->VerifyNotFound();
+}
+
 #if defined(ANDROID) && defined(VALIDATION_APK)
 const char *appTag = "VulkanLayerValidationTests";
 static bool initialized = false;


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/300