### PR TITLE
Build fixes for nested project builds

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -479,8 +479,8 @@ class OutputDatabase:
 /*
  * Vulkan
  *
- * Copyright (c) 2016-2018 Google Inc.
- * Copyright (c) 2016-2018 LunarG, Inc.
+ * Copyright (c) 2016-2019 Google Inc.
+ * Copyright (c) 2016-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -52,6 +52,7 @@ generated_layer_source_directories = [
 'build',
 'dbuild',
 'release',
+'../build/Vulkan-ValidationLayers/'
 ]
 generated_layer_source_files = [
 'parameter_validation.cpp',

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 
 # ~~~
 # The vulkan loader search is:
+#     Existing vulkan target already present in the build
 #     User-supplied setting of CMAKE_PREFIX_PATH
 #     VULKAN_LOADER_INSTALL_DIR defined via cmake option
 #     VULKAN_LOADER_INSTALL_DIR defined via environment variable
@@ -88,16 +89,24 @@ endif()
 # ~~~
 set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
 
-if(VULKAN_LOADER_INSTALL_DIR)
-    message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
-elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
-    message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
+if (TARGET vulkan)
+    add_library(Vulkan::Vulkan ALIAS vulkan)
+else()
+    if(VULKAN_LOADER_INSTALL_DIR)
+        message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
+    elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
+        message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
+    endif()
+    set(
+        CMAKE_PREFIX_PATH
+        ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR}
+        )
+    find_package(Vulkan)
+    add_library(vulkan STATIC IMPORTED)
+
+    set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${Vulkan_LIBRARY}")
+    target_include_directories(vulkan INTERFACE "${Vulkan_INCLUDE_DIR}")
 endif()
-set(
-    CMAKE_PREFIX_PATH
-    ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR}
-    )
-find_package(Vulkan)
 
 set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
 add_executable(vk_layer_validation_tests


### PR DESCRIPTION
In some nested project build configurations, Vulkan-Loader is built at the same time as Vulkan-ValidationLayers, so we should use the built Vulkan::Vulkan target rather than the installed one.

Other fixes are trivial extensions to the same.