### PR TITLE
Fix format of required extensions error message.

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -223,7 +223,7 @@ static bool validate_extension_reqs(const instance_layer_data *instance_data, co
         return skip;  // Unknown extensions cannot be checked so report OK
     }
 
-    // Check agains the reqs list in the info
+    // Check against the required list in the info
     std::vector<const char *> missing;
     for (const auto &req : info.requires) {
         if (!(extensions.*(req.enabled))) {
@@ -235,8 +235,8 @@ static bool validate_extension_reqs(const instance_layer_data *instance_data, co
     if (missing.size()) {
         std::string missing_joined_list = string_join(", ", missing);
         skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,
-                        HandleToUint64(instance_data->instance), vuid, "Missing required extensions for %s extension %s, %s.",
-                        extension_type, extension_name, missing_joined_list.c_str());
+                        HandleToUint64(instance_data->instance), vuid, "Missing extension%s required by the %s extension %s: %s.",
+                        ((missing.size() > 1) ? "s" : ""), extension_type, extension_name, missing_joined_list.c_str());
     }
     return skip;
 }


### PR DESCRIPTION
For missing extension dependencies, the current validation layer
support emits error messages like:

  Missing required extensions for instance extension VK_EXT_xxx,
  VK_KHR_yyy.

With the comma, it's easy to read this as saying that there are
unspecified missing required extensions for both "VK_EXT_xxx" and
"VK_KHR_yyy".

Using a colon instead:

  Missing required extensions for instance extension VK_EXT_xxx:
  VK_KHR_yyy.

makes it clearer VK_KHR_yyy (plus any other listed extensions that
follow) is a missing required extension for VK_EXT_xxx.