### PR TITLE
tests: Fix Testing Regressions on Android

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2197,7 +2197,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedSamples) {
 TEST_F(VkLayerTest, GpuValidationArrayOOB) {
     TEST_DESCRIPTION("GPU validation: Verify detection of out-of-bounds descriptor array indexing.");
     if (!VkRenderFramework::DeviceCanDraw()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw. Test skipped.\n", kSkipPrefix);
+        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
@@ -2207,6 +2207,10 @@ TEST_F(VkLayerTest, GpuValidationArrayOOB) {
     features.pEnabledValidationFeatures = enables;
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, pool_flags, &features));
+    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+        printf("%s GPU-Assisted validation test requires Vulkan 1.1+.\n", kSkipPrefix);
+        return;
+    }
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2324,12 +2324,17 @@ TEST_F(VkLayerTest, GpuValidationArrayOOB) {
         char const *expected_error;
     };
 
-    const std::array<TestCase, 4> tests = {{
-        {vsSource_vert, fsSource_vert, false, "Index of 25 used to index descriptor array of length 6."},
-        {vsSource_frag, fsSource_frag, false, "Index of 25 used to index descriptor array of length 6."},
-        {vsSource_vert, fsSource_vert, true, "gl_Position += 1e-30 * texture(tex[uniform_index_buffer.tex_index[0]], vec2(0, 0));"},
-        {vsSource_frag, fsSource_frag, true, "uFragColor = texture(tex[tex_ind], vec2(0, 0));"},
-    }};
+    std::vector<TestCase> tests;
+    tests.push_back({vsSource_vert, fsSource_vert, false, "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({vsSource_frag, fsSource_frag, false, "Index of 25 used to index descriptor array of length 6."});
+#if !defined(ANDROID)
+    // The Android test framework uses shaderc for online compilations.  Even when configured to compile with debug info,
+    // shaderc seems to drop the OpLine instructions from the shader binary.  This causes the following two tests to fail
+    // on Android platforms.  Skip these tests until the shaderc issue is understood/resolved.
+    tests.push_back({vsSource_vert, fsSource_vert, true,
+                     "gl_Position += 1e-30 * texture(tex[uniform_index_buffer.tex_index[0]], vec2(0, 0));"});
+    tests.push_back({vsSource_frag, fsSource_frag, true, "uFragColor = texture(tex[tex_ind], vec2(0, 0));"});
+#endif
 
     VkViewport viewport = m_viewports[0];
     VkRect2D scissors = m_scissors[0];

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -81,8 +81,13 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
                                 bool debug) {
     // On Android, use shaderc instead.
     shaderc::Compiler compiler;
+    shaderc::CompileOptions options;
+    if (debug) {
+        options.SetOptimizationLevel(shaderc_optimization_level_zero);
+        options.SetGenerateDebugInfo();
+    }
     shaderc::SpvCompilationResult result =
-        compiler.CompileGlslToSpv(pshader, strlen(pshader), MapShadercType(shader_type), "shader");
+        compiler.CompileGlslToSpv(pshader, strlen(pshader), MapShadercType(shader_type), "shader", options);
     if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
         __android_log_print(ANDROID_LOG_ERROR, "VkLayerValidationTest", "GLSLtoSPV compilation failed: %s",
                             result.GetErrorMessage().c_str());


### PR DESCRIPTION
These regressions were introduced with the GPU validation code.

1. Need to skip GPU validation VLT test if device is not Vulkan 1.1 or better.  Not strictly an Android issue, but discovered on an Android test farm with 1.0 devices.
1. Add missing code to Android testing framework to set debug option on shaderc compiler.
1. Workaround to skip gpu validation source code checking on Android only.  It seems that shaderc is not retaining SPIR-V OpLine instructions when compiling with debug info.

Android tests now run clean on LunarG test farm.

I believe that the last issue is caused by the Android build using an old version of shaderc that does not handle OpLine as needed.  The TOT shaderc does retain OpLine when tested with the online compilation example in shaderc.