### PR TITLE
CMake cleanup, part 1

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,4 +1,4 @@
-# Configuration for cmake-format (v0.3.6, circa Apr 2018)
+# Configuration for cmake-format (v0.4.1, circa Jul 2018)
 # https://github.com/cheshirekow/cmake_format
 
 # How wide to allow formatted cmake files

--- a/BUILD.md
+++ b/BUILD.md
@@ -200,8 +200,6 @@ The following is a table of all string options currently supported by this repos
 | Option | Platform | Default | Description |
 | ------ | -------- | ------- | ----------- |
 | CMAKE_OSX_DEPLOYMENT_TARGET | MacOS | `10.12` | The minimum version of MacOS for loader deployment. |
-| FALLBACK_CONFIG_DIRS | Linux/MacOS | `/etc/xdg` | Configuration path(s) to use instead of `XDG_CONFIG_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
-| FALLBACK_DATA_DIRS | Linux/MacOS | `/usr/local/share:/usr/share` | Configuration path(s) to use instead of `XDG_DATA_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
 
 These variables should be set using the `-D` option when invoking CMake to
 generate the native platform files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,12 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 
-# This must come before the project command.
+# Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
 
 project(Vulkan-ValidationLayers)
-# set (CMAKE_VERBOSE_MAKEFILE 1)
 
 # The API_NAME allows renaming builds to avoid conflicts with installed SDKs. The MAJOR number of the version we're building, used
 # in naming <api-name>-<major>.dll (and other files).
@@ -40,14 +39,15 @@ if(USE_CCACHE)
     find_program(CCACHE_FOUND ccache)
     if(CCACHE_FOUND)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    endif(CCACHE_FOUND)
+    endif()
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(GNUInstallDirs)
-# Set a better default install location for Windows only if the user did not provide one.
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
+
+if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    # Windows: if install locations not set by user, set install prefix to "<build_dir>\install".
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
 endif()
 
@@ -62,21 +62,6 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # "Helper" targets that don't have interesting source code should set their FOLDER property to this
 set(LAYERS_HELPER_FOLDER "Helper Targets")
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(
-        FALLBACK_CONFIG_DIRS "/etc/xdg"
-        CACHE
-            STRING
-            "Search path to use when XDG_CONFIG_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant."
-        )
-    set(
-        FALLBACK_DATA_DIRS "/usr/local/share:/usr/share"
-        CACHE
-            STRING
-            "Search path to use when XDG_DATA_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant."
-        )
-endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     include(FindPkgConfig)
@@ -126,20 +111,20 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 endif()
 
-if(WIN32)
+if(MSVC)
     # Treat warnings as errors
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/WX>")
+    add_compile_options("/WX")
     # Disable RTTI
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/GR->")
+    add_compile_options("/GR-")
     # Warn about nested declarations
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34456>")
+    add_compile_options("/w34456")
     # Warn about potentially uninitialized variables
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34701>")
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34703>")
+    add_compile_options("/w34701")
+    add_compile_options("/w34703")
     # Warn about different indirection types.
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34057>")
+    add_compile_options("/w34057")
     # Warn about signed/unsigned mismatch.
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34245>")
+    add_compile_options("/w34245")
 endif()
 
 if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
