### PR TITLE
WIP: build: Use set_target_properties

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
     add_library(vulkan STATIC IMPORTED)
 
     set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${Vulkan_LIBRARY}")
-    target_include_directories(vulkan INTERFACE "${Vulkan_INCLUDE_DIR}")
+    set_target_properties(vulkan PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Vulkan_INCLUDE_DIR}")
 endif()
 
 set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
We are seeing an error indicating that set_include_directories is
being used incorrectly:

CMake Error at tests/CMakeLists.txt:108 (target_include_directories):
Cannot specify include directories for imported target "vulkan".

This patch is a potential fix using set_target_properties.

Change-Id: Ifeb8ac09071e5dbd4f9a90140ecea3558293e850