### PR TITLE
layers: Kill false thread errors re: command pool

### DIFF
--- a/scripts/threading_generator.py
+++ b/scripts/threading_generator.py
@@ -376,6 +376,8 @@ class ThreadOutputGenerator(OutputGenerator):
             'vkDestroyInstance',
             'vkAllocateCommandBuffers',
             'vkFreeCommandBuffers',
+            'vkResetCommandPool',
+            'vkDestroyCommandPool',
             'vkCreateDebugReportCallbackEXT',
             'vkDestroyDebugReportCallbackEXT',
             'vkAllocateDescriptorSets',


### PR DESCRIPTION
Change the transitivity of usage counters such that only externally
synchronized command buffers mark their command pool as being an active
writer.

Added additional tracking for non-externally sync'd command buffers
s.t. command pool reset and destroy operations detect usage races.

Fixes #376 