### PR TITLE
Add DebugUtils naming and labeling to chassis

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -14448,7 +14448,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDev
 }
 
 // VK_EXT_debug_utils commands
-static void PreCallRecordSetDebugUtilsObectNameEXT(layer_data *dev_data, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+static void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data *dev_data, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
     if (pNameInfo->pObjectName) {
         lock_guard_t lock(global_lock);
         dev_data->report_data->debugUtilsObjectNameMap->insert(
@@ -14463,7 +14463,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(VkDevice device, const
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_SUCCESS;
 
-    PreCallRecordSetDebugUtilsObectNameEXT(dev_data, pNameInfo);
+    PreCallRecordSetDebugUtilsObjectNameEXT(dev_data, pNameInfo);
 
     if (nullptr != dev_data->dispatch_table.SetDebugUtilsObjectNameEXT) {
         result = dev_data->dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -537,10 +537,11 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct  = [struct_decl]
             struct.extend([ '    bool %s{false};' % field_name[ext_name] for ext_name, info in extension_items])
 
-            # Create struct entries for saving extension count and extension list from DeviceCreateInfo
-            struct.extend([
-                '',
-                '    std::unordered_set<std::string> device_extension_set;'])
+            # Create struct entries for saving extension count and extension list from Instance, DeviceCreateInfo
+            if type == 'Instance':
+                struct.extend([
+                    '',
+                    '    std::unordered_set<std::string> device_extension_set;'])
 
             # Construct the extension information map -- mapping name to data member (field), and required extensions
             # The map is contained within a static function member for portability reasons.
@@ -605,13 +606,13 @@ class HelperFileOutputGenerator(OutputGenerator):
                     '        // Initialize: this to defaults,  base class fields to input.',
                     '        assert(instance_extensions);',
                     '        *this = %s(*instance_extensions);' % struct_type,
+                    '']),
+            struct.extend([
                     '',
                     '        // Save pCreateInfo device extension list',
                     '        for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {',
                     '           device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);',
-                    '        }']),
-
-            struct.extend([
+                    '        }',
                 '',
                 '        static const std::vector<const char *> V_1_0_promoted_%s_extensions = {' % type.lower() ])
             struct.extend(['            %s_EXTENSION_NAME,' % ext_name.upper() for ext_name in promoted_ext_list])


### PR DESCRIPTION
Added support for object naming, queue labeling, and command buffer labeling to the layer chassis.
Also add instance extensions to the list of extensions enabled for GetDeviceProcAddress calls to pick up device APIs that are part of instance extensions.

Fixes #522.

It is likely that to properly test the features of this extension (without overhauling the LVTs) requires a standalone test script, similar to the ones for vulkaninfo or the assistant layer.