### PR TITLE
Add validation for vkGetDeviceMemoryCommitment

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2050,6 +2050,17 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(VkDevice device, uin
     return result;
 }
 
+VKAPI_ATTR void VKAPI_CALL GetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory mem, VkDeviceSize *pCommittedMem) {
+    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    unique_lock_t lock(global_lock);
+    bool skip = PreCallValidateGetDeviceMemoryCommitment(device, mem, pCommittedMem);
+    lock.unlock();
+
+    if (skip) return;
+
+    dev_data->dispatch_table.GetDeviceMemoryCommitment(device, mem, pCommittedMem);
+}
+
 VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
@@ -3385,6 +3396,7 @@ static const std::unordered_map<std::string, void *> name_to_funcptr_map = {
     {"vkUnmapMemory", (void *)UnmapMemory},
     {"vkFlushMappedMemoryRanges", (void *)FlushMappedMemoryRanges},
     {"vkInvalidateMappedMemoryRanges", (void *)InvalidateMappedMemoryRanges},
+    {"vkGetDeviceMemoryCommitment", (void *)GetDeviceMemoryCommitment},
     {"vkAllocateMemory", (void *)AllocateMemory},
     {"vkFreeMemory", (void *)FreeMemory},
     {"vkBindBufferMemory", (void *)BindBufferMemory},

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10933,6 +10933,24 @@ void PostCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memRan
     }
 }
 
+bool PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory mem, VkDeviceSize *pCommittedMem) {
+    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    bool skip = false;
+    auto mem_info = GetMemObjInfo(dev_data, mem);
+
+    if (mem_info) {
+        if ((dev_data->phys_dev_mem_props.memoryTypes[mem_info->alloc_info.memoryTypeIndex].propertyFlags &
+             VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) == 0) {
+            skip = log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT,
+                           HandleToUint64(mem), "VUID-vkGetDeviceMemoryCommitment-memory-00690",
+                           "Querying commitment for memory without VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT set: mem obj 0x%" PRIx64
+                           ".",
+                           HandleToUint64(mem));
+        }
+    }
+    return skip;
+}
+
 bool ValidateBindImageMemory(layer_data *device_data, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset,
                              const char *api_name) {
     bool skip = false;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1775,6 +1775,7 @@ bool PreCallValidateFlushMappedMemoryRanges(VkDevice device, uint32_t memRangeCo
 bool PreCallValidateInvalidateMappedMemoryRanges(VkDevice device, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
 void PostCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges,
                                                 VkResult result);
+bool PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory mem, VkDeviceSize* pCommittedMem);
 bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset);
 void PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset, VkResult result);
 bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR* pBindInfos);


### PR DESCRIPTION
Adds a validation check for `VUID-vkGetDeviceMemoryCommitment-memory-00690` that enforces the `memory must have been created with a memory type that reports VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT` valid usage from the spec. Also adds a negative test for this case.