### PR TITLE
layers: Wrap a unique_lock around chassis mutex

### DIFF
--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -356,8 +356,10 @@ class ThreadSafety : public ValidationObject {
 public:
 
     // Override chassis read/write locks for this validation object
-    void write_lock() {}
-    void write_unlock() {}
+    // This override takes a deferred lock. i.e. it is not acquired.
+    std::unique_lock<std::mutex> write_lock() {
+        return std::unique_lock<std::mutex>(validation_object_mutex, std::defer_lock);
+    }
 
     std::mutex command_pool_lock;
     std::unordered_map<VkCommandBuffer, VkCommandPool> command_pool_map;


### PR DESCRIPTION
The default behavior is to return a lock that has acquired the mutex.
Overrides, such as thread_safety, may take a deferred lock. i.e. It
doesn't acquire the mutex. The goal here is to leverage RAII and SBRM
for lock management.

Change-Id: I274b1e44e62bf143898cca4bee63a6d76effce87