### PR TITLE
layers: Fix false positive in pointsize write check

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -915,7 +915,9 @@ static bool IsPointSizeWritten(shader_module const *src, spirv_inst_iter builtin
         }
     }
 
-    bool found_write = !init_complete && (type == spv::OpMemberDecorate);
+    if (!init_complete && (type == spv::OpMemberDecorate)) return false;
+
+    bool found_write = false;
     std::unordered_set<uint32_t> worklist;
     worklist.insert(entrypoint.word(2));
 


### PR DESCRIPTION
Take care of false positives related to implicit decls in glsl gl_PerVertex structures.

Fixes #321.