### PR TITLE
tests: set target API version correctly for some tests

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -25443,6 +25443,7 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     if (mp_extensions) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
     mp_extensions = mp_extensions && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE1_EXTENSION_NAME);
     mp_extensions = mp_extensions && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
@@ -34113,6 +34114,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
     if (mp_extensions) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
     mp_extensions = mp_extensions && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE1_EXTENSION_NAME);
     mp_extensions = mp_extensions && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);


### PR DESCRIPTION
Both tests had been configured for Vulkan 1.0 version but used some non-KHR functions that were not in core until 1.1, so the respective pointer was NULL and used stubs instead, which means than some objects were not properly initialized.

As these are tests for the validation layers themselves, the patch sets the target version to Vulkan 1.1 to fix this.

Fixes segfaults on the following tests on Intel's ANV driver:

```VkPositiveLayerTest.MultiplaneImageTests```
```VkLayerTest.MultiplaneImageSamplerConversionMismatch```