### PR TITLE
Add default output config entries for khronos layer

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -139,6 +139,7 @@ VK_LAYER_EXPORT void setLayerOption(const char *_option, const char *_val) { g_c
 // Constructor for ConfigFile. Initialize layers to log error messages to stdout by default. If a vk_layer_settings file is present,
 // its settings will override the defaults.
 ConfigFile::ConfigFile() : m_fileIsParsed(false) {
+    m_valueMap["khronos_validation.report_flags"] = "error";
     m_valueMap["lunarg_core_validation.report_flags"] = "error";
     m_valueMap["lunarg_object_tracker.report_flags"] = "error";
     m_valueMap["lunarg_parameter_validation.report_flags"] = "error";
@@ -147,6 +148,8 @@ ConfigFile::ConfigFile() : m_fileIsParsed(false) {
 
 #ifdef WIN32
     // For Windows, enable message logging AND OutputDebugString
+    m_valueMap["khronos_validation.debug_action"] =
+        "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG,VK_DBG_LAYER_ACTION_DEBUG_OUTPUT";
     m_valueMap["lunarg_core_validation.debug_action"] =
         "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG,VK_DBG_LAYER_ACTION_DEBUG_OUTPUT";
     m_valueMap["lunarg_object_tracker.debug_action"] =
@@ -158,13 +161,14 @@ ConfigFile::ConfigFile() : m_fileIsParsed(false) {
     m_valueMap["google_unique_objects.debug_action"] =
         "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG,VK_DBG_LAYER_ACTION_DEBUG_OUTPUT";
 #else   // WIN32
+    m_valueMap["khronos_validation.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
     m_valueMap["lunarg_core_validation.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
     m_valueMap["lunarg_object_tracker.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
     m_valueMap["lunarg_parameter_validation.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
     m_valueMap["google_threading.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
     m_valueMap["google_unique_objects.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
 #endif  // WIN32
-
+    m_valueMap["khronos_validation.log_filename"] = "stdout";
     m_valueMap["lunarg_core_validation.log_filename"] = "stdout";
     m_valueMap["lunarg_object_tracker.log_filename"] = "stdout";
     m_valueMap["lunarg_parameter_validation.log_filename"] = "stdout";


### PR DESCRIPTION
This prevented validation output from going to `stdout `when not using a debug callback.

