### PR TITLE
Fix validation for CreateXxxPipelines partial results

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5249,13 +5249,11 @@ void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipe
                                            // Default parameter
                                            create_graphics_pipeline_api_state *cgpl_state) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
-    if (result == VK_SUCCESS) {
-        for (uint32_t i = 0; i < count; i++) {
-            if (pPipelines[i] != VK_NULL_HANDLE) {
-                (cgpl_state->pipe_state)[i]->pipeline = pPipelines[i];
-                device_data->pipelineMap[pPipelines[i]] = std::move((cgpl_state->pipe_state)[i]);
-            }
+    // This API may create pipelines regardless of the return value
+    for (uint32_t i = 0; i < count; i++) {
+        if (pPipelines[i] != VK_NULL_HANDLE) {
+            (cgpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            device_data->pipelineMap[pPipelines[i]] = std::move((cgpl_state->pipe_state)[i]);
         }
     }
     // GPU val needs clean up regardless of result
@@ -5291,7 +5289,7 @@ void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipel
                                           std::vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
-    if (VK_SUCCESS != result) return;
+    // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
             (*pipe_state)[i]->pipeline = pPipelines[i];
@@ -5332,7 +5330,7 @@ void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache 
                                                vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
-    if (VK_SUCCESS != result) return;
+    // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
             (*pipe_state)[i]->pipeline = pPipelines[i];

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -695,6 +695,8 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                 object_dest = '%s[index]' % cmd_info[-1].name
 
             dispobj = params[0].find('type').text
+            if 'CreateGraphicsPipelines' in proto.text or 'CreateComputePipelines' in proto.text or 'CreateRayTracingPipelines' in proto.text:
+                create_obj_code += '%sif (!pPipelines[index]) continue;\n' % indent
             create_obj_code += '%sCreateObject(%s, %s, %s, %s);\n' % (indent, params[0].find('name').text, object_dest, self.GetVulkanObjType(cmd_info[-1].type), allocator)
             if object_array == True:
                 indent = self.decIndent(indent)
@@ -975,7 +977,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
 
                     if result_type.text == 'VkResult':
                         post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult                                    result)')
-                        post_cr_func_decl = post_cr_func_decl.replace('{', '{\n    if (result != VK_SUCCESS) return;')
+                        # The two createpipelines APIs may create on failure -- skip the success result check
+                        if 'CreateGraphicsPipelines' not in cmdname and 'CreateComputePipelines' not in cmdname and 'CreateRayTracingPipelines' not in cmdname:
+                            post_cr_func_decl = post_cr_func_decl.replace('{', '{\n    if (result != VK_SUCCESS) return;')
                     self.appendSection('command', post_cr_func_decl)
 
 


### PR DESCRIPTION
The three CreatePipelines APIs are perfectly happy returning less than _count_ number of pipelines objects.  Non-created array members will be set to NULL by the driver, so allow recording of only the created pipeline objects in object_tracker and core_validation.  Fixes crashes in these two CTS tests:

```
dEQP-VK.api.object_management.alloc_callback_fail_multiple.graphics_pipeline
dEQP-VK.api.object_management.alloc_callback_fail_multiple.compute_pipeline
```

Fixes #719.