### PR TITLE
Codegen fixes for VkBase(In|Out)Structure

### DIFF
--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -624,8 +624,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         for member in struct_members:
             if self.isHandleTypeObject(member.type):
                 return True
-            elif member.type in struct_member_dict:
-                if self.struct_contains_object(member.type) == True:
+            # recurse for member structs, guard against infinite recursion
+            elif member.type in struct_member_dict and member.type != struct_item:
+                if self.struct_contains_object(member.type):
                     return True
         return False
     #

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -416,8 +416,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         for member in struct_members:
             if self.isHandleTypeNonDispatchable(member.type):
                 return True
-            elif member.type in struct_member_dict:
-                if self.struct_contains_ndo(member.type) == True:
+            # recurse for member structs, guard against infinite recursion
+            elif member.type in struct_member_dict and member.type != struct_item:
+                if self.struct_contains_ndo(member.type):
                     return True
         return False
     #


### PR DESCRIPTION
Current code gen will tolerate the self-referential VkBase* structures in the header, but will crash if they are actually used in any entry point.