### PR TITLE
layers: Dont validate non-const pNexts

### DIFF
--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -1157,7 +1157,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                     elif value.israngedenum and value.isconst:
                         enum_value_list = 'All%sEnums' % value.type
                         usedLines.append('skip |= validate_ranged_enum_array(local_data->report_data, "{}", {ppp}"{}"{pps}, {ppp}"{}"{pps}, "{}", {}, {pf}{}, {pf}{}, {}, {});\n'.format(funcName, lenDisplayName, valueDisplayName, value.type, enum_value_list, lenParam.name, value.name, cvReq, req, pf=valuePrefix, **postProcSpec))
-                    elif value.name == 'pNext':
+                    elif value.name == 'pNext' and value.isconst:
                         usedLines += self.makeStructNextCheck(valuePrefix, value, funcName, valueDisplayName, postProcSpec, structTypeName)
                     else:
                         usedLines += self.makePointerCheck(valuePrefix, value, lenParam, req, cvReq, cpReq, funcName, lenDisplayName, valueDisplayName, postProcSpec, structTypeName)


### PR DESCRIPTION
Avoids validating structs that could be uninitialized until filled in by the driver
Address #458

Change removes pNext validation from:
vkEnumeratePhysicalDeviceGroups
vkGetImageMemoryRequirements2
vkGetBufferMemoryRequirements2
vkGetImageSparseMemoryRequirements2
vkGetPhysicalDeviceProperties2
vkGetPhysicalDeviceFormatProperties2
vkGetPhysicalDeviceImageFormatProperties2
vkGetPhysicalDeviceQueueFamilyProperties2
vkGetPhysicalDeviceMemoryProperties2
vkGetPhysicalDeviceSparseImageFormatProperties2
vkGetPhysicalDeviceExternalBufferProperties
vkGetPhysicalDeviceExternalFenceProperties
vkGetPhysicalDeviceExternalSemaphoreProperties
vkGetDescriptorSetLayoutSupport
vkGetPhysicalDeviceProperties2KHR
vkGetPhysicalDeviceFormatProperties2KHR
vkGetPhysicalDeviceImageFormatProperties2KHR
vkGetPhysicalDeviceQueueFamilyProperties2KHR
vkGetPhysicalDeviceMemoryProperties2KHR
vkGetPhysicalDeviceSparseImageFormatProperties2KHR
vkEnumeratePhysicalDeviceGroupsKHR
vkGetPhysicalDeviceExternalBufferPropertiesKHR
vkGetMemoryWin32HandlePropertiesKHR
vkGetMemoryFdPropertiesKHR
vkGetPhysicalDeviceExternalSemaphorePropertiesKHR
vkGetPhysicalDeviceExternalFencePropertiesKHR
vkGetPhysicalDeviceSurfaceCapabilities2KHR
vkGetPhysicalDeviceSurfaceFormats2KHR
vkGetPhysicalDeviceDisplayProperties2KHR
vkGetPhysicalDeviceDisplayPlaneProperties2KHR
vkGetDisplayModeProperties2KHR
vkGetDisplayPlaneCapabilities2KHR
vkGetImageMemoryRequirements2KHR
vkGetBufferMemoryRequirements2KHR
vkGetImageSparseMemoryRequirements2KHR
vkGetDescriptorSetLayoutSupportKHR
vkGetPhysicalDeviceSurfaceCapabilities2EXT
vkGetAndroidHardwareBufferPropertiesANDROID
vkGetPhysicalDeviceMultisamplePropertiesEXT
vkGetImageDrmFormatModifierPropertiesEXT
vkGetQueueCheckpointDataNV