### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -168,7 +168,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
     # Determine if this API should be ignored or added to the instance or device dispatch table
     def AddCommandToDispatchList(self, name, handle_type, protect, cmdinfo):
         handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
-        if handle == None:
+        if handle is None:
             return
         if handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice' and name != 'vkGetInstanceProcAddr':
             self.device_dispatch_list.append((name, self.featureExtraProtect))

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -192,7 +192,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         if self.helper_file_type == 'enum_string_header':
             value_set = set()
             for elem in groupElem.findall('enum'):
-                if elem.get('supported') != 'disabled' and elem.get('alias') == None:
+                if elem.get('supported') != 'disabled' and elem.get('alias') is None:
                     value_set.add(elem.get('name'))
             self.enum_output += self.GenerateEnumStringConversion(groupName, value_set)
         elif self.helper_file_type == 'object_types_header':
@@ -428,7 +428,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         for item in self.structMembers:
             if self.NeedSafeStruct(item) == True:
                 safe_struct_header += '\n'
-                if item.ifdef_protect != None:
+                if item.ifdef_protect is not None:
                     safe_struct_header += '#ifdef %s\n' % item.ifdef_protect
                 safe_struct_header += 'struct safe_%s {\n' % (item.name)
                 for member in item.members:
@@ -454,7 +454,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 safe_struct_header += '    %s *ptr() { return reinterpret_cast<%s *>(this); }\n' % (item.name, item.name)
                 safe_struct_header += '    %s const *ptr() const { return reinterpret_cast<%s const *>(this); }\n' % (item.name, item.name)
                 safe_struct_header += '};\n'
-                if item.ifdef_protect != None:
+                if item.ifdef_protect is not None:
                     safe_struct_header += '#endif // %s\n' % item.ifdef_protect
         return safe_struct_header
     #
@@ -805,7 +805,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 continue
             if item.name in wsi_structs:
                 continue
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 safe_struct_body.append("#ifdef %s\n" % item.ifdef_protect)
             ss_name = "safe_%s" % item.name
             init_list = ''          # list of members in struct constructor initializer
@@ -1116,7 +1116,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             init_copy = copy_construct_init.replace('src.', 'src->')
             init_construct = copy_construct_txt.replace('src.', 'src->')
             safe_struct_body.append("\nvoid %s::initialize(const %s* src)\n{\n%s%s}" % (ss_name, ss_name, init_copy, init_construct))
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 safe_struct_body.append("#endif // %s\n" % item.ifdef_protect)
         return "\n".join(safe_struct_body)
     #
@@ -1208,7 +1208,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             if not info:
                 continue
 
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 code.append('#ifdef %s' % item.ifdef_protect)
 
             code.append('// Map type {} to id {}'.format(typename, info.value))
@@ -1216,7 +1216,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 id_decl=id_decl, id_member=id_member))
             code.append(idmap_format.format(template=idmap, typename=typename, id_value=info.value, typedef=type_member))
 
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 code.append('#endif // %s' % item.ifdef_protect)
 
         # Generate utilities for all types

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -298,7 +298,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
 
         return_type =  cmdinfo.elem.find('proto/type')
-        if (return_type != None and return_type.text == 'void'):
+        if (return_type is not None and return_type.text == 'void'):
            return_type = None
 
         cmd_params = []
@@ -320,7 +320,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
             cmd_params.append(self.CommandParam(type=param_type, name=param_name,
                                                 cdecl=param_cdecl))
 
-        if handle != None and handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice':
+        if handle is not None and handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice':
             # The Core Vulkan code will be wrapped in a feature called VK_VERSION_#_#
             # For example: VK_VERSION_1_0 wraps the core 1.0 Vulkan functionality
             if 'VK_VERSION_' in extension_name:
@@ -691,13 +691,13 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 if cur_cmd.name in PRE_INSTANCE_FUNCTIONS:
                     mod_string = mod_string.replace(cur_cmd.name[2:] + '(\n', cur_cmd.name[2:] + '(\n    const Vk' + cur_cmd.name[2:] + 'Chain* chain,\n')
 
-                if (cur_cmd.protect != None):
+                if (cur_cmd.protect is not None):
                     terminators += '#ifdef %s\n' % cur_cmd.protect
 
                 terminators += mod_string
                 terminators += '\n'
 
-                if (cur_cmd.protect != None):
+                if (cur_cmd.protect is not None):
                     terminators += '#endif // %s\n' % cur_cmd.protect
 
         terminators += '\n'
@@ -950,7 +950,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     physdev_type_to_replace = 'VkPhysicalDevice'
                     physdev_name_replacement = 'phys_dev_term->phys_dev'
 
-            if (ext_cmd.return_type != None):
+            if (ext_cmd.return_type is not None):
                 return_prefix += 'return '
                 has_return_type = True
 

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -32,7 +32,7 @@ def endTimer(timeit, msg):
 
 # Turn a list of strings into a regexp string matching exactly those strings
 def makeREstring(list, default = None):
-    if len(list) > 0 or default == None:
+    if len(list) > 0 or default is None:
         return '^(' + '|'.join(list) + ')$'
     else:
         return default

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -435,12 +435,12 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         # Actually write the interface to the output file.
         if (self.emit):
             self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             # Write the object_tracker code to the file
             if (self.sections['command']):
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('\n#endif //', self.featureExtraProtect, file=self.outFile)
             else:
                 self.newline()
@@ -464,10 +464,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
 
         if self.featureName != 'VK_VERSION_1_0' and self.featureName != 'VK_VERSION_1_1':
             white_list_entry = []
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#ifdef %s' % self.featureExtraProtect ]
             white_list_entry += [ '"%s"' % self.featureName ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#endif' ]
             featureType = interface.get('type')
             if featureType == 'instance':
@@ -952,7 +952,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             if not api_decls and not api_pre and not api_post:
                 continue
             feature_extra_protect = cmddata.extra_protect
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '')
                 self.appendSection('command', '#ifdef '+ feature_extra_protect)
                 self.intercepts += [ '#ifdef %s' % feature_extra_protect ]
@@ -965,9 +965,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             self.appendSection('command', '    bool skip = false;')
             # Handle return values, if any
             resulttype = cmdinfo.elem.find('proto/type')
-            if (resulttype != None and resulttype.text == 'void'):
+            if (resulttype is not None and resulttype.text == 'void'):
               resulttype = None
-            if (resulttype != None):
+            if (resulttype is not None):
                 assignresult = resulttype.text + ' result = '
             else:
                 assignresult = ''
@@ -1004,9 +1004,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             # And add the post-API-call codegen
             self.appendSection('command', "\n".join(str(api_post).rstrip().split("\n")))
             # Handle the return result variable, if any
-            if (resulttype != None):
+            if (resulttype is not None):
                 self.appendSection('command', '    return result;')
             self.appendSection('command', '}')
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '#endif // '+ feature_extra_protect)
                 self.intercepts += [ '#endif' ]

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -417,7 +417,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             # If type declarations are needed by other features based on this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
             ifdef = ''
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 ifdef = '#ifdef %s\n' % self.featureExtraProtect
                 self.validation.append(ifdef)
             # Generate the struct member checking code from the captured data
@@ -439,7 +439,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                     decl += ';'
                     write(decl, file=self.outFile)
             endif = '\n'
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 endif = '#endif // %s\n' % self.featureExtraProtect
             self.validation.append(endif)
         # Finish processing in superclass
@@ -448,7 +448,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
     # Type generation
     def genType(self, typeinfo, name, alias):
         # record the name/alias pair
-        if alias != None:
+        if alias is not None:
             self.alias_dict[name]=alias
         OutputGenerator.genType(self, typeinfo, name, alias)
         typeElem = typeinfo.elem
@@ -549,7 +549,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
     # These are concatenated together with other types.
     def genGroup(self, groupinfo, groupName, alias):
         # record the name/alias pair
-        if alias != None:
+        if alias is not None:
             self.alias_dict[groupName]=alias
         OutputGenerator.genGroup(self, groupinfo, groupName, alias)
         groupElem = groupinfo.elem
@@ -589,14 +589,14 @@ class ParameterValidationOutputGenerator(OutputGenerator):
     # Capture command parameter info to be used for param check code generation.
     def genCmd(self, cmdinfo, name, alias):
         # record the name/alias pair
-        if alias != None:
+        if alias is not None:
             self.alias_dict[name]=alias
         OutputGenerator.genCmd(self, cmdinfo, name, alias)
         decls = self.makeCDecls(cmdinfo.elem)
         typedef = decls[1]
         typedef = typedef.split(')',1)[1]
         if name not in self.blacklist:
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.declarations += [ '#ifdef %s' % self.featureExtraProtect ]
                 self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
                 if (name not in self.validate_only):
@@ -608,7 +608,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             self.intercepts += [ '    {"%s", (void*)%s},' % (name,name) ]
             # Strip off 'vk' from API name
             self.declarations += [ '%s' % decls[0].replace("VKAPI_CALL vk", "VKAPI_CALL ") ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.intercepts += [ '#endif' ]
                 self.declarations += [ '#endif' ]
                 if (name not in self.validate_only):
@@ -647,7 +647,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             # Save return value information, if any
             result_type = ''
             resultinfo = cmdinfo.elem.find('proto/type')
-            if (resultinfo != None and resultinfo.text != 'void'):
+            if (resultinfo is not None and resultinfo.text != 'void'):
                 result_type = resultinfo.text
             self.commands.append(self.CommandData(name=name, params=paramsInfo, cdecl=self.makeCDecls(cmdinfo.elem)[0], extension_type=self.extension_type, result=result_type))
     #

--- a/scripts/parse_test_results.py
+++ b/scripts/parse_test_results.py
@@ -109,18 +109,18 @@ class OutputStats(object):
         return did_fail
 
     def new_profile_match(self, line):
-        if re.search(r'Testing with profile .*/(.*)', line) != None:
+        if re.search(r'Testing with profile .*/(.*)', line) is not None:
             self.current_profile = re.search(r'Testing with profile .*/(.*)', line).group(1)
 
     def test_suite_end_match(self, line):
-        if re.search(r'\[-*\]', line) != None:
+        if re.search(r'\[-*\]', line) is not None:
             if self.current_test != "":
                 # Here we see a message that starts [----------] before another test
                 # finished running. This should mean that that other test died.
                 self.test_died()
 
     def start_test_match(self, line):
-        if re.search(r'\[ RUN\s*\]', line) != None:
+        if re.search(r'\[ RUN\s*\]', line) is not None:
             # This parser doesn't handle the case where one test's start comes between another
             # test's start and result.
             assert self.current_test == ""
@@ -128,23 +128,23 @@ class OutputStats(object):
             self.current_test_output = ""
 
     def skip_test_match(self, line):
-        if re.search(r'TEST SKIPPED', line) != None:
+        if re.search(r'TEST SKIPPED', line) is not None:
             self.test_results[self.current_test][self.current_profile] = "skip"
 
     def pass_test_match(self, line):
-        if re.search(r'\[\s*OK \]', line) != None:
+        if re.search(r'\[\s*OK \]', line) is not None:
             # If gtest says the test passed, check if it was skipped before marking it passed
             if self.test_results.get(self.current_test, {}).get(self.current_profile, "") != "skip":
                     self.test_results[self.current_test][self.current_profile] = "pass"
             self.current_test = ""
 
     def fail_test_match(self, line):
-        if re.search(r'\[\s*FAILED\s*\]', line) != None and self.current_test != "":
+        if re.search(r'\[\s*FAILED\s*\]', line) is not None and self.current_test != "":
             self.test_results[self.current_test][self.current_profile] = "fail"
             self.current_test = ""
 
     def unexpected_error_match(self, line):
-        if re.search(r'^Unexpected: ', line) != None:
+        if re.search(r'^Unexpected: ', line) is not None:
             self.unexpected_errors[self.current_test][self.current_profile] = "true"
 
     def test_died(self):

--- a/scripts/threading_generator.py
+++ b/scripts/threading_generator.py
@@ -307,7 +307,7 @@ class ThreadOutputGenerator(OutputGenerator):
             # this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
             #write('// endFeature looking at self.featureExtraProtect', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             #write('#define', self.featureName, '1', file=self.outFile)
             for section in self.TYPE_SECTIONS:
@@ -320,7 +320,7 @@ class ThreadOutputGenerator(OutputGenerator):
             if (self.sections['command']):
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
                 self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
             if (self.genOpts.protectFeature):
                 write('#endif /*', self.featureName, '*/', file=self.outFile)
@@ -403,10 +403,10 @@ class ThreadOutputGenerator(OutputGenerator):
             return
         finishthreadsafety = self.makeThreadUseBlock(cmdinfo.elem, 'finish')
         # record that the function will be intercepted
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
         self.intercepts += [ '    {"%s", (void*)%s},' % (name,name[2:]) ]
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#endif' ]
 
         OutputGenerator.genCmd(self, cmdinfo, name, alias)
@@ -427,9 +427,9 @@ class ThreadOutputGenerator(OutputGenerator):
             self.appendSection('command', '    VkLayerDispatchTable *pTable = my_data->device_dispatch_table;')
         # Declare result variable, if any.
         resulttype = cmdinfo.elem.find('proto/type')
-        if (resulttype != None and resulttype.text == 'void'):
+        if (resulttype is not None and resulttype.text == 'void'):
           resulttype = None
-        if (resulttype != None):
+        if (resulttype is not None):
             self.appendSection('command', '    ' + resulttype.text + ' result;')
             assignresult = 'result = '
         else:
@@ -449,7 +449,7 @@ class ThreadOutputGenerator(OutputGenerator):
         self.appendSection('command', '        finishMultiThread();')
         self.appendSection('command', '    }')
         # Return result variable, if any.
-        if (resulttype != None):
+        if (resulttype is not None):
             self.appendSection('command', '    return result;')
         self.appendSection('command', '}')
     #

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -238,12 +238,12 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         # Actually write the interface to the output file.
         if (self.emit):
             self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             # Write the unique_objects code to the file
             if (self.sections['command']):
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('\n#endif //', self.featureExtraProtect, file=self.outFile)
             else:
                 self.newline()
@@ -265,10 +265,10 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         self.featureExtraProtect = GetFeatureProtect(interface)
         if self.featureName != 'VK_VERSION_1_0' and self.featureName != 'VK_VERSION_1_1':
             white_list_entry = []
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#ifdef %s' % self.featureExtraProtect ]
             white_list_entry += [ '"%s"' % self.featureName ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 white_list_entry += [ '#endif' ]
             featureType = interface.get('type')
             if featureType == 'instance':
@@ -874,7 +874,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             if not api_decls and not api_pre and not api_post:
                 continue
             feature_extra_protect = cmd_protect_dict[api_call.name]
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '')
                 self.appendSection('command', '#ifdef '+ feature_extra_protect)
                 self.intercepts += [ '#ifdef %s' % feature_extra_protect ]
@@ -894,9 +894,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                 self.appendSection('command', '    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key('+dispatchable_name+'), layer_data_map);')
             # Handle return values, if any
             resulttype = cmdinfo.elem.find('proto/type')
-            if (resulttype != None and resulttype.text == 'void'):
+            if (resulttype is not None and resulttype.text == 'void'):
               resulttype = None
-            if (resulttype != None):
+            if (resulttype is not None):
                 assignresult = resulttype.text + ' result = '
             else:
                 assignresult = ''
@@ -925,9 +925,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             # And add the post-API-call codegen
             self.appendSection('command', "\n".join(str(api_post).rstrip().split("\n")))
             # Handle the return result variable, if any
-            if (resulttype != None):
+            if (resulttype is not None):
                 self.appendSection('command', '    return result;')
             self.appendSection('command', '}')
-            if (feature_extra_protect != None):
+            if (feature_extra_protect is not None):
                 self.appendSection('command', '#endif // '+ feature_extra_protect)
                 self.intercepts += [ '#endif' ]

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -264,7 +264,7 @@ class ValidationSource:
                     if True in [line.strip().startswith(comment) for comment in ['//', '/*']]:
                         continue
                     # Find vuid strings
-                    if prepend != None:
+                    if prepend is not None:
                         line = prepend[:-2] + line.lstrip().lstrip('"') # join lines skipping CR, whitespace and trailing/leading quote char
                         prepend = None
                     if any(prefix in line for prefix in vuid_prefixes):
@@ -332,7 +332,7 @@ class ValidationTests:
                         continue
 
                     # if line ends in a broken VUID string, fix that before proceeding
-                    if prepend != None:
+                    if prepend is not None:
                         line = prepend[:-2] + line.lstrip().lstrip('"') # join lines skipping CR, whitespace and trailing/leading quote char
                         prepend = None
                     if any(prefix in line for prefix in vuid_prefixes):


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations