### PR TITLE
layers: Add plane aspect bits as valid flags

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2357,7 +2357,12 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyImage(VkCommandBuffer com
 
     VkImageAspectFlags legal_aspect_flags =
         VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_METADATA_BIT;
-    if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
+    // YCbCr is core after 1.1
+    if (api_version >= VK_API_VERSION_1_1) {
+        legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT);
+    }
+    // If physical device does not support 1.1, check for YCbCr extension support
+    else if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
         legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR);
     }
 
@@ -2386,7 +2391,12 @@ bool StatelessValidation::manual_PreCallValidateCmdBlitImage(VkCommandBuffer com
 
     VkImageAspectFlags legal_aspect_flags =
         VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_METADATA_BIT;
-    if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
+    // YCbCr is core after 1.1
+    if (api_version >= VK_API_VERSION_1_1) {
+        legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT);
+    }
+    // If physical device does not support 1.1, check for YCbCr extension support
+    else if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
         legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR);
     }
 
@@ -2414,7 +2424,12 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyBufferToImage(VkCommandBu
 
     VkImageAspectFlags legal_aspect_flags =
         VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_METADATA_BIT;
-    if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
+    // YCbCr is core after 1.1
+    if (api_version >= VK_API_VERSION_1_1) {
+        legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT);
+    }
+    // If physical device does not support 1.1, check for YCbCr extension support
+    else if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
         legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR);
     }
 
@@ -2436,7 +2451,12 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyImageToBuffer(VkCommandBu
 
     VkImageAspectFlags legal_aspect_flags =
         VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_METADATA_BIT;
-    if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
+    // YCbCr is core after 1.1
+    if (api_version >= VK_API_VERSION_1_1) {
+        legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT);
+    }
+    // If physical device does not support 1.1, check for YCbCr extension support
+    else if (device_extensions.vk_khr_sampler_ycbcr_conversion) {
         legal_aspect_flags |= (VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR);
     }
 


### PR DESCRIPTION
According to the description of vkCmdCopyBufferToImage: "
If the format of dstImage is a multi-planar image format,
regions of each plane to be a target of a copy must be specified
separately using the pRegions member of the VkBufferImageCopy
structure. In this case, the aspectMask of imageSubresource must
be VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or
VK_IMAGE_ASPECT_PLANE_2_BIT.". This is relevant for YCbCr image
formats.

As of Vulkan 1.1.0, YCbCr is core and the mentioned aspect flag
bits should not yield validation layer errors any more if used
as the aspect flag for a region in vkCmdCopyBufferToImage. The
same holds true for vkCmdCopyImageToBuffer, vkCmdBlitImage and
vkCmdCopyImage.

This has now been added to parameter_validation_utils. A check is
performed to check if the physical device >= 1.1 support. If yes,
these aspect flag bits are taken into consideration. If not, the
old check to see if the YCbCr extension is supported is performed.