### PR TITLE
Remove workarounds in gpu assisted validation

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -712,10 +712,8 @@ static void GenerateStageMessage(const uint32_t *debug_record, std::string &msg)
     std::ostringstream strm;
     switch (debug_record[kInstCommonOutStageIdx]) {
         case 0: {
-            // TODO: When we find a spirv-tools / glslang / shaderc combination that works well with validation layers,
-            // replace the 4 below with kInstVertOutVertexIndex and the 5 with kInstVertOutInstanceIndex.  Change the
-            // message to refer to Vertex Index instead of Vertex ID and Instance Index instead of Instance ID
-            strm << "Stage = Vertex. Vertex ID = " << debug_record[4] << " Instance ID = " << debug_record[5] << ". ";
+            strm << "Stage = Vertex. Vertex Index = " << debug_record[kInstVertOutVertexIndex]
+                 << " Instance Index = " << debug_record[kInstVertOutInstanceIndex] << ". ";
         } break;
         case 1: {
             strm << "Stage = Tessellation Control.  Invocation ID = " << debug_record[kInstTessOutInvocationId] << ". ";


### PR DESCRIPTION
Now that the glslang / spirv-tools dependencies have been updated, these are no longer necessary