### PR TITLE
Add VK_EXT_vertex_attribute_divisor validation

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1165,6 +1165,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features;
     VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8;
+    VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vtx_attrib_divisor_features;
     VkPhysicalDeviceScalarBlockLayoutFeaturesEXT scalar_block_layout_features;
     VkPhysicalDeviceBufferAddressFeaturesEXT buffer_address;
 };


### PR DESCRIPTION
Add checks for explicit VUIDs in the extension, and tests to exercise.

Resolves #168