### PR TITLE
Fix DebugUtils user debug callbacks

### DIFF
--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -177,7 +177,11 @@ class LayerChassisOutputGenerator(OutputGenerator):
     post_dispatch_debug_utils_functions = {
         'vkQueueEndDebugUtilsLabelEXT' : 'EndQueueDebugUtilsLabel(layer_data->report_data, queue);',
         'vkCmdEndDebugUtilsLabelEXT' : 'EndCmdDebugUtilsLabel(layer_data->report_data, commandBuffer);',
-        'vkCmdInsertDebugUtilsLabelEXT' : 'InsertCmdDebugUtilsLabel(layer_data->report_data, commandBuffer, pLabelInfo);'
+        'vkCmdInsertDebugUtilsLabelEXT' : 'InsertCmdDebugUtilsLabel(layer_data->report_data, commandBuffer, pLabelInfo);',
+        'vkCreateDebugReportCallbackEXT' : 'layer_create_report_callback(layer_data->report_data, false, pCreateInfo, pAllocator, pCallback);',
+        'vkDestroyDebugReportCallbackEXT' : 'layer_destroy_report_callback(layer_data->report_data, callback, pAllocator);',
+        'vkCreateDebugUtilsMessengerEXT' : 'layer_create_messenger_callback(layer_data->report_data, false, pCreateInfo, pAllocator, pMessenger);',
+        'vkDestroyDebugUtilsMessengerEXT' : 'layer_destroy_messenger_callback(layer_data->report_data, messenger, pAllocator);',
         }
 
     precallvalidate_loop = "for (auto intercept : layer_data->object_dispatch) {"

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -132,8 +132,6 @@ class LayerChassisOutputGenerator(OutputGenerator):
         'vkDestroyDevice',
         'vkCreateInstance',
         'vkDestroyInstance',
-        'vkCreateDebugReportCallbackEXT',
-        'vkDestroyDebugReportCallbackEXT',
         'vkEnumerateInstanceLayerProperties',
         'vkEnumerateInstanceExtensionProperties',
         'vkEnumerateDeviceLayerProperties',
@@ -745,47 +743,6 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCall
         delete *item;
     }
     FreeLayerDataPtr(key, layer_data_map);
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(VkInstance instance,
-                                                            const VkDebugReportCallbackCreateInfoEXT *pCreateInfo,
-                                                            const VkAllocationCallbacks *pAllocator,
-                                                            VkDebugReportCallbackEXT *pCallback) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
-    """ + precallvalidate_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PreCallValidateCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
-    }
-    """ + precallrecord_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PreCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
-    }
-    VkResult result = DispatchCreateDebugReportCallbackEXT(layer_data, instance, pCreateInfo, pAllocator, pCallback);
-    result = layer_create_report_callback(layer_data->report_data, false, pCreateInfo, pAllocator, pCallback);
-    """ + postcallrecord_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PostCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, result);
-    }
-    return result;
-}
-
-VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
-                                                         const VkAllocationCallbacks *pAllocator) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
-    """ + precallvalidate_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PreCallValidateDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
-    }
-    """ + precallrecord_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PreCallRecordDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
-    }
-    DispatchDestroyDebugReportCallbackEXT(layer_data, instance, callback, pAllocator);
-    layer_destroy_report_callback(layer_data->report_data, callback, pAllocator);
-    """ + postcallrecord_loop + """
-        auto lock = intercept->write_lock();
-        intercept->PostCallRecordDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
-    }
 }"""
 
     inline_custom_source_postamble = """

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1582,9 +1582,17 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    // Provoke an error from the core_validation layer
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "Popbutton_T_Bumfuzzle");
     vkDestroyEvent(m_device->device(), event_handle, NULL);
     m_errorMonitor->VerifyFound();
+    vkQueueWaitIdle(m_device->m_queue);
+
+    // Provoke an error from the object tracker layer
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "Popbutton_T_Bumfuzzle");
+    vkDestroyEvent(m_device->device(), event_handle, NULL);
+    m_errorMonitor->VerifyFound();
+
     vkQueueWaitIdle(m_device->m_queue);
 }
 


### PR DESCRIPTION
Layer chassis ignored `DebugUtilsMessenger `callbacks.  Restored this capability for those layers, and added the special-cased `DebugReportCallback `functions to the code-gen'd pile.

Fixes #717.

