### PR TITLE
Remove duplicate attachment reference checking and add image layout check for duplicate references.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10929,9 +10929,12 @@ static bool AddAttachmentUse(const layer_data *dev_data, RenderPassCreateVersion
     const char *const function_name = use_rp2 ? "vkCreateRenderPass2KHR()" : "vkCreateRenderPass()";
 
     if (uses & new_use) {
-        log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                kVUID_Core_DrawState_InvalidRenderpass, "%s: subpass %u already uses attachment %u as a %s attachment.",
-                function_name, subpass, attachment, StringAttachmentType(new_use));
+        if (attachment_layouts[attachment] != new_layout) {
+            vuid = use_rp2 ? "VUID-VkSubpassDescription2KHR-layout-02528" : "VUID-VkSubpassDescription-layout-02519";
+            log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
+                    "%s: subpass %u already uses attachment %u with a different image layout (%s vs %s).", function_name, subpass,
+                    attachment, string_VkImageLayout(attachment_layouts[attachment]), string_VkImageLayout(new_layout));
+        }
     } else if (uses & ~ATTACHMENT_INPUT || (uses && (new_use == ATTACHMENT_RESOLVE || new_use == ATTACHMENT_PRESERVE))) {
         /* Note: input attachments are assumed to be done first. */
         vuid = use_rp2 ? "VUID-VkSubpassDescription2KHR-pPreserveAttachments-03074"

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5420,8 +5420,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReadOnlyButCleared) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentUsedTwiceColor) {
-    TEST_DESCRIPTION("Attachment is used simultaneously as two color attachments. This is usually unintended.");
+TEST_F(VkLayerTest, RenderPassCreateAttachmentMismatchingLayoutsColor) {
+    TEST_DESCRIPTION("Attachment is used simultaneously as two color attachments with different layouts.");
 
     // Check for VK_KHR_get_physical_device_properties2
     if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
@@ -5452,7 +5452,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentUsedTwiceColor) {
     };
     VkAttachmentReference refs[] = {
         {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
-        {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
+        {0, VK_IMAGE_LAYOUT_GENERAL},
     };
     VkSubpassDescription subpasses[] = {
         {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 2, refs, nullptr, nullptr, 0, nullptr},
@@ -5461,8 +5461,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentUsedTwiceColor) {
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attach, 1, subpasses, 0, nullptr};
 
     TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, vkCreateRenderPass2KHR,
-                         "subpass 0 already uses attachment 0 as a color attachment",
-                         "subpass 0 already uses attachment 0 as a color attachment");
+                         "subpass 0 already uses attachment 0 with a different image layout",
+                         "subpass 0 already uses attachment 0 with a different image layout");
 }
 
 TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {


### PR DESCRIPTION
There was a check that attachment referenced don't have duplicate attachment IDs. Spec says it's allowed as long as they have identical image layouts. The duplicate reference check was removed, and a check for the image layouts was added. There's also some code cleanup to reuse the same renderpass2 related code repeated in several tests.