### PR TITLE
Fix GLSL compilation errors in vk_layer_validation_tests

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -10,7 +10,7 @@
       "name" : "glslang",
       "url" : "https://github.com/KhronosGroup/glslang.git",
       "sub_dir" : "shaderc/third_party/glslang",
-      "commit" : "806af25f749b4d7cd861eaebc32474b3a7d102c0"
+      "commit" : "a8453d4bc00998049db0d448764784a6a0767539"
     },
     {
       "name" : "Vulkan-Headers",

--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -4,7 +4,7 @@
       "name" : "shaderc",
       "url" : "https://github.com/google/shaderc.git",
       "sub_dir" : "shaderc",
-      "commit" : "30af9f9899aefd018669e81a5b8e605d14d40431"
+      "commit" : "9340ae565aceeb9ef8440fb38f8a98346df5a417"
     },
     {
       "name" : "glslang",
@@ -28,13 +28,13 @@
       "name" : "SPIRV-Tools",
       "url" : "https://github.com/KhronosGroup/SPIRV-Tools.git",
       "sub_dir" : "shaderc/third_party/spirv-tools",
-      "commit" : "85d3715725cada0cdce42dfba7ba7e51fa64b80c"
+      "commit" : "9bfe0eb25e3dfdf4f3fd86ab6c0cda009c9bd661"
     },
     {
       "name" : "SPIRV-Headers",
       "url" : "https://github.com/KhronosGroup/SPIRV-Headers.git",
       "sub_dir" : "shaderc/third_party/spirv-tools/external/spirv-headers",
-      "commit" : "ff684ffc6a35d2a58f0f63108877d0064ea33feb"
+      "commit" : "d5b2e1255f706ce1f88812217e9a554f299848af"
     }
   ]
 }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "1323bf8e39fa17da3e0901a4b1ab5dfd61ee5460",
+      "commit" : "a8453d4bc00998049db0d448764784a6a0767539",
       "prebuild" : [
         "python update_glslang_sources.py"
       ],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,9 @@
 
 set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
 
+# Needed to make structure definitions match with glslang libraries
+add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -315,6 +315,15 @@ static const char *DefaultConfig =
     "MaxCullDistances 8\n"
     "MaxCombinedClipAndCullDistances 8\n"
     "MaxSamples 4\n"
+    "MaxMeshOutputVerticesNV 256\n"
+    "MaxMeshOutputPrimitivesNV 512\n"
+    "MaxMeshWorkGroupSizeX_NV 32\n"
+    "MaxMeshWorkGroupSizeY_NV 1\n"
+    "MaxMeshWorkGroupSizeZ_NV 1\n"
+    "MaxTaskWorkGroupSizeX_NV 32\n"
+    "MaxTaskWorkGroupSizeY_NV 1\n"
+    "MaxTaskWorkGroupSizeZ_NV 1\n"
+    "MaxMeshViewCountNV 4\n"
 
     "nonInductiveForLoops 1\n"
     "whileLoops 1\n"
@@ -536,6 +545,24 @@ void VkTestFramework::ProcessConfigFile() {
             Resources.maxCombinedClipAndCullDistances = value;
         else if (strcmp(token, "MaxSamples") == 0)
             Resources.maxSamples = value;
+        else if (strcmp(token, "MaxMeshOutputVerticesNV") == 0)
+            Resources.maxMeshOutputVerticesNV = value;
+        else if (strcmp(token, "MaxMeshOutputPrimitivesNV") == 0)
+            Resources.maxMeshOutputPrimitivesNV = value;
+        else if (strcmp(token, "MaxMeshWorkGroupSizeX_NV") == 0)
+            Resources.maxMeshWorkGroupSizeX_NV = value;
+        else if (strcmp(token, "MaxMeshWorkGroupSizeY_NV") == 0)
+            Resources.maxMeshWorkGroupSizeY_NV = value;
+        else if (strcmp(token, "MaxMeshWorkGroupSizeZ_NV") == 0)
+            Resources.maxMeshWorkGroupSizeZ_NV = value;
+        else if (strcmp(token, "MaxTaskWorkGroupSizeX_NV") == 0)
+            Resources.maxTaskWorkGroupSizeX_NV = value;
+        else if (strcmp(token, "MaxTaskWorkGroupSizeY_NV") == 0)
+            Resources.maxTaskWorkGroupSizeY_NV = value;
+        else if (strcmp(token, "MaxTaskWorkGroupSizeZ_NV") == 0)
+            Resources.maxTaskWorkGroupSizeZ_NV = value;
+        else if (strcmp(token, "MaxMeshViewCountNV") == 0)
+            Resources.maxMeshViewCountNV = value;
 
         else if (strcmp(token, "nonInductiveForLoops") == 0)
             Resources.limits.nonInductiveForLoops = (value != 0);


### PR DESCRIPTION
Fix compilation errors in vk_layer_validation_tests due to uninitialized garbage in glslang's builtin limits. This was caused in part by the structure size mismatching between the glslang library compile and the test framework compile, which is fixed by #defining NV_EXTENSIONS in cmake.

This happens when running a TOT validation layer against a glslang after the Turing extensions were merged yesterday.

I've talked with JohnK about possibly removing the ifdef from the structure definitions, but this gets things working in the meantime.
