### PR TITLE
tests: Make khronos layer default for LVTs

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -468,16 +468,14 @@ class VkLayerTest : public VkRenderFramework {
         // Add default instance extensions to the list
         m_instance_extension_names.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 
-        // Use Threading layer first to protect others from
-        // ThreadCommandBufferCollision test
-        if (VkTestFramework::m_khronos_layer) {
-            m_instance_layer_names.push_back("VK_LAYER_KHRONOS_validation");
-        } else {
+        if (VkTestFramework::m_khronos_layer_disable) {
             m_instance_layer_names.push_back("VK_LAYER_GOOGLE_threading");
             m_instance_layer_names.push_back("VK_LAYER_LUNARG_parameter_validation");
             m_instance_layer_names.push_back("VK_LAYER_LUNARG_object_tracker");
             m_instance_layer_names.push_back("VK_LAYER_LUNARG_core_validation");
             m_instance_layer_names.push_back("VK_LAYER_GOOGLE_unique_objects");
+        } else {
+            m_instance_layer_names.push_back("VK_LAYER_KHRONOS_validation");
         }
         if (VkTestFramework::m_devsim_layer) {
             if (InstanceLayerSupported("VK_LAYER_LUNARG_device_simulation")) {

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -144,7 +144,7 @@ bool VkTestFramework::m_canonicalize_spv = false;
 bool VkTestFramework::m_strip_spv = false;
 bool VkTestFramework::m_do_everything_spv = false;
 bool VkTestFramework::m_devsim_layer = false;
-bool VkTestFramework::m_khronos_layer = false;
+bool VkTestFramework::m_khronos_layer_disable = false;
 int VkTestFramework::m_width = 0;
 int VkTestFramework::m_height = 0;
 
@@ -165,8 +165,8 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_canonicalize_spv = true;
         else if (optionMatch("--devsim", argv[i]))
             m_devsim_layer = true;
-        else if (optionMatch("--uberlayer", argv[i]))
-            m_khronos_layer = true;
+        else if (optionMatch("--disable_uberlayer", argv[i]))
+            m_khronos_layer_disable = true;
         else if (optionMatch("--help", argv[i]) || optionMatch("-h", argv[i])) {
             printf("\nOther options:\n");
             printf(

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -74,7 +74,7 @@ class VkTestFramework : public ::testing::Test {
     static bool m_strip_spv;
     static bool m_do_everything_spv;
     static bool m_devsim_layer;
-    static bool m_khronos_layer;
+    static bool m_khronos_layer_disable;
 
     char **ReadFileData(const char *fileName);
     void FreeFileData(char **data);

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -26,7 +26,7 @@ VkTestFramework::~VkTestFramework() {}
 
 // Define static elements
 bool VkTestFramework::m_devsim_layer = false;
-bool VkTestFramework::m_khronos_layer = false;
+bool VkTestFramework::m_khronos_layer_disable = false;
 
 VkFormat VkTestFramework::GetFormat(VkInstance instance, vk_testing::Device *device) {
     VkFormatProperties format_props;

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -47,7 +47,7 @@ class VkTestFramework : public ::testing::Test {
                    bool debug = false);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_devsim_layer;
-    static bool m_khronos_layer;
+    static bool m_khronos_layer_disable;
 };
 
 class TestEnvironment : public ::testing::Environment {


### PR DESCRIPTION
Switches the layer validation tests to load the Khronos_validation layer by default.  

The option to change this has been renamed to '--uberlayer_disable', which if used will explicitly load the old five individual layers.

