### PR TITLE
Normalize *queue* pre/post call function signatures

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1494,8 +1494,9 @@ bool PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreat
 }
 
 void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                               VkImage *pImage) {
+                               VkImage *pImage, VkResult result) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), core_validation::layer_data_map);
+    if (VK_SUCCESS != result) return;
     IMAGE_LAYOUT_NODE image_state;
     image_state.layout = pCreateInfo->initialLayout;
     image_state.format = pCreateInfo->format;
@@ -3966,9 +3967,9 @@ bool PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCre
 }
 
 void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                VkBuffer *pBuffer) {
+                                VkBuffer *pBuffer, VkResult result) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
+    if (result != VK_SUCCESS) return;
     // TODO : This doesn't create deep copy of pQueueFamilyIndices so need to fix that if/when we want that data to be valid
     GetBufferMap(device_data)
         ->insert(std::make_pair(*pBuffer, std::unique_ptr<BUFFER_STATE>(new BUFFER_STATE(*pBuffer, pCreateInfo))));
@@ -4019,9 +4020,9 @@ bool PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateIn
 }
 
 void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkBufferView *pView) {
+                                    const VkAllocationCallbacks *pAllocator, VkBufferView *pView, VkResult result) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
+    if (result != VK_SUCCESS) return;
     (*GetBufferViewMap(device_data))[*pView] = std::unique_ptr<BUFFER_VIEW_STATE>(new BUFFER_VIEW_STATE(*pView, pCreateInfo));
 }
 
@@ -4459,8 +4460,9 @@ bool PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo
 }
 
 void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
-                                   const VkAllocationCallbacks *pAllocator, VkImageView *pView) {
+                                   const VkAllocationCallbacks *pAllocator, VkImageView *pView, VkResult result) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (result != VK_SUCCESS) return;
     auto image_view_map = GetImageViewMap(device_data);
     (*image_view_map)[*pView] = std::unique_ptr<IMAGE_VIEW_STATE>(new IMAGE_VIEW_STATE(*pView, pCreateInfo));
 

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -44,7 +44,7 @@ bool PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreat
                                 VkImage *pImage);
 
 void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                               VkImage *pImage);
+                               VkImage *pImage, VkResult result);
 
 void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator);
 
@@ -218,13 +218,13 @@ bool PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCre
                                  VkBuffer *pBuffer);
 
 void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                VkBuffer *pBuffer);
+                                VkBuffer *pBuffer, VkResult result);
 
 bool PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
                                      const VkAllocationCallbacks *pAllocator, VkBufferView *pView);
 
 void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkBufferView *pView);
+                                    const VkAllocationCallbacks *pAllocator, VkBufferView *pView, VkResult result);
 
 bool ValidateImageAspectMask(const layer_data *device_data, VkImage image, VkFormat format, VkImageAspectFlags aspect_mask,
                              const char *func_name, const char *vuid = "VUID-VkImageSubresource-aspectMask-parameter");
@@ -246,7 +246,7 @@ bool PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo
                                     const VkAllocationCallbacks *pAllocator, VkImageView *pView);
 
 void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
-                                   const VkAllocationCallbacks *pAllocator, VkImageView *pView);
+                                   const VkAllocationCallbacks *pAllocator, VkImageView *pView, VkResult result);
 
 bool ValidateCopyBufferImageTransferGranularityRequirements(layer_data *device_data, const GLOBAL_CB_NODE *cb_node,
                                                             const IMAGE_STATE *img, const VkBufferImageCopy *region,

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -956,11 +956,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     VkResult result = dev_data->dispatch_table.CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
 
-    if (VK_SUCCESS == result) {
-        lock.lock();
-        PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
-        lock.unlock();
-    }
+    lock.lock();
+    PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, result);
+    lock.unlock();
     return result;
 }
 
@@ -972,11 +970,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(VkDevice device, const VkBufferV
     lock.unlock();
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     VkResult result = dev_data->dispatch_table.CreateBufferView(device, pCreateInfo, pAllocator, pView);
-    if (VK_SUCCESS == result) {
-        lock.lock();
-        PostCallRecordCreateBufferView(device, pCreateInfo, pAllocator, pView);
-        lock.unlock();
-    }
+    lock.lock();
+    PostCallRecordCreateBufferView(device, pCreateInfo, pAllocator, pView, result);
+    lock.unlock();
     return result;
 }
 
@@ -984,14 +980,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(VkDevice device, const VkImageCreateI
                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCreateImage(device, pCreateInfo, pAllocator, pImage);
+    lock.unlock();
     if (!skip) {
         result = dev_data->dispatch_table.CreateImage(device, pCreateInfo, pAllocator, pImage);
     }
-    if (VK_SUCCESS == result) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage);
-    }
+    lock.lock();
+    PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, result);
+    lock.unlock();
     return result;
 }
 
@@ -1003,12 +1000,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(VkDevice device, const VkImageVie
     lock.unlock();
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     VkResult result = dev_data->dispatch_table.CreateImageView(device, pCreateInfo, pAllocator, pView);
-    if (VK_SUCCESS == result) {
-        lock.lock();
-        PostCallRecordCreateImageView(device, pCreateInfo, pAllocator, pView);
-        lock.unlock();
-    }
-
+    lock.lock();
+    PostCallRecordCreateImageView(device, pCreateInfo, pAllocator, pView, result);
+    lock.unlock();
     return result;
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2987,11 +2987,11 @@ static bool ValidateFenceForSubmit(layer_data *dev_data, FENCE_NODE *pFence) {
     return skip;
 }
 
-void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                               VkFence fence) {
+void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
     uint64_t early_retire_seq = 0;
-    auto pQueue = GetQueueState(dev_data, queue);
-    auto pFence = GetFenceNode(dev_data, fence);
+    auto pQueue = GetQueueState(device_data, queue);
+    auto pFence = GetFenceNode(device_data, fence);
 
     if (pFence) {
         if (pFence->scope == kSyncScopeInternal) {
@@ -3007,9 +3007,9 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
         } else {
             // Retire work up until this fence early, we will not see the wait that corresponds to this signal
             early_retire_seq = pQueue->seq + pQueue->submissions.size();
-            if (!dev_data->external_sync_warning) {
-                dev_data->external_sync_warning = true;
-                log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
+            if (!device_data->external_sync_warning) {
+                device_data->external_sync_warning = true;
+                log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
                         HandleToUint64(fence), kVUID_Core_DrawState_QueueForwardProgress,
                         "vkQueueSubmit(): Signaling external fence 0x%" PRIx64 " on queue 0x%" PRIx64
                         " will disable validation of preceding command buffer lifecycle states and the in-use status of associated "
@@ -3028,7 +3028,7 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
         vector<VkSemaphore> semaphore_externals;
         for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
             VkSemaphore semaphore = submit->pWaitSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore) {
                 if (pSemaphore->scope == kSyncScopeInternal) {
                     if (pSemaphore->signaler.first != VK_NULL_HANDLE) {
@@ -3048,7 +3048,7 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
         }
         for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
             VkSemaphore semaphore = submit->pSignalSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore) {
                 if (pSemaphore->scope == kSyncScopeInternal) {
                     pSemaphore->signaler.first = queue;
@@ -3059,10 +3059,11 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
                 } else {
                     // Retire work up until this submit early, we will not see the wait that corresponds to this signal
                     early_retire_seq = std::max(early_retire_seq, pQueue->seq + pQueue->submissions.size() + 1);
-                    if (!dev_data->external_sync_warning) {
-                        dev_data->external_sync_warning = true;
-                        log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                    if (!device_data->external_sync_warning) {
+                        device_data->external_sync_warning = true;
+                        log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, HandleToUint64(semaphore),
+                                kVUID_Core_DrawState_QueueForwardProgress,
                                 "vkQueueSubmit(): Signaling external semaphore 0x%" PRIx64 " on queue 0x%" PRIx64
                                 " will disable validation of preceding command buffer lifecycle states and the in-use status of "
                                 "associated objects.",
@@ -3072,18 +3073,18 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
             }
         }
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            auto cb_node = GetCBNode(dev_data, submit->pCommandBuffers[i]);
+            auto cb_node = GetCBNode(device_data, submit->pCommandBuffers[i]);
             if (cb_node) {
                 cbs.push_back(submit->pCommandBuffers[i]);
                 for (auto secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
                     cbs.push_back(secondaryCmdBuffer->commandBuffer);
-                    UpdateCmdBufImageLayouts(dev_data, secondaryCmdBuffer);
-                    IncrementResources(dev_data, secondaryCmdBuffer);
-                    RecordQueuedQFOTransfers(dev_data, secondaryCmdBuffer);
+                    UpdateCmdBufImageLayouts(device_data, secondaryCmdBuffer);
+                    IncrementResources(device_data, secondaryCmdBuffer);
+                    RecordQueuedQFOTransfers(device_data, secondaryCmdBuffer);
                 }
-                UpdateCmdBufImageLayouts(dev_data, cb_node);
-                IncrementResources(dev_data, cb_node);
-                RecordQueuedQFOTransfers(dev_data, cb_node);
+                UpdateCmdBufImageLayouts(device_data, cb_node);
+                IncrementResources(device_data, cb_node);
+                RecordQueuedQFOTransfers(device_data, cb_node);
             }
         }
         pQueue->submissions.emplace_back(cbs, semaphore_waits, semaphore_signals, semaphore_externals,
@@ -3091,14 +3092,18 @@ void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t sub
     }
 
     if (early_retire_seq) {
-        RetireWorkOnQueue(dev_data, pQueue, early_retire_seq);
+        RetireWorkOnQueue(device_data, pQueue, early_retire_seq);
+    }
+
+    if (GetEnables(device_data)->gpu_validation) {
+        GpuPostCallQueueSubmit(device_data, queue, submitCount, pSubmits, fence);
     }
 }
 
-bool PreCallValidateQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                                VkFence fence) {
-    auto pFence = GetFenceNode(dev_data, fence);
-    bool skip = ValidateFenceForSubmit(dev_data, pFence);
+bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    auto pFence = GetFenceNode(device_data, fence);
+    bool skip = ValidateFenceForSubmit(device_data, pFence);
     if (skip) {
         return true;
     }
@@ -3113,18 +3118,19 @@ bool PreCallValidateQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t su
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
             skip |= ValidateStageMaskGsTsEnables(
-                dev_data, submit->pWaitDstStageMask[i], "vkQueueSubmit()", "VUID-VkSubmitInfo-pWaitDstStageMask-00076",
+                device_data, submit->pWaitDstStageMask[i], "vkQueueSubmit()", "VUID-VkSubmitInfo-pWaitDstStageMask-00076",
                 "VUID-VkSubmitInfo-pWaitDstStageMask-00077", "VUID-VkSubmitInfo-pWaitDstStageMask-02089",
                 "VUID-VkSubmitInfo-pWaitDstStageMask-02090");
             VkSemaphore semaphore = submit->pWaitSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore && (pSemaphore->scope == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
                 if (unsignaled_semaphores.count(semaphore) ||
                     (!(signaled_semaphores.count(semaphore)) && !(pSemaphore->signaled))) {
-                    skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                    HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
-                                    "Queue 0x%" PRIx64 " is waiting on semaphore 0x%" PRIx64 " that has no way to be signaled.",
-                                    HandleToUint64(queue), HandleToUint64(semaphore));
+                    skip |=
+                        log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
+                                HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                                "Queue 0x%" PRIx64 " is waiting on semaphore 0x%" PRIx64 " that has no way to be signaled.",
+                                HandleToUint64(queue), HandleToUint64(semaphore));
                 } else {
                     signaled_semaphores.erase(semaphore);
                     unsignaled_semaphores.insert(semaphore);
@@ -3136,15 +3142,15 @@ bool PreCallValidateQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t su
         }
         for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
             VkSemaphore semaphore = submit->pSignalSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore && (pSemaphore->scope == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
                 if (signaled_semaphores.count(semaphore) || (!(unsignaled_semaphores.count(semaphore)) && pSemaphore->signaled)) {
-                    skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                    HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
-                                    "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64
-                                    " that was previously signaled by queue 0x%" PRIx64
-                                    " but has not since been waited on by any queue.",
-                                    HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
+                    skip |= log_msg(
+                        device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
+                        HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                        "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64 " that was previously signaled by queue 0x%" PRIx64
+                        " but has not since been waited on by any queue.",
+                        HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
                 } else {
                     unsignaled_semaphores.erase(semaphore);
                     signaled_semaphores.insert(semaphore);
@@ -3155,14 +3161,14 @@ bool PreCallValidateQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t su
         QFOTransferCBScoreboards<VkBufferMemoryBarrier> qfo_buffer_scoreboards;
 
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            auto cb_node = GetCBNode(dev_data, submit->pCommandBuffers[i]);
+            auto cb_node = GetCBNode(device_data, submit->pCommandBuffers[i]);
             if (cb_node) {
-                skip |= ValidateCmdBufImageLayouts(dev_data, cb_node, dev_data->imageLayoutMap, localImageLayoutMap);
+                skip |= ValidateCmdBufImageLayouts(device_data, cb_node, device_data->imageLayoutMap, localImageLayoutMap);
                 current_cmds.push_back(submit->pCommandBuffers[i]);
                 skip |= ValidatePrimaryCommandBufferState(
-                    dev_data, cb_node, (int)std::count(current_cmds.begin(), current_cmds.end(), submit->pCommandBuffers[i]),
+                    device_data, cb_node, (int)std::count(current_cmds.begin(), current_cmds.end(), submit->pCommandBuffers[i]),
                     &qfo_image_scoreboards, &qfo_buffer_scoreboards);
-                skip |= ValidateQueueFamilyIndices(dev_data, cb_node, queue);
+                skip |= ValidateQueueFamilyIndices(device_data, cb_node, queue);
 
                 // Potential early exit here as bad object state may crash in delayed function calls
                 if (skip) {
@@ -3924,14 +3930,18 @@ void PostCallRecordGetDeviceQueue(layer_data *dev_data, uint32_t q_family_index,
     }
 }
 
-bool PreCallValidateQueueWaitIdle(layer_data *dev_data, VkQueue queue, QUEUE_STATE **queue_state) {
-    *queue_state = GetQueueState(dev_data, queue);
-    if (dev_data->instance_data->disabled.queue_wait_idle) return false;
-    return VerifyQueueStateToSeq(dev_data, *queue_state, (*queue_state)->seq + (*queue_state)->submissions.size());
+bool PreCallValidateQueueWaitIdle(VkQueue queue) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    QUEUE_STATE *queue_state = GetQueueState(device_data, queue);
+    if (device_data->instance_data->disabled.queue_wait_idle) return false;
+    return VerifyQueueStateToSeq(device_data, queue_state, queue_state->seq + queue_state->submissions.size());
 }
 
-void PostCallRecordQueueWaitIdle(layer_data *dev_data, QUEUE_STATE *queue_state) {
-    RetireWorkOnQueue(dev_data, queue_state, queue_state->seq + queue_state->submissions.size());
+void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    QUEUE_STATE *queue_state = GetQueueState(device_data, queue);
+    RetireWorkOnQueue(device_data, queue_state, queue_state->seq + queue_state->submissions.size());
 }
 
 bool PreCallValidateDeviceWaitIdle(layer_data *dev_data) {
@@ -10293,10 +10303,10 @@ void PreCallRecordSetEvent(layer_data *dev_data, VkEvent event) {
     }
 }
 
-bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                    VkFence fence) {
-    auto pFence = GetFenceNode(dev_data, fence);
-    bool skip = ValidateFenceForSubmit(dev_data, pFence);
+bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    auto pFence = GetFenceNode(device_data, fence);
+    bool skip = ValidateFenceForSubmit(device_data, pFence);
     if (skip) {
         return true;
     }
@@ -10311,14 +10321,15 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
         std::vector<VkSemaphore> semaphore_signals;
         for (uint32_t i = 0; i < bindInfo.waitSemaphoreCount; ++i) {
             VkSemaphore semaphore = bindInfo.pWaitSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore && (pSemaphore->scope == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
                 if (unsignaled_semaphores.count(semaphore) ||
                     (!(signaled_semaphores.count(semaphore)) && !(pSemaphore->signaled))) {
-                    skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                    HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
-                                    "Queue 0x%" PRIx64 " is waiting on semaphore 0x%" PRIx64 " that has no way to be signaled.",
-                                    HandleToUint64(queue), HandleToUint64(semaphore));
+                    skip |=
+                        log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
+                                HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                                "Queue 0x%" PRIx64 " is waiting on semaphore 0x%" PRIx64 " that has no way to be signaled.",
+                                HandleToUint64(queue), HandleToUint64(semaphore));
                 } else {
                     signaled_semaphores.erase(semaphore);
                     unsignaled_semaphores.insert(semaphore);
@@ -10330,15 +10341,15 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
         }
         for (uint32_t i = 0; i < bindInfo.signalSemaphoreCount; ++i) {
             VkSemaphore semaphore = bindInfo.pSignalSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore && pSemaphore->scope == kSyncScopeInternal) {
                 if (signaled_semaphores.count(semaphore) || (!(unsignaled_semaphores.count(semaphore)) && pSemaphore->signaled)) {
-                    skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                    HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
-                                    "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64
-                                    " that was previously signaled by queue 0x%" PRIx64
-                                    " but has not since been waited on by any queue.",
-                                    HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
+                    skip |= log_msg(
+                        device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
+                        HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                        "Queue 0x%" PRIx64 " is signaling semaphore 0x%" PRIx64 " that was previously signaled by queue 0x%" PRIx64
+                        " but has not since been waited on by any queue.",
+                        HandleToUint64(queue), HandleToUint64(semaphore), HandleToUint64(pSemaphore->signaler.first));
                 } else {
                     unsignaled_semaphores.erase(semaphore);
                     signaled_semaphores.insert(semaphore);
@@ -10350,14 +10361,14 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
         // If we're binding sparse image memory make sure reqs were queried and note if metadata is required and bound
         for (uint32_t i = 0; i < bindInfo.imageBindCount; ++i) {
             const auto &image_bind = bindInfo.pImageBinds[i];
-            auto image_state = GetImageState(dev_data, image_bind.image);
+            auto image_state = GetImageState(device_data, image_bind.image);
             if (!image_state)
                 continue;  // Param/Object validation should report image_bind.image handles being invalid, so just skip here.
             sparse_images.insert(image_state);
             if (image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    return log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                    return log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                                    HandleToUint64(image_state->image), kVUID_Core_MemTrack_InvalidState,
                                    "vkQueueBindSparse(): Binding sparse memory to image 0x%" PRIx64
                                    " without first calling vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
@@ -10366,7 +10377,7 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
             }
             if (!image_state->memory_requirements_checked) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                return log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                return log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                                HandleToUint64(image_state->image), kVUID_Core_MemTrack_InvalidState,
                                "vkQueueBindSparse(): Binding sparse memory to image 0x%" PRIx64
                                " without first calling vkGetImageMemoryRequirements() to retrieve requirements.",
@@ -10375,14 +10386,14 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
         }
         for (uint32_t i = 0; i < bindInfo.imageOpaqueBindCount; ++i) {
             const auto &image_opaque_bind = bindInfo.pImageOpaqueBinds[i];
-            auto image_state = GetImageState(dev_data, bindInfo.pImageOpaqueBinds[i].image);
+            auto image_state = GetImageState(device_data, bindInfo.pImageOpaqueBinds[i].image);
             if (!image_state)
                 continue;  // Param/Object validation should report image_bind.image handles being invalid, so just skip here.
             sparse_images.insert(image_state);
             if (image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    return log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                    return log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                                    HandleToUint64(image_state->image), kVUID_Core_MemTrack_InvalidState,
                                    "vkQueueBindSparse(): Binding opaque sparse memory to image 0x%" PRIx64
                                    " without first calling vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
@@ -10391,7 +10402,7 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
             }
             if (!image_state->memory_requirements_checked) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                return log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                return log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                                HandleToUint64(image_state->image), kVUID_Core_MemTrack_InvalidState,
                                "vkQueueBindSparse(): Binding opaque sparse memory to image 0x%" PRIx64
                                " without first calling vkGetImageMemoryRequirements() to retrieve requirements.",
@@ -10407,7 +10418,7 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
             if (sparse_image_state->sparse_metadata_required && !sparse_image_state->sparse_metadata_bound) {
                 // Warn if sparse image binding metadata required for image with sparse binding, but metadata not bound
                 return log_msg(
-                    dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                    device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                     HandleToUint64(sparse_image_state->image), kVUID_Core_MemTrack_InvalidState,
                     "vkQueueBindSparse(): Binding sparse memory to image 0x%" PRIx64
                     " which requires a metadata aspect but no binding with VK_SPARSE_MEMORY_BIND_METADATA_BIT set was made.",
@@ -10418,11 +10429,13 @@ bool PreCallValidateQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_
 
     return skip;
 }
-void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                   VkFence fence) {
+void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence,
+                                   VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    if (result != VK_SUCCESS) return;
     uint64_t early_retire_seq = 0;
-    auto pFence = GetFenceNode(dev_data, fence);
-    auto pQueue = GetQueueState(dev_data, queue);
+    auto pFence = GetFenceNode(device_data, fence);
+    auto pQueue = GetQueueState(device_data, queue);
 
     if (pFence) {
         if (pFence->scope == kSyncScopeInternal) {
@@ -10435,9 +10448,9 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
         } else {
             // Retire work up until this fence early, we will not see the wait that corresponds to this signal
             early_retire_seq = pQueue->seq + pQueue->submissions.size();
-            if (!dev_data->external_sync_warning) {
-                dev_data->external_sync_warning = true;
-                log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
+            if (!device_data->external_sync_warning) {
+                device_data->external_sync_warning = true;
+                log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
                         HandleToUint64(fence), kVUID_Core_DrawState_QueueForwardProgress,
                         "vkQueueBindSparse(): Signaling external fence 0x%" PRIx64 " on queue 0x%" PRIx64
                         " will disable validation of preceding command buffer lifecycle states and the in-use status of associated "
@@ -10453,14 +10466,14 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
         for (uint32_t j = 0; j < bindInfo.bufferBindCount; j++) {
             for (uint32_t k = 0; k < bindInfo.pBufferBinds[j].bindCount; k++) {
                 auto sparse_binding = bindInfo.pBufferBinds[j].pBinds[k];
-                SetSparseMemBinding(dev_data, {sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
+                SetSparseMemBinding(device_data, {sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
                                     HandleToUint64(bindInfo.pBufferBinds[j].buffer), kVulkanObjectTypeBuffer);
             }
         }
         for (uint32_t j = 0; j < bindInfo.imageOpaqueBindCount; j++) {
             for (uint32_t k = 0; k < bindInfo.pImageOpaqueBinds[j].bindCount; k++) {
                 auto sparse_binding = bindInfo.pImageOpaqueBinds[j].pBinds[k];
-                SetSparseMemBinding(dev_data, {sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
+                SetSparseMemBinding(device_data, {sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
                                     HandleToUint64(bindInfo.pImageOpaqueBinds[j].image), kVulkanObjectTypeImage);
             }
         }
@@ -10469,7 +10482,7 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
                 auto sparse_binding = bindInfo.pImageBinds[j].pBinds[k];
                 // TODO: This size is broken for non-opaque bindings, need to update to comprehend full sparse binding data
                 VkDeviceSize size = sparse_binding.extent.depth * sparse_binding.extent.height * sparse_binding.extent.width * 4;
-                SetSparseMemBinding(dev_data, {sparse_binding.memory, sparse_binding.memoryOffset, size},
+                SetSparseMemBinding(device_data, {sparse_binding.memory, sparse_binding.memoryOffset, size},
                                     HandleToUint64(bindInfo.pImageBinds[j].image), kVulkanObjectTypeImage);
             }
         }
@@ -10479,7 +10492,7 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
         std::vector<VkSemaphore> semaphore_externals;
         for (uint32_t i = 0; i < bindInfo.waitSemaphoreCount; ++i) {
             VkSemaphore semaphore = bindInfo.pWaitSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore) {
                 if (pSemaphore->scope == kSyncScopeInternal) {
                     if (pSemaphore->signaler.first != VK_NULL_HANDLE) {
@@ -10499,7 +10512,7 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
         }
         for (uint32_t i = 0; i < bindInfo.signalSemaphoreCount; ++i) {
             VkSemaphore semaphore = bindInfo.pSignalSemaphores[i];
-            auto pSemaphore = GetSemaphoreNode(dev_data, semaphore);
+            auto pSemaphore = GetSemaphoreNode(device_data, semaphore);
             if (pSemaphore) {
                 if (pSemaphore->scope == kSyncScopeInternal) {
                     pSemaphore->signaler.first = queue;
@@ -10510,10 +10523,11 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
                 } else {
                     // Retire work up until this submit early, we will not see the wait that corresponds to this signal
                     early_retire_seq = std::max(early_retire_seq, pQueue->seq + pQueue->submissions.size() + 1);
-                    if (!dev_data->external_sync_warning) {
-                        dev_data->external_sync_warning = true;
-                        log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                                HandleToUint64(semaphore), kVUID_Core_DrawState_QueueForwardProgress,
+                    if (!device_data->external_sync_warning) {
+                        device_data->external_sync_warning = true;
+                        log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, HandleToUint64(semaphore),
+                                kVUID_Core_DrawState_QueueForwardProgress,
                                 "vkQueueBindSparse(): Signaling external semaphore 0x%" PRIx64 " on queue 0x%" PRIx64
                                 " will disable validation of preceding command buffer lifecycle states and the in-use status of "
                                 "associated objects.",
@@ -10528,7 +10542,7 @@ void PostCallRecordQueueBindSparse(layer_data *dev_data, VkQueue queue, uint32_t
     }
 
     if (early_retire_seq) {
-        RetireWorkOnQueue(dev_data, pQueue, early_retire_seq);
+        RetireWorkOnQueue(device_data, pQueue, early_retire_seq);
     }
 }
 
@@ -11034,34 +11048,36 @@ void PostCallRecordGetSwapchainImagesKHR(layer_data *device_data, SWAPCHAIN_NODE
     }
 }
 
-bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+
     bool skip = false;
 
     lock_guard_t lock(global_lock);
-    auto queue_state = GetQueueState(dev_data, queue);
+    auto queue_state = GetQueueState(device_data, queue);
 
     for (uint32_t i = 0; i < pPresentInfo->waitSemaphoreCount; ++i) {
-        auto pSemaphore = GetSemaphoreNode(dev_data, pPresentInfo->pWaitSemaphores[i]);
+        auto pSemaphore = GetSemaphoreNode(device_data, pPresentInfo->pWaitSemaphores[i]);
         if (pSemaphore && !pSemaphore->signaled) {
-            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, 0,
-                            kVUID_Core_DrawState_QueueForwardProgress,
+            skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
+                            0, kVUID_Core_DrawState_QueueForwardProgress,
                             "Queue 0x%" PRIx64 " is waiting on semaphore 0x%" PRIx64 " that has no way to be signaled.",
                             HandleToUint64(queue), HandleToUint64(pPresentInfo->pWaitSemaphores[i]));
         }
     }
 
     for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
-        auto swapchain_data = GetSwapchainNode(dev_data, pPresentInfo->pSwapchains[i]);
+        auto swapchain_data = GetSwapchainNode(device_data, pPresentInfo->pSwapchains[i]);
         if (swapchain_data) {
             if (pPresentInfo->pImageIndices[i] >= swapchain_data->images.size()) {
                 skip |=
-                    log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
+                    log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
                             HandleToUint64(pPresentInfo->pSwapchains[i]), kVUID_Core_DrawState_SwapchainInvalidImage,
                             "vkQueuePresentKHR: Swapchain image index too large (%u). There are only %u images in this swapchain.",
                             pPresentInfo->pImageIndices[i], (uint32_t)swapchain_data->images.size());
             } else {
                 auto image = swapchain_data->images[pPresentInfo->pImageIndices[i]];
-                auto image_state = GetImageState(dev_data, image);
+                auto image_state = GetImageState(device_data, image);
 
                 if (image_state->shared_presentable) {
                     image_state->layout_locked = true;
@@ -11069,22 +11085,23 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
 
                 if (!image_state->acquired) {
                     skip |= log_msg(
-                        dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
+                        device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
                         HandleToUint64(pPresentInfo->pSwapchains[i]), kVUID_Core_DrawState_SwapchainImageNotAcquired,
                         "vkQueuePresentKHR: Swapchain image index %u has not been acquired.", pPresentInfo->pImageIndices[i]);
                 }
 
                 vector<VkImageLayout> layouts;
-                if (FindLayouts(dev_data, image, layouts)) {
+                if (FindLayouts(device_data, image, layouts)) {
                     for (auto layout : layouts) {
-                        if ((layout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) && (!dev_data->extensions.vk_khr_shared_presentable_image ||
-                                                                            (layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR))) {
-                            skip |=
-                                log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT,
-                                        HandleToUint64(queue), "VUID-VkPresentInfoKHR-pImageIndices-01296",
-                                        "Images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR or "
-                                        "VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR but is in %s.",
-                                        string_VkImageLayout(layout));
+                        if ((layout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) &&
+                            (!device_data->extensions.vk_khr_shared_presentable_image ||
+                             (layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR))) {
+                            skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                            VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, HandleToUint64(queue),
+                                            "VUID-VkPresentInfoKHR-pImageIndices-01296",
+                                            "Images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR or "
+                                            "VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR but is in %s.",
+                                            string_VkImageLayout(layout));
                         }
                     }
                 }
@@ -11092,20 +11109,21 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
 
             // All physical devices and queue families are required to be able to present to any native window on Android; require
             // the application to have established support on any other platform.
-            if (!dev_data->instance_data->extensions.vk_khr_android_surface) {
-                auto surface_state = GetSurfaceState(dev_data->instance_data, swapchain_data->createInfo.surface);
-                auto support_it = surface_state->gpu_queue_support.find({dev_data->physical_device, queue_state->queueFamilyIndex});
+            if (!device_data->instance_data->extensions.vk_khr_android_surface) {
+                auto surface_state = GetSurfaceState(device_data->instance_data, swapchain_data->createInfo.surface);
+                auto support_it =
+                    surface_state->gpu_queue_support.find({device_data->physical_device, queue_state->queueFamilyIndex});
 
                 if (support_it == surface_state->gpu_queue_support.end()) {
-                    skip |=
-                        log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
-                                HandleToUint64(pPresentInfo->pSwapchains[i]), kVUID_Core_DrawState_SwapchainUnsupportedQueue,
-                                "vkQueuePresentKHR: Presenting image without calling vkGetPhysicalDeviceSurfaceSupportKHR");
+                    skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                    VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, HandleToUint64(pPresentInfo->pSwapchains[i]),
+                                    kVUID_Core_DrawState_SwapchainUnsupportedQueue,
+                                    "vkQueuePresentKHR: Presenting image without calling vkGetPhysicalDeviceSurfaceSupportKHR");
                 } else if (!support_it->second) {
-                    skip |=
-                        log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
-                                HandleToUint64(pPresentInfo->pSwapchains[i]), "VUID-vkQueuePresentKHR-pSwapchains-01292",
-                                "vkQueuePresentKHR: Presenting image on queue that cannot present to this surface.");
+                    skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                    VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, HandleToUint64(pPresentInfo->pSwapchains[i]),
+                                    "VUID-vkQueuePresentKHR-pSwapchains-01292",
+                                    "vkQueuePresentKHR: Presenting image on queue that cannot present to this surface.");
                 }
             }
         }
@@ -11115,13 +11133,13 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
         const auto *present_regions = lvl_find_in_chain<VkPresentRegionsKHR>(pPresentInfo->pNext);
         if (present_regions) {
             for (uint32_t i = 0; i < present_regions->swapchainCount; ++i) {
-                auto swapchain_data = GetSwapchainNode(dev_data, pPresentInfo->pSwapchains[i]);
+                auto swapchain_data = GetSwapchainNode(device_data, pPresentInfo->pSwapchains[i]);
                 assert(swapchain_data);
                 VkPresentRegionKHR region = present_regions->pRegions[i];
                 for (uint32_t j = 0; j < region.rectangleCount; ++j) {
                     VkRectLayerKHR rect = region.pRectangles[j];
                     if ((rect.offset.x + rect.extent.width) > swapchain_data->createInfo.imageExtent.width) {
-                        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                        skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                         VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, HandleToUint64(pPresentInfo->pSwapchains[i]),
                                         "VUID-VkRectLayerKHR-offset-01261",
                                         "vkQueuePresentKHR(): For VkPresentRegionKHR down pNext chain, "
@@ -11130,7 +11148,7 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
                                         i, j, rect.offset.x, rect.extent.width, swapchain_data->createInfo.imageExtent.width);
                     }
                     if ((rect.offset.y + rect.extent.height) > swapchain_data->createInfo.imageExtent.height) {
-                        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                        skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                         VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, HandleToUint64(pPresentInfo->pSwapchains[i]),
                                         "VUID-VkRectLayerKHR-offset-01261",
                                         "vkQueuePresentKHR(): For VkPresentRegionKHR down pNext chain, "
@@ -11140,7 +11158,7 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
                     }
                     if (rect.layer > swapchain_data->createInfo.imageArrayLayers) {
                         skip |= log_msg(
-                            dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
+                            device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
                             HandleToUint64(pPresentInfo->pSwapchains[i]), "VUID-VkRectLayerKHR-layer-01262",
                             "vkQueuePresentKHR(): For VkPresentRegionKHR down pNext chain, pRegion[%i].pRectangles[%i], the layer "
                             "(%i) is greater than the corresponding swapchain's imageArrayLayers (%i).",
@@ -11154,7 +11172,7 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
         if (present_times_info) {
             if (pPresentInfo->swapchainCount != present_times_info->swapchainCount) {
                 skip |=
-                    log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
+                    log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
                             HandleToUint64(pPresentInfo->pSwapchains[0]), "VUID-VkPresentTimesInfoGOOGLE-swapchainCount-01247",
                             "vkQueuePresentKHR(): VkPresentTimesInfoGOOGLE.swapchainCount is %i but pPresentInfo->swapchainCount "
                             "is %i. For VkPresentTimesInfoGOOGLE down pNext chain of VkPresentInfoKHR, "
@@ -11167,10 +11185,11 @@ bool PreCallValidateQueuePresentKHR(layer_data *dev_data, VkQueue queue, const V
     return skip;
 }
 
-void PostCallRecordQueuePresentKHR(layer_data *dev_data, const VkPresentInfoKHR *pPresentInfo, const VkResult &result) {
+void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
     // Semaphore waits occur before error generation, if the call reached the ICD. (Confirm?)
     for (uint32_t i = 0; i < pPresentInfo->waitSemaphoreCount; ++i) {
-        auto pSemaphore = GetSemaphoreNode(dev_data, pPresentInfo->pWaitSemaphores[i]);
+        auto pSemaphore = GetSemaphoreNode(device_data, pPresentInfo->pWaitSemaphores[i]);
         if (pSemaphore) {
             pSemaphore->signaler.first = VK_NULL_HANDLE;
             pSemaphore->signaled = false;
@@ -11181,20 +11200,17 @@ void PostCallRecordQueuePresentKHR(layer_data *dev_data, const VkPresentInfoKHR 
         // Note: this is imperfect, in that we can get confused about what did or didn't succeed-- but if the app does that, it's
         // confused itself just as much.
         auto local_result = pPresentInfo->pResults ? pPresentInfo->pResults[i] : result;
-
         if (local_result != VK_SUCCESS && local_result != VK_SUBOPTIMAL_KHR) continue;  // this present didn't actually happen.
-
         // Mark the image as having been released to the WSI
-        auto swapchain_data = GetSwapchainNode(dev_data, pPresentInfo->pSwapchains[i]);
+        auto swapchain_data = GetSwapchainNode(device_data, pPresentInfo->pSwapchains[i]);
         if (swapchain_data && (swapchain_data->images.size() > pPresentInfo->pImageIndices[i])) {
             auto image = swapchain_data->images[pPresentInfo->pImageIndices[i]];
-            auto image_state = GetImageState(dev_data, image);
+            auto image_state = GetImageState(device_data, image);
             if (image_state) {
                 image_state->acquired = false;
             }
         }
     }
-
     // Note: even though presentation is directed to a queue, there is no direct ordering between QP and subsequent work, so QP (and
     // its semaphore waits) /never/ participate in any completion proof.
 }
@@ -11715,16 +11731,19 @@ void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data *dev_data, const VkDebug
     }
 }
 
-void PreCallRecordQueueBeginDebugUtilsLabelEXT(layer_data *dev_data, VkQueue queue, const VkDebugUtilsLabelEXT *pLabelInfo) {
-    BeginQueueDebugUtilsLabel(dev_data->report_data, queue, pLabelInfo);
+void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT *pLabelInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    BeginQueueDebugUtilsLabel(device_data->report_data, queue, pLabelInfo);
 }
 
-void PostCallRecordQueueEndDebugUtilsLabelEXT(layer_data *dev_data, VkQueue queue) {
-    EndQueueDebugUtilsLabel(dev_data->report_data, queue);
+void PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    EndQueueDebugUtilsLabel(device_data->report_data, queue);
 }
 
-void PreCallRecordQueueInsertDebugUtilsLabelEXT(layer_data *dev_data, VkQueue queue, const VkDebugUtilsLabelEXT *pLabelInfo) {
-    InsertQueueDebugUtilsLabel(dev_data->report_data, queue, pLabelInfo);
+void PreCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT *pLabelInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
+    InsertQueueDebugUtilsLabel(device_data->report_data, queue, pLabelInfo);
 }
 
 void PreCallRecordCmdBeginDebugUtilsLabelEXT(layer_data *dev_data, VkCommandBuffer commandBuffer,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1376,10 +1376,8 @@ void PostCallRecordCreateSamplerYcbcrConversion(layer_data* dev_data, const VkSa
                                                 VkSamplerYcbcrConversion ycbcr_conversion);
 bool PreCallValidateCmdDebugMarkerBeginEXT(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);
 void PreCallRecordDestroyDevice(layer_data* dev_data, VkDevice device);
-bool PreCallValidateQueueSubmit(layer_data* dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits,
-                                VkFence fence);
-void PostCallRecordQueueSubmit(layer_data* dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits,
-                               VkFence fence);
+bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
+void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence, VkResult result);
 bool PreCallValidateAllocateMemory(layer_data* dev_data, const VkMemoryAllocateInfo* alloc_info);
 void PostCallRecordAllocateMemory(layer_data* dev_data, const VkMemoryAllocateInfo* pAllocateInfo, VkDeviceMemory* pMemory);
 bool PreCallValidateFreeMemory(layer_data* dev_data, VkDeviceMemory mem, DEVICE_MEM_INFO** mem_info, VK_OBJECT* obj_struct);
@@ -1388,8 +1386,8 @@ bool PreCallValidateWaitForFences(layer_data* dev_data, uint32_t fence_count, co
 void PostCallRecordWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences, VkBool32 wait_all);
 bool PreCallValidateGetFenceStatus(layer_data* dev_data, VkFence fence);
 void PostCallRecordGetFenceStatus(layer_data* dev_data, VkFence fence);
-bool PreCallValidateQueueWaitIdle(layer_data* dev_data, VkQueue queue, QUEUE_STATE** queue_state);
-void PostCallRecordQueueWaitIdle(layer_data* dev_data, QUEUE_STATE* queue_state);
+bool PreCallValidateQueueWaitIdle(VkQueue queue);
+void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result);
 bool PreCallValidateDeviceWaitIdle(layer_data* dev_data);
 void PostCallRecordDeviceWaitIdle(layer_data* dev_data);
 bool PreCallValidateDestroyFence(layer_data* dev_data, VkFence fence, FENCE_NODE** fence_node, VK_OBJECT* obj_struct);
@@ -1677,10 +1675,9 @@ void PostCallRecordBindImageMemory2(layer_data* dev_data, const std::vector<IMAG
                                     const VkBindImageMemoryInfoKHR* pBindInfos);
 bool PreCallValidateSetEvent(layer_data* dev_data, VkEvent event);
 void PreCallRecordSetEvent(layer_data* dev_data, VkEvent event);
-bool PreCallValidateQueueBindSparse(layer_data* dev_data, VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                    VkFence fence);
-void PostCallRecordQueueBindSparse(layer_data* dev_data, VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                   VkFence fence);
+bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence);
+void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
+                                   VkResult result);
 void PostCallRecordCreateSemaphore(layer_data* dev_data, VkSemaphore* pSemaphore);
 bool PreCallValidateImportSemaphore(layer_data* dev_data, VkSemaphore semaphore, const char* caller_name);
 void PostCallRecordImportSemaphore(layer_data* dev_data, VkSemaphore semaphore,
@@ -1701,8 +1698,8 @@ bool PreCallValidateGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NOD
                                           uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
 void PostCallRecordGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NODE* swapchain_state, VkDevice device,
                                          uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
-bool PreCallValidateQueuePresentKHR(layer_data* dev_data, VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
-void PostCallRecordQueuePresentKHR(layer_data* dev_data, const VkPresentInfoKHR* pPresentInfo, const VkResult& result);
+bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
+void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, VkResult result);
 bool PreCallValidateCreateSharedSwapchainsKHR(layer_data* dev_data, uint32_t swapchainCount,
                                               const VkSwapchainCreateInfoKHR* pCreateInfos, VkSwapchainKHR* pSwapchains,
                                               std::vector<SURFACE_STATE*>& surface_state,
@@ -1753,9 +1750,9 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(instance_layer_data* inst
 void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
 void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data* dev_data, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
-void PreCallRecordQueueBeginDebugUtilsLabelEXT(layer_data* dev_data, VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
-void PostCallRecordQueueEndDebugUtilsLabelEXT(layer_data* dev_data, VkQueue queue);
-void PreCallRecordQueueInsertDebugUtilsLabelEXT(layer_data* dev_data, VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
+void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
+void PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue);
+void PreCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
 void PreCallRecordCmdBeginDebugUtilsLabelEXT(layer_data* dev_data, VkCommandBuffer commandBuffer,
                                              const VkDebugUtilsLabelEXT* pLabelInfo);
 void PostCallRecordCmdEndDebugUtilsLabelEXT(layer_data* dev_data, VkCommandBuffer commandBuffer);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1113,11 +1113,10 @@ static void ProcessInstrumentationBuffer(const layer_data *dev_data, VkQueue que
 // Wait for the queue to complete execution.  Check the debug buffers for all the
 // command buffers that were submitted.
 void GpuPostCallQueueSubmit(const layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                            VkFence fence, mutex_t &global_lock) {
+                            VkFence fence) {
     auto gpu_state = GetGpuValidationState(dev_data);
     if (gpu_state->aborted) return;
-    core_validation::QueueWaitIdle(queue);
-    unique_lock_t lock(global_lock);
+    dev_data->dispatch_table.QueueWaitIdle(queue);
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -127,7 +127,7 @@ VkResult GpuOverrideDispatchCreatePipelineLayout(layer_data *dev_data, const VkP
 void GpuPostCallDispatchCmdBindPipeline(layer_data *dev_data, VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                         VkPipeline pipeline);
 void GpuPostCallQueueSubmit(const layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                            VkFence fence, mutex_t &global_lock);
+                            VkFence fence);
 void GpuPreCallValidateCmdWaitEvents(layer_data *dev_data, VkPipelineStageFlags sourceStageMask);
 std::vector<safe_VkGraphicsPipelineCreateInfo> GpuPreCallRecordCreateGraphicsPipelines(
     layer_data *dev_data, VkPipelineCache pipelineCache, uint32_t count, const VkGraphicsPipelineCreateInfo *pCreateInfos,


### PR DESCRIPTION
Note that this includes supporting changes to GpuPostCallQueueSubmit.

- PreCallValidateQueueSubmit
- PreCallValidateQueueWaitIdle
- PreCallValidateQueueBindSparse
- PreCallValidateQueuePresentKHR
- PostCallRecordQueueBindSparse
- PostCallRecordQueuePresentKHR
- PostCallRecordQueueEndDebugUtilsLabelEXT
- PreCallRecordQueueBeginDebugUtilsLabelEXT
- PostCallRecordQueueSubmit
- PostCallRecordQueueWaitIdle
- PreCallRecordQueueInsertDebugUtilsLabelEXT

Also includes a commit to add passing of return codes through the PostCallRecord buffer/image functions.