### PR TITLE
layers: Fix DescSet Image Layout null deref

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7055,7 +7055,9 @@ static void UpdateStateCmdDrawType(layer_data *dev_data, GLOBAL_CB_NODE *cb_stat
     // Add descriptor image/CIS layouts to CB layout map
     auto &desc_sets = cb_state->lastBound->boundDescriptorSets;
     for (auto &desc : desc_sets) {
-        desc->UpdateDSImageLayoutState(cb_state);
+        if (desc) {
+            desc->UpdateDSImageLayoutState(cb_state);
+        }
     }
 }
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1126,7 +1126,7 @@ void cvdescriptorset::DescriptorSet::BindCommandBuffer(GLOBAL_CB_NODE *cb_node,
 // Update CB layout map with any image/imagesampler descriptor image layouts
 void cvdescriptorset::DescriptorSet::UpdateDSImageLayoutState(GLOBAL_CB_NODE *cb_state) {
     for (auto const &desc : descriptors_) {
-        if (desc->descriptor_class == ImageSampler || desc->descriptor_class == Image) {
+        if (desc->updated && (desc->descriptor_class == ImageSampler || desc->descriptor_class == Image)) {
             VkImageView image_view;
             VkImageLayout image_layout;
             if (desc->descriptor_class == ImageSampler) {


### PR DESCRIPTION
Tony's CTS test passes revealed a couple of logic holes -- check if image/sampler descriptors are updated before adding to image layout map, and account for a sparse descriptor set vector.
