### PR TITLE
layers: Handle texel block size for image to buffer copies

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4383,7 +4383,7 @@ static inline bool ValidateBufferBounds(const debug_report_data *report_data, IM
             }
         }
 
-        if (FormatIsCompressed(image_state->createInfo.format)) {
+        if (FormatIsCompressed(image_state->createInfo.format) || FormatIsSinglePlane_422(image_state->createInfo.format)) {
             // Switch to texel block units, rounding up for any partially-used blocks
             auto block_dim = FormatCompressedTexelBlockExtent(image_state->createInfo.format);
             buffer_width = (buffer_width + block_dim.width - 1) / block_dim.width;


### PR DESCRIPTION
When checking buffer bounds in image to buffer copies, the required buffer size must
account for the texel block size for compressed or single plane "_422" image formats.

Change-Id: Id9de7debe9e66cba35e39762a67cfb7e3c35bc07