### PR TITLE
Make stateless validation more stateless

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1490,6 +1490,13 @@ bool PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreat
         }
     }
 
+    if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT && pCreateInfo->pQueueFamilyIndices) {
+        skip |= core_validation::ValidateQueueFamilies(
+            device_data, pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices, "vkCreateImage",
+            "pCreateInfo->pQueueFamilyIndices", "VUID-VkImageCreateInfo-sharingMode-01420",
+            "VUID-VkImageCreateInfo-sharingMode-01420", false);
+    }
+
     return skip;
 }
 
@@ -3897,6 +3904,13 @@ bool PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCre
                         "VUID-VkBufferCreateInfo-usage-02606",
                         "vkCreateBuffer(): the bufferDeviceAddress device feature is disabled: Buffers cannot be created with "
                         "the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_EXT set.");
+    }
+
+    if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT && pCreateInfo->pQueueFamilyIndices) {
+        skip |= core_validation::ValidateQueueFamilies(
+            device_data, pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices, "vkCreateBuffer",
+            "pCreateInfo->pQueueFamilyIndices", "VUID-VkBufferCreateInfo-sharingMode-01419",
+            "VUID-VkBufferCreateInfo-sharingMode-01419", false);
     }
 
     return skip;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -606,8 +606,8 @@ bool ValidateDeviceQueueFamily(layer_data *device_data, uint32_t queue_family, c
 }
 
 bool ValidateQueueFamilies(layer_data *device_data, uint32_t queue_family_count, const uint32_t *queue_families,
-                           const char *cmd_name, const char *array_parameter_name, const std::string &unique_error_code,
-                           const std::string &valid_error_code, bool optional = false) {
+                           const char *cmd_name, const char *array_parameter_name, const char *unique_error_code,
+                           const char *valid_error_code, bool optional = false) {
     bool skip = false;
     if (queue_families) {
         std::unordered_set<uint32_t> set;
@@ -616,13 +616,13 @@ bool ValidateQueueFamilies(layer_data *device_data, uint32_t queue_family_count,
 
             if (set.count(queue_families[i])) {
                 skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
-                                HandleToUint64(device_data->device), unique_error_code.c_str(),
+                                HandleToUint64(device_data->device), unique_error_code,
                                 "%s: %s (=%" PRIu32 ") is not unique within %s array.", cmd_name, parameter_name.c_str(),
                                 queue_families[i], array_parameter_name);
             } else {
                 set.insert(queue_families[i]);
                 skip |= ValidateDeviceQueueFamily(device_data, queue_families[i], cmd_name, parameter_name.c_str(),
-                                                  valid_error_code.c_str(), optional);
+                                                  valid_error_code, optional);
             }
         }
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -230,6 +230,8 @@ struct layer_data {
     std::unordered_set<uint64_t> ahb_ext_formats_set;
     GlobalQFOTransferBarrierMap<VkImageMemoryBarrier> qfo_release_image_barrier_map;
     GlobalQFOTransferBarrierMap<VkBufferMemoryBarrier> qfo_release_buffer_barrier_map;
+    // Map for queue family index to queue count
+    unordered_map<uint32_t, uint32_t> queue_family_index_map;
 
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -1357,6 +1359,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(VkInstance instance
 using std::vector;
 SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR surface);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
+bool ValidateQueueFamilies(layer_data *device_data, uint32_t queue_family_count, const uint32_t *queue_families,
+    const char *cmd_name, const char *array_parameter_name, const std::string &unique_error_code,
+    const std::string &valid_error_code, bool optional);
 
 void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                   VkInstance* pInstance, VkResult result);
@@ -1370,6 +1375,7 @@ void PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBu
                                    const void* pData);
 void PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                VkFence* pFence, VkResult result);
+bool PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue);
 void PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue);
 void PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue);
 bool PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
@@ -1470,6 +1476,8 @@ bool PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPoo
                                        const VkCommandBuffer* pCommandBuffers);
 void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                      const VkCommandBuffer* pCommandBuffers);
+bool PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool);
 void PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool, VkResult result);
 bool PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1359,10 +1359,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(VkInstance instance
 using std::vector;
 SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR surface);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
-bool ValidateQueueFamilies(layer_data *device_data, uint32_t queue_family_count, const uint32_t *queue_families,
-    const char *cmd_name, const char *array_parameter_name, const std::string &unique_error_code,
-    const std::string &valid_error_code, bool optional);
-
+bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
+                           const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
+                           const char* valid_error_code, bool optional);
 void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                   VkInstance* pInstance, VkResult result);
 bool PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -1442,6 +1442,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 bool uses_color_attachment = false;
                 bool uses_depthstencil_attachment = false;
                 {
+                    std::unique_lock<std::mutex> lock(renderpass_map_mutex);
                     const auto subpasses_uses_it = renderpasses_states.find(pCreateInfos[i].renderPass);
                     if (subpasses_uses_it != renderpasses_states.end()) {
                         const auto &subpasses_uses = subpasses_uses_it->second;
@@ -1450,6 +1451,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (subpasses_uses.subpasses_using_depthstencil_attachment.count(pCreateInfos[i].subpass))
                             uses_depthstencil_attachment = true;
                     }
+                    lock.unlock();
                 }
 
                 if (pCreateInfos[i].pDepthStencilState != nullptr && uses_depthstencil_attachment) {
@@ -2926,6 +2928,7 @@ void StatelessValidation::PostCallRecordCreateRenderPass2KHR(VkDevice device, co
 void StatelessValidation::PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass,
                                                           const VkAllocationCallbacks *pAllocator) {
     // Track the state necessary for checking vkCreateGraphicsPipeline (subpass usage of depth and color attachments)
+    std::unique_lock<std::mutex> lock(renderpass_map_mutex);
     renderpasses_states.erase(renderPass);
 }
 

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -91,9 +91,6 @@ struct LogMiscParams {
 
 class StatelessValidation : public ValidationObject {
    public:
-    // Map for queue family index to queue count
-    std::unordered_map<uint32_t, uint32_t> queueFamilyIndexMap;
-
     VkPhysicalDeviceLimits device_limits = {};
     VkPhysicalDeviceFeatures physical_device_features = {};
     VkDevice device = VK_NULL_HANDLE;
@@ -918,8 +915,6 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice);
 
-    bool manual_PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue);
-
     bool manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer);
 
@@ -1038,8 +1033,6 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride);
-    bool manual_PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool);
 
     bool manual_PreCallValidateEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char *pLayerName,
                                                                   uint32_t *pPropertyCount, VkExtensionProperties *pProperties);

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -135,10 +135,8 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCreateInstance',
             'vkCreateDevice',
             'vkCreateQueryPool'
-            'vkCreateCommandPool',
             'vkCreateRenderPass',
             'vkCreateRenderPass2KHR',
-            'vkGetDeviceQueue',
             'vkCreateBuffer',
             'vkCreateImage',
             'vkCreateImageView',

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -15688,7 +15688,7 @@ TEST_F(VkLayerTest, IdxBufferAlignmentError) {
 }
 
 TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
-    // Create an out-of-range queueFamilyIndex
+    // Miscellaneous queueFamilyIndex validation tests
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     VkBufferCreateInfo buffCI = {};
@@ -15705,9 +15705,14 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
     buffCI.sharingMode = VK_SHARING_MODE_CONCURRENT;  // qfi only matters in CONCURRENT mode
 
     VkBuffer ib;
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "vkCreateBuffer: pCreateInfo->pQueueFamilyIndices[0] (= 777) is not one of the queue "
-                                         "families given via VkDeviceQueueCreateInfo structures when the device was created.");
+    // Test for queue family index out of range
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBufferCreateInfo-sharingMode-01419");
+    vkCreateBuffer(m_device->device(), &buffCI, NULL, &ib);
+    m_errorMonitor->VerifyFound();
+
+    // Test for non-unique QFI in array
+    qfi[0] = 0;
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBufferCreateInfo-sharingMode-01419");
     vkCreateBuffer(m_device->device(), &buffCI, NULL, &ib);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
As @jeffbolznv pointed out, this layer is almost completely stateless and should not require the standard locking/unlocking around validation calls. 
Parameter validation did contain two bits of state -- one was QueueFamilyIndex range/validity checks which were moved into core validation, and some CreateGraphicsPipeline checks which are dependent on a small bit of renderpass state.  These state updates/checks are now guarded by a local mutex and the base write_lock function has been overridden to avoid taking the validation object lock (like the threading layer). 

Also updated/added QFIndex tests for the new CV checks.

Fixes #643.