### PR TITLE
tests: Remove SpirvGroupDecorations

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -19851,7 +19851,9 @@ TEST_F(VkPositiveLayerTest, ShaderRelaxedBlockLayout) {
         vkDestroyShaderModule(m_device->handle(), shader_module, NULL);
     }
 }
-
+#ifdef DONT_RUN_THIS
+// This test has problems that cause some Linux Nvidia drivers to report errors
+// Removing it until errors can be addressed
 TEST_F(VkPositiveLayerTest, SpirvGroupDecorations) {
     TEST_DESCRIPTION("Test shader validation support for group decorations.");
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
@@ -20048,6 +20050,7 @@ TEST_F(VkPositiveLayerTest, SpirvGroupDecorations) {
     vkDestroyPipelineLayout(device(), pipeline_layout, nullptr);
     vkDestroyDescriptorSetLayout(device(), ds_layout, nullptr);
 }
+#endif  // DONT_RUN_THIS
 
 TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension1of2) {
     // This is a positive test, no errors expected


### PR DESCRIPTION
This test is causing some unexpected driver errors on some Nvidia
Linux drivers.  Removing it until it can be fixed.

Change-Id: I87c9eab032d515b33006dfefdd84099965c189c0