### PR TITLE
Clean up validation issues with ClearAttachments

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -710,7 +710,7 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
     if (failCase == BsoFailCmdClearAttachments) {
         VkClearAttachment color_attachment = {};
         color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        color_attachment.colorAttachment = 1;  // Someone who knew what they were doing would use 0 for the index;
+        color_attachment.colorAttachment = 2000000000;  // Someone who knew what they were doing would use 0 for the index;
         VkClearRect clear_rect = {{{0, 0}, {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height)}}, 0, 0};
 
         vkCmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);


### PR DESCRIPTION
Fixes #657 :  Refactored validation of ClearAttachment to improve coverage for secondary command buffers, including those with null framebuffer inheritance. DRY/clean by moving common code to utility adding robust null checks (since nulls are valid in some cases).  Reduced number of lambda functions added to deferred (execute command buffer time) list to one per attachment vs. one per attachment per clear area.

Fixes #678 : Reorder/refactor vkCmdClearAttachments validation s.t. bounds are checked before validation comparison values are looked up.  Added additional bounds checks for renderpass and framebuffer attachment look-ups.