### PR TITLE
Update Android NDK and platform versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     # Android build.
     - os: linux
       compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-26 ANDROID_ABI=armeabi-v7a
     # Android 64-bit build.
     - os: linux
       compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=arm64-v8a
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-26 ANDROID_ABI=arm64-v8a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc
@@ -52,9 +52,9 @@ before_install:
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
       # Install the Android NDK.
       export ARCH=`uname -m`
-      wget http://dl.google.com/android/repository/android-ndk-r15c-linux-${ARCH}.zip
-      unzip -u -q android-ndk-r15c-linux-${ARCH}.zip
-      export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
+      wget http://dl.google.com/android/repository/android-ndk-r18b-linux-${ARCH}.zip
+      unzip -u -q android-ndk-r18b-linux-${ARCH}.zip
+      export ANDROID_NDK_HOME=`pwd`/android-ndk-r18b
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
     fi

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -18,6 +18,8 @@ SRC_DIR := ../..
 LAYER_DIR := ../generated
 THIRD_PARTY := ../third_party
 
+NATIVE_LIBS := -landroid -llog -lnativewindow
+
 VULKAN_INCLUDE := $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include
 
 include $(CLEAR_VARS)
@@ -47,7 +49,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES += layer_utils glslang SPIRV-Tools
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
-LOCAL_LDLIBS    := -llog
+LOCAL_LDLIBS    := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
@@ -62,7 +64,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES += layer_utils
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
-LOCAL_LDLIBS    := -llog
+LOCAL_LDLIBS    := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
@@ -77,7 +79,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES += layer_utils
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
-LOCAL_LDLIBS    := -llog
+LOCAL_LDLIBS    := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
@@ -91,7 +93,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES += layer_utils
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
-LOCAL_LDLIBS    := -llog
+LOCAL_LDLIBS    := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
@@ -105,7 +107,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES += layer_utils
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
-LOCAL_LDLIBS    := -llog
+LOCAL_LDLIBS    := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
@@ -128,7 +130,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := $(NATIVE_LIBS)
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_EXECUTABLE)
@@ -153,7 +155,7 @@ LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden -DVALIDATION_APK --include=$(THIRD_PARTY)/Vulkan-Tools/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
-LOCAL_LDLIBS := -llog -landroid
+LOCAL_LDLIBS := $(NATIVE_LIBS)
 LOCAL_LDFLAGS := -u ANativeActivity_onCreate
 include $(BUILD_SHARED_LIBRARY)
 

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
-APP_PLATFORM := android-22
+APP_PLATFORM := android-26
 APP_STL := c++_static
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .


### PR DESCRIPTION
Updates the `travis.yml` and `Android.mk` files to specify building with the current NDK version (r18b) and for platform 26 (Oreo). Required to support the `VK_ANDROID_external_memory_android_hardware_buffer`
extension, which is defined in the NDK only at platform 26 or later.