### PR TITLE
VK_KHR_depth_stencil_resolve validation: Add a missing nullptr check

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9325,6 +9325,10 @@ static bool ValidateDepthStencilResolve(const debug_report_data *report_data,
         VkSubpassDescription2KHR subpass = pCreateInfo->pSubpasses[i];
         const auto *resolve = lvl_find_in_chain<VkSubpassDescriptionDepthStencilResolveKHR>(subpass.pNext);
 
+        if (resolve == nullptr) {
+            continue;
+        }
+
         if (resolve->pDepthStencilResolveAttachment != nullptr &&
             resolve->pDepthStencilResolveAttachment->attachment != VK_ATTACHMENT_UNUSED) {
             if (subpass.pDepthStencilAttachment->attachment == VK_ATTACHMENT_UNUSED) {


### PR DESCRIPTION
This adds a missing check which fixes a crash seen when running apps that use VK_KHR_depth_stencil_resolve extension together with validation layers.