### PR TITLE
Track DescriptorImageInfo layouts

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7051,6 +7051,12 @@ static void UpdateStateCmdDrawType(layer_data *dev_data, GLOBAL_CB_NODE *cb_stat
     UpdateStateCmdDrawDispatchType(dev_data, cb_state, bind_point);
     UpdateResourceTrackingOnDraw(cb_state);
     cb_state->hasDrawCmd = true;
+
+    // Add descriptor image/CIS layouts to CB layout map
+    auto &desc_sets = cb_state->lastBound->boundDescriptorSets;
+    for (auto &desc : desc_sets) {
+        desc->UpdateDSImageLayoutState(cb_state);
+    }
 }
 
 static bool PreCallValidateCmdDraw(layer_data *dev_data, VkCommandBuffer cmd_buffer, bool indexed, VkPipelineBindPoint bind_point,

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1122,6 +1122,25 @@ void cvdescriptorset::DescriptorSet::BindCommandBuffer(GLOBAL_CB_NODE *cb_node,
         }
     }
 }
+
+// Update CB layout map with any image/imagesampler descriptor image layouts
+void cvdescriptorset::DescriptorSet::UpdateDSImageLayoutState(GLOBAL_CB_NODE *cb_state) {
+    for (auto const &desc : descriptors_) {
+        if (desc->descriptor_class == ImageSampler || desc->descriptor_class == Image) {
+            VkImageView image_view;
+            VkImageLayout image_layout;
+            if (desc->descriptor_class == ImageSampler) {
+                image_view = static_cast<ImageSamplerDescriptor *>(desc.get())->GetImageView();
+                image_layout = static_cast<ImageSamplerDescriptor *>(desc.get())->GetImageLayout();
+            } else {
+                image_view = static_cast<ImageDescriptor *>(desc.get())->GetImageView();
+                image_layout = static_cast<ImageDescriptor *>(desc.get())->GetImageLayout();
+            }
+            SetImageViewLayout(device_data_, cb_state, image_view, image_layout);
+        }
+    }
+}
+
 void cvdescriptorset::DescriptorSet::FilterAndTrackOneBindingReq(const BindingReqMap::value_type &binding_req_pair,
                                                                  const BindingReqMap &in_req, BindingReqMap *out_req,
                                                                  TrackedBindings *bindings) {
@@ -1135,6 +1154,7 @@ void cvdescriptorset::DescriptorSet::FilterAndTrackOneBindingReq(const BindingRe
         out_req->emplace(binding_req_pair);
     }
 }
+
 void cvdescriptorset::DescriptorSet::FilterAndTrackOneBindingReq(const BindingReqMap::value_type &binding_req_pair,
                                                                  const BindingReqMap &in_req, BindingReqMap *out_req,
                                                                  TrackedBindings *bindings, uint32_t limit) {

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -493,6 +493,8 @@ class DescriptorSet : public BASE_NODE {
     std::unordered_set<GLOBAL_CB_NODE *> GetBoundCmdBuffers() const { return cb_bindings; }
     // Bind given cmd_buffer to this descriptor set
     void BindCommandBuffer(GLOBAL_CB_NODE *, const std::map<uint32_t, descriptor_req> &);
+    // Update CB image layout map with image/imagesampler descriptor image layouts
+    void UpdateDSImageLayoutState(GLOBAL_CB_NODE *);
 
     // Track work that has been bound or validated to avoid duplicate work, important when large descriptor arrays
     // are present


### PR DESCRIPTION
There was a hole in the DescriptorImageInfo layout checking for the first use of the image subresource in a command buffer.  The layout requirement was not recorded and so validation was not properly done at execution-time.  

Fixes #43. 