### PR TITLE
Normalize *CommandBuffer* and *Memory* pre/post function call signatures

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -331,30 +331,29 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(VkDevice device, const VkMemoryAll
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateAllocateMemory(dev_data, pAllocateInfo);
+    bool skip = PreCallValidateAllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
+    lock.unlock();
     if (!skip) {
-        lock.unlock();
         result = dev_data->dispatch_table.AllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
         lock.lock();
-        if (VK_SUCCESS == result) {
-            PostCallRecordAllocateMemory(dev_data, pAllocateInfo, pMemory);
-        }
+        PostCallRecordAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, result);
+        lock.unlock();
     }
     return result;
 }
 
 VKAPI_ATTR void VKAPI_CALL FreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks *pAllocator) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    DEVICE_MEM_INFO *mem_info = nullptr;
-    VK_OBJECT obj_struct;
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateFreeMemory(dev_data, mem, &mem_info, &obj_struct);
+    bool skip = PreCallValidateFreeMemory(device, mem, pAllocator);
+    lock.unlock();
     if (!skip) {
         if (mem != VK_NULL_HANDLE) {
             // Avoid free/alloc race by recording state change before dispatching
-            PreCallRecordFreeMemory(dev_data, mem, mem_info, obj_struct);
+            lock.lock();
+            PreCallRecordFreeMemory(device, mem, pAllocator);
+            lock.unlock();
         }
-        lock.unlock();
         dev_data->dispatch_table.FreeMemory(device, mem, pAllocator);
     }
 }
@@ -543,17 +542,14 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(VkDevice device, VkImage image, const Vk
 VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    BUFFER_STATE *buffer_state;
-    {
-        unique_lock_t lock(global_lock);
-        buffer_state = GetBufferState(dev_data, buffer);
-    }
-    bool skip = PreCallValidateBindBufferMemory(dev_data, buffer, buffer_state, mem, memoryOffset, "vkBindBufferMemory()");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateBindBufferMemory(device, buffer, mem, memoryOffset);
+    lock.unlock();
     if (!skip) {
         result = dev_data->dispatch_table.BindBufferMemory(device, buffer, mem, memoryOffset);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindBufferMemory(dev_data, buffer, buffer_state, mem, memoryOffset, "vkBindBufferMemory()");
-        }
+        lock.lock();
+        PostCallRecordBindBufferMemory(device, buffer, mem, memoryOffset, result);
+        lock.unlock();
     }
     return result;
 }
@@ -562,12 +558,15 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(VkDevice device, uint32_t bindI
                                                  const VkBindBufferMemoryInfoKHR *pBindInfos) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    std::vector<BUFFER_STATE *> buffer_state(bindInfoCount);
-    if (!PreCallValidateBindBufferMemory2(dev_data, &buffer_state, bindInfoCount, pBindInfos)) {
+    bool skip = false;
+    unique_lock_t lock(global_lock);
+    skip = PreCallValidateBindBufferMemory2(device, bindInfoCount, pBindInfos);
+    lock.unlock();
+    if (!skip) {
         result = dev_data->dispatch_table.BindBufferMemory2(device, bindInfoCount, pBindInfos);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindBufferMemory2(dev_data, buffer_state, bindInfoCount, pBindInfos);
-        }
+        lock.lock();
+        PostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, result);
+        lock.unlock();
     }
     return result;
 }
@@ -576,12 +575,15 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(VkDevice device, uint32_t bi
                                                     const VkBindBufferMemoryInfoKHR *pBindInfos) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    std::vector<BUFFER_STATE *> buffer_state(bindInfoCount);
-    if (!PreCallValidateBindBufferMemory2(dev_data, &buffer_state, bindInfoCount, pBindInfos)) {
-        result = dev_data->dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindBufferMemory2(dev_data, buffer_state, bindInfoCount, pBindInfos);
-        }
+    bool skip = false;
+    unique_lock_t lock(global_lock);
+    skip = PreCallValidateBindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
+    lock.unlock();
+    if (!skip) {
+        result = dev_data->dispatch_table.BindBufferMemory2(device, bindInfoCount, pBindInfos);
+        lock.lock();
+        PostCallRecordBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, result);
+        lock.unlock();
     }
     return result;
 }
@@ -2300,17 +2302,14 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(VkDevice device, uin
 VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    IMAGE_STATE *image_state;
-    {
-        unique_lock_t lock(global_lock);
-        image_state = GetImageState(dev_data, image);
-    }
-    bool skip = PreCallValidateBindImageMemory(dev_data, image, image_state, mem, memoryOffset, "vkBindImageMemory()");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateBindImageMemory(device, image, mem, memoryOffset);
+    lock.unlock();
     if (!skip) {
         result = dev_data->dispatch_table.BindImageMemory(device, image, mem, memoryOffset);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindImageMemory(dev_data, image, image_state, mem, memoryOffset, "vkBindImageMemory()");
-        }
+        lock.lock();
+        PostCallRecordBindImageMemory(device, image, mem, memoryOffset, result);
+        lock.unlock();
     }
     return result;
 }
@@ -2319,12 +2318,14 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(VkDevice device, uint32_t bindIn
                                                 const VkBindImageMemoryInfoKHR *pBindInfos) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    std::vector<IMAGE_STATE *> image_state(bindInfoCount);
-    if (!PreCallValidateBindImageMemory2(dev_data, &image_state, bindInfoCount, pBindInfos)) {
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateBindImageMemory2(device, bindInfoCount, pBindInfos);
+    lock.unlock();
+    if (!skip) {
         result = dev_data->dispatch_table.BindImageMemory2(device, bindInfoCount, pBindInfos);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindImageMemory2(dev_data, image_state, bindInfoCount, pBindInfos);
-        }
+        lock.lock();
+        PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, result);
+        lock.unlock();
     }
     return result;
 }
@@ -2333,12 +2334,14 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(VkDevice device, uint32_t bin
                                                    const VkBindImageMemoryInfoKHR *pBindInfos) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    std::vector<IMAGE_STATE *> image_state(bindInfoCount);
-    if (!PreCallValidateBindImageMemory2(dev_data, &image_state, bindInfoCount, pBindInfos)) {
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateBindImageMemory2KHR(device, bindInfoCount, pBindInfos);
+    lock.unlock();
+    if (!skip) {
         result = dev_data->dispatch_table.BindImageMemory2KHR(device, bindInfoCount, pBindInfos);
-        if (result == VK_SUCCESS) {
-            PostCallRecordBindImageMemory2(dev_data, image_state, bindInfoCount, pBindInfos);
-        }
+        lock.lock();
+        PostCallRecordBindImageMemory2KHR(device, bindInfoCount, pBindInfos, result);
+        lock.unlock();
     }
     return result;
 }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1658,15 +1658,16 @@ bool PreCallValidateCmdExecuteCommands(layer_data* dev_data, GLOBAL_CB_NODE* cb_
                                        uint32_t commandBuffersCount, const VkCommandBuffer* pCommandBuffers);
 void PreCallRecordCmdExecuteCommands(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, uint32_t commandBuffersCount,
                                      const VkCommandBuffer* pCommandBuffers);
-bool PreCallValidateMapMemory(layer_data* dev_data, VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size);
-void PostCallRecordMapMemory(layer_data* dev_data, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
-bool PreCallValidateUnmapMemory(const layer_data* dev_data, DEVICE_MEM_INFO* mem_info, const VkDeviceMemory mem);
-void PreCallRecordUnmapMemory(DEVICE_MEM_INFO* mem_info);
-bool PreCallValidateFlushMappedMemoryRanges(layer_data* dev_data, uint32_t mem_range_count, const VkMappedMemoryRange* mem_ranges);
-bool PreCallValidateInvalidateMappedMemoryRanges(layer_data* dev_data, uint32_t mem_range_count,
-                                                 const VkMappedMemoryRange* mem_ranges);
-void PostCallRecordInvalidateMappedMemoryRanges(layer_data* dev_data, uint32_t mem_range_count,
-                                                const VkMappedMemoryRange* mem_ranges);
+bool PreCallValidateMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
+                              void** ppData);
+void PostCallRecordMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
+                             void** ppData, VkResult result);
+bool PreCallValidateUnmapMemory(VkDevice device, VkDeviceMemory mem);
+void PreCallRecordUnmapMemory(VkDevice device, VkDeviceMemory mem);
+bool PreCallValidateFlushMappedMemoryRanges(VkDevice device, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
+bool PreCallValidateInvalidateMappedMemoryRanges(VkDevice device, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
+void PostCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges,
+                                                VkResult result);
 bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset);
 void PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset, VkResult result);
 bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1435,8 +1435,9 @@ bool PreCallValidateDestroyDescriptorPool(layer_data* dev_data, VkDescriptorPool
                                           VK_OBJECT* obj_struct);
 void PreCallRecordDestroyDescriptorPool(layer_data* dev_data, VkDescriptorPool descriptorPool,
                                         DESCRIPTOR_POOL_STATE* desc_pool_state, VK_OBJECT obj_struct);
-bool PreCallValidateFreeCommandBuffers(layer_data* dev_data, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
-void PreCallRecordFreeCommandBuffers(layer_data* dev_data, VkCommandPool commandPool, uint32_t commandBufferCount,
+bool PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
+                                       const VkCommandBuffer* pCommandBuffers);
+void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                      const VkCommandBuffer* pCommandBuffers);
 void PostCallRecordCreateCommandPool(layer_data* dev_data, const VkCommandPoolCreateInfo* pCreateInfo, VkCommandPool* pCommandPool);
 bool PreCallValidateCreateQueryPool(layer_data* dev_data, const VkQueryPoolCreateInfo* pCreateInfo);
@@ -1497,16 +1498,14 @@ bool PreCallValidateUpdateDescriptorSets(layer_data* dev_data, uint32_t descript
 void PreCallRecordUpdateDescriptorSets(layer_data* dev_data, uint32_t descriptorWriteCount,
                                        const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                        const VkCopyDescriptorSet* pDescriptorCopies);
-void PostCallRecordAllocateCommandBuffers(layer_data* dev_data, VkDevice device, const VkCommandBufferAllocateInfo* pCreateInfo,
-                                          VkCommandBuffer* pCommandBuffer);
-bool PreCallValidateBeginCommandBuffer(layer_data* dev_data, const GLOBAL_CB_NODE* cb_state, const VkCommandBuffer commandBuffer,
-                                       const VkCommandBufferBeginInfo* pBeginInfo);
-void PreCallRecordBeginCommandBuffer(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, const VkCommandBuffer commandBuffer,
-                                     const VkCommandBufferBeginInfo* pBeginInfo);
-bool PreCallValidateEndCommandBuffer(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, VkCommandBuffer commandBuffer);
-void PostCallRecordEndCommandBuffer(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, const VkResult& result);
-bool PreCallValidateResetCommandBuffer(layer_data* dev_data, VkCommandBuffer commandBuffer);
-void PostCallRecordResetCommandBuffer(layer_data* dev_data, VkCommandBuffer commandBuffer);
+void PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pCreateInfo,
+                                          VkCommandBuffer* pCommandBuffer, VkResult result);
+bool PreCallValidateBeginCommandBuffer(const VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
+void PreCallRecordBeginCommandBuffer(const VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
+bool PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer);
+void PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, VkResult result);
+bool PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags);
+void PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags, VkResult result);
 bool PreCallValidateCmdBindPipeline(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);
 void PreCallRecordCmdBindPipeline(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint pipelineBindPoint,
                                   VkPipeline pipeline);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1378,10 +1378,12 @@ bool PreCallValidateCmdDebugMarkerBeginEXT(layer_data* dev_data, GLOBAL_CB_NODE*
 void PreCallRecordDestroyDevice(layer_data* dev_data, VkDevice device);
 bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
 void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence, VkResult result);
-bool PreCallValidateAllocateMemory(layer_data* dev_data, const VkMemoryAllocateInfo* alloc_info);
-void PostCallRecordAllocateMemory(layer_data* dev_data, const VkMemoryAllocateInfo* pAllocateInfo, VkDeviceMemory* pMemory);
-bool PreCallValidateFreeMemory(layer_data* dev_data, VkDeviceMemory mem, DEVICE_MEM_INFO** mem_info, VK_OBJECT* obj_struct);
-void PreCallRecordFreeMemory(layer_data* dev_data, VkDeviceMemory mem, DEVICE_MEM_INFO* mem_info, VK_OBJECT obj_struct);
+bool PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory);
+void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                  const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory, VkResult result);
+bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator);
+void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences);
 void PostCallRecordWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences, VkBool32 wait_all);
 bool PreCallValidateGetFenceStatus(layer_data* dev_data, VkFence fence);
@@ -1405,14 +1407,15 @@ bool PreCallValidateGetQueryPoolResults(layer_data* dev_data, VkQueryPool query_
                                         unordered_map<QueryObject, std::vector<VkCommandBuffer>>* queries_in_flight);
 void PostCallRecordGetQueryPoolResults(layer_data* dev_data, VkQueryPool query_pool, uint32_t first_query, uint32_t query_count,
                                        unordered_map<QueryObject, std::vector<VkCommandBuffer>>* queries_in_flight);
-bool PreCallValidateBindBufferMemory2(layer_data* dev_data, std::vector<BUFFER_STATE*>* buffer_state, uint32_t bindInfoCount,
-                                      const VkBindBufferMemoryInfoKHR* pBindInfos);
-void PostCallRecordBindBufferMemory2(layer_data* dev_data, const std::vector<BUFFER_STATE*>& buffer_state, uint32_t bindInfoCount,
-                                     const VkBindBufferMemoryInfoKHR* pBindInfos);
-bool PreCallValidateBindBufferMemory(layer_data* dev_data, VkBuffer buffer, BUFFER_STATE* buffer_state, VkDeviceMemory mem,
-                                     VkDeviceSize memoryOffset, const char* api_name);
-void PostCallRecordBindBufferMemory(layer_data* dev_data, VkBuffer buffer, BUFFER_STATE* buffer_state, VkDeviceMemory mem,
-                                    VkDeviceSize memoryOffset, const char* api_name);
+bool PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos);
+void PostCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos,
+                                        VkResult result);
+bool PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos);
+void PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos,
+                                     VkResult result);
+bool PreCallValidateBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
+void PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset,
+                                    VkResult result);
 void PostCallRecordGetBufferMemoryRequirements(layer_data* dev_data, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
 bool PreCallValidateGetImageMemoryRequirements2(layer_data* dev_data, const VkImageMemoryRequirementsInfo2* pInfo);
 void PostCallRecordGetImageMemoryRequirements(layer_data* dev_data, VkImage image, VkMemoryRequirements* pMemoryRequirements);
@@ -1664,14 +1667,14 @@ bool PreCallValidateInvalidateMappedMemoryRanges(layer_data* dev_data, uint32_t 
                                                  const VkMappedMemoryRange* mem_ranges);
 void PostCallRecordInvalidateMappedMemoryRanges(layer_data* dev_data, uint32_t mem_range_count,
                                                 const VkMappedMemoryRange* mem_ranges);
-bool PreCallValidateBindImageMemory(layer_data* dev_data, VkImage image, IMAGE_STATE* image_state, VkDeviceMemory mem,
-                                    VkDeviceSize memoryOffset, const char* api_name);
-void PostCallRecordBindImageMemory(layer_data* dev_data, VkImage image, IMAGE_STATE* image_state, VkDeviceMemory mem,
-                                   VkDeviceSize memoryOffset, const char* api_name);
-bool PreCallValidateBindImageMemory2(layer_data* dev_data, std::vector<IMAGE_STATE*>* image_state, uint32_t bindInfoCount,
-                                     const VkBindImageMemoryInfoKHR* pBindInfos);
-void PostCallRecordBindImageMemory2(layer_data* dev_data, const std::vector<IMAGE_STATE*>& image_state, uint32_t bindInfoCount,
-                                    const VkBindImageMemoryInfoKHR* pBindInfos);
+bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset);
+void PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset, VkResult result);
+bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos);
+void PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos,
+                                    VkResult result);
+bool PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos);
+void PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos,
+                                       VkResult result);
 bool PreCallValidateSetEvent(layer_data* dev_data, VkEvent event);
 void PreCallRecordSetEvent(layer_data* dev_data, VkEvent event);
 bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence);


### PR DESCRIPTION

- PreCallValidateFreeCommandBuffers
- PreCallValidateBeginCommandBuffer
- PreCallValidateEndCommandBuffer
- PreCallValidateResetCommandBuffer
- PreCallRecordFreeCommandBuffers
- PreCallRecordBeginCommandBuffer
- PostCallRecordAllocateCommandBuffers
- PostCallRecordEndCommandBuffer
- PostCallRecordResetCommandBuffer
- PreCallValidateAllocateMemory
- PreCallValidateFreeMemory
- PreCallValidateBindBufferMemory2
- PreCallValidateBindBufferMemory
- PreCallValidateBindImageMemory
- PreCallValidateBindImageMemory2
- PostCallRecordAllocateMemory
- PreCallRecordFreeMemory
- PostCallRecordBindBufferMemory2
- PostCallRecordBindBufferMemory
- PostCallRecordBindImageMemory
- PostCallRecordBindImageMemory2
- PostCallRecordBindBufferMemory2KHR
- PreCallValidateBindBufferMemory2KHR
- PostCallRecordBindImageMemory2KHR
- PreCallValidateBindImageMemory2KHR
- PreCallValidateMapMemory
- PreCallValidateUnmapMemory
- PreCallValidateFlushMappedMemoryRanges
- PreCallValidateInvalidateMappedMemoryRanges
- PreCallRecordUnmapMemory
- PostCallRecordMapMemory
- PostCallRecordInvalidateMappedMemoryRanges

