### PR TITLE
object_tracker: #590 Validate debug naming

### DIFF
--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -725,6 +725,20 @@ class HelperFileOutputGenerator(OutputGenerator):
             object_types_header += '    %s,   // %s\n' % (vk_object_type, object_type)
         object_types_header += '};\n'
 
+        # Create a function to convert from VkObjectType to VulkanObjectType
+        object_types_header += '\n'
+        object_types_header += '// Helper function to convert from VkObjectType to VulkanObjectType\n'
+        object_types_header += 'static inline VulkanObjectType convertCoreObjectTypeToInternalObjectType(VkObjectType core_type){\n'
+        object_types_header += '    switch (core_type) {\n'
+        object_types_header += '        default: return kVulkanObjectTypeUnknown;\n'
+        vko_re = '^VK_OBJECT_TYPE_(.*)'
+        vko_map = {to_key(vko_re, vko) : vko for vko in self.core_object_types}
+        for object_type in type_list:
+            vk_object_type = vko_map[object_type.replace("kVulkanObjectType", "").lower()]
+            object_types_header += '        case %s: return %s;\n' % (vk_object_type, object_type)
+        object_types_header += '    }\n'
+        object_types_header += '}\n'
+
         # Create a function to convert from VkDebugReportObjectTypeEXT to VkObjectType
         object_types_header += '\n'
         object_types_header += '// Helper function to convert from VkDebugReportObjectTypeEXT to VkObjectType\n'


### PR DESCRIPTION
Debug utils breaks out some handles into a generic uint64_t.
These weren't getting properly validated in the object tracker
layer.

This change modifies the scripts to detect the case where we have
debug utils object types and handles and generates the appropriate
code to validate their values.

Change-Id: I4dc9fecd2cea0fa05efb9c3cea6204099d19fdd8