### PR TITLE
Prevent duplicate validation messages when using default debug callbacks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2143,7 +2143,6 @@ bool OutsideRenderPass(const layer_data *dev_data, GLOBAL_CB_NODE *pCB, const ch
 }
 
 static void InitCoreValidation(instance_layer_data *instance_data, const VkAllocationCallbacks *pAllocator) {
-    layer_debug_report_actions(instance_data->report_data, instance_data->logging_callback, pAllocator, "lunarg_core_validation");
     layer_debug_messenger_actions(instance_data->report_data, instance_data->logging_messenger, pAllocator,
                                   "lunarg_core_validation");
 }

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -30,7 +30,6 @@ uint64_t object_track_index = 0;
 uint32_t loader_layer_if_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
 
 void InitObjectTracker(layer_data *my_data, const VkAllocationCallbacks *pAllocator) {
-    layer_debug_report_actions(my_data->report_data, my_data->logging_callback, pAllocator, "lunarg_object_tracker");
     layer_debug_messenger_actions(my_data->report_data, my_data->logging_messenger, pAllocator, "lunarg_object_tracker");
 }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -103,8 +103,6 @@ std::unordered_map<void *, instance_layer_data *> instance_layer_data_map;
 void InitializeManualParameterValidationFunctionPointers(void);
 
 static void init_parameter_validation(instance_layer_data *instance_data, const VkAllocationCallbacks *pAllocator) {
-    layer_debug_report_actions(instance_data->report_data, instance_data->logging_callback, pAllocator,
-                               "lunarg_parameter_validation");
     layer_debug_messenger_actions(instance_data->report_data, instance_data->logging_messenger, pAllocator,
                                   "lunarg_parameter_validation");
 }

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -40,7 +40,6 @@ namespace threading {
 static uint32_t loader_layer_if_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
 
 static void initThreading(layer_data *my_data, const VkAllocationCallbacks *pAllocator) {
-    layer_debug_report_actions(my_data->report_data, my_data->logging_callback, pAllocator, "google_threading");
     layer_debug_messenger_actions(my_data->report_data, my_data->logging_messenger, pAllocator, "google_threading");
 }
 

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -59,7 +59,6 @@ namespace unique_objects {
 static uint32_t loader_layer_if_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
 
 static void initUniqueObjects(instance_layer_data *instance_data, const VkAllocationCallbacks *pAllocator) {
-    layer_debug_report_actions(instance_data->report_data, instance_data->logging_callback, pAllocator, "google_unique_objects");
     layer_debug_messenger_actions(instance_data->report_data, instance_data->logging_messenger, pAllocator,
                                   "google_unique_objects");
 }

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -87,6 +87,65 @@ VK_LAYER_EXPORT bool white_list(const char *item, const std::set<std::string> &l
 // If a vk_layer_settings.txt file is present and an application defines a debug callback, both callbacks
 // will be active.  If no vk_layer_settings.txt file is present, creating an application-defined debug
 // callback will cause the default callbacks to be unregisterd and removed.
+VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data,
+                                                   std::vector<VkDebugUtilsMessengerEXT> &logging_messenger,
+                                                   const VkAllocationCallbacks *pAllocator, const char *layer_identifier) {
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+
+    std::string report_flags_key = layer_identifier;
+    std::string debug_action_key = layer_identifier;
+    std::string log_filename_key = layer_identifier;
+    report_flags_key.append(".report_flags");
+    debug_action_key.append(".debug_action");
+    log_filename_key.append(".log_filename");
+
+    // Initialize layer options
+    VkDebugReportFlagsEXT report_flags = GetLayerOptionFlags(report_flags_key, report_flags_option_definitions, 0);
+    VkLayerDbgActionFlags debug_action = GetLayerOptionFlags(debug_action_key, debug_actions_option_definitions, 0);
+    // Flag as default if these settings are not from a vk_layer_settings.txt file
+    bool default_layer_callback = (debug_action & VK_DBG_LAYER_ACTION_DEFAULT) ? true : false;
+    VkDebugUtilsMessengerCreateInfoEXT dbgCreateInfo;
+    memset(&dbgCreateInfo, 0, sizeof(dbgCreateInfo));
+    dbgCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
+    dbgCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    if (report_flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
+        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    }
+    if (report_flags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
+        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    }
+    if (report_flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
+        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+        dbgCreateInfo.messageType |= VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+    }
+    if (report_flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
+        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    }
+    if (report_flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
+        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+    }
+
+    if (debug_action & VK_DBG_LAYER_ACTION_LOG_MSG) {
+        const char *log_filename = getLayerOption(log_filename_key.c_str());
+        FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
+        dbgCreateInfo.pfnUserCallback = messenger_log_callback;
+        dbgCreateInfo.pUserData = (void *)log_output;
+        layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
+        logging_messenger.push_back(messenger);
+    }
+
+    messenger = VK_NULL_HANDLE;
+
+    if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
+        dbgCreateInfo.pfnUserCallback = messenger_win32_debug_output_msg;
+        dbgCreateInfo.pUserData = NULL;
+        layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
+        logging_messenger.push_back(messenger);
+    }
+}
+
+// NOTE: This function has been deprecated, and the above function (layer_debug_messenger_actions) should be
+//       used in its place.
 VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data,
                                                 std::vector<VkDebugReportCallbackEXT> &logging_callback,
                                                 const VkAllocationCallbacks *pAllocator, const char *layer_identifier) {
@@ -142,63 +201,6 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data,
         dbgCreateInfo.pUserData = NULL;
         layer_create_report_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &callback);
         logging_callback.push_back(callback);
