### PR TITLE
docs: Change references to cube to vkcube

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -347,7 +347,7 @@ location of the loader's install directory:
 After making any changes to the repository, you should perform some quick
 sanity tests, including the run_all_tests Powershell script. In addition,
 running sample applications such as the
-[cube demo](https://www.github.com/KhronosGroup/Vulkan-Tools.git)
+[vkcube demo](https://www.github.com/KhronosGroup/Vulkan-Tools.git)
 with validation enabled is advised.
 
 To run the validation test script, open a Powershell Console, change to the
@@ -575,7 +575,7 @@ Finally, rebuild the repository using `cmake` and `make`, as explained above.
 
     export VK_LAYER_PATH=<path to your repository root>/build/layers
 
-You can run the `cube` or `vulkaninfo` applications from the Vulkan-Tools
+You can run the `vkcube` or `vulkaninfo` applications from the Vulkan-Tools
 repository to see which driver, loader and layers are being used.
 
 ## Building On Android
@@ -690,8 +690,8 @@ for VS2013:
 ### Android Tests and Demos
 
 After making any changes to the repository you should perform some quick
-sanity tests, including the layer validation tests and the cube and smoke
-demos with validation enabled.
+sanity tests, including the layer validation tests and the vkcube
+demo with validation enabled.
 
 #### Run Layer Validation Tests
 
@@ -820,7 +820,7 @@ This script will run the following tests:
 
 - `vk_layer_validation_tests`: Test Vulkan validation layers
 
-Further testing and sanity checking can be achieved by running the cube and
+Further testing and sanity checking can be achieved by running the vkcube and
 vulkaninfo applications in the
 [Vulkan-Tools](https://github.com/KhronosGroup/Vulkan-Tools)
 repository.


### PR DESCRIPTION
The name of the cube demo in Vulkan-Tools has changed to vkcube