### PR TITLE
gpu: Fix error codes to match implementation

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -645,10 +645,8 @@ For the *Uninitialized errors, one word will follow: Word0:DescriptorIndex
 
 | Error                       | Code | Word 0         | Word 1                |
 |-----------------------------|:----:|----------------|-----------------------|
-|ImageIndexOutOfBounds        |0     |Descriptor Index|Descriptor Array Length|
-|SampleIndexOutOfBounds       |1     |Descriptor Index|Descriptor Array Length|
-|ImageDescriptorUninitialized |2     |Descriptor Index|unused                 |
-|SampleDescriptorUninitialized|3     |Descriptor Index|unused                 |
+|IndexOutOfBounds             |0     |Descriptor Index|Descriptor Array Length|
+|DescriptorUninitialized      |1     |Descriptor Index|unused                 |
 
 So the words written for an image descriptor bounds error in a fragment shader is:
 

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -654,20 +654,11 @@ static void GenerateValidationMessage(const uint32_t *debug_record, std::string 
         case 0: {
             strm << "Index of " << debug_record[kInstBindlessOutDescIndex] << " used to index descriptor array of length "
                  << debug_record[kInstBindlessOutDescBound] << ". ";
-            vuid_msg = "UNASSIGNED-Image descriptor index out of bounds";
+            vuid_msg = "UNASSIGNED-Descriptor index out of bounds";
         } break;
         case 1: {
-            strm << "Index of " << debug_record[kInstBindlessOutDescIndex] << " used to index descriptor array of length "
-                 << debug_record[kInstBindlessOutDescBound] << ". ";
-            vuid_msg = "UNASSIGNED-Sampler index out of bounds";
-        } break;
-        case 2: {
             strm << "Descriptor index " << debug_record[kInstBindlessOutDescIndex] << " is uninitialized. ";
-            vuid_msg = "UNASSIGNED-Image descriptor uninitialized";
-        } break;
-        case 3: {
-            strm << "Descriptor index " << debug_record[kInstBindlessOutDescIndex] << " is uninitialized. ";
-            vuid_msg = "UNASSIGNED-Sampler descriptor uninitialized";
+            vuid_msg = "UNASSIGNED-Descriptor uninitialized";
         } break;
         default: {
             strm << "Internal Error (unexpected error type = " << debug_record[kInstValidationOutError] << "). ";


### PR DESCRIPTION
The spirv-tools implementation returns only 0 for out of bounds or 1 for descriptor uninitialized