### PR TITLE
layers: Compile everything with bigobj

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -156,14 +156,7 @@ if(WIN32)
     # Applies to all configurations
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
-    set_source_files_properties(core_validation.cpp
-                                core_dispatch.cpp
-                                thread_safety.cpp
-                                parameter_validation_utils.cpp
-                                chassis.cpp
-                                PROPERTIES
-                                COMPILE_FLAGS
-                                "/bigobj")
+    add_compile_options("/bigobj")
     # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is
     # that constructor initializers are now fixed to clear the struct members.
     add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")


### PR DESCRIPTION
A quick Google search showed no downside to doing so, so rather than adding buffer_validation, use it for all files in layers