### PR TITLE
build: More CMake refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@
 # limitations under the License.
 # ~~~
 
+# CMake project initialization ---------------------------------------------------------------------------------------------------
+# This section contains pre-project() initialization, and ends with the project() command.
+
 cmake_minimum_required(VERSION 3.4)
 
 # Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
@@ -22,11 +25,14 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ve
 
 project(Vulkan-ValidationLayers)
 
-# The API_NAME allows renaming builds to avoid conflicts with installed SDKs. The MAJOR number of the version we're building, used
-# in naming <api-name>-<major>.dll (and other files).
+# User-interface declarations ----------------------------------------------------------------------------------------------------
+# This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
+# with the CACHE property.
+
+# API_NAME allows renaming builds to avoid conflicts with installed SDKs.  It is referenced by layers/vk_loader_platform.h
 set(API_NAME "Vulkan" CACHE STRING "API name to use when building")
-set(MAJOR "1")
 string(TOLOWER ${API_NAME} API_LOWERCASE)
+add_definitions(-DAPI_NAME="${API_NAME}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -63,7 +69,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # "Helper" targets that don't have interesting source code should set their FOLDER property to this
 set(LAYERS_HELPER_FOLDER "Helper Targets")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# Options for Linux only
+if(UNIX AND NOT APPLE) # i.e. Linux
     include(FindPkgConfig)
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
@@ -89,29 +96,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 endif()
 
+# Platform-specific compiler switches
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
-    set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
+    add_compile_options(-Wall
+                        -Wextra
+                        -Wno-unused-parameter
+                        -Wno-missing-field-initializers
+                        -fno-strict-aliasing
+                        -fno-builtin-memcmp
+                        -fvisibility=hidden)
+    set(CMAKE_C_STANDARD 99)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
     # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
     # all compilers until they all accept the C++17 standard.
     if(CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.1))
-        set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -Wimplicit-fallthrough=0")
+        add_compile_options(-Wimplicit-fallthrough=0)
     endif()
-
-    if(APPLE)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_COMPILE_FLAGS}")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 ${COMMON_COMPILE_FLAGS}")
-    endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_COMPILE_FLAGS} -std=c++11 -fno-rtti")
-    if(UNIX)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-    endif()
-endif()
-
-if(MSVC)
+elseif(MSVC)
     # Treat warnings as errors
     add_compile_options("/WX")
     # Disable RTTI
@@ -132,6 +135,7 @@ if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
 else()
     option(BUILD_TESTS "Build tests" OFF)
 endif()
+
 option(INSTALL_TESTS "Install tests" OFF)
 option(BUILD_LAYERS "Build layers" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Generate layer files" OFF) # For generating files when not building layers
@@ -141,7 +145,7 @@ if(NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR})
     message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
 endif()
 
-# Cmake command line option overrides environment variable
+# CMake command line option overrides environment variable
 if(NOT GLSLANG_INSTALL_DIR)
     set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
 endif()
@@ -251,10 +255,12 @@ else()
         ${SPIRV_TOOLS_LIBRARIES})
 endif()
 
-# Generate dependent helper files
+# Generate dependent helper files ------------------------------------------------------------------------------------------------
+
 set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/scripts")
-# Define macro used for building vkxml generated files
-macro(run_vk_xml_generate dependency output)
+
+# Generate a source file from vk.xml
+macro(GenerateFromVkXml dependency output)
     add_custom_command(OUTPUT ${output}
                        COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts
                                ${VulkanRegistry_DIR} ${output}
@@ -264,6 +270,18 @@ macro(run_vk_xml_generate dependency output)
                                ${SCRIPTS_DIR}/lvl_genvk.py
                                ${VulkanRegistry_DIR}/reg.py)
 endmacro()
