### PR TITLE
layers: Fixed build warning

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -114,7 +114,7 @@ static inline dispatch_key get_dispatch_key(const void *object) { return (dispat
 VK_LAYER_EXPORT VkLayerInstanceCreateInfo *get_chain_info(const VkInstanceCreateInfo *pCreateInfo, VkLayerFunction func);
 VK_LAYER_EXPORT VkLayerDeviceCreateInfo *get_chain_info(const VkDeviceCreateInfo *pCreateInfo, VkLayerFunction func);
 
-static bool IsPowerOfTwo(unsigned x) { return x && !(x & (x - 1)); }
+static inline bool IsPowerOfTwo(unsigned x) { return x && !(x & (x - 1)); }
 
 extern "C" {
 #endif


### PR DESCRIPTION
The function IsPowerOfTwo in vk_layer_utils.h caused a warning when
building libVkLayer_utils.a since the function was not used in this
module.
Made the function an inline function to fix the warning.