### PR TITLE
wrong descriptor layout assert expression and proper message when creating image view for a null image handle

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4135,6 +4135,12 @@ bool PreCallValidateCreateImageView(layer_data *device_data, const VkImageViewCr
             }
         }
     }
+	else
+	{
+		skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                                HandleToUint64(create_info->image), "VUID-VkImageViewCreateInfo-image-parameter",
+                                "vkCreateImageView() image handle is VK_NULL_HANDLE. Image is either not created or it is destroyed at this point.");
+	}
     return skip;
 }
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -239,7 +239,7 @@ bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout cons
     bool detailed_compat_check =
         GetLayoutDef()->IsCompatible(layout_, rh_ds_layout->GetDescriptorSetLayout(), rh_ds_layout->GetLayoutDef(), error_msg);
     // The detailed check should never tell us mismatching DSL are compatible
-    assert(!detailed_compat_check);
+    assert(detailed_compat_check);
     return detailed_compat_check;
 }
 


### PR DESCRIPTION
- Proper validation and message when creating an image view for a VkImage which is null handle.
- Fixes wrong descriptor layout compatibility check assert expression.