### PR TITLE
WIP on Android Hardware Buffer extension support

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -24,6 +24,7 @@
 
 #include <sstream>
 #include <string>
+#include <cmath>
 
 #include "vk_enum_string_helper.h"
 #include "vk_layer_data.h"
@@ -956,17 +957,173 @@ void TransitionFinalSubpassLayouts(layer_data *device_data, GLOBAL_CB_NODE *pCB,
     }
 }
 
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+// Android-specific validation that uses types defined only with VK_USE_PLATFORM_ANDROID_KHR
+// This could also move into a seperate core_validation_android.cpp file... ?
+
+bool PreCallValidateCreateImageANDROID(layer_data *device_data, const debug_report_data *report_data,
+                                       const VkImageCreateInfo *create_info, bool unknown_format) {
+    bool skip = false;
+
+    if (unknown_format) {
+        return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                       "VUID-VkImageCreateInfo-pNext-01889",
+                       "vkCreateImage: The combination of format, type, tiling, usage and flags supplied in the VkImageCreateInfo "
+                       "struct is reported by vkGetPhysicalDeviceImageFormatProperties() as unsupported.");
+    }
+
+    const VkExternalFormatANDROID *ext_fmt_android = lvl_find_in_chain<VkExternalFormatANDROID>(create_info->pNext);
+    const VkExternalMemoryImageCreateInfo *emici = lvl_find_in_chain<VkExternalMemoryImageCreateInfo>(create_info->pNext);
+    if (emici && (emici->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID)) {
+        bool failed_01892 = true;  // Assume failure
+        do {                       // once-through only, breaking out means we've detected the failure
+            if (create_info->imageType != VK_IMAGE_TYPE_2D) break;
+
+            uint32_t max_dim = std::max({create_info->extent.height, create_info->extent.width, create_info->extent.depth});
+            uint32_t full_mip_depth = 1 + (uint32_t)log2(max_dim);  // floor() is implicit in the cast
+            if ((create_info->mipLevels != 1) && (create_info->mipLevels != full_mip_depth)) break;
+
+            if (create_info->format == VK_FORMAT_UNDEFINED) {
+                if (nullptr == ext_fmt_android) break;
+                if (0 == ext_fmt_android->externalFormat) break;
+            } else {
+                // Inputs
+                VkPhysicalDeviceExternalImageFormatInfo eifi = {};
+                eifi.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+                eifi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+                VkPhysicalDeviceImageFormatInfo2 info = {};
+                info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR;
+                info.pNext = &eifi;  // chain the external format info
+                info.format = create_info->format;
+                info.type = create_info->imageType;
+                info.tiling = create_info->tiling;
+                info.usage = create_info->usage;
+                info.flags = create_info->flags;
+                // Outputs
+                VkExternalImageFormatProperties eifp = {};
+                eifp.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+                VkImageFormatProperties2 props = {};
+                props.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+                props.pNext = &eifp;  // chain the external image properties
+                if (VK_SUCCESS != GetImageFormatProperties2(device_data, &info, &props)) break;
+            }
+            failed_01892 = false;  // If we reach here, no error found
+        } while (false);
+        if (failed_01892) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-pNext-01892",
+                            "vkCreateImage: VkImageCreateInfo struct contains values incompatible with the chained "
+                            "VkExternalMemoryImageCreateInfo struct.");
+        }
+    }  // End 01892 check
+
+    if (ext_fmt_android && 0 != ext_fmt_android->externalFormat) {
+        if ((VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT & create_info->flags) || (~VK_IMAGE_USAGE_SAMPLED_BIT & create_info->usage) ||
+            (VK_IMAGE_TILING_OPTIMAL != create_info->tiling)) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-pNext-01893",
+                            "vkCreateImage: Illegal flags, usage or tiling specified in VkImageCreateInfo struct with a chained "
+                            "VkExternalFormatANDROID struct whose external format is non-zero.");
+        }
+    }
+
+    if (ext_fmt_android && (0 != ext_fmt_android->externalFormat)) {
+        if (VK_FORMAT_UNDEFINED != create_info->format) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-pNext-01974",
+                            "vkCreateImage: VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with non-zero "
+                            "external format, but the VkImageCreateInfo's format is not VK_FORMAT_UNDEFINED.");
+        }
+    } else {
+        if (VK_FORMAT_UNDEFINED == create_info->format) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-pNext-01975",
+                            "vkCreateImage: VkImageCreateInfo struct's format is VK_FORMAT_UNDEFINED, but either does not have a "
+                            "chained VkExternalFormatANDROID struct or the struct exists but has an external format of 0.");
+        }
+    }
+
+    return skip;
+}
+
+bool PreCallValidateCreateImageViewANDROID(layer_data *device_data, const VkImageViewCreateInfo *create_info) {
+    bool skip = false;
+    const debug_report_data *report_data = core_validation::GetReportData(device_data);
+    const VkExternalFormatANDROID *ext_format_android = lvl_find_in_chain<VkExternalFormatANDROID>(create_info->pNext);
+    if (ext_format_android) {
+        // Traverse all the ways VU 01896 can fail. Breaking out at any point indicates a VU violation
+        bool vu_01896 = true;  // assume error
+        do {
+            // Errors in create_info struct
+            if ((create_info->format != VK_FORMAT_UNDEFINED) | (create_info->components.r != VK_COMPONENT_SWIZZLE_IDENTITY) |
+                (create_info->components.g != VK_COMPONENT_SWIZZLE_IDENTITY) |
+                (create_info->components.b != VK_COMPONENT_SWIZZLE_IDENTITY) |
+                (create_info->components.a != VK_COMPONENT_SWIZZLE_IDENTITY)) {
+                break;
+            }
+
+            // Chain must include a cbcr conversion
+            const VkSamplerYcbcrConversionInfo *ycbcr_conv_info =
+                lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(create_info->pNext);
+            if (ycbcr_conv_info == nullptr) {
+                break;
+            }
+
+            // External formats must match
+            VkSamplerYcbcrConversion conv_handle = ycbcr_conv_info->conversion;
+            auto fmap = GetYcbcrConversionFormatMap(device_data);
+            if (fmap->find(conv_handle) == fmap->end()) {
+                break;
+            }
+            if (fmap->at(conv_handle) != ext_format_android->externalFormat) {
+                break;
+            }
+            vu_01896 = false;  // No error if we reach here
+        } while (false);       // one time through only
+
+        if (vu_01896) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                            HandleToUint64(create_info->image), "VUID-VkImageViewCreateInfo-image-01896",
+                            "vkCreateImageView(): VkExternalFormatANDROID struct chained with an illegal combination of "
+                            "format, swizzle, or external format specified.");
+        }
+    }
+    return skip;
+}
+
+#else
+
+bool PreCallValidateCreateImageANDROID(layer_data *device_data, const debug_report_data *report_data,
+                                       const VkImageCreateInfo *create_info, bool unknown_format) {
+    return false;
+}
+
+bool PreCallValidateCreateImageViewANDROID(layer_data *device_data, const VkImageViewCreateInfo *create_info) { return false; }
+
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+
 bool PreCallValidateCreateImage(layer_data *device_data, const VkImageCreateInfo *pCreateInfo,
                                 const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
     bool skip = false;
     const debug_report_data *report_data = core_validation::GetReportData(device_data);
+    VkImageFormatProperties format_limits;
+    bool unknown_format = (VK_SUCCESS != GetImageFormatProperties(device_data, pCreateInfo, &format_limits));
 
-    if (pCreateInfo->format == VK_FORMAT_UNDEFINED) {
-        skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-VkImageCreateInfo-format-00943", "vkCreateImage: VkFormat for image must not be VK_FORMAT_UNDEFINED.");
-
-        return skip;
+    if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
+        skip |= PreCallValidateCreateImageANDROID(device_data, report_data, pCreateInfo, unknown_format);
+        if (unknown_format) return skip;
+    } else {  // These checks are omitted or replaced when Android HW Buffer extension is active
+        if (pCreateInfo->format == VK_FORMAT_UNDEFINED) {
+            return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                           "VUID-VkImageCreateInfo-format-00943",
+                           "vkCreateImage: VkFormat for image must not be VK_FORMAT_UNDEFINED.");
+        }
+        if (unknown_format) {
+            return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                           "VUID-VkImageCreateInfo-format-00940",
+                           "vkCreateImage: The combination of format, type, tiling, usage and flags supplied in the "
+                           "VkImageCreateInfo struct is reported by vkGetPhysicalDeviceImageFormatProperties() as unsupported.");
+        }
     }
 
     const char *format_string = string_VkFormat(pCreateInfo->format);
@@ -979,17 +1136,6 @@ bool PreCallValidateCreateImage(layer_data *device_data, const VkImageCreateInfo
     }
 
     const VkPhysicalDeviceLimits *device_limits = &(GetPhysicalDeviceProperties(device_data)->limits);
-    VkImageFormatProperties format_limits;  // Format limits may exceed general device limits
-    VkResult err = GetImageFormatProperties(device_data, pCreateInfo, &format_limits);
-    if (VK_SUCCESS != err) {
-        std::stringstream ss;
-        ss << "vkCreateImage: The combination of format, type, tiling, usage and flags supplied in the VkImageCreateInfo struct is "
-              "reported by vkGetPhysicalDeviceImageFormatProperties() as unsupported";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-format-00940", "%s.", ss.str().c_str());
-        return skip;
-    }
-
     if ((VK_IMAGE_TYPE_1D == pCreateInfo->imageType) &&
         (pCreateInfo->extent.width > std::max(device_limits->maxImageDimension1D, format_limits.maxExtent.width))) {
         std::stringstream ss;
@@ -3864,19 +4010,25 @@ bool PreCallValidateCreateImageView(layer_data *device_data, const VkImageViewCr
                 break;
         }
 
+        // External format checks needed when VK_ANDROID_external_memory_android_hardware_buffer enabled
+        if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
+            skip |= PreCallValidateCreateImageViewANDROID(device_data, create_info);
+        }
+
         VkFormatProperties format_properties = GetFormatProperties(device_data, view_format);
         bool check_tiling_features = false;
         VkFormatFeatureFlags tiling_features = 0;
-        std::string linear_error_codes[] = {
-            "VUID-VkImageViewCreateInfo-image-01006", "VUID-VkImageViewCreateInfo-image-01008",
-            "VUID-VkImageViewCreateInfo-image-01009", "VUID-VkImageViewCreateInfo-image-01010",
-            "VUID-VkImageViewCreateInfo-image-01011",
-        };
-        std::string optimal_error_codes[] = {
-            "VUID-VkImageViewCreateInfo-image-01012", "VUID-VkImageViewCreateInfo-image-01013",
-            "VUID-VkImageViewCreateInfo-image-01014", "VUID-VkImageViewCreateInfo-image-01015",
-            "VUID-VkImageViewCreateInfo-image-01016",
-        };
+        std::string linear_error_codes[] = {"VUID-VkImageViewCreateInfo-image-01006", "VUID-VkImageViewCreateInfo-image-01008",
+                                            "VUID-VkImageViewCreateInfo-image-01009", "VUID-VkImageViewCreateInfo-image-01010",
+                                            "VUID-VkImageViewCreateInfo-image-01011"};
+        std::string optimal_error_codes[] = {"VUID-VkImageViewCreateInfo-image-01012", "VUID-VkImageViewCreateInfo-image-01013",
+                                             "VUID-VkImageViewCreateInfo-image-01014", "VUID-VkImageViewCreateInfo-image-01015",
+                                             "VUID-VkImageViewCreateInfo-image-01016"};
+        std::string ext_mem_android_hw_buffer_error_codes[] = {
+            "VUID-VkImageViewCreateInfo-image-01965", "VUID-VkImageViewCreateInfo-image-01966",
+            "VUID-VkImageViewCreateInfo-image-01967", "VUID-VkImageViewCreateInfo-image-01968",
+            "VUID-VkImageViewCreateInfo-image-01969"};
+
         std::string *error_codes = nullptr;
         if (image_tiling == VK_IMAGE_TILING_LINEAR) {
             tiling_features = format_properties.linearTilingFeatures;
@@ -3884,8 +4036,13 @@ bool PreCallValidateCreateImageView(layer_data *device_data, const VkImageViewCr
             check_tiling_features = true;
         } else if (image_tiling == VK_IMAGE_TILING_OPTIMAL) {
             tiling_features = format_properties.optimalTilingFeatures;
-            error_codes = optimal_error_codes;
-            check_tiling_features = true;
+            if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
+                error_codes = ext_mem_android_hw_buffer_error_codes;
+                check_tiling_features = (view_format != VK_FORMAT_UNDEFINED);  // Only check defined internal (VK_blah) formats
+            } else {
+                error_codes = optimal_error_codes;
+                check_tiling_features = true;
+            }
         }
 
         if (check_tiling_features) {

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (C) 2015-2017 Google Inc.
+/* Copyright (c) 2015-2018 The Khronos Group Inc.
+ * Copyright (c) 2015-2018 Valve Corporation
+ * Copyright (c) 2015-2018 LunarG, Inc.
+ * Copyright (C) 2015-2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
  * limitations under the License.
  *
  * Mark Lobodzinski <mark@lunarg.com>
+ * Dave Houlton <daveh@lunarg.com>
  */
 #ifndef CORE_VALIDATION_BUFFER_VALIDATION_H_
 #define CORE_VALIDATION_BUFFER_VALIDATION_H_
 
-#include "core_validation_types.h"
-#include "core_validation_error_enums.h"
+#include "core_validation.h"
 #include "descriptor_sets.h"
 #include "vulkan/vk_layer.h"
 #include <limits.h>

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
- * Copyright (C) 2015-2016 Google Inc.
+/* Copyright (c) 2015-2018 The Khronos Group Inc.
+ * Copyright (c) 2015-2018 Valve Corporation
+ * Copyright (c) 2015-2018 LunarG, Inc.
+ * Copyright (C) 2015-2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  * Author: Tobin Ehlis <tobine@google.com>
  * Author: Chris Forbes <chrisf@ijw.co.nz>
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 #pragma once
@@ -28,6 +29,7 @@
 #include "descriptor_sets.h"
 #include "vk_layer_logging.h"
 #include "vulkan/vk_layer.h"
+#include "vk_typemap_helper.h"
 #include <atomic>
 #include <functional>
 #include <memory>

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
- * Copyright (C) 2015-2016 Google Inc.
+/* Copyright (c) 2015-2018 The Khronos Group Inc.
+ * Copyright (c) 2015-2018 Valve Corporation
+ * Copyright (c) 2015-2018 LunarG, Inc.
+ * Copyright (C) 2015-2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  * Author: Tobin Ehlis <tobine@google.com>
  * Author: Chris Forbes <chrisf@ijw.co.nz>
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
  */
 #ifndef CORE_VALIDATION_TYPES_H_
 #define CORE_VALIDATION_TYPES_H_
@@ -1050,6 +1051,100 @@ struct DeviceFeatures {
     VkPhysicalDevice8BitStorageFeaturesKHR eight_bit_storage;
 };
 
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+// Enumerations of format and usage flags for Android opaque external memory blobs
+typedef enum AHardwareBufferFormat {
+    AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1,
+    AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM = 2,
+    AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM = 3,
+    AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM = 4,
+    AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT = 0x16,
+    AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM = 0x2b,
+    AHARDWAREBUFFER_FORMAT_D16_UNORM = 0x30,
+    AHARDWAREBUFFER_FORMAT_D24_UNORM = 0x31,
+    AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT = 0x32,
+    AHARDWAREBUFFER_FORMAT_D32_FLOAT = 0x33,
+    AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT = 0x34,
+    AHARDWAREBUFFER_FORMAT_S8_UINT = 0x35,
+    AHARDWAREBUFFER_FORMAT_BLOB = 0x21
+} AHardwareBufferFormat;
+
+typedef enum AHardwareBufferUsage {
+    AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE = 0x100,
+    AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT = 0x200,
+    AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP = 0x2000000,
+    AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE = 0x4000000,
+    AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT = 0x4000,
+    AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER = 0x1000000
+} AHardwareBufferUsage;
+
+/* NDK definitions
+Native Activity
+#include <hardware_buffer.h>
+#include <native_activity.h>
+#include <native_window.h>
+#include <native_window_jni.h>
+#include <rect.h>
+#include <window.h>
+Summary
+Enumerations
+Anonymous Enum 15{
+  AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1,
+  AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM = 2,
+  AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM = 3,
+  AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM = 4,
+  AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT = 0x16,
+  AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM = 0x2b,
+  AHARDWAREBUFFER_FORMAT_BLOB = 0x21,
+  AHARDWAREBUFFER_FORMAT_D16_UNORM = 0x30,
+  AHARDWAREBUFFER_FORMAT_D24_UNORM = 0x31,
+  AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT = 0x32,
+  AHARDWAREBUFFER_FORMAT_D32_FLOAT = 0x33,
+  AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT = 0x34,
+  AHARDWAREBUFFER_FORMAT_S8_UINT = 0x35
+}	enum
+Buffer pixel formats.
+Anonymous Enum 16{
+  AHARDWAREBUFFER_USAGE_CPU_READ_NEVER = 0UL,
+  AHARDWAREBUFFER_USAGE_CPU_READ_RARELY = 2UL,
+  AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN = 3UL,
+  AHARDWAREBUFFER_USAGE_CPU_READ_MASK = 0xFUL,
+  AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER = 0UL << 4,
+  AHARDWAREBUFFER_USAGE_CPU_WRITE_RARELY = 2UL << 4,
+  AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN = 3UL << 4,
+  AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK = 0xFUL << 4,
+  AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE = 1UL << 8,
+  AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT = 1UL << 9,
+  AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT = 1UL << 14,
+  AHARDWAREBUFFER_USAGE_VIDEO_ENCODE = 1UL << 16,
+  AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA = 1UL << 23,
+  AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER = 1UL << 24,
+  AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP = 1UL << 25,
+  AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE = 1UL << 26,
+  AHARDWAREBUFFER_USAGE_VENDOR_0 = 1ULL << 28,
+  AHARDWAREBUFFER_USAGE_VENDOR_1 = 1ULL << 29,
+  AHARDWAREBUFFER_USAGE_VENDOR_2 = 1ULL << 30,
+  AHARDWAREBUFFER_USAGE_VENDOR_3 = 1ULL << 31,
+  AHARDWAREBUFFER_USAGE_VENDOR_4 = 1ULL << 48,
+  AHARDWAREBUFFER_USAGE_VENDOR_5 = 1ULL << 49,
+  AHARDWAREBUFFER_USAGE_VENDOR_6 = 1ULL << 50,
+  AHARDWAREBUFFER_USAGE_VENDOR_7 = 1ULL << 51,
+  AHARDWAREBUFFER_USAGE_VENDOR_8 = 1ULL << 52,
+  AHARDWAREBUFFER_USAGE_VENDOR_9 = 1ULL << 53,
+  AHARDWAREBUFFER_USAGE_VENDOR_10 = 1ULL << 54,
+  AHARDWAREBUFFER_USAGE_VENDOR_11 = 1ULL << 55,
+  AHARDWAREBUFFER_USAGE_VENDOR_12 = 1ULL << 56,
+  AHARDWAREBUFFER_USAGE_VENDOR_13 = 1ULL << 57,
+  AHARDWAREBUFFER_USAGE_VENDOR_14 = 1ULL << 58,
+  AHARDWAREBUFFER_USAGE_VENDOR_15 = 1ULL << 59,
+  AHARDWAREBUFFER_USAGE_VENDOR_16 = 1ULL << 60,
+  AHARDWAREBUFFER_USAGE_VENDOR_17 = 1ULL << 61,
+  AHARDWAREBUFFER_USAGE_VENDOR_18 = 1ULL << 62,
+  AHARDWAREBUFFER_USAGE_VENDOR_19 = 1ULL << 63
+}*/
+#endif // VK_USE_PLATFORM_ANDROID_KHR
+
+
 // Fwd declarations of layer_data and helpers to look-up/validate state from layer_data maps
 namespace core_validation {
 struct layer_data;
@@ -1106,8 +1201,9 @@ bool ValidateCmd(layer_data *dev_data, const GLOBAL_CB_NODE *cb_state, const CMD
 
 // Prototypes for layer_data accessor functions.  These should be in their own header file at some point
 VkFormatProperties GetFormatProperties(const core_validation::layer_data *device_data, const VkFormat format);
-VkResult GetImageFormatProperties(core_validation::layer_data *device_data, const VkImageCreateInfo *image_ci,
-                                  VkImageFormatProperties *image_format_properties);
+VkResult GetImageFormatProperties(core_validation::layer_data *, const VkImageCreateInfo *, VkImageFormatProperties *);
+VkResult GetImageFormatProperties2(core_validation::layer_data *, const VkPhysicalDeviceImageFormatInfo2 *,
+                                   VkImageFormatProperties2 *);
 const debug_report_data *GetReportData(const layer_data *);
 const VkPhysicalDeviceProperties *GetPhysicalDeviceProperties(const layer_data *);
 const CHECK_DISABLED *GetDisables(layer_data *);
@@ -1118,6 +1214,7 @@ std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> const *GetImageLayou
 std::unordered_map<VkBuffer, std::unique_ptr<BUFFER_STATE>> *GetBufferMap(layer_data *device_data);
 std::unordered_map<VkBufferView, std::unique_ptr<BUFFER_VIEW_STATE>> *GetBufferViewMap(layer_data *device_data);
 std::unordered_map<VkImageView, std::unique_ptr<IMAGE_VIEW_STATE>> *GetImageViewMap(layer_data *device_data);
+std::unordered_map<VkSamplerYcbcrConversion, uint64_t> *GetYcbcrConversionFormatMap(core_validation::layer_data *device_data);
 const DeviceExtensions *GetDeviceExtensions(const layer_data *);
 uint32_t GetApiVersion(const layer_data *);
 


### PR DESCRIPTION
WIP for review only, most likely will not push in this state.

Contains progress to date on validation support for AHB extension, with 23.5 out of 33 valid usage changes / additions implemented. The remaining VUs in general are ones requiring more research and/or clarification from the authors or working group to determine the intent, or in a couple cases just one-offs that don't have dependencies within the completed VUs. Very limited testing so far, using mock ICD, and not included in this PR.

Several of the VUs included are actually 3-6 valid usage statements in bullet-point form under a single VUID. These are handled via a slightly ugly pattern like this:

```
bool failed = true;
do {
    if (failure condition 1) break;
    if (failure condition 2) break;
   ...

    failed = false;
while (false); // once-through
if (failed) dbg_report("it failed");
```

My requests for clarifications seem to have set off an effort to ban multi-bullet-point VUs from the spec (https://gitlab.khronos.org/vulkan/vulkan/issues/1382), so expect each of these multi VUs to become a handful of individual VUs in the near future. This once-through loop pattern will be removed at that point.


   