### PR TITLE
layers: in object_tracker, have descriptor_pool track sets it owns

### DIFF
--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -54,10 +54,11 @@ enum ObjectStatusFlagBits {
 
 // Object and state information structure
 struct ObjTrackState {
-    uint64_t handle;               // Object handle (new)
-    VulkanObjectType object_type;  // Object type identifier
-    ObjectStatusFlags status;      // Object state
-    uint64_t parent_object;        // Parent object
+    uint64_t handle;                                               // Object handle (new)
+    VulkanObjectType object_type;                                  // Object type identifier
+    ObjectStatusFlags status;                                      // Object state
+    uint64_t parent_object;                                        // Parent object
+    std::unique_ptr<std::unordered_set<uint64_t> > child_objects;  // Child objects (used for VkDescriptorPool only)
 };
 
 // Track Queue information
@@ -182,6 +183,10 @@ class ObjectLifetimes : public ValidationObject {
             object_map[object_type][object_handle] = pNewObjNode;
             num_objects[object_type]++;
             num_total_objects++;
+
+            if (object_type == kVulkanObjectTypeDescriptorPool) {
+                pNewObjNode->child_objects.reset(new std::unordered_set<uint64_t>);
+            }
         }
     }
 


### PR DESCRIPTION
Resetting descriptor pools at the end of a frame has some potentially
O(N^2) behavior in the object_tracker layer, where resetting each pool
iterates over ALL allocated sets (across all pools), checking that the
parent matches the pool being reset. This change has each pool track
its children, and Reset only iterates over its children.

This is worth around 5% performance.
