### PR TITLE
layers: Add CreateRenderPass2KHR to unique objects

### DIFF
--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -153,6 +153,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             'vkDebugMarkerSetObjectTagEXT',
             'vkDebugMarkerSetObjectNameEXT',
             'vkCreateRenderPass',
+            'vkCreateRenderPass2KHR',
             'vkDestroyRenderPass',
             'vkSetDebugUtilsObjectNameEXT',
             'vkSetDebugUtilsObjectTagEXT',


### PR DESCRIPTION
Adds CreateRenderPass2KHR to unique objects, mimicking the CreateRenderPass code, but with a VkRenderPassCreatInfo2KHR struct