### PR TITLE
layers: Tolerate return code of INCOMPLETE

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12971,7 +12971,7 @@ static void PostCallRecordEnumeratePhysicalDevices(instance_layer_data *instance
                                                    uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices) {
     if (NULL == pPhysicalDevices) {
         instance_data->physical_devices_count = *pPhysicalDeviceCount;
-    } else if (result == VK_SUCCESS) {  // Save physical devices
+    } else if (result == VK_SUCCESS || result == VK_INCOMPLETE) {  // Save physical devices
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
             auto &phys_device_state = instance_data->physical_device_map[pPhysicalDevices[i]];
             phys_device_state.phys_device = pPhysicalDevices[i];
@@ -13960,7 +13960,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(VkInstance instance
     PreCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupProperties);
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount,
                                                                                   pPhysicalDeviceGroupProperties);
-    if (result == VK_SUCCESS) {
+    if (result == VK_SUCCESS || result == VK_INCOMPLETE) {
         PostCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     }
     return result;

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -1045,7 +1045,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
     VkResult result =
         instance_data->instance_dispatch_table.EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
     lock.lock();
-    if (result == VK_SUCCESS) {
+    if (result == VK_SUCCESS || result == VK_INCOMPLETE) {
         if (pPhysicalDevices) {
             for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
                 CreateObject(instance, pPhysicalDevices[i], kVulkanObjectTypePhysicalDevice, nullptr);


### PR DESCRIPTION
After finding the display routines that needed to handle VK_INCOMPLETE as a return code, I went through the spec to see which other routines needed to handle it and verified that they were.  This fixes the api calls that were not handling it correctly.