### PR TITLE
layers: Clarify semaphore error message

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2986,7 +2986,8 @@ static bool PreCallValidateQueueSubmit(layer_data *dev_data, VkQueue queue, uint
                     skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
                                     HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
                                     "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64
-                                    " that has already been signaled but not waited on by queue 0x%" PRIx64 ".",
+                                    " that was previously signaled by queue 0x%" PRIx64
+                                    " but has not since been waited on by any queue.",
                                     HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
                 } else {
                     unsignaled_semaphores.erase(semaphore);
@@ -10617,7 +10618,8 @@ static bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, 
                     skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
                                     HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
                                     "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64
-                                    " that has already been signaled but not waited on by queue 0x%" PRIx64 ".",
+                                    " that was previously signaled by queue 0x%" PRIx64
+                                    " but has not since been waited on by any queue.",
                                     HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
                 } else {
                     unsignaled_semaphores.erase(semaphore);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -17089,7 +17089,7 @@ TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    const char *queue_forward_progress_message = " that has already been signaled but not waited on by queue 0x";
+    const char *queue_forward_progress_message = " that was previously signaled by queue 0x";
     const char *invalid_fence_wait_message = " which has not been submitted on a Queue or during acquire next image.";
 
     VkCommandBufferObj cb1(m_device, m_commandPool);


### PR DESCRIPTION
The language of the error message was confusing relative to whether the
second queue handle displayed referred to a signalling or waiting queue.

Rephrased message to clarify that the second queue is the prior
signalling queue.  Updated test to handle changed message text.