@@ -209,19 +194,46 @@ if(WIN32)
     find_library(SPIRV_REMAPPER_DLIB NAMES SPVRemapperd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
     find_library(SPIRV_TOOLS_DLIB NAMES SPIRV-Toolsd HINTS ${SPIRV_TOOLS_DEBUG_SEARCH_PATH})
     find_library(SPIRV_TOOLS_OPT_DLIB NAMES SPIRV-Tools-optd HINTS ${SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH})
-    set_target_properties(glslang PROPERTIES IMPORTED_LOCATION "${GLSLANG_LIB}" IMPORTED_LOCATION_DEBUG "${GLSLANG_DLIB}")
-    set_target_properties(
-        OGLCompiler PROPERTIES IMPORTED_LOCATION "${OGLCompiler_LIB}" IMPORTED_LOCATION_DEBUG "${OGLCompiler_DLIB}")
-    set_target_properties(
-        OSDependent PROPERTIES IMPORTED_LOCATION "${OSDependent_LIB}" IMPORTED_LOCATION_DEBUG "${OSDependent_DLIB}")
-    set_target_properties(HLSL PROPERTIES IMPORTED_LOCATION "${HLSL_LIB}" IMPORTED_LOCATION_DEBUG "${HLSL_DLIB}")
-    set_target_properties(SPIRV PROPERTIES IMPORTED_LOCATION "${SPIRV_LIB}" IMPORTED_LOCATION_DEBUG "${SPIRV_DLIB}")
-    set_target_properties(
-        SPVRemapper PROPERTIES IMPORTED_LOCATION "${SPIRV_REMAPPER_LIB}" IMPORTED_LOCATION_DEBUG "${SPIRV_REMAPPER_DLIB}")
-    set_target_properties(
-        SPIRV-Tools PROPERTIES IMPORTED_LOCATION "${SPIRV_TOOLS_LIB}" IMPORTED_LOCATION_DEBUG "${SPIRV_TOOLS_DLIB}")
-    set_target_properties(
-        SPIRV-Tools-opt PROPERTIES IMPORTED_LOCATION "${SPIRV_TOOLS_OPT_LIB}" IMPORTED_LOCATION_DEBUG "${SPIRV_TOOLS_OPT_DLIB}")
+    set_target_properties(glslang
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${GLSLANG_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${GLSLANG_DLIB}")
+    set_target_properties(OGLCompiler
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${OGLCompiler_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${OGLCompiler_DLIB}")
+    set_target_properties(OSDependent
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${OSDependent_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${OSDependent_DLIB}")
+    set_target_properties(HLSL
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${HLSL_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${HLSL_DLIB}")
+    set_target_properties(SPIRV
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${SPIRV_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${SPIRV_DLIB}")
+    set_target_properties(SPVRemapper
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${SPIRV_REMAPPER_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${SPIRV_REMAPPER_DLIB}")
+    set_target_properties(SPIRV-Tools
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${SPIRV_TOOLS_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${SPIRV_TOOLS_DLIB}")
+    set_target_properties(SPIRV-Tools-opt
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${SPIRV_TOOLS_OPT_LIB}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${SPIRV_TOOLS_OPT_DLIB}")
 endif()
 
 if(WIN32)
@@ -239,25 +251,12 @@ else()
         ${SPIRV_TOOLS_LIBRARIES})
 endif()
 
-set(PYTHON_CMD ${PYTHON_EXECUTABLE})
-
-if(NOT WIN32)
-    add_definitions(-DFALLBACK_CONFIG_DIRS="${FALLBACK_CONFIG_DIRS}")
-    add_definitions(-DFALLBACK_DATA_DIRS="${FALLBACK_DATA_DIRS}")
-    add_definitions(-DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
-
-    # Make sure /etc is searched by the loader
-    if(NOT (CMAKE_INSTALL_FULL_SYSCONFDIR STREQUAL "/etc"))
-        add_definitions(-DEXTRASYSCONFDIR="/etc")
-    endif()
-endif()
-
 # Generate dependent helper files
 set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/scripts")
 # Define macro used for building vkxml generated files
 macro(run_vk_xml_generate dependency output)
     add_custom_command(OUTPUT ${output}
-                       COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts
+                       COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts
                                ${VulkanRegistry_DIR} ${output}
                        DEPENDS ${VulkanRegistry_DIR}/vk.xml
                                ${VulkanRegistry_DIR}/generator.py
@@ -306,15 +305,15 @@ install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 set_target_properties(VkLayer_utils PROPERTIES LINKER_LANGUAGE CXX)
 add_dependencies(VkLayer_utils generate_helper_files)
 target_include_directories(VkLayer_utils
-                           PUBLIC
-                           ${VulkanHeaders_INCLUDE_DIR}
-                           ${CMAKE_CURRENT_BINARY_DIR}
-                           ${CMAKE_CURRENT_BINARY_DIR}/layers
-                           ${PROJECT_BINARY_DIR})
+                           PUBLIC ${VulkanHeaders_INCLUDE_DIR}
+                                  ${CMAKE_CURRENT_BINARY_DIR}
+                                  ${CMAKE_CURRENT_BINARY_DIR}/layers
+                                  ${PROJECT_BINARY_DIR})
 
 # uninstall target
 if(NOT TARGET uninstall)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
                    IMMEDIATE
                    @ONLY)
     add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
@@ -327,7 +326,10 @@ add_definitions(-DAPI_NAME="${API_NAME}")
 file(STRINGS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
 list(LENGTH lines len)
 if(${len} EQUAL 1)
-    string(REGEX MATCHALL "[0-9]+" vk_header_version ${lines})
+    string(REGEX MATCHALL
+                 "[0-9]+"
+                 vk_header_version
+                 ${lines})
 else()
     message(FATAL_ERROR "Unable to fetch version from vulkan_core.h")
 endif()

--- a/cmake/FindVulkan.cmake
+++ b/cmake/FindVulkan.cmake
@@ -65,7 +65,6 @@ endif()
 set(Vulkan_LIBRARIES ${Vulkan_LIBRARY})
 set(Vulkan_INCLUDE_DIRS ${Vulkan_INCLUDE_DIR})
 
-#include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Vulkan
   DEFAULT_MSG

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -15,26 +15,29 @@
 # limitations under the License.
 # ~~~
 
+# Add your optional dependencies in this "external" directory.
+
+# googletest is an optional external dependency for this repo.
 if(BUILD_TESTS)
-    # googletest is an external dependency for the tests in the ValidationLayers repo. Add googletest to the project if present and
-    # not already defined.
+    # Attempt to enable googletest if available.
 
     # Suppress all warnings from external projects.
     set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
 
     if(TARGET gtest_main)
-        # It is possible that a project enclosing this one has defined the gtest target
-        message(STATUS "Vulkan-ValidationLayers/external: " "Google Test (googletest) already configured - use it")
-    elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
-        message(STATUS "Vulkan-ValidationLayers/external: " "googletests found - configuring it for tests")
+        # Already enabled as a target (perhaps by a project enclosing this one)
+        message(STATUS "Vulkan-ValidationLayers/external: " "googletest already configured - using it")
+    elseif(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+        # The googletest directory exists, so enable it as a target.
+        message(STATUS "Vulkan-ValidationLayers/external: " "googletest found - configuring it for tests")
         set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
         set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
         set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
         set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
         # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
-        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/googletest EXCLUDE_FROM_ALL)
+        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest" EXCLUDE_FROM_ALL)
     else()
-        message(SEND_ERROR "Vulkan-ValidationLayers/external: Google Test was not found.  "
+        message(SEND_ERROR "Vulkan-ValidationLayers/external: " "Google Test was not found.  "
                            "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
     endif()
 endif()

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -19,9 +19,9 @@ cmake_minimum_required(VERSION 2.8.11)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
-    add_custom_target(mk_layer_config_dir ALL COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+    add_custom_target(mk_layer_config_dir ALL
+                      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
     set_target_properties(mk_layer_config_dir PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-    set(DisplayServer Win32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR -DVK_USE_PLATFORM_ANDROID_KHX)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -44,18 +44,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
     if(CMAKE_GENERATOR MATCHES "^Xcode.*")
-        add_custom_target(mk_layer_config_dir ALL COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+        add_custom_target(mk_layer_config_dir ALL
+                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
     endif()
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
 
-set(PYTHON_CMD ${PYTHON_EXECUTABLE})
-
 # Define macro used for generating header files containing commit IDs for external dependencies
 macro(run_external_revision_generate symbol_name output)
     add_custom_command(OUTPUT ${output}
-                       COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/external_revision_generator.py
+                       COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/external_revision_generator.py
                                --from_uuid -s ${symbol_name} -o ${output}
                        DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py)
 endmacro()
@@ -71,30 +70,29 @@ endif()
 
 # Configure installation of source files that are dependencies of other repos.
 set(LAYER_UTIL_FILES
-   hash_util.h
-   hash_vk_types.h
-   vk_format_utils.h
-   vk_format_utils.cpp
-   vk_layer_config.h
-   vk_layer_config.cpp
-   vk_layer_data.h
-   vk_layer_extension_utils.h
-   vk_layer_extension_utils.cpp
-   vk_layer_logging.h
-   vk_layer_utils.h
-   vk_layer_utils.cpp
-   vk_loader_layer.h
-   vk_loader_platform.h
-   vk_validation_error_messages.h
-   ${PROJECT_BINARY_DIR}/vk_layer_dispatch_table.h
-   ${PROJECT_BINARY_DIR}/vk_dispatch_table_helper.h
-   ${PROJECT_BINARY_DIR}/vk_safe_struct.h
-   ${PROJECT_BINARY_DIR}/vk_safe_struct.cpp
-   ${PROJECT_BINARY_DIR}/vk_enum_string_helper.h
-   ${PROJECT_BINARY_DIR}/vk_object_types.h
-   ${PROJECT_BINARY_DIR}/vk_extension_helper.h
-   ${PROJECT_BINARY_DIR}/vk_typemap_helper.h
-   )
+    hash_util.h
+    hash_vk_types.h
+    vk_format_utils.h
+    vk_format_utils.cpp
+    vk_layer_config.h
+    vk_layer_config.cpp
+    vk_layer_data.h
+    vk_layer_extension_utils.h
+    vk_layer_extension_utils.cpp
+    vk_layer_logging.h
+    vk_layer_utils.h
+    vk_layer_utils.cpp
+    vk_loader_layer.h
+    vk_loader_platform.h
+    vk_validation_error_messages.h
+    ${PROJECT_BINARY_DIR}/vk_layer_dispatch_table.h
+    ${PROJECT_BINARY_DIR}/vk_dispatch_table_helper.h
+    ${PROJECT_BINARY_DIR}/vk_safe_struct.h
+    ${PROJECT_BINARY_DIR}/vk_safe_struct.cpp
+    ${PROJECT_BINARY_DIR}/vk_enum_string_helper.h
+    ${PROJECT_BINARY_DIR}/vk_object_types.h
+    ${PROJECT_BINARY_DIR}/vk_extension_helper.h
+    ${PROJECT_BINARY_DIR}/vk_typemap_helper.h)
 install(FILES ${LAYER_UTIL_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 set(TARGET_NAMES
@@ -123,7 +121,11 @@ elseif(APPLE)
         add_library(VkLayer_${target} SHARED ${ARGN})
         target_link_libraries(VkLayer_${target} VkLayer_utils)
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
-        set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl" INSTALL_RPATH "@loader_path/")
+        set_target_properties(VkLayer_${target}
+                              PROPERTIES LINK_FLAGS
+                                         "-Wl"
+                                         INSTALL_RPATH
+                                         "@loader_path/")
         install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     endmacro()
 else()
@@ -180,33 +182,32 @@ if(BUILD_LAYERS)
     add_dependencies(VkLayer_core_validation spirv_tools_revision_file)
 endif()
 
-# The output file needs Unix "/" separators or Windows "\" separators
-# On top of that, Windows separators actually need to be doubled because the json format uses backslash escapes
+# The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
+# because the json format uses backslash escapes
 file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)
-string(REPLACE "\\" "\\\\" RELATIVE_PATH_PREFIX "${RELATIVE_PATH_PREFIX}")
+string(REPLACE "\\"
+               "\\\\"
+               RELATIVE_PATH_PREFIX
+               "${RELATIVE_PATH_PREFIX}")
 
-# Run each .json.in file through the generator
-# We need to create the generator.cmake script so that the generator can be run at compile time, instead of configure time
-# Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and TARGET_FILE_DIR, specifically)
+# Run each .json.in file through the generator We need to create the generator.cmake script so that the generator can be run at
+# compile time, instead of configure time Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and
+# TARGET_FILE_DIR, specifically)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
 foreach(TARGET_NAME ${TARGET_NAMES})
-    set(CONFIG_DEFINES
-        -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
-        -DVK_VERSION=1.1.${vk_header_version}
-    )
+    set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=1.1.${vk_header_version})
     # If this json file is not a metalayer, get the needed properties from that target
     if(TARGET ${TARGET_NAME})
-        set(CONFIG_DEFINES ${CONFIG_DEFINES}
+        set(CONFIG_DEFINES
+            ${CONFIG_DEFINES}
             -DOUTPUT_FILE="$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json"
-            -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>"
-        )
-    # If this json file is a metalayer, make the output path match core validation, and there is no layer binary file
+            -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>")
+        # If this json file is a metalayer, make the output path match core validation, and there is no layer binary file
     else()
-        set(CONFIG_DEFINES ${CONFIG_DEFINES}
-            -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_core_validation>/${TARGET_NAME}.json"
-        )
+        set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_core_validation>/${TARGET_NAME}.json")
     endif()
-    add_custom_target(${TARGET_NAME}-json ALL COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+    add_custom_target(${TARGET_NAME}-json ALL
+                      COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
 endforeach()
 
 # Install the layer json files

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    set(DisplayServer Win32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -50,8 +49,6 @@ endif()
 if(WIN32)
     file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
 endif()
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
@@ -103,21 +100,19 @@ set(
     ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR}
     )
 find_package(Vulkan)
-set(LIBVK "Vulkan::Vulkan")
 
 add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
 set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 target_include_directories(vk_layer_validation_tests
-                           PUBLIC
-                           ${VulkanHeaders_INCLUDE_DIR}
-                           ${CMAKE_CURRENT_SOURCE_DIR}
-                           ${GTEST_LOCATION}/googletest/include
-                           ${PROJECT_SOURCE_DIR}/layers
-                           ${GLSLANG_SPIRV_INCLUDE_DIR}
-                           ${CMAKE_CURRENT_BINARY_DIR}
-                           ${CMAKE_BINARY_DIR}
-                           ${PROJECT_BINARY_DIR}
-                           ${PROJECT_BINARY_DIR}/layers)
+                           PUBLIC ${VulkanHeaders_INCLUDE_DIR}
+                                  ${CMAKE_CURRENT_SOURCE_DIR}
+                                  ${GTEST_LOCATION}/googletest/include
+                                  ${PROJECT_SOURCE_DIR}/layers
+                                  ${GLSLANG_SPIRV_INCLUDE_DIR}
+                                  ${CMAKE_CURRENT_BINARY_DIR}
+                                  ${CMAKE_BINARY_DIR}
+                                  ${PROJECT_BINARY_DIR}
+                                  ${PROJECT_BINARY_DIR}/layers)
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils
                  VkLayer_core_validation-json
@@ -131,21 +126,27 @@ add_dependencies(vk_layer_validation_tests
 if(NOT WIN32)
     set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
     if(BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
-        target_link_libraries(
-            vk_layer_validation_tests ${LIBVK} ${XCB_LIBRARIES} ${X11_LIBRARIES} gtest gtest_main ${GLSLANG_LIBRARIES})
+        target_link_libraries(vk_layer_validation_tests
+                              Vulkan::Vulkan
+                              ${XCB_LIBRARIES}
+                              ${X11_LIBRARIES}
+                              gtest
+                              gtest_main
+                              ${GLSLANG_LIBRARIES})
     else()
-        target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
+        target_link_libraries(vk_layer_validation_tests Vulkan::Vulkan gtest gtest_main ${GLSLANG_LIBRARIES})
     endif()
 endif()
 if(WIN32)
-    target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main ${GLSLANG_LIBRARIES})
+    target_link_libraries(vk_layer_validation_tests Vulkan::Vulkan gtest gtest_main ${GLSLANG_LIBRARIES})
 endif()
 
 if(WIN32)
     # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
-    file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIGURATION>/*.dll SRC_GTEST_DLLS)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION> DST_GTEST_DLLS)
-    add_custom_command(TARGET vk_layer_validation_tests POST_BUILD COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
+    file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/*.dll SRC_GTEST_DLLS)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> DST_GTEST_DLLS)
+    add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+                       COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
     # Copy the loader shared lib (if supplied) to the test application directory so the test app finds it.
     if(VULKAN_LOADER_INSTALL_DIR)
         add_custom_command(TARGET vk_layer_validation_tests POST_BUILD

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -15,8 +15,6 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 2.8.11)
-
 set(LAYER_JSON_FILES VkLayer_device_profile_api)
 
 set(VK_LAYER_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
@@ -27,7 +25,7 @@ if(WIN32)
         foreach(config_file ${LAYER_JSON_FILES})
             file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${config_file}.json src_json)
             if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-                file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/${config_file}.json dst_json)
+                file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${config_file}.json dst_json)
             else()
                 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${config_file}.json dst_json)
             endif()
@@ -116,9 +114,9 @@ add_test_layer(device_profile_api ${DEVICE_PROFILE_API_SRCS})
 
 if(WIN32)
     # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/*device_profile_api.* SRC_LAYER)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/*device_profile_api.* SRC_LAYER)
     file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/VkLayer_device_profile_api.json SRC_JSON)
-    file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/layers/$<CONFIGURATION> DST_LAYER)
+    file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/layers/$<CONFIG> DST_LAYER)
     add_custom_command(TARGET VkLayer_device_profile_api POST_BUILD
                        COMMAND xcopy /Y /I ${SRC_LAYER} ${DST_LAYER}
                        COMMAND xcopy /Y /I ${SRC_JSON} ${DST_LAYER})


### PR DESCRIPTION
This is the first PR cleaning up CMake files in Khronos repos.  It consists primarily of cleanup, dead code/variable removal, and simplification.

This PR (in its current form of many separate commits) meant to make it easier to review;  it will be squashed to a single commit before pushing to VVL master.