### PR TITLE
Fix positive error: push descriptor not set

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1214,6 +1214,14 @@ static bool ValidateCmdBufDrawState(layer_data *dev_data, GLOBAL_CB_NODE *cb_nod
 
     for (const auto &set_binding_pair : pPipe->active_slots) {
         uint32_t setIndex = set_binding_pair.first;
+
+        // TODO -- remove this continue path when CmdPushDescriptorSet is implemented, for now it prevents a false positive
+        if ((setIndex < pipeline_layout.set_layouts.size()) && pipeline_layout.set_layouts[setIndex] &&
+            pipeline_layout.set_layouts[setIndex]->IsPushDescriptor()) {
+            // Push descriptors currently don't
+            continue;
+        }
+
         // If valid set is not bound throw an error
         if ((state.boundDescriptorSets.size() <= setIndex) || (!state.boundDescriptorSets[setIndex])) {
             result |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,


### PR DESCRIPTION
Prevent false positive regarding push descriptors that have been set,
not being set.

This fix avoids the false positive but adds no additional push
descriptor validation. 

Fixes #341 -- tested against the given CTS testcase.