### PR TITLE
Speed up BindDescriptor validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6869,33 +6869,37 @@ bool PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipel
                                     (dynamicOffsetCount - total_dynamic_descriptors));
                 } else {  // Validate dynamic offsets and Dynamic Offset Minimums
                     uint32_t cur_dyn_offset = total_dynamic_descriptors;
-                    for (uint32_t d = 0; d < descriptor_set->GetTotalDescriptorCount(); d++) {
-                        if (descriptor_set->GetTypeFromGlobalIndex(d) == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
-                            if (SafeModulo(pDynamicOffsets[cur_dyn_offset],
-                                           device_data->phys_dev_properties.properties.limits.minUniformBufferOffsetAlignment) !=
-                                0) {
-                                skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                                VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0,
-                                                "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971",
-                                                "vkCmdBindDescriptorSets(): pDynamicOffsets[%d] is %d but must be a multiple of "
-                                                "device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
-                                                cur_dyn_offset, pDynamicOffsets[cur_dyn_offset],
-                                                device_data->phys_dev_properties.properties.limits.minUniformBufferOffsetAlignment);
+                    const auto dsl = descriptor_set->GetLayout();
+                    const auto binding_count = dsl->GetBindingCount();
+                    const auto &limits = device_data->phys_dev_properties.properties.limits;
+                    for (uint32_t binding_idx = 0; binding_idx < binding_count; binding_idx++) {
+                        const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+                        if (binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
+                            for (uint32_t descriptor_idx = 0; descriptor_idx < binding->descriptorCount; descriptor_idx++) {
+                                if (SafeModulo(pDynamicOffsets[cur_dyn_offset], limits.minUniformBufferOffsetAlignment) != 0) {
+                                    skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0,
+                                                    "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971",
+                                                    "vkCmdBindDescriptorSets(): pDynamicOffsets[%d] is %d but must be a multiple "
+                                                    "of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                                    cur_dyn_offset, pDynamicOffsets[cur_dyn_offset],
+                                                    limits.minUniformBufferOffsetAlignment);
+                                }
+                                cur_dyn_offset++;
                             }
-                            cur_dyn_offset++;
-                        } else if (descriptor_set->GetTypeFromGlobalIndex(d) == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
-                            if (SafeModulo(pDynamicOffsets[cur_dyn_offset],
-                                           device_data->phys_dev_properties.properties.limits.minStorageBufferOffsetAlignment) !=
-                                0) {
-                                skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                                VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0,
-                                                "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972",
-                                                "vkCmdBindDescriptorSets(): pDynamicOffsets[%d] is %d but must be a multiple of "
-                                                "device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
-                                                cur_dyn_offset, pDynamicOffsets[cur_dyn_offset],
-                                                device_data->phys_dev_properties.properties.limits.minStorageBufferOffsetAlignment);
+                        } else if (binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
+                            for (uint32_t descriptor_idx = 0; descriptor_idx < binding->descriptorCount; descriptor_idx++) {
+                                if (SafeModulo(pDynamicOffsets[cur_dyn_offset], limits.minStorageBufferOffsetAlignment) != 0) {
+                                    skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0,
+                                                    "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972",
+                                                    "vkCmdBindDescriptorSets(): pDynamicOffsets[%d] is %d but must be a multiple "
+                                                    "of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                                    cur_dyn_offset, pDynamicOffsets[cur_dyn_offset],
+                                                    limits.minStorageBufferOffsetAlignment);
+                                }
+                                cur_dyn_offset++;
                             }
-                            cur_dyn_offset++;
                         }
                     }
                     // Keep running total of dynamic descriptor count to verify at the end

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (C) 2015-2018 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
  * Author: Chris Forbes <chrisf@ijw.co.nz>
  * Author: Mark Lobodzinski <mark@lunarg.com>
  * Author: Dave Houlton <daveh@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
  */
 #ifndef CORE_VALIDATION_ERROR_ENUMS_H_
 #define CORE_VALIDATION_ERROR_ENUMS_H_
@@ -63,7 +64,6 @@ static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidBuffer = "UNASSIG
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidCommandBuffer = "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidCommandBufferSimultaneousUse = "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBufferSimultaneousUse";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidDescriptorSet = "UNASSIGNED-CoreValidation-DrawState-InvalidDescriptorSet";
-static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidDynamicOffsetCount = "UNASSIGNED-CoreValidation-DrawState-InvalidDynamicOffsetCount";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidEvent = "UNASSIGNED-CoreValidation-DrawState-InvalidEvent";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidExtents = "UNASSIGNED-CoreValidation-DrawState-InvalidExtents";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidFeature = "UNASSIGNED-CoreValidation-DrawState-InvalidFeature";


### PR DESCRIPTION
Refactored dynamic descriptor validation to do *per binding* array lookups instead of *per descriptor* nested map lookups. Locally significant speedup. Small, but measurable overall performance improvement.

Fixes #644 