### PR TITLE
layers: Reduce time spent constructing strings and vectors

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -61,8 +61,7 @@ bool VerifyClearImageLayout(layer_data *device_data, GLOBAL_CB_NODE *cb_node, IM
 
 bool VerifyImageLayout(layer_data const *device_data, GLOBAL_CB_NODE const *cb_node, IMAGE_STATE *image_state,
                        VkImageSubresourceLayers subLayers, VkImageLayout explicit_layout, VkImageLayout optimal_layout,
-                       const char *caller, const std::string &layout_invalid_msg_code, const std::string &layout_mismatch_msg_code,
-                       bool *error);
+                       const char *caller, const char *layout_invalid_msg_code, const char *layout_mismatch_msg_code, bool *error);
 
 void RecordClearImageLayout(layer_data *dev_data, GLOBAL_CB_NODE *cb_node, VkImage image, VkImageSubresourceRange range,
                             VkImageLayout dest_image_layout);
@@ -202,7 +201,7 @@ bool ValidateMapImageLayouts(core_validation::layer_data *dev_data, VkDevice dev
                              VkDeviceSize offset, VkDeviceSize end_offset);
 
 bool ValidateImageUsageFlags(layer_data *dev_data, IMAGE_STATE const *image_state, VkFlags desired, bool strict,
-                             const std::string &msgCode, char const *func_name, char const *usage_string);
+                             const char *msgCode, char const *func_name, char const *usage_string);
 
 bool ValidateImageFormatFeatureFlags(layer_data *dev_data, IMAGE_STATE const *image_state, VkFormatFeatureFlags desired,
                                      char const *func_name, const std::string &linear_vuid, const std::string &optimal_vuid);
@@ -212,7 +211,7 @@ bool ValidateImageSubresourceLayers(layer_data *dev_data, const GLOBAL_CB_NODE *
                                     uint32_t i);
 
 bool ValidateBufferUsageFlags(const layer_data *dev_data, BUFFER_STATE const *buffer_state, VkFlags desired, bool strict,
-                              const std::string &msgCode, char const *func_name, char const *usage_string);
+                              const char *msgCode, char const *func_name, char const *usage_string);
 
 bool PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
                                  VkBuffer *pBuffer);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1220,8 +1220,8 @@ const DeviceFeatures *GetEnabledFeatures(const layer_data *device_data);
 const DeviceExtensions *GetEnabledExtensions(const layer_data *device_data);
 
 void InvalidateCommandBuffers(const layer_data *, std::unordered_set<GLOBAL_CB_NODE *> const &, VK_OBJECT);
-bool ValidateMemoryIsBoundToBuffer(const layer_data *, const BUFFER_STATE *, const char *, const std::string &);
-bool ValidateMemoryIsBoundToImage(const layer_data *, const IMAGE_STATE *, const char *, const std::string &);
+bool ValidateMemoryIsBoundToBuffer(const layer_data *, const BUFFER_STATE *, const char *, const char *);
+bool ValidateMemoryIsBoundToImage(const layer_data *, const IMAGE_STATE *, const char *, const char *);
 void AddCommandBufferBindingSampler(GLOBAL_CB_NODE *, SAMPLER_STATE *);
 void AddCommandBufferBindingImage(const layer_data *, GLOBAL_CB_NODE *, IMAGE_STATE *);
 void AddCommandBufferBindingImageView(const layer_data *, GLOBAL_CB_NODE *, IMAGE_VIEW_STATE *);
@@ -1234,11 +1234,11 @@ void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEM_INFO *mem_info);
 void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEM_INFO *mem_info);
 void ClearMemoryObjectBindings(layer_data *dev_data, uint64_t handle, VulkanObjectType type);
 bool ValidateCmdQueueFlags(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const char *caller_name, VkQueueFlags flags,
-                           const std::string &error_code);
+                           const char *error_code);
 bool ValidateCmd(layer_data *my_data, const GLOBAL_CB_NODE *pCB, const CMD_TYPE cmd, const char *caller_name);
-bool InsideRenderPass(const layer_data *my_data, const GLOBAL_CB_NODE *pCB, const char *apiName, const std::string &msgCode);
+bool InsideRenderPass(const layer_data *my_data, const GLOBAL_CB_NODE *pCB, const char *apiName, const char *msgCode);
 void SetImageMemoryValid(layer_data *dev_data, IMAGE_STATE *image_state, bool valid);
-bool OutsideRenderPass(const layer_data *my_data, GLOBAL_CB_NODE *pCB, const char *apiName, const std::string &msgCode);
+bool OutsideRenderPass(const layer_data *my_data, GLOBAL_CB_NODE *pCB, const char *apiName, const char *msgCode);
 void SetLayout(GLOBAL_CB_NODE *pCB, ImageSubresourcePair imgpair, const IMAGE_CMD_BUF_LAYOUT_NODE &node);
 void SetLayout(GLOBAL_CB_NODE *pCB, ImageSubresourcePair imgpair, const VkImageLayout &layout);
 bool ValidateImageMemoryIsValid(layer_data *dev_data, IMAGE_STATE *image_state, const char *functionName);

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
- * Copyright (C) 2015-2018 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class ObjectLifetimes : public ValidationObject {
     void CreateSwapchainImageObject(VkDevice dispatchable_object, VkImage swapchain_image, VkSwapchainKHR swapchain);
     bool ReportUndestroyedObjects(VkDevice device, const std::string &error_code);
     void DestroyUndestroyedObjects(VkDevice device);
-    bool ValidateDeviceObject(uint64_t device_handle, const std::string &invalid_handle_code, const std::string &wrong_device_code);
+    bool ValidateDeviceObject(uint64_t device_handle, const char *invalid_handle_code, const char *wrong_device_code);
     void DestroyQueueDataStructures(VkDevice device);
     bool ValidateCommandBuffer(VkDevice device, VkCommandPool command_pool, VkCommandBuffer command_buffer);
     bool ValidateDescriptorSet(VkDevice device, VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set);
@@ -114,7 +114,7 @@ class ObjectLifetimes : public ValidationObject {
 
     template <typename T1, typename T2>
     bool ValidateObject(T1 dispatchable_object, T2 object, VulkanObjectType object_type, bool null_allowed,
-                        const std::string &invalid_handle_code, const std::string &wrong_device_code) {
+                        const char *invalid_handle_code, const char *wrong_device_code) {
         if (null_allowed && (object == VK_NULL_HANDLE)) {
             return false;
         }
@@ -218,8 +218,8 @@ class ObjectLifetimes : public ValidationObject {
 
     template <typename T1, typename T2>
     bool ValidateDestroyObject(T1 dispatchable_object, T2 object, VulkanObjectType object_type,
-                               const VkAllocationCallbacks *pAllocator, const std::string &expected_custom_allocator_code,
-                               const std::string &expected_default_allocator_code) {
+                               const VkAllocationCallbacks *pAllocator, const char *expected_custom_allocator_code,
+                               const char *expected_default_allocator_code) {
         auto object_handle = HandleToUint64(object);
         bool custom_allocator = pAllocator != nullptr;
         VkDebugReportObjectTypeEXT debug_object_type = get_debug_report_enum[object_type];

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -86,8 +86,7 @@ void ObjectLifetimes::ValidateQueueFlags(VkQueue queue, const char *function) {
 // Look for this device object in any of the instance child devices lists.
 // NOTE: This is of dubious value. In most circumstances Vulkan will die a flaming death if a dispatchable object is invalid.
 // However, if this layer is loaded first and GetProcAddress is used to make API calls, it will detect bad DOs.
-bool ObjectLifetimes::ValidateDeviceObject(uint64_t device_handle, const std::string &invalid_handle_code,
-                                           const std::string &wrong_device_code) {
+bool ObjectLifetimes::ValidateDeviceObject(uint64_t device_handle, const char *invalid_handle_code, const char *wrong_device_code) {
     auto instance_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
     auto instance_object_lifetime_data = GetObjectLifetimeData(instance_data->object_dispatch);
     for (auto object : instance_object_lifetime_data->object_map[kVulkanObjectTypeDevice]) {

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -187,8 +187,8 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T1, typename T2>
     bool validate_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, T1 count,
-                        const T2 *array, bool countRequired, bool arrayRequired, const std::string &count_required_vuid,
-                        const std::string &array_required_vuid) {
+                        const T2 *array, bool countRequired, bool arrayRequired, const char *count_required_vuid,
+                        const char *array_required_vuid) {
         bool skip_call = false;
 
         // Count parameters not tagged as optional cannot be 0
@@ -230,7 +230,7 @@ class StatelessValidation : public ValidationObject {
     template <typename T1, typename T2>
     bool validate_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, const T1 *count,
                         const T2 *array, bool countPtrRequired, bool countValueRequired, bool arrayRequired,
-                        const std::string &count_required_vuid, const std::string &array_required_vuid) {
+                        const char *count_required_vuid, const char *array_required_vuid) {
         bool skip_call = false;
 
         if (count == NULL) {
@@ -264,7 +264,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool validate_struct_type(const char *apiName, const ParameterName &parameterName, const char *sTypeName, const T *value,
-                              VkStructureType sType, bool required, const std::string &struct_vuid, const std::string &stype_vuid) {
+                              VkStructureType sType, bool required, const char *struct_vuid, const char *stype_vuid) {
         bool skip_call = false;
 
         if (value == NULL) {
@@ -302,8 +302,7 @@ class StatelessValidation : public ValidationObject {
     template <typename T>
     bool validate_struct_type_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName,
                                     const char *sTypeName, uint32_t count, const T *array, VkStructureType sType,
-                                    bool countRequired, bool arrayRequired, const std::string &stype_vuid,
-                                    const std::string &param_vuid) {
+                                    bool countRequired, bool arrayRequired, const char *stype_vuid, const char *param_vuid) {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -346,8 +345,8 @@ class StatelessValidation : public ValidationObject {
     template <typename T>
     bool validate_struct_type_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName,
                                     const char *sTypeName, uint32_t *count, const T *array, VkStructureType sType,
-                                    bool countPtrRequired, bool countValueRequired, bool arrayRequired,
-                                    const std::string &stype_vuid, const std::string &param_vuid) {
+                                    bool countPtrRequired, bool countValueRequired, bool arrayRequired, const char *stype_vuid,
+                                    const char *param_vuid) {
         bool skip_call = false;
 
         if (count == NULL) {
@@ -449,8 +448,8 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     bool validate_string_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, uint32_t count,
-                               const char *const *array, bool countRequired, bool arrayRequired,
-                               const std::string &count_required_vuid, const std::string &array_required_vuid) {
+                               const char *const *array, bool countRequired, bool arrayRequired, const char *count_required_vuid,
+                               const char *array_required_vuid) {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -491,10 +490,8 @@ class StatelessValidation : public ValidationObject {
      */
     bool validate_struct_pnext(const char *api_name, const ParameterName &parameter_name, const char *allowed_struct_names,
                                const void *next, size_t allowed_type_count, const VkStructureType *allowed_types,
-                               uint32_t header_version, const std::string &vuid) {
+                               uint32_t header_version, const char *vuid) {
         bool skip_call = false;
-        std::unordered_set<const void *> cycle_check;
-        std::unordered_set<VkStructureType, std::hash<int>> unique_stype_check;
 
         const char disclaimer[] =
             "This warning is based on the Valid Usage documentation for version %d of the Vulkan header.  It is possible that you "
@@ -506,6 +503,9 @@ class StatelessValidation : public ValidationObject {
         // TODO: The valid pNext structure types are not recursive. Each structure has its own list of valid sTypes for pNext.
         // Codegen a map of vectors containing the allowable pNext types for each struct and use that here -- also simplifies parms.
         if (next != NULL) {
+            std::unordered_set<const void *> cycle_check;
+            std::unordered_set<VkStructureType, std::hash<int>> unique_stype_check;
+
             if (allowed_type_count == 0) {
                 std::string message = "%s: value of %s must be NULL. ";
                 message += disclaimer;
@@ -617,7 +617,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool validate_ranged_enum(const char *apiName, const ParameterName &parameterName, const char *enumName,
-                              const std::vector<T> &valid_values, T value, const std::string &vuid) {
+                              const std::vector<T> &valid_values, T value, const char *vuid) {
         bool skip = false;
 
         if (std::find(valid_values.begin(), valid_values.end(), value) == valid_values.end()) {
@@ -687,8 +687,7 @@ class StatelessValidation : public ValidationObject {
      * @param value Value to validate.
      * @return Boolean value indicating that the call should be skipped.
      */
-    bool validate_reserved_flags(const char *api_name, const ParameterName &parameter_name, VkFlags value,
-                                 const std::string &vuid) {
+    bool validate_reserved_flags(const char *api_name, const ParameterName &parameter_name, VkFlags value, const char *vuid) {
         bool skip_call = false;
 
         if (value != 0) {
@@ -715,7 +714,7 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     bool validate_flags(const char *api_name, const ParameterName &parameter_name, const char *flag_bits_name, VkFlags all_flags,
-                        VkFlags value, bool flags_required, bool singleFlag, const std::string &vuid) {
+                        VkFlags value, bool flags_required, bool singleFlag, const char *vuid) {
         bool skip_call = false;
 
         if (value == 0) {
@@ -787,7 +786,7 @@ class StatelessValidation : public ValidationObject {
     }
 
     template <typename ExtensionState>
-    bool validate_extension_reqs(const ExtensionState &extensions, const std::string &vuid, const char *extension_type,
+    bool validate_extension_reqs(const ExtensionState &extensions, const char *vuid, const char *extension_type,
                                  const char *extension_name) {
         bool skip = false;
         if (!extension_name) {


### PR DESCRIPTION
Change many function parameters from (const)std::string(&) to const char * to reduce
time spent allocating, copying, and deallocating constant string literals into string
objects.

Change ParameterName to hold a const char * and a const size_t * rather than a string
and vector constructed for each parameter validation.

I tested this with a UE4 test app I got from @RCalocaO. Without the validation layers, it is vsynced to 16ms/frame. With the validation layers (before this change) it was around 180ms/frame. After this change (and one other I will push shortly) it is in the 90-100ms range. I also measured around a 33% reduction in validation time running dota2 (cc @danginsburg). Most of the benefit is in parameter_validation, and then smaller improvements in core_validation and object_tracker.

Fixes #641. I'm sure there are a few cases remaining here and there, but this PR covers the majority of the hotspots.
