### PR TITLE
layers: Add stub functions for DebugUtils functions

### DIFF
--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -174,7 +174,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
             self.device_dispatch_list.append((name, self.featureExtraProtect))
             extension = "VK_VERSION" not in self.featureName
             promoted = not extension and "VK_VERSION_1_0" != self.featureName
-            if promoted or (extension and self.extension_type == 'device'):
+            if promoted or extension:
                 self.device_stub_list.append([name, self.featureName])
                 if extension:
                     self.device_extension_list.append([name, self.featureName])


### PR DESCRIPTION
The DebugUtils functions are from an Instance extension but are in the device dispatch table. This change prevents their exclusion from having  stub functions generated for them. Previously, the last layer didn't hook this function, and the other layers specifically made this null-check in their intercept routines (which should have been unnecessary, and now will be).

This fixes crashes when running `cube --validate.`

Change-Id: I67d351e13ede9995642a0922b146a02da6c153b2