### PR TITLE
Ignore external queue family validation/record at barrier record time

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8071,9 +8071,6 @@ class ValidatorState {
     // Logical helpers for semantic clarity
     inline bool KhrExternalMem() const { return mem_ext_; }
     inline bool IsValid(uint32_t queue_family) const { return (queue_family < limit_); }
-    inline bool IsSpecial(uint32_t queue_family) const {
-        return (queue_family == VK_QUEUE_FAMILY_EXTERNAL_KHR) || (queue_family == VK_QUEUE_FAMILY_FOREIGN_EXT);
-    }
     inline bool IsValidOrSpecial(uint32_t queue_family) const {
         return IsValid(queue_family) || (mem_ext_ && IsSpecial(queue_family));
     }
@@ -8130,8 +8127,8 @@ bool Validate(const layer_data *device_data, const char *func_name, GLOBAL_CB_NO
             if (!(src_ignored || dst_ignored)) {
                 skip |= val.LogMsg(kSrcOrDstMustBeIgnore, src_queue_family, dst_queue_family);
             }
-            if ((src_ignored && !(dst_ignored || val.IsSpecial(dst_queue_family))) ||
-                (dst_ignored && !(src_ignored || val.IsSpecial(src_queue_family)))) {
+            if ((src_ignored && !(dst_ignored || IsSpecial(dst_queue_family))) ||
+                (dst_ignored && !(src_ignored || IsSpecial(src_queue_family)))) {
                 skip |= val.LogMsg(kSpecialOrIgnoreOnly, src_queue_family, dst_queue_family);
             }
         } else {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -92,6 +92,10 @@ static bool IsAcquireOp(const COMMAND_POOL_NODE *pool, const Barrier *barrier) {
     return (assume_transfer || IsTransferOp(barrier)) && (pool->queueFamilyIndex == barrier->dstQueueFamilyIndex);
 }
 
+inline const bool IsSpecial(const uint32_t queue_family_index) {
+    return (queue_family_index == VK_QUEUE_FAMILY_EXTERNAL_KHR) || (queue_family_index == VK_QUEUE_FAMILY_FOREIGN_EXT);
+}
+
 // Generic wrapper for vulkan objects
 struct VK_OBJECT {
     uint64_t handle;


### PR DESCRIPTION
A release or acquire from an external queue isn't visible to the current instance's validation so to avoid false warnings we no longer validate QFO transfers involving external queues at barrier record time.

Resolves #290
Partially addresses #307