### PR TITLE
Normalize last big batch of pre/post function signatures

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2100,16 +2100,13 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(VkDevice device, uint32_t bin
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetEvent(VkDevice device, VkEvent event) {
-    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateSetEvent(dev_data, event);
-    PreCallRecordSetEvent(dev_data, event);
+    bool skip = PreCallValidateSetEvent(device, event);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+    PreCallRecordSetEvent(device, event);
     lock.unlock();
-
-    if (!skip) result = dev_data->dispatch_table.SetEvent(device, event);
-    return result;
+    return dev_data->dispatch_table.SetEvent(device, event);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
@@ -2143,16 +2140,14 @@ VKAPI_ATTR VkResult VKAPI_CALL
 ImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo) {
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip =
-        PreCallValidateImportSemaphore(dev_data, pImportSemaphoreWin32HandleInfo->semaphore, "vkImportSemaphoreWin32HandleKHR");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo);
 
     if (!skip) {
+        lock.unlock();
         result = dev_data->dispatch_table.ImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo);
-    }
-
-    if (result == VK_SUCCESS) {
-        PostCallRecordImportSemaphore(dev_data, pImportSemaphoreWin32HandleInfo->semaphore,
-                                      pImportSemaphoreWin32HandleInfo->handleType, pImportSemaphoreWin32HandleInfo->flags);
+        lock.lock();
+        PostCallRecordImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo, result);
     }
     return result;
 }
@@ -2161,15 +2156,14 @@ ImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32Handl
 VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo) {
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = PreCallValidateImportSemaphore(dev_data, pImportSemaphoreFdInfo->semaphore, "vkImportSemaphoreFdKHR");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo);
 
     if (!skip) {
+        lock.unlock();
         result = dev_data->dispatch_table.ImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo);
-    }
-
-    if (result == VK_SUCCESS) {
-        PostCallRecordImportSemaphore(dev_data, pImportSemaphoreFdInfo->semaphore, pImportSemaphoreFdInfo->handleType,
-                                      pImportSemaphoreFdInfo->flags);
+        lock.lock();
+        PostCallRecordImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, result);
     }
     return result;
 }
@@ -2199,31 +2193,30 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(VkDevice device,
                                                          const VkImportFenceWin32HandleInfoKHR *pImportFenceWin32HandleInfo) {
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = PreCallValidateImportFence(dev_data, pImportFenceWin32HandleInfo->fence, "vkImportFenceWin32HandleKHR");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo);
 
     if (!skip) {
+        lock.unlock();
         result = dev_data->dispatch_table.ImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo);
-    }
-
-    if (result == VK_SUCCESS) {
-        PostCallRecordImportFence(dev_data, pImportFenceWin32HandleInfo->fence, pImportFenceWin32HandleInfo->handleType,
-                                  pImportFenceWin32HandleInfo->flags);
+        lock.lock();
+        PostCallRecordImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo, result);
     }
     return result;
 }
-#endif
+#endif  // VK_USE_PLATFORM_WIN32_KHR
 
 VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *pImportFenceFdInfo) {
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = PreCallValidateImportFence(dev_data, pImportFenceFdInfo->fence, "vkImportFenceFdKHR");
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateImportFenceFdKHR(device, pImportFenceFdInfo);
 
     if (!skip) {
+        lock.unlock();
         result = dev_data->dispatch_table.ImportFenceFdKHR(device, pImportFenceFdInfo);
-    }
-
-    if (result == VK_SUCCESS) {
-        PostCallRecordImportFence(dev_data, pImportFenceFdInfo->fence, pImportFenceFdInfo->handleType, pImportFenceFdInfo->flags);
+        lock.lock();
+        PostCallRecordImportFenceFdKHR(device, pImportFenceFdInfo, result);
     }
     return result;
 }
@@ -2331,20 +2324,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(VkDevice device, uint32
 VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                    VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateCommonAcquireNextImage(dev_data, device, swapchain, timeout, semaphore, fence, pImageIndex,
-                                                      "vkAcquireNextImageKHR");
+    bool skip = PreCallValidateAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
     lock.unlock();
-
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkResult result = dev_data->dispatch_table.AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
-
     lock.lock();
-    if (result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR) {
-        PostCallRecordCommonAcquireNextImage(dev_data, device, swapchain, timeout, semaphore, fence, pImageIndex);
-    }
+    PostCallRecordAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, result);
     lock.unlock();
 
     return result;
@@ -2353,25 +2340,16 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(VkDevice device, VkSwapchainK
 VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                     uint32_t *pImageIndex) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
     unique_lock_t lock(global_lock);
-    bool skip =
-        PreCallValidateCommonAcquireNextImage(dev_data, device, pAcquireInfo->swapchain, pAcquireInfo->timeout,
-                                              pAcquireInfo->semaphore, pAcquireInfo->fence, pImageIndex, "vkAcquireNextImage2KHR");
+    bool skip = PreCallValidateAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex);
     lock.unlock();
 
     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkResult result = dev_data->dispatch_table.AcquireNextImage2KHR(device, pAcquireInfo, pImageIndex);
-
     lock.lock();
-    if (result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR) {
-        PostCallRecordCommonAcquireNextImage(dev_data, device, pAcquireInfo->swapchain, pAcquireInfo->timeout,
-                                             pAcquireInfo->semaphore, pAcquireInfo->fence, pImageIndex);
-        // TODO: consider physical device masks
-    }
+    PostCallRecordAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, result);
+    // TODO: consider physical device masks
     lock.unlock();
-
     return result;
 }
 
@@ -2382,20 +2360,13 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
     assert(instance_data);
 
     unique_lock_t lock(global_lock);
-    // For this instance, flag when vkEnumeratePhysicalDevices goes to QUERY_COUNT and then QUERY_DETAILS
-    if (pPhysicalDevices) {
-        skip |= PreCallValidateEnumeratePhysicalDevices(instance_data, pPhysicalDeviceCount);
-    }
-    PreCallRecordEnumeratePhysicalDevices(instance_data);
+    skip |= PreCallValidateEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+    PreCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
     lock.unlock();
-
-    if (skip) {
-        return VK_ERROR_VALIDATION_FAILED_EXT;
-    }
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-
     lock.lock();
-    PostCallRecordEnumeratePhysicalDevices(instance_data, result, pPhysicalDeviceCount, pPhysicalDevices);
+    PostCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, result);
     return result;
 }
 
@@ -2832,17 +2803,15 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(VkInstance instance
                                                              VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
     bool skip = false;
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-
+    unique_lock_t lock(global_lock);
     skip = PreCallValidateEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    if (skip) {
-        return VK_ERROR_VALIDATION_FAILED_EXT;
-    }
-    PreCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupProperties);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+    PreCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+    lock.unlock();
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount,
                                                                                   pPhysicalDeviceGroupProperties);
-    if (result == VK_SUCCESS || result == VK_INCOMPLETE) {
-        PostCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    }
+    lock.lock();
+    PostCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     return result;
 }
 
@@ -2850,17 +2819,16 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     VkInstance instance, uint32_t *pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
     bool skip = false;
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
+    unique_lock_t lock(global_lock);
 
-    skip = PreCallValidateEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    if (skip) {
-        return VK_ERROR_VALIDATION_FAILED_EXT;
-    }
-    PreCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupProperties);
+    skip = PreCallValidateEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+    lock.unlock();
+    PreCallRecordEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount,
                                                                                      pPhysicalDeviceGroupProperties);
-    if (result == VK_SUCCESS) {
-        PostCallRecordEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    }
+    lock.lock();
+    PostCallRecordEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     return result;
 }
 

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -1172,12 +1172,10 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(VkDevice device, uint32_t descri
     // Only map look-up at top level is for device-level layer_data
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateUpdateDescriptorSets(dev_data, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
+    bool skip = PreCallValidateUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
                                                     pDescriptorCopies);
     if (!skip) {
-        // Since UpdateDescriptorSets() is void, nothing to check prior to updating state & we can update before call down chain
-        PreCallRecordUpdateDescriptorSets(dev_data, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
-                                          pDescriptorCopies);
+        PreCallRecordUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
         lock.unlock();
         dev_data->dispatch_table.UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
                                                       pDescriptorCopies);
@@ -2672,12 +2670,10 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDev
 VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_SUCCESS;
-
-    PreCallRecordSetDebugUtilsObjectNameEXT(dev_data, pNameInfo);
-
-    if (nullptr != dev_data->dispatch_table.SetDebugUtilsObjectNameEXT) {
-        result = dev_data->dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);
-    }
+    unique_lock_t lock(global_lock);
+    PreCallRecordSetDebugUtilsObjectNameEXT(device, pNameInfo);
+    lock.unlock();
+    result = dev_data->dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);
     return result;
 }
 
@@ -2898,10 +2894,10 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplate(VkDevice device, VkDe
 
     unique_lock_t lock(global_lock);
     bool skip = false;
-    skip = PreCallValidateUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+    skip = PreCallValidateUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
 
     if (!skip) {
-        PreCallRecordUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+        PreCallRecordUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
         lock.unlock();
         device_data->dispatch_table.UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
     }
@@ -2914,10 +2910,10 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice device, V
 
     unique_lock_t lock(global_lock);
     bool skip = false;
-    skip = PreCallValidateUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+    skip = PreCallValidateUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
 
     if (!skip) {
-        PreCallRecordUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+        PreCallRecordUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
         lock.unlock();
         device_data->dispatch_table.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
     }
@@ -3000,9 +2996,9 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(VkPhysicalDevice 
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-    unique_lock_t lock(global_lock);
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    PreCallRecordDebugMarkerSetObjectNameEXT(device_data, pNameInfo);
+    unique_lock_t lock(global_lock);
+    PreCallRecordDebugMarkerSetObjectNameEXT(device, pNameInfo);
     lock.unlock();
     VkResult result = device_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
     return result;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3876,21 +3876,28 @@ static void RetireFence(layer_data *dev_data, VkFence fence) {
     }
 }
 
-bool PreCallValidateWaitForFences(layer_data *dev_data, uint32_t fence_count, const VkFence *fences) {
-    if (dev_data->instance_data->disabled.wait_for_fences) return false;
+bool PreCallValidateWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkBool32 waitAll,
+                                  uint64_t timeout) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    // Verify fence status of submitted fences
+    if (device_data->instance_data->disabled.wait_for_fences) return false;
     bool skip = false;
-    for (uint32_t i = 0; i < fence_count; i++) {
-        skip |= VerifyWaitFenceState(dev_data, fences[i], "vkWaitForFences");
-        skip |= VerifyQueueStateToFence(dev_data, fences[i]);
+    for (uint32_t i = 0; i < fenceCount; i++) {
+        skip |= VerifyWaitFenceState(device_data, pFences[i], "vkWaitForFences");
+        skip |= VerifyQueueStateToFence(device_data, pFences[i]);
     }
     return skip;
 }
 
-void PostCallRecordWaitForFences(layer_data *dev_data, uint32_t fence_count, const VkFence *fences, VkBool32 wait_all) {
+void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkBool32 waitAll, uint64_t timeout,
+                                 VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+
     // When we know that all fences are complete we can clean/remove their CBs
-    if ((VK_TRUE == wait_all) || (1 == fence_count)) {
-        for (uint32_t i = 0; i < fence_count; i++) {
-            RetireFence(dev_data, fences[i]);
+    if ((VK_TRUE == waitAll) || (1 == fenceCount)) {
+        for (uint32_t i = 0; i < fenceCount; i++) {
+            RetireFence(device_data, pFences[i]);
         }
     }
     // NOTE : Alternate case not handled here is when some fences have completed. In
@@ -3944,18 +3951,21 @@ void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result) {
     RetireWorkOnQueue(device_data, queue_state, queue_state->seq + queue_state->submissions.size());
 }
 
-bool PreCallValidateDeviceWaitIdle(layer_data *dev_data) {
-    if (dev_data->instance_data->disabled.device_wait_idle) return false;
+bool PreCallValidateDeviceWaitIdle(VkDevice device) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (device_data->instance_data->disabled.device_wait_idle) return false;
     bool skip = false;
-    for (auto &queue : dev_data->queueMap) {
-        skip |= VerifyQueueStateToSeq(dev_data, &queue.second, queue.second.seq + queue.second.submissions.size());
+    for (auto &queue : device_data->queueMap) {
+        skip |= VerifyQueueStateToSeq(device_data, &queue.second, queue.second.seq + queue.second.submissions.size());
     }
     return skip;
 }
 
-void PostCallRecordDeviceWaitIdle(layer_data *dev_data) {
-    for (auto &queue : dev_data->queueMap) {
-        RetireWorkOnQueue(dev_data, &queue.second, queue.second.seq + queue.second.submissions.size());
+void PostCallRecordDeviceWaitIdle(VkDevice device, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    for (auto &queue : device_data->queueMap) {
+        RetireWorkOnQueue(device_data, &queue.second, queue.second.seq + queue.second.submissions.size());
     }
 }
 
@@ -4792,22 +4802,30 @@ void PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
     }
 }
 
-bool PreCallValidateResetCommandPool(layer_data *dev_data, COMMAND_POOL_NODE *pPool) {
-    return CheckCommandBuffersInFlight(dev_data, pPool, "reset command pool with", "VUID-vkResetCommandPool-commandPool-00040");
+bool PreCallValidateResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    auto command_pool_state = GetCommandPoolNode(device_data, commandPool);
+    return CheckCommandBuffersInFlight(device_data, command_pool_state, "reset command pool with",
+                                       "VUID-vkResetCommandPool-commandPool-00040");
 }
 
-void PostCallRecordResetCommandPool(layer_data *dev_data, COMMAND_POOL_NODE *pPool) {
-    for (auto cmdBuffer : pPool->commandBuffers) {
-        ResetCommandBufferState(dev_data, cmdBuffer);
+void PostCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    // Reset all of the CBs allocated from this pool
+    auto command_pool_state = GetCommandPoolNode(device_data, commandPool);
+    for (auto cmdBuffer : command_pool_state->commandBuffers) {
+        ResetCommandBufferState(device_data, cmdBuffer);
     }
 }
 
-bool PreCallValidateResetFences(layer_data *dev_data, uint32_t fenceCount, const VkFence *pFences) {
+bool PreCallValidateResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
     for (uint32_t i = 0; i < fenceCount; ++i) {
-        auto pFence = GetFenceNode(dev_data, pFences[i]);
+        auto pFence = GetFenceNode(device_data, pFences[i]);
         if (pFence && pFence->scope == kSyncScopeInternal && pFence->state == FENCE_INFLIGHT) {
-            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
+            skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,
                             HandleToUint64(pFences[i]), "VUID-vkResetFences-pFences-01123", "Fence 0x%" PRIx64 " is in use.",
                             HandleToUint64(pFences[i]));
         }
@@ -4815,9 +4833,10 @@ bool PreCallValidateResetFences(layer_data *dev_data, uint32_t fenceCount, const
     return skip;
 }
 
-void PostCallRecordResetFences(layer_data *dev_data, uint32_t fenceCount, const VkFence *pFences) {
+void PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     for (uint32_t i = 0; i < fenceCount; ++i) {
-        auto pFence = GetFenceNode(dev_data, pFences[i]);
+        auto pFence = GetFenceNode(device_data, pFences[i]);
         if (pFence) {
             if (pFence->scope == kSyncScopeInternal) {
                 pFence->state = FENCE_UNSIGNALED;
@@ -5933,21 +5952,19 @@ void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolC
     dev_data->descriptorPoolMap[*pDescriptorPool] = pNewNode;
 }
 
-// Validate that given pool does not store any descriptor sets used by an in-flight CmdBuffer
-// pool stores the descriptor sets to be validated
-// Return false if no errors occur
-// Return true if validation error occurs and callback returns true (to skip upcoming API call down the chain)
-bool PreCallValidateResetDescriptorPool(layer_data *dev_data, VkDescriptorPool descriptorPool) {
-    if (dev_data->instance_data->disabled.idle_descriptor_set) return false;
+bool PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    // Make sure sets being destroyed are not currently in-use
+    if (device_data->instance_data->disabled.idle_descriptor_set) return false;
     bool skip = false;
-    DESCRIPTOR_POOL_STATE *pPool = GetDescriptorPoolState(dev_data, descriptorPool);
+    DESCRIPTOR_POOL_STATE *pPool = GetDescriptorPoolState(device_data, descriptorPool);
     if (pPool != nullptr) {
         for (auto ds : pPool->sets) {
             if (ds && ds->in_use.load()) {
-                skip |=
-                    log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                            HandleToUint64(descriptorPool), "VUID-vkResetDescriptorPool-descriptorPool-00313",
-                            "It is invalid to call vkResetDescriptorPool() with descriptor sets in use by a command buffer.");
+                skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, HandleToUint64(descriptorPool),
+                                "VUID-vkResetDescriptorPool-descriptorPool-00313",
+                                "It is invalid to call vkResetDescriptorPool() with descriptor sets in use by a command buffer.");
                 if (skip) break;
             }
         }
@@ -5955,13 +5972,15 @@ bool PreCallValidateResetDescriptorPool(layer_data *dev_data, VkDescriptorPool d
     return skip;
 }
 
-void PostCallRecordResetDescriptorPool(layer_data *dev_data, VkDevice device, VkDescriptorPool descriptorPool,
-                                       VkDescriptorPoolResetFlags flags) {
-    DESCRIPTOR_POOL_STATE *pPool = GetDescriptorPoolState(dev_data, descriptorPool);
+void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
+                                       VkResult result) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (VK_SUCCESS != result) return;
+    DESCRIPTOR_POOL_STATE *pPool = GetDescriptorPoolState(device_data, descriptorPool);
     // TODO: validate flags
     // For every set off of this pool, clear it, remove from setMap, and free cvdescriptorset::DescriptorSet
     for (auto ds : pPool->sets) {
-        FreeDescriptorSet(dev_data, ds);
+        FreeDescriptorSet(device_data, ds);
     }
     pPool->sets.clear();
     // Reset available count for each type and available sets for this pool
@@ -5991,47 +6010,46 @@ void PostCallRecordAllocateDescriptorSets(layer_data *dev_data, const VkDescript
                                                    &dev_data->setMap, dev_data);
 }
 
-// TODO: PostCallRecord routine is dependent on data generated in PreCallValidate -- needs to be moved out
-// Verify state before freeing DescriptorSets
-bool PreCallValidateFreeDescriptorSets(const layer_data *dev_data, VkDescriptorPool pool, uint32_t count,
-                                       const VkDescriptorSet *descriptor_sets) {
-    if (dev_data->instance_data->disabled.free_descriptor_sets) return false;
+bool PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
+                                       const VkDescriptorSet *pDescriptorSets) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    // Make sure that no sets being destroyed are in-flight
     bool skip = false;
     // First make sure sets being destroyed are not currently in-use
     for (uint32_t i = 0; i < count; ++i) {
-        if (descriptor_sets[i] != VK_NULL_HANDLE) {
-            skip |= ValidateIdleDescriptorSet(dev_data, descriptor_sets[i], "vkFreeDescriptorSets");
+        if (pDescriptorSets[i] != VK_NULL_HANDLE) {
+            skip |= ValidateIdleDescriptorSet(device_data, pDescriptorSets[i], "vkFreeDescriptorSets");
         }
     }
-
-    DESCRIPTOR_POOL_STATE *pool_state = GetDescriptorPoolState(dev_data, pool);
+    DESCRIPTOR_POOL_STATE *pool_state = GetDescriptorPoolState(device_data, descriptorPool);
     if (pool_state && !(VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT & pool_state->createInfo.flags)) {
         // Can't Free from a NON_FREE pool
-        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                        HandleToUint64(pool), "VUID-vkFreeDescriptorSets-descriptorPool-00312",
+        skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
+                        HandleToUint64(descriptorPool), "VUID-vkFreeDescriptorSets-descriptorPool-00312",
                         "It is invalid to call vkFreeDescriptorSets() with a pool created without setting "
                         "VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT.");
     }
     return skip;
 }
-// Sets are being returned to the pool so update the pool state
-void PreCallRecordFreeDescriptorSets(layer_data *dev_data, VkDescriptorPool pool, uint32_t count,
-                                     const VkDescriptorSet *descriptor_sets) {
-    DESCRIPTOR_POOL_STATE *pool_state = GetDescriptorPoolState(dev_data, pool);
+
+void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
+                                     const VkDescriptorSet *pDescriptorSets) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    DESCRIPTOR_POOL_STATE *pool_state = GetDescriptorPoolState(device_data, descriptorPool);
     // Update available descriptor sets in pool
     pool_state->availableSets += count;
 
     // For each freed descriptor add its resources back into the pool as available and remove from pool and setMap
     for (uint32_t i = 0; i < count; ++i) {
-        if (descriptor_sets[i] != VK_NULL_HANDLE) {
-            auto descriptor_set = dev_data->setMap[descriptor_sets[i]];
+        if (pDescriptorSets[i] != VK_NULL_HANDLE) {
+            auto descriptor_set = device_data->setMap[pDescriptorSets[i]];
             uint32_t type_index = 0, descriptor_count = 0;
             for (uint32_t j = 0; j < descriptor_set->GetBindingCount(); ++j) {
                 type_index = static_cast<uint32_t>(descriptor_set->GetTypeFromIndex(j));
                 descriptor_count = descriptor_set->GetDescriptorCountFromIndex(j);
                 pool_state->availableDescriptorTypeCount[type_index] += descriptor_count;
             }
-            FreeDescriptorSet(dev_data, descriptor_set);
+            FreeDescriptorSet(device_data, descriptor_set);
             pool_state->sets.erase(descriptor_set);
         }
     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6055,14 +6055,11 @@ void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descripto
     }
 }
 
-// TODO : This is a Proof-of-concept for core validation architecture
-//  Really we'll want to break out these functions to separate files but
-//  keeping it all together here to prove out design
-// PreCallValidate* handles validating all of the state prior to calling down chain to UpdateDescriptorSets()
-bool PreCallValidateUpdateDescriptorSets(layer_data *dev_data, uint32_t descriptorWriteCount,
+bool PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
                                          const VkCopyDescriptorSet *pDescriptorCopies) {
-    if (dev_data->instance_data->disabled.update_descriptor_sets) return false;
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (device_data->instance_data->disabled.update_descriptor_sets) return false;
     // First thing to do is perform map look-ups.
     // NOTE : UpdateDescriptorSets is somewhat unique in that it's operating on a number of DescriptorSets
     //  so we can't just do a single map look-up up-front, but do them individually in functions below
@@ -6070,14 +6067,16 @@ bool PreCallValidateUpdateDescriptorSets(layer_data *dev_data, uint32_t descript
     // Now make call(s) that validate state, but don't perform state updates in this function
     // Note, here DescriptorSets is unique in that we don't yet have an instance. Using a helper function in the
     //  namespace which will parse params and make calls into specific class instances
-    return cvdescriptorset::ValidateUpdateDescriptorSets(dev_data->report_data, dev_data, descriptorWriteCount, pDescriptorWrites,
-                                                         descriptorCopyCount, pDescriptorCopies, "vkUpdateDescriptorSets()");
+    return cvdescriptorset::ValidateUpdateDescriptorSets(device_data->report_data, device_data, descriptorWriteCount,
+                                                         pDescriptorWrites, descriptorCopyCount, pDescriptorCopies,
+                                                         "vkUpdateDescriptorSets()");
 }
-// PostCallRecord* handles recording state updates following call down chain to UpdateDescriptorSets()
-void PreCallRecordUpdateDescriptorSets(layer_data *dev_data, uint32_t descriptorWriteCount,
+
+void PreCallRecordUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                        const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
                                        const VkCopyDescriptorSet *pDescriptorCopies) {
-    cvdescriptorset::PerformUpdateDescriptorSets(dev_data, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    cvdescriptorset::PerformUpdateDescriptorSets(device_data, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount,
                                                  pDescriptorCopies);
 }
 
@@ -12498,14 +12497,13 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physical
     }
 }
 
-void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data *dev_data, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+void PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (pNameInfo->pObjectName) {
-        lock_guard_t lock(global_lock);
-        dev_data->report_data->debugUtilsObjectNameMap->insert(
+        device_data->report_data->debugUtilsObjectNameMap->insert(
             std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->objectHandle, pNameInfo->pObjectName));
     } else {
-        lock_guard_t lock(global_lock);
-        dev_data->report_data->debugUtilsObjectNameMap->erase(pNameInfo->objectHandle);
+        device_data->report_data->debugUtilsObjectNameMap->erase(pNameInfo->objectHandle);
     }
 }
 
@@ -12763,8 +12761,8 @@ void PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDe
     RecordCreateDescriptorUpdateTemplateState(device_data, pCreateInfo, pDescriptorUpdateTemplate);
 }
 
-bool PreCallValidateUpdateDescriptorSetWithTemplate(layer_data *device_data, VkDescriptorSet descriptorSet,
-                                                    VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+bool ValidateUpdateDescriptorSetWithTemplate(layer_data *device_data, VkDescriptorSet descriptorSet,
+                                             VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
     bool skip = false;
     auto const template_map_entry = device_data->desc_template_map.find(descriptorUpdateTemplate);
     if ((template_map_entry == device_data->desc_template_map.end()) || (template_map_entry->second.get() == nullptr)) {
@@ -12781,8 +12779,20 @@ bool PreCallValidateUpdateDescriptorSetWithTemplate(layer_data *device_data, VkD
     return skip;
 }
 
-void PreCallRecordUpdateDescriptorSetWithTemplate(layer_data *device_data, VkDescriptorSet descriptorSet,
-                                                  VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+bool PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
+                                                    VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void *pData) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    return ValidateUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+}
+
+bool PreCallValidateUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
+                                                       VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    return ValidateUpdateDescriptorSetWithTemplate(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+}
+
+void RecordUpdateDescriptorSetWithTemplateState(layer_data *device_data, VkDescriptorSet descriptorSet,
+                                                VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
     auto const template_map_entry = device_data->desc_template_map.find(descriptorUpdateTemplate);
     if ((template_map_entry == device_data->desc_template_map.end()) || (template_map_entry->second.get() == nullptr)) {
         assert(0);
@@ -12793,6 +12803,18 @@ void PreCallRecordUpdateDescriptorSetWithTemplate(layer_data *device_data, VkDes
             cvdescriptorset::PerformUpdateDescriptorSetsWithTemplateKHR(device_data, descriptorSet, template_state, pData);
         }
     }
+}
+
+void PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
+                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void *pData) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    RecordUpdateDescriptorSetWithTemplateState(device_data, descriptorSet, descriptorUpdateTemplate, pData);
+}
+
+void PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
+                                                     VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    RecordUpdateDescriptorSetWithTemplateState(device_data, descriptorSet, descriptorUpdateTemplate, pData);
 }
 
 static std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> GetDslFromPipelineLayout(PIPELINE_LAYOUT_NODE const *layout_data,
@@ -12988,12 +13010,13 @@ bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDev
     return skip;
 }
 
-void PreCallRecordDebugMarkerSetObjectNameEXT(layer_data *dev_data, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+void PreCallRecordDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (pNameInfo->pObjectName) {
-        dev_data->report_data->debugObjectNameMap->insert(
+        device_data->report_data->debugObjectNameMap->insert(
             std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->object, pNameInfo->pObjectName));
     } else {
-        dev_data->report_data->debugObjectNameMap->erase(pNameInfo->object);
+        device_data->report_data->debugObjectNameMap->erase(pNameInfo->object);
     }
 }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1394,14 +1394,15 @@ void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* p
                                   const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory, VkResult result);
 bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences);
-void PostCallRecordWaitForFences(layer_data* dev_data, uint32_t fence_count, const VkFence* fences, VkBool32 wait_all);
+bool PreCallValidateWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll, uint64_t timeout);
+void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll, uint64_t timeout,
+                                 VkResult result);
 bool PreCallValidateGetFenceStatus(VkDevice device, VkFence fence);
 void PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, VkResult result);
 bool PreCallValidateQueueWaitIdle(VkQueue queue);
 void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result);
-bool PreCallValidateDeviceWaitIdle(layer_data* dev_data);
-void PostCallRecordDeviceWaitIdle(layer_data* dev_data);
+bool PreCallValidateDeviceWaitIdle(VkDevice device);
+void PostCallRecordDeviceWaitIdle(VkDevice device, VkResult result);
 bool PreCallValidateDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator);
@@ -1477,10 +1478,10 @@ void PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo*
                                    const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool, VkResult result);
 bool PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateResetCommandPool(layer_data* dev_data, COMMAND_POOL_NODE* pPool);
-void PostCallRecordResetCommandPool(layer_data* dev_data, COMMAND_POOL_NODE* pPool);
-bool PreCallValidateResetFences(layer_data* dev_data, uint32_t fenceCount, const VkFence* pFences);
-void PostCallRecordResetFences(layer_data* dev_data, uint32_t fenceCount, const VkFence* pFences);
+bool PreCallValidateResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags);
+void PostCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags, VkResult result);
+bool PreCallValidateResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences);
+void PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkResult result);
 bool PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
@@ -1513,18 +1514,18 @@ void PostCallRecordCreatePipelineLayout(layer_data* dev_data, const VkPipelineLa
 void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
                                         VkResult result);
-bool PreCallValidateResetDescriptorPool(layer_data* dev_data, VkDescriptorPool descriptorPool);
-void PostCallRecordResetDescriptorPool(layer_data* dev_data, VkDevice device, VkDescriptorPool descriptorPool,
-                                       VkDescriptorPoolResetFlags flags);
+bool PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags);
+void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
+                                       VkResult result);
 bool PreCallValidateAllocateDescriptorSets(layer_data* dev_data, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                            cvdescriptorset::AllocateDescriptorSetsData* common_data);
 void PostCallRecordAllocateDescriptorSets(layer_data* dev_data, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                           VkDescriptorSet* pDescriptorSets,
                                           const cvdescriptorset::AllocateDescriptorSetsData* common_data);
-bool PreCallValidateFreeDescriptorSets(const layer_data* dev_data, VkDescriptorPool pool, uint32_t count,
-                                       const VkDescriptorSet* descriptor_sets);
-void PreCallRecordFreeDescriptorSets(layer_data* dev_data, VkDescriptorPool pool, uint32_t count,
-                                     const VkDescriptorSet* descriptor_sets);
+bool PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
+                                       const VkDescriptorSet* pDescriptorSets);
+void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
+                                     const VkDescriptorSet* pDescriptorSets);
 bool PreCallValidateUpdateDescriptorSets(layer_data* dev_data, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                          const VkCopyDescriptorSet* pDescriptorCopies);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1526,10 +1526,10 @@ bool PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descrip
                                        const VkDescriptorSet* pDescriptorSets);
 void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
                                      const VkDescriptorSet* pDescriptorSets);
-bool PreCallValidateUpdateDescriptorSets(layer_data* dev_data, uint32_t descriptorWriteCount,
+bool PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                          const VkCopyDescriptorSet* pDescriptorCopies);
-void PreCallRecordUpdateDescriptorSets(layer_data* dev_data, uint32_t descriptorWriteCount,
+void PreCallRecordUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                        const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                        const VkCopyDescriptorSet* pDescriptorCopies);
 void PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pCreateInfo,
@@ -1818,7 +1818,7 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physical
                                                        VkResult result);
 void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
-void PreCallRecordSetDebugUtilsObjectNameEXT(layer_data* dev_data, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
+void PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
 void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
 void PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue);
 void PreCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
@@ -1865,11 +1865,15 @@ void PreCallRecordDestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorU
                                                   const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                      const VkAllocationCallbacks* pAllocator);
-
-bool PreCallValidateUpdateDescriptorSetWithTemplate(layer_data* device_data, VkDescriptorSet descriptorSet,
+bool PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                     VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
-void PreCallRecordUpdateDescriptorSetWithTemplate(layer_data* device_data, VkDescriptorSet descriptorSet,
+void PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                   VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
+bool PreCallValidateUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
+                                                       VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
+void PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
+                                                     VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
+
 bool PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                         VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                         VkPipelineLayout layout, uint32_t set, const void* pData);
@@ -1887,7 +1891,7 @@ bool PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevi
 bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
                                                     const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
                                                     VkDisplayPlaneCapabilities2KHR* pCapabilities);
-void PreCallRecordDebugMarkerSetObjectNameEXT(layer_data* dev_data, const VkDebugMarkerObjectNameInfoEXT* pNameInfo);
+void PreCallRecordDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo);
 bool PreCallValidateCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer);
 bool PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                               uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1721,26 +1721,33 @@ void PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, con
 bool PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos);
 void PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos,
                                        VkResult result);
-bool PreCallValidateSetEvent(layer_data* dev_data, VkEvent event);
-void PreCallRecordSetEvent(layer_data* dev_data, VkEvent event);
+bool PreCallValidateSetEvent(VkDevice device, VkEvent event);
+void PreCallRecordSetEvent(VkDevice device, VkEvent event);
 bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence);
 void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                    VkResult result);
 void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore, VkResult result);
-bool PreCallValidateImportSemaphore(layer_data* dev_data, VkSemaphore semaphore, const char* caller_name);
-void PostCallRecordImportSemaphore(layer_data* dev_data, VkSemaphore semaphore,
-                                   VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type, VkSemaphoreImportFlagsKHR flags);
-void PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd, VkResult result);
-bool PreCallValidateImportFence(layer_data* dev_data, VkFence fence, const char* caller_name);
-void PostCallRecordImportFence(layer_data* dev_data, VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type,
-                               VkFenceImportFlagsKHR flags);
+bool PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo);
+void PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo, VkResult result);
 #ifdef VK_USE_PLATFORM_WIN32_KHR
+void PostCallRecordImportSemaphoreWin32HandleKHR(VkDevice device,
+                                                 const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo,
+                                                 VkResult result);
+bool PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device,
+                                                  const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo);
+bool PreCallValidateImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo);
+void PostCallRecordImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
+                                             VkResult result);
 void PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                               HANDLE* pHandle, VkResult result);
 void PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle,
                                           VkResult result);
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+bool PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo);
+void PostCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo, VkResult result);
+
+void PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd, VkResult result);
 void PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd, VkResult result);
 void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                VkEvent* pEvent, VkResult result);
@@ -1760,14 +1767,18 @@ bool PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchai
                                               VkSwapchainKHR* pSwapchains);
 void PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount, const VkSwapchainCreateInfoKHR* pCreateInfos,
                                              const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains, VkResult result);
-bool PreCallValidateCommonAcquireNextImage(layer_data* dev_data, VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                           VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex, const char* func_name);
-void PostCallRecordCommonAcquireNextImage(layer_data* dev_data, VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                          VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex);
-bool PreCallValidateEnumeratePhysicalDevices(instance_layer_data* instance_data, uint32_t* pPhysicalDeviceCount);
-void PreCallRecordEnumeratePhysicalDevices(instance_layer_data* instance_data);
-void PostCallRecordEnumeratePhysicalDevices(instance_layer_data* instance_data, const VkResult& result,
-                                            uint32_t* pPhysicalDeviceCount, VkPhysicalDevice* pPhysicalDevices);
+bool PreCallValidateAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
+                                        VkFence fence, uint32_t* pImageIndex);
+bool PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex);
+void PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
+                                       VkFence fence, uint32_t* pImageIndex, VkResult result);
+void PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex,
+                                        VkResult result);
+bool PreCallValidateEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                             VkPhysicalDevice* pPhysicalDevices);
+void PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount, VkPhysicalDevice* pPhysicalDevices);
+void PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount, VkPhysicalDevice* pPhysicalDevices,
+                                            VkResult result);
 bool PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,
                                                            VkQueueFamilyProperties* pQueueFamilyProperties);
 void PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,
@@ -1826,10 +1837,18 @@ void PostCallDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCal
                                            const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                   VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-void PreCallRecordEnumeratePhysicalDeviceGroups(instance_layer_data* instance_data,
+void PreCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                 VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-void PostCallRecordEnumeratePhysicalDeviceGroups(instance_layer_data* instance_data, uint32_t* pPhysicalDeviceGroupCount,
-                                                 VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
+void PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+                                                 VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties,
+                                                 VkResult result);
+bool PreCallValidateEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+                                                     VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
+void PreCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+                                                   VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
+void PostCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+                                                    VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties,
+                                                    VkResult result);
 bool PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator,
                                                    VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);


### PR DESCRIPTION
Leaving only the stateful or down-chain-modifier APIs, to be handled next.  Passes internal CI and on Pixel 2.0.


- PreCallValidateSetEvent
- PreCallRecordSetEvent
- PreCallValidateImportSemaphoreWin32HandleKHR
- PostCallRecordImportSemaphoreWin32HandleKHR
- PreCallValidateImportSemaphoreFdKHR
- PostCallRecordImportSemaphoreFdKHR
- PreCallValidateImportFenceWin32HandleKHR
- PostCallRecordImportFenceWin32HandleKHR
- PreCallValidateImportFenceFdKHR
- PostCallRecordImportFenceFdKHR
- PreCallValidateAcquireNextImageKHR
- PostCallRecordAcquireNextImageKHR
- PreCallValidateAcquireNextImage2KHR
- PostCallRecordAcquireNextImage2KHR
- PreCallValidateEnumeratePhysicalDevices
- PostCallRecordEnumeratePhysicalDevices
- PreCallRecordEnumeratePhysicalDevices
- PreCallValidateEnumeratePhysicalDeviceGroups
- PostCallRecordEnumeratePhysicalDeviceGroups
- PreCallRecordEnumeratePhysicalDeviceGroups
- PreCallValidateEnumeratePhysicalDeviceGroupsKHR
- PostCallRecordEnumeratePhysicalDeviceGroupsKHR
- PreCallRecordEnumeratePhysicalDeviceGroupsKHR
- PreCallValidateUpdateDescriptorSetWithTemplate
- PreCallRecordUpdateDescriptorSetWithTemplate
- PreCallValidateUpdateDescriptorSetWithTemplateKHR
- PreCallRecordUpdateDescriptorSetWithTemplateKHR
- PreCallRecordFreeDescriptorSets
- PreCallRecordUpdateDescriptorSets
- PreCallValidateUpdateDescriptorSets
- PreCallRecordSetDebugUtilsObjectNameEXT
- PreCallRecordDebugMarkerSetObjectNameEXT

