### PR TITLE
Add guards for missing Android hardware buffer symbols with old NDKs

### DIFF
--- a/layers/android_ndk_types.h
+++ b/layers/android_ndk_types.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2018 The Khronos Group Inc.
- * Copyright (c) 2018 Valve Corporation
- * Copyright (c) 2018 LunarG, Inc.
- * Copyright (C) 2018 Google Inc.
+/* Copyright (c) 2018-2019 The Khronos Group Inc.
+ * Copyright (c) 2018-2019 Valve Corporation
+ * Copyright (c) 2018-2019 LunarG, Inc.
+ * Copyright (C) 2018-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,38 @@
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 
-#ifdef __ANDROID__  // If we have an NDK, use it
+// All eums referenced by VK_ANDROID_external_memory_android_hardware_buffer are present in
+// the platform-28 (Android P) versions of the header files.  A partial set exists in the
+// platform-26 (O) headers, where hardware_buffer.h first appears in the NDK.
+//
+// Building Vulkan validation with NDK header files prior to platform-26 is not supported.
+//
+// Decoder ring for Android compile symbols found here: https://github.com/android-ndk/ndk/issues/407
 
-#include <android/hardware_buffer.h>
+#ifdef __ANDROID__  // Compiling for Android
+#include <android/api-level.h>
+#include <android/hardware_buffer.h>  // First appearance in Android O (platform-26)
 
-#else
+// If NDK is O (platform-26 or -27), supplement the missing enums with pre-processor defined literals
+// If Android P or later, then all required enums are already defined
+#if defined(__ANDROID_API_O__) && !defined(__ANDROID_API_P__)
+// Formats
+#define AHARDWAREBUFFER_FORMAT_D16_UNORM 0x30
+#define AHARDWAREBUFFER_FORMAT_D24_UNORM 0x31
+#define AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT 0x32
+#define AHARDWAREBUFFER_FORMAT_D32_FLOAT 0x33
+#define AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT 0x34
+#define AHARDWAREBUFFER_FORMAT_S8_UINT 0x35
+// Usage bits
+#define AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP 0x2000000
+#define AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE 0x4000000
+#endif  // __ANDROID_API_O__ && !_P__
 
-// For convenience, define the minimal set of NDK enums and structs needed to compile
+#else  // Not __ANDROID__, but VK_USE_PLATFORM_ANDROID_KHR
+// This combination should not be seen in the wild, but can be used to allow testing
+// of the AHB extension validation on other platforms using MockICD
+//
+// Define the minimal set of NDK enums and structs needed to compile
 // VK_ANDROID_external_memory_android_hardware_buffer validation without an NDK present
 struct AHardwareBuffer {};
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3166,7 +3166,8 @@ bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSub
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-// Android-specific validation that uses types defined only with VK_USE_PLATFORM_ANDROID_KHR
+// Android-specific validation that uses types defined only on Android and only for NDK versions
+// that support the VK_ANDROID_external_memory_android_hardware_buffer extension.
 // This chunk could move into a seperate core_validation_android.cpp file... ?
 
 // clang-format off
@@ -3248,7 +3249,6 @@ std::map<VkImageCreateFlags, uint64_t> ahb_create_map_v2a = {
 //
 // AHB-extension new APIs
 //
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer *buffer,
                                                        VkAndroidHardwareBufferPropertiesANDROID *pProperties) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
@@ -3279,7 +3279,6 @@ void PostCallRecordGetAndroidHardwareBufferProperties(VkDevice device, const str
         ext_formats->insert(ahb_format_props->externalFormat);
     }
 }
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 bool PreCallValidateGetMemoryAndroidHardwareBuffer(VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
                                                    struct AHardwareBuffer **pBuffer) {
@@ -3638,7 +3637,7 @@ static void RecordDestroySamplerYcbcrConversionANDROID(layer_data *dev_data, VkS
     dev_data->ycbcr_conversion_ahb_fmt_map.erase(ycbcr_conversion);
 };
 
-#else
+#else  // !VK_USE_PLATFORM_ANDROID_KHR
 
 static bool ValidateAllocateMemoryANDROID(layer_data *dev_data, const VkMemoryAllocateInfo *alloc_info) { return false; }
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -36166,7 +36166,7 @@ TEST_F(VkPositiveLayerTest, ViewportArray2NV) {
     }
 }
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR  // or ifdef ANDROID?
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include "android_ndk_types.h"
 
 TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
@@ -37056,7 +37056,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     vkDestroyImage(dev, img, NULL);
 }
 
-#endif
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 TEST_F(VkLayerTest, ViewportSwizzleNV) {
     TEST_DESCRIPTION("Verify VK_NV_viewprot_swizzle.");


### PR DESCRIPTION
The VK_ANDROID_external_memory_android_hardware_buffer references enums in the Android NDK that were added in the platform-28 (Android P) timeframe. This adds compilation guards to avoid missing symbols on Android builds which use older versions of those header files.

Fixes #623