### PR TITLE
Move gpu assisted validation cleanup out of destructors

### DIFF
--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -43,18 +43,12 @@ class GpuDeviceMemoryManager {
         dev_data_ = dev_data;
     }
 
-    ~GpuDeviceMemoryManager() {
-        for (auto &chunk : chunk_list_) {
-            FreeMemoryChunk(chunk);
-        }
-        chunk_list_.clear();
-    }
-
     uint32_t GetBlockSize() { return block_size_; }
 
     VkResult GetBlock(GpuDeviceMemoryBlock *block);
     void PutBackBlock(VkBuffer buffer, VkDeviceMemory memory, uint32_t offset);
     void PutBackBlock(GpuDeviceMemoryBlock &block);
+    void FreeAllBlocks();
 
    private:
     // Define allocation granularity of Vulkan resources.
@@ -87,15 +81,9 @@ class GpuDescriptorSetManager {
    public:
     GpuDescriptorSetManager(layer_data *dev_data) { dev_data_ = dev_data; }
 
-    ~GpuDescriptorSetManager() {
-        for (auto &pool : desc_pool_map_) {
-            GetDispatchTable(dev_data_)->DestroyDescriptorPool(GetDevice(dev_data_), pool.first, NULL);
-        }
-        desc_pool_map_.clear();
-    }
-
     VkResult GetDescriptorSets(uint32_t count, VkDescriptorPool *pool, std::vector<VkDescriptorSet> *desc_sets);
     void PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDescriptorSet desc_set);
+    void DestroyDescriptorPools();
 
    private:
     static const uint32_t kItemsPerChunk = 512;


### PR DESCRIPTION
dEQP-VK.binding_model.descriptorset_random.sets32.runtimesize.
ubolimithigh.sbolimithigh.imglimithigh.iublimithigh.frag.0
and
dEQP-VK.binding_model.descriptorset_random.sets32.runtimesize.
ubolimithigh.sbolimithigh.imglimithigh.iublimithigh.vert.0

both have issues with destroy device happening before the memory
and descriptor set managers go out of scope, causing the validation
code to use an already destroyed device to free the resources

Change-Id: I536b3262f5ddd08fc7aabb6df94b3bb455dc633a