### PR TITLE
 Fix Android tests

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -124,7 +124,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
 LOCAL_LDLIBS := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -146,7 +146,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden -DVALIDATION_APK --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden -DVALIDATION_APK --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS := -llog -landroid
 LOCAL_LDFLAGS := -u ANativeActivity_onCreate

--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -4,7 +4,7 @@
       "name" : "shaderc",
       "url" : "https://github.com/google/shaderc.git",
       "sub_dir" : "shaderc",
-      "commit" : "9340ae565aceeb9ef8440fb38f8a98346df5a417"
+      "commit" : "38fbaeda7b34543042367547bc3cb025c9b84a9f"
     },
     {
       "name" : "glslang",

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -83,7 +83,8 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
     shaderc::SpvCompilationResult result =
         compiler.CompileGlslToSpv(pshader, strlen(pshader), MapShadercType(shader_type), "shader");
     if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
-        __android_log_print(ANDROID_LOG_ERROR, "VkLayerValidationTest", "GLSLtoSPV compilation failed");
+        __android_log_print(ANDROID_LOG_ERROR, "VkLayerValidationTest", "GLSLtoSPV compilation failed: %s",
+                            result.GetErrorMessage().c_str());
         return false;
     }
 


### PR DESCRIPTION
This sprinkles the extension defines around and adds some logging for the future.  Also updates shaderc revision to pull in upstream fixes.  Android tests get back to passing state.