-    }
-}
-
-VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data,
-                                                   std::vector<VkDebugUtilsMessengerEXT> &logging_messenger,
-                                                   const VkAllocationCallbacks *pAllocator, const char *layer_identifier) {
-    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
-
-    std::string report_flags_key = layer_identifier;
-    std::string debug_action_key = layer_identifier;
-    std::string log_filename_key = layer_identifier;
-    report_flags_key.append(".report_flags");
-    debug_action_key.append(".debug_action");
-    log_filename_key.append(".log_filename");
-
-    // Initialize layer options
-    VkDebugReportFlagsEXT report_flags = GetLayerOptionFlags(report_flags_key, report_flags_option_definitions, 0);
-    VkLayerDbgActionFlags debug_action = GetLayerOptionFlags(debug_action_key, debug_actions_option_definitions, 0);
-    // Flag as default if these settings are not from a vk_layer_settings.txt file
-    bool default_layer_callback = (debug_action & VK_DBG_LAYER_ACTION_DEFAULT) ? true : false;
-    VkDebugUtilsMessengerCreateInfoEXT dbgCreateInfo;
-    memset(&dbgCreateInfo, 0, sizeof(dbgCreateInfo));
-    dbgCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
-    dbgCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-    if (report_flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
-        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-    }
-    if (report_flags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
-        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-    }
-    if (report_flags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
-        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-        dbgCreateInfo.messageType |= VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-    }
-    if (report_flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
-        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-    }
-    if (report_flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
-        dbgCreateInfo.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-    }
-
-    if (debug_action & VK_DBG_LAYER_ACTION_LOG_MSG) {
-        const char *log_filename = getLayerOption(log_filename_key.c_str());
-        FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
-        dbgCreateInfo.pfnUserCallback = messenger_log_callback;
-        dbgCreateInfo.pUserData = (void *)log_output;
-        layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
-        logging_messenger.push_back(messenger);
-    }
-
-    messenger = VK_NULL_HANDLE;
-
-    if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
-        dbgCreateInfo.pfnUserCallback = messenger_win32_debug_output_msg;
-        dbgCreateInfo.pUserData = NULL;
-        layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
-        logging_messenger.push_back(messenger);
     }
 }
 


### PR DESCRIPTION
Layers registered two default callbacks if application registered none, which resulted in duplicate validation messages being output.  Fixed this in the validation layers, as well as a bug in the windows outputdebugstring version of the callback logging function.

@karl-lunarg, once the board is clear, can you check that this resolves your issues?