### PR TITLE
Add fuchsia to platform dictionary

### DIFF
--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -49,6 +49,7 @@ prefixStrings = [
 
 platform_dict = {
     'android' : 'VK_USE_PLATFORM_ANDROID_KHR',
+    'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
     'mir' : 'VK_USE_PLATFORM_MIR_KHR',


### PR DESCRIPTION
Vulkan header 1.1.87 requires the presence of the fuchsia platform in the platform dictionary for validation layers to build.