### PR TITLE
Separate GPUval data from core_validation data

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2484,9 +2484,7 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
         core_checks->phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
     }
     if (GetEnables()->gpu_validation) {
-        // Copy any needed instance data into the gpu validation state
-        core_checks->gpu_validation_state.reserve_binding_slot = GetEnables()->gpu_validation_reserve_binding_slot;
-        core_checks->GpuPostCallRecordCreateDevice();
+        core_checks->GpuPostCallRecordCreateDevice(GetEnables());
     }
 
     // Store queue family data
@@ -4872,10 +4870,6 @@ std::unordered_map<VkImageView, std::unique_ptr<IMAGE_VIEW_STATE>> *CoreChecks::
 const DeviceFeatures *CoreChecks::GetEnabledFeatures() { return &enabled_features; }
 
 const DeviceExtensions *CoreChecks::GetDeviceExtensions() { return &device_extensions; }
-
-GpuValidationState *CoreChecks::GetGpuValidationState() { return &gpu_validation_state; }
-
-VkDevice CoreChecks::GetDevice() { return device; }
 
 uint32_t CoreChecks::GetApiVersion() { return api_version; }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -164,6 +164,7 @@ struct SURFACE_STATE {
 };
 
 using std::unordered_map;
+struct GpuValidationState;
 
 class CoreChecks : public ValidationObject {
    public:
@@ -227,7 +228,7 @@ class CoreChecks : public ValidationObject {
     DeviceExtensionProperties phys_dev_ext_props = {};
     bool external_sync_warning = false;
     uint32_t api_version = 0;
-    GpuValidationState gpu_validation_state = {};
+    std::unique_ptr<GpuValidationState> gpu_validation_state;
     uint32_t physical_device_count;
 
     // Class Declarations for helper functions
@@ -509,8 +510,6 @@ class CoreChecks : public ValidationObject {
     std::unordered_set<uint64_t>* GetAHBExternalFormatsSet();
 
     const DeviceExtensions* GetDeviceExtensions();
-    GpuValidationState* GetGpuValidationState();
-    VkDevice GetDevice();
 
     uint32_t GetApiVersion();
 
@@ -599,7 +598,7 @@ class CoreChecks : public ValidationObject {
     // Gpu Validation Functions
     void GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, std::unique_ptr<safe_VkDeviceCreateInfo>& modified_create_info,
                                       VkPhysicalDeviceFeatures* supported_features);
-    void GpuPostCallRecordCreateDevice();
+    void GpuPostCallRecordCreateDevice(const CHECK_ENABLED* enables);
     void GpuPreCallRecordDestroyDevice();
     void GpuPreCallRecordFreeCommandBuffers(uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
     bool GpuPreCallCreateShaderModule(const VkShaderModuleCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -957,20 +957,6 @@ struct QFOTransferCBScoreboards {
     QFOTransferCBScoreboard<Barrier> release;
 };
 
-struct GpuDeviceMemoryBlock {
-    VkBuffer buffer;
-    VkDeviceMemory memory;
-    uint32_t offset;
-};
-
-struct GpuBufferInfo {
-    GpuDeviceMemoryBlock mem_block;
-    VkDescriptorSet desc_set;
-    VkDescriptorPool desc_pool;
-    GpuBufferInfo(GpuDeviceMemoryBlock mem_block, VkDescriptorSet desc_set, VkDescriptorPool desc_pool)
-        : mem_block(mem_block), desc_set(desc_set), desc_pool(desc_pool){};
-};
-
 // Cmd Buffer Wrapper Struct - TODO : This desperately needs its own class
 struct GLOBAL_CB_NODE : public BASE_NODE {
     VkCommandBuffer commandBuffer;
@@ -1037,8 +1023,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::unordered_set<cvdescriptorset::DescriptorSet *> validated_descriptor_sets;
     // Contents valid only after an index buffer is bound (CBSTATUS_INDEX_BUFFER_BOUND set)
     IndexBufferBinding index_buffer_binding;
-    // GPU Validation data
-    std::vector<GpuBufferInfo> gpu_buffer_list;
 };
 
 static inline QFOTransferBarrierSets<VkImageMemoryBarrier> &GetQFOBarrierSets(
@@ -1118,26 +1102,10 @@ struct DeviceFeatures {
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };
 
-class GpuDeviceMemoryManager;
-class GpuDescriptorSetManager;
 struct ShaderTracker {
     VkPipeline pipeline;
     VkShaderModule shader_module;
     std::vector<unsigned int> pgm;
-};
-struct GpuValidationState {
-    bool aborted;
-    bool reserve_binding_slot;
-    VkDescriptorSetLayout debug_desc_layout;
-    VkDescriptorSetLayout dummy_desc_layout;
-    uint32_t adjusted_max_desc_sets;
-    uint32_t desc_set_bind_index;
-    uint32_t unique_shader_module_id;
-    std::unordered_map<uint32_t, ShaderTracker> shader_map;
-    std::unique_ptr<GpuDeviceMemoryManager> memory_manager;
-    std::unique_ptr<GpuDescriptorSetManager> desc_set_manager;
-    VkCommandPool barrier_command_pool;
-    VkCommandBuffer barrier_command_buffer;
 };
 
 enum BarrierOperationsType {


### PR DESCRIPTION
Reduces GPU validation dependencies needed for the core_validation types & structs.

