### PR TITLE
cmake: don't build glslang if not building layers or tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,136 +150,139 @@ option(INSTALL_TESTS "Install tests" OFF)
 option(BUILD_LAYERS "Build layers" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Generate layer files" OFF) # For generating files when not building layers
 
-set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
-if(NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR} AND NOT TARGET glslang)
-    message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
-endif()
+if(BUILD_TESTS OR BUILD_LAYERS)
 
-# GLSLANG_INSTALL_DIR is used as the path to all dependent projects' install dirs
-# CMake command line option overrides environment variable
-if(NOT GLSLANG_INSTALL_DIR)
-    set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
-endif()
-
-if (NOT TARGET glslang)
-    message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
-    set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to glslang spirv headers")
-
-    find_library(GLSLANG_LIB NAMES glslang HINTS ${GLSLANG_SEARCH_PATH})
-    find_library(OGLCompiler_LIB NAMES OGLCompiler HINTS ${GLSLANG_SEARCH_PATH})
-    find_library(OSDependent_LIB NAMES OSDependent HINTS ${GLSLANG_SEARCH_PATH})
-    find_library(HLSL_LIB NAMES HLSL HINTS ${GLSLANG_SEARCH_PATH})
-    find_library(SPIRV_LIB NAMES SPIRV HINTS ${GLSLANG_SEARCH_PATH})
-    find_library(SPIRV_REMAPPER_LIB NAMES SPVRemapper HINTS ${GLSLANG_SEARCH_PATH})
-
-    if(WIN32)
-        add_library(glslang STATIC IMPORTED)
-        add_library(OGLCompiler STATIC IMPORTED)
-        add_library(OSDependent STATIC IMPORTED)
-        add_library(HLSL STATIC IMPORTED)
-        add_library(SPIRV STATIC IMPORTED)
-        add_library(SPVRemapper STATIC IMPORTED)
-        add_library(Loader STATIC IMPORTED)
-
-        find_library(GLSLANG_DLIB NAMES glslangd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-        find_library(OGLCompiler_DLIB NAMES OGLCompilerd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-        find_library(OSDependent_DLIB NAMES OSDependentd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-        find_library(HLSL_DLIB NAMES HLSLd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-        find_library(SPIRV_DLIB NAMES SPIRVd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-        find_library(SPIRV_REMAPPER_DLIB NAMES SPVRemapperd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-
-        set_target_properties(glslang
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${GLSLANG_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${GLSLANG_DLIB}")
-        set_target_properties(OGLCompiler
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${OGLCompiler_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${OGLCompiler_DLIB}")
-        set_target_properties(OSDependent
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${OSDependent_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${OSDependent_DLIB}")
-        set_target_properties(HLSL
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${HLSL_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${HLSL_DLIB}")
-        set_target_properties(SPIRV
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${SPIRV_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${SPIRV_DLIB}")
-        set_target_properties(SPVRemapper
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${SPIRV_REMAPPER_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${SPIRV_REMAPPER_DLIB}")
-
-        set(GLSLANG_LIBRARIES glslang OGLCompiler OSDependent HLSL SPIRV SPVRemapper ${SPIRV_TOOLS_LIBRARIES})
-    else()
-        set(GLSLANG_LIBRARIES
-            ${GLSLANG_LIB}
-            ${OGLCompiler_LIB}
-            ${OSDependent_LIB}
-            ${HLSL_LIB}
-            ${SPIRV_LIB}
-            ${SPIRV_REMAPPER_LIB}
-            ${SPIRV_TOOLS_LIBRARIES})
+    set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
+    if(NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR} AND NOT TARGET glslang)
+        message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
     endif()
-else()
-    set(GLSLANG_SPIRV_INCLUDE_DIR "${glslang_SOURCE_DIR}" CACHE PATH "Path to glslang spirv headers")
-    set(GLSLANG_LIBRARIES glslang SPIRV SPVRemapper)
-endif()
 
-# spirv-tools
-if (NOT TARGET SPIRV-Tools)
-    set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib"
-        CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
-    set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib"
-        CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
-    set(SPIRV_TOOLS_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
-    set(SPIRV_TOOLS_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-    set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
-
-    find_library(SPIRV_TOOLS_LIB NAMES SPIRV-Tools HINTS ${SPIRV_TOOLS_SEARCH_PATH})
-    find_library(SPIRV_TOOLS_OPT_LIB NAMES SPIRV-Tools-opt HINTS ${SPIRV_TOOLS_OPT_SEARCH_PATH})
-
-    if(WIN32)
-        add_library(SPIRV-Tools-opt STATIC IMPORTED)
-        add_library(SPIRV-Tools STATIC IMPORTED)
-
-        find_library(SPIRV_TOOLS_DLIB NAMES SPIRV-Toolsd HINTS ${SPIRV_TOOLS_DEBUG_SEARCH_PATH})
-        find_library(SPIRV_TOOLS_OPT_DLIB NAMES SPIRV-Tools-optd HINTS ${SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH})
-
-        set_target_properties(SPIRV-Tools
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${SPIRV_TOOLS_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${SPIRV_TOOLS_DLIB}")
-        set_target_properties(SPIRV-Tools-opt
-                              PROPERTIES IMPORTED_LOCATION
-                                         "${SPIRV_TOOLS_OPT_LIB}"
-                                         IMPORTED_LOCATION_DEBUG
-                                         "${SPIRV_TOOLS_OPT_DLIB}")
-
-        set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools-opt SPIRV-Tools)
-    else()
-        set(SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
+    # GLSLANG_INSTALL_DIR is used as the path to all dependent projects' install dirs
+    # CMake command line option overrides environment variable
+    if(NOT GLSLANG_INSTALL_DIR)
+        set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
     endif()
-else()
-    set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools SPIRV-Tools-opt)
-    set(SPIRV_TOOLS_INCLUDE_DIR "${spirv-tools_SOURCE_DIR}/include" CACHE PATH "Path to spirv tools headers")
-endif()
 
-set(GLSLANG_LIBRARIES ${GLSLANG_LIBRARIES} ${SPIRV_TOOLS_LIBRARIES})
+    if (NOT TARGET glslang)
+        message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
+        set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+        set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+        set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to glslang spirv headers")
+
+        find_library(GLSLANG_LIB NAMES glslang HINTS ${GLSLANG_SEARCH_PATH})
+        find_library(OGLCompiler_LIB NAMES OGLCompiler HINTS ${GLSLANG_SEARCH_PATH})
+        find_library(OSDependent_LIB NAMES OSDependent HINTS ${GLSLANG_SEARCH_PATH})
+        find_library(HLSL_LIB NAMES HLSL HINTS ${GLSLANG_SEARCH_PATH})
+        find_library(SPIRV_LIB NAMES SPIRV HINTS ${GLSLANG_SEARCH_PATH})
+        find_library(SPIRV_REMAPPER_LIB NAMES SPVRemapper HINTS ${GLSLANG_SEARCH_PATH})
+
+        if(WIN32)
+            add_library(glslang STATIC IMPORTED)
+            add_library(OGLCompiler STATIC IMPORTED)
+            add_library(OSDependent STATIC IMPORTED)
+            add_library(HLSL STATIC IMPORTED)
+            add_library(SPIRV STATIC IMPORTED)
+            add_library(SPVRemapper STATIC IMPORTED)
+            add_library(Loader STATIC IMPORTED)
+
+            find_library(GLSLANG_DLIB NAMES glslangd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+            find_library(OGLCompiler_DLIB NAMES OGLCompilerd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+            find_library(OSDependent_DLIB NAMES OSDependentd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+            find_library(HLSL_DLIB NAMES HLSLd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+            find_library(SPIRV_DLIB NAMES SPIRVd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+            find_library(SPIRV_REMAPPER_DLIB NAMES SPVRemapperd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+
+            set_target_properties(glslang
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${GLSLANG_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${GLSLANG_DLIB}")
+            set_target_properties(OGLCompiler
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${OGLCompiler_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${OGLCompiler_DLIB}")
+            set_target_properties(OSDependent
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${OSDependent_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${OSDependent_DLIB}")
+            set_target_properties(HLSL
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${HLSL_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${HLSL_DLIB}")
+            set_target_properties(SPIRV
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${SPIRV_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${SPIRV_DLIB}")
+            set_target_properties(SPVRemapper
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${SPIRV_REMAPPER_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${SPIRV_REMAPPER_DLIB}")
+
+            set(GLSLANG_LIBRARIES glslang OGLCompiler OSDependent HLSL SPIRV SPVRemapper ${SPIRV_TOOLS_LIBRARIES})
+        else()
+            set(GLSLANG_LIBRARIES
+                ${GLSLANG_LIB}
+                ${OGLCompiler_LIB}
+                ${OSDependent_LIB}
+                ${HLSL_LIB}
+                ${SPIRV_LIB}
+                ${SPIRV_REMAPPER_LIB}
+                ${SPIRV_TOOLS_LIBRARIES})
+        endif()
+    else()
+        set(GLSLANG_SPIRV_INCLUDE_DIR "${glslang_SOURCE_DIR}" CACHE PATH "Path to glslang spirv headers")
+        set(GLSLANG_LIBRARIES glslang SPIRV SPVRemapper)
+    endif()
+
+    # spirv-tools
+    if (NOT TARGET SPIRV-Tools)
+        set(SPIRV_TOOLS_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib"
+            CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
+        set(SPIRV_TOOLS_OPT_BINARY_ROOT "${GLSLANG_INSTALL_DIR}/lib"
+            CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
+        set(SPIRV_TOOLS_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
+        set(SPIRV_TOOLS_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_OPT_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
+
+        find_library(SPIRV_TOOLS_LIB NAMES SPIRV-Tools HINTS ${SPIRV_TOOLS_SEARCH_PATH})
+        find_library(SPIRV_TOOLS_OPT_LIB NAMES SPIRV-Tools-opt HINTS ${SPIRV_TOOLS_OPT_SEARCH_PATH})
+
+        if(WIN32)
+            add_library(SPIRV-Tools-opt STATIC IMPORTED)
+            add_library(SPIRV-Tools STATIC IMPORTED)
+
+            find_library(SPIRV_TOOLS_DLIB NAMES SPIRV-Toolsd HINTS ${SPIRV_TOOLS_DEBUG_SEARCH_PATH})
+            find_library(SPIRV_TOOLS_OPT_DLIB NAMES SPIRV-Tools-optd HINTS ${SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH})
+
+            set_target_properties(SPIRV-Tools
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${SPIRV_TOOLS_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${SPIRV_TOOLS_DLIB}")
+            set_target_properties(SPIRV-Tools-opt
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${SPIRV_TOOLS_OPT_LIB}"
+                                             IMPORTED_LOCATION_DEBUG
+                                             "${SPIRV_TOOLS_OPT_DLIB}")
+
+            set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools-opt SPIRV-Tools)
+        else()
+            set(SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
+        endif()
+    else()
+        set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools SPIRV-Tools-opt)
+        set(SPIRV_TOOLS_INCLUDE_DIR "${spirv-tools_SOURCE_DIR}/include" CACHE PATH "Path to spirv tools headers")
+    endif()
+
+    set(GLSLANG_LIBRARIES ${GLSLANG_LIBRARIES} ${SPIRV_TOOLS_LIBRARIES})
+endif()
 
 # Generate dependent helper files ------------------------------------------------------------------------------------------------
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -91,22 +91,24 @@ set(TARGET_NAMES
     VkLayer_standard_validation
     VkLayer_thread_safety)
 
-# Install the layer json files
-if(WIN32)
-    if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+if(BUILD_LAYERS)
+    # Install the layer json files
+    if(WIN32)
+        if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+            foreach(TARGET_NAME ${TARGET_NAMES})
+                install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TARGET_NAME}.json DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            endforeach()
+        else()
+            foreach(TARGET_NAME ${TARGET_NAMES})
+                install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.json DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            endforeach()
+        endif()
+    elseif(UNIX) # UNIX includes APPLE
         foreach(TARGET_NAME ${TARGET_NAMES})
-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${TARGET_NAME}.json DESTINATION ${CMAKE_INSTALL_LIBDIR})
-        endforeach()
-    else()
-        foreach(TARGET_NAME ${TARGET_NAMES})
-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.json DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json
+                    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d)
         endforeach()
     endif()
-elseif(UNIX) # UNIX includes APPLE
-    foreach(TARGET_NAME ${TARGET_NAMES})
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json
-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d)
-    endforeach()
 endif()
 
 # System-specific macros to create a library target.
@@ -213,52 +215,52 @@ if(BUILD_LAYERS)
     target_include_directories(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
     target_link_libraries(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
     add_dependencies(VkLayer_core_validation spirv_tools_revision_file)
-endif()
 
-# The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
-# because the json format uses backslash escapes
-file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)
-string(REPLACE "\\"
-               "\\\\"
-               RELATIVE_PATH_PREFIX
-               "${RELATIVE_PATH_PREFIX}")
+    # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
+    # because the json format uses backslash escapes
+    file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)
+    string(REPLACE "\\"
+                   "\\\\"
+                   RELATIVE_PATH_PREFIX
+                   "${RELATIVE_PATH_PREFIX}")
 
-# Run each .json.in file through the generator We need to create the generator.cmake script so that the generator can be run at
-# compile time, instead of configure time Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and
-# TARGET_FILE_DIR, specifically)
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
-foreach(TARGET_NAME ${TARGET_NAMES})
-    set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=1.1.${vk_header_version})
-    # If this json file is not a metalayer, get the needed properties from that target
-    if(TARGET ${TARGET_NAME})
-        set(CONFIG_DEFINES
-            ${CONFIG_DEFINES}
-            -DOUTPUT_FILE="$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json"
-            -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>")
-        # If this json file is a metalayer, make the output path match core validation, and there is no layer binary file
-    else()
-        set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_core_validation>/${TARGET_NAME}.json")
-    endif()
-    add_custom_target(${TARGET_NAME}-json ALL
-                      COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
-    if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-        set_target_properties(${TARGET_NAME}-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-    endif()
-endforeach()
-
-# For UNIX-based systems, `library_path` should not contain a relative path (indicated by "./") before installing to system
-# directories, so we do not include it in the staging-json files which are used for installation
-if(UNIX)
+    # Run each .json.in file through the generator We need to create the generator.cmake script so that the generator can be run at
+    # compile time, instead of configure time Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and
+    # TARGET_FILE_DIR, specifically)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
     foreach(TARGET_NAME ${TARGET_NAMES})
-        set(INSTALL_DEFINES
-            -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
-            -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json"
-            -DVK_VERSION=1.1.${vk_header_version})
+        set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=1.1.${vk_header_version})
         # If this json file is not a metalayer, get the needed properties from that target
         if(TARGET ${TARGET_NAME})
-            set(INSTALL_DEFINES ${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY="$<TARGET_FILE_NAME:${TARGET_NAME}>")
+            set(CONFIG_DEFINES
+                ${CONFIG_DEFINES}
+                -DOUTPUT_FILE="$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json"
+                -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>")
+            # If this json file is a metalayer, make the output path match core validation, and there is no layer binary file
+        else()
+            set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_core_validation>/${TARGET_NAME}.json")
         endif()
-        add_custom_target(${TARGET_NAME}-staging-json ALL
-                          COMMAND ${CMAKE_COMMAND} ${INSTALL_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+        add_custom_target(${TARGET_NAME}-json ALL
+                          COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+        if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+            set_target_properties(${TARGET_NAME}-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+        endif()
     endforeach()
+
+    # For UNIX-based systems, `library_path` should not contain a relative path (indicated by "./") before installing to system
+    # directories, so we do not include it in the staging-json files which are used for installation
+    if(UNIX)
+        foreach(TARGET_NAME ${TARGET_NAMES})
+            set(INSTALL_DEFINES
+                -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
+                -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json"
+                -DVK_VERSION=1.1.${vk_header_version})
+            # If this json file is not a metalayer, get the needed properties from that target
+            if(TARGET ${TARGET_NAME})
+                set(INSTALL_DEFINES ${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY="$<TARGET_FILE_NAME:${TARGET_NAME}>")
+            endif()
+            add_custom_target(${TARGET_NAME}-staging-json ALL
+                              COMMAND ${CMAKE_COMMAND} ${INSTALL_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+        endforeach()
+    endif()
 endif()


### PR DESCRIPTION
Disable build of glslang if not building layers or tests.
This is needed so that VulkanTools doesn't need to build glslang.

Change-Id: Ifbed510d689756ed5b36bdf03aa7f31f3914adde