### PR TITLE
Make vk_layer_validation_tests fail on encountering unexpected errors

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -37684,6 +37684,11 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
         }
     }
 
+    if (DeviceIsMockICD() || DeviceSimulation()) {
+        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
         (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -35880,6 +35880,11 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     dslb.descriptorCount = 4;
     dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
+    if (inline_uniform_props.maxInlineUniformBlockSize < dslb.descriptorCount) {
+        printf("%sDescriptorCount exceeds InlineUniformBlockSize limit, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     uint32_t maxBlocks = std::max(inline_uniform_props.maxPerStageDescriptorInlineUniformBlocks,
                                   inline_uniform_props.maxDescriptorSetInlineUniformBlocks);
     for (uint32_t i = 0; i < 1 + maxBlocks; ++i) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1524,6 +1524,11 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
         return;
     }
 
+    if (DeviceSimulation()) {
+        printf("%sSkipping object naming test.\n", kSkipPrefix);
+        return;
+    }
+
     VkBuffer buffer;
     VkDeviceMemory memory_1, memory_2;
     std::string memory_name = "memory_name";
@@ -1629,6 +1634,11 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
         (PFN_vkSetDebugUtilsObjectNameEXT)vkGetDeviceProcAddr(m_device->device(), "vkSetDebugUtilsObjectNameEXT");
     if (!(fpvkSetDebugUtilsObjectNameEXT)) {
         printf("%s Can't find fpvkSetDebugUtilsObjectNameEXT; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    if (DeviceSimulation()) {
+        printf("%sSkipping object naming test.\n", kSkipPrefix);
         return;
     }
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13132,6 +13132,13 @@ TEST_F(VkLayerTest, VertexAttributeDivisorDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props = {};
+    pdvad_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT;
+    VkPhysicalDeviceProperties2 pd_props2 = {};
+    pd_props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    pd_props2.pNext = &pdvad_props;
+    vkGetPhysicalDeviceProperties2(gpu(), &pd_props2);
+
     VkVertexInputBindingDivisorDescriptionEXT vibdd = {};
     vibdd.binding = 0;
     vibdd.divisor = 2;
@@ -13143,6 +13150,12 @@ TEST_F(VkLayerTest, VertexAttributeDivisorDisabled) {
     vibd.binding = vibdd.binding;
     vibd.stride = 12;
     vibd.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+
+    if (pdvad_props.maxVertexAttribDivisor < pvids_ci.vertexBindingDivisorCount) {
+        printf("%sThis device does not support %d vertexBindingDivisors, skipping tests\n", kSkipPrefix,
+               pvids_ci.vertexBindingDivisorCount);
+        return;
+    }
 
     const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
         helper.vi_ci_.pNext = &pvids_ci;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -20664,6 +20664,11 @@ TEST_F(VkPositiveLayerTest, SpirvGroupDecorations) {
     ds_layout_ci.bindingCount = 6;
     ds_layout_ci.pBindings = dslb;
 
+    if (m_device->props.limits.maxPerStageDescriptorStorageBuffers < ds_layout_ci.bindingCount) {
+        printf("%sNeeded storage buffer bindings exceeds this devices limit.  Skipping tests.\n", kSkipPrefix);
+        return;
+    }
+
     VkDescriptorSetLayout ds_layout = {};
     vkCreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5622,6 +5622,8 @@ TEST_F(VkPositiveLayerTest, SecondaryCommandBufferBarrier) {
     TEST_DESCRIPTION("Add a pipeline barrier in a secondary command buffer");
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    m_errorMonitor->ExpectSuccess();
+
     // A renderpass with a single subpass that declared a self-dependency
     VkAttachmentDescription attach[] = {
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
@@ -5723,6 +5725,7 @@ TEST_F(VkPositiveLayerTest, SecondaryCommandBufferBarrier) {
 
     vkDestroyFramebuffer(m_device->device(), fb, nullptr);
     vkDestroyRenderPass(m_device->device(), rp, nullptr);
+    m_errorMonitor->VerifyNotFound();
 }
 
 static void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo *create_info,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -35087,6 +35087,11 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
         }
     }
 
+    if (DeviceIsMockICD() || DeviceSimulation()) {
+        printf("%sTest not suppored by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
         (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -37777,6 +37777,11 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
         }
     }
 
+    if (DeviceIsMockICD() || DeviceSimulation()) {
+        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
         (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13049,6 +13049,12 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
     vibd.stride = 12;
     vibd.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
+    if (pdvad_props.maxVertexAttribDivisor < pvids_ci.vertexBindingDivisorCount) {
+        printf("%sThis device does not support %d vertexBindingDivisors, skipping tests\n", kSkipPrefix,
+               pvids_ci.vertexBindingDivisorCount);
+        return;
+    }
+
     using std::vector;
     struct TestCase {
         uint32_t div_binding;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -34961,6 +34961,11 @@ TEST_F(VkLayerTest, ExclusiveScissorNV) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    if (m_device->phy().properties().limits.maxViewports) {
+        printf("%s Device doesn't support the necessary number of viewports, skipping test.\n", kSkipPrefix);
+        return;
+    }
+
     // Based on PSOViewportStateTests
     {
         VkViewport viewport = {0.0f, 0.0f, 64.0f, 64.0f, 0.0f, 1.0f};

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -35608,6 +35608,11 @@ TEST_F(VkLayerTest, MeshShaderNV) {
         }
     }
 
+    if (DeviceIsMockICD() || DeviceSimulation()) {
+        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
         (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -388,6 +388,16 @@ class ErrorMonitor {
             for (const auto desired_msg : desired_message_strings_) {
                 ADD_FAILURE() << "Did not receive expected error '" << desired_msg << "'";
             }
+        } else if (GetOtherFailureMsgs().size() > 0) {
+            // Fail test case for any unexpected errors
+#if defined(ANDROID) && defined(VALIDATION_APK)
+            // This will get unexpected errors into the adb log
+            for (auto msg : other_messages_) {
+                __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "[ UNEXPECTED_ERR ] '%s'", msg.c_str());
+            }
+#else
+            ADD_FAILURE() << "Received unexpected error(s).";
+#endif
         }
         Reset();
     }
@@ -399,6 +409,16 @@ class ErrorMonitor {
             for (const auto msg : failure_message_strings_) {
                 ADD_FAILURE() << "Expected to succeed but got error: " << msg;
             }
+        } else if (GetOtherFailureMsgs().size() > 0) {
+            // Fail test case for any unexpected errors
+#if defined(ANDROID) && defined(VALIDATION_APK)
+            // This will get unexpected errors into the adb log
+            for (auto msg : other_messages_) {
+                __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "[ UNEXPECTED_ERR ] '%s'", msg.c_str());
+            }
+#else
+            ADD_FAILURE() << "Received unexpected error(s).";
+#endif
         }
         Reset();
     }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -36100,6 +36100,13 @@ TEST_F(VkLayerTest, FramebufferMixedSamplesNV) {
         return;
     }
 
+    VkPhysicalDeviceFeatures device_features = {};
+    ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&device_features));
+    if (VK_TRUE != device_features.sampleRateShading) {
+        printf("%s Test requires unsupported sampleRateShading feature.\n", kSkipPrefix);
+        return;
+    }
+
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -16046,6 +16046,15 @@ TEST_F(VkLayerTest, DSUsageBitsErrors) {
     TEST_DESCRIPTION("Attempt to update descriptor sets for images and buffers that do not have correct usage bits sets.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
+
+    const VkFormat buffer_format = VK_FORMAT_R8_UNORM;
+    VkFormatProperties format_properties;
+    vkGetPhysicalDeviceFormatProperties(gpu(), buffer_format, &format_properties);
+    if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
+        printf("%s Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format; skipped.\n", kSkipPrefix);
+        return;
+    }
+
     std::array<VkDescriptorPoolSize, VK_DESCRIPTOR_TYPE_RANGE_SIZE> ds_type_count;
     for (uint32_t i = 0; i < ds_type_count.size(); ++i) {
         ds_type_count[i].type = VkDescriptorType(i);

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -188,6 +188,9 @@ bool VkRenderFramework::DeviceIsMockICD() {
     return false;
 }
 
+// Some tests may need to be skipped if the devsim layer is in use.
+bool VkRenderFramework::DeviceSimulation() { return m_devsim_layer; }
+
 // Render into a RenderTarget and read the pixels back to see if the device can really draw.
 // Note: This cannot be called from inside an initialized VkRenderFramework because frameworks cannot be "nested".
 // It is best to call it before "Init()".

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -111,6 +111,7 @@ class VkRenderFramework : public VkTestFramework {
     bool DeviceExtensionSupported(VkPhysicalDevice dev, const char *layer, const char *name, uint32_t specVersion = 0);
     bool DeviceExtensionEnabled(const char *name);
     bool DeviceIsMockICD();
+    bool DeviceSimulation();
     bool DeviceCanDraw();
 
    protected:


### PR DESCRIPTION
It has been long agreed-upon that layer validation tests should not have unexpected errors (validation errors other than the intended target error(s)).  However, as the tests succeed even with unexpected errors, they slowly build up over time, making it impossible to tell if new changes cause new unexpected errors.

This PR will make LVTs fail on unexpected errors for Linux and Windows platforms, and to print out the errors on Android.  After the Android issues are all addressed, it can also be updated to fail on unexpecteds. 