### PR TITLE
Add GPU-Assisted Validation Support

### DIFF
--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -66,7 +66,8 @@ add_library(VkLayer_core_validation SHARED
         ${SRC_DIR}/layers/descriptor_sets.cpp
         ${SRC_DIR}/layers/buffer_validation.cpp
         ${SRC_DIR}/layers/shader_validation.cpp
-	    ${SRC_DIR}/layers/xxhash.c)
+        ${SRC_DIR}/layers/gpu_validation.cpp
+        ${SRC_DIR}/layers/xxhash.c)
 target_include_directories(VkLayer_core_validation PRIVATE
         ${SRC_DIR}/include
         ${SRC_DIR}/layers

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -39,6 +39,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/core_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/descriptor_sets.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_validation.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/convert_to_renderpass2.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/xxhash.c
 LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \

--- a/docs/core_validation_layer.md
+++ b/docs/core_validation_layer.md
@@ -1,44 +1,48 @@
 # VK\_LAYER\_LUNARG\_core\_validation
+
 The `VK_LAYER_LUNARG_core_validation` layer validates the status of descriptor sets, command buffers, shader modules, pipeline states, renderpass usage, synchronization, dynamic states and is the workhorse layer for many other types of valid usage.
 
 `VK_LAYER_LUNARG_core_validation` validates that:
 
- - the descriptor set state and pipeline state at each draw call are consistent
- - pipelines are created correctly, known when used and bound at draw time
- - descriptor sets are known and consist of valid types, formats, and layout
- - descriptor set regions are valid, bound, and updated appropriately
- - command buffers referenced are known and valid
- - command sequencing for specific state dependencies and renderpass use is correct
- - memory is available
- - dynamic state is correctly set.
+- the descriptor set state and pipeline state at each draw call are consistent
+- pipelines are created correctly, known when used and bound at draw time
+- descriptor sets are known and consist of valid types, formats, and layout
+- descriptor set regions are valid, bound, and updated appropriately
+- command buffers referenced are known and valid
+- command sequencing for specific state dependencies and renderpass use is correct
+- memory is available
+- dynamic state is correctly set.
 
 The `VK_LAYER_LUNARG_core_validation` layer will print errors if validation checks are not correctly met.  `VK_LAYER_LUNARG_core_validation` will also display the values of the objects tracked.
 
 ## Memory/Resource related functionality
+
 This layer additionally attempts to ensure that memory objects are managed correctly by the application.  These memory objects may be bound to pipelines, objects, and command buffers, and then submitted to the GPU for work. Specifically the layer validates that:
 
- - the correct memory objects have been bound
- - memory objects are specified correctly upon command buffer submittal
- - only existing memory objects are referenced
- - destroyed memory objects are not referenced
- - the application has confirmed any memory objects to be reused or destroyed have been properly unbound
- - checks texture formats and render target formats.
+- the correct memory objects have been bound
+- memory objects are specified correctly upon command buffer submittal
+- only existing memory objects are referenced
+- destroyed memory objects are not referenced
+- the application has confirmed any memory objects to be reused or destroyed have been properly unbound
+- checks texture formats and render target formats.
 
 Errors will be printed if validation checks are not correctly met and warnings if improper (but not illegal) use of memory is detected.  This validation layer also dumps all memory references and bindings for each operation.
 
 ## Shader validation functionality
+
 Checks performed by this layer apply to the VS->FS and FS->CB interfaces with the pipeline.  These checks include:
 
- - validating that all variables which are part of a shader interface are  decorated with either `spv::DecLocation` or `spv::DecBuiltin` (that is, only the SSO rendezvous-by-location model is supported)
- - emitting a warning if a location is declared only in the producing stage (useless work is being done)
- - emitting an error if a location is declared only in the consuming stage (garbage will be read).
+- validating that all variables which are part of a shader interface are  decorated with either `spv::DecLocation` or `spv::DecBuiltin` (that is, only the SSO rendezvous-by-location model is supported)
+- emitting a warning if a location is declared only in the producing stage (useless work is being done)
+- emitting an error if a location is declared only in the consuming stage (garbage will be read).
 
 A special error checking case invoked when the FS stage writes a built-in corresponding to the legacy `gl_FragColor`.  In this case, an error is emitted if
 
-  - the FS also writes any user-defined output
-  - the CB has any attachment with a `UINT` or `SINT` type.
+- the FS also writes any user-defined output
+- the CB has any attachment with a `UINT` or `SINT` type.
 
 These extra checks are to ensure that the legacy broadcast of `gl_FragColor` to all bound color attachments is well-defined.
 
 ## Swapchain validation functionality
+
 This area of functionality validates the use of the WSI (Window System Integration) "swapchain" extensions (e.g., `VK_EXT_KHR_swapchain` and `VK_EXT_KHR_device_swapchain`).

--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -1,0 +1,707 @@
+# GPU-Assisted Validation
+
+GPU-Assisted validation is implemented in the SPIR-V optimizer and the `VK_LAYER_LUNARG_core_validation` layer.
+This document covers the design of the layer portion of the implementation.
+
+## Basic Operation
+
+The basic operation of GPU-Assisted validation is comprised of instrumenting shader code to perform run-time checking in shaders and
+reporting any error conditions to the layer which then reports them to the user via the existing reporting mechanisms.
+
+The layer instruments the shaders by passing the shader's SPIR-V bytecode to the SPIR-V optimizer component and
+instructs the optimizer to perform an instrumentation pass to add the additional instructions to perform the run-time checking.
+The layer then passes the resulting modified SPIR-V bytecode to the driver as part of the process of creating a ShaderModule.
+
+At run-time, the instrumented shader code performs the run-time checks.
+If a check detects an error condition, the instrumentation code writes an error record into the GPU's device memory.
+This record is small and is on the order of a dozen 32-bit words.
+Since multiple shader stages and multiple invocations of a shader can all detect errors, the instrumentation code
+writes error records into consecutive memory locations as long as there is space available in the pre-allocated block of device memory.
+
+The layer inspects this device memory block after completion of a queue submission.
+If the GPU had written an error record to this memory block,
+the layer analyzes this error record and constructs a validation error message
+which is then reported in the same manner as other validation messages.
+If the shader was compiled with debug information (source code and SPIR-V instruction mapping to source code lines), the layer
+also provides the line of shader source code that provoked the error as part of the validation error message.
+
+## GPU-Assisted Validation Checks
+
+The initial release (Jan 2019) of GPU-Assisted Validation includes checking for out-of-bounds descriptor array indexing.
+Future releases are planned to add checking for other hazards such as proper population of descriptors when using the
+`descriptorBindingPartiallyBound` feature of the `VK_EXT_descriptor_indexing` extension.
+
+### Out-of-Bounds(OOB) Descriptor Array Indexing
+
+Checking for correct indexing of descriptor arrays is sometimes referred to as "bind-less validation".
+It is called "bind-less" because a binding in a descriptor set may contain an array of like descriptors.
+And unless there is a constant or compile-time indication of which descriptor in the array is selected,
+the descriptor binding status is considered to be ambiguous, leaving the actual binding to be determined at run-time.
+
+As an example, a fragment shader program may use a variable to index an array of combined image samplers.
+Such a line might look like:
+
+```glsl
+uFragColor = light * texture(tex[tex_ind], texcoord.xy);
+```
+
+The array of combined image samplers is `tex` and has 6 samplers in the array.
+The complete validation error message issued when `tex_ind` indexes past the array is:
+
+```terminal
+ERROR : VALIDATION - Message Id Number: 0 | Message Id Name: UNASSIGNED-Image descriptor index out of bounds
+        Index of 6 used to index descriptor array of length 6.  Command buffer (CubeDrawCommandBuf)(0xbc24b0).
+        Pipeline (0x45). Shader Module (0x43). Shader Instruction Index = 108.  Stage = Fragment.
+        Fragment coord (x,y) = (419.5, 254.5). Shader validation error occurred in file:
+        /home/user/src/Vulkan-ValidationLayers/external/Vulkan-Tools/cube/cube.frag at line 45.
+45:    uFragColor = light * texture(tex[tex_ind], texcoord.xy);
+```
+
+## GPU-Assisted Validation Options
+
+Here are the options related to activating GPU-Assisted Validation:
+
+1. Enable GPU-Assisted Validation - GPU-Assisted Validation is off by default and must be enabled.
+2. Reserve a Descriptor Set Binding Slot - Modifies the value of the `VkPhysicalDeviceLimits::maxBoundDescriptorSets`
+   property to return a value one less than the actual device's value to "reserve" a descriptor set binding slot for use by GPU validation.
+
+   This feature is likely only of interest to applications that dynamically adjust their descriptor set bindings to adjust for
+   the limits of the device.
+
+## Activating GPU-Assisted Validation
+
+GPU-Assisted Validation is disabled by default because the shader instrumentation may introduce significant
+shader performance degradation.
+GPU-Assisted Validation requires additional resources such as device memory and descriptors.
+It is better for the user to opt-in to this feature because of these requirements.
+In addition, there are several limitations that may adversely affect application behavior,
+as described later in this document.
+
+### Enabling With a Configuration File
+
+The existing layer configuration file mechanism can be used to enable GPU-Assisted Validation.
+This mechanism is described on the
+[LunarXChange website](https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_configuration.html),
+in the "Layers Overview and Configuration" document.
+To turn on GPU validation, add the following to your layer settings file, which is often
+named `vk_layer_settings.txt`.
+
+```code
+lunarg_core_validation.gpu_validation = all
+```
+
+To turn on GPU validation and request to reserve a binding slot:
+
+```code
+lunarg_core_validation.gpu_validation = all,reserve_binding_slot
+```
+
+Some platforms do not support configuration of the validation layers with this configuration file.
+Programs running on these platforms must then use the programmatic interface.
+
+### Enabling With the Programmatic Interface
+
+The `VK_EXT_validation_features` extension can be used to enable GPU-Assisted Validation at CreateInstance time.
+
+Here is sample code illustrating how to enable it:
+
+```C
+VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
+VkValidationFeaturesEXT features = {};
+features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+features.enabledValidationFeatureCount = 1;
+features.pEnabledValidationFeatures = enables;
+
+VkInstanceCreateInfo info = {};
+info.pNext = &features;
+```
+
+Use the `VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT` enum to reserve a binding slot.
+
+## GPU-Assisted Validation Internal Design
+
+### General
+
+In general, the implementation does:
+
+* For each command buffer, allocate a block of device memory to hold a single debug output record written by the
+    instrumented shader code.
+    There is a device memory manager to handle this efficiently.
+
+    There is probably little advantage in providing a larger buffer in order to obtain more debug records.
+    It is likely, especially for fragment shaders, that multiple errors occurring near each other have the same root cause.
+
+    A block is allocated on a per-command buffer basis to make it possible to associate a shader debug error record with
+    an individual command buffer.
+    This is done partly to give the user more information in the error report, namely the command buffer handle/name.
+    An alternative design allocates this block on a per-device or per-queue basis and should work.
+    However, it is not possible to identify the command buffer that causes the error if multiple command buffers
+    are submitted at once.
+* For each command buffer, allocate a descriptor set and update it to point to the block of device memory just allocated.
+    There is a descriptor set manager to handle this efficiently.
+* Determine the descriptor set binding index that is eventually used to bind the descriptor set just allocated and updated.
+    Usually, it is `VkPhysicalDeviceLimits::maxBoundDescriptorSets` minus one.
+    For devices that have a very high or no limit on this bound, pick an index that isn't too high, but above most other device
+    maxima such as 32.
+* When creating a ShaderModule, pass the SPIR-V bytecode to the SPIR-V optimizer to perform the instrumentation pass.
+    Pass the desired descriptor set binding index to the optimizer via a parameter so that the instrumented
+    code knows which descriptor to use for writing error report data to the memory block.
+    Use the instrumented bytecode to create the ShaderModule.
+* For all pipeline layouts, add our descriptor set to the layout, at the binding index determined earlier.
+    Fill any gaps with empty descriptor sets.
+
+    If the incoming layout already has a descriptor set placed at our desired index, the layer must not add its
+    descriptor set to the layout, replacing the one in the incoming layout.
+    Instead, the layer leaves the layout alone and later replaces the instrumented shaders with
+    non-instrumented ones when the pipeline layout is later used to create a graphics pipeline.
+    The layer issues an error message to report this condition.
+* When creating a GraphicsPipeline, check to see if the pipeline is using the debug binding index.
+    If it is, replace the instrumented shaders in the pipeline with non-instrumented ones.
+* After binding a pipeline to a command buffer,  make an additional call down the chain to
+    create a bind descriptor set command to bind our descriptor set at the desired index.
+    This has the effect of binding the device memory block belonging to this command buffer so that the GPU instrumentation
+    writes into this buffer for the duration of the command buffer.
+    The end result is that each command buffer has its own device memory block containing GPU instrumentation error
+    records, if any occurred while running that command buffer.
+
+    As was the case with the pipeline layout, don't do this additional binding if the binding slot is already used in the pipeline layout.
+* After calling QueueSubmit, perform a wait on the queue to allow the queue to finish executing.
+    Then map and examine the device memory block for each command buffer that was submitted.
+    If any debug record is found, generate a validation error message for each record found.
+
+The above describes only the high-level details of GPU-Assisted Validation operation.
+More detail is found in the discussion of the individual hooked functions below.
+
+### Initialization
+
+When the core validation layer loads, it examines the user options from both the layer settings file and the
+`VK_EXT_validation_features` extension.
+Note that it also processes the subsumed `VK_EXT_validation_flags` extension for simple backwards compatibility.
+From these options, the layer sets instance-scope flags in the core validation layer tracking data to indicate if
+GPU-Assisted Validation has been requested, along with any other associated options.
+
+### "Calling Down the Chain"
+
+Much of the GPU-Assisted Validation implementation involves making "application level" Vulkan API
+calls outside of the application's API usage to create resources and perform its required operations
+inside of the core validation layer.
+These calls are not routed up through the top of the loader/layer/driver call stack via the loader.
+Instead, they are simply dispatched via the core validation layer's dispatch table.
+
+These calls therefore don't pass through core validation or any other validation layers that may be
+loaded/dispatched prior to code validation.
+This doesn't present any particular problem, but it does raise some issues:
+
+* The additional API calls are not fully validated
+
+  This implies that this additional code may never be checked for validation errors.
+  
+  To address this, the code can "just" be written carefully so that it is "valid" Vulkan,
+  which is hard to do.
+
+  Or, this code can be checked by loading a core validation layer with
+  GPU validation enabled on top of "normal" standard validation in the
+  layer stack, which effectively validates the API usage of this code.
+  This sort of checking is performed by layer developers to check that the additional
+  Vulkan usage is valid.
+
+  This validation can be accomplished by:
+  
+  * Building the core validation layer with a hack to force GPU-Assisted Validation to be enabled.
+  Can't use the exposed mechanisms because we probably don't want it on twice.
+  * Rename this layer binary to something else like "core_validation2" to keep it apart from the
+  "normal" core validation.
+  * Create a new JSON file with the new layer name.
+  * Set up the layer stack so that the "core_validation2" layer is on top of or before the standard validation
+  layer
+  * Then run tests and check for validation errors pointing to API usage in the "core_validation2" layer.
+
+  This should only need to be done after making any major changes to the implementation.
+
+  Another approach involves capturing an application trace with `vktrace` and then playing
+  it back with `vkreplay`.
+
+* The additional API calls are not state-tracked
+
+  This means that things like device memory allocations and descriptor allocations are not
+  tracked and do not show up in any of the bookkeeping performed by the validation layers.
+  For example, any device memory allocation performed by GPU-Assisted Validation won't be
+  counted towards the maximum number of allocations allowed by a device.
+  This could lead to an early allocation failure that is not accompanied by a validation error.
+
+  This shortcoming is left unaddressed in this implementation because it is anticipated that
+  a later implementation of GPU-Assisted Validation will have less of a need to allocate these
+  tracked resources and it therefore becomes less of an issue.
+
+### Code Structure and Relationship to the Core Validation Layer
+
+The GPU-Assisted Validation code is largely contained in one
+[file](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/layers/gpu_validation.cpp), with "hooks" in
+the other core validation code that call functions in this file.
+These hooks in the core validation code look something like this:
+
+```C
+if (GetEnables(dev_data)->gpu_validation) {
+    GpuPreCallRecordDestroyPipeline(dev_data, pipeline_state);
+}
+```
+
+The GPU-Assisted Validation code is linked into the shared library for the core validation layer.
+
+#### Review of Core Validation Code Structure
+
+Each function for a Vulkan API command intercepted in the core validation layer is usually split up
+into several decomposed functions in order to organize the implementation.
+These functions take the form of:
+
+* PreCallValidate&lt;foo&gt;: Perform validation steps before calling down the chain
+* PostCallValidate&lt;foo&gt;: Perform validation steps after calling down the chain
+* PreCallRecord&lt;foo&gt;: Perform state recording before calling down the chain
+* PostCallRecord&lt;foo&gt;: Perform state recording after calling down the chain
+
+The GPU-Assisted Validation functions follow this pattern not by hooking into the top-level core validation API shim, but
+by hooking one of these decomposed functions.
+In a few unusual cases, the GPU-Assisted Validation function "takes over" the call to the driver (down the chain) and so
+must hook the top-level API shim.
+These functions deviate from the above naming convention to make their purpose more evident.
+
+The design of each hooked function follows:
+
+#### GpuPreCallRecordCreateDevice
+
+* Modify the `VkPhysicalDeviceFeatures` to turn on two additional physical device features:
+  * `fragmentStoresAndAtomics`
+  * `vertexPipelineStoresAndAtomics`
+
+#### GpuPostCallRecordCreateDevice
+
+* Determine and record (save in device state) the desired descriptor set binding index.
+* Initialize device memory manager
+  * Determine error record block size based on the maximum size of the error record and alignment limits of the device.
+* Initialize descriptor set manager
+* Make a descriptor set layout to describe our descriptor set
+* Make a descriptor set layout to describe a "dummy" descriptor set that contains no descriptors
+  * This is used to "pad" pipeline layouts to fill any gaps between the used bind indices and our bind index
+* Record these objects in the per-device state
+
+#### GpuPreCallRecordDestroyDevice
+
+* Destroy descriptor set layouts created in CreateDevice
+* Clean up descriptor set manager
+* Clean up device memory manager
+* Clean up device state
+
+#### GpuPostCallRecordAllocateCommandBuffers
+
+* For each command buffer:
+  * Get a descriptor set from the descriptor set manager
+  * Get a device memory block from the device memory manager
+  * Update (write) the descriptor set with the memory info
+* Record the above objects in the per-CB state
+
+#### GpuPreCallRecordFreeCommandBuffers
+
+* For each command buffer:
+  * Give the memory block back to the device memory manager
+  * Give the descriptor set back to the descriptor set manager
+  * Clean up CB state
+
+#### GpuOverrideDispatchCreateShaderModule
+
+This function is called from CreateShaderModule and can't really be called from one of the decomposed functions
+because it replaces the SPIR-V, which requires modifying the bytecode passed down to the driver.
+This routine sets up to call the SPIR-V optimizer to run the "BindlessCheckPass", replacing the original SPIR-V with the instrumented SPIR-V
+which is then used in the call down the chain to CreateShaderModule.
+
+This function generates a "unique shader ID" that is passed to the SPIR-V optimizer,
+which the instrumented code puts in the debug error record to identify the shader.
+This ID is returned by this function so it can be recorded in the shader module at PostCallRecord time.
+It would have been convenient to use the shader module handle returned from the driver to use as this shader ID.
+But the shader needs to be instrumented before creating the shader module and therefore the handle is not available to use
+as this ID to pass to the optimizer.
+Therefore, the layer keeps a "counter" in per-device state that is incremented each time a shader is instrumented
+to generate unique IDs.
+This unique ID is given to the SPIR-V optimizer and is stored in the shader module state tracker after the shader module is created, which creates the necessary association between the ID and the shader module.
+
+The process of instrumenting the SPIR-V also includes passing the selected descriptor set binding index
+to the SPIR-V optimizer which the instrumented
+code uses to locate the memory block used to write the debug error record.
+An instrumented shader is now "hard-wired" to write error records via the descriptor set at that binding
+if it detects an error.
+This implies that the instrumented shaders should only be allowed to run when the correct bindings are in place.
+
+The original SPIR-V bytecode is left stored in the shader module tracking data.
+This is important because the layer may need to replace the instrumented shader with the original shader if, for example,
+there is a binding index conflict.
+The application cannot destroy the shader module until it has used the shader module to create the pipeline.
+This ensures that the original SPIR-V bytecode is available if we need it to replace the instrumented shader.
+
+#### GpuOverrideDispatchCreatePipelineLayout
+
+This is another function that replaces the parameters and so can't be called from a decomposed function.
+
+* Check for a descriptor set binding index conflict.
+  * If there is one, issue an error message and leave the pipeline layout unmodified
+  * If no conflict, for each pipeline layout:
+    * Create a new pipeline layout
+    * Copy the original descriptor set layouts into the new pipeline layout
+    * Pad the new pipeline layout with dummy descriptor set layouts up to but not including the last one
+    * Add our descriptor set layout as the last one in the new pipeline layout
+* Create the pipeline layouts by calling down the chain with the original or modified create info
+
+#### GpuPostCallDispatchCmdBindPipeline
+
+* Check to see if the layout for the pipeline just bound is using our selected bind index
+  * If no conflict, add an additional command to the command buffer to bind our descriptor set at our selected index
+
+#### GpuPostCallQueueSubmit
+
+* The core validation function calls QueueWaitIdle and then this routine at the end of QueueSubmit processing.
+* For each primary and secondary command buffer in the submission:
+  * Call a helper function to process the instrumentation debug buffer (described later)
+
+#### GpuPreCallValidateCmdWaitEvents
+
+* Report an error about a possible deadlock if CmdWaitEvents is recorded with VK_PIPELINE_STAGE_HOST_BIT set.
+
+#### GpuPreCallRecordCreateGraphicsPipelines
+
+* Examine the pipelines to see if any use the debug descriptor set binding index
+* For those that do:
+  * Create non-instrumented shader modules from the saved original SPIR-V
+  * Modify the CreateInfo data to use these non-instumented shaders.
+    * This prevents instrumented shaders from using the application's descriptor set.
+
+#### GpuPostCallRecordCreateGraphicsPipelines
+
+* For every shader in the pipeline:
+  * Destroy the shader module created in GpuPreCallRecordCreateGraphicsPipelines, if any
+    * These are found in the CreateInfo used to create the pipeline and not in the shader_module
+  * Create a shader tracking record that saves:
+    * shader module handle
+    * unique shader id
+    * graphics pipeline handle
+    * shader bytecode if it contains debug info
+
+This tracker is used to attach the shader bytecode to the shader in case it is needed
+later to get the shader source code debug info.
+
+The current shader module tracker in core validation stores the bytecode,
+but this tracker has the same life cycle as the shader module itself.
+It is possible for the application to destroy the shader module after
+creating graphics pipeline and before submitting work that uses the shader,
+making the shader bytecode unavailable if needed for later analysis.
+Therefore, the bytecode must be saved at this opportunity.
+
+This tracker exists as long as the graphics pipeline exists,
+so the graphics pipeline handle is also stored in this tracker so that it can
+be looked up when the graphics pipeline is destroyed.
+At that point, it is safe to free the bytecode since the pipeline is never used again.
+
+#### GpuPreCallRecordDestroyPipeline
+
+* Find the shader tracker(s) with the graphics pipeline handle and free the tracker, along with any bytecode it has stored in it.
+
+## Shader Instrumentation Error Record Format
+
+The instrumented shader code generates "error records" in a specific format.
+
+This description includes the support for future GPU-Assisted Validation features
+such as checking for uninitialized descriptors in the partially-bound scenario.
+These items are not used in the current implementation for descriptor array
+bounds checking, but are provided here to complete the description of the
+error record format.
+
+The format of this buffer is as follows:
+
+```C
+struct DebugOutputBuffer_t
+{
+   uint DataWrittenLength;
+   uint Data[];
+}
+```
+
+`DataWrittenLength` is the number of uint32_t words that have been attempted to be written.
+It should be initialized to 0.
+
+The `Data` array is the uint32_t words written by the shaders of the pipeline to record bindless validation errors.
+All elements of `Data` should be initialized to 0.
+Note that the `Data` array has runtime length.
+The shader queries the length of the `Data` array to make sure that it does not write past the end of `Data`.
+The shader only writes complete records.
+The layer uses the length of `Data` to control the number of records written by the shaders.
+
+The `DataWrittenLength` is atomically updated by the shaders so that shaders do not overwrite each others data.
+The shader takes the value it gets from the atomic update.
+If the value plus the record length is greater than the length of `Data`, it does not write the record.
+
+Given this protocol, the value in `DataWrittenLength` is not very meaningful if it is greater than the length of `Data`.
+However, the format of the written records plus the fact that `Data` is initialized to 0 should be enough to determine
+the records that were written.
+
+### Record Format
+
+The format of an output record is the following:
+
+    Word 0: Record size
+    Word 1: Shader ID
+    Word 2: Instruction Index
+    Word 3: Stage
+    <Stage-Specific Words>
+    <Validation-Specific Words>
+
+The Record Size is the number of words in this record, including the the Record Size.
+
+The Shader ID is a handle that was provided by the layer when the shader was instrumented.
+
+The Instruction Index is the instruction within the original function at which the error occurred.
+For bindless, this will be the instruction which consumes the descriptor in question,
+or the instruction that consumes the OpSampledImage that consumes the descriptor.
+
+The Stage is the integer value used in SPIR-V for each of the Graphics Execution Models:
+
+| Stage  | Value |
+|--------|:-----:|
+|Vertex  |0      |
+|TessCtrl|1      |
+|TessEval|2      |
+|Geometry|3      |
+|Fragment|4      |
+|Compute |5      |
+
+### Stage Specific Words
+
+These are words that identify which "instance" of the shader the validation error occurred in.
+Here are words for each stage:
+
+| Stage  | Word 0           | Word 1     |
+|--------|------------------|------------|
+|Vertex  |VertexID          |InstanceID  |
+|Tess*   |InvocationID      |unused      |
+|Geometry|PrimitiveID       |InvocationID|
+|Fragment|FragCoord.x       |FragCoord.y |
+|Compute |GlobalInvocationID|unused      |
+
+"unused" means not relevant, but still present.
+
+### Validation-Specific Words
+
+These are words that are specific to the validation being done.
+For bindless validation, they are variable.
+
+The first word is the Error Code.
+
+For the *OutOfBounds errors, two words will follow: Word0:DescriptorIndex, Word1:DescriptorArrayLength
+
+For the *Uninitialized errors, one word will follow: Word0:DescriptorIndex
+
+| Error                       | Code | Word 0         | Word 1                |
+|-----------------------------|:----:|----------------|-----------------------|
+|ImageIndexOutOfBounds        |0     |Descriptor Index|Descriptor Array Length|
+|SampleIndexOutOfBounds       |1     |Descriptor Index|Descriptor Array Length|
+|ImageDescriptorUninitialized |2     |Descriptor Index|unused                 |
+|SampleDescriptorUninitialized|3     |Descriptor Index|unused                 |
+
+So the words written for an image descriptor bounds error in a fragment shader is:
+
+    Word 0: Record size (9)
+    Word 1: Shader ID
+    Word 2: Instruction Index
+    Word 3: Stage (4:Fragment)
+    Word 4: FragCoord.x
+    Word 5: FragCoord.y
+    Word 6: Error (0: ImageIndexOutOfBounds)
+    Word 7: DescriptorIndex
+    Word 8: DescriptorArrayLength
+
+If another error is encountered, that record is written starting at Word 10, if the whole record will not overflow Data.
+If overflow will happen, no words are written..
+
+The validation layer can continue to read valid records until it sees a Record Length of 0 or the end of Data is reached.
+
+#### Programmatic interface
+
+The programmatic interface for the above informal description is codified in the
+[SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools) repository in file
+[`instrument.hpp`](https://github.com/KhronosGroup/SPIRV-Tools/blob/master/include/spirv-tools/instrument.hpp).
+It consists largely of integer constant definitions for the codes and values mentioned above and
+offsets into the record for locating each item.
+
+## GPU-Assisted Validation Error Report
+
+This is a fairly simple process of mapping the debug report buffer associated with
+each command buffer that was just submitted and looking to see if the GPU instrumentation
+code wrote anything.
+The layer clears the buffer to zeroes when it is allocated and after processing any
+buffer that was written to.
+The instrumented shader code expects these buffers to be cleared to zeroes before it
+writes to them.
+
+The layer then prepares a "common" validation error message containing:
+
+* command buffer handle - This is easily obtained because we are looping over the command
+  buffers just submitted.
+* pipeline handle - The shader tracker discussed earlier contains this handle
+* shader module handle - The "Shader ID" (Word 1 in the record) is used to lookup
+  the shader tracker which is then used to obtain the shader module and pipeline handles
+* instruction index - This is the SPIR-V instruction index where the invalid array access ocurred.
+  It is not that useful by itself, since the user would have to use it to locate a SPIR-V instruction
+  in a SPIR-V disassembly and somehow relate it back to the shader source code.
+  But it could still be useful to some and it is easy to report.
+  The user can build the shader with debug information to get source-level information.
+
+For all objects, the layer also looks up the objects in the Debug Utils object name map in
+case the application used that extension to name any objects.
+If a name exists for that object, it is included in the error message.
+
+The layer then adds on error message text obtained from decoding the stage-specific and
+validation-specific data as described earlier.
+
+This completes the error report when there is no source-level debug information in the shader.
+
+### Source-Level Debug Information
+
+This is one of the more complicated and code-heavy parts of the GPU-Assisted Validation feature
+and all it really does is display source-level information when the shader is compiled
+with debugging info (`-g` option in the case of `glslangValidator`).
+
+The process breaks down into two steps:
+
+#### OpLine Processing
+
+The SPIR-V generator (e.g., glslangValidator) places an OpLine SPIR-V instruction in the
+shader program ahead of code generated for each source code statement.
+The OpLine instruction contains the filename id (for an OpString),
+the source code line number and the source code column number.
+It is possible to have two source code statements on the same line in the source file,
+which explains the need for the column number.
+
+The layer scans the SPIR-V looking for the last OpLine instruction that appears before the instruction
+at the instruction index obtained from the debug report.
+This OpLine then contains the correct filename id, line number, and column number of the
+statement causing the error.
+The filename itself is obtained by scanning the SPIR-V again for an OpString instruction that
+matches the id from the OpLine.
+This OpString contains the text string representing the filename.
+This information is added to the validation error message.
+
+#### OpSource Processing
+
+The SPIR-V built with source-level debug info also contains OpSource instructions that
+have a string containing the source code, delimited by newlines.
+Due to possible pre-processing, the layer just cannot simply use the source file line number
+from the OpLine to index into this set of source code lines.
+
+Instead, the correct source code line is found by locating the "#line" directive in the
+source that specifies a line number closest to and less than the source line number reported
+by the OpLine located in the previous step.
+The correct "#line" directive must also match its filename, if specified,
+with the filename from the OpLine.
+
+Then the difference between the "#line" line number and the OpLine line number is added
+to the place where the "#line" was found to locate the actual line of source, which is
+then added to the validation error message.
+
+For example, if the OpLine line number is 15, and there is a "#line 10" on line 40
+in the OpSource source, then line 45 in the OpSource contains the correct source line.
+
+## GPU-Assisted Validation Limitations
+
+There are several limitations that may impede the operation of GPU-Assisted Validation:
+
+Note that with the recent availablilty of the `VK_EXT_buffer_device_address` extension,
+it is possible to create an alternate implementation of GPU-Assisted Validation.
+This new approach would use this extension to obtain a GPU machine pointer to a storage
+buffer and pass it to the shader via a specialization constant.
+This technique removes the need to create descriptors, use a descriptor set slot,
+modify pipeline layouts, etc, and would relax some of the limitations listed below.
+
+### Vulkan 1.1
+
+Vulkan 1.1 or later is required because the GPU instrumentation code uses SPIR-V 1.3 features.
+Vulkan 1,1 is required to ensure that SPIR-V 1.3 is available.
+
+### Compute Shaders
+
+Compute Shaders are not supported.
+
+### Descriptor Set Binding Limit
+
+This is probably the most important limitation and is related to the
+`VkPhysicalDeviceLimits::maxBoundDescriptorSets` device limit.
+
+Basically, when applications use all the available descriptor set binding slots,
+GPU-Assisted Validation cannot be performed because it needs a descriptor set to
+locate the memory for writing the error report record.
+
+This problem is most likely to occur on devices, often mobile, that support only the
+minimum required value for `VkPhysicalDeviceLimits::maxBoundDescriptorSets`, which is 4.
+Some applications may be written to use 4 slots since this is the highest value that
+is guaranteed by the specification.
+When such an application runs on a device with only 4 slots, then GPU-Assisted Validation
+cannot be performed.
+
+In this implementation, this condition is detected and gracefully recovered from by
+building the graphics pipeline with non-instrumented shaders instead of instrumented ones.
+An error message is also displayed informing the user of the condition.
+
+Applications don't have many options in this situation and it is anticipated that
+changing the application to free a slot is difficult.
+
+This problem can be addressed in the future using the `VK_EXT_buffer_device_address` extension.
+
+### Device Memory
+
+GPU-Assisted Validation does allocate device memory for the error report buffers.
+This can lead to a greater chance of memory exhaustion, especially in cases where
+the application is trying to use all of the available memory.
+The extra memory allocations are also not visible to the application, making it
+impossible for the application to account for them.
+
+If GPU-Assisted Validation device memory allocations fail, the device could become
+unstable because some previously-built pipelines may contain instrumented shaders.
+This is a condition that is nearly impossible to recover from, so the layer just
+prints an error message and refrains from any further allocations or instrumentations.
+There is a reasonable chance to recover from all this, especially if the instrumentation
+does not write any error records.
+
+This problem can be addressed in the future using the `VK_EXT_buffer_device_address` extension.
+
+### Descriptors
+
+This is roughly the same problem as the device memory problem mentioned above,
+but for descriptors.
+Any failure to allocate a descriptor set means that the instrumented shader code
+won't have a place to write error records, resulting in unpredictable device
+behavior.
+
+This problem can be addressed in the future using the `VK_EXT_buffer_device_address` extension.
+
+### Other Device Limits
+
+This implementation uses additional resources that may count against the following limits,
+and possibly others:
+
+* maxMemoryAllocationCount
+* maxBoundDescriptorSets
+* maxPerStageDescriptorStorageBuffers
+* maxPerStageResources
+* maxDescriptorSetStorageBuffers
+* maxFragmentCombinedOutputResources
+
+The implementation does not take steps to avoid exceeding these limits
+and does not update the tracking performed by other validation functions.
+
+## GPU-Assisted Validation Testing
+
+Validation Layer Tests (VLTs) exist for GPU-Assisted Validation.
+They cannot be run with the "mock ICD" in headless CI environments because they need to
+actually execute shaders.
+But they are still useful to run on real devices to check for regressions.
+
+There isn't anything else that remarkable or different about these tests.
+They do need to activate GPU-Assisted Validation programmatically as described earlier.
+
+The tests do exercise the extraction of source code information when the shader
+is built with debug info.

--- a/docs/object_tracker_layer.md
+++ b/docs/object_tracker_layer.md
@@ -1,12 +1,13 @@
 # VK\_LAYER\_LUNARG\_object\_tracker
+
 The `VK_LAYER_LUNARG_object_tracker` layer tracks all Vulkan objects. Object lifetimes are validated along with issues related to unknown objects and object destruction and cleanup.
 
 All Vulkan dispatchable and non-dispatchable objects are tracked by the `VK_LAYER_LUNARG_object_tracker` layer.
 
 This layer validates that:
 
- - only known objects are referenced and destroyed
- - lookups are performed only on objects being tracked
- - objects are correctly freed/destroyed.
+- only known objects are referenced and destroyed
+- lookups are performed only on objects being tracked
+- objects are correctly freed/destroyed.
 
 The `VK_LAYER_LUNARG_object_tracker` layer will print errors if validation checks are not correctly met and warnings if improper reference of objects is detected.

--- a/docs/parameter_validation_layer.md
+++ b/docs/parameter_validation_layer.md
@@ -1,8 +1,9 @@
 # VK\_LAYER\_LUNARG\_parameter\_validation
+
 The `VK_LAYER_LUNARG_parameter_validation` validation layer checks the input parameters to API calls for validity. This layer performs the following tasks:
 
- - validation of structures; structures are recursed if necessary
- - validation of enumerated type values
- - null pointer conditions
- - stateless valid usage checks
- - validation of `VkResult`.
+- validation of structures; structures are recursed if necessary
+- validation of enumerated type values
+- null pointer conditions
+- stateless valid usage checks
+- validation of `VkResult`.

--- a/docs/threading_layer.md
+++ b/docs/threading_layer.md
@@ -1,2 +1,3 @@
 # VK\_LAYER\_GOOGLE\_threading
+
 The `VK_LAYER_GOOGLE_threading` layer checks multi-threading of API calls for validity.  Checks performed by this layer include ensuring that only one thread at a time uses an object in free-threaded API calls.

--- a/docs/unique_objects_layer.md
+++ b/docs/unique_objects_layer.md
@@ -1,4 +1,5 @@
 # VK\_LAYER\_GOOGLE\_unique\_objects
+
 The `VK_LAYER_LUNARG_unique_objects` is a validation-supporting utility layer which enables consistent and coherent validation in addition to proper operation on systems which return non-unique object handles.  This layer aliases all non-dispatchable Vulkan objects with a unique identifier at object-creation time. The aliased handles are used during validation to ensure that duplicate object handles are correctly managed and tracked by the validation layers.
 
 Note:  

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2018 Valve Corporation
-# Copyright (c) 2014-2018 LunarG, Inc.
+# Copyright (c) 2014-2019 Valve Corporation
+# Copyright (c) 2014-2019 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -196,7 +196,7 @@ add_custom_target(VulkanVL_generate_chassis_files
 set_target_properties(VulkanVL_generate_chassis_files PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
 
 if(BUILD_LAYERS)
-    AddVkLayer(core_validation "" core_validation.cpp convert_to_renderpass2.cpp descriptor_sets.cpp buffer_validation.cpp shader_validation.cpp xxhash.c)
+    AddVkLayer(core_validation "" core_validation.cpp convert_to_renderpass2.cpp descriptor_sets.cpp buffer_validation.cpp shader_validation.cpp gpu_validation.cpp xxhash.c)
     AddVkLayer(object_lifetimes "BUILD_OBJECT_TRACKER" object_tracker.cpp object_tracker.h object_tracker_utils.cpp chassis.cpp layer_chassis_dispatch.cpp)
     AddVkLayer(thread_safety "BUILD_THREAD_SAFETY" thread_safety.cpp thread_safety.h chassis.cpp layer_chassis_dispatch.cpp)
     AddVkLayer(unique_objects "LAYER_CHASSIS_CAN_WRAP_HANDLES" chassis.cpp layer_chassis_dispatch.cpp)

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1,0 +1,1033 @@
+/* Copyright (c) 2018-2019 The Khronos Group Inc.
+ * Copyright (c) 2018-2019 Valve Corporation
+ * Copyright (c) 2018-2019 LunarG, Inc.
+ * Copyright (C) 2018-2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Allow use of STL min and max functions in Windows
+#define NOMINMAX
+
+#include "core_validation.h"
+#include "shader_validation.h"
+#include "gpu_validation.h"
+#include "spirv-tools/libspirv.h"
+#include "spirv-tools/optimizer.hpp"
+#include "spirv-tools/instrument.hpp"
+#include <SPIRV/spirv.hpp>
+#include <algorithm>
+#include <regex>
+
+// This is the number of bindings in the debug descriptor set.
+static const uint32_t kNumBindingsInSet = 1;
+
+// Implementation for Device Memory Manager class
+VkResult GpuDeviceMemoryManager::GetBlock(GpuDeviceMemoryBlock *block) {
+    assert(block->buffer == VK_NULL_HANDLE);  // avoid possible overwrite/leak of an allocated block
+    VkResult result = VK_SUCCESS;
+    MemoryChunk *pChunk = nullptr;
+    // Look for a chunk with available offsets.
+    for (auto &chunk : chunk_list_) {
+        if (!chunk.available_offsets.empty()) {
+            pChunk = &chunk;
+            break;
+        }
+    }
+    // If no chunks with available offsets, allocate device memory and set up offsets.
+    if (pChunk == nullptr) {
+        MemoryChunk new_chunk;
+        result = AllocMemoryChunk(new_chunk);
+        if (result == VK_SUCCESS) {
+            new_chunk.available_offsets.resize(blocks_per_chunk_);
+            for (uint32_t offset = 0, i = 0; i < blocks_per_chunk_; offset += block_size_, ++i) {
+                new_chunk.available_offsets[i] = offset;
+            }
+            chunk_list_.push_front(std::move(new_chunk));
+            pChunk = &chunk_list_.front();
+        } else {
+            // Indicate failure
+            block->buffer = VK_NULL_HANDLE;
+            block->memory = VK_NULL_HANDLE;
+            return result;
+        }
+    }
+    // Give the requester an available offset
+    block->buffer = pChunk->buffer;
+    block->memory = pChunk->memory;
+    block->offset = pChunk->available_offsets.back();
+    pChunk->available_offsets.pop_back();
+    return result;
+}
+
+void GpuDeviceMemoryManager::PutBackBlock(VkBuffer buffer, VkDeviceMemory memory, uint32_t offset) {
+    GpuDeviceMemoryBlock block = {buffer, memory, offset};
+    PutBackBlock(block);
+}
+
+void GpuDeviceMemoryManager::PutBackBlock(GpuDeviceMemoryBlock &block) {
+    // Find the chunk belonging to the allocated offset and make the offset available again
+    auto chunk = std::find_if(std::begin(chunk_list_), std::end(chunk_list_),
+                              [&block](const MemoryChunk &c) { return c.buffer == block.buffer; });
+    if (chunk_list_.end() == chunk) {
+        assert(false);
+    } else {
+        chunk->available_offsets.push_back(block.offset);
+        if (chunk->available_offsets.size() == blocks_per_chunk_) {
+            // All offsets have been returned
+            FreeMemoryChunk(*chunk);
+            chunk_list_.erase(chunk);
+        }
+    }
+}
+
+void ResetBlock(GpuDeviceMemoryBlock &block) {
+    block.buffer = VK_NULL_HANDLE;
+    block.memory = VK_NULL_HANDLE;
+    block.offset = 0;
+}
+
+bool BlockUsed(GpuDeviceMemoryBlock &block) { return (block.buffer != VK_NULL_HANDLE) && (block.memory != VK_NULL_HANDLE); }
+
+bool GpuDeviceMemoryManager::MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex) {
+    // Search memtypes to find first index with those properties
+    const VkPhysicalDeviceMemoryProperties *props = GetPhysicalDeviceMemoryProperties(dev_data_);
+    for (uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++) {
+        if ((typeBits & 1) == 1) {
+            // Type is available, does it match user properties?
+            if ((props->memoryTypes[i].propertyFlags & requirements_mask) == requirements_mask) {
+                *typeIndex = i;
+                return true;
+            }
+        }
+        typeBits >>= 1;
+    }
+    // No memory types matched, return failure
+    return false;
+}
+
+VkResult GpuDeviceMemoryManager::AllocMemoryChunk(MemoryChunk &chunk) {
+    VkBuffer buffer;
+    VkDeviceMemory memory;
+    VkBufferCreateInfo buffer_create_info = {};
+    VkMemoryRequirements mem_reqs = {};
+    VkMemoryAllocateInfo mem_alloc = {};
+    VkResult result = VK_SUCCESS;
+    bool pass;
+    void *pData;
+    const auto *dispatch_table = GetDispatchTable(dev_data_);
+
+    buffer_create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    buffer_create_info.size = chunk_size_;
+    result = dispatch_table->CreateBuffer(GetDevice(dev_data_), &buffer_create_info, NULL, &buffer);
+    if (result != VK_SUCCESS) {
+        return result;
+    }
+
+    dispatch_table->GetBufferMemoryRequirements(GetDevice(dev_data_), buffer, &mem_reqs);
+
+    mem_alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    mem_alloc.pNext = NULL;
+    mem_alloc.allocationSize = mem_reqs.size;
+    pass = MemoryTypeFromProperties(mem_reqs.memoryTypeBits,
+                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                    &mem_alloc.memoryTypeIndex);
+    if (!pass) {
+        dispatch_table->DestroyBuffer(GetDevice(dev_data_), buffer, NULL);
+        return result;
+    }
+    result = dispatch_table->AllocateMemory(GetDevice(dev_data_), &mem_alloc, NULL, &memory);
+    if (result != VK_SUCCESS) {
+        dispatch_table->DestroyBuffer(GetDevice(dev_data_), buffer, NULL);
+        return result;
+    }
+
+    result = dispatch_table->BindBufferMemory(GetDevice(dev_data_), buffer, memory, 0);
+    if (result != VK_SUCCESS) {
+        dispatch_table->DestroyBuffer(GetDevice(dev_data_), buffer, NULL);
+        dispatch_table->FreeMemory(GetDevice(dev_data_), memory, NULL);
+        return result;
+    }
+
+    result = dispatch_table->MapMemory(GetDevice(dev_data_), memory, 0, mem_alloc.allocationSize, 0, &pData);
+    if (result == VK_SUCCESS) {
+        memset(pData, 0, chunk_size_);
+        dispatch_table->UnmapMemory(GetDevice(dev_data_), memory);
+    } else {
+        dispatch_table->DestroyBuffer(GetDevice(dev_data_), buffer, NULL);
+        dispatch_table->FreeMemory(GetDevice(dev_data_), memory, NULL);
+        return result;
+    }
+    chunk.buffer = buffer;
+    chunk.memory = memory;
+    return result;
+}
+
+void GpuDeviceMemoryManager::FreeMemoryChunk(MemoryChunk &chunk) {
+    GetDispatchTable(dev_data_)->DestroyBuffer(GetDevice(dev_data_), chunk.buffer, NULL);
+    GetDispatchTable(dev_data_)->FreeMemory(GetDevice(dev_data_), chunk.memory, NULL);
+}
+
+// Implementation for Descriptor Set Manager class
+VkResult GpuDescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescriptorPool *pool,
+                                                    std::vector<VkDescriptorSet> *desc_sets) {
+    auto gpu_state = GetGpuValidationState(dev_data_);
+    const uint32_t default_pool_size = kItemsPerChunk;
+    VkResult result = VK_SUCCESS;
+    VkDescriptorPool pool_to_use = VK_NULL_HANDLE;
+
+    if (0 == count) {
+        return result;
+    }
+    desc_sets->clear();
+    desc_sets->resize(count);
+
+    for (auto &pool : desc_pool_map_) {
+        if (pool.second.used + count < pool.second.size) {
+            pool_to_use = pool.first;
+            break;
+        }
+    }
+    if (VK_NULL_HANDLE == pool_to_use) {
+        uint32_t pool_count = default_pool_size;
+        if (count > default_pool_size) {
+            pool_count = count;
+        }
+        const VkDescriptorPoolSize size_counts = {
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            pool_count * kNumBindingsInSet,
+        };
+        VkDescriptorPoolCreateInfo desc_pool_info = {};
+        desc_pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        desc_pool_info.pNext = NULL;
+        desc_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        desc_pool_info.maxSets = pool_count;
+        desc_pool_info.poolSizeCount = 1;
+        desc_pool_info.pPoolSizes = &size_counts;
+        result = GetDispatchTable(dev_data_)->CreateDescriptorPool(GetDevice(dev_data_), &desc_pool_info, NULL, &pool_to_use);
+        assert(result == VK_SUCCESS);
+        if (result != VK_SUCCESS) {
+            return result;
+        }
+        desc_pool_map_[pool_to_use].size = desc_pool_info.maxSets;
+        desc_pool_map_[pool_to_use].used = 0;
+    }
+    std::vector<VkDescriptorSetLayout> desc_layouts(count, gpu_state->debug_desc_layout);
+
+    VkDescriptorSetAllocateInfo alloc_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, NULL, pool_to_use, count,
+                                              desc_layouts.data()};
+
+    result = GetDispatchTable(dev_data_)->AllocateDescriptorSets(GetDevice(dev_data_), &alloc_info, desc_sets->data());
+    assert(result == VK_SUCCESS);
+    if (result != VK_SUCCESS) {
+        return result;
+    }
+    *pool = pool_to_use;
+    desc_pool_map_[pool_to_use].used += count;
+    return result;
+}
+
+void GpuDescriptorSetManager::PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDescriptorSet desc_set) {
+    auto iter = desc_pool_map_.find(desc_pool);
+    if (iter != desc_pool_map_.end()) {
+        VkResult result = GetDispatchTable(dev_data_)->FreeDescriptorSets(GetDevice(dev_data_), desc_pool, 1, &desc_set);
+        assert(result == VK_SUCCESS);
+        if (result != VK_SUCCESS) {
+            return;
+        }
+        desc_pool_map_[desc_pool].used--;
+        if (0 == desc_pool_map_[desc_pool].used) {
+            GetDispatchTable(dev_data_)->DestroyDescriptorPool(GetDevice(dev_data_), desc_pool, NULL);
+            desc_pool_map_.erase(desc_pool);
+        }
+    }
+    return;
+}
+
+// Convenience function for reporting problems with setting up GPU Validation.
+static void ReportSetupProblem(const layer_data *dev_data, VkDebugReportObjectTypeEXT object_type, uint64_t object_handle,
+                               const char *const specific_message) {
+    log_msg(GetReportData(dev_data), VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
+            "UNASSIGNED-GPU-Assisted Validation Error. ", "Detail: (%s)", specific_message);
+}
+
+// Turn on necessary device features.
+std::unique_ptr<safe_VkDeviceCreateInfo> GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *create_info,
+                                                                      VkPhysicalDeviceFeatures *supported_features) {
+    std::unique_ptr<safe_VkDeviceCreateInfo> new_info(new safe_VkDeviceCreateInfo(create_info));
+    if (supported_features->fragmentStoresAndAtomics || supported_features->vertexPipelineStoresAndAtomics) {
+        VkPhysicalDeviceFeatures new_features = *new_info->pEnabledFeatures;
+        new_features.fragmentStoresAndAtomics = supported_features->fragmentStoresAndAtomics;
+        new_features.vertexPipelineStoresAndAtomics = supported_features->vertexPipelineStoresAndAtomics;
+        delete new_info->pEnabledFeatures;
+        new_info->pEnabledFeatures = new VkPhysicalDeviceFeatures(new_features);
+    }
+    return new_info;
+}
+
+// Perform initializations that can be done at Create Device time.
+void GpuPostCallRecordCreateDevice(layer_data *dev_data) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    const auto *dispatch_table = GetDispatchTable(dev_data);
+
+    if (GetPhysicalDeviceProperties(dev_data)->apiVersion < VK_API_VERSION_1_1) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "GPU-Assisted validation requires Vulkan 1.1 or later.  GPU-Assisted Validation disabled.");
+        gpu_state->aborted = true;
+        return;
+    }
+    // Some devices have extremely high limits here, so set a reasonable max because we have to pad
+    // the pipeline layout with dummy descriptor set layouts.
+    gpu_state->adjusted_max_desc_sets = GetPhysicalDeviceProperties(dev_data)->limits.maxBoundDescriptorSets;
+    gpu_state->adjusted_max_desc_sets = std::min(33U, gpu_state->adjusted_max_desc_sets);
+
+    // We can't do anything if there is only one.
+    // Device probably not a legit Vulkan device, since there should be at least 4. Protect ourselves.
+    if (gpu_state->adjusted_max_desc_sets == 1) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "Device can bind only a single descriptor set.  GPU-Assisted Validation disabled.");
+        gpu_state->aborted = true;
+        return;
+    }
+    gpu_state->desc_set_bind_index = gpu_state->adjusted_max_desc_sets - 1;
+    log_msg(GetReportData(dev_data), VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
+            HandleToUint64(GetDevice(dev_data)), "UNASSIGNED-GPU-Assisted Validation. ",
+            "Shaders using descriptor set at index %d. ", gpu_state->desc_set_bind_index);
+
+    std::unique_ptr<GpuDeviceMemoryManager> memory_manager(
+        new GpuDeviceMemoryManager(dev_data, sizeof(uint32_t) * (spvtools::kInstMaxOutCnt + 1)));
+    std::unique_ptr<GpuDescriptorSetManager> desc_set_manager(new GpuDescriptorSetManager(dev_data));
+
+    // The descriptor indexing checks require only the first "output" binding.
+    const VkDescriptorSetLayoutBinding debug_desc_layout_bindings[kNumBindingsInSet] = {
+        {
+            0,  // output
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            1,
+            VK_SHADER_STAGE_ALL_GRAPHICS,
+            NULL,
+        },
+    };
+
+    const VkDescriptorSetLayoutCreateInfo debug_desc_layout_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, NULL, 0,
+                                                                    kNumBindingsInSet, debug_desc_layout_bindings};
+
+    const VkDescriptorSetLayoutCreateInfo dummy_desc_layout_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, NULL, 0, 0,
+                                                                    NULL};
+
+    VkResult result = dispatch_table->CreateDescriptorSetLayout(GetDevice(dev_data), &debug_desc_layout_info, NULL,
+                                                                &gpu_state->debug_desc_layout);
+
+    // This is a layout used to "pad" a pipeline layout to fill in any gaps to the selected bind index.
+    VkResult result2 = dispatch_table->CreateDescriptorSetLayout(GetDevice(dev_data), &dummy_desc_layout_info, NULL,
+                                                                 &gpu_state->dummy_desc_layout);
+    assert((result == VK_SUCCESS) && (result2 == VK_SUCCESS));
+    if ((result != VK_SUCCESS) || (result2 != VK_SUCCESS)) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "Unable to create descriptor set layout.  GPU-Assisted Validation disabled.");
+        if (result == VK_SUCCESS) {
+            dispatch_table->DestroyDescriptorSetLayout(GetDevice(dev_data), gpu_state->debug_desc_layout, NULL);
+        }
+        if (result2 == VK_SUCCESS) {
+            dispatch_table->DestroyDescriptorSetLayout(GetDevice(dev_data), gpu_state->dummy_desc_layout, NULL);
+        }
+        gpu_state->debug_desc_layout = VK_NULL_HANDLE;
+        gpu_state->dummy_desc_layout = VK_NULL_HANDLE;
+        gpu_state->aborted = true;
+        return;
+    }
+    gpu_state->memory_manager = std::move(memory_manager);
+    gpu_state->desc_set_manager = std::move(desc_set_manager);
+}
+
+// Clean up device-related resources
+void GpuPreCallRecordDestroyDevice(layer_data *dev_data) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+
+    if (gpu_state->debug_desc_layout) {
+        GetDispatchTable(dev_data)->DestroyDescriptorSetLayout(GetDevice(dev_data), gpu_state->debug_desc_layout, NULL);
+        gpu_state->debug_desc_layout = VK_NULL_HANDLE;
+    }
+    if (gpu_state->dummy_desc_layout) {
+        GetDispatchTable(dev_data)->DestroyDescriptorSetLayout(GetDevice(dev_data), gpu_state->dummy_desc_layout, NULL);
+        gpu_state->dummy_desc_layout = VK_NULL_HANDLE;
+    }
+}
+
+// Bind our debug descriptor set immediately after binding a pipeline if the pipeline layout is not using our slot.
+void GpuPostCallDispatchCmdBindPipeline(layer_data *dev_data, VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+                                        VkPipeline pipeline) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) {
+        return;
+    }
+    const GLOBAL_CB_NODE *cb_state = GetCBNode(dev_data, commandBuffer);
+    auto iter = cb_state->lastBound.find(pipelineBindPoint);  // find() allows read-only access to cb_state
+    if (iter != cb_state->lastBound.end()) {
+        auto pipeline_state = iter->second.pipeline_state;
+        if (pipeline_state && (pipeline_state->pipeline_layout.set_layouts.size() <= gpu_state->desc_set_bind_index)) {
+            GetDispatchTable(dev_data)->CmdBindDescriptorSets(
+                commandBuffer, pipelineBindPoint, pipeline_state->pipeline_layout.layout, gpu_state->desc_set_bind_index, 1,
+                &cb_state->gpu_buffer_desc_set, 0, nullptr);
+        }
+    }
+}
+
+// Modify the pipeline layout to include our debug descriptor set and any needed padding with the dummy descriptor set.
+VkResult GpuOverrideDispatchCreatePipelineLayout(layer_data *dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
+                                                 const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) {
+        return GetDispatchTable(dev_data)->CreatePipelineLayout(GetDevice(dev_data), pCreateInfo, pAllocator, pPipelineLayout);
+    }
+    VkPipelineLayoutCreateInfo new_create_info = *pCreateInfo;
+    std::vector<VkDescriptorSetLayout> new_layouts;
+    if (new_create_info.setLayoutCount >= gpu_state->adjusted_max_desc_sets) {
+        std::ostringstream strm;
+        strm << "Pipeline Layout conflict with validation's descriptor set at slot " << gpu_state->desc_set_bind_index << ". "
+             << "Application has too many descriptor sets in the pipeline layout to continue with gpu validation. "
+             << "Validation is not modifying the pipeline layout. "
+             << "Instrumented shaders are replaced with non-instrumented shaders.";
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           strm.str().c_str());
+    } else {
+        // Modify the pipeline layout by:
+        // 1. Copying the caller's descriptor set desc_layouts
+        // 2. Fill in dummy descriptor layouts up to the max binding
+        // 3. Fill in with the debug descriptor layout at the max binding slot
+        new_layouts.reserve(gpu_state->adjusted_max_desc_sets);
+        new_layouts.insert(new_layouts.end(), &pCreateInfo->pSetLayouts[0], &pCreateInfo->pSetLayouts[pCreateInfo->setLayoutCount]);
+        for (uint32_t i = pCreateInfo->setLayoutCount; i < gpu_state->adjusted_max_desc_sets - 1; ++i) {
+            new_layouts.push_back(gpu_state->dummy_desc_layout);
+        }
+        new_layouts.push_back(gpu_state->debug_desc_layout);
+        new_create_info.pSetLayouts = new_layouts.data();
+        new_create_info.setLayoutCount = gpu_state->adjusted_max_desc_sets;
+    }
+    VkResult result;
+    result = GetDispatchTable(dev_data)->CreatePipelineLayout(GetDevice(dev_data), &new_create_info, pAllocator, pPipelineLayout);
+    assert(result == VK_SUCCESS);
+    if (result != VK_SUCCESS) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "Unable to create pipeline layout.  Device could become unstable.");
+        gpu_state->aborted = true;
+    }
+    return result;
+}
+
+// Each command buffer gets a piece of device memory and a descriptor set for the debug buffer.
+void GpuPostCallRecordAllocateCommandBuffers(layer_data *dev_data, const VkCommandBufferAllocateInfo *pCreateInfo,
+                                             VkCommandBuffer *pCommandBuffer) {
+    VkResult result;
+
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) return;
+
+    std::vector<VkDescriptorSet> desc_sets;
+    VkDescriptorPool desc_pool = VK_NULL_HANDLE;
+    result = gpu_state->desc_set_manager->GetDescriptorSets(pCreateInfo->commandBufferCount, &desc_pool, &desc_sets);
+    assert(result == VK_SUCCESS);
+    if (result != VK_SUCCESS) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "Unable to allocate descriptor sets.  Device could become unstable.");
+        gpu_state->aborted = true;
+        return;
+    }
+
+    VkDescriptorBufferInfo desc_buffer_info = {};
+    desc_buffer_info.range = gpu_state->memory_manager->GetBlockSize();
+
+    VkWriteDescriptorSet desc_write = {};
+    desc_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    desc_write.descriptorCount = 1;
+    desc_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    desc_write.pBufferInfo = &desc_buffer_info;
+
+    for (uint32_t i = 0; i < pCreateInfo->commandBufferCount; i++) {
+        auto cb_node = GetCBNode(dev_data, pCommandBuffer[i]);
+
+        GpuDeviceMemoryBlock block = {};
+        result = gpu_state->memory_manager->GetBlock(&block);
+        if (result != VK_SUCCESS) {
+            ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                               "Unable to allocate device memory.  Device could become unstable.");
+            gpu_state->aborted = true;
+            return;
+        }
+
+        // Record buffer and memory info in CB state tracking
+        cb_node->gpu_output_memory_block = block;
+        cb_node->gpu_buffer_desc_set = desc_sets[i];
+        cb_node->gpu_buffer_desc_pool = desc_pool;
+
+        // Write the descriptor
+        desc_buffer_info.buffer = block.buffer;
+        desc_buffer_info.offset = block.offset;
+        desc_write.dstSet = cb_node->gpu_buffer_desc_set;
+        GetDispatchTable(dev_data)->UpdateDescriptorSets(GetDevice(dev_data), 1, &desc_write, 0, NULL);
+    }
+}
+
+// Free the device memory and descriptor set associated with a command buffer.
+void GpuPreCallRecordFreeCommandBuffers(layer_data *dev_data, uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) {
+        return;
+    }
+    for (uint32_t i = 0; i < commandBufferCount; ++i) {
+        auto cb_node = GetCBNode(dev_data, pCommandBuffers[i]);
+        if (BlockUsed(cb_node->gpu_output_memory_block)) {
+            gpu_state->memory_manager->PutBackBlock(cb_node->gpu_output_memory_block);
+            ResetBlock(cb_node->gpu_output_memory_block);
+        }
+        if (cb_node->gpu_buffer_desc_set != VK_NULL_HANDLE) {
+            gpu_state->desc_set_manager->PutBackDescriptorSet(cb_node->gpu_buffer_desc_pool, cb_node->gpu_buffer_desc_set);
+            cb_node->gpu_buffer_desc_set = VK_NULL_HANDLE;
+        }
+    }
+}
+
+// Just gives a warning about a possible deadlock.
+void GpuPreCallValidateCmdWaitEvents(layer_data *dev_data, VkPipelineStageFlags sourceStageMask) {
+    if (sourceStageMask & VK_PIPELINE_STAGE_HOST_BIT) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(GetDevice(dev_data)),
+                           "CmdWaitEvents recorded with VK_PIPELINE_STAGE_HOST_BIT set. "
+                           "GPU_Assisted validation waits on queue completion. "
+                           "This wait could block the host's signaling of this event, resulting in deadlock.");
+    }
+}
+
+// Examine the pipelines to see if they use the debug descriptor set binding index.
+// If any do, create new non-instrumented shader modules and use them to replace the instrumented
+// shaders in the pipeline.  Return the (possibly) modified create infos to the caller.
+std::vector<safe_VkGraphicsPipelineCreateInfo> GpuPreCallRecordCreateGraphicsPipelines(
+    layer_data *dev_data, VkPipelineCache pipelineCache, uint32_t count, const VkGraphicsPipelineCreateInfo *pCreateInfos,
+    const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, std::vector<std::unique_ptr<PIPELINE_STATE>> &pipe_state) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+
+    std::vector<safe_VkGraphicsPipelineCreateInfo> new_pipeline_create_infos;
+    std::vector<unsigned int> pipeline_uses_debug_index(count);
+
+    // Walk through all the pipelines, make a copy of each and flag each pipeline that contains a shader that uses the debug
+    // descriptor set index.
+    for (uint32_t pipeline = 0; pipeline < count; ++pipeline) {
+        new_pipeline_create_infos.push_back(pipe_state[pipeline]->graphicsPipelineCI);
+        if (pipe_state[pipeline]->active_slots.find(gpu_state->desc_set_bind_index) != pipe_state[pipeline]->active_slots.end()) {
+            pipeline_uses_debug_index[pipeline] = 1;
+        }
+    }
+
+    // See if any pipeline has shaders using the debug descriptor set index
+    if (std::all_of(pipeline_uses_debug_index.begin(), pipeline_uses_debug_index.end(), [](unsigned int i) { return i == 0; })) {
+        // None of the shaders in all the pipelines use the debug descriptor set index, so use the pipelines
+        // as they stand with the instrumented shaders.
+        return new_pipeline_create_infos;
+    }
+
+    // At least one pipeline has a shader that uses the debug descriptor set index.
+    for (uint32_t pipeline = 0; pipeline < count; ++pipeline) {
+        if (pipeline_uses_debug_index[pipeline]) {
+            for (uint32_t stage = 0; stage < pCreateInfos[pipeline].stageCount; ++stage) {
+                const shader_module *shader = GetShaderModuleState(dev_data, pCreateInfos[pipeline].pStages[stage].module);
+                VkShaderModuleCreateInfo create_info = {};
+                VkShaderModule shader_module;
+                create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+                create_info.pCode = shader->words.data();
+                create_info.codeSize = shader->words.size() * sizeof(uint32_t);
+                VkResult result =
+                    GetDispatchTable(dev_data)->CreateShaderModule(GetDevice(dev_data), &create_info, pAllocator, &shader_module);
+                if (result == VK_SUCCESS) {
+                    new_pipeline_create_infos[pipeline].pStages[stage].module = shader_module;
+                } else {
+                    ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT,
+                                       HandleToUint64(pCreateInfos[pipeline].pStages[stage].module),
+                                       "Unable to replace instrumented shader with non-instrumented one.  "
+                                       "Device could become unstable.");
+                }
+            }
+        }
+    }
+    return new_pipeline_create_infos;
+}
+
+// For every pipeline:
+// - For every shader in a pipeline:
+//   - If the shader had to be replaced in PreCallRecord (because the pipeline is using the debug desc set index):
+//     - Destroy it since it has been bound into the pipeline by now.  This is our only chance to delete it.
+//   - Track the shader in the shader_map
+//   - Save the shader binary if it contains debug code
+void GpuPostCallRecordCreateGraphicsPipelines(layer_data *dev_data, const uint32_t count,
+                                              const VkGraphicsPipelineCreateInfo *pCreateInfos,
+                                              const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    for (uint32_t pipeline = 0; pipeline < count; ++pipeline) {
+        auto pipeline_state = GetPipelineState(dev_data, pPipelines[pipeline]);
+        if (nullptr == pipeline_state) continue;
+        for (uint32_t stage = 0; stage < pipeline_state->graphicsPipelineCI.stageCount; ++stage) {
+            if (pipeline_state->active_slots.find(gpu_state->desc_set_bind_index) != pipeline_state->active_slots.end()) {
+                GetDispatchTable(dev_data)->DestroyShaderModule(GetDevice(dev_data), pCreateInfos->pStages[stage].module,
+                                                                pAllocator);
+            }
+            auto shader_state = GetShaderModuleState(dev_data, pipeline_state->graphicsPipelineCI.pStages[stage].module);
+            std::vector<unsigned int> code;
+            // Save the shader binary if debug info is present.
+            // The core_validation ShaderModule tracker saves the binary too, but discards it when the ShaderModule
+            // is destroyed.  Applications may destroy ShaderModules after they are placed in a pipeline and before
+            // the pipeline is used, so we have to keep another copy.
+            if (shader_state && shader_state->has_valid_spirv) {  // really checking for presense of SPIR-V code.
+                for (auto insn : *shader_state) {
+                    if (insn.opcode() == spv::OpLine) {
+                        code = shader_state->words;
+                        break;
+                    }
+                }
+            }
+            gpu_state->shader_map[shader_state->gpu_validation_shader_id].pipeline = pipeline_state->pipeline;
+            // Be careful to use the originally bound (instrumented) shader here, even if PreCallRecord had to back it
+            // out with a non-instrumented shader.  The non-instrumented shader (found in pCreateInfo) was destroyed above.
+            gpu_state->shader_map[shader_state->gpu_validation_shader_id].shader_module =
+                pipeline_state->graphicsPipelineCI.pStages[stage].module;
+            gpu_state->shader_map[shader_state->gpu_validation_shader_id].pgm = std::move(code);
+        }
+    }
+}
+
+// Remove all the shader trackers associated with this destroyed pipeline.
+void GpuPreCallRecordDestroyPipeline(layer_data *dev_data, const VkPipeline pipeline) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    for (auto it = gpu_state->shader_map.begin(); it != gpu_state->shader_map.end();) {
+        if (it->second.pipeline == pipeline) {
+            it = gpu_state->shader_map.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+// Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
+static bool GpuInstrumentShader(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
+                                std::vector<unsigned int> &new_pgm, uint32_t *unique_shader_id) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) return false;
+    if (pCreateInfo->pCode[0] != spv::MagicNumber) return false;
+
+    // Load original shader SPIR-V
+    uint32_t num_words = static_cast<uint32_t>(pCreateInfo->codeSize / 4);
+    new_pgm.clear();
+    new_pgm.reserve(num_words);
+    new_pgm.insert(new_pgm.end(), &pCreateInfo->pCode[0], &pCreateInfo->pCode[num_words]);
+
+    // Call the optimizer to instrument the shader.
+    // Use the unique_shader_module_id as a shader ID so we can look up its handle later in the shader_map.
+    using namespace spvtools;
+    spv_target_env target_env = SPV_ENV_VULKAN_1_1;
+    Optimizer optimizer(target_env);
+    optimizer.RegisterPass(CreateInstBindlessCheckPass(gpu_state->desc_set_bind_index, gpu_state->unique_shader_module_id));
+    optimizer.RegisterPass(CreateAggressiveDCEPass());
+    bool pass = optimizer.Run(new_pgm.data(), new_pgm.size(), &new_pgm);
+    if (!pass) {
+        ReportSetupProblem(dev_data, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, VK_NULL_HANDLE,
+                           "Failure to instrument shader.  Proceeding with non-instrumented shader.");
+    }
+    *unique_shader_id = gpu_state->unique_shader_module_id++;
+    return pass;
+}
+
+// Override the CreateShaderModule command to provide the instrumented shader to the driver.
+VkResult GpuOverrideDispatchCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
+                                               const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                               uint32_t *unique_shader_id) {
+    VkShaderModuleCreateInfo instrumented_create_info = *pCreateInfo;
+    std::vector<unsigned int> instrumented_pgm;
+    bool pass = GpuInstrumentShader(dev_data, pCreateInfo, instrumented_pgm, unique_shader_id);
+    if (pass) {
+        instrumented_create_info.pCode = instrumented_pgm.data();
+        instrumented_create_info.codeSize = instrumented_pgm.size() * sizeof(unsigned int);
+    }
+    // We trust the optimizer's instrumentation pass to not change the validity of the SPIR-V as determined by
+    // the prior call to PreCallValidate.
+    // But we do pass the instrumented shader to the driver.
+    VkResult result =
+        GetDispatchTable(dev_data)->CreateShaderModule(GetDevice(dev_data), &instrumented_create_info, pAllocator, pShaderModule);
+    return result;
+}
+
+// Generate the stage-specific part of the message.
+static void GenerateStageMessage(const uint32_t *debug_record, std::string &msg) {
+    using namespace spvtools;
+    std::ostringstream strm;
+    switch (debug_record[kInstCommonOutStageIdx]) {
+        case 0: {
+            strm << "Stage = Vertex. Vertex ID = " << debug_record[kInstVertOutVertexId]
+                 << " Instance ID = " << debug_record[kInstVertOutInstanceId] << ". ";
+        } break;
+        case 1: {
+            strm << "Stage = Tessellation Control.  Invocation ID = " << debug_record[kInstTessOutInvocationId] << ". ";
+        } break;
+        case 2: {
+            strm << "Stage = Tessellation Eval.  Invocation ID = " << debug_record[kInstTessOutInvocationId] << ". ";
+        } break;
+        case 3: {
+            strm << "Stage = Geometry.  Primitive ID = " << debug_record[kInstGeomOutPrimitiveId]
+                 << " Invocation ID = " << debug_record[kInstGeomOutInvocationId] << ". ";
+        } break;
+        case 4: {
+            strm << "Stage = Fragment.  Fragment coord (x,y) = ("
+                 << *reinterpret_cast<const float *>(&debug_record[kInstFragOutFragCoordX]) << ", "
+                 << *reinterpret_cast<const float *>(&debug_record[kInstFragOutFragCoordY]) << "). ";
+        } break;
+        case 5: {
+            strm << "Stage = Compute.  Global invocation ID = " << debug_record[kInstCompOutGlobalInvocationId] << ". ";
+        } break;
+        default: {
+            strm << "Internal Error (unexpected stage = " << debug_record[kInstCommonOutStageIdx] << "). ";
+            assert(false);
+        } break;
+    }
+    msg = strm.str();
+}
+
+// Generate the part of the message describing the violation.
+static void GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, std::string &vuid_msg) {
+    using namespace spvtools;
+    std::ostringstream strm;
+    switch (debug_record[kInstValidationOutError]) {
+        case 0: {
+            strm << "Index of " << debug_record[kInstBindlessOutDescIndex] << " used to index descriptor array of length "
+                 << debug_record[kInstBindlessOutDescBound] << ". ";
+            vuid_msg = "UNASSIGNED-Image descriptor index out of bounds";
+        } break;
+        case 1: {
+            strm << "Index of " << debug_record[kInstBindlessOutDescIndex] << " used to index descriptor array of length "
+                 << debug_record[kInstBindlessOutDescBound] << ". ";
+            vuid_msg = "UNASSIGNED-Sampler index out of bounds";
+        } break;
+        case 2: {
+            strm << "Descriptor index " << debug_record[kInstBindlessOutDescIndex] << " is uninitialized. ";
+            vuid_msg = "UNASSIGNED-Image descriptor uninitialized";
+        } break;
+        case 3: {
+            strm << "Descriptor index " << debug_record[kInstBindlessOutDescIndex] << " is uninitialized. ";
+            vuid_msg = "UNASSIGNED-Sampler descriptor uninitialized";
+        } break;
+        default: {
+            strm << "Internal Error (unexpected error type = " << debug_record[kInstValidationOutError] << "). ";
+            vuid_msg = "UNASSIGNED-Internal Error";
+            assert(false);
+        } break;
+    }
+    msg = strm.str();
+}
+
+static std::string LookupDebugUtilsName(const layer_data *dev_data, const uint64_t object) {
+    const debug_report_data *debug_data = GetReportData(dev_data);
+    auto utils_name_iter = debug_data->debugUtilsObjectNameMap->find(object);
+    if (utils_name_iter != debug_data->debugUtilsObjectNameMap->end()) {
+        return "(" + utils_name_iter->second + ")";
+    } else {
+        return "";
+    }
+}
+
+// Generate message from the common portion of the debug report record.
+static void GenerateCommonMessage(const layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const uint32_t *debug_record,
+                                  const VkShaderModule shader_module_handle, const VkPipeline pipeline_handle, std::string &msg) {
+    using namespace spvtools;
+    std::ostringstream strm;
+    if (shader_module_handle == VK_NULL_HANDLE) {
+        strm << std::hex << std::showbase << "Internal Error: Unable to locate information for shader used in command buffer "
+             << LookupDebugUtilsName(dev_data, HandleToUint64(cb_node->commandBuffer)) << "("
+             << HandleToUint64(cb_node->commandBuffer) << "). ";
+        assert(true);
+    } else {
+        strm << std::hex << std::showbase << "Command buffer "
+             << LookupDebugUtilsName(dev_data, HandleToUint64(cb_node->commandBuffer)) << "("
+             << HandleToUint64(cb_node->commandBuffer) << "). "
+             << "Pipeline " << LookupDebugUtilsName(dev_data, HandleToUint64(pipeline_handle)) << "("
+             << HandleToUint64(pipeline_handle) << "). "
+             << "Shader Module " << LookupDebugUtilsName(dev_data, HandleToUint64(shader_module_handle)) << "("
+             << HandleToUint64(shader_module_handle) << "). ";
+    }
+    strm << std::dec << std::noshowbase;
+    strm << "Shader Instruction Index = " << debug_record[kInstCommonOutInstructionIdx] << ". ";
+    msg = strm.str();
+}
+
+// Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
+// Split the single string into a vector of strings, one for each line, for easier processing.
+static void ReadOpSource(const shader_module &shader, const uint32_t reported_file_id, std::vector<std::string> &opsource_lines) {
+    for (auto insn : shader) {
+        if ((insn.opcode() == spv::OpSource) && (insn.len() >= 5) && (insn.word(3) == reported_file_id)) {
+            std::istringstream in_stream;
+            std::string cur_line;
+            in_stream.str((char *)&insn.word(4));
+            while (std::getline(in_stream, cur_line)) {
+                opsource_lines.push_back(cur_line);
+            }
+            while ((++insn).opcode() == spv::OpSourceContinued) {
+                in_stream.str((char *)&insn.word(1));
+                while (std::getline(in_stream, cur_line)) {
+                    opsource_lines.push_back(cur_line);
+                }
+            }
+            break;
+        }
+    }
+}
+
+// Extract the filename, line number, and column number from the correct OpLine and build a message string from it.
+// Scan the source (from OpSource) to find the line of source at the reported line number and place it in another message string.
+static void GenerateSourceMessages(const std::vector<unsigned int> &pgm, const uint32_t *debug_record, std::string &filename_msg,
+                                   std::string &source_msg) {
+    using namespace spvtools;
+    std::ostringstream filename_stream;
+    std::ostringstream source_stream;
+    shader_module shader;
+    shader.words = pgm;
+    // Find the OpLine just before the failing instruction indicated by the debug info.
+    // SPIR-V can only be iterated in the forward direction due to its opcode/length encoding.
+    uint32_t instruction_index = 0;
+    uint32_t reported_file_id = 0;
+    uint32_t reported_line_number = 0;
+    uint32_t reported_column_number = 0;
+    if (shader.words.size() > 0) {
+        for (auto insn : shader) {
+            if (insn.opcode() == spv::OpLine) {
+                reported_file_id = insn.word(1);
+                reported_line_number = insn.word(2);
+                reported_column_number = insn.word(3);
+            }
+            if (instruction_index == debug_record[kInstCommonOutInstructionIdx]) {
+                break;
+            }
+            instruction_index++;
+        }
+    }
+    // Create message with file information obtained from the OpString pointed to by the discovered OpLine.
+    std::string reported_filename;
+    if (reported_file_id == 0) {
+        filename_stream
+            << "Unable to find SPIR-V OpLine for source information.  Build shader with debug info to get source information.";
+    } else {
+        bool found_opstring = false;
+        for (auto insn : shader) {
+            if ((insn.opcode() == spv::OpString) && (insn.len() >= 3) && (insn.word(1) == reported_file_id)) {
+                found_opstring = true;
+                reported_filename = (char *)&insn.word(2);
+                if (reported_filename.empty()) {
+                    filename_stream << "Shader validation error occurred at line " << reported_line_number;
+                } else {
+                    filename_stream << "Shader validation error occurred in file: " << reported_filename << " at line "
+                                    << reported_line_number;
+                }
+                if (reported_column_number > 0) {
+                    filename_stream << ", column " << reported_column_number;
+                }
+                filename_stream << ".";
+                break;
+            }
+        }
+        if (!found_opstring) {
+            filename_stream << "Unable to find SPIR-V OpString for file id " << reported_file_id << " from OpLine instruction.";
+        }
+    }
+    filename_msg = filename_stream.str();
+
+    // Create message to display source code line containing error.
+    if ((reported_file_id != 0)) {
+        // Read the source code and split it up into separate lines.
+        std::vector<std::string> opsource_lines;
+        ReadOpSource(shader, reported_file_id, opsource_lines);
+        // Find the line in the OpSource content that corresponds to the reported error file and line.
+        if (!opsource_lines.empty()) {
+            // The task here is to search the OpSource content to find the #line directive with the
+            // line number that is closest to, but still prior to the reported error line number and
+            // still within the reported filename.
+            // From this known position in the OpSource content we can add the difference between
+            // the #line line number and the reported error line number to determine the location
+            // in the OpSource content of the reported error line.
+            //
+            // Considerations:
+            // - Look only at #line directives that specify the reported_filename since
+            //   the reported error line number refers to its location in the reported filename.
+            // - If a #line directive does not have a filename, the file is the reported filename, or
+            //   the filename found in a prior #line directive.  (This is C-preprocessor behavior)
+            // - It is possible (e.g., inlining) for blocks of code to get shuffled out of their
+            //   original order and the #line directives are used to keep the numbering correct.  This
+            //   is why we need to examine the entire contents of the source, instead of leaving early
+            //   when finding a #line line number larger than the reported error line number.
+            //
+            std::regex line_regex(  // matches #line directives
+                "^"                 // beginning of line
+                "\\s*"              // optional whitespace
+                "#"                 // required text
+                "\\s*"              // optional whitespace
+                "line"              // required text
+                "\\s+"              // required whitespace
+                "([0-9]+)"          // required first capture - line number
+                "(\\s+)?"           // optional second capture - whitespace
+                "(\".+\")?"         // optional third capture - quoted filename with at least one char inside
+                ".*");              // rest of line (needed when using std::regex_match since the entire line is tested)
+            uint32_t saved_line_number = 0;
+            std::string current_filename = reported_filename;  // current "preprocessor" filename state.
+            std::vector<std::string>::size_type saved_opsource_offset = 0;
+            bool found_best_line = false;
+            for (auto it = opsource_lines.begin(); it != opsource_lines.end(); ++it) {
+                std::smatch captures;
+                bool found_line = std::regex_match(*it, captures, line_regex);
+                if (!found_line) continue;
+                // filename is optional and considered found only if the whitespace and the filename are captured
+                bool found_filename = captures[2].matched && captures[3].matched;
+                if (found_filename) {
+                    // Remove enclosing double quotes.  The regex guarantees the quotes and at least one char.
+                    current_filename = captures[3].str().substr(1, captures[3].str().size() - 2);
+                }
+                if ((!found_filename) || (current_filename == reported_filename)) {
+                    // captures[1] is valid whenever the regex matches, which it has at this point.
+                    uint32_t parsed_line_number = std::stoul(captures[1]);
+                    // Update the candidate best line directive, if the current one is prior and closer to the reported line
+                    if (reported_line_number >= parsed_line_number) {
+                        if (!found_best_line ||
+                            (reported_line_number - parsed_line_number <= reported_line_number - saved_line_number)) {
+                            saved_line_number = parsed_line_number;
+                            saved_opsource_offset = std::distance(opsource_lines.begin(), it);
+                            found_best_line = true;
+                        }
+                    }
+                }
+            }
+            if (found_best_line) {
+                assert(reported_line_number >= saved_line_number);
+                std::vector<std::string>::size_type opsource_index =
+                    (reported_line_number - saved_line_number) + 1 + saved_opsource_offset;
+                if (opsource_index < opsource_lines.size()) {
+                    source_stream << "\n" << reported_line_number << ": " << opsource_lines[opsource_index].c_str();
+                } else {
+                    source_stream << "Internal error: calculated source line of " << opsource_index << " for source size of "
+                                  << opsource_lines.size() << " lines.";
+                }
+            } else {
+                source_stream << "Unable to find suitable #line directive in SPIR-V OpSource.";
+            }
+        } else {
+            source_stream << "Unable to find SPIR-V OpSource.";
+        }
+    }
+    source_msg = source_stream.str();
+}
+
+// Pull together all the information from the debug record to build the error message strings,
+// and then assemble them into a single message string.
+// Retrieve the shader program referenced by the unique shader ID provided in the debug record.
+// We had to keep a copy of the shader program with the same lifecycle as the pipeline to make
+// sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
+// keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
+//
+static void AnalyzeAndReportError(const layer_data *dev_data, GLOBAL_CB_NODE *cb_node, VkQueue queue,
+                                  uint32_t *const debug_output_buffer) {
+    using namespace spvtools;
+    const uint32_t total_words = debug_output_buffer[0];
+    // A zero here means that the shader instrumentation didn't write anything.
+    // If you have nothing to say, don't say it here.
+    if (0 == total_words) {
+        return;
+    }
+    // The first word in the debug output buffer is the number of words that would have
+    // been written by the shader instrumentation, if there was enough room in the buffer we provided.
+    // The number of words actually written by the shaders is determined by the size of the buffer
+    // we provide via the descriptor.  So, we process only the number of words that can fit in the
+    // buffer.
+    // Each "report" written by the shader instrumentation is considered a "record".  This function
+    // is hard-coded to process only one record because it expects the buffer to be large enough to
+    // hold only one record.  If there is a desire to process more than one record, this function needs
+    // to be modified to loop over records and the buffer size increased.
+    auto gpu_state = GetGpuValidationState(dev_data);
+    std::string validation_message;
+    std::string stage_message;
+    std::string common_message;
+    std::string filename_message;
+    std::string source_message;
+    std::string vuid_msg;
+    VkShaderModule shader_module_handle = VK_NULL_HANDLE;
+    VkPipeline pipeline_handle = VK_NULL_HANDLE;
+    std::vector<unsigned int> pgm;
+    // The first record starts at this offset after the total_words.
+    const uint32_t *debug_record = &debug_output_buffer[kDebugOutputDataOffset];
+    // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
+    // by the instrumented shader.
+    auto it = gpu_state->shader_map.find(debug_record[kInstCommonOutShaderId]);
+    if (it != gpu_state->shader_map.end()) {
+        shader_module_handle = it->second.shader_module;
+        pipeline_handle = it->second.pipeline;
+        pgm = it->second.pgm;
+    }
+    GenerateValidationMessage(debug_record, validation_message, vuid_msg);
+    GenerateStageMessage(debug_record, stage_message);
+    GenerateCommonMessage(dev_data, cb_node, debug_record, shader_module_handle, pipeline_handle, common_message);
+    GenerateSourceMessages(pgm, debug_record, filename_message, source_message);
+    log_msg(GetReportData(dev_data), VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, HandleToUint64(queue),
+            vuid_msg.c_str(), "%s %s %s %s%s", validation_message.c_str(), common_message.c_str(), stage_message.c_str(),
+            filename_message.c_str(), source_message.c_str());
+    // The debug record at word kInstCommonOutSize is the number of words in the record
+    // written by the shader.  Clear the entire record plus the total_words word at the start.
+    const uint32_t words_to_clear = 1 + std::min(debug_record[kInstCommonOutSize], (uint32_t)kInstMaxOutCnt);
+    memset(debug_output_buffer, 0, sizeof(uint32_t) * words_to_clear);
+}
+
+// For the given command buffer, map its debug data buffer and read its contents for analysis.
+static void ProcessInstrumentationBuffer(const layer_data *dev_data, VkQueue queue, GLOBAL_CB_NODE *cb_node) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (cb_node && cb_node->hasDrawCmd && cb_node->gpu_output_memory_block.memory) {
+        VkResult result;
+        char *pData;
+        uint32_t block_offset = cb_node->gpu_output_memory_block.offset;
+        uint32_t block_size = gpu_state->memory_manager->GetBlockSize();
+        uint32_t offset_to_data = 0;
+        const uint32_t map_align =
+            std::max(1U, static_cast<uint32_t>(GetPhysicalDeviceProperties(dev_data)->limits.minMemoryMapAlignment));
+
+        // Adjust the offset to the alignment required for mapping.
+        block_offset = (block_offset / map_align) * map_align;
+        offset_to_data = cb_node->gpu_output_memory_block.offset - block_offset;
+        block_size += offset_to_data;
+        result = GetDispatchTable(dev_data)->MapMemory(cb_node->device, cb_node->gpu_output_memory_block.memory, block_offset,
+                                                       block_size, 0, (void **)&pData);
+        // Analyze debug output buffer
+        if (result == VK_SUCCESS) {
+            AnalyzeAndReportError(dev_data, cb_node, queue, (uint32_t *)(pData + offset_to_data));
+            GetDispatchTable(dev_data)->UnmapMemory(cb_node->device, cb_node->gpu_output_memory_block.memory);
+        }
+    }
+}
+
+// Wait for the queue to complete execution.  Check the debug buffers for all the
+// command buffers that were submitted.
+void GpuPostCallQueueSubmit(const layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
+                            VkFence fence, mutex_t &global_lock) {
+    auto gpu_state = GetGpuValidationState(dev_data);
+    if (gpu_state->aborted) return;
+    core_validation::QueueWaitIdle(queue);
+    unique_lock_t lock(global_lock);
+    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
+        const VkSubmitInfo *submit = &pSubmits[submit_idx];
+        for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
+            auto cb_node = GetCBNode(dev_data, submit->pCommandBuffers[i]);
+            ProcessInstrumentationBuffer(dev_data, queue, cb_node);
+            for (auto secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
+                ProcessInstrumentationBuffer(dev_data, queue, secondaryCmdBuffer);
+            }
+        }
+    }
+}

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -1,0 +1,140 @@
+/* Copyright (c) 2018-2019 The Khronos Group Inc.
+ * Copyright (c) 2018-2019 Valve Corporation
+ * Copyright (c) 2018-2019 LunarG, Inc.
+ * Copyright (C) 2018-2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef VULKAN_GPU_VALIDATION_H
+#define VULKAN_GPU_VALIDATION_H
+
+// Class to encapsulate Vulkan Device Memory allocations.
+// It allocates device memory in large chunks for efficiency and to avoid
+// hitting the device limit of the number of allocations.
+// This manager handles only fixed-sized blocks of "data_size" bytes.
+// The interface allows the caller to "get" and "put back" blocks.
+// The manager allocates and frees chunks as needed.
+
+class GpuDeviceMemoryManager {
+   public:
+    GpuDeviceMemoryManager(layer_data *dev_data, uint32_t data_size) {
+        uint32_t align = static_cast<uint32_t>(GetPhysicalDeviceProperties(dev_data)->limits.minStorageBufferOffsetAlignment);
+        if (0 == align) {
+            align = 1;
+        }
+        record_size_ = data_size;
+        // Round the requested size up to the next multiple of the storage buffer offset alignment
+        // so that we can address each block in the storage buffer using the offset.
+        block_size_ = ((record_size_ + align - 1) / align) * align;
+        blocks_per_chunk_ = kItemsPerChunk;
+        chunk_size_ = blocks_per_chunk_ * block_size_;
+        dev_data_ = dev_data;
+    }
+
+    ~GpuDeviceMemoryManager() {
+        for (auto &chunk : chunk_list_) {
+            FreeMemoryChunk(chunk);
+        }
+        chunk_list_.clear();
+    }
+
+    uint32_t GetBlockSize() { return block_size_; }
+
+    VkResult GetBlock(GpuDeviceMemoryBlock *block);
+    void PutBackBlock(VkBuffer buffer, VkDeviceMemory memory, uint32_t offset);
+    void PutBackBlock(GpuDeviceMemoryBlock &block);
+
+   private:
+    // Define allocation granularity of Vulkan resources.
+    // Things like device memory and descriptors are allocated in "chunks".
+    // This number should be chosen to try to avoid too many chunk allocations
+    // and chunk allocations that are too large.
+    static const uint32_t kItemsPerChunk = 512;
+
+    struct MemoryChunk {
+        VkBuffer buffer;
+        VkDeviceMemory memory;
+        std::vector<uint32_t> available_offsets;
+    };
+
+    layer_data *dev_data_;
+    uint32_t record_size_;
+    uint32_t block_size_;
+    uint32_t blocks_per_chunk_;
+    uint32_t chunk_size_;
+    std::list<MemoryChunk> chunk_list_;
+
+    bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex);
+    VkResult AllocMemoryChunk(MemoryChunk &chunk);
+    void FreeMemoryChunk(MemoryChunk &chunk);
+};
+
+// Class to encapsulate Descriptor Set allocation.  This manager creates and destroys Descriptor Pools
+// as needed to satisfy requests for descriptor sets.
+class GpuDescriptorSetManager {
+   public:
+    GpuDescriptorSetManager(layer_data *dev_data) { dev_data_ = dev_data; }
+
+    ~GpuDescriptorSetManager() {
+        for (auto &pool : desc_pool_map_) {
+            GetDispatchTable(dev_data_)->DestroyDescriptorPool(GetDevice(dev_data_), pool.first, NULL);
+        }
+        desc_pool_map_.clear();
+    }
+
+    VkResult GetDescriptorSets(uint32_t count, VkDescriptorPool *pool, std::vector<VkDescriptorSet> *desc_sets);
+    void PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDescriptorSet desc_set);
+
+   private:
+    static const uint32_t kItemsPerChunk = 512;
+    struct PoolTracker {
+        uint32_t size;
+        uint32_t used;
+    };
+
+    layer_data *dev_data_;
+    std::unordered_map<VkDescriptorPool, struct PoolTracker> desc_pool_map_;
+};
+
+using mutex_t = std::mutex;
+using lock_guard_t = std::lock_guard<mutex_t>;
+using unique_lock_t = std::unique_lock<mutex_t>;
+
+std::unique_ptr<safe_VkDeviceCreateInfo> GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *create_info,
+                                                                      VkPhysicalDeviceFeatures *supported_features);
+void GpuPostCallRecordCreateDevice(layer_data *dev_data);
+void GpuPreCallRecordDestroyDevice(layer_data *dev_data);
+void GpuPostCallRecordAllocateCommandBuffers(layer_data *dev_data, const VkCommandBufferAllocateInfo *pCreateInfo,
+                                             VkCommandBuffer *pCommandBuffer);
+void GpuPreCallRecordFreeCommandBuffers(layer_data *dev_data, uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers);
+VkResult GpuOverrideDispatchCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
+                                               const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                               uint32_t *unique_shader_id);
+VkResult GpuOverrideDispatchCreatePipelineLayout(layer_data *dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
+                                                 const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout);
+void GpuPostCallDispatchCmdBindPipeline(layer_data *dev_data, VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+                                        VkPipeline pipeline);
+void GpuPostCallQueueSubmit(const layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
+                            VkFence fence, mutex_t &global_lock);
+void GpuPreCallValidateCmdWaitEvents(layer_data *dev_data, VkPipelineStageFlags sourceStageMask);
+std::vector<safe_VkGraphicsPipelineCreateInfo> GpuPreCallRecordCreateGraphicsPipelines(
+    layer_data *dev_data, VkPipelineCache pipelineCache, uint32_t count, const VkGraphicsPipelineCreateInfo *pCreateInfos,
+    const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, std::vector<std::unique_ptr<PIPELINE_STATE>> &pipe_state);
+void GpuPostCallRecordCreateGraphicsPipelines(layer_data *dev_data, const uint32_t count,
+                                              const VkGraphicsPipelineCreateInfo *pCreateInfos,
+                                              const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines);
+void GpuPreCallRecordDestroyPipeline(layer_data *dev_data, const VkPipeline pipeline);
+
+#endif  // VULKAN_GPU_VALIDATION_H

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (C) 2015-2018 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2261,7 +2261,8 @@ static ValidationCache *GetValidationCacheInfo(VkShaderModuleCreateInfo const *p
     return nullptr;
 }
 
-bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreateInfo const *pCreateInfo, bool *spirv_valid) {
+bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreateInfo const *pCreateInfo, bool *is_spirv,
+                                       bool *spirv_valid) {
     bool skip = false;
     spv_result_t spv_valid = SPV_SUCCESS;
     auto report_data = GetReportData(dev_data);
@@ -2320,6 +2321,7 @@ bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreat
         spvContextDestroy(ctx);
     }
 
+    *is_spirv = (pCreateInfo->pCode[0] == spv::MagicNumber);
     *spirv_valid = (spv_valid == SPV_SUCCESS);
     return skip;
 }

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (C) 2015-2017 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ struct shader_module {
     std::unordered_map<unsigned, unsigned> def_index;
     bool has_valid_spirv;
     VkShaderModule vk_shader_module;
+    uint32_t gpu_validation_shader_id;
 
     std::vector<uint32_t> PreprocessShaderBinary(uint32_t *src_binary, size_t binary_size, spv_target_env env) {
         spvtools::Optimizer optimizer(env);
@@ -85,11 +86,13 @@ struct shader_module {
         return (result ? optimized_binary : std::vector<uint32_t>(src_binary, src_binary + binary_size / sizeof(uint32_t)));
     }
 
-    shader_module(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env)
+    shader_module(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env,
+                  uint32_t unique_shader_id)
         : words(PreprocessShaderBinary((uint32_t *)pCreateInfo->pCode, pCreateInfo->codeSize, env)),
           def_index(),
           has_valid_spirv(true),
-          vk_shader_module(shaderModule) {
+          vk_shader_module(shaderModule),
+          gpu_validation_shader_id(unique_shader_id) {
         BuildDefIndex();
     }
 
@@ -207,6 +210,7 @@ bool ValidateAndCapturePipelineShaderState(layer_data *dev_data, PIPELINE_STATE 
 bool ValidateComputePipeline(layer_data *dev_data, PIPELINE_STATE *pPipeline);
 bool ValidateRayTracingPipelineNV(layer_data *dev_data, PIPELINE_STATE *pipeline);
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;
-bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreateInfo const *pCreateInfo, bool *spirv_valid);
+bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreateInfo const *pCreateInfo, bool *is_spirv,
+                                       bool *spirv_valid);
 
 #endif  // VULKAN_SHADER_VALIDATION_H

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -264,7 +264,7 @@ bool VkRenderFramework::DeviceCanDraw() {
     return pixels[0][0] == 0x20202020;
 }
 
-void VkRenderFramework::InitFramework(PFN_vkDebugReportCallbackEXT dbgFunction, void *userData) {
+void VkRenderFramework::InitFramework(PFN_vkDebugReportCallbackEXT dbgFunction, void *userData, void *instance_pnext) {
     // Only enable device profile layer by default if devsim is not enabled
     if (!VkTestFramework::m_devsim_layer && InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {
         m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_profile_api");
@@ -297,7 +297,7 @@ void VkRenderFramework::InitFramework(PFN_vkDebugReportCallbackEXT dbgFunction, 
     VkResult U_ASSERT_ONLY err;
 
     instInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    instInfo.pNext = NULL;
+    instInfo.pNext = instance_pnext;
     instInfo.pApplicationInfo = &app_info;
     instInfo.enabledLayerCount = m_instance_layer_names.size();
     instInfo.ppEnabledLayerNames = m_instance_layer_names.data();
@@ -1352,7 +1352,7 @@ VkConstantBufferObj::VkConstantBufferObj(VkDeviceObj *device, VkDeviceSize alloc
 VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
 
 VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderStageFlagBits stage, VkRenderFramework *framework,
-                         char const *name) {
+                         char const *name, bool debug) {
     VkResult U_ASSERT_ONLY err = VK_SUCCESS;
     std::vector<unsigned int> spv;
     VkShaderModuleCreateInfo moduleCreateInfo;
@@ -1369,7 +1369,7 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderS
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     moduleCreateInfo.pNext = nullptr;
 
-    framework->GLSLtoSPV(stage, shader_code, spv);
+    framework->GLSLtoSPV(stage, shader_code, spv, debug);
     moduleCreateInfo.pCode = spv.data();
     moduleCreateInfo.codeSize = spv.size() * sizeof(unsigned int);
     moduleCreateInfo.flags = 0;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -94,7 +94,7 @@ class VkRenderFramework : public VkTestFramework {
     void InitRenderTarget(VkImageView *dsBinding);
     void InitRenderTarget(uint32_t targets, VkImageView *dsBinding);
     void DestroyRenderTarget();
-    void InitFramework(PFN_vkDebugReportCallbackEXT = NULL, void *userData = NULL);
+    void InitFramework(PFN_vkDebugReportCallbackEXT = NULL, void *userData = NULL, void *instance_pnext = NULL);
 
     void ShutdownFramework();
     void GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features);
@@ -404,7 +404,7 @@ class VkDescriptorSetObj : public vk_testing::DescriptorPool {
 class VkShaderObj : public vk_testing::ShaderModule {
    public:
     VkShaderObj(VkDeviceObj *device, const char *shaderText, VkShaderStageFlagBits stage, VkRenderFramework *framework,
-                char const *name = "main");
+                char const *name = "main", bool debug = false);
     VkShaderObj(VkDeviceObj *device, const std::string spv_source, VkShaderStageFlagBits stage, VkRenderFramework *framework,
                 char const *name = "main");
     VkPipelineShaderStageCreateInfo const &GetStageCreateInfo() const;

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -754,7 +754,8 @@ EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_typ
 // Compile a given string containing GLSL into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv) {
+bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv,
+                                bool debug) {
     glslang::TProgram program;
     const char *shaderStrings[1];
 
@@ -767,6 +768,9 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
     EShMessages messages = EShMsgDefault;
     SetMessageOptions(messages);
     messages = static_cast<EShMessages>(messages | EShMsgSpvRules | EShMsgVulkanRules);
+    if (debug) {
+        messages = static_cast<EShMessages>(messages | EShMsgDebugInfo);
+    }
 
     EShLanguage stage = FindLanguage(shader_type);
     glslang::TShader *shader = new glslang::TShader(stage);
@@ -803,7 +807,11 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
         program.dumpReflection();
     }
 
-    glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
+    glslang::SpvOptions spv_options;
+    if (debug) {
+        spv_options.generateDebugInfo = true;
+    }
+    glslang::GlslangToSpv(*program.getIntermediate(stage), spirv, &spv_options);
 
     //
     // Test the different modes of SPIR-V modification

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -67,7 +67,8 @@ class VkTestFramework : public ::testing::Test {
     static void InitArgs(int *argc, char *argv[]);
     static void Finish();
 
-    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv);
+    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv,
+                   bool debug = false);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_canonicalize_spv;
     static bool m_strip_spv;

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2016 The Khronos Group Inc.
-//  Copyright (c) 2015-2016 Valve Corporation
-//  Copyright (c) 2015-2016 LunarG, Inc.
-//  Copyright (c) 2015-2016 Google, Inc.
+//  Copyright (c) 2015-2019 The Khronos Group Inc.
+//  Copyright (c) 2015-2019 Valve Corporation
+//  Copyright (c) 2015-2019 LunarG, Inc.
+//  Copyright (c) 2015-2019 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,7 +77,8 @@ shaderc_shader_kind MapShadercType(VkShaderStageFlagBits vkShader) {
 
 // Compile a given string containing GLSL into SPIR-V
 // Return value of false means an error was encountered
-bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv) {
+bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv,
+                                bool debug) {
     // On Android, use shaderc instead.
     shaderc::Compiler compiler;
     shaderc::SpvCompilationResult result =

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2016 The Khronos Group Inc.
-//  Copyright (c) 2015-2016 Valve Corporation
-//  Copyright (c) 2015-2016 LunarG, Inc.
-//  Copyright (c) 2015-2016 Google, Inc.
+//  Copyright (c) 2015-2019 The Khronos Group Inc.
+//  Copyright (c) 2015-2019 Valve Corporation
+//  Copyright (c) 2015-2019 LunarG, Inc.
+//  Copyright (c) 2015-2019 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ class VkTestFramework : public ::testing::Test {
     static void Finish();
 
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
-    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv);
+    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv,
+                   bool debug = false);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_devsim_layer;
 };


### PR DESCRIPTION
Add GPU-Assisted support to the core validation layer
Add VLT test for above
Add documentation
Bump glslang version to pickup required SPIRV-Tools dependencies

Please see `docs/gpu_validation.md` for a design document which may be helpful for review.

The original development branch is in karl-lunarg/Vulkan-ValidationLayers branch: karl-gpu which has all the individual commits, but is unlikely to be useful for review.  It will probably be easier to look at the design doc and the code.  The main code file is all brand new anyway.