### PR TITLE
Preserve pNext chain data in chassis dispatch (unique objects)

### DIFF
--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2018 The Khronos Group Inc.
-# Copyright (c) 2015-2018 Valve Corporation
-# Copyright (c) 2015-2018 LunarG, Inc.
-# Copyright (c) 2015-2018 Google Inc.
+# Copyright (c) 2015-2019 The Khronos Group Inc.
+# Copyright (c) 2015-2019 Valve Corporation
+# Copyright (c) 2015-2019 LunarG, Inc.
+# Copyright (c) 2015-2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -118,10 +118,10 @@ class LayerChassisDispatchOutputGenerator(OutputGenerator):
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_dispatch_generator.py for modifications.
 
-/* Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (c) 2015-2018 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (c) 2015-2018 Google, Inc.
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2019 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -344,6 +344,11 @@ class ErrorMonitor {
 
     bool AllDesiredMsgsFound() const { return desired_message_strings_.empty(); }
 
+    void SetError(const char *const errorString) {
+        message_found_ = true;
+        failure_message_strings_.insert(errorString);
+    }
+
     void SetBailout(bool *bailout) { bailout_ = bailout; }
 
     void DumpFailureMsgs() const {
@@ -26905,6 +26910,74 @@ TEST_F(VkLayerTest, SetDynViewportParamMultiviewportTests) {
 // POSITIVE VALIDATION TESTS
 //
 // These tests do not expect to encounter ANY validation errors pass only if this is true
+
+TEST_F(VkPositiveLayerTest, PnextOnlyStructWrapping) {
+    TEST_DESCRIPTION(
+        "Pass a struct containing no non-dispatchable objects in which data will be returned as part of a pNext chain");
+
+    // Bail if using a mock ICD
+    if (!DeviceCanDraw()) {
+        printf("%s PnextOnlyStructWrapping positive test requires real hardware; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) &&
+        InstanceExtensionSupported(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        m_instance_extension_names.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+    } else {
+        printf("%s Did not find VK_KHR_get_physical_device_properties2 and VK_KHR_external_memory_capabilities; skipped.\n",
+               kSkipPrefix);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR GetPDIFP2KHR =
+        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vkGetInstanceProcAddr(inst,
+                                                                                "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    if (NULL == GetPDIFP2KHR) {
+        printf("%s GetPhysicalDeviceProperties2 not supported.  Skipping test.\n", kSkipPrefix);
+        return;
+    }
+
+    m_errorMonitor->ExpectSuccess();
+
+    VkPhysicalDeviceProperties2KHR properties = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR,
+        nullptr,
+    };
+    vkGetPhysicalDeviceProperties2(gpu(), &properties);
+    VkPhysicalDeviceExternalImageFormatInfoKHR devExtImgFmtInfo = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO_KHR};
+    devExtImgFmtInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT_KHR;
+
+    VkPhysicalDeviceImageFormatInfo2KHR dev_img_fmt_info = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR,
+                                                            &devExtImgFmtInfo};
+    dev_img_fmt_info.format = VK_FORMAT_R8G8B8A8_SRGB;
+    dev_img_fmt_info.type = VK_IMAGE_TYPE_2D;
+    dev_img_fmt_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    dev_img_fmt_info.usage =
+        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+    // Without pnext-only struct wrapping, ext_img_fmt_props will be ignored by the call to
+    // GetPhysicalDeviceImageFormatProperties2KHR
+    VkExternalImageFormatPropertiesKHR ext_img_fmt_props = {
+        VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES_KHR,
+        nullptr,
+    };
+    ext_img_fmt_props.externalMemoryProperties = {999, 999, 999};
+
+    VkImageFormatProperties2KHR imgFmtProps = {VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR};
+    imgFmtProps.pNext = &ext_img_fmt_props;
+    imgFmtProps.imageFormatProperties.sampleCounts = VK_SAMPLE_COUNT_64_BIT;
+
+    vkGetPhysicalDeviceImageFormatProperties2(gpu(), &dev_img_fmt_info, &imgFmtProps);
+
+    if (ext_img_fmt_props.externalMemoryProperties.compatibleHandleTypes == 999) {
+        m_errorMonitor->SetError("VkExternalImageFormatPropertiesKHR ignored by GetPhysicalDeviceImageFormatProperties2KHR");
+    }
+    m_errorMonitor->VerifyNotFound();
+}
 
 TEST_F(VkPositiveLayerTest, PointSizeWriteInFunction) {
     TEST_DESCRIPTION("Create a pipeline using TOPOLOGY_POINT_LIST and write PointSize in vertex shader function.");


### PR DESCRIPTION
When the handle-wrapping code processed pnext chains, it ignored pnext-only structures that contained no non-dispatchable objects (or that had no sister structures containing NDOs). This change causes **all** structs that can be part of a pNext chain to be wrapped by the dispatcher, which allows data returned from the driver to be passed back up to the caller.

Fixes LunarXchange issue #817.