### PR TITLE
Avoid crashes/report errors for condition where attachment handles have become stale

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -297,8 +297,8 @@ void SetImageLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, const IMAG
 }
 
 // Set image layout for all slices of an image view
-void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, VkImageView imageView, const VkImageLayout &layout) {
-    auto view_state = GetImageViewState(device_data, imageView);
+void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, IMAGE_VIEW_STATE *view_state,
+                        const VkImageLayout &layout) {
     assert(view_state);
 
     IMAGE_STATE *image_state = GetImageState(device_data, view_state->create_info.image);
@@ -312,6 +312,11 @@ void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, VkImag
     }
 
     SetImageLayout(device_data, cb_node, image_state, sub_range, layout);
+}
+
+void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, VkImageView imageView, const VkImageLayout &layout) {
+    auto view_state = GetImageViewState(device_data, imageView);
+    SetImageViewLayout(device_data, cb_node, view_state, layout);
 }
 
 bool VerifyFramebufferAndRenderPassLayouts(layer_data *device_data, GLOBAL_CB_NODE *pCB,

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -99,6 +99,8 @@ void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imag
                VkImageLayout layout);
 
 void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *pCB, VkImageView imageView, const VkImageLayout &layout);
+void SetImageViewLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, IMAGE_VIEW_STATE *view_state,
+                        const VkImageLayout &layout);
 
 bool VerifyFramebufferAndRenderPassLayouts(layer_data *dev_data, GLOBAL_CB_NODE *pCB, const VkRenderPassBeginInfo *pRenderPassBegin,
                                            const FRAMEBUFFER_STATE *framebuffer_state);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -260,6 +260,17 @@ GlobalQFOTransferBarrierMap<VkBufferMemoryBarrier> &GetGlobalQFOReleaseBarrierMa
     return dev_data->qfo_release_buffer_barrier_map;
 }
 
+// Get the image viewstate for a given framebuffer attachment
+IMAGE_VIEW_STATE *GetAttachmentImageViewState(layer_data *dev_data, FRAMEBUFFER_STATE *framebuffer, uint32_t index) {
+    assert(framebuffer && (index < framebuffer->createInfo.attachmentCount));
+#ifdef FRAMEBUFFER_ATTACHMENT_STATE_CACHE
+    return framebuffer->attachments[index].view_state;
+#else
+    const VkImageView &image_view = framebuffer->createInfo.pAttachments[index];
+    return GetImageViewState(dev_data, image_view);
+#endif
+}
+
 // Return IMAGE_VIEW_STATE ptr for specified imageView or else NULL
 IMAGE_VIEW_STATE *GetImageViewState(const layer_data *dev_data, VkImageView image_view) {
     auto iv_it = dev_data->imageViewMap.find(image_view);
@@ -6042,8 +6053,10 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(VkDevice device, const VkC
 static void AddFramebufferBinding(layer_data *dev_data, GLOBAL_CB_NODE *cb_state, FRAMEBUFFER_STATE *fb_state) {
     AddCommandBufferBinding(&fb_state->cb_bindings, {HandleToUint64(fb_state->framebuffer), kVulkanObjectTypeFramebuffer},
                             cb_state);
-    for (auto attachment : fb_state->attachments) {
-        auto view_state = attachment.view_state;
+
+    const uint32_t attachmentCount = fb_state->createInfo.attachmentCount;
+    for (uint32_t attachment = 0; attachment < attachmentCount; ++attachment) {
+        auto view_state = GetAttachmentImageViewState(dev_data, fb_state, attachment);
         if (view_state) {
             AddCommandBufferBindingImageView(dev_data, cb_state, view_state);
         }
@@ -7693,15 +7706,15 @@ static bool ValidateImageBarrierImage(layer_data *device_data, const char *funcN
     bool sub_image_found = false;  // Do we find a corresponding subpass description
     VkImageLayout sub_image_layout = VK_IMAGE_LAYOUT_UNDEFINED;
     uint32_t attach_index = 0;
-    uint32_t index_count = 0;
     // Verify that a framebuffer image matches barrier image
-    for (const auto &fb_attach : fb_state->attachments) {
-        if (img_bar_image == fb_attach.image) {
+    const auto attachmentCount = fb_state->createInfo.attachmentCount;
+    for (uint32_t attachment = 0; attachment < attachmentCount; ++attachment) {
+        auto view_state = GetAttachmentImageViewState(device_data, fb_state, attachment);
+        if (view_state && (img_bar_image == view_state->create_info.image)) {
             image_match = true;
-            attach_index = index_count;
+            attach_index = attachment;
             break;
         }
-        index_count++;
     }
     if (image_match) {  // Make sure subpass is referring to matching attachment
         if (sub_desc.pDepthStencilAttachment && sub_desc.pDepthStencilAttachment->attachment == attach_index) {
@@ -9155,10 +9168,12 @@ static void PostCallRecordCreateFramebuffer(layer_data *dev_data, const VkFrameb
         if (!view_state) {
             continue;
         }
+#ifdef FRAMEBUFFER_ATTACHMENT_STATE_CACHE
         MT_FB_ATTACHMENT_INFO fb_info;
         fb_info.view_state = view_state;
         fb_info.image = view_state->create_info.image;
         fb_state->attachments.push_back(fb_info);
+#endif
     }
     dev_data->frameBufferMap[fb] = std::move(fb_state);
 }
@@ -9890,7 +9905,9 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(VkCommandBuffer commandBuffer, con
     auto framebuffer = pRenderPassBegin ? GetFramebufferState(dev_data, pRenderPassBegin->framebuffer) : nullptr;
     if (cb_state) {
         skip |= PreCallValidateCmdBeginRenderPass(dev_data, render_pass_state, cb_state, framebuffer, pRenderPassBegin);
-        PreCallRecordCmdBeginRenderPass(dev_data, cb_state, framebuffer, render_pass_state, pRenderPassBegin, contents);
+        if (!skip) {
+            PreCallRecordCmdBeginRenderPass(dev_data, cb_state, framebuffer, render_pass_state, pRenderPassBegin, contents);
+        }
     }
     lock.unlock();
     if (!skip) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1036,7 +1036,12 @@ class FRAMEBUFFER_STATE : public BASE_NODE {
     VkFramebuffer framebuffer;
     safe_VkFramebufferCreateInfo createInfo;
     std::shared_ptr<RENDER_PASS_STATE> rp_state;
+#ifdef FRAMEBUFFER_ATTACHMENT_STATE_CACHE
+    // TODO Re-enable attachment state cache once staleness protection is implemented
+    //      For staleness protection destoryed images and image view must invalidate the cached data and tag the framebuffer object
+    //      as no longer valid
     std::vector<MT_FB_ATTACHMENT_INFO> attachments;
+#endif
     FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate)
         : framebuffer(fb), createInfo(pCreateInfo), rp_state(rpstate){};
 };
@@ -1061,6 +1066,7 @@ IMAGE_STATE *GetImageState(const layer_data *, VkImage);
 DEVICE_MEM_INFO *GetMemObjInfo(const layer_data *, VkDeviceMemory);
 BUFFER_VIEW_STATE *GetBufferViewState(const layer_data *, VkBufferView);
 SAMPLER_STATE *GetSamplerState(const layer_data *, VkSampler);
+IMAGE_VIEW_STATE *GetAttachmentImageViewState(layer_data *dev_data, FRAMEBUFFER_STATE *framebuffer, uint32_t index);
 IMAGE_VIEW_STATE *GetImageViewState(const layer_data *, VkImageView);
 SWAPCHAIN_NODE *GetSwapchainNode(const layer_data *, VkSwapchainKHR);
 GLOBAL_CB_NODE *GetCBNode(layer_data const *my_data, const VkCommandBuffer cb);


### PR DESCRIPTION
During BeginRenderpass, if a framebuffer contain references to (incorrectly) deleted image view objects, the stale handles could cause a variety of crashes.

Validation error reporting and crash prevention/robustness checks have been added, and a unit test created for the condition (thanks @karl-lunarg for the ULT)

Fixes #329 .