### PR TITLE
Add Ability to Change Debug Object Labels

### DIFF
--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -99,7 +99,7 @@ typedef struct _debug_report_data {
     void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
         std::unique_lock<std::mutex> lock(debug_report_mutex);
         if (pNameInfo->pObjectName) {
-            debugUtilsObjectNameMap.emplace(pNameInfo->objectHandle, pNameInfo->pObjectName);
+            debugUtilsObjectNameMap[pNameInfo->objectHandle] = pNameInfo->pObjectName;
         } else {
             debugUtilsObjectNameMap.erase(pNameInfo->objectHandle);
         }
@@ -108,7 +108,7 @@ typedef struct _debug_report_data {
     void DebugReportSetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
         std::unique_lock<std::mutex> lock(debug_report_mutex);
         if (pNameInfo->pObjectName) {
-            debugObjectNameMap.emplace(pNameInfo->object, pNameInfo->pObjectName);
+            debugObjectNameMap[pNameInfo->object] = pNameInfo->pObjectName;
         } else {
             debugObjectNameMap.erase(pNameInfo->object);
         }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1593,6 +1593,13 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     vkDestroyEvent(m_device->device(), event_handle, NULL);
     m_errorMonitor->VerifyFound();
 
+    // Change label for a given object, then provoke an error from core_validation and look for the new name
+    name_info.pObjectName = "A_Totally_Different_Name";
+    fpvkSetDebugUtilsObjectNameEXT(device(), &name_info);
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "A_Totally_Different_Name");
+    vkDestroyEvent(m_device->device(), event_handle, NULL);
+    m_errorMonitor->VerifyFound();
+
     vkQueueWaitIdle(m_device->m_queue);
 }
 


### PR DESCRIPTION
Spec says a debug label can be changed by calling a debug label API with an old handle and a new name, which was never implemented in the layers logging support.  Also added a test.

Fixes #737.