### PR TITLE
layers: Prevent layer calls with null dispatches.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2327,6 +2327,7 @@ static bool PreCallValidateCreateDevice(instance_layer_data *instance_data, cons
     return skip;
 }
 
+std::unordered_map<std::string, void *> &GetNameToFuncptrMap();
 static void PreCallRecordCreateDevice(VkLayerDeviceCreateInfo *chain_info) {
     chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
 }
@@ -2340,7 +2341,8 @@ static void PostCallRecordCreateDevice(instance_layer_data *instance_data, const
 
     device_data->instance_data = instance_data;
     // Setup device dispatch table
-    layer_init_device_dispatch_table(*pDevice, &device_data->dispatch_table, fpGetDeviceProcAddr);
+    auto &name_to_funcptr_map = GetNameToFuncptrMap();
+    layer_init_device_dispatch_table(*pDevice, &device_data->dispatch_table, fpGetDeviceProcAddr, &name_to_funcptr_map);
     device_data->device = *pDevice;
     // Save PhysicalDevice handle
     device_data->physical_device = gpu;
@@ -14228,7 +14230,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance in
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char *funcName);
 
 // Map of all APIs to be intercepted by this layer
-static const std::unordered_map<std::string, void *> name_to_funcptr_map = {
+static std::unordered_map<std::string, void *> name_to_funcptr_map = {
     {"vkGetInstanceProcAddr", (void *)GetInstanceProcAddr},
     {"vk_layerGetPhysicalDeviceProcAddr", (void *)GetPhysicalDeviceProcAddr},
     {"vkGetDeviceProcAddr", (void *)GetDeviceProcAddr},
@@ -14475,6 +14477,7 @@ static const std::unordered_map<std::string, void *> name_to_funcptr_map = {
     {"vkCmdDrawMeshTasksIndirectCountNV", (void *)CmdDrawMeshTasksIndirectCountNV},
     {"vkCreateRaytracingPipelinesNVX", (void *)CreateRaytracingPipelinesNVX},
 };
+std::unordered_map<std::string, void *> &GetNameToFuncptrMap() { return name_to_funcptr_map; }
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char *funcName) {
     assert(device);

--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -146,7 +146,7 @@ extern std::unordered_map<void *, layer_data *> layer_data_map;
 extern std::mutex global_lock;
 extern uint64_t object_track_index;
 extern uint32_t loader_layer_if_version;
-extern const std::unordered_map<std::string, void *> name_to_funcptr_map;
+extern std::unordered_map<std::string, void *> name_to_funcptr_map;
 
 void DeviceReportUndestroyedObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
 void DeviceDestroyUndestroyedObjects(VkDevice device, VulkanObjectType object_type);

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -843,7 +843,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
 
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
     device_data->report_data = layer_debug_utils_create_device(phy_dev_data->report_data, *pDevice);
-    layer_init_device_dispatch_table(*pDevice, &device_data->device_dispatch_table, fpGetDeviceProcAddr);
+    layer_init_device_dispatch_table(*pDevice, &device_data->device_dispatch_table, fpGetDeviceProcAddr, &name_to_funcptr_map);
 
     // Save pCreateInfo device extension list for GetDeviceProcAddr()
     for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {

--- a/layers/parameter_validation.h
+++ b/layers/parameter_validation.h
@@ -42,7 +42,7 @@
 namespace parameter_validation {
 
 extern const uint32_t GeneratedHeaderVersion;
-extern const std::unordered_map<std::string, void *> name_to_funcptr_map;
+extern std::unordered_map<std::string, void *> name_to_funcptr_map;
 
 extern const VkQueryPipelineStatisticFlags AllVkQueryPipelineStatisticFlagBits;
 extern const VkColorComponentFlags AllVkColorComponentFlagBits;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -625,7 +625,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, c
             assert(my_device_data != nullptr);
 
             my_device_data->report_data = layer_debug_utils_create_device(my_instance_data->report_data, *pDevice);
-            layer_init_device_dispatch_table(*pDevice, &my_device_data->dispatch_table, fpGetDeviceProcAddr);
+            layer_init_device_dispatch_table(*pDevice, &my_device_data->dispatch_table, fpGetDeviceProcAddr, &name_to_funcptr_map);
 
             my_device_data->api_version = api_version;
             my_device_data->extensions = extensions;

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -169,7 +169,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     // Setup device dispatch table
     my_device_data->device_dispatch_table = new VkLayerDispatchTable;
-    layer_init_device_dispatch_table(*pDevice, my_device_data->device_dispatch_table, fpGetDeviceProcAddr);
+    layer_init_device_dispatch_table(*pDevice, my_device_data->device_dispatch_table, fpGetDeviceProcAddr, &name_to_funcptr_map);
     // Save pCreateInfo device extension list for GetDeviceProcAddr()
     for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
         my_device_data->device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -214,7 +214,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     my_device_data->report_data = layer_debug_utils_create_device(my_instance_data->report_data, *pDevice);
 
     // Setup layer's device dispatch table
-    layer_init_device_dispatch_table(*pDevice, &my_device_data->dispatch_table, fpGetDeviceProcAddr);
+    layer_init_device_dispatch_table(*pDevice, &my_device_data->dispatch_table, fpGetDeviceProcAddr, &name_to_funcptr_map);
     // Save pCreateInfo device extension list for GetDeviceProcAddr()
     for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
         my_device_data->device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -447,7 +447,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
 
         # Record intercepted procedures
         write('// Map of all APIs to be intercepted by this layer', file=self.outFile)
-        write('const std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
+        write('std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
         write('\n'.join(self.intercepts), file=self.outFile)
         write('};\n', file=self.outFile)
         self.newline()

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -357,7 +357,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         write('// Declarations', file=self.outFile)
         write('\n'.join(self.declarations), file=self.outFile)
         write('// Map of all APIs to be intercepted by this layer', file=self.outFile)
-        write('const std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
+        write('std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
         write('\n'.join(self.intercepts), file=self.outFile)
         write('};\n', file=self.outFile)
         self.newline()

--- a/scripts/threading_generator.py
+++ b/scripts/threading_generator.py
@@ -274,7 +274,7 @@ class ThreadOutputGenerator(OutputGenerator):
         self.newline()
         # record intercepted procedures
         write('// Map of all APIs to be intercepted by this layer', file=self.outFile)
-        write('static const std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
+        write('static std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
         write('\n'.join(self.intercepts), file=self.outFile)
         write('};\n', file=self.outFile)
         self.newline()

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -250,7 +250,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
 
         # Record intercepted procedures
         write('// Map of all APIs to be intercepted by this layer', file=self.outFile)
-        write('static const std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
+        write('static std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)
         write('\n'.join(self.intercepts), file=self.outFile)
         write('};\n', file=self.outFile)
         self.newline()


### PR DESCRIPTION
Change GetDeviceProcAddr policy such that nullptr are returned for any
entry point which has a nullptr in the dispatch table.

Fixes #304