### PR TITLE
Add push descriptor validation

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -229,6 +229,10 @@ static const char DECORATE_UNUSED *kVUID_Core_Swapchain_PriorCount = "UNASSIGNED
 static const char DECORATE_UNUSED *kVUID_Core_Image_InvalidFormatLimitsViolation = "UNASSIGNED-CoreValidation-Image-InvalidFormatLimitsViolation";
 static const char DECORATE_UNUSED *kVUID_Core_Image_ZeroAreaSubregion = "UNASSIGNED-CoreValidation-Image-ZeroAreaSubregion";
 
+static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_TemplateType = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-descriptorUpdateTemplate-templateType";
+static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_Template_SetMismatched = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-set";
+static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_Template_LayoutMismatched = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-layout";
+
 // clang-format on
 
 #undef DECORATE_UNUSED

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -648,6 +648,18 @@ struct PIPELINE_LAYOUT_NODE {
     }
 };
 
+static inline bool CompatForSet(uint32_t set, const std::vector<PipelineLayoutCompatId> &a,
+                                const std::vector<PipelineLayoutCompatId> &b) {
+    bool result = (set < a.size()) && (set < b.size()) && (a[set] == b[set]);
+    return result;
+}
+
+static inline bool CompatForSet(uint32_t set, const PIPELINE_LAYOUT_NODE *a, const PIPELINE_LAYOUT_NODE *b) {
+    // Intentionally have a result variable to simplify debugging
+    bool result = a && b && CompatForSet(set, a->compat_for_set, b->compat_for_set);
+    return result;
+}
+
 class PIPELINE_STATE : public BASE_NODE {
    public:
     VkPipeline pipeline;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -444,7 +444,7 @@ struct DecodedTemplateUpdate {
     std::vector<VkWriteDescriptorSet> desc_writes;
     std::vector<VkWriteDescriptorSetInlineUniformBlockEXT> inline_infos;
     DecodedTemplateUpdate(layer_data *device_data, VkDescriptorSet descriptorSet, const TEMPLATE_STATE *template_state,
-                          const void *pData);
+                          const void *pData, VkDescriptorSetLayout push_layout = VK_NULL_HANDLE);
 };
 // Helper wrapping ValidateUpdateDescriptorSets, updating via templates
 bool ValidateUpdateDescriptorSetsWithTemplateKHR(layer_data *device_data, VkDescriptorSet descriptorSet,
@@ -515,6 +515,11 @@ class DescriptorSet : public BASE_NODE {
 
     std::string StringifySetAndLayout() const;
     // Descriptor Update functions. These functions validate state and perform update separately
+    // Validate contents of a push descriptor update
+    bool ValidatePushDescriptorsUpdate(const debug_report_data *report_data, uint32_t write_count,
+                                       const VkWriteDescriptorSet *p_wds, const char *func_name);
+    // Perform a push update whose contents were just validated using ValidatePushDescriptorsUpdate
+    void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *p_wds);
     // Validate contents of a WriteUpdate
     bool ValidateWriteUpdate(const debug_report_data *, const VkWriteDescriptorSet *, const char *, std::string *, std::string *);
     // Perform a WriteUpdate whose contents were just validated using ValidateWriteUpdate

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -513,6 +513,7 @@ class DescriptorSet : public BASE_NODE {
     uint32_t GetStorageUpdates(const std::map<uint32_t, descriptor_req> &, std::unordered_set<VkBuffer> *,
                                std::unordered_set<VkImageView> *) const;
 
+    std::string StringifySetAndLayout() const;
     // Descriptor Update functions. These functions validate state and perform update separately
     // Validate contents of a WriteUpdate
     bool ValidateWriteUpdate(const debug_report_data *, const VkWriteDescriptorSet *, const char *, std::string *, std::string *);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -28541,7 +28541,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     const VkPipelineLayoutObj pipeline_layout(m_device, {&ds_layout});
 
     static const float vbo_data[3] = {1.f, 0.f, 1.f};
-    VkConstantBufferObj vbo(m_device, sizeof(vbo_data), (const void *)&vbo_data);
+    VkConstantBufferObj vbo(m_device, sizeof(vbo_data), (const void *)&vbo_data, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     VkDescriptorBufferInfo buff_info;
     buff_info.buffer = vbo.handle();


### PR DESCRIPTION
  Add validation of CmdPushDescriptorSet(WithTemplate) descriptor state updates, removing the code disabling later use of the recorded data.

Addresses #413 and #428
