### PR TITLE
docs: Make copyright internal to file

### DIFF
--- a/docs/core_validation_layer.md
+++ b/docs/core_validation_layer.md
@@ -1,11 +1,12 @@
 <!-- markdownlint-disable MD041 -->
+<!-- Copyright 2015-2019 LunarG, Inc. -->
+
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
 # VK\_LAYER\_LUNARG\_core\_validation
-Copyright &copy; 2015-2019 LunarG, Inc.
 
 [![Creative Commons][3]][4]
 

--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable MD041 -->
+<!-- Copyright 2015-2019 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
 # GPU-Assisted Validation
-Copyright &copy; 2015-2019 LunarG, Inc.
 
 [![Creative Commons][3]][4]
 

--- a/docs/object_tracker_layer.md
+++ b/docs/object_tracker_layer.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable MD041 -->
+<!-- Copyright 2015-2019 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
 # VK\_LAYER\_LUNARG\_object\_tracker
-Copyright &copy; 2015-2019 LunarG, Inc.
 
 [![Creative Commons][3]][4]
 

--- a/docs/parameter_validation_layer.md
+++ b/docs/parameter_validation_layer.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable MD041 -->
+<!-- Copyright 2015-2019 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
 # VK\_LAYER\_LUNARG\_parameter\_validation
-Copyright &copy; 2015-2019 LunarG, Inc.
 
 [![Creative Commons][3]][4]
 


### PR DESCRIPTION
As part of sdk rebranding, retain LunarG copyright information in file
internally.

(merged from PR 732-735)

