### PR TITLE
Normalize function signatures for vkCreate* pre- and post-calls

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -70,10 +70,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(VkDevice device, const VkFenceCreateI
                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = dev_data->dispatch_table.CreateFence(device, pCreateInfo, pAllocator, pFence);
-    if (VK_SUCCESS == result) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateFence(dev_data, pCreateInfo, pFence);
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateFence(device, pCreateInfo, pAllocator, pFence, result);
     return result;
 }
 
@@ -286,12 +284,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(VkDevice device, con
                                                             const VkAllocationCallbacks *pAllocator,
                                                             VkSamplerYcbcrConversion *pYcbcrConversion) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = PreCallValidateCreateSamplerYcbcrConversion(dev_data, pCreateInfo);
+    bool skip = PreCallValidateCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkResult result = dev_data->dispatch_table.CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
     unique_lock_t lock(global_lock);
-    PostCallRecordCreateSamplerYcbcrConversion(dev_data, pCreateInfo, *pYcbcrConversion);
+    PostCallRecordCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, result);
     lock.unlock();
     return result;
 };
@@ -301,12 +299,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(VkDevice device,
                                                                const VkAllocationCallbacks *pAllocator,
                                                                VkSamplerYcbcrConversion *pYcbcrConversion) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = PreCallValidateCreateSamplerYcbcrConversion(dev_data, pCreateInfo);
+    bool skip = PreCallValidateCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkResult result = dev_data->dispatch_table.CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
     unique_lock_t lock(global_lock);
-    PostCallRecordCreateSamplerYcbcrConversion(dev_data, pCreateInfo, *pYcbcrConversion);
+    PostCallRecordCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, result);
     lock.unlock();
     return result;
 };
@@ -827,13 +825,9 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(VkDevice device, VkCommandPool com
 VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
                                                  const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
     VkResult result = dev_data->dispatch_table.CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
-
-    if (VK_SUCCESS == result) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateCommandPool(dev_data, pCreateInfo, pCommandPool);
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, result);
     return result;
 }
 
@@ -1114,10 +1108,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(VkDevice device, const VkSamplerCre
                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = dev_data->dispatch_table.CreateSampler(device, pCreateInfo, pAllocator, pSampler);
-    if (VK_SUCCESS == result) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateSampler(dev_data, pCreateInfo, pSampler);
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateSampler(device, pCreateInfo, pAllocator, pSampler, result);
     return result;
 }
 
@@ -1141,18 +1133,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(VkDevice device, const VkDes
                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = dev_data->dispatch_table.CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
-    if (VK_SUCCESS == result) {
-        DESCRIPTOR_POOL_STATE *pNewNode = new DESCRIPTOR_POOL_STATE(*pDescriptorPool, pCreateInfo);
-        lock_guard_t lock(global_lock);
-        if (NULL == pNewNode) {
-            bool skip = PostCallValidateCreateDescriptorPool(dev_data, pDescriptorPool);
-            if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-        } else {
-            PostCallRecordCreateDescriptorPool(dev_data, pNewNode, pDescriptorPool);
-        }
-    } else {
-        // Need to do anything if pool create fails?
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, result);
     return result;
 }
 
@@ -2345,10 +2327,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(VkDevice device, const VkSemaphor
                                                const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = dev_data->dispatch_table.CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
-    if (result == VK_SUCCESS) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateSemaphore(dev_data, pSemaphore);
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, result);
     return result;
 }
 
@@ -2473,10 +2453,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(VkDevice device, const VkEventCreateI
                                            const VkAllocationCallbacks *pAllocator, VkEvent *pEvent) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = dev_data->dispatch_table.CreateEvent(device, pCreateInfo, pAllocator, pEvent);
-    if (result == VK_SUCCESS) {
-        lock_guard_t lock(global_lock);
-        PostCallRecordCreateEvent(dev_data, pEvent);
-    }
+    lock_guard_t lock(global_lock);
+    PostCallRecordCreateEvent(device, pCreateInfo, pAllocator, pEvent, result);
     return result;
 }
 
@@ -3098,10 +3076,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(VkInstance instance,
                                                             VkDebugUtilsMessengerEXT *pMessenger) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = instance_data->dispatch_table.CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
-
-    if (VK_SUCCESS == result) {
-        PostCallRecordCreateDebugUtilsMessengerEXT(instance_data, pCreateInfo, pAllocator, pMessenger);
-    }
+    std::unique_lock<std::mutex> lock(global_lock);
+    PostCallRecordCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, result);
     return result;
 }
 

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -828,7 +828,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(VkDevice device, const VkQueryPoo
                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateCreateQueryPool(dev_data, pCreateInfo);
+    bool skip = PreCallValidateCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
     lock.unlock();
 
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
@@ -837,7 +837,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(VkDevice device, const VkQueryPoo
     }
     if (result == VK_SUCCESS) {
         lock.lock();
-        PostCallRecordCreateQueryPool(dev_data, pCreateInfo, pQueryPool);
+        PostCallRecordCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, result);
     }
     return result;
 }

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2692,10 +2692,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(VkInstance instance,
                                                             const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateDisplayPlaneSurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 
@@ -2704,10 +2702,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(VkInstance instance, cons
                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateAndroidSurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -2717,10 +2713,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(VkInstance instance, const Vk
                                                    const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateIOSSurfaceMVK)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
@@ -2732,7 +2726,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(VkInstance instance, const 
     VkResult result = (instance_data->dispatch_table.CreateMacOSSurfaceMVK)(instance, pCreateInfo, pAllocator, pSurface);
     if (result == VK_SUCCESS) {
         unique_lock_t lock(global_lock);
-        PostCallRecordCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
+        PostCallRecordCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, result);
     }
     return result;
 }
@@ -2743,10 +2737,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(VkInstance instance, cons
                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateWaylandSurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 
@@ -2773,10 +2765,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(VkInstance instance, const 
                                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateWin32SurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 
@@ -2802,10 +2792,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(VkInstance instance, const Vk
                                                    const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateXcbSurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 
@@ -2832,10 +2820,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(VkInstance instance, const V
                                                     const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     VkResult result = (instance_data->dispatch_table.CreateXlibSurfaceKHR)(instance, pCreateInfo, pAllocator, pSurface);
-    if (result == VK_SUCCESS) {
-        unique_lock_t lock(global_lock);
-        PostCallRecordCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     return result;
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4664,11 +4664,13 @@ void PostCallRecordCreateCommandPool(layer_data *dev_data, const VkCommandPoolCr
     dev_data->commandPoolMap[*pCommandPool].queueFamilyIndex = pCreateInfo->queueFamilyIndex;
 }
 
-bool PreCallValidateCreateQueryPool(layer_data *dev_data, const VkQueryPoolCreateInfo *pCreateInfo) {
+bool PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
+                                    const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
     if (pCreateInfo && pCreateInfo->queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS) {
-        if (!dev_data->enabled_features.core.pipelineStatisticsQuery) {
-            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT, 0,
+        if (!device_data->enabled_features.core.pipelineStatisticsQuery) {
+            skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT, 0,
                             "VUID-VkQueryPoolCreateInfo-queryType-00791",
                             "Query pool with type VK_QUERY_TYPE_PIPELINE_STATISTICS created on a device with "
                             "VkDeviceCreateInfo.pEnabledFeatures.pipelineStatisticsQuery == VK_FALSE.");
@@ -4677,8 +4679,11 @@ bool PreCallValidateCreateQueryPool(layer_data *dev_data, const VkQueryPoolCreat
     return skip;
 }
 
-void PostCallRecordCreateQueryPool(layer_data *dev_data, const VkQueryPoolCreateInfo *pCreateInfo, VkQueryPool *pQueryPool) {
-    QUERY_POOL_NODE *qp_node = &dev_data->queryPoolMap[*pQueryPool];
+void PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
+                                   const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    QUERY_POOL_NODE *qp_node = &device_data->queryPoolMap[*pQueryPool];
     qp_node->createInfo = *pCreateInfo;
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11668,39 +11668,44 @@ static void RecordVulkanSurface(instance_layer_data *instance_data, VkSurfaceKHR
 }
 
 void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                                const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 void PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
 void PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK *pCreateInfo,
-                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 void PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK *pCreateInfo,
-                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 void PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 
@@ -11716,8 +11721,9 @@ bool PreCallValidateGetPhysicalDeviceWaylandPresentationSupportKHR(instance_laye
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR *pCreateInfo,
-                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 
@@ -11732,8 +11738,9 @@ bool PreCallValidateGetPhysicalDeviceWin32PresentationSupportKHR(instance_layer_
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
 void PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR *pCreateInfo,
-                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 
@@ -11748,8 +11755,9 @@ bool PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(instance_layer_da
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 void PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR *pCreateInfo,
-                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface, VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     RecordVulkanSurface(instance_data, pSurface);
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4637,10 +4637,12 @@ void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
     FreeCommandBufferStates(device_data, pPool, commandBufferCount, pCommandBuffers);
 }
 
-void PostCallRecordCreateCommandPool(layer_data *dev_data, const VkCommandPoolCreateInfo *pCreateInfo,
-                                     VkCommandPool *pCommandPool) {
-    dev_data->commandPoolMap[*pCommandPool].createFlags = pCreateInfo->flags;
-    dev_data->commandPoolMap[*pCommandPool].queueFamilyIndex = pCreateInfo->queueFamilyIndex;
+void PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
+                                     const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    device_data->commandPoolMap[*pCommandPool].createFlags = pCreateInfo->flags;
+    device_data->commandPoolMap[*pCommandPool].queueFamilyIndex = pCreateInfo->queueFamilyIndex;
 }
 
 bool PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
@@ -4880,8 +4882,11 @@ VkDevice GetDevice(const layer_data *device_data) { return device_data->device; 
 
 uint32_t GetApiVersion(const layer_data *device_data) { return device_data->api_version; }
 
-void PostCallRecordCreateFence(layer_data *dev_data, const VkFenceCreateInfo *pCreateInfo, VkFence *pFence) {
-    auto &fence_node = dev_data->fenceMap[*pFence];
+void PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
+                               VkFence *pFence, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    auto &fence_node = device_data->fenceMap[*pFence];
     fence_node.fence = *pFence;
     fence_node.createInfo = *pCreateInfo;
     fence_node.state = (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED;
@@ -5083,8 +5088,10 @@ void PostCallRecordCreateRayTracingPipelinesNV(layer_data *dev_data, uint32_t co
     }
 }
 
-void PostCallRecordCreateSampler(layer_data *dev_data, const VkSamplerCreateInfo *pCreateInfo, VkSampler *pSampler) {
-    dev_data->samplerMap[*pSampler] = unique_ptr<SAMPLER_STATE>(new SAMPLER_STATE(pSampler, pCreateInfo));
+void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
+                                 VkSampler *pSampler, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    device_data->samplerMap[*pSampler] = unique_ptr<SAMPLER_STATE>(new SAMPLER_STATE(pSampler, pCreateInfo));
 }
 
 bool PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
@@ -5820,13 +5827,13 @@ void PostCallRecordCreatePipelineLayout(layer_data *dev_data, const VkPipelineLa
     // Implicit unlock
 };
 
-bool PostCallValidateCreateDescriptorPool(layer_data *dev_data, VkDescriptorPool *pDescriptorPool) {
-    return log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                   HandleToUint64(*pDescriptorPool), kVUID_Core_DrawState_OutOfMemory,
-                   "Out of memory while attempting to allocate DESCRIPTOR_POOL_STATE in vkCreateDescriptorPool()");
-}
-
-void PostCallRecordCreateDescriptorPool(layer_data *dev_data, DESCRIPTOR_POOL_STATE *pNewNode, VkDescriptorPool *pDescriptorPool) {
+void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
+                                        const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool,
+                                        VkResult result) {
+    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    DESCRIPTOR_POOL_STATE *pNewNode = new DESCRIPTOR_POOL_STATE(*pDescriptorPool, pCreateInfo);
+    assert(pNewNode);
     dev_data->descriptorPoolMap[*pDescriptorPool] = pNewNode;
 }
 
@@ -10713,8 +10720,11 @@ void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const 
     }
 }
 
-void PostCallRecordCreateSemaphore(layer_data *dev_data, VkSemaphore *pSemaphore) {
-    SEMAPHORE_NODE *sNode = &dev_data->semaphoreMap[*pSemaphore];
+void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
+                                   const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    SEMAPHORE_NODE *sNode = &device_data->semaphoreMap[*pSemaphore];
     sNode->signaler.first = VK_NULL_HANDLE;
     sNode->signaler.second = 0;
     sNode->signaled = false;
@@ -10789,10 +10799,13 @@ void PostCallRecordGetFence(layer_data *dev_data, VkFence fence, VkExternalFence
     }
 }
 
-void PostCallRecordCreateEvent(layer_data *dev_data, VkEvent *pEvent) {
-    dev_data->eventMap[*pEvent].needsSignaled = false;
-    dev_data->eventMap[*pEvent].write_in_use = 0;
-    dev_data->eventMap[*pEvent].stageMask = VkPipelineStageFlags(0);
+void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
+                               VkEvent *pEvent, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    device_data->eventMap[*pEvent].needsSignaled = false;
+    device_data->eventMap[*pEvent].write_in_use = 0;
+    device_data->eventMap[*pEvent].stageMask = VkPipelineStageFlags(0);
 }
 
 bool PreCallValidateCreateSwapchainKHR(layer_data *dev_data, const char *func_name, VkSwapchainCreateInfoKHR const *pCreateInfo,
@@ -11928,9 +11941,11 @@ void PreCallRecordCmdInsertDebugUtilsLabelEXT(layer_data *dev_data, VkCommandBuf
     InsertCmdDebugUtilsLabel(dev_data->report_data, commandBuffer, pLabelInfo);
 }
 
-void PostCallRecordCreateDebugUtilsMessengerEXT(instance_layer_data *instance_data,
-                                                const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkDebugUtilsMessengerEXT *pMessenger) {
+void PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
+                                                const VkAllocationCallbacks *pAllocator, VkDebugUtilsMessengerEXT *pMessenger,
+                                                VkResult result) {
+    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    if (VK_SUCCESS != result) return;
     layer_create_messenger_callback(instance_data->report_data, false, pCreateInfo, pAllocator, pMessenger);
 }
 
@@ -12497,27 +12512,57 @@ void PreCallRecordCmdDrawMeshTasksIndirectCountNV(layer_data *dev_data, GLOBAL_C
     }
 }
 
-bool PreCallValidateCreateSamplerYcbcrConversion(const layer_data *dev_data,
+static bool ValidateCreateSamplerYcbcrConversion(const layer_data *device_data, const char *func_name,
                                                  const VkSamplerYcbcrConversionCreateInfo *create_info) {
     bool skip = false;
-    if (GetDeviceExtensions(dev_data)->vk_android_external_memory_android_hardware_buffer) {
-        skip |= ValidateCreateSamplerYcbcrConversionANDROID(dev_data, create_info);
+    if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
+        skip |= ValidateCreateSamplerYcbcrConversionANDROID(device_data, create_info);
     } else {  // Not android hardware buffer
         if (VK_FORMAT_UNDEFINED == create_info->format) {
-            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+            skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                             VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT, 0,
                             "VUID-VkSamplerYcbcrConversionCreateInfo-format-01649",
-                            "vkCreateSamplerYcbcrConversion[KHR]: CreateInfo format type is VK_FORMAT_UNDEFINED.");
+                            "%s: CreateInfo format type is VK_FORMAT_UNDEFINED.", func_name);
         }
     }
     return skip;
 }
 
-void PostCallRecordCreateSamplerYcbcrConversion(layer_data *dev_data, const VkSamplerYcbcrConversionCreateInfo *create_info,
-                                                VkSamplerYcbcrConversion ycbcr_conversion) {
-    if (GetDeviceExtensions(dev_data)->vk_android_external_memory_android_hardware_buffer) {
-        RecordCreateSamplerYcbcrConversionANDROID(dev_data, create_info, ycbcr_conversion);
+bool PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+                                                 const VkAllocationCallbacks *pAllocator,
+                                                 VkSamplerYcbcrConversion *pYcbcrConversion) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    return ValidateCreateSamplerYcbcrConversion(device_data, "vkCreateSamplerYcbcrConversion()", pCreateInfo);
+}
+
+bool PreCallValidateCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+                                                    const VkAllocationCallbacks *pAllocator,
+                                                    VkSamplerYcbcrConversion *pYcbcrConversion) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    return ValidateCreateSamplerYcbcrConversion(device_data, "vkCreateSamplerYcbcrConversionKHR()", pCreateInfo);
+}
+
+static void RecordCreateSamplerYcbcrConversionState(layer_data *device_data, const VkSamplerYcbcrConversionCreateInfo *create_info,
+                                                    VkSamplerYcbcrConversion ycbcr_conversion) {
+    if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
+        RecordCreateSamplerYcbcrConversionANDROID(device_data, create_info, ycbcr_conversion);
     }
+}
+
+void PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+                                                const VkAllocationCallbacks *pAllocator, VkSamplerYcbcrConversion *pYcbcrConversion,
+                                                VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    RecordCreateSamplerYcbcrConversionState(device_data, pCreateInfo, *pYcbcrConversion);
+}
+
+void PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+                                                   const VkAllocationCallbacks *pAllocator,
+                                                   VkSamplerYcbcrConversion *pYcbcrConversion, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    RecordCreateSamplerYcbcrConversionState(device_data, pCreateInfo, *pYcbcrConversion);
 }
 
 void PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1358,13 +1358,12 @@ using std::vector;
 SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR surface);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
 
-void PreCallRecordCreateInstance(VkLayerInstanceCreateInfo* chain_info);
-void PostCallRecordCreateInstance(instance_layer_data* instance_data, const VkInstanceCreateInfo* pCreateInfo);
-bool PreCallValidateCreateDevice(instance_layer_data* instance_data, const VkPhysicalDeviceFeatures** enabled_features_found,
-                                 VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo);
-void PostCallRecordCreateDevice(instance_layer_data* instance_data, const VkPhysicalDeviceFeatures* enabled_features_found,
-                                PFN_vkGetDeviceProcAddr fpGetDeviceProcAddr, VkPhysicalDevice gpu,
-                                const VkDeviceCreateInfo* pCreateInfo, VkDevice* pDevice);
+void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                  VkInstance* pInstance, VkResult result);
+bool PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
+                                 const VkAllocationCallbacks* pAllocator, VkDevice* pDevice);
+void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
+                                const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
 bool PreCallCmdUpdateBuffer(layer_data* device_data, const GLOBAL_CB_NODE* cb_state, const BUFFER_STATE* dst_buffer_state);
 void PostCallRecordCmdUpdateBuffer(layer_data* device_data, GLOBAL_CB_NODE* cb_state, BUFFER_STATE* dst_buffer_state);
 
@@ -1776,13 +1775,18 @@ void PreCallRecordEnumeratePhysicalDeviceGroups(instance_layer_data* instance_da
                                                 VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
 void PostCallRecordEnumeratePhysicalDeviceGroups(instance_layer_data* instance_data, uint32_t* pPhysicalDeviceGroupCount,
                                                  VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-bool PreCallValidateCreateDescriptorUpdateTemplate(const char* func_name, layer_data* device_data,
-                                                   const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+bool PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator,
                                                    VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
-void PostCallRecordCreateDescriptorUpdateTemplate(layer_data* device_data,
-                                                  const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
-                                                  VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
+void PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator,
+                                                  VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate, VkResult result);
+bool PreCallValidateCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator,
+                                                      VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
+void PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate, VkResult result);
 void PreCallRecordDestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                   const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1439,8 +1439,10 @@ bool PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPoo
 void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                      const VkCommandBuffer* pCommandBuffers);
 void PostCallRecordCreateCommandPool(layer_data* dev_data, const VkCommandPoolCreateInfo* pCreateInfo, VkCommandPool* pCommandPool);
-bool PreCallValidateCreateQueryPool(layer_data* dev_data, const VkQueryPoolCreateInfo* pCreateInfo);
-void PostCallRecordCreateQueryPool(layer_data* dev_data, const VkQueryPoolCreateInfo* pCreateInfo, VkQueryPool* pQueryPool);
+bool PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool);
+void PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool, VkResult result);
 bool PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateResetCommandPool(layer_data* dev_data, COMMAND_POOL_NODE* pPool);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1366,12 +1366,21 @@ void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* 
                                 const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
 bool PreCallCmdUpdateBuffer(layer_data* device_data, const GLOBAL_CB_NODE* cb_state, const BUFFER_STATE* dst_buffer_state);
 void PostCallRecordCmdUpdateBuffer(layer_data* device_data, GLOBAL_CB_NODE* cb_state, BUFFER_STATE* dst_buffer_state);
-
-void PostCallRecordCreateFence(layer_data* dev_data, const VkFenceCreateInfo* pCreateInfo, VkFence* pFence);
+void PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                               VkFence* pFence, VkResult result);
 void PostCallRecordGetDeviceQueue(layer_data* dev_data, uint32_t q_family_index, VkQueue queue);
-bool PreCallValidateCreateSamplerYcbcrConversion(const layer_data* dev_data, const VkSamplerYcbcrConversionCreateInfo* create_info);
-void PostCallRecordCreateSamplerYcbcrConversion(layer_data* dev_data, const VkSamplerYcbcrConversionCreateInfo* create_info,
-                                                VkSamplerYcbcrConversion ycbcr_conversion);
+bool PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator,
+                                                 VkSamplerYcbcrConversion* pYcbcrConversion);
+void PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                VkResult result);
+bool PreCallValidateCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator,
+                                                    VkSamplerYcbcrConversion* pYcbcrConversion);
+void PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator,
+                                                   VkSamplerYcbcrConversion* pYcbcrConversion, VkResult result);
 bool PreCallValidateCmdDebugMarkerBeginEXT(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);
 void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
@@ -1437,7 +1446,8 @@ bool PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPoo
                                        const VkCommandBuffer* pCommandBuffers);
 void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                      const VkCommandBuffer* pCommandBuffers);
-void PostCallRecordCreateCommandPool(layer_data* dev_data, const VkCommandPoolCreateInfo* pCreateInfo, VkCommandPool* pCommandPool);
+void PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool, VkResult result);
 bool PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool);
 void PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
@@ -1467,7 +1477,8 @@ bool PreCallValidateCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t c
                                                 vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state);
 void PostCallRecordCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t count,
                                                vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state, VkPipeline* pPipelines);
-void PostCallRecordCreateSampler(layer_data* dev_data, const VkSamplerCreateInfo* pCreateInfo, VkSampler* pSampler);
+void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                 VkSampler* pSampler, VkResult result);
 bool PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout);
 void PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
@@ -1476,8 +1487,9 @@ void PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptor
 bool PreCallValidateCreatePipelineLayout(const layer_data* dev_data, const VkPipelineLayoutCreateInfo* pCreateInfo);
 void PostCallRecordCreatePipelineLayout(layer_data* dev_data, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                         const VkPipelineLayout* pPipelineLayout);
-bool PostCallValidateCreateDescriptorPool(layer_data* dev_data, VkDescriptorPool* pDescriptorPool);
-void PostCallRecordCreateDescriptorPool(layer_data* dev_data, DESCRIPTOR_POOL_STATE* pNewNode, VkDescriptorPool* pDescriptorPool);
+void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
+                                        VkResult result);
 bool PreCallValidateResetDescriptorPool(layer_data* dev_data, VkDescriptorPool descriptorPool);
 void PostCallRecordResetDescriptorPool(layer_data* dev_data, VkDevice device, VkDescriptorPool descriptorPool,
                                        VkDescriptorPoolResetFlags flags);
@@ -1679,7 +1691,8 @@ void PreCallRecordSetEvent(layer_data* dev_data, VkEvent event);
 bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence);
 void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                    VkResult result);
-void PostCallRecordCreateSemaphore(layer_data* dev_data, VkSemaphore* pSemaphore);
+void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore, VkResult result);
 bool PreCallValidateImportSemaphore(layer_data* dev_data, VkSemaphore semaphore, const char* caller_name);
 void PostCallRecordImportSemaphore(layer_data* dev_data, VkSemaphore semaphore,
                                    VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type, VkSemaphoreImportFlagsKHR flags);
@@ -1688,7 +1701,8 @@ bool PreCallValidateImportFence(layer_data* dev_data, VkFence fence, const char*
 void PostCallRecordImportFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type,
                                VkFenceImportFlagsKHR flags);
 void PostCallRecordGetFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type);
-void PostCallRecordCreateEvent(layer_data* dev_data, VkEvent* pEvent);
+void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                               VkEvent* pEvent, VkResult result);
 bool PreCallValidateCreateSwapchainKHR(layer_data* dev_data, const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo,
                                        SURFACE_STATE* surface_state, SWAPCHAIN_NODE* old_swapchain_state);
 void PostCallRecordCreateSwapchainKHR(layer_data* dev_data, VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo,
@@ -1759,9 +1773,9 @@ void PreCallRecordCmdBeginDebugUtilsLabelEXT(layer_data* dev_data, VkCommandBuff
 void PostCallRecordCmdEndDebugUtilsLabelEXT(layer_data* dev_data, VkCommandBuffer commandBuffer);
 void PreCallRecordCmdInsertDebugUtilsLabelEXT(layer_data* dev_data, VkCommandBuffer commandBuffer,
                                               const VkDebugUtilsLabelEXT* pLabelInfo);
-void PostCallRecordCreateDebugUtilsMessengerEXT(instance_layer_data* instance_data,
-                                                const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
-                                                const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger);
+void PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger,
+                                                VkResult result);
 void PostCallRecordDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
                                                  const VkAllocationCallbacks* pAllocator);
 void PostCallRecordCreateDebugReportCallbackEXT(instance_layer_data* instance_data,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1469,9 +1469,11 @@ bool PreCallValidateCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t c
 void PostCallRecordCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t count,
                                                vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state, VkPipeline* pPipelines);
 void PostCallRecordCreateSampler(layer_data* dev_data, const VkSamplerCreateInfo* pCreateInfo, VkSampler* pSampler);
-bool PreCallValidateCreateDescriptorSetLayout(layer_data* dev_data, const VkDescriptorSetLayoutCreateInfo* create_info);
-void PostCallRecordCreateDescriptorSetLayout(layer_data* dev_data, const VkDescriptorSetLayoutCreateInfo* create_info,
-                                             VkDescriptorSetLayout set_layout);
+bool PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout);
+void PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                             const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout,
+                                             VkResult result);
 bool PreCallValidateCreatePipelineLayout(const layer_data* dev_data, const VkPipelineLayoutCreateInfo* pCreateInfo);
 void PostCallRecordCreatePipelineLayout(layer_data* dev_data, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                         const VkPipelineLayout* pPipelineLayout);
@@ -1629,15 +1631,18 @@ bool PreCallValidateCmdPushConstants(layer_data* dev_data, VkCommandBuffer comma
                                      VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size);
 bool PreCallValidateCmdWriteTimestamp(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);
 void PostCallRecordCmdWriteTimestamp(GLOBAL_CB_NODE* cb_state, VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot);
-bool PreCallValidateCreateFramebuffer(layer_data* dev_data, const VkFramebufferCreateInfo* pCreateInfo);
-// CreateFramebuffer state has been validated and call down chain completed so record new framebuffer object
-void PostCallRecordCreateFramebuffer(layer_data* dev_data, const VkFramebufferCreateInfo* pCreateInfo, VkFramebuffer fb);
-bool PreCallValidateCreateRenderPass(const layer_data* dev_data, VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
-                                     RENDER_PASS_STATE* render_pass);
-void PostCallRecordCreateRenderPass(layer_data* dev_data, const VkRenderPass render_pass_handle,
-                                    std::shared_ptr<RENDER_PASS_STATE>&& render_pass);
-bool PreCallValidateCreateRenderPass2KHR(const layer_data* dev_data, VkDevice device, const VkRenderPassCreateInfo2KHR* pCreateInfo,
-                                         RENDER_PASS_STATE* render_pass);
+bool PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer);
+void PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer, VkResult result);
+bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass);
+void PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, VkResult result);
+bool PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2KHR* pCreateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass);
+void PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2KHR* pCreateInfo,
+                                        const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, VkResult result);
 bool PreCallValidateCmdBeginRenderPass(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, RenderPassCreateVersion rp_version,
                                        const VkRenderPassBeginInfo* pRenderPassBegin);
 void PreCallRecordCmdBeginRenderPass(layer_data* dev_data, GLOBAL_CB_NODE* cb_state, const VkRenderPassBeginInfo* pRenderPassBegin,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1759,7 +1759,7 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(PHYSICAL_DEVICE_STATE* phy
 void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(instance_layer_data* instanceData, VkPhysicalDevice physicalDevice,
                                                        uint32_t* pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats);
 void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
-                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data* dev_data, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
 void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
 void PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue);
@@ -1859,39 +1859,39 @@ void PostCallRecordGetAndroidHardwareBufferProperties(layer_data* dev_data,
 bool PreCallValidateGetMemoryAndroidHardwareBuffer(const layer_data* dev_data,
                                                    const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo);
 void PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
-                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #ifdef VK_USE_PLATFORM_IOS_MVK
 void PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
-                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_IOS_MVK
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 void PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
-                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 bool PreCallValidateGetPhysicalDeviceWaylandPresentationSupportKHR(instance_layer_data* instance_data,
                                                                    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex);
 void PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
-                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 bool PreCallValidateGetPhysicalDeviceWin32PresentationSupportKHR(instance_layer_data* instance_data,
                                                                  VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex);
 void PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
-                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_XCB_KHR
 bool PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(instance_layer_data* instance_data, VkPhysicalDevice physicalDevice,
                                                                uint32_t queueFamilyIndex);
 void PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
-                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_XCB_KHR
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 bool PreCallValidateGetPhysicalDeviceXlibPresentationSupportKHR(instance_layer_data* instance_data, VkPhysicalDevice physicalDevice,
                                                                 uint32_t queueFamilyIndex);
 void PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
-                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 };  // namespace core_validation

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1703,11 +1703,10 @@ void PostCallRecordImportFence(layer_data* dev_data, VkFence fence, VkExternalFe
 void PostCallRecordGetFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type);
 void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                VkEvent* pEvent, VkResult result);
-bool PreCallValidateCreateSwapchainKHR(layer_data* dev_data, const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo,
-                                       SURFACE_STATE* surface_state, SWAPCHAIN_NODE* old_swapchain_state);
-void PostCallRecordCreateSwapchainKHR(layer_data* dev_data, VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo,
-                                      VkSwapchainKHR* pSwapchain, SURFACE_STATE* surface_state,
-                                      SWAPCHAIN_NODE* old_swapchain_state);
+bool PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain);
+void PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain, VkResult result);
 void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NODE* swapchain_state, VkDevice device,
                                           uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
@@ -1715,14 +1714,11 @@ void PostCallRecordGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NODE
                                          uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
 bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
 void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, VkResult result);
-bool PreCallValidateCreateSharedSwapchainsKHR(layer_data* dev_data, uint32_t swapchainCount,
-                                              const VkSwapchainCreateInfoKHR* pCreateInfos, VkSwapchainKHR* pSwapchains,
-                                              std::vector<SURFACE_STATE*>& surface_state,
-                                              std::vector<SWAPCHAIN_NODE*>& old_swapchain_state);
-void PostCallRecordCreateSharedSwapchainsKHR(layer_data* dev_data, VkResult result, uint32_t swapchainCount,
-                                             const VkSwapchainCreateInfoKHR* pCreateInfos, VkSwapchainKHR* pSwapchains,
-                                             std::vector<SURFACE_STATE*>& surface_state,
-                                             std::vector<SWAPCHAIN_NODE*>& old_swapchain_state);
+bool PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
+                                              const VkSwapchainCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                              VkSwapchainKHR* pSwapchains);
+void PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount, const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                             const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains, VkResult result);
 bool PreCallValidateCommonAcquireNextImage(layer_data* dev_data, VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                            VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex, const char* func_name);
 void PostCallRecordCommonAcquireNextImage(layer_data* dev_data, VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
@@ -1778,9 +1774,9 @@ void PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instance, const VkDeb
                                                 VkResult result);
 void PostCallRecordDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
                                                  const VkAllocationCallbacks* pAllocator);
-void PostCallRecordCreateDebugReportCallbackEXT(instance_layer_data* instance_data,
-                                                const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-                                                const VkAllocationCallbacks* pAllocator, VkDebugReportCallbackEXT* pMsgCallback);
+void PostCallRecordCreateDebugReportCallbackEXT(VkInstance instance, const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkDebugReportCallbackEXT* pMsgCallback,
+                                                VkResult result);
 void PostCallDestroyDebugReportCallbackEXT(instance_layer_data* instance_data, VkDebugReportCallbackEXT msgCallback,
                                            const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,


### PR DESCRIPTION
Includes some refactoring of some mixed renderpass recording/validation, and of some goofy create*swapchain support.