### PR TITLE
Refactor stateful or special-case APIs for future chassis integration

### DIFF
--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -1038,24 +1038,21 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(VkDevice de
 VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                       const VkComputePipelineCreateInfo *pCreateInfos,
                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
-    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
+    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
+
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateCreateComputePipelines(dev_data, &pipe_state, count, pCreateInfos);
-    if (skip) {
-        for (uint32_t i = 0; i < count; i++) {
-            pPipelines[i] = VK_NULL_HANDLE;
-        }
-        return VK_ERROR_VALIDATION_FAILED_EXT;
-    }
+    bool skip =
+        PreCallValidateCreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, &pipe_state);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     lock.unlock();
 
-    auto result =
+    VkResult result =
         dev_data->dispatch_table.CreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines);
 
     lock.lock();
-    PostCallRecordCreateComputePipelines(dev_data, &pipe_state, count, pPipelines);
+    PostCallRecordCreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, result, &pipe_state);
 
     return result;
 }

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -3224,7 +3224,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
 VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo) {
     layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     unique_lock_t lock(global_lock);
-    bool skip = PreCallValidateGetBufferDeviceAddressEXT(dev_data, pInfo);
+    bool skip = PreCallValidateGetBufferDeviceAddressEXT(device, pInfo);
     if (!skip) {
         lock.unlock();
         return dev_data->dispatch_table.GetBufferDeviceAddressEXT(device, pInfo);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9487,14 +9487,6 @@ static bool ValidateRenderPassDAG(const layer_data *dev_data, RenderPassCreateVe
     return skip;
 }
 
-void PostCallRecordCreateShaderModule(layer_data *dev_data, bool is_spirv, const VkShaderModuleCreateInfo *pCreateInfo,
-                                      VkShaderModule *pShaderModule, uint32_t unique_shader_id) {
-    spv_target_env spirv_environment = ((GetApiVersion(dev_data) >= VK_API_VERSION_1_1) ? SPV_ENV_VULKAN_1_1 : SPV_ENV_VULKAN_1_0);
-    unique_ptr<shader_module> new_shader_module(
-        is_spirv ? new shader_module(pCreateInfo, *pShaderModule, spirv_environment, unique_shader_id) : new shader_module());
-    dev_data->shaderModuleMap[*pShaderModule] = std::move(new_shader_module);
-}
-
 static bool ValidateAttachmentIndex(const layer_data *dev_data, RenderPassCreateVersion rp_version, uint32_t attachment,
                                     uint32_t attachment_count, const char *type) {
     bool skip = false;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13503,30 +13503,31 @@ void PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYc
     }
 }
 
-bool PreCallValidateGetBufferDeviceAddressEXT(layer_data *dev_data, const VkBufferDeviceAddressInfoEXT *pInfo) {
+bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo) {
+    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-    if (!GetEnabledFeatures(dev_data)->buffer_address.bufferDeviceAddress) {
-        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
+    if (!GetEnabledFeatures(device_data)->buffer_address.bufferDeviceAddress) {
+        skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
                         HandleToUint64(pInfo->buffer), "VUID-vkGetBufferDeviceAddressEXT-None-02598",
                         "The bufferDeviceAddress feature must: be enabled.");
     }
 
-    if (dev_data->physical_device_count > 1 && !GetEnabledFeatures(dev_data)->buffer_address.bufferDeviceAddressMultiDevice) {
-        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
+    if (device_data->physical_device_count > 1 && !GetEnabledFeatures(device_data)->buffer_address.bufferDeviceAddressMultiDevice) {
+        skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
                         HandleToUint64(pInfo->buffer), "VUID-vkGetBufferDeviceAddressEXT-device-02599",
                         "If device was created with multiple physical devices, then the "
                         "bufferDeviceAddressMultiDevice feature must: be enabled.");
     }
 
-    auto buffer_state = GetBufferState(dev_data, pInfo->buffer);
+    auto buffer_state = GetBufferState(device_data, pInfo->buffer);
     if (buffer_state) {
         if (!(buffer_state->createInfo.flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT)) {
-            skip |= ValidateMemoryIsBoundToBuffer(dev_data, buffer_state, "vkGetBufferDeviceAddressEXT()",
+            skip |= ValidateMemoryIsBoundToBuffer(device_data, buffer_state, "vkGetBufferDeviceAddressEXT()",
                                                   "VUID-VkBufferDeviceAddressInfoEXT-buffer-02600");
         }
 
-        skip |= ValidateBufferUsageFlags(dev_data, buffer_state, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_EXT, true,
+        skip |= ValidateBufferUsageFlags(device_data, buffer_state, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_EXT, true,
                                          "VUID-VkBufferDeviceAddressInfoEXT-buffer-02601", "vkGetBufferDeviceAddressEXT()",
                                          "VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_EXT");
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -161,7 +161,6 @@ struct create_shader_module_api_state {
     std::vector<unsigned int> instrumented_pgm;
 };
 
-
 struct GpuQueue {
     VkPhysicalDevice gpu;
     uint32_t queue_family_index;
@@ -1415,6 +1414,12 @@ void PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCr
 void PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                         VkResult result);
+bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                           VkDescriptorSet* pDescriptorSets,
+                                           cvdescriptorset::AllocateDescriptorSetsData* common_data);
+void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                          VkDescriptorSet* pDescriptorSets, VkResult result,
+                                          cvdescriptorset::AllocateDescriptorSetsData* common_data);
 
 bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
                            const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
@@ -1568,11 +1573,6 @@ void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolC
 bool PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags);
 void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
                                        VkResult result);
-bool PreCallValidateAllocateDescriptorSets(layer_data* dev_data, const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                           cvdescriptorset::AllocateDescriptorSetsData* common_data);
-void PostCallRecordAllocateDescriptorSets(layer_data* dev_data, const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                          VkDescriptorSet* pDescriptorSets,
-                                          const cvdescriptorset::AllocateDescriptorSetsData* common_data);
 bool PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
                                        const VkDescriptorSet* pDescriptorSets);
 void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -153,6 +153,15 @@ struct create_pipeline_layout_api_state {
     VkPipelineLayoutCreateInfo modified_create_info;
 };
 
+// This structure is used modify and pass parameters for the CreateShaderModule down-chain API call
+
+struct create_shader_module_api_state {
+    uint32_t unique_shader_id;
+    VkShaderModuleCreateInfo instrumented_create_info;
+    std::vector<unsigned int> instrumented_pgm;
+};
+
+
 struct GpuQueue {
     VkPhysicalDevice gpu;
     uint32_t queue_family_index;
@@ -1971,8 +1980,6 @@ void PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcr
                                                  const VkAllocationCallbacks* pAllocator);
 void PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                     const VkAllocationCallbacks* pAllocator);
-void PostCallRecordCreateShaderModule(layer_data* dev_data, bool is_spirv, const VkShaderModuleCreateInfo* pCreateInfo,
-                                      VkShaderModule* pShaderModule, uint32_t unique_shader_id);
 bool PreCallValidateGetBufferDeviceAddressEXT(layer_data* dev_data, const VkBufferDeviceAddressInfoEXT* pInfo);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1983,7 +1983,7 @@ void PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcr
                                                  const VkAllocationCallbacks* pAllocator);
 void PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                     const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateGetBufferDeviceAddressEXT(layer_data* dev_data, const VkBufferDeviceAddressInfoEXT* pInfo);
+bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
                                                        VkAndroidHardwareBufferPropertiesANDROID* pProperties);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1368,20 +1368,30 @@ SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR 
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
 
 bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-    const VkGraphicsPipelineCreateInfo* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-    // Default parameter
-    create_graphics_pipeline_api_state* cgpl_state);
+                                            const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                            // Default parameter
+                                            create_graphics_pipeline_api_state* cgpl_state);
 void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-    const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-    VkPipeline* pPipelines,
-    // Default parameter
-    create_graphics_pipeline_api_state* cgpl_state);
+                                          const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                          VkPipeline* pPipelines,
+                                          // Default parameter
+                                          create_graphics_pipeline_api_state* cgpl_state);
 void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-    const VkGraphicsPipelineCreateInfo* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
-    // Default parameter
-    create_graphics_pipeline_api_state* cgpl_state);
+                                           const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                           const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
+                                           // Default parameter
+                                           create_graphics_pipeline_api_state* cgpl_state);
+bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                           const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                           VkPipeline* pPipelines,
+                                           // Default parameter
+                                           std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
+void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                          const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                          VkPipeline* pPipelines, VkResult result,
+                                          // Default parameter
+                                          std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
 
 bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
                            const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
@@ -1517,11 +1527,6 @@ bool PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffe
 void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateCreateComputePipelines(layer_data* dev_data, std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,
-                                           const uint32_t count, const VkComputePipelineCreateInfo* pCreateInfos);
-void PostCallRecordCreateComputePipelines(layer_data* dev_data, vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,
-                                          const uint32_t count, VkPipeline* pPipelines);
-
 bool PreCallValidateCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t count,
                                                 const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                 vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -260,6 +260,13 @@ struct layer_data {
     uint32_t physical_device_count;
 };
 
+// This structure is used to save data across the CreateGraphicsPipelines down-chain API call
+struct create_graphics_pipeline_api_state {
+    std::vector<safe_VkGraphicsPipelineCreateInfo> gpu_create_infos;
+    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
+    const VkGraphicsPipelineCreateInfo* pCreateInfos;
+};
+
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                               VkInstance* pInstance);
 
@@ -1359,6 +1366,23 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(VkInstance instance
 using std::vector;
 SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR surface);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
+
+bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+    const VkGraphicsPipelineCreateInfo* pCreateInfos,
+    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+    // Default parameter
+    create_graphics_pipeline_api_state* cgpl_state);
+void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+    const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+    VkPipeline* pPipelines,
+    // Default parameter
+    create_graphics_pipeline_api_state* cgpl_state);
+void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+    const VkGraphicsPipelineCreateInfo* pCreateInfos,
+    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
+    // Default parameter
+    create_graphics_pipeline_api_state* cgpl_state);
+
 bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
                            const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
                            const char* valid_error_code, bool optional);
@@ -1493,11 +1517,6 @@ bool PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffe
 void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateCreateGraphicsPipelines(layer_data* dev_data, std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,
-                                            const uint32_t count, const VkGraphicsPipelineCreateInfo* pCreateInfos);
-void PostCallRecordCreateGraphicsPipelines(layer_data* dev_data, vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,
-                                           const uint32_t count, const VkGraphicsPipelineCreateInfo* pCreateInfos,
-                                           const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
 bool PreCallValidateCreateComputePipelines(layer_data* dev_data, std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,
                                            const uint32_t count, const VkComputePipelineCreateInfo* pCreateInfos);
 void PostCallRecordCreateComputePipelines(layer_data* dev_data, vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1420,6 +1420,14 @@ bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSe
 void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                           VkDescriptorSet* pDescriptorSets, VkResult result,
                                           cvdescriptorset::AllocateDescriptorSetsData* common_data);
+bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                                const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
+void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                               const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
+                                               vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
 
 bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
                            const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
@@ -1555,11 +1563,6 @@ bool PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffe
 void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
 void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t count,
-                                                const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
-                                                vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state);
-void PostCallRecordCreateRayTracingPipelinesNV(layer_data* dev_data, uint32_t count,
-                                               vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state, VkPipeline* pPipelines);
 void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                  VkSampler* pSampler, VkResult result);
 bool PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -120,8 +120,11 @@ void GpuPreCallRecordFreeCommandBuffers(layer_data *dev_data, uint32_t commandBu
 VkResult GpuOverrideDispatchCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                uint32_t *unique_shader_id);
-VkResult GpuOverrideDispatchCreatePipelineLayout(layer_data *dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout);
+bool GpuPreCallCreatePipelineLayout(layer_data *device_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
+                                    const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
+                                    std::vector<VkDescriptorSetLayout> *new_layouts,
+                                    VkPipelineLayoutCreateInfo *modified_create_info);
+void GpuPostCallCreatePipelineLayout(layer_data *device_data, VkResult result);
 void GpuPostCallQueueSubmit(layer_data *dev_data, VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence);
 void GpuPreCallValidateCmdWaitEvents(layer_data *dev_data, VkPipelineStageFlags sourceStageMask);
 std::vector<safe_VkGraphicsPipelineCreateInfo> GpuPreCallRecordCreateGraphicsPipelines(

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -117,9 +117,10 @@ std::unique_ptr<safe_VkDeviceCreateInfo> GpuPreCallRecordCreateDevice(VkPhysical
 void GpuPostCallRecordCreateDevice(layer_data *dev_data);
 void GpuPreCallRecordDestroyDevice(layer_data *dev_data);
 void GpuPreCallRecordFreeCommandBuffers(layer_data *dev_data, uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers);
-VkResult GpuOverrideDispatchCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
-                                               const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                               uint32_t *unique_shader_id);
+bool GpuPreCallCreateShaderModule(layer_data *dev_data, const VkShaderModuleCreateInfo *pCreateInfo,
+                                  const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                  uint32_t *unique_shader_id, VkShaderModuleCreateInfo *instrumented_create_info,
+                                  std::vector<unsigned int> *instrumented_pgm);
 bool GpuPreCallCreatePipelineLayout(layer_data *device_data, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
                                     std::vector<VkDescriptorSetLayout> *new_layouts,

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -210,7 +210,13 @@ bool ValidateAndCapturePipelineShaderState(layer_data *dev_data, PIPELINE_STATE 
 bool ValidateComputePipeline(layer_data *dev_data, PIPELINE_STATE *pPipeline);
 bool ValidateRayTracingPipelineNV(layer_data *dev_data, PIPELINE_STATE *pipeline);
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;
-bool PreCallValidateCreateShaderModule(layer_data *dev_data, VkShaderModuleCreateInfo const *pCreateInfo, bool *is_spirv,
-                                       bool *spirv_valid);
+bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                       const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule);
+void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                     const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                     create_shader_module_api_state *csm_state);
+void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                      const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule, VkResult result,
+                                      create_shader_module_api_state *csm_state);
 
 #endif  // VULKAN_SHADER_VALIDATION_H


### PR DESCRIPTION
Reworked the following API pre/post routines to normalize the function calls, along with a single custom additional parameter to preserve state across the API call.  These will get special-cased in the chassis to preserve this method of operation (these special use cases exist either for performance (!) or for GPU validation to modify call parameters.

- bool PreCallValidateCreateGraphicsPipelines
- void PreCallRecordCreateGraphicsPipelines
- void PostCallRecordCreateGraphicsPipelines
- bool PreCallValidateCreateComputePipelines
- void PostCallRecordCreateComputePipelines
- bool PreCallValidateCreatePipelineLayout
- void PreCallRecordCreatePipelineLayout
- void PostCallRecordCreatePipelineLayout
- bool PreCallValidateCreateShaderModule
- void PreCallRecordCreateShaderModule
- void PostCallRecordCreateShaderModule
- bool PreCallValidateAllocateDescriptorSets
- void PostCallRecordAllocateDescriptorSets
- void PostCallRecordCreateRayTracingPipelinesNV
- bool PreCallValidateCreateRayTracingPipelinesNV
- bool PreCallValidateGetBufferDeviceAddressEXT



