### PR TITLE
Make GPU assisted validation per draw

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -1462,8 +1462,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(VkCommandBuffer commandBuffer, uint32_t verte
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
-    lock.unlock();
     if (!skip) {
+        PreCallRecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+        lock.unlock();
         dev_data->dispatch_table.CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
         lock.lock();
         PostCallRecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
@@ -1476,8 +1477,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
-    lock.unlock();
     if (!skip) {
+        PreCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+        lock.unlock();
         dev_data->dispatch_table.CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
         lock.lock();
         PostCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
@@ -1490,8 +1492,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(VkCommandBuffer commandBuffer,
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDrawIndexedIndirect(commandBuffer, buffer, offset, count, stride);
-    lock.unlock();
     if (!skip) {
+        PreCallRecordCmdDrawIndexedIndirect(commandBuffer, buffer, offset, count, stride);
+        lock.unlock();
         dev_data->dispatch_table.CmdDrawIndexedIndirect(commandBuffer, buffer, offset, count, stride);
         lock.lock();
         PostCallRecordCmdDrawIndexedIndirect(commandBuffer, buffer, offset, count, stride);
@@ -1503,8 +1506,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(VkCommandBuffer commandBuffer, uint32_t x
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDispatch(commandBuffer, x, y, z);
-    lock.unlock();
     if (!skip) {
+        PreCallRecordCmdDispatch(commandBuffer, x, y, z);
+        lock.unlock();
         dev_data->dispatch_table.CmdDispatch(commandBuffer, x, y, z);
         lock.lock();
         PostCallRecordCmdDispatch(commandBuffer, x, y, z);
@@ -1516,8 +1520,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(VkCommandBuffer commandBuffer, Vk
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDispatchIndirect(commandBuffer, buffer, offset);
-    lock.unlock();
     if (!skip) {
+        PreCallValidateCmdDispatchIndirect(commandBuffer, buffer, offset);
+        lock.unlock();
         dev_data->dispatch_table.CmdDispatchIndirect(commandBuffer, buffer, offset);
         lock.lock();
         PostCallRecordCmdDispatchIndirect(commandBuffer, buffer, offset);
@@ -1558,8 +1563,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuff
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateCmdDrawIndirect(commandBuffer, buffer, offset, count, stride);
-    lock.unlock();
     if (!skip) {
+        PreCallRecordCmdDrawIndirect(commandBuffer, buffer, offset, count, stride);
+        lock.unlock();
         dev_data->dispatch_table.CmdDrawIndirect(commandBuffer, buffer, offset, count, stride);
         lock.lock();
         PostCallRecordCmdDrawIndirect(commandBuffer, buffer, offset, count, stride);
@@ -3210,9 +3216,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(VkCommandBuffer commandBuffer, VkPipe
         PreCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
         lock.unlock();
         dev_data->dispatch_table.CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
-        lock.lock();
-        PostCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
-        lock.unlock();
     }
 }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1542,7 +1542,6 @@ bool PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandB
 void PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags, VkResult result);
 bool PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
 void PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
-void PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
 bool PreCallValidateCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                    const VkViewport* pViewports);
 void PreCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
@@ -1599,25 +1598,35 @@ void PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t f
                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets);
 bool PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                             uint32_t firstInstance);
+void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+                          uint32_t firstInstance);
 void PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                            uint32_t firstInstance);
 bool PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex,
                                    int32_t vertexOffset, uint32_t firstInstance);
+void PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex,
+                                 int32_t vertexOffset, uint32_t firstInstance);
 void PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex,
                                   int32_t vertexOffset, uint32_t firstInstance);
 bool PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                            uint32_t stride);
+void PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
+                                         uint32_t stride);
 void PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                           uint32_t stride);
 bool PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                    uint32_t stride);
 bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z);
+void PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z);
 void PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z);
 bool PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
+void PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
 void PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
 bool PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                     uint32_t stride);
+void PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
+                                  uint32_t stride);
 void PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                    uint32_t stride);
 bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -976,6 +976,14 @@ struct GpuDeviceMemoryBlock {
     uint32_t offset;
 };
 
+struct GpuBufferInfo {
+    GpuDeviceMemoryBlock mem_block;
+    VkDescriptorSet desc_set;
+    VkDescriptorPool desc_pool;
+    GpuBufferInfo(GpuDeviceMemoryBlock mem_block, VkDescriptorSet desc_set, VkDescriptorPool desc_pool)
+        : mem_block(mem_block), desc_set(desc_set), desc_pool(desc_pool){};
+};
+
 // Cmd Buffer Wrapper Struct - TODO : This desperately needs its own class
 struct GLOBAL_CB_NODE : public BASE_NODE {
     VkCommandBuffer commandBuffer;
@@ -1043,9 +1051,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     // Contents valid only after an index buffer is bound (CBSTATUS_INDEX_BUFFER_BOUND set)
     IndexBufferBinding index_buffer_binding;
     // GPU Validation data
-    GpuDeviceMemoryBlock gpu_output_memory_block;
-    VkDescriptorSet gpu_buffer_desc_set;
-    VkDescriptorPool gpu_buffer_desc_pool;
+    std::vector<GpuBufferInfo> gpu_buffer_list;
 };
 
 static inline QFOTransferBarrierSets<VkImageMemoryBarrier> &GetQFOBarrierSets(

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -116,16 +116,12 @@ std::unique_ptr<safe_VkDeviceCreateInfo> GpuPreCallRecordCreateDevice(VkPhysical
                                                                       VkPhysicalDeviceFeatures *supported_features);
 void GpuPostCallRecordCreateDevice(layer_data *dev_data);
 void GpuPreCallRecordDestroyDevice(layer_data *dev_data);
-void GpuPostCallRecordAllocateCommandBuffers(layer_data *dev_data, const VkCommandBufferAllocateInfo *pCreateInfo,
-                                             VkCommandBuffer *pCommandBuffer);
 void GpuPreCallRecordFreeCommandBuffers(layer_data *dev_data, uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers);
 VkResult GpuOverrideDispatchCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                uint32_t *unique_shader_id);
 VkResult GpuOverrideDispatchCreatePipelineLayout(layer_data *dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                  const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout);
-void GpuPostCallDispatchCmdBindPipeline(layer_data *dev_data, VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                        VkPipeline pipeline);
 void GpuPostCallQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence);
 void GpuPreCallValidateCmdWaitEvents(layer_data *dev_data, VkPipelineStageFlags sourceStageMask);
 std::vector<safe_VkGraphicsPipelineCreateInfo> GpuPreCallRecordCreateGraphicsPipelines(
@@ -135,5 +131,6 @@ void GpuPostCallRecordCreateGraphicsPipelines(layer_data *dev_data, const uint32
                                               const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                               const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines);
 void GpuPreCallRecordDestroyPipeline(layer_data *dev_data, const VkPipeline pipeline);
+void GpuAllocateValidationResources(layer_data *dev_data, const VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point);
 
 #endif  // VULKAN_GPU_VALIDATION_H


### PR DESCRIPTION
This is in preparation for our next phase of gpu assisted validation.  It also allows reporting of which draw
in the command buffer got which errors.