### PR TITLE
Fix a crash with unbalanced debug markers

### DIFF
--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -1131,8 +1131,11 @@ static inline void EndCmdDebugUtilsLabel(debug_report_data *report_data, VkComma
             report_data->cmdBufLabelHasInsert = false;
             label_iter->second.pop_back();
         }
-        // Now pop the normal item
-        label_iter->second.pop_back();
+        // Guard against unbalanced markers.
+        if (label_iter->second.size() > 0) {
+            // Now pop the normal item
+            label_iter->second.pop_back();
+        }
     }
 }
 


### PR DESCRIPTION
If there are more End markers than Begin markers at any time, the vector
that keeps track of the labels will issue a `pop_back()` while being
empty, causing a crash.

This was observed on ANGLE's Vulkan backend executing deqp test
dEQP.GLES2/functional_debug_marker_random.