### PR TITLE
Add descriptor validation for UpdateDescriptorSetWithTemplate

### DIFF
--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -435,6 +435,14 @@ bool ValidateUpdateDescriptorSets(const debug_report_data *, const core_validati
 // "Perform" does the update with the assumption that ValidateUpdateDescriptorSets() has passed for the given update
 void PerformUpdateDescriptorSets(const core_validation::layer_data *, uint32_t, const VkWriteDescriptorSet *, uint32_t,
                                  const VkCopyDescriptorSet *);
+
+// Helper class to encapsulate the descriptor update template decoding logic
+struct DecodedTemplateUpdate {
+    std::vector<VkWriteDescriptorSet> desc_writes;
+    std::vector<VkWriteDescriptorSetInlineUniformBlockEXT> inline_infos;
+    DecodedTemplateUpdate(layer_data *device_data, VkDescriptorSet descriptorSet, const TEMPLATE_STATE *template_state,
+                          const void *pData);
+};
 // Similar to PerformUpdateDescriptorSets, this function will do the same for updating via templates
 void PerformUpdateDescriptorSetsWithTemplateKHR(layer_data *, VkDescriptorSet, std::unique_ptr<TEMPLATE_STATE> const &,
                                                 const void *);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -10723,9 +10723,8 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatchInternal) {
     vkCmdSetScissor(cmd_buf.handle(), 0, 1, &scissor);
     // At draw time the update layout will mis-match the actual layout
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkDescriptorImageInfo-imageLayout-00344");
-    m_errorMonitor->SetDesiredFailureMsg(
-        VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        " Image layout specified at vkUpdateDescriptorSets() time doesn't match actual image layout at time descriptor is used.");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                         "UNASSIGNED-CoreValidation-DrawState-DescriptorSetNotUpdated");
     cmd_buf.Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     cmd_buf.EndRenderPass();


### PR DESCRIPTION
Fixes #395

 Reuse the descriptor set template decoder to validate the update using the non-template functionality, with parameterization of the calling function name to disambiguate the validation messages.

One test had to be changed to VUID string avoid expected message

Add tests to spot check the addition of descriptor update validation for templated updates.
