### PR TITLE
Pass VkResult to PostCallRecordApi* functions

### DIFF
--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (C) 2015-2018 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,7 +325,8 @@ bool ObjectLifetimes::PreCallValidateEnumeratePhysicalDevices(VkInstance instanc
 }
 
 void ObjectLifetimes::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
-                                                             VkPhysicalDevice *pPhysicalDevices) {
+                                                             VkPhysicalDevice *pPhysicalDevices, VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     if (pPhysicalDevices) {
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
             CreateObject(instance, pPhysicalDevices[i], kVulkanObjectTypePhysicalDevice, nullptr);
@@ -494,7 +495,8 @@ bool ObjectLifetimes::PreCallValidateGetSwapchainImagesKHR(VkDevice device, VkSw
 }
 
 void ObjectLifetimes::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                                          VkImage *pSwapchainImages) {
+                                                          VkImage *pSwapchainImages, VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     if (pSwapchainImages != NULL) {
         for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
             CreateSwapchainImageObject(device, pSwapchainImages[i], swapchain);
@@ -529,7 +531,8 @@ bool ObjectLifetimes::PreCallValidateCreateDescriptorSetLayout(VkDevice device, 
 
 void ObjectLifetimes::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                                               const VkAllocationCallbacks *pAllocator,
-                                                              VkDescriptorSetLayout *pSetLayout) {
+                                                              VkDescriptorSetLayout *pSetLayout, VkResult result) {
+    if (result != VK_SUCCESS) return;
     CreateObject(device, *pSetLayout, kVulkanObjectTypeDescriptorSetLayout, pAllocator);
 }
 
@@ -591,7 +594,8 @@ void ObjectLifetimes::PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhy
 }
 
 void ObjectLifetimes::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                                   VkInstance *pInstance) {
+                                                   VkInstance *pInstance, VkResult result) {
+    if (result != VK_SUCCESS) return;
     CreateObject(*pInstance, *pInstance, kVulkanObjectTypeInstance, pAllocator);
 }
 
@@ -606,7 +610,8 @@ bool ObjectLifetimes::PreCallValidateAllocateCommandBuffers(VkDevice device, con
 }
 
 void ObjectLifetimes::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                                           VkCommandBuffer *pCommandBuffers) {
+                                                           VkCommandBuffer *pCommandBuffers, VkResult result) {
+    if (result != VK_SUCCESS) return;
     for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
         AllocateCommandBuffer(device, pAllocateInfo->commandPool, pCommandBuffers[i], pAllocateInfo->level);
     }
@@ -629,7 +634,8 @@ bool ObjectLifetimes::PreCallValidateAllocateDescriptorSets(VkDevice device, con
 }
 
 void ObjectLifetimes::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                           VkDescriptorSet *pDescriptorSets) {
+                                                           VkDescriptorSet *pDescriptorSets, VkResult result) {
+    if (result != VK_SUCCESS) return;
     for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
         AllocateDescriptorSet(device, pAllocateInfo->descriptorPool, pDescriptorSets[i]);
     }
@@ -824,7 +830,8 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceDisplayPropertiesKHR(VkPhy
 }
 
 void ObjectLifetimes::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                                          VkDisplayPropertiesKHR *pProperties) {
+                                                                          VkDisplayPropertiesKHR *pProperties, VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     if (pProperties) {
         for (uint32_t i = 0; i < *pPropertyCount; ++i) {
             CreateObject(physicalDevice, pProperties[i].display, kVulkanObjectTypeDisplayKHR, nullptr);
@@ -845,7 +852,9 @@ bool ObjectLifetimes::PreCallValidateGetDisplayModePropertiesKHR(VkPhysicalDevic
 }
 
 void ObjectLifetimes::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                                uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties) {
+                                                                uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties,
+                                                                VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     if (pProperties) {
         for (uint32_t i = 0; i < *pPropertyCount; ++i) {
             CreateObject(physicalDevice, pProperties[i].displayMode, kVulkanObjectTypeDisplayModeKHR, nullptr);
@@ -862,7 +871,8 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceDisplayProperties2KHR(VkPh
 
 void ObjectLifetimes::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                            uint32_t *pPropertyCount,
-                                                                           VkDisplayProperties2KHR *pProperties) {
+                                                                           VkDisplayProperties2KHR *pProperties, VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     for (uint32_t index = 0; index < *pPropertyCount; ++index) {
         CreateObject(physicalDevice, pProperties[index].displayProperties.display, kVulkanObjectTypeDisplayKHR, nullptr);
     }
@@ -881,8 +891,9 @@ bool ObjectLifetimes::PreCallValidateGetDisplayModeProperties2KHR(VkPhysicalDevi
 }
 
 void ObjectLifetimes::PostCallRecordGetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                                 uint32_t *pPropertyCount,
-                                                                 VkDisplayModeProperties2KHR *pProperties) {
+                                                                 uint32_t *pPropertyCount, VkDisplayModeProperties2KHR *pProperties,
+                                                                 VkResult result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
     for (uint32_t index = 0; index < *pPropertyCount; ++index) {
         CreateObject(physicalDevice, pProperties[index].displayModeProperties.displayMode, kVulkanObjectTypeDisplayModeKHR,
                      nullptr);

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -149,15 +149,18 @@ bool StatelessValidation::manual_PreCallValidateCreateInstance(const VkInstanceC
 }
 
 void StatelessValidation::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
+                                                       const VkAllocationCallbacks *pAllocator, VkInstance *pInstance,
+                                                       VkResult result) {
     auto instance_data = GetLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
     // Copy extension data into local object
+    if (result != VK_SUCCESS) return;
     this->instance_extensions = instance_data->instance_extensions;
 }
 
 void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
+                                                     const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, VkResult result) {
     auto device_data = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
+    if (result != VK_SUCCESS) return;
     ValidationObject *validation_data = GetValidationObject(device_data->object_dispatch, LayerObjectTypeParameterValidation);
     StatelessValidation *stateless_validation = static_cast<StatelessValidation *>(validation_data);
 
@@ -2994,13 +2997,17 @@ bool StatelessValidation::manual_PreCallValidateEnumerateDeviceExtensionProperti
 }
 
 void StatelessValidation::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                         const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+                                                         const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                         VkResult result) {
+    if (result != VK_SUCCESS) return;
     RecordRenderPass(*pRenderPass, pCreateInfo);
 }
 
 void StatelessValidation::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2KHR *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+                                                             const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                             VkResult result) {
     // Track the state necessary for checking vkCreateGraphicsPipeline (subpass usage of depth and color attachments)
+    if (result != VK_SUCCESS) return;
     RecordRenderPass(*pRenderPass, pCreateInfo);
 }
 

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -900,15 +900,15 @@ class StatelessValidation : public ValidationObject {
     bool OutputExtensionError(const std::string &api_name, const std::string &extension_name);
 
     void PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                        const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass);
+                                        const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass, VkResult result);
     void PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2KHR *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass);
+                                            const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass, VkResult result);
     void PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator);
     void PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkDevice *pDevice);
+                                    const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, VkResult result);
 
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                      VkInstance *pInstance);
+                                      VkInstance *pInstance, VkResult result);
 
     bool manual_PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool);


### PR DESCRIPTION
In several cases, PostCallRecordApi functions need to do different things depending upon the return code. The most flexible way to handle this is to allow each validation object's PCR routines to decide this for themselves.

All PostCallRecord functions returning a VkResult will now have VkResult as an additional, final parameter.
