### PR TITLE
Normalize vkGet* pre/post function call signatures

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -650,8 +650,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(VkDevice device, VkI
     dev_data->dispatch_table.GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount,
                                                               pSparseMemoryRequirements);
     unique_lock_t lock(global_lock);
-    auto image_state = GetImageState(dev_data, image);
-    PostCallRecordGetImageSparseMemoryRequirements(image_state, *pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    PostCallRecordGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount,
+        pSparseMemoryRequirements);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(VkDevice device, const VkImageSparseMemoryRequirementsInfo2KHR *pInfo,
@@ -662,8 +662,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(VkDevice device, co
     dev_data->dispatch_table.GetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount,
                                                                pSparseMemoryRequirements);
     unique_lock_t lock(global_lock);
-    auto image_state = GetImageState(dev_data, pInfo->image);
-    PostCallRecordGetImageSparseMemoryRequirements2(image_state, *pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    PostCallRecordGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount,
+        pSparseMemoryRequirements);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(VkDevice device,
@@ -675,8 +675,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(VkDevice device,
     dev_data->dispatch_table.GetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount,
                                                                   pSparseMemoryRequirements);
     unique_lock_t lock(global_lock);
-    auto image_state = GetImageState(dev_data, pInfo->image);
-    PostCallRecordGetImageSparseMemoryRequirements2(image_state, *pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    PostCallRecordGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount,
+        pSparseMemoryRequirements);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1393,8 +1393,8 @@ bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllo
 void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences);
 void PostCallRecordWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences, VkBool32 wait_all);
-bool PreCallValidateGetFenceStatus(layer_data* dev_data, VkFence fence);
-void PostCallRecordGetFenceStatus(layer_data* dev_data, VkFence fence);
+bool PreCallValidateGetFenceStatus(VkDevice device, VkFence fence);
+void PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, VkResult result);
 bool PreCallValidateQueueWaitIdle(VkQueue queue);
 void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result);
 bool PreCallValidateDeviceWaitIdle(layer_data* dev_data);
@@ -1407,11 +1407,11 @@ bool PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocat
 void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateGetQueryPoolResults(layer_data* dev_data, VkQueryPool query_pool, uint32_t first_query, uint32_t query_count,
-                                        VkQueryResultFlags flags,
-                                        unordered_map<QueryObject, std::vector<VkCommandBuffer>>* queries_in_flight);
-void PostCallRecordGetQueryPoolResults(layer_data* dev_data, VkQueryPool query_pool, uint32_t first_query, uint32_t query_count,
-                                       unordered_map<QueryObject, std::vector<VkCommandBuffer>>* queries_in_flight);
+bool PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
+                                        size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags);
+void PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
+                                       size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags,
+                                       VkResult result);
 bool PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos);
 void PostCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfoKHR* pBindInfos,
                                         VkResult result);
@@ -1421,9 +1421,20 @@ void PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, co
 bool PreCallValidateBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
 void PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset,
                                     VkResult result);
-void PostCallRecordGetBufferMemoryRequirements(layer_data* dev_data, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
-bool PreCallValidateGetImageMemoryRequirements2(layer_data* dev_data, const VkImageMemoryRequirementsInfo2* pInfo);
-void PostCallRecordGetImageMemoryRequirements(layer_data* dev_data, VkImage image, VkMemoryRequirements* pMemoryRequirements);
+void PostCallRecordGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
+void PostCallRecordGetBufferMemoryRequirements2(VkDevice device, const VkBufferMemoryRequirementsInfo2KHR* pInfo,
+                                                VkMemoryRequirements2KHR* pMemoryRequirements);
+void PostCallRecordGetBufferMemoryRequirements2KHR(VkDevice device, const VkBufferMemoryRequirementsInfo2KHR* pInfo,
+                                                   VkMemoryRequirements2KHR* pMemoryRequirements);
+bool PreCallValidateGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                                VkMemoryRequirements2* pMemoryRequirements);
+bool PreCallValidateGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                                   VkMemoryRequirements2* pMemoryRequirements);
+void PostCallRecordGetImageMemoryRequirements(VkDevice device, VkImage image, VkMemoryRequirements* pMemoryRequirements);
+void PostCallRecordGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                               VkMemoryRequirements2* pMemoryRequirements);
+void PostCallRecordGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                                  VkMemoryRequirements2* pMemoryRequirements);
 void PostCallRecordGetImageSparseMemoryRequirements2(IMAGE_STATE* image_state, uint32_t req_count,
                                                      VkSparseImageMemoryRequirements2KHR* reqs);
 void PostCallRecordGetImageSparseMemoryRequirements(IMAGE_STATE* image_state, uint32_t req_count,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1437,8 +1437,14 @@ void PostCallRecordGetImageMemoryRequirements2KHR(VkDevice device, const VkImage
                                                   VkMemoryRequirements2* pMemoryRequirements);
 void PostCallRecordGetImageSparseMemoryRequirements2(IMAGE_STATE* image_state, uint32_t req_count,
                                                      VkSparseImageMemoryRequirements2KHR* reqs);
-void PostCallRecordGetImageSparseMemoryRequirements(IMAGE_STATE* image_state, uint32_t req_count,
-                                                    VkSparseImageMemoryRequirements* reqs);
+void PostCallRecordGetImageSparseMemoryRequirements(VkDevice device, VkImage image, uint32_t* pSparseMemoryRequirementCount,
+                                                    VkSparseImageMemoryRequirements* pSparseMemoryRequirements);
+void PostCallRecordGetImageSparseMemoryRequirements2(VkDevice device, const VkImageSparseMemoryRequirementsInfo2KHR* pInfo,
+                                                     uint32_t* pSparseMemoryRequirementCount,
+                                                     VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements);
+void PostCallRecordGetImageSparseMemoryRequirements2KHR(VkDevice device, const VkImageSparseMemoryRequirementsInfo2KHR* pInfo,
+                                                        uint32_t* pSparseMemoryRequirementCount,
+                                                        VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements);
 bool PreCallValidateGetPhysicalDeviceImageFormatProperties2(const debug_report_data* report_data,
                                                             const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
                                                             const VkImageFormatProperties2* pImageFormatProperties);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1368,7 +1368,8 @@ bool PreCallCmdUpdateBuffer(layer_data* device_data, const GLOBAL_CB_NODE* cb_st
 void PostCallRecordCmdUpdateBuffer(layer_data* device_data, GLOBAL_CB_NODE* cb_state, BUFFER_STATE* dst_buffer_state);
 void PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                VkFence* pFence, VkResult result);
-void PostCallRecordGetDeviceQueue(layer_data* dev_data, uint32_t q_family_index, VkQueue queue);
+void PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue);
+void PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue);
 bool PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator,
                                                  VkSamplerYcbcrConversion* pYcbcrConversion);
@@ -1731,10 +1732,10 @@ bool PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateI
 void PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain, VkResult result);
 void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NODE* swapchain_state, VkDevice device,
-                                          uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
-void PostCallRecordGetSwapchainImagesKHR(layer_data* device_data, SWAPCHAIN_NODE* swapchain_state, VkDevice device,
-                                         uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages);
+bool PreCallValidateGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
+                                          VkImage* pSwapchainImages);
+void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
+                                         VkImage* pSwapchainImages, VkResult result);
 bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
 void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, VkResult result);
 bool PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
@@ -1837,10 +1838,13 @@ void PreCallRecordCmdPushDescriptorSetWithTemplateKHR(layer_data* device_data, G
                                                       VkPipelineLayout layout, uint32_t set, const void* pData);
 void PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(instance_layer_data* instanceData, VkPhysicalDevice physicalDevice,
                                                               uint32_t* pPropertyCount, void* pProperties);
-bool PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(instance_layer_data* instance_data, VkPhysicalDevice physicalDevice,
-                                                        uint32_t planeIndex);
-bool PreCallValidateGetDisplayPlaneCapabilitiesKHR(instance_layer_data* instance_data, VkPhysicalDevice physicalDevice,
-                                                   uint32_t planeIndex);
+bool PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
+                                                        uint32_t* pDisplayCount, VkDisplayKHR* pDisplays);
+bool PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode, uint32_t planeIndex,
+                                                   VkDisplayPlaneCapabilitiesKHR* pCapabilities);
+bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
+                                                    const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
+                                                    VkDisplayPlaneCapabilities2KHR* pCapabilities);
 void PreCallRecordDebugMarkerSetObjectNameEXT(layer_data* dev_data, const VkDebugMarkerObjectNameInfoEXT* pNameInfo);
 bool PreCallValidateCmdDebugMarkerEndEXT(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);
 bool PreCallValidateCmdSetDiscardRectangleEXT(layer_data* dev_data, GLOBAL_CB_NODE* cb_state);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1713,11 +1713,17 @@ void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo*
 bool PreCallValidateImportSemaphore(layer_data* dev_data, VkSemaphore semaphore, const char* caller_name);
 void PostCallRecordImportSemaphore(layer_data* dev_data, VkSemaphore semaphore,
                                    VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type, VkSemaphoreImportFlagsKHR flags);
-void PostCallRecordGetSemaphore(layer_data* dev_data, VkSemaphore semaphore, VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type);
+void PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd, VkResult result);
 bool PreCallValidateImportFence(layer_data* dev_data, VkFence fence, const char* caller_name);
 void PostCallRecordImportFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type,
                                VkFenceImportFlagsKHR flags);
-void PostCallRecordGetFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type);
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+void PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                              HANDLE* pHandle, VkResult result);
+void PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle,
+                                          VkResult result);
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+void PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd, VkResult result);
 void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                VkEvent* pEvent, VkResult result);
 bool PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
@@ -1870,11 +1876,12 @@ void PostCallRecordCreateShaderModule(layer_data* dev_data, bool is_spirv, const
                                       VkShaderModule* pShaderModule, uint32_t unique_shader_id);
 bool PreCallValidateGetBufferDeviceAddressEXT(layer_data* dev_data, const VkBufferDeviceAddressInfoEXT* pInfo);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-bool PreCallValidateGetAndroidHardwareBufferProperties(const layer_data* dev_data, const AHardwareBuffer* ahb);
-void PostCallRecordGetAndroidHardwareBufferProperties(layer_data* dev_data,
-                                                      const VkAndroidHardwareBufferPropertiesANDROID* ahb_props);
-bool PreCallValidateGetMemoryAndroidHardwareBuffer(const layer_data* dev_data,
-                                                   const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo);
+bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                       VkAndroidHardwareBufferPropertiesANDROID* pProperties);
+void PostCallRecordGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                      VkAndroidHardwareBufferPropertiesANDROID* pProperties, VkResult result);
+bool PreCallValidateGetMemoryAndroidHardwareBuffer(VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
+                                                   struct AHardwareBuffer** pBuffer);
 void PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_ANDROID_KHR


### PR DESCRIPTION
Includes a surprising amount of lock/unlock cleanup and some new support functions.

- PreCallValidateGetQueryPoolResults
- PreCallValidateGetFenceStatus
- PreCallValidateGetImageMemoryRequirements2
- PreCallValidateGetImageMemoryRequirements2KHR
- PreCallValidateGetSwapchainImagesKHR
- PreCallValidateGetDisplayPlaneSupportedDisplaysKHR
- PreCallValidateGetDisplayPlaneCapabilitiesKHR
- PreCallValidateGetDisplayPlaneCapabilities2KHR
- PreCallValidateGetAndroidHardwareBufferProperties
- PreCallValidateGetMemoryAndroidHardwareBuffer
- PostCallRecordGetFenceStatus
- PostCallRecordGetQueryPoolResults
- PostCallRecordGetDeviceQueue
- PostCallRecordGetBufferMemoryRequirements
- PostCallRecordGetBufferMemoryRequirements2
- PostCallRecordGetBufferMemoryRequirements2KHR
- PostCallRecordGetImageMemoryRequirements
- PostCallRecordGetImageMemoryRequirements2
- PostCallRecordGetImageMemoryRequirements2KHR
- PostCallRecordGetImageSparseMemoryRequirements2KHR
- PostCallRecordGetImageSparseMemoryRequirements2
- PostCallRecordGetImageSparseMemoryRequirements
- PostCallRecordGetSwapchainImagesKHR
- PostCallRecordGetFenceWin32HandleKHR
- PostCallRecordGetFenceFdKHR
- PostCallRecordGetSemaphoreWin32HandleKHR
- PostCallRecordGetSemaphoreFdKHR
- PostCallRecordGetAndroidHardwareBufferProperties

