### PR TITLE
scripts: Add glslang to Vulkan-Tools VVL known good dependency list 

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -110,6 +110,10 @@
           "repo_name" : "Vulkan-Loader"
         },
         {
+          "var_name" : "GLSLANG_INSTALL_DIR",
+          "repo_name" : "glslang"
+        },
+        {
           "var_name" : "MOLTENVK_REPO_ROOT",
           "repo_name" : "MoltenVK"
         }


### PR DESCRIPTION
The wget from glslang master-tot is failing... but we don't really need it....

Since update is already building glsl, have Vulkan-Tools point to the
built copy and not wget it.