### PR TITLE
Switch VK_LAYER_LUNARG_standard_validation to load KHRONOS_validation layer

### DIFF
--- a/layers/json/VkLayer_standard_validation.json.in
+++ b/layers/json/VkLayer_standard_validation.json.in
@@ -7,11 +7,7 @@
         "implementation_version": "1",
         "description": "LunarG Standard Validation",
         "component_layers": [
-            "VK_LAYER_GOOGLE_threading",
-            "VK_LAYER_LUNARG_parameter_validation",
-            "VK_LAYER_LUNARG_object_tracker",
-            "VK_LAYER_LUNARG_core_validation",
-            "VK_LAYER_GOOGLE_unique_objects"
+            "VK_LAYER_KHRONOS_validation"
         ]
     }
 }


### PR DESCRIPTION
The definition of the meta-layer gets changed to load the khronos validation layer in place of the five legacy layers.

@lenny-lunarg promised this would not affect the loader in any way.