+
+# Add rules to generate XML-derived source files.
+GenerateFromVkXml(loader_extension_generator.py vk_layer_dispatch_table.h)
+GenerateFromVkXml(dispatch_table_helper_generator.py vk_dispatch_table_helper.h)
+GenerateFromVkXml(helper_file_generator.py vk_safe_struct.h)
+GenerateFromVkXml(helper_file_generator.py vk_safe_struct.cpp)
+GenerateFromVkXml(helper_file_generator.py vk_enum_string_helper.h)
+GenerateFromVkXml(helper_file_generator.py vk_object_types.h)
+GenerateFromVkXml(helper_file_generator.py vk_extension_helper.h)
+GenerateFromVkXml(helper_file_generator.py vk_typemap_helper.h)
+
+# This target causes the source files to be generated.
 add_custom_target(generate_helper_files
                   DEPENDS vk_enum_string_helper.h
                           vk_safe_struct.h
@@ -274,32 +292,20 @@ add_custom_target(generate_helper_files
                           vk_extension_helper.h
                           vk_typemap_helper.h)
 set_target_properties(generate_helper_files PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-# Rules to build generated helper files
-run_vk_xml_generate(loader_extension_generator.py vk_layer_dispatch_table.h)
-run_vk_xml_generate(dispatch_table_helper_generator.py vk_dispatch_table_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_safe_struct.h)
-run_vk_xml_generate(helper_file_generator.py vk_safe_struct.cpp)
-run_vk_xml_generate(helper_file_generator.py vk_enum_string_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_object_types.h)
-run_vk_xml_generate(helper_file_generator.py vk_extension_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_typemap_helper.h)
 
-# ~~~
-# Layer Utils Library.
-# For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search
-# path that can't be easily modified to point it to the same directory that contains the layers.
-# TODO: This should not be a library -- in future, include files directly in layers.
-# ~~~
-set(VALIDATION_LAYER_UTILS_SOURCES
-    layers/vk_layer_config.cpp
-    layers/vk_layer_extension_utils.cpp
-    layers/vk_layer_utils.cpp
-    layers/vk_format_utils.cpp)
+# VkLayer_utils library ----------------------------------------------------------------------------------------------------------
+# For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search path that can't be easily
+# modified to point it to the same directory that contains the layers. TODO: This should not be a library -- in future, include
+# files directly in layers.
+
+add_library(VkLayer_utils
+            STATIC
+            layers/vk_layer_config.cpp
+            layers/vk_layer_extension_utils.cpp
+            layers/vk_layer_utils.cpp
+            layers/vk_format_utils.cpp)
 if(WIN32)
-    add_library(VkLayer_utils STATIC ${VALIDATION_LAYER_UTILS_SOURCES})
     target_compile_definitions(VkLayer_utils PUBLIC _CRT_SECURE_NO_WARNINGS)
-else()
-    add_library(VkLayer_utils STATIC ${VALIDATION_LAYER_UTILS_SOURCES})
 endif()
 install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 set_target_properties(VkLayer_utils PROPERTIES LINKER_LANGUAGE CXX)
@@ -310,7 +316,7 @@ target_include_directories(VkLayer_utils
                                   ${CMAKE_CURRENT_BINARY_DIR}/layers
                                   ${PROJECT_BINARY_DIR})
 
-# uninstall target
+# uninstall target ---------------------------------------------------------------------------------------------------------------
 if(NOT TARGET uninstall)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
                    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
@@ -320,9 +326,7 @@ if(NOT TARGET uninstall)
     set_target_properties(uninstall PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
 endif()
 
-add_definitions(-DAPI_NAME="${API_NAME}")
-
-# Fetch header version from vulkan_core.h
+# Fetch header version from vulkan_core.h ----------------------------------------------------------------------------------------
 file(STRINGS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
 list(LENGTH lines len)
 if(${len} EQUAL 1)
@@ -333,6 +337,8 @@ if(${len} EQUAL 1)
 else()
     message(FATAL_ERROR "Unable to fetch version from vulkan_core.h")
 endif()
+
+# Add subprojects ----------------------------------------------------------------------------------------------------------------
 
 add_subdirectory(external)
 if(BUILD_TESTS)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,8 +21,10 @@
 if(BUILD_TESTS)
     # Attempt to enable googletest if available.
 
-    # Suppress all warnings from external projects.
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
+    # Suppress all warnings from external projects (i.e.: in this directory's scope).
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-w")
+    endif()
 
     if(TARGET gtest_main)
         # Already enabled as a target (perhaps by a project enclosing this one)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -15,16 +15,20 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 2.8.11)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
     add_custom_target(mk_layer_config_dir ALL
                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
     set_target_properties(mk_layer_config_dir PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR -DVK_USE_PLATFORM_ANDROID_KHX)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(APPLE)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+    if(CMAKE_GENERATOR MATCHES "^Xcode.*")
+        add_custom_target(mk_layer_config_dir ALL
+                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+    endif()
+elseif(UNIX AND NOT APPLE) # i.e. Linux
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XCB_KHX)
     endif()
@@ -41,31 +45,20 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_definitions(-DVK_USE_PLATFORM_MIR_KHR -DVK_USE_PLATFORM_MIR_KHX)
         include_directories(${MIR_INCLUDE_DIR})
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
-    if(CMAKE_GENERATOR MATCHES "^Xcode.*")
-        add_custom_target(mk_layer_config_dir ALL
-                          COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
-    endif()
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
 
-# Define macro used for generating header files containing commit IDs for external dependencies
-macro(run_external_revision_generate symbol_name output)
-    add_custom_command(OUTPUT ${output}
-                       COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/external_revision_generator.py
-                               --from_uuid -s ${symbol_name} -o ${output}
-                       DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py)
-endmacro()
-
 # Custom targets for generated validation layer helper file dependencies
 add_custom_target(spirv_tools_revision_file DEPENDS spirv_tools_commit_id.h)
-
 set_target_properties(spirv_tools_revision_file PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
 
 if(BUILD_LAYERS)
-    run_external_revision_generate(SPIRV_TOOLS_COMMIT_ID spirv_tools_commit_id.h)
+    # generate header file containing commit IDs of external dependencies
+    add_custom_command(OUTPUT spirv_tools_commit_id.h
+                       COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/external_revision_generator.py
+                               --from_uuid -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h
+                       DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py)
 endif()
 
 # Configure installation of source files that are dependencies of other repos.
@@ -121,23 +114,24 @@ elseif(UNIX) # UNIX includes APPLE
     endforeach()
 endif()
 
+# System-specific macros to create a library target.
 if(WIN32)
-    macro(add_vk_layer target)
+    macro(AddVkLayer target)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_${target}.def DEF_FILE)
         add_custom_target(copy-${target}-def-file ALL
                           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkLayer_${target}.def
                           VERBATIM)
         set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+
         add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
-        add_dependencies(VkLayer_${target} generate_helper_files)
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
         install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endmacro()
 elseif(APPLE)
-    macro(add_vk_layer target)
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
         set_target_properties(VkLayer_${target}
                               PROPERTIES LINK_FLAGS
@@ -146,10 +140,10 @@ elseif(APPLE)
                                          "@loader_path/")
         install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     endmacro()
-else()
-    macro(add_vk_layer target)
+else(UNIX AND NOT APPLE) # i.e.: Linux
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic,--exclude-libs,ALL")
         install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -162,7 +156,13 @@ if(WIN32)
     # Applies to all configurations
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
-    set_source_files_properties(core_validation.cpp threading.cpp parameter_validation_utils.cpp unique_objects.cpp PROPERTIES COMPILE_FLAGS "/bigobj")
+    set_source_files_properties(core_validation.cpp
+                                threading.cpp
+                                parameter_validation_utils.cpp
+                                unique_objects.cpp
+                                PROPERTIES
+                                COMPILE_FLAGS
+                                "/bigobj")
     # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is
     # that constructor initializers are now fixed to clear the struct members.
     add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
@@ -176,27 +176,27 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set_source_files_properties(parameter_validation.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-const-variable")
 endif()
 
-run_vk_xml_generate(threading_generator.py thread_check.h)
-run_vk_xml_generate(parameter_validation_generator.py parameter_validation.cpp)
-run_vk_xml_generate(unique_objects_generator.py unique_objects_wrappers.h)
-run_vk_xml_generate(dispatch_table_helper_generator.py vk_dispatch_table_helper.h)
-run_vk_xml_generate(object_tracker_generator.py object_tracker.cpp)
+GenerateFromVkXml(threading_generator.py thread_check.h)
+GenerateFromVkXml(parameter_validation_generator.py parameter_validation.cpp)
+GenerateFromVkXml(unique_objects_generator.py unique_objects_wrappers.h)
+GenerateFromVkXml(dispatch_table_helper_generator.py vk_dispatch_table_helper.h)
+GenerateFromVkXml(object_tracker_generator.py object_tracker.cpp)
 
 if(BUILD_LAYERS)
-    add_vk_layer(core_validation core_validation.cpp descriptor_sets.cpp buffer_validation.cpp shader_validation.cpp xxhash.c)
-    add_vk_layer(object_tracker object_tracker.cpp object_tracker_utils.cpp)
-    add_vk_layer(threading threading.cpp thread_check.h)
-    add_vk_layer(unique_objects unique_objects.cpp unique_objects_wrappers.h)
-    add_vk_layer(parameter_validation
-                 parameter_validation.cpp
-                 parameter_validation_utils.cpp
-                 parameter_validation.h
-                 vk_validation_error_messages.h)
+    AddVkLayer(core_validation core_validation.cpp descriptor_sets.cpp buffer_validation.cpp shader_validation.cpp xxhash.c)
+    AddVkLayer(object_tracker object_tracker.cpp object_tracker_utils.cpp)
+    AddVkLayer(threading threading.cpp thread_check.h)
+    AddVkLayer(unique_objects unique_objects.cpp unique_objects_wrappers.h)
+    AddVkLayer(parameter_validation
+               parameter_validation.cpp
+               parameter_validation_utils.cpp
+               parameter_validation.h
+               vk_validation_error_messages.h)
 
     # Core validation has additional dependencies
     target_include_directories(VkLayer_core_validation PRIVATE ${GLSLANG_SPIRV_INCLUDE_DIR})
     target_include_directories(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
-    target_link_libraries(VkLayer_core_validation ${SPIRV_TOOLS_LIBRARIES})
+    target_link_libraries(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
     add_dependencies(VkLayer_core_validation spirv_tools_revision_file)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,13 +20,15 @@ set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
 # Needed to make structure definitions match with glslang libraries
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(APPLE)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+elseif(UNIX AND NOT APPLE) # i.e. Linux
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
@@ -43,8 +45,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
         include_directories(${MIR_INCLUDE_DIR})
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
@@ -104,7 +104,12 @@ set(
     )
 find_package(Vulkan)
 
-add_executable(vk_layer_validation_tests layer_validation_tests.cpp ../layers/vk_format_utils.cpp ${COMMON_CPP})
+set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
+add_executable(vk_layer_validation_tests
+               layer_validation_tests.cpp
+               ../layers/vk_format_utils.cpp
+               ${PROJECT_BINARY_DIR}/vk_safe_struct.cpp
+               ${COMMON_CPP})
 set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 target_include_directories(vk_layer_validation_tests
                            PUBLIC ${VulkanHeaders_INCLUDE_DIR}
@@ -126,22 +131,30 @@ add_dependencies(vk_layer_validation_tests
                  VkLayer_threading-json
                  VkLayer_unique_objects-json)
 
-if(NOT WIN32)
-    set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+# Specify target_link_libraries
+if(WIN32)
+    target_link_libraries(vk_layer_validation_tests
+                          PRIVATE Vulkan::Vulkan
+                                  gtest
+                                  gtest_main
+                                  ${GLSLANG_LIBRARIES})
+else()
+    target_compile_options(vk_layer_validation_tests PRIVATE "-Wno-sign-compare")
     if(BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
         target_link_libraries(vk_layer_validation_tests
-                              Vulkan::Vulkan
-                              ${XCB_LIBRARIES}
-                              ${X11_LIBRARIES}
-                              gtest
-                              gtest_main
-                              ${GLSLANG_LIBRARIES})
+                              PRIVATE Vulkan::Vulkan
+                                      ${XCB_LIBRARIES}
+                                      ${X11_LIBRARIES}
+                                      gtest
+                                      gtest_main
+                                      ${GLSLANG_LIBRARIES})
     else()
-        target_link_libraries(vk_layer_validation_tests Vulkan::Vulkan gtest gtest_main ${GLSLANG_LIBRARIES})
+        target_link_libraries(vk_layer_validation_tests
+                              PRIVATE Vulkan::Vulkan
+                                      gtest
+                                      gtest_main
+                                      ${GLSLANG_LIBRARIES})
     endif()
-endif()
-if(WIN32)
-    target_link_libraries(vk_layer_validation_tests Vulkan::Vulkan gtest gtest_main ${GLSLANG_LIBRARIES})
 endif()
 
 if(WIN32)

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -15,24 +15,22 @@
 # limitations under the License.
 # ~~~
 
-set(LAYER_JSON_FILES VkLayer_device_profile_api)
+set(TEST_LAYER_NAME VkLayer_device_profile_api)
 
 set(VK_LAYER_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
 set(CMAKE_INSTALL_RPATH ${VK_LAYER_RPATH})
 
 if(WIN32)
     if(NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        foreach(config_file ${LAYER_JSON_FILES})
-            file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${config_file}.json src_json)
-            if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-                file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${config_file}.json dst_json)
-            else()
-                file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${config_file}.json dst_json)
-            endif()
-            add_custom_target(${config_file}-json ALL COMMAND copy ${src_json} ${dst_json} VERBATIM)
-            add_dependencies(${config_file}-json ${config_file})
-            set_target_properties(${config_file}-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-        endforeach(config_file)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${TEST_LAYER_NAME}.json src_json)
+        if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TEST_LAYER_NAME}.json dst_json)
+        else()
+            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${TEST_LAYER_NAME}.json dst_json)
+        endif()
+        add_custom_target(${TEST_LAYER_NAME}-json ALL COMMAND copy ${src_json} ${dst_json} VERBATIM)
+        add_dependencies(${TEST_LAYER_NAME}-json ${TEST_LAYER_NAME})
+        set_target_properties(${TEST_LAYER_NAME}-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
     endif()
 elseif(APPLE)
     # extra setup for out-of-tree builds
@@ -40,103 +38,98 @@ elseif(APPLE)
         if(CMAKE_GENERATOR MATCHES "^Xcode.*")
             add_custom_target(mk_test_layer_config_dir ALL
                               COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
-            foreach(config_file ${LAYER_JSON_FILES})
-                add_custom_target(${config_file}-json ALL
-                                  DEPENDS mk_test_layer_config_dir
-                                  COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/macos/${config_file}.json $<CONFIG>
-                                  VERBATIM)
-            endforeach(config_file)
+            add_custom_target(${TEST_LAYER_NAME}-json ALL
+                              DEPENDS mk_test_layer_config_dir
+                              COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/macos/${TEST_LAYER_NAME}.json $<CONFIG>
+                              VERBATIM)
         else()
-            foreach(config_file ${LAYER_JSON_FILES})
-                add_custom_target(${config_file}-json ALL
-                                  COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/macos/${config_file}.json
-                                  VERBATIM)
-            endforeach(config_file)
+            add_custom_target(${TEST_LAYER_NAME}-json ALL
+                              COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/macos/${TEST_LAYER_NAME}.json
+                              VERBATIM)
         endif()
     endif()
 else()
     # extra setup for out-of-tree builds
     if(NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        foreach(config_file ${LAYER_JSON_FILES})
-            add_custom_target(${config_file}-json ALL COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/linux/${config_file}.json VERBATIM)
-        endforeach(config_file)
+        add_custom_target(${TEST_LAYER_NAME}-json ALL
+                          COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/linux/${TEST_LAYER_NAME}.json
+                          VERBATIM)
     endif()
 endif()
 
+# --------------------------------------------------------------------------------------------------------------------------------
+
+# System-specific macros to create a library target.
 if(WIN32)
-    macro(add_test_layer target)
+    macro(AddVkLayer target)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_${target}.def DEF_FILE)
         add_custom_target(copy-${target}-def-file ALL
                           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkLayer_${target}.def
                           VERBATIM)
         set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+
         add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
+        target_compile_definitions(VkLayer_${target} PRIVATE "_CRT_SECURE_NO_WARNINGS")
+        target_compile_options(VkLayer_${target} PRIVATE $<$<CONFIG:Debug>:/bigobj>)
     endmacro()
 elseif(APPLE)
-    macro(add_test_layer target)
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl")
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
+        target_compile_options(VkLayer_${target} PRIVATE "-Wpointer-arith" "-Wno-unused-function")
     endmacro()
-else()
-    macro(add_test_layer target)
+else(UNIX AND NOT APPLE) # i.e.: Linux
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
         add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
-        target_link_libraries(VkLayer_${target} VkLayer_utils)
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
+        target_compile_options(VkLayer_${target} PRIVATE "-Wpointer-arith" "-Wno-unused-function")
     endmacro()
 endif()
 
-include_directories(${VulkanHeaders_INCLUDE_DIR} # TODO: Clear out this list
-                    ${CMAKE_CURRENT_SOURCE_DIR}
-                    ${PROJECT_SOURCE_DIR}/layers
-                    ${CMAKE_CURRENT_BINARY_DIR}
-                    ${PROJECT_BINARY_DIR}
-                    ${PROJECT_BINARY_DIR}/layers
-                    ${CMAKE_BINARY_DIR})
+AddVkLayer(device_profile_api device_profile_api.cpp ${PROJECT_SOURCE_DIR}/layers/vk_layer_extension_utils.cpp)
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_CRT_SECURE_NO_WARNINGS")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -D_CRT_SECURE_NO_WARNINGS")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wno-unused-function")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function")
-endif()
+# --------------------------------------------------------------------------------------------------------------------------------
 
-set(DEVICE_PROFILE_API_SRCS device_profile_api.cpp ${PROJECT_SOURCE_DIR}/layers/vk_layer_extension_utils.cpp)
-
-add_test_layer(device_profile_api ${DEVICE_PROFILE_API_SRCS})
+# TODO: Clear out this list
+target_include_directories(${TEST_LAYER_NAME}
+                           PRIVATE ${VulkanHeaders_INCLUDE_DIR}
+                                   ${CMAKE_CURRENT_SOURCE_DIR}
+                                   ${PROJECT_SOURCE_DIR}/layers
+                                   ${CMAKE_CURRENT_BINARY_DIR}
+                                   ${PROJECT_BINARY_DIR}
+                                   ${PROJECT_BINARY_DIR}/layers
+                                   ${CMAKE_BINARY_DIR})
 
 if(WIN32)
     # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
     file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/*device_profile_api.* SRC_LAYER)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/VkLayer_device_profile_api.json SRC_JSON)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${TEST_LAYER_NAME}.json SRC_JSON)
     file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/layers/$<CONFIG> DST_LAYER)
-    add_custom_command(TARGET VkLayer_device_profile_api POST_BUILD
+    add_custom_command(TARGET ${TEST_LAYER_NAME} POST_BUILD
                        COMMAND xcopy /Y /I ${SRC_LAYER} ${DST_LAYER}
                        COMMAND xcopy /Y /I ${SRC_JSON} ${DST_LAYER})
 elseif(APPLE)
     if(CMAKE_GENERATOR MATCHES "^Xcode.*")
-        add_custom_command(TARGET VkLayer_device_profile_api POST_BUILD
-                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/VkLayer_device_profile_api.json
-                                   ${CMAKE_BINARY_DIR}/layers/$<CONFIG>
-                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/libVkLayer_device_profile_api.dylib
+        add_custom_command(TARGET ${TEST_LAYER_NAME} POST_BUILD
+                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/${TEST_LAYER_NAME}.json ${CMAKE_BINARY_DIR}/layers/$<CONFIG>
+                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/lib${TEST_LAYER_NAME}.dylib
                                    ${CMAKE_BINARY_DIR}/layers/$<CONFIG>
                            VERBATIM)
     else()
-        add_custom_command(TARGET VkLayer_device_profile_api POST_BUILD
-                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/VkLayer_device_profile_api.json ${CMAKE_BINARY_DIR}/layers
-                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/libVkLayer_device_profile_api.dylib ${CMAKE_BINARY_DIR}/layers
+        add_custom_command(TARGET ${TEST_LAYER_NAME} POST_BUILD
+                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/${TEST_LAYER_NAME}.json ${CMAKE_BINARY_DIR}/layers
+                           COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/lib${TEST_LAYER_NAME}.dylib ${CMAKE_BINARY_DIR}/layers
                            VERBATIM)
     endif()
-else()
-    add_custom_command(TARGET VkLayer_device_profile_api POST_BUILD
-                       COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/VkLayer_device_profile_api.json ${PROJECT_BINARY_DIR}/layers
-                       COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/libVkLayer_device_profile_api.so ${PROJECT_BINARY_DIR}/layers
+else(UNIX AND NOT APPLE) # i.e.: Linux
+    add_custom_command(TARGET ${TEST_LAYER_NAME} POST_BUILD
+                       COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/${TEST_LAYER_NAME}.json ${PROJECT_BINARY_DIR}/layers
+                       COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/lib${TEST_LAYER_NAME}.so ${PROJECT_BINARY_DIR}/layers
                        VERBATIM)
 endif()


### PR DESCRIPTION
This is another PR cleaning up CMake files.  It includes: using modern CMake idioms, removing dead code/variables, simplifying conditions, and some cosmetic/whitespace changes.

This PR, in its current form of many separate commits, meant to make it easier to review.  It will be squashed to a single commit before pushing into master.

The last commit of the series runs the cmake_format tool, so don't worry about ugly code in intermediate commits.

This PR passes LunarG internal CI.