### PR TITLE
Add VU check for sampled image descriptors

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2277,7 +2277,7 @@ TEST_F(VkLayerTest, GpuValidationArrayOOB) {
 
     VkDescriptorImageInfo image_info[6] = {};
     for (int i = 0; i < 6; i++) {
-        image_info[i] = texture.m_imageInfo;
+        image_info[i] = texture.DescriptorImageInfo();
         image_info[i].sampler = sampler.handle();
         image_info[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -730,7 +730,7 @@ int VkDescriptorSetObj::AppendSamplerTexture(VkSamplerObj *sampler, VkTextureObj
 
     m_layout_bindings.push_back(binding);
     m_type_counts[VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER] += binding.descriptorCount;
-    VkDescriptorImageInfo tmp = texture->m_imageInfo;
+    VkDescriptorImageInfo tmp = texture->DescriptorImageInfo();
     tmp.sampler = sampler->handle();
     m_imageSamplerDescriptors.push_back(tmp);
 
@@ -1244,8 +1244,6 @@ VkTextureObj::VkTextureObj(VkDeviceObj *device, uint32_t *colors) : VkImageObj(d
 
     if (colors == NULL) colors = tex_colors;
 
-    memset(&m_imageInfo, 0, sizeof(m_imageInfo));
-
     VkImageViewCreateInfo view = {};
     view.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     view.pNext = NULL;
@@ -1269,7 +1267,7 @@ VkTextureObj::VkTextureObj(VkDeviceObj *device, uint32_t *colors) : VkImageObj(d
     /* create image view */
     view.image = handle();
     m_textureView.init(*m_device, view);
-    m_imageInfo.imageView = m_textureView.handle();
+    m_descriptorImageInfo.imageView = m_textureView.handle();
 
     data = stagingImage.MapMemory();
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -326,7 +326,7 @@ class VkTextureObj : public VkImageObj {
    public:
     VkTextureObj(VkDeviceObj *device, uint32_t *colors = NULL);
 
-    VkDescriptorImageInfo m_imageInfo;
+    const VkDescriptorImageInfo &DescriptorImageInfo() const { return m_descriptorImageInfo; }
 
    protected:
     VkDeviceObj *m_device;


### PR DESCRIPTION
Implement check and unit test for VUID-VkWriteDescriptorSet-descriptorType-01403 which requires that descriptor updates for sampled images have specific image layout values.  Note that the language of the spec is being updated to refer to the body text which gives the full set of (extension specific) valid image layout values.

Addtionally
* fixed existing issue in imageLayout tracking in test framework
* refactored/simplified test case which would get the ...-01403 unit test.

Fixes #551