### PR TITLE
Thread-protect debug report/messenger functions and normalize object label handling

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2670,9 +2670,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDev
 VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = VK_SUCCESS;
-    unique_lock_t lock(global_lock);
-    PreCallRecordSetDebugUtilsObjectNameEXT(device, pNameInfo);
-    lock.unlock();
+    dev_data->report_data->DebugReportSetUtilsObjectName(pNameInfo);
     result = dev_data->dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);
     return result;
 }
@@ -2997,9 +2995,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(VkPhysicalDevice 
 
 VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    unique_lock_t lock(global_lock);
-    PreCallRecordDebugMarkerSetObjectNameEXT(device, pNameInfo);
-    lock.unlock();
+    device_data->report_data->DebugReportSetMarkerObjectName(pNameInfo);
     VkResult result = device_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
     return result;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12694,16 +12694,6 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physical
     }
 }
 
-void PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
-    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    if (pNameInfo->pObjectName) {
-        device_data->report_data->debugUtilsObjectNameMap->insert(
-            std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->objectHandle, pNameInfo->pObjectName));
-    } else {
-        device_data->report_data->debugUtilsObjectNameMap->erase(pNameInfo->objectHandle);
-    }
-}
-
 void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT *pLabelInfo) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
     BeginQueueDebugUtilsLabel(device_data->report_data, queue, pLabelInfo);
@@ -13205,16 +13195,6 @@ bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDev
     skip |= ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(instance_data, physicalDevice, pDisplayPlaneInfo->planeIndex,
                                                                     "vkGetDisplayPlaneCapabilities2KHR");
     return skip;
-}
-
-void PreCallRecordDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    if (pNameInfo->pObjectName) {
-        device_data->report_data->debugObjectNameMap->insert(
-            std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->object, pNameInfo->pObjectName));
-    } else {
-        device_data->report_data->debugObjectNameMap->erase(pNameInfo->object);
-    }
 }
 
 bool PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT *pMarkerInfo) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1880,7 +1880,6 @@ void PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physical
                                                        VkResult result);
 void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
-void PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
 void PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
 void PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue);
 void PreCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
@@ -1953,7 +1952,6 @@ bool PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevi
 bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
                                                     const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
                                                     VkDisplayPlaneCapabilities2KHR* pCapabilities);
-void PreCallRecordDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo);
 bool PreCallValidateCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer);
 bool PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                               uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -678,14 +678,13 @@ static void GenerateValidationMessage(const uint32_t *debug_record, std::string 
     msg = strm.str();
 }
 
-static std::string LookupDebugUtilsName(const layer_data *dev_data, const uint64_t object) {
-    const debug_report_data *debug_data = GetReportData(dev_data);
-    auto utils_name_iter = debug_data->debugUtilsObjectNameMap->find(object);
-    if (utils_name_iter != debug_data->debugUtilsObjectNameMap->end()) {
-        return "(" + utils_name_iter->second + ")";
-    } else {
-        return "";
+static std::string LookupDebugUtilsName(const layer_data *device_data, const uint64_t object) {
+    debug_report_data *report_data = device_data->report_data;
+    auto object_label = report_data->DebugReportGetUtilsObjectName(object);
+    if (object_label != "") {
+        object_label = "(" + object_label + ")";
     }
+    return object_label;
 }
 
 // Generate message from the common portion of the debug report record.

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2518,17 +2518,6 @@ bool StatelessValidation::manual_PreCallValidateCreateWin32SurfaceKHR(VkInstance
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-bool StatelessValidation::manual_PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device,
-                                                                            const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-    if (pNameInfo->pObjectName) {
-        report_data->debugObjectNameMap->insert(
-            std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->object, pNameInfo->pObjectName));
-    } else {
-        report_data->debugObjectNameMap->erase(pNameInfo->object);
-    }
-    return false;
-}
-
 bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkDescriptorPool *pDescriptorPool) {

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1017,8 +1017,6 @@ class StatelessValidation : public ValidationObject {
                                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface);
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-    bool manual_PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo);
-
     bool manual_PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool);
     bool manual_PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -91,6 +91,43 @@ typedef struct _debug_report_data {
     bool queueLabelHasInsert;
     std::unordered_map<VkCommandBuffer, std::vector<LoggingLabelData>> *debugUtilsCmdBufLabels;
     bool cmdBufLabelHasInsert;
+
+    void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+        if (pNameInfo->pObjectName) {
+            debugUtilsObjectNameMap->insert(
+                std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->objectHandle, pNameInfo->pObjectName));
+        } else {
+            debugUtilsObjectNameMap->erase(pNameInfo->objectHandle);
+        }
+    }
+
+    void DebugReportSetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+        if (pNameInfo->pObjectName) {
+            debugObjectNameMap->insert(
+                std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->object, pNameInfo->pObjectName));
+        } else {
+            debugObjectNameMap->erase(pNameInfo->object);
+        }
+    }
+
+    std::string DebugReportGetUtilsObjectName(const uint64_t object) const {
+        std::string label = "";
+        auto utils_name_iter = debugUtilsObjectNameMap->find(object);
+        if (utils_name_iter != debugUtilsObjectNameMap->end()) {
+            label = utils_name_iter->second;
+        }
+        return label;
+    }
+
+    std::string DebugReportGetMarkerObjectName(const uint64_t object) const {
+        std::string label = "";
+        auto marker_name_iter = debugObjectNameMap->find(object);
+        if (marker_name_iter != debugObjectNameMap->end()) {
+            label = marker_name_iter->second;
+        }
+        return label;
+    }
+
 } debug_report_data;
 
 template debug_report_data *GetLayerDataPtr<debug_report_data>(void *data_key,

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -99,8 +99,7 @@ typedef struct _debug_report_data {
     void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
         std::unique_lock<std::mutex> lock(debug_report_mutex);
         if (pNameInfo->pObjectName) {
-            debugUtilsObjectNameMap.insert(
-                std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->objectHandle, pNameInfo->pObjectName));
+            debugUtilsObjectNameMap.emplace(pNameInfo->objectHandle, pNameInfo->pObjectName);
         } else {
             debugUtilsObjectNameMap.erase(pNameInfo->objectHandle);
         }
@@ -109,8 +108,7 @@ typedef struct _debug_report_data {
     void DebugReportSetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
         std::unique_lock<std::mutex> lock(debug_report_mutex);
         if (pNameInfo->pObjectName) {
-            debugObjectNameMap.insert(
-                std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->object, pNameInfo->pObjectName));
+            debugObjectNameMap.emplace(pNameInfo->object, pNameInfo->pObjectName);
         } else {
             debugObjectNameMap.erase(pNameInfo->object);
         }
@@ -118,7 +116,7 @@ typedef struct _debug_report_data {
 
     std::string DebugReportGetUtilsObjectName(const uint64_t object) const {
         std::string label = "";
-        auto utils_name_iter = debugUtilsObjectNameMap.find(object);
+        const auto utils_name_iter = debugUtilsObjectNameMap.find(object);
         if (utils_name_iter != debugUtilsObjectNameMap.end()) {
             label = utils_name_iter->second;
         }
@@ -127,7 +125,7 @@ typedef struct _debug_report_data {
 
     std::string DebugReportGetMarkerObjectName(const uint64_t object) const {
         std::string label = "";
-        auto marker_name_iter = debugObjectNameMap.find(object);
+        const auto marker_name_iter = debugObjectNameMap.find(object);
         if (marker_name_iter != debugObjectNameMap.end()) {
             label = marker_name_iter->second;
         }

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -166,7 +166,8 @@ class LayerChassisOutputGenerator(OutputGenerator):
     ]
 
     pre_dispatch_debug_utils_functions = {
-        'vkSetDebugUtilsObjectNameEXT' : 'layer_data->report_data->debugUtilsObjectNameMap->insert(std::make_pair<uint64_t, std::string>((uint64_t &&) pNameInfo->objectHandle, pNameInfo->pObjectName));',
+        'vkDebugMarkerSetObjectNameEXT' : 'layer_data->report_data->DebugReportSetMarkerObjectName(pNameInfo);',
+        'vkSetDebugUtilsObjectNameEXT' : 'layer_data->report_data->DebugReportSetUtilsObjectName(pNameInfo);',
         'vkQueueBeginDebugUtilsLabelEXT' : 'BeginQueueDebugUtilsLabel(layer_data->report_data, queue, pLabelInfo);',
         'vkQueueInsertDebugUtilsLabelEXT' : 'InsertQueueDebugUtilsLabel(layer_data->report_data, queue, pLabelInfo);',
         'vkCmdBeginDebugUtilsLabelEXT' : 'BeginCmdDebugUtilsLabel(layer_data->report_data, commandBuffer, pLabelInfo);',
@@ -1082,20 +1083,14 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
 
         # Insert pre-dispatch debug utils function call
         if name in self.pre_dispatch_debug_utils_functions:
-            self.appendSection('command', '    {')
-            self.appendSection('command', '        std::lock_guard<std::mutex> lock(layer_data->validation_object_mutex);')
-            self.appendSection('command', '        %s' % self.pre_dispatch_debug_utils_functions[name])
-            self.appendSection('command', '    }')
+            self.appendSection('command', '    %s' % self.pre_dispatch_debug_utils_functions[name])
 
         # Output dispatch (down-chain) function call
         self.appendSection('command', '    ' + assignresult + API + paramstext + ');')
 
         # Insert post-dispatch debug utils function call
         if name in self.post_dispatch_debug_utils_functions:
-            self.appendSection('command', '    {')
-            self.appendSection('command', '        std::lock_guard<std::mutex> lock(layer_data->validation_object_mutex);')
-            self.appendSection('command', '        %s' % self.post_dispatch_debug_utils_functions[name])
-            self.appendSection('command', '    }')
+            self.appendSection('command', '    %s' % self.post_dispatch_debug_utils_functions[name])
 
         # Generate post-call object processing source code
         self.appendSection('command', '    %s' % self.postcallrecord_loop)


### PR DESCRIPTION
Should close some potential holes around calling log_msg from multiple threads.  Added object NAME support to the chassis and to core_dispatch, taking it out of the Pre/Post calls.  

This should simplify the work Locke is beginning as well.

