### PR TITLE
Prepare for core_validation conversion to layer chassis

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -34,6 +34,9 @@
 #include "vk_layer_logging.h"
 #include "vk_typemap_helper.h"
 
+#include "core_validation.h"
+#include "shader_validation.h"
+#include "descriptor_sets.h"
 #include "buffer_validation.h"
 
 namespace core_validation {

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1960,7 +1960,7 @@ static inline VkExtent3D GetScaledItg(layer_data *device_data, const GLOBAL_CB_N
     auto pPool = GetCommandPoolNode(device_data, cb_node->createInfo.commandPool);
     if (pPool) {
         granularity =
-            GetPhysDevProperties(device_data)->queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
+            GetPhysicalDeviceState(device_data)->queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
         if (FormatIsCompressed(img->createInfo.format)) {
             auto block_size = FormatTexelBlockExtent(img->createInfo.format);
             granularity.width *= block_size.width;
@@ -4922,7 +4922,8 @@ bool PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage 
     // Command pool must support graphics, compute, or transfer operations
     auto pPool = GetCommandPoolNode(device_data, cb_node->createInfo.commandPool);
 
-    VkQueueFlags queue_flags = GetPhysDevProperties(device_data)->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
+    VkQueueFlags queue_flags = GetPhysicalDeviceState(device_data)->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
+
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(cb_node->createInfo.commandPool), "VUID-vkCmdCopyImageToBuffer-commandBuffer-cmdpool",
@@ -5009,7 +5010,7 @@ bool PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer
 
     // Command pool must support graphics, compute, or transfer operations
     auto pPool = GetCommandPoolNode(device_data, cb_node->createInfo.commandPool);
-    VkQueueFlags queue_flags = GetPhysDevProperties(device_data)->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
+    VkQueueFlags queue_flags = GetPhysicalDeviceState(device_data)->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(cb_node->createInfo.commandPool), "VUID-vkCmdCopyBufferToImage-commandBuffer-cmdpool",

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -21,9 +21,6 @@
 #ifndef CORE_VALIDATION_BUFFER_VALIDATION_H_
 #define CORE_VALIDATION_BUFFER_VALIDATION_H_
 
-#include "core_validation.h"
-#include "shader_validation.h"
-#include "descriptor_sets.h"
 #include "vulkan/vk_layer.h"
 #include <limits.h>
 #include <memory>

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -971,43 +971,22 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(VkDevice device, const VkImageVie
 VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT *pCreateInfo,
                                                         const VkAllocationCallbacks *pAllocator,
                                                         VkValidationCacheEXT *pValidationCache) {
-    *pValidationCache = ValidationCache::Create(pCreateInfo);
-    return *pValidationCache ? VK_SUCCESS : VK_ERROR_INITIALIZATION_FAILED;
+    return CoreLayerCreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
 }
 
 VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
                                                      const VkAllocationCallbacks *pAllocator) {
-    delete (ValidationCache *)validationCache;
+    CoreLayerDestroyValidationCacheEXT(device, validationCache, pAllocator);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t *pDataSize,
                                                          void *pData) {
-    size_t inSize = *pDataSize;
-    ((ValidationCache *)validationCache)->Write(pDataSize, pData);
-    return (pData && *pDataSize != inSize) ? VK_INCOMPLETE : VK_SUCCESS;
+    return CoreLayerGetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
                                                         const VkValidationCacheEXT *pSrcCaches) {
-    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    bool skip = false;
-    auto dst = (ValidationCache *)dstCache;
-    auto src = (ValidationCache const *const *)pSrcCaches;
-    VkResult result = VK_SUCCESS;
-    for (uint32_t i = 0; i < srcCacheCount; i++) {
-        if (src[i] == dst) {
-            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT,
-                            0, "VUID-vkMergeValidationCachesEXT-dstCache-01536",
-                            "vkMergeValidationCachesEXT: dstCache (0x%" PRIx64 ") must not appear in pSrcCaches array.",
-                            HandleToUint64(dstCache));
-            result = VK_ERROR_VALIDATION_FAILED_EXT;
-        }
-        if (!skip) {
-            dst->Merge(src[i]);
-        }
-    }
-
-    return result;
+    return CoreLayerMergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches);
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -173,9 +173,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_data->physical_device = gpu;
     device_data->report_data = layer_debug_utils_create_device(instance_data->report_data, *pDevice);
     // Get physical device limits for this device
-    instance_data->dispatch_table.GetPhysicalDeviceProperties(gpu, &(device_data->phys_dev_properties.properties));
+    VkPhysicalDeviceProperties phys_dev_properties;
+    instance_data->dispatch_table.GetPhysicalDeviceProperties(gpu, &phys_dev_properties);
     // Setup the validation tables based on the application API version from the instance and the capabilities of the device driver.
-    uint32_t effective_api_version = std::min(device_data->phys_dev_properties.properties.apiVersion, instance_data->api_version);
+    uint32_t effective_api_version = std::min(phys_dev_properties.apiVersion, instance_data->api_version);
     device_data->api_version =
         device_data->extensions.InitFromDeviceCreateInfo(&instance_data->extensions, effective_api_version, pCreateInfo);
     PostCallRecordCreateDevice(gpu, pCreateInfo, pAllocator, pDevice, result);

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2800,33 +2800,21 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(VkInstance instance, VkDebugRep
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
                                                              VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    bool skip = false;
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    unique_lock_t lock(global_lock);
-    skip = PreCallValidateEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-    PreCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    lock.unlock();
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount,
                                                                                   pPhysicalDeviceGroupProperties);
-    lock.lock();
+    unique_lock_t lock(global_lock);
     PostCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     return result;
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     VkInstance instance, uint32_t *pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    bool skip = false;
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    unique_lock_t lock(global_lock);
 
-    skip = PreCallValidateEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-    lock.unlock();
-    PreCallRecordEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount,
                                                                                      pPhysicalDeviceGroupProperties);
-    lock.lock();
+    unique_lock_t lock(global_lock);
     PostCallRecordEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     return result;
 }

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2364,17 +2364,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(VkDevice device, const VkAcq
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
                                                         VkPhysicalDevice *pPhysicalDevices) {
-    bool skip = false;
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
     assert(instance_data);
 
-    unique_lock_t lock(global_lock);
-    skip |= PreCallValidateEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-    PreCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-    lock.unlock();
     VkResult result = instance_data->dispatch_table.EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-    lock.lock();
+    unique_lock_t lock(global_lock);
     PostCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, result);
     return result;
 }

--- a/layers/core_dispatch.cpp
+++ b/layers/core_dispatch.cpp
@@ -2357,15 +2357,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(VkPhysicalDevice physical
                                                        VkPhysicalDeviceProperties *pPhysicalDeviceProperties) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), instance_layer_data_map);
     instance_data->dispatch_table.GetPhysicalDeviceProperties(physicalDevice, pPhysicalDeviceProperties);
-    if (instance_data->enabled.gpu_validation && instance_data->enabled.gpu_validation_reserve_binding_slot) {
-        if (pPhysicalDeviceProperties->limits.maxBoundDescriptorSets > 1) {
-            pPhysicalDeviceProperties->limits.maxBoundDescriptorSets -= 1;
-        } else {
-            log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                    HandleToUint64(physicalDevice), "UNASSIGNED-GPU-Assisted Validation Setup Error.",
-                    "Unable to reserve descriptor binding slot on a device with only one slot.");
-        }
-    }
+    unique_lock_t lock(global_lock);
+    PostCallRecordGetPhysicalDeviceProperties(physicalDevice, pPhysicalDeviceProperties);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13472,6 +13472,20 @@ bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDev
     return skip;
 }
 
+void PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
+                                               VkPhysicalDeviceProperties *pPhysicalDeviceProperties) {
+    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), instance_layer_data_map);
+    if (instance_data->enabled.gpu_validation && instance_data->enabled.gpu_validation_reserve_binding_slot) {
+        if (pPhysicalDeviceProperties->limits.maxBoundDescriptorSets > 1) {
+            pPhysicalDeviceProperties->limits.maxBoundDescriptorSets -= 1;
+        } else {
+            log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
+                    HandleToUint64(physicalDevice), "UNASSIGNED-GPU-Assisted Validation Setup Error.",
+                    "Unable to reserve descriptor binding slot on a device with only one slot.");
+        }
+    }
+}
+
 VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkValidationCacheEXT *pValidationCache) {
     *pValidationCache = ValidationCache::Create(pCreateInfo);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -263,6 +263,24 @@ PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(instance_layer_data *instance_data
     return &it->second;
 }
 
+PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(const layer_data *device_data) {
+    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(device_data->physical_device), instance_layer_data_map);
+    auto it = instance_data->physical_device_map.find(device_data->physical_device);
+    if (it == instance_data->physical_device_map.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(layer_data *device_data) {
+    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(device_data->physical_device), instance_layer_data_map);
+    auto it = instance_data->physical_device_map.find(device_data->physical_device);
+    if (it == instance_data->physical_device_map.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
 SURFACE_STATE *GetSurfaceState(instance_layer_data *instance_data, VkSurfaceKHR surface) {
     auto it = instance_data->surface_map.find(surface);
     if (it == instance_data->surface_map.end()) {
@@ -1857,7 +1875,7 @@ bool ValidateCmdQueueFlags(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, 
                            VkQueueFlags required_flags, const char *error_code) {
     auto pool = GetCommandPoolNode(dev_data, cb_node->createInfo.commandPool);
     if (pool) {
-        VkQueueFlags queue_flags = dev_data->phys_dev_properties.queue_family_properties[pool->queueFamilyIndex].queueFlags;
+        VkQueueFlags queue_flags = GetPhysicalDeviceState(dev_data)->queue_family_properties[pool->queueFamilyIndex].queueFlags;
         if (!(required_flags & queue_flags)) {
             string required_flags_string;
             for (auto flag : {VK_QUEUE_TRANSFER_BIT, VK_QUEUE_GRAPHICS_BIT, VK_QUEUE_COMPUTE_BIT}) {
@@ -2437,11 +2455,14 @@ void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *
         device_data->enabled_features.core = *enabled_features_found;
     }
 
+    // Make sure that queue_family_properties are obtained for this device's physical_device, even if the app has not
+    // previously set them through an explicit API call.
     uint32_t count;
+    auto pd_state = GetPhysicalDeviceState(instance_data, gpu);
     instance_data->dispatch_table.GetPhysicalDeviceQueueFamilyProperties(gpu, &count, nullptr);
-    device_data->phys_dev_properties.queue_family_properties.resize(count);
-    instance_data->dispatch_table.GetPhysicalDeviceQueueFamilyProperties(
-        gpu, &count, &device_data->phys_dev_properties.queue_family_properties[0]);
+    pd_state->queue_family_count = std::max(pd_state->queue_family_count, count);
+    pd_state->queue_family_properties.resize(std::max(static_cast<uint32_t>(pd_state->queue_family_properties.size()), count));
+    instance_data->dispatch_table.GetPhysicalDeviceQueueFamilyProperties(gpu, &count, &pd_state->queue_family_properties[0]);
 
     const auto *device_group_ci = lvl_find_in_chain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);
     device_data->physical_device_count =
@@ -7098,7 +7119,7 @@ bool ValidatePipelineBindPoint(layer_data *device_data, GLOBAL_CB_NODE *cb_state
             std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_NV,
                            static_cast<VkQueueFlags>(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)),
         };
-        const auto &qfp = GetPhysDevProperties(device_data)->queue_family_properties[pool->queueFamilyIndex];
+        const auto &qfp = GetPhysicalDeviceState(device_data)->queue_family_properties[pool->queueFamilyIndex];
         if (0 == (qfp.queueFlags & flag_mask.at(bind_point))) {
             const std::string &error = bind_errors.at(bind_point);
             auto cb_u64 = HandleToUint64(cb_state->commandBuffer);
@@ -8121,7 +8142,7 @@ class ValidatorState {
           sharing_mode_(sharing_mode),
           object_type_(object_type),
           val_codes_(val_codes),
-          limit_(static_cast<uint32_t>(device_data->phys_dev_properties.queue_family_properties.size())),
+          limit_(static_cast<uint32_t>(GetPhysicalDeviceState(device_data)->queue_family_properties.size())),
           mem_ext_(device_data->extensions.vk_khr_external_memory) {}
 
     // Create a validator state from an image state... reducing the image specific to the generic version.

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5319,15 +5319,16 @@ void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipel
 bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                 const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
+                                                void *pipe_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
-
     // The order of operations here is a little convoluted but gets the job done
     //  1. Pipeline create state is first shadowed into PIPELINE_STATE struct
     //  2. Create state is then validated (which uses flags setup during shadowing)
     //  3. If everything looks good, we'll then create the pipeline and add NODE to pipelineMap
     uint32_t i = 0;
+    vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
+        reinterpret_cast<vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
     pipe_state->reserve(count);
     for (i = 0; i < count; i++) {
         pipe_state->push_back(std::unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
@@ -5345,9 +5346,10 @@ bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache
 void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, VkResult result,
-                                               vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
+                                               void *pipe_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
+    vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
+        reinterpret_cast<vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5216,13 +5216,12 @@ static bool ValidatePipelineVertexDivisors(layer_data *dev_data, vector<std::uni
 bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                             const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                            // Default parameter
-                                            create_graphics_pipeline_api_state *cgpl_state) {
+                                            void *cgpl_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
     bool skip = false;
+    create_graphics_pipeline_api_state *cgpl_state = reinterpret_cast<create_graphics_pipeline_api_state *>(cgpl_state_data);
     cgpl_state->pipe_state.reserve(count);
-    // TODO - State changes and validation need to be untangled here -- potentially a performance issue
     for (uint32_t i = 0; i < count; i++) {
         cgpl_state->pipe_state.push_back(std::unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
         (cgpl_state->pipe_state)[i]->initGraphicsPipeline(&pCreateInfos[i],
@@ -5248,10 +5247,9 @@ bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pip
 // GPU validation may replace pCreateInfos for the down-chain call
 void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                           const VkGraphicsPipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                          VkPipeline *pPipelines,
-                                          // Default parameter
-                                          create_graphics_pipeline_api_state *cgpl_state) {
+                                          VkPipeline *pPipelines, void *cgpl_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    create_graphics_pipeline_api_state *cgpl_state = reinterpret_cast<create_graphics_pipeline_api_state *>(cgpl_state_data);
     cgpl_state->pCreateInfos = pCreateInfos;
     // GPU Validation may replace instrumented shaders with non-instrumented ones, so allow it to modify the createinfos.
     if (GetEnables(device_data)->gpu_validation) {
@@ -5264,9 +5262,9 @@ void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipel
 void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                            const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                            const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, VkResult result,
-                                           // Default parameter
-                                           create_graphics_pipeline_api_state *cgpl_state) {
+                                           void *cgpl_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    create_graphics_pipeline_api_state *cgpl_state = reinterpret_cast<create_graphics_pipeline_api_state *>(cgpl_state_data);
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12760,53 +12760,9 @@ void PostCallDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCal
     layer_destroy_report_callback(instance_data->report_data, msgCallback, pAllocator);
 }
 
-static bool ValidateEnumeratePhysicalDeviceGroups(instance_layer_data *instance_data, uint32_t *pPhysicalDeviceGroupCount,
-                                                  VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties,
-                                                  const char *func_name) {
-    bool skip = false;
-
-    // For this instance, flag when EnumeratePhysicalDeviceGroups goes to QUERY_COUNT and then QUERY_DETAILS.
-    if (NULL != pPhysicalDeviceGroupProperties) {
-        if (UNCALLED == instance_data->vkEnumeratePhysicalDeviceGroupsState) {
-            // Flag warning here. You can call this without having queried the count, but it may not be
-            // robust on platforms with multiple physical devices.
-            skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,
-                            0, kVUID_Core_DevLimit_MissingQueryCount,
-                            "Call sequence has vkEnumeratePhysicalDeviceGroups() w/ non-NULL "
-                            "pPhysicalDeviceGroupProperties. You should first call %s w/ "
-                            "NULL pPhysicalDeviceGroupProperties to query pPhysicalDeviceGroupCount.",
-                            func_name);
-        }  // TODO : Could also flag a warning if re-calling this function in QUERY_DETAILS state
-        else if (instance_data->physical_device_groups_count != *pPhysicalDeviceGroupCount) {
-            // Having actual count match count from app is not a requirement, so this can be a warning
-            skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                            VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, kVUID_Core_DevLimit_CountMismatch,
-                            "Call to %s w/ pPhysicalDeviceGroupCount value %u, but actual count "
-                            "supported by this instance is %u.",
-                            func_name, *pPhysicalDeviceGroupCount, instance_data->physical_device_groups_count);
-        }
-    }
-
-    return skip;
-}
-
-static void PreRecordEnumeratePhysicalDeviceGroupsState(instance_layer_data *instance_data,
-                                                        VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    if (instance_data) {
-        // For this instance, flag when EnumeratePhysicalDeviceGroups goes to QUERY_COUNT and then QUERY_DETAILS.
-        if (NULL == pPhysicalDeviceGroupProperties) {
-            instance_data->vkEnumeratePhysicalDeviceGroupsState = QUERY_COUNT;
-        } else {
-            instance_data->vkEnumeratePhysicalDeviceGroupsState = QUERY_DETAILS;
-        }
-    }
-}
-
 static void PostRecordEnumeratePhysicalDeviceGroupsState(instance_layer_data *instance_data, uint32_t *pPhysicalDeviceGroupCount,
                                                          VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    if (NULL == pPhysicalDeviceGroupProperties) {
-        instance_data->physical_device_groups_count = *pPhysicalDeviceGroupCount;
-    } else {  // Save physical devices
+    if (NULL != pPhysicalDeviceGroupProperties) {
         for (uint32_t i = 0; i < *pPhysicalDeviceGroupCount; i++) {
             for (uint32_t j = 0; j < pPhysicalDeviceGroupProperties[i].physicalDeviceCount; j++) {
                 VkPhysicalDevice cur_phys_dev = pPhysicalDeviceGroupProperties[i].physicalDevices[j];
@@ -12819,17 +12775,6 @@ static void PostRecordEnumeratePhysicalDeviceGroupsState(instance_layer_data *in
     }
 }
 
-bool PreCallValidateEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
-                                                  VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    return ValidateEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties,
-                                                 "vkEnumeratePhysicalDeviceGroups()");
-}
-void PreCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
-                                                VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    PreRecordEnumeratePhysicalDeviceGroupsState(instance_data, pPhysicalDeviceGroupProperties);
-}
 void PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
                                                  VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties,
                                                  VkResult result) {
@@ -12838,17 +12783,6 @@ void PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *
     PostRecordEnumeratePhysicalDeviceGroupsState(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
 }
 
-bool PreCallValidateEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
-                                                     VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    return ValidateEnumeratePhysicalDeviceGroups(instance_data, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties,
-                                                 "vkEnumeratePhysicalDeviceGroupsKHR()");
-}
-void PreCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
-                                                   VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    PreRecordEnumeratePhysicalDeviceGroupsState(instance_data, pPhysicalDeviceGroupProperties);
-}
 void PostCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
                                                     VkPhysicalDeviceGroupPropertiesKHR *pPhysicalDeviceGroupProperties,
                                                     VkResult result) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3747,11 +3747,11 @@ bool PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *
                                    const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
-    if (device_data->memObjMap.size() >= device_data->phys_dev_properties.properties.limits.maxMemoryAllocationCount) {
+    if (device_data->memObjMap.size() >= device_data->phys_dev_props.limits.maxMemoryAllocationCount) {
         skip |= log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
                         HandleToUint64(device), kVUIDUndefined,
                         "Number of currently valid memory objects is not less than the maximum allowed (%u).",
-                        device_data->phys_dev_properties.properties.limits.maxMemoryAllocationCount);
+                        device_data->phys_dev_props.limits.maxMemoryAllocationCount);
     }
 
     if (GetDeviceExtensions(device_data)->vk_android_external_memory_android_hardware_buffer) {
@@ -3900,11 +3900,10 @@ static void InitializeAndTrackMemory(layer_data *dev_data, VkDeviceMemory mem, V
             if (size == VK_WHOLE_SIZE) {
                 size = mem_info->alloc_info.allocationSize - offset;
             }
-            mem_info->shadow_pad_size = dev_data->phys_dev_properties.properties.limits.minMemoryMapAlignment;
-            assert(SafeModulo(mem_info->shadow_pad_size, dev_data->phys_dev_properties.properties.limits.minMemoryMapAlignment) ==
-                   0);
+            mem_info->shadow_pad_size = dev_data->phys_dev_props.limits.minMemoryMapAlignment;
+            assert(SafeModulo(mem_info->shadow_pad_size, dev_data->phys_dev_props.limits.minMemoryMapAlignment) == 0);
             // Ensure start of mapped region reflects hardware alignment constraints
-            uint64_t map_alignment = dev_data->phys_dev_properties.properties.limits.minMemoryMapAlignment;
+            uint64_t map_alignment = dev_data->phys_dev_props.limits.minMemoryMapAlignment;
 
             // From spec: (ppData - offset) must be aligned to at least limits::minMemoryMapAlignment.
             uint64_t start_offset = offset % map_alignment;
@@ -4225,7 +4224,7 @@ static bool RangesIntersect(layer_data const *dev_data, MEMORY_RANGE const *rang
     auto r2_end = range2->end;
     VkDeviceSize pad_align = 1;
     if (range1->linear != range2->linear) {
-        pad_align = dev_data->phys_dev_properties.properties.limits.bufferImageGranularity;
+        pad_align = dev_data->phys_dev_props.limits.bufferImageGranularity;
     }
     if ((r1_end & ~(pad_align - 1)) < (r2_start & ~(pad_align - 1))) return false;
     if ((r1_start & ~(pad_align - 1)) > (r2_end & ~(pad_align - 1))) return false;
@@ -5096,8 +5095,6 @@ std::unordered_map<VkImageView, std::unique_ptr<IMAGE_VIEW_STATE>> *GetImageView
     return &device_data->imageViewMap;
 }
 
-const PHYS_DEV_PROPERTIES_NODE *GetPhysDevProperties(const layer_data *device_data) { return &device_data->phys_dev_properties; }
-
 const DeviceFeatures *GetEnabledFeatures(const layer_data *device_data) { return &device_data->enabled_features; }
 
 const DeviceExtensions *GetDeviceExtensions(const layer_data *device_data) { return &device_data->extensions; }
@@ -5391,7 +5388,7 @@ void PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptor
 static bool ValidatePushConstantRange(const layer_data *dev_data, const uint32_t offset, const uint32_t size,
                                       const char *caller_name, uint32_t index = 0) {
     if (dev_data->instance_data->disabled.push_constant_range) return false;
-    uint32_t const maxPushConstantsSize = dev_data->phys_dev_properties.properties.limits.maxPushConstantsSize;
+    uint32_t const maxPushConstantsSize = dev_data->phys_dev_props.limits.maxPushConstantsSize;
     bool skip = false;
     // Check that offset + size don't exceed the max.
     // Prevent arithetic overflow here by avoiding addition and testing in this order.
@@ -7069,7 +7066,7 @@ bool PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipel
                     uint32_t cur_dyn_offset = total_dynamic_descriptors;
                     const auto dsl = descriptor_set->GetLayout();
                     const auto binding_count = dsl->GetBindingCount();
-                    const auto &limits = device_data->phys_dev_properties.properties.limits;
+                    const auto &limits = device_data->phys_dev_props.limits;
                     for (uint32_t binding_idx = 0; binding_idx < binding_count; binding_idx++) {
                         const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
                         skip |= ValidateDynamicOffsetAlignment(device_data->report_data, binding,
@@ -9095,26 +9092,26 @@ static bool ValidateFramebufferCreateInfo(layer_data *dev_data, const VkFramebuf
         }
     }
     // Verify FB dimensions are within physical device limits
-    if (pCreateInfo->width > dev_data->phys_dev_properties.properties.limits.maxFramebufferWidth) {
+    if (pCreateInfo->width > dev_data->phys_dev_props.limits.maxFramebufferWidth) {
         skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         "VUID-VkFramebufferCreateInfo-width-00886",
                         "vkCreateFramebuffer(): Requested VkFramebufferCreateInfo width exceeds physical device limits. Requested "
                         "width: %u, device max: %u\n",
-                        pCreateInfo->width, dev_data->phys_dev_properties.properties.limits.maxFramebufferWidth);
+                        pCreateInfo->width, dev_data->phys_dev_props.limits.maxFramebufferWidth);
     }
-    if (pCreateInfo->height > dev_data->phys_dev_properties.properties.limits.maxFramebufferHeight) {
+    if (pCreateInfo->height > dev_data->phys_dev_props.limits.maxFramebufferHeight) {
         skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         "VUID-VkFramebufferCreateInfo-height-00888",
                         "vkCreateFramebuffer(): Requested VkFramebufferCreateInfo height exceeds physical device limits. Requested "
                         "height: %u, device max: %u\n",
-                        pCreateInfo->height, dev_data->phys_dev_properties.properties.limits.maxFramebufferHeight);
+                        pCreateInfo->height, dev_data->phys_dev_props.limits.maxFramebufferHeight);
     }
-    if (pCreateInfo->layers > dev_data->phys_dev_properties.properties.limits.maxFramebufferLayers) {
+    if (pCreateInfo->layers > dev_data->phys_dev_props.limits.maxFramebufferLayers) {
         skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         "VUID-VkFramebufferCreateInfo-layers-00890",
                         "vkCreateFramebuffer(): Requested VkFramebufferCreateInfo layers exceeds physical device limits. Requested "
                         "layers: %u, device max: %u\n",
-                        pCreateInfo->layers, dev_data->phys_dev_properties.properties.limits.maxFramebufferLayers);
+                        pCreateInfo->layers, dev_data->phys_dev_props.limits.maxFramebufferLayers);
     }
     // Verify FB dimensions are greater than zero
     if (pCreateInfo->width <= 0) {
@@ -10904,7 +10901,7 @@ static bool ValidateMappedMemoryRangeDeviceLimits(layer_data *dev_data, const ch
                                                   const VkMappedMemoryRange *mem_ranges) {
     bool skip = false;
     for (uint32_t i = 0; i < mem_range_count; ++i) {
-        uint64_t atom_size = dev_data->phys_dev_properties.properties.limits.nonCoherentAtomSize;
+        uint64_t atom_size = dev_data->phys_dev_props.limits.nonCoherentAtomSize;
         if (SafeModulo(mem_ranges[i].offset, atom_size) != 0) {
             skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT,
                             HandleToUint64(mem_ranges->memory), "VUID-VkMappedMemoryRange-offset-00687",

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6174,25 +6174,27 @@ void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descrip
 // an allocation request. Fills common_data with the total number of descriptors of each type required,
 // as well as DescriptorSetLayout ptrs used for later update.
 bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                           VkDescriptorSet *pDescriptorSets,
-                                           cvdescriptorset::AllocateDescriptorSetsData *common_data) {
+                                           VkDescriptorSet *pDescriptorSets, void *ads_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
 
     // Always update common data
-    cvdescriptorset::UpdateAllocateDescriptorSetsData(device_data, pAllocateInfo, common_data);
+    cvdescriptorset::AllocateDescriptorSetsData *ads_state =
+        reinterpret_cast<cvdescriptorset::AllocateDescriptorSetsData *>(ads_state_data);
+    cvdescriptorset::UpdateAllocateDescriptorSetsData(device_data, pAllocateInfo, ads_state);
     if (device_data->instance_data->disabled.allocate_descriptor_sets) return false;
     // All state checks for AllocateDescriptorSets is done in single function
-    return cvdescriptorset::ValidateAllocateDescriptorSets(device_data, pAllocateInfo, common_data);
+    return cvdescriptorset::ValidateAllocateDescriptorSets(device_data, pAllocateInfo, ads_state);
 }
 
 // Allocation state was good and call down chain was made so update state based on allocating descriptor sets
 void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                          VkDescriptorSet *pDescriptorSets, VkResult result,
-                                          cvdescriptorset::AllocateDescriptorSetsData *common_data) {
+                                          VkDescriptorSet *pDescriptorSets, VkResult result, void *ads_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (VK_SUCCESS != result) return;
     // All the updates are contained in a single cvdescriptorset function
-    cvdescriptorset::PerformAllocateDescriptorSets(pAllocateInfo, pDescriptorSets, common_data, &device_data->descriptorPoolMap,
+    cvdescriptorset::AllocateDescriptorSetsData *ads_state =
+        reinterpret_cast<cvdescriptorset::AllocateDescriptorSetsData *>(ads_state_data);
+    cvdescriptorset::PerformAllocateDescriptorSets(pAllocateInfo, pDescriptorSets, ads_state, &device_data->descriptorPoolMap,
                                                    &device_data->setMap, device_data);
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13472,4 +13472,44 @@ bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDev
     return skip;
 }
 
+VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT *pCreateInfo,
+                                           const VkAllocationCallbacks *pAllocator, VkValidationCacheEXT *pValidationCache) {
+    *pValidationCache = ValidationCache::Create(pCreateInfo);
+    return *pValidationCache ? VK_SUCCESS : VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
+                                        const VkAllocationCallbacks *pAllocator) {
+    delete (ValidationCache *)validationCache;
+}
+
+VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t *pDataSize, void *pData) {
+    size_t inSize = *pDataSize;
+    ((ValidationCache *)validationCache)->Write(pDataSize, pData);
+    return (pData && *pDataSize != inSize) ? VK_INCOMPLETE : VK_SUCCESS;
+}
+
+VkResult CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
+                                           const VkValidationCacheEXT *pSrcCaches) {
+    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    bool skip = false;
+    auto dst = (ValidationCache *)dstCache;
+    auto src = (ValidationCache const *const *)pSrcCaches;
+    VkResult result = VK_SUCCESS;
+    for (uint32_t i = 0; i < srcCacheCount; i++) {
+        if (src[i] == dst) {
+            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT,
+                            0, "VUID-vkMergeValidationCachesEXT-dstCache-01536",
+                            "vkMergeValidationCachesEXT: dstCache (0x%" PRIx64 ") must not appear in pSrcCaches array.",
+                            HandleToUint64(dstCache));
+            result = VK_ERROR_VALIDATION_FAILED_EXT;
+        }
+        if (!skip) {
+            dst->Merge(src[i]);
+        }
+    }
+
+    return result;
+}
+
 }  // namespace core_validation

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6082,8 +6082,9 @@ static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const Pus
 
 void PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                        const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
-                                       create_pipeline_layout_api_state *cpl_state) {
+                                       void *cpl_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    create_pipeline_layout_api_state *cpl_state = reinterpret_cast<create_pipeline_layout_api_state *>(cpl_state_data);
     if (GetEnables(device_data)->gpu_validation) {
         GpuPreCallCreatePipelineLayout(device_data, pCreateInfo, pAllocator, pPipelineLayout, &cpl_state->new_layouts,
                                        &cpl_state->modified_create_info);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5282,10 +5282,11 @@ void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipe
 
 bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                            const VkComputePipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                           VkPipeline *pPipelines, std::vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
+                                           VkPipeline *pPipelines, void *pipe_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-
     bool skip = false;
+    std::vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
+        reinterpret_cast<std::vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
     pipe_state->reserve(count);
     for (uint32_t i = 0; i < count; i++) {
         // Create and initialize internal tracking data structure
@@ -5301,9 +5302,10 @@ bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipe
 
 void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                           const VkComputePipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                          VkPipeline *pPipelines, VkResult result,
-                                          std::vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state) {
+                                          VkPipeline *pPipelines, VkResult result, void *pipe_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    std::vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
+        reinterpret_cast<std::vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
 
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12289,42 +12289,10 @@ void PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImag
                                 pAcquireInfo->fence, pImageIndex);
 }
 
-bool PreCallValidateEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
-                                             VkPhysicalDevice *pPhysicalDevices) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    if (!pPhysicalDevices) return false;
-    bool skip = false;
-    if (UNCALLED == instance_data->vkEnumeratePhysicalDevicesState) {
-        // Flag warning here. You can call this without having queried the count, but it may not be
-        // robust on platforms with multiple physical devices.
-        skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, 0,
-                        kVUID_Core_DevLimit_MissingQueryCount,
-                        "Call sequence has vkEnumeratePhysicalDevices() w/ non-NULL pPhysicalDevices. You should first call "
-                        "vkEnumeratePhysicalDevices() w/ NULL pPhysicalDevices to query pPhysicalDeviceCount.");
-    }  // TODO : Could also flag a warning if re-calling this function in QUERY_DETAILS state
-    else if (instance_data->physical_devices_count != *pPhysicalDeviceCount) {
-        // Having actual count match count from app is not a requirement, so this can be a warning
-        skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                        VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, kVUID_Core_DevLimit_CountMismatch,
-                        "Call to vkEnumeratePhysicalDevices() w/ pPhysicalDeviceCount value %u, but actual count supported by "
-                        "this instance is %u.",
-                        *pPhysicalDeviceCount, instance_data->physical_devices_count);
-    }
-    return skip;
-}
-
-void PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
-                                           VkPhysicalDevice *pPhysicalDevices) {
-    instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    instance_data->vkEnumeratePhysicalDevicesState = QUERY_COUNT;
-}
-
 void PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices,
                                             VkResult result) {
     instance_layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(instance), instance_layer_data_map);
-    if (NULL == pPhysicalDevices) {
-        instance_data->physical_devices_count = *pPhysicalDeviceCount;
-    } else if (result == VK_SUCCESS || result == VK_INCOMPLETE) {  // Save physical devices
+    if ((NULL != pPhysicalDevices) && ((result == VK_SUCCESS || result == VK_INCOMPLETE))) {
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
             auto &phys_device_state = instance_data->physical_device_map[pPhysicalDevices[i]];
             phys_device_state.phys_device = pPhysicalDevices[i];

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -249,6 +249,12 @@ struct layer_data {
     // Map for queue family index to queue count
     unordered_map<uint32_t, uint32_t> queue_family_index_map;
 
+    // Used for instance versions of this object
+    unordered_map<VkPhysicalDevice, PHYSICAL_DEVICE_STATE> physical_device_map;
+    unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
+    CHECK_DISABLED disabled = {};
+    CHECK_ENABLED enabled = {};
+
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -199,8 +199,6 @@ struct instance_layer_data {
     std::vector<VkDebugUtilsMessengerEXT> logging_messenger;
     VkLayerInstanceDispatchTable dispatch_table;
 
-    CALL_STATE vkEnumeratePhysicalDeviceGroupsState = UNCALLED;
-    uint32_t physical_device_groups_count = 0;
     CHECK_DISABLED disabled = {};
     CHECK_ENABLED enabled = {};
 
@@ -1892,17 +1890,9 @@ void PostCallRecordCreateDebugReportCallbackEXT(VkInstance instance, const VkDeb
                                                 VkResult result);
 void PostCallDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT msgCallback,
                                            const VkAllocationCallbacks* pAllocator);
-bool PreCallValidateEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
-                                                  VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-void PreCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
-                                                VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
 void PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                  VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties,
                                                  VkResult result);
-bool PreCallValidateEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
-                                                     VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-void PreCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
-                                                   VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
 void PostCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                     VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties,
                                                     VkResult result);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1426,13 +1426,11 @@ void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSet
                                           cvdescriptorset::AllocateDescriptorSetsData* common_data);
 bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
-                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
+                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* pipe_state);
 void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
-                                               vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
-
+                                               void* pipe_state);
 bool ValidateQueueFamilies(layer_data* device_data, uint32_t queue_family_count, const uint32_t* queue_families,
                            const char* cmd_name, const char* array_parameter_name, const char* unique_error_code,
                            const char* valid_error_code, bool optional);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -262,7 +262,6 @@ struct layer_data {
 
     DeviceFeatures enabled_features = {};
     // Device specific data
-    PHYS_DEV_PROPERTIES_NODE phys_dev_properties = {};
     VkPhysicalDeviceMemoryProperties phys_dev_mem_props = {};
     VkPhysicalDeviceProperties phys_dev_props = {};
     // Device extension properties -- storing properties gathered from VkPhysicalDeviceProperties2KHR::pNext chain

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1406,14 +1406,10 @@ void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipe
                                            void* cgpl_state);
 bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                            const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-                                           VkPipeline* pPipelines,
-                                           // Default parameter
-                                           std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
+                                           VkPipeline* pPipelines, void* pipe_state);
 void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                           const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-                                          VkPipeline* pPipelines, VkResult result,
-                                          // Default parameter
-                                          std::vector<std::unique_ptr<PIPELINE_STATE>>* pipe_state);
+                                          VkPipeline* pPipelines, VkResult result, void* pipe_state);
 bool PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout);
 void PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1381,6 +1381,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(VkInstance instance
 using std::vector;
 SURFACE_STATE* GetSurfaceState(instance_layer_data* instance_data, VkSurfaceKHR surface);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data, VkPhysicalDevice phys);
+PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(const layer_data* device_data);
+PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(layer_data* device_data);
 
 bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                             const VkGraphicsPipelineCreateInfo* pCreateInfos,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1985,6 +1985,8 @@ void PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcr
 void PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                     const VkAllocationCallbacks* pAllocator);
 bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
+void PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
+                                               VkPhysicalDeviceProperties* pPhysicalDeviceProperties);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
                                                        VkAndroidHardwareBufferPropertiesANDROID* pProperties);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1396,19 +1396,14 @@ VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEX
 
 bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                             const VkGraphicsPipelineCreateInfo* pCreateInfos,
-                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                            // Default parameter
-                                            create_graphics_pipeline_api_state* cgpl_state);
+                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* cgpl_state);
 void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                           const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-                                          VkPipeline* pPipelines,
-                                          // Default parameter
-                                          create_graphics_pipeline_api_state* cgpl_state);
+                                          VkPipeline* pPipelines, void* cgpl_state);
 void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                            const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result,
-                                           // Default parameter
-                                           create_graphics_pipeline_api_state* cgpl_state);
+                                           void* cgpl_state);
 bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                            const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
                                            VkPipeline* pPipelines,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1413,8 +1413,7 @@ void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipel
 bool PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout);
 void PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
-                                       const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
-                                       create_pipeline_layout_api_state* cpl_state);
+                                       const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout, void* cpl_state);
 void PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                         VkResult result);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1418,11 +1418,9 @@ void PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutC
                                         const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                         VkResult result);
 bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                           VkDescriptorSet* pDescriptorSets,
-                                           cvdescriptorset::AllocateDescriptorSetsData* common_data);
+                                           VkDescriptorSet* pDescriptorSets, void* ads_state);
 void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                          VkDescriptorSet* pDescriptorSets, VkResult result,
-                                          cvdescriptorset::AllocateDescriptorSetsData* common_data);
+                                          VkDescriptorSet* pDescriptorSets, VkResult result, void* ads_state);
 bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* pipe_state);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1383,6 +1383,17 @@ PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(instance_layer_data* instance_data
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(const layer_data* device_data);
 PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(layer_data* device_data);
 
+VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);
+
+void CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
+                                        const VkAllocationCallbacks* pAllocator);
+
+VkResult CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
+                                           const VkValidationCacheEXT* pSrcCaches);
+
+VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData);
+
 bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                             const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -199,8 +199,6 @@ struct instance_layer_data {
     std::vector<VkDebugUtilsMessengerEXT> logging_messenger;
     VkLayerInstanceDispatchTable dispatch_table;
 
-    CALL_STATE vkEnumeratePhysicalDevicesState = UNCALLED;
-    uint32_t physical_devices_count = 0;
     CALL_STATE vkEnumeratePhysicalDeviceGroupsState = UNCALLED;
     uint32_t physical_device_groups_count = 0;
     CHECK_DISABLED disabled = {};
@@ -1837,9 +1835,6 @@ void PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain
                                        VkFence fence, uint32_t* pImageIndex, VkResult result);
 void PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex,
                                         VkResult result);
-bool PreCallValidateEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
-                                             VkPhysicalDevice* pPhysicalDevices);
-void PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount, VkPhysicalDevice* pPhysicalDevices);
 void PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount, VkPhysicalDevice* pPhysicalDevices,
                                             VkResult result);
 bool PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -123,7 +123,6 @@ struct hash<VK_OBJECT> {
 class PHYS_DEV_PROPERTIES_NODE {
    public:
     VkPhysicalDeviceProperties properties;
-    std::vector<VkQueueFamilyProperties> queue_family_properties;
 };
 
 // Flags describing requirements imposed by the pipeline on a descriptor. These

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -120,11 +120,6 @@ struct hash<VK_OBJECT> {
 };
 }  // namespace std
 
-class PHYS_DEV_PROPERTIES_NODE {
-   public:
-    VkPhysicalDeviceProperties properties;
-};
-
 // Flags describing requirements imposed by the pipeline on a descriptor. These
 // can't be checked at pipeline creation time as they depend on the Image or
 // ImageView bound.
@@ -1220,7 +1215,6 @@ std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(layer_data const 
 FRAMEBUFFER_STATE *GetFramebufferState(const layer_data *my_data, VkFramebuffer framebuffer);
 COMMAND_POOL_NODE *GetCommandPoolNode(layer_data *dev_data, VkCommandPool pool);
 shader_module const *GetShaderModuleState(layer_data const *dev_data, VkShaderModule module);
-const PHYS_DEV_PROPERTIES_NODE *GetPhysDevProperties(const layer_data *device_data);
 const DeviceFeatures *GetEnabledFeatures(const layer_data *device_data);
 const DeviceExtensions *GetEnabledExtensions(const layer_data *device_data);
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -22,6 +22,8 @@
 // Allow use of STL min and max functions in Windows
 #define NOMINMAX
 
+#include "core_validation_error_enums.h"
+#include "core_validation.h"
 #include "descriptor_sets.h"
 #include "hash_vk_types.h"
 #include "vk_enum_string_helper.h"

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -596,7 +596,7 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, const V
       pool_state_(nullptr),
       p_layout_(layout),
       device_data_(dev_data),
-      limits_(GetPhysDevProperties(dev_data)->properties.limits),
+      limits_(dev_data->phys_dev_props.limits),
       variable_count_(variable_count) {
     pool_state_ = GetDescriptorPoolState(dev_data, pool);
     // Foreach binding, create default descriptors of given type

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -21,8 +21,6 @@
 #ifndef CORE_VALIDATION_DESCRIPTOR_SETS_H_
 #define CORE_VALIDATION_DESCRIPTOR_SETS_H_
 
-#include "core_validation_error_enums.h"
-#include "core_validation_types.h"
 #include "hash_vk_types.h"
 #include "vk_layer_logging.h"
 #include "vk_layer_utils.h"

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1022,7 +1022,7 @@ static void SubmitBarrier(layer_data *dev_data, VkQueue queue) {
 
     // Pay attention only to queues that support graphics.
     // This ensures that the command buffer pool is created so that it can be used on a graphics queue.
-    VkQueueFlags queue_flags = dev_data->phys_dev_properties.queue_family_properties[queue_family_index].queueFlags;
+    VkQueueFlags queue_flags = GetPhysicalDeviceState(dev_data)->queue_family_properties[queue_family_index].queueFlags;
     if (!(queue_flags & VK_QUEUE_GRAPHICS_BIT)) {
         return;
     }

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2329,10 +2329,9 @@ bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCrea
 }
 
 void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                     const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                     create_shader_module_api_state *csm_state) {
+                                     const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule, void *csm_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), core_validation::layer_data_map);
-
+    create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
     if (GetEnables(device_data)->gpu_validation) {
         GpuPreCallCreateShaderModule(device_data, pCreateInfo, pAllocator, pShaderModule, &csm_state->unique_shader_id,
                                      &csm_state->instrumented_create_info, &csm_state->instrumented_pgm);
@@ -2341,9 +2340,10 @@ void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreate
 
 void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                       const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule, VkResult result,
-                                      create_shader_module_api_state *csm_state) {
+                                      void *csm_state_data) {
     layer_data *device_data = GetLayerDataPtr(get_dispatch_key(device), core_validation::layer_data_map);
     if (VK_SUCCESS != result) return;
+    create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
 
     spv_target_env spirv_environment =
         ((GetApiVersion(device_data) >= VK_API_VERSION_1_1) ? SPV_ENV_VULKAN_1_1 : SPV_ENV_VULKAN_1_0);

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1647,7 +1647,7 @@ static bool ValidateShaderStageInputOutputLimits(layer_data *dev_data, shader_mo
     }
 
     bool skip = false;
-    auto const &properties = GetPhysDevProperties(dev_data);
+    auto const &limits = dev_data->phys_dev_props.limits;
     auto const report_data = GetReportData(dev_data);
 
     std::vector<uint32_t> builtInBlockIDs;
@@ -1724,89 +1724,85 @@ static bool ValidateShaderStageInputOutputLimits(layer_data *dev_data, shader_mo
 
     switch (pStage->stage) {
         case VK_SHADER_STAGE_VERTEX_BIT:
-            if (numCompOut > properties->properties.limits.maxVertexOutputComponents) {
+            if (numCompOut > limits.maxVertexOutputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Vertex shader exceeds "
                                 "VkPhysicalDeviceLimits::maxVertexOutputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxVertexOutputComponents,
-                                numCompOut - properties->properties.limits.maxVertexOutputComponents);
+                                limits.maxVertexOutputComponents, numCompOut - limits.maxVertexOutputComponents);
             }
             break;
 
         case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-            if (numCompIn > properties->properties.limits.maxTessellationControlPerVertexInputComponents) {
+            if (numCompIn > limits.maxTessellationControlPerVertexInputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Tessellation control shader exceeds "
                                 "VkPhysicalDeviceLimits::maxTessellationControlPerVertexInputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxTessellationControlPerVertexInputComponents,
-                                numCompIn - properties->properties.limits.maxTessellationControlPerVertexInputComponents);
+                                limits.maxTessellationControlPerVertexInputComponents,
+                                numCompIn - limits.maxTessellationControlPerVertexInputComponents);
             }
-            if (numCompOut > properties->properties.limits.maxTessellationControlPerVertexOutputComponents) {
+            if (numCompOut > limits.maxTessellationControlPerVertexOutputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Tessellation control shader exceeds "
                                 "VkPhysicalDeviceLimits::maxTessellationControlPerVertexOutputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxTessellationControlPerVertexOutputComponents,
-                                numCompOut - properties->properties.limits.maxTessellationControlPerVertexOutputComponents);
+                                limits.maxTessellationControlPerVertexOutputComponents,
+                                numCompOut - limits.maxTessellationControlPerVertexOutputComponents);
             }
             break;
 
         case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-            if (numCompIn > properties->properties.limits.maxTessellationEvaluationInputComponents) {
+            if (numCompIn > limits.maxTessellationEvaluationInputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Tessellation evaluation shader exceeds "
                                 "VkPhysicalDeviceLimits::maxTessellationEvaluationInputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxTessellationEvaluationInputComponents,
-                                numCompIn - properties->properties.limits.maxTessellationEvaluationInputComponents);
+                                limits.maxTessellationEvaluationInputComponents,
+                                numCompIn - limits.maxTessellationEvaluationInputComponents);
             }
-            if (numCompOut > properties->properties.limits.maxTessellationEvaluationOutputComponents) {
+            if (numCompOut > limits.maxTessellationEvaluationOutputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Tessellation evaluation shader exceeds "
                                 "VkPhysicalDeviceLimits::maxTessellationEvaluationOutputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxTessellationEvaluationOutputComponents,
-                                numCompOut - properties->properties.limits.maxTessellationEvaluationOutputComponents);
+                                limits.maxTessellationEvaluationOutputComponents,
+                                numCompOut - limits.maxTessellationEvaluationOutputComponents);
             }
             break;
 
         case VK_SHADER_STAGE_GEOMETRY_BIT:
-            if (numCompIn > properties->properties.limits.maxGeometryInputComponents) {
+            if (numCompIn > limits.maxGeometryInputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
                                 "VkPhysicalDeviceLimits::maxGeometryInputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxGeometryInputComponents,
-                                numCompIn - properties->properties.limits.maxGeometryInputComponents);
+                                limits.maxGeometryInputComponents, numCompIn - limits.maxGeometryInputComponents);
             }
-            if (numCompOut > properties->properties.limits.maxGeometryOutputComponents) {
+            if (numCompOut > limits.maxGeometryOutputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
                                 "VkPhysicalDeviceLimits::maxGeometryOutputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxGeometryOutputComponents,
-                                numCompOut - properties->properties.limits.maxGeometryOutputComponents);
+                                limits.maxGeometryOutputComponents, numCompOut - limits.maxGeometryOutputComponents);
             }
             break;
 
         case VK_SHADER_STAGE_FRAGMENT_BIT:
-            if (numCompIn > properties->properties.limits.maxFragmentInputComponents) {
+            if (numCompIn > limits.maxFragmentInputComponents) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
                                 "Invalid Pipeline CreateInfo State: Fragment shader exceeds "
                                 "VkPhysicalDeviceLimits::maxFragmentInputComponents of %u "
                                 "components by %u components",
-                                properties->properties.limits.maxFragmentInputComponents,
-                                numCompIn - properties->properties.limits.maxFragmentInputComponents);
+                                limits.maxFragmentInputComponents, numCompIn - limits.maxFragmentInputComponents);
             }
             break;
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -33,7 +33,6 @@
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
 #include "core_validation.h"
-#include "core_validation_types.h"
 #include "shader_validation.h"
 #include "spirv-tools/libspirv.h"
 #include "xxhash.h"

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -213,10 +213,9 @@ typedef std::pair<unsigned, unsigned> descriptor_slot_t;
 bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                        const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule);
 void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                     const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                     create_shader_module_api_state *csm_state);
+                                     const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule, void *csm_state);
 void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                       const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule, VkResult result,
-                                      create_shader_module_api_state *csm_state);
+                                      void *csm_state);
 
 #endif  // VULKAN_SHADER_VALIDATION_H


### PR DESCRIPTION
Some housekeeping and prep for an upcoming blob of changes for the basic conversion of CV to use the chassis, including handling the weird CV cases that pass state between the pre- and post-calls. That'll be a big fat commit as it is and this should help to reduce the size somewhat.