### PR TITLE
tests: Temp disable GPU test on Android

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2200,6 +2200,12 @@ TEST_F(VkLayerTest, GpuValidationArrayOOB) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
+#if defined(ANDROID)
+    if (instance() == VK_NULL_HANDLE) {
+        printf("%s Skipping test on Android temporarily while debugging test execution failure.\n", kSkipPrefix);
+        return;
+    }
+#endif
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
     VkValidationFeaturesEXT features = {};
     features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;


### PR DESCRIPTION
Tests failing on Pixel2, probably due to issues in gpu validation.
Disabling test on Android until solved.

Change-Id: Ib14363dd7ffccddeffa38cf59ce288b9ba86e218