### PR TITLE
layers:Remove dev_data requirement from Dispatch*

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1551,7 +1551,7 @@ bool CoreChecks::ValidatePipelineUnlocked(std::vector<std::unique_ptr<PIPELINE_S
             VkFormat format = vi->pVertexAttributeDescriptions[j].format;
             // Internal call to get format info.  Still goes through layers, could potentially go directly to ICD.
             VkFormatProperties properties;
-            DispatchGetPhysicalDeviceFormatProperties(this, physical_device, format, &properties);
+            DispatchGetPhysicalDeviceFormatProperties(physical_device, format, &properties);
             if ((properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
                 skip |=
                     log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
@@ -2332,7 +2332,7 @@ void CoreChecks::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceC
     // GPU Validation can possibly turn on device features, so give it a chance to change the create info.
     if (GetEnables()->gpu_validation) {
         VkPhysicalDeviceFeatures supported_features;
-        DispatchGetPhysicalDeviceFeatures(this, gpu, &supported_features);
+        DispatchGetPhysicalDeviceFeatures(gpu, &supported_features);
         GpuPreCallRecordCreateDevice(gpu, modified_create_info, &supported_features);
     }
 }
@@ -2363,10 +2363,10 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
     // previously set them through an explicit API call.
     uint32_t count;
     auto pd_state = GetPhysicalDeviceState(gpu);
-    DispatchGetPhysicalDeviceQueueFamilyProperties(this, gpu, &count, nullptr);
+    DispatchGetPhysicalDeviceQueueFamilyProperties(gpu, &count, nullptr);
     pd_state->queue_family_count = std::max(pd_state->queue_family_count, count);
     pd_state->queue_family_properties.resize(std::max(static_cast<uint32_t>(pd_state->queue_family_properties.size()), count));
-    DispatchGetPhysicalDeviceQueueFamilyProperties(this, gpu, &count, &pd_state->queue_family_properties[0]);
+    DispatchGetPhysicalDeviceQueueFamilyProperties(gpu, &count, &pd_state->queue_family_properties[0]);
     // Save local link to this device's physical device state
     core_checks->physical_device_state = pd_state;
 
@@ -2431,56 +2431,56 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
     }
 
     // Store physical device properties and physical device mem limits into CoreChecks structs
-    DispatchGetPhysicalDeviceMemoryProperties(this, gpu, &core_checks->phys_dev_mem_props);
-    DispatchGetPhysicalDeviceProperties(this, gpu, &core_checks->phys_dev_props);
+    DispatchGetPhysicalDeviceMemoryProperties(gpu, &core_checks->phys_dev_mem_props);
+    DispatchGetPhysicalDeviceProperties(gpu, &core_checks->phys_dev_props);
 
     if (core_checks->device_extensions.vk_khr_push_descriptor) {
         // Get the needed push_descriptor limits
         auto push_descriptor_prop = lvl_init_struct<VkPhysicalDevicePushDescriptorPropertiesKHR>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&push_descriptor_prop);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.max_push_descriptors = push_descriptor_prop.maxPushDescriptors;
     }
     if (core_checks->device_extensions.vk_ext_descriptor_indexing) {
         // Get the needed descriptor_indexing limits
         auto descriptor_indexing_props = lvl_init_struct<VkPhysicalDeviceDescriptorIndexingPropertiesEXT>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&descriptor_indexing_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.descriptor_indexing_props = descriptor_indexing_props;
     }
     if (core_checks->device_extensions.vk_nv_shading_rate_image) {
         // Get the needed shading rate image limits
         auto shading_rate_image_props = lvl_init_struct<VkPhysicalDeviceShadingRateImagePropertiesNV>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&shading_rate_image_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.shading_rate_image_props = shading_rate_image_props;
     }
     if (core_checks->device_extensions.vk_nv_mesh_shader) {
         // Get the needed mesh shader limits
         auto mesh_shader_props = lvl_init_struct<VkPhysicalDeviceMeshShaderPropertiesNV>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&mesh_shader_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.mesh_shader_props = mesh_shader_props;
     }
     if (core_checks->device_extensions.vk_ext_inline_uniform_block) {
         // Get the needed inline uniform block limits
         auto inline_uniform_block_props = lvl_init_struct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&inline_uniform_block_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.inline_uniform_block_props = inline_uniform_block_props;
     }
     if (core_checks->device_extensions.vk_ext_vertex_attribute_divisor) {
         // Get the needed vertex attribute divisor limits
         auto vtx_attrib_divisor_props = lvl_init_struct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&vtx_attrib_divisor_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.vtx_attrib_divisor_props = vtx_attrib_divisor_props;
     }
     if (core_checks->device_extensions.vk_khr_depth_stencil_resolve) {
         // Get the needed depth and stencil resolve modes
         auto depth_stencil_resolve_props = lvl_init_struct<VkPhysicalDeviceDepthStencilResolvePropertiesKHR>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&depth_stencil_resolve_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, gpu, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         core_checks->phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
     }
     if (GetEnables()->gpu_validation) {
@@ -3332,7 +3332,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         VkExternalBufferProperties ext_buf_props = {};
         ext_buf_props.sType = VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES;
 
-        DispatchGetPhysicalDeviceExternalBufferProperties(this, physical_device, &pdebi, &ext_buf_props);
+        DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &pdebi, &ext_buf_props);
 
         // Collect external format info
         VkPhysicalDeviceExternalImageFormatInfo pdeifi = {};
@@ -3383,7 +3383,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         VkAndroidHardwareBufferPropertiesANDROID ahb_props = {};
         ahb_props.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
         ahb_props.pNext = &ahb_format_props;
-        DispatchGetAndroidHardwareBufferPropertiesANDROID(this, device, import_ahb_info->buffer, &ahb_props);
+        DispatchGetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &ahb_props);
 
         // allocationSize must be the size returned by vkGetAndroidHardwareBufferPropertiesANDROID for the Android hardware buffer
         if (alloc_info->allocationSize != ahb_props.allocationSize) {
@@ -4261,7 +4261,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, V
                         "%s: Binding memory to buffer %s but vkGetBufferMemoryRequirements() has not been called on that buffer.",
                         api_name, report_data->FormatHandle(buffer_handle).c_str());
             // Make the call for them so we can verify the state
-            DispatchGetBufferMemoryRequirements(this, device, buffer, &buffer_state->requirements);
+            DispatchGetBufferMemoryRequirements(device, buffer, &buffer_state->requirements);
         }
 
         // Validate bound memory range information
@@ -4826,21 +4826,20 @@ void CoreChecks::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass re
 // Access helper functions for external modules
 VkFormatProperties CoreChecks::GetPDFormatProperties(const VkFormat format) {
     VkFormatProperties format_properties;
-    DispatchGetPhysicalDeviceFormatProperties(this, physical_device, format, &format_properties);
+    DispatchGetPhysicalDeviceFormatProperties(physical_device, format, &format_properties);
     return format_properties;
 }
 
 VkResult CoreChecks::GetPDImageFormatProperties(const VkImageCreateInfo *image_ci,
                                                 VkImageFormatProperties *pImageFormatProperties) {
-    return DispatchGetPhysicalDeviceImageFormatProperties(this, physical_device, image_ci->format, image_ci->imageType,
-                                                          image_ci->tiling, image_ci->usage, image_ci->flags,
-                                                          pImageFormatProperties);
+    return DispatchGetPhysicalDeviceImageFormatProperties(physical_device, image_ci->format, image_ci->imageType, image_ci->tiling,
+                                                          image_ci->usage, image_ci->flags, pImageFormatProperties);
 }
 
 VkResult CoreChecks::GetPDImageFormatProperties2(const VkPhysicalDeviceImageFormatInfo2 *phys_dev_image_fmt_info,
                                                  VkImageFormatProperties2 *pImageFormatProperties) {
     if (!instance_extensions.vk_khr_get_physical_device_properties_2) return VK_ERROR_EXTENSION_NOT_PRESENT;
-    return DispatchGetPhysicalDeviceImageFormatProperties2(this, physical_device, phys_dev_image_fmt_info, pImageFormatProperties);
+    return DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, phys_dev_image_fmt_info, pImageFormatProperties);
 }
 
 const debug_report_data *CoreChecks::GetReportData() { return report_data; }
@@ -10550,7 +10549,7 @@ bool CoreChecks::ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDe
                             "%s: Binding memory to image %s but vkGetImageMemoryRequirements() has not been called on that image.",
                             api_name, report_data->FormatHandle(image_handle).c_str());
             // Make the call for them so we can verify the state
-            DispatchGetImageMemoryRequirements(this, device, image, &image_state->requirements);
+            DispatchGetImageMemoryRequirements(device, image, &image_state->requirements);
         }
 
         // Validate bound memory range information
@@ -11832,7 +11831,7 @@ void CoreChecks::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uin
             auto &phys_device_state = physical_device_map[pPhysicalDevices[i]];
             phys_device_state.phys_device = pPhysicalDevices[i];
             // Init actual features for each physical device
-            DispatchGetPhysicalDeviceFeatures(this, pPhysicalDevices[i], &phys_device_state.features2.features);
+            DispatchGetPhysicalDeviceFeatures(pPhysicalDevices[i], &phys_device_state.features2.features);
         }
     }
 }
@@ -12276,7 +12275,7 @@ void CoreChecks::PostRecordEnumeratePhysicalDeviceGroupsState(uint32_t *pPhysica
                 auto &phys_device_state = physical_device_map[cur_phys_dev];
                 phys_device_state.phys_device = cur_phys_dev;
                 // Init actual features for each physical device
-                DispatchGetPhysicalDeviceFeatures(this, cur_phys_dev, &phys_device_state.features2.features);
+                DispatchGetPhysicalDeviceFeatures(cur_phys_dev, &phys_device_state.features2.features);
             }
         }
     }

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -127,14 +127,14 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
 
     VkPhysicalDeviceProperties device_properties = {};
     // Need to get instance and do a getlayerdata call...
-    DispatchGetPhysicalDeviceProperties(this, physicalDevice, &device_properties);
+    DispatchGetPhysicalDeviceProperties(physicalDevice, &device_properties);
     memcpy(&stateless_validation->device_limits, &device_properties.limits, sizeof(VkPhysicalDeviceLimits));
 
     if (device_extensions.vk_nv_shading_rate_image) {
         // Get the needed shading rate image limits
         auto shading_rate_image_props = lvl_init_struct<VkPhysicalDeviceShadingRateImagePropertiesNV>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&shading_rate_image_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, physicalDevice, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(physicalDevice, &prop2);
         phys_dev_ext_props.shading_rate_image_props = shading_rate_image_props;
     }
 
@@ -142,7 +142,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed mesh shader limits
         auto mesh_shader_props = lvl_init_struct<VkPhysicalDeviceMeshShaderPropertiesNV>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&mesh_shader_props);
-        DispatchGetPhysicalDeviceProperties2KHR(this, physicalDevice, &prop2);
+        DispatchGetPhysicalDeviceProperties2KHR(physicalDevice, &prop2);
         phys_dev_ext_props.mesh_shader_props = mesh_shader_props;
     }
 

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -139,10 +139,10 @@ class LayerChassisDispatchOutputGenerator(OutputGenerator):
  */"""
 
     inline_custom_source_preamble = """
-VkResult DispatchCreateComputePipelines(ValidationObject *layer_data,
-                                        VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
+VkResult DispatchCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                         const VkComputePipelineCreateInfo *pCreateInfos,
                                         const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.CreateComputePipelines(device, pipelineCache, createInfoCount,
                                                                                           pCreateInfos, pAllocator, pPipelines);
     safe_VkComputePipelineCreateInfo *local_pCreateInfos = NULL;
@@ -181,10 +181,10 @@ VkResult DispatchCreateComputePipelines(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchCreateGraphicsPipelines(ValidationObject *layer_data,
-                                         VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
+VkResult DispatchCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                          const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.CreateGraphicsPipelines(device, pipelineCache, createInfoCount,
                                                                                            pCreateInfos, pAllocator, pPipelines);
     safe_VkGraphicsPipelineCreateInfo *local_pCreateInfos = nullptr;
@@ -263,9 +263,9 @@ static void UpdateCreateRenderPassState(ValidationObject *layer_data, const T *p
     }
 }
 
-VkResult DispatchCreateRenderPass(ValidationObject *layer_data,
-                                  VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
+VkResult DispatchCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
                                   const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = layer_data->device_dispatch_table.CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
     if (!wrap_handles) return result;
     if (VK_SUCCESS == result) {
@@ -276,9 +276,9 @@ VkResult DispatchCreateRenderPass(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchCreateRenderPass2KHR(ValidationObject *layer_data,
-                                      VkDevice device, const VkRenderPassCreateInfo2KHR *pCreateInfo,
+VkResult DispatchCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2KHR *pCreateInfo,
                                       const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     VkResult result = layer_data->device_dispatch_table.CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
     if (!wrap_handles) return result;
     if (VK_SUCCESS == result) {
@@ -289,8 +289,8 @@ VkResult DispatchCreateRenderPass2KHR(ValidationObject *layer_data,
     return result;
 }
 
-void DispatchDestroyRenderPass(ValidationObject *layer_data,
-                               VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator) {
+void DispatchDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.DestroyRenderPass(device, renderPass, pAllocator);
     std::unique_lock<std::mutex> lock(dispatch_lock);
     uint64_t renderPass_id = reinterpret_cast<uint64_t &>(renderPass);
@@ -303,9 +303,9 @@ void DispatchDestroyRenderPass(ValidationObject *layer_data,
     layer_data->renderpasses_states.erase(renderPass);
 }
 
-VkResult DispatchCreateSwapchainKHR(ValidationObject *layer_data,
-                                    VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
+VkResult DispatchCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
     safe_VkSwapchainCreateInfoKHR *local_pCreateInfo = NULL;
     if (pCreateInfo) {
@@ -326,12 +326,12 @@ VkResult DispatchCreateSwapchainKHR(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchCreateSharedSwapchainsKHR(ValidationObject *layer_data,
-                                           VkDevice device, uint32_t swapchainCount,
-                                           const VkSwapchainCreateInfoKHR *pCreateInfos,
+VkResult DispatchCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount, const VkSwapchainCreateInfoKHR *pCreateInfos,
                                            const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchains) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos,
-                                                                                          pAllocator, pSwapchains);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator,
+                                                                           pSwapchains);
     safe_VkSwapchainCreateInfoKHR *local_pCreateInfos = NULL;
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -361,10 +361,11 @@ VkResult DispatchCreateSharedSwapchainsKHR(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchGetSwapchainImagesKHR(ValidationObject *layer_data,
-                                       VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
+VkResult DispatchGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
                                        VkImage *pSwapchainImages) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
     VkSwapchainKHR wrapped_swapchain_handle = swapchain;
     if (VK_NULL_HANDLE != swapchain) {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -387,8 +388,8 @@ VkResult DispatchGetSwapchainImagesKHR(ValidationObject *layer_data,
     return result;
 }
 
-void DispatchDestroySwapchainKHR(ValidationObject *layer_data,
-                                 VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator) {
+void DispatchDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.DestroySwapchainKHR(device, swapchain, pAllocator);
     std::unique_lock<std::mutex> lock(dispatch_lock);
 
@@ -405,8 +406,8 @@ void DispatchDestroySwapchainKHR(ValidationObject *layer_data,
     layer_data->device_dispatch_table.DestroySwapchainKHR(device, swapchain, pAllocator);
 }
 
-VkResult DispatchQueuePresentKHR(ValidationObject *layer_data,
-                                 VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+VkResult DispatchQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.QueuePresentKHR(queue, pPresentInfo);
     safe_VkPresentInfoKHR *local_pPresentInfo = NULL;
     {
@@ -438,8 +439,8 @@ VkResult DispatchQueuePresentKHR(ValidationObject *layer_data,
     return result;
 }
 
-void DispatchDestroyDescriptorPool(ValidationObject *layer_data, VkDevice device, VkDescriptorPool descriptorPool,
-                                   const VkAllocationCallbacks *pAllocator) {
+void DispatchDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, const VkAllocationCallbacks *pAllocator) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.DestroyDescriptorPool(device, descriptorPool, pAllocator);
     std::unique_lock<std::mutex> lock(dispatch_lock);
 
@@ -456,8 +457,8 @@ void DispatchDestroyDescriptorPool(ValidationObject *layer_data, VkDevice device
     layer_data->device_dispatch_table.DestroyDescriptorPool(device, descriptorPool, pAllocator);
 }
 
-VkResult DispatchResetDescriptorPool(ValidationObject *layer_data, VkDevice device, VkDescriptorPool descriptorPool,
-                                     VkDescriptorPoolResetFlags flags) {
+VkResult DispatchResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.ResetDescriptorPool(device, descriptorPool, flags);
     VkDescriptorPool local_descriptor_pool = VK_NULL_HANDLE;
     {
@@ -477,8 +478,9 @@ VkResult DispatchResetDescriptorPool(ValidationObject *layer_data, VkDevice devi
     return result;
 }
 
-VkResult DispatchAllocateDescriptorSets(ValidationObject *layer_data, VkDevice device,
-                                        const VkDescriptorSetAllocateInfo *pAllocateInfo, VkDescriptorSet *pDescriptorSets) {
+VkResult DispatchAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
+                                        VkDescriptorSet *pDescriptorSets) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
     safe_VkDescriptorSetAllocateInfo *local_pAllocateInfo = NULL;
     {
@@ -511,8 +513,9 @@ VkResult DispatchAllocateDescriptorSets(ValidationObject *layer_data, VkDevice d
     return result;
 }
 
-VkResult DispatchFreeDescriptorSets(ValidationObject *layer_data, VkDevice device, VkDescriptorPool descriptorPool,
-                                    uint32_t descriptorSetCount, const VkDescriptorSet *pDescriptorSets) {
+VkResult DispatchFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
+                                    const VkDescriptorSet *pDescriptorSets) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles)
         return layer_data->device_dispatch_table.FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
     VkDescriptorSet *local_pDescriptorSets = NULL;
@@ -543,15 +546,14 @@ VkResult DispatchFreeDescriptorSets(ValidationObject *layer_data, VkDevice devic
     return result;
 }
 
-
 // This is the core version of this routine.  The extension version is below.
-VkResult DispatchCreateDescriptorUpdateTemplate(ValidationObject *layer_data,
-                                                VkDevice device,
-                                                const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo,
+VkResult DispatchCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo,
                                                 const VkAllocationCallbacks *pAllocator,
                                                 VkDescriptorUpdateTemplateKHR *pDescriptorUpdateTemplate) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator,
-                                                                                               pDescriptorUpdateTemplate);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator,
+                                                                                pDescriptorUpdateTemplate);
     safe_VkDescriptorUpdateTemplateCreateInfo *local_create_info = NULL;
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -579,13 +581,13 @@ VkResult DispatchCreateDescriptorUpdateTemplate(ValidationObject *layer_data,
 }
 
 // This is the extension version of this routine.  The core version is above.
-VkResult DispatchCreateDescriptorUpdateTemplateKHR(ValidationObject *layer_data,
-                                                   VkDevice device,
-                                                   const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo,
+VkResult DispatchCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo,
                                                    const VkAllocationCallbacks *pAllocator,
                                                    VkDescriptorUpdateTemplateKHR *pDescriptorUpdateTemplate) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator,
-                                                                                                  pDescriptorUpdateTemplate);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator,
+                                                                                   pDescriptorUpdateTemplate);
     safe_VkDescriptorUpdateTemplateCreateInfo *local_create_info = NULL;
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -613,10 +615,11 @@ VkResult DispatchCreateDescriptorUpdateTemplateKHR(ValidationObject *layer_data,
 }
 
 // This is the core version of this routine.  The extension version is below.
-void DispatchDestroyDescriptorUpdateTemplate(ValidationObject *layer_data,
-                                             VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
+void DispatchDestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                              const VkAllocationCallbacks *pAllocator) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
     std::unique_lock<std::mutex> lock(dispatch_lock);
     uint64_t descriptor_update_template_id = reinterpret_cast<uint64_t &>(descriptorUpdateTemplate);
     layer_data->desc_template_map.erase(descriptor_update_template_id);
@@ -627,11 +630,11 @@ void DispatchDestroyDescriptorUpdateTemplate(ValidationObject *layer_data,
 }
 
 // This is the extension version of this routine.  The core version is above.
-void DispatchDestroyDescriptorUpdateTemplateKHR(ValidationObject *layer_data,
-                                                VkDevice device,
-                                                VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
+void DispatchDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                 const VkAllocationCallbacks *pAllocator) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
     std::unique_lock<std::mutex> lock(dispatch_lock);
     uint64_t descriptor_update_template_id = reinterpret_cast<uint64_t &>(descriptorUpdateTemplate);
     layer_data->desc_template_map.erase(descriptor_update_template_id);
@@ -740,11 +743,12 @@ void *BuildUnwrappedUpdateTemplateBuffer(ValidationObject *layer_data, uint64_t 
     return (void *)unwrapped_data;
 }
 
-void DispatchUpdateDescriptorSetWithTemplate(ValidationObject *layer_data,
-                                             VkDevice device, VkDescriptorSet descriptorSet,
-                                             VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
-                                             const void *pData) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
+void DispatchUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
+                                             VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate,
+                                                                                 pData);
     uint64_t template_handle = reinterpret_cast<uint64_t &>(descriptorUpdateTemplate);
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -756,11 +760,12 @@ void DispatchUpdateDescriptorSetWithTemplate(ValidationObject *layer_data,
     free(unwrapped_buffer);
 }
 
-void DispatchUpdateDescriptorSetWithTemplateKHR(ValidationObject *layer_data,
-                                                VkDevice device, VkDescriptorSet descriptorSet,
-                                                VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
-                                                const void *pData) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
+void DispatchUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
+                                                VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void *pData) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate,
+                                                                                    pData);
     uint64_t template_handle = reinterpret_cast<uint64_t &>(descriptorUpdateTemplate);
     void *unwrapped_buffer = nullptr;
     {
@@ -773,11 +778,13 @@ void DispatchUpdateDescriptorSetWithTemplateKHR(ValidationObject *layer_data,
     free(unwrapped_buffer);
 }
 
-void DispatchCmdPushDescriptorSetWithTemplateKHR(ValidationObject *layer_data,
-                                                 VkCommandBuffer commandBuffer,
-                                                 VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
-                                                 VkPipelineLayout layout, uint32_t set, const void *pData) {
-    if (!wrap_handles) return layer_data->device_dispatch_table.CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData);
+void DispatchCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
+                                                 VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout,
+                                                 uint32_t set, const void *pData) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->device_dispatch_table.CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate,
+                                                                                     layout, set, pData);
     uint64_t template_handle = reinterpret_cast<uint64_t &>(descriptorUpdateTemplate);
     void *unwrapped_buffer = nullptr;
     {
@@ -791,9 +798,9 @@ void DispatchCmdPushDescriptorSetWithTemplateKHR(ValidationObject *layer_data,
     free(unwrapped_buffer);
 }
 
-VkResult DispatchGetPhysicalDeviceDisplayPropertiesKHR(ValidationObject *layer_data,
-                                                       VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
+VkResult DispatchGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
                                                        VkDisplayPropertiesKHR *pProperties) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     VkResult result =
         layer_data->instance_dispatch_table.GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
@@ -806,9 +813,9 @@ VkResult DispatchGetPhysicalDeviceDisplayPropertiesKHR(ValidationObject *layer_d
     return result;
 }
 
-VkResult DispatchGetPhysicalDeviceDisplayProperties2KHR(ValidationObject *layer_data,
-                                                        VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
+VkResult DispatchGetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
                                                         VkDisplayProperties2KHR *pProperties) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     VkResult result =
         layer_data->instance_dispatch_table.GetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
@@ -822,10 +829,9 @@ VkResult DispatchGetPhysicalDeviceDisplayProperties2KHR(ValidationObject *layer_
     return result;
 }
 
-VkResult DispatchGetPhysicalDeviceDisplayPlanePropertiesKHR(ValidationObject *layer_data,
-                                                            VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
+VkResult DispatchGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
                                                             VkDisplayPlanePropertiesKHR *pProperties) {
-
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     VkResult result =
         layer_data->instance_dispatch_table.GetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
@@ -839,12 +845,11 @@ VkResult DispatchGetPhysicalDeviceDisplayPlanePropertiesKHR(ValidationObject *la
     return result;
 }
 
-VkResult DispatchGetPhysicalDeviceDisplayPlaneProperties2KHR(ValidationObject *layer_data,VkPhysicalDevice physicalDevice,
-                                                             uint32_t *pPropertyCount,
+VkResult DispatchGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
                                                              VkDisplayPlaneProperties2KHR *pProperties) {
-
-    VkResult result =
-        layer_data->instance_dispatch_table.GetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties);
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    VkResult result = layer_data->instance_dispatch_table.GetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice,
+                                                                                                      pPropertyCount, pProperties);
     if (!wrap_handles) return result;
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pProperties) {
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -856,11 +861,11 @@ VkResult DispatchGetPhysicalDeviceDisplayPlaneProperties2KHR(ValidationObject *l
     return result;
 }
 
-VkResult DispatchGetDisplayPlaneSupportedDisplaysKHR(ValidationObject *layer_data,
-                                                     VkPhysicalDevice physicalDevice, uint32_t planeIndex,
-                                                     uint32_t *pDisplayCount, VkDisplayKHR *pDisplays) {
-    VkResult result =
-        layer_data->instance_dispatch_table.GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays);
+VkResult DispatchGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex, uint32_t *pDisplayCount,
+                                                     VkDisplayKHR *pDisplays) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    VkResult result = layer_data->instance_dispatch_table.GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex,
+                                                                                              pDisplayCount, pDisplays);
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pDisplays) {
     if (!wrap_handles) return result;
         std::lock_guard<std::mutex> lock(dispatch_lock);
@@ -871,10 +876,12 @@ VkResult DispatchGetDisplayPlaneSupportedDisplaysKHR(ValidationObject *layer_dat
     return result;
 }
 
-VkResult DispatchGetDisplayModePropertiesKHR(ValidationObject *layer_data,
-                                             VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                             uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties) {
-    if (!wrap_handles) return layer_data->instance_dispatch_table.GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
+VkResult DispatchGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t *pPropertyCount,
+                                             VkDisplayModePropertiesKHR *pProperties) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->instance_dispatch_table.GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount,
+                                                                               pProperties);
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
         display = layer_data->Unwrap(display);
@@ -890,10 +897,12 @@ VkResult DispatchGetDisplayModePropertiesKHR(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchGetDisplayModeProperties2KHR(ValidationObject *layer_data,
-                                              VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                              uint32_t *pPropertyCount, VkDisplayModeProperties2KHR *pProperties) {
-    if (!wrap_handles) return layer_data->instance_dispatch_table.GetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties);
+VkResult DispatchGetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t *pPropertyCount,
+                                              VkDisplayModeProperties2KHR *pProperties) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (!wrap_handles)
+        return layer_data->instance_dispatch_table.GetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount,
+                                                                                pProperties);
     {
         std::lock_guard<std::mutex> lock(dispatch_lock);
         display = layer_data->Unwrap(display);
@@ -910,8 +919,8 @@ VkResult DispatchGetDisplayModeProperties2KHR(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchDebugMarkerSetObjectTagEXT(ValidationObject *layer_data,
-                                            VkDevice device, const VkDebugMarkerObjectTagInfoEXT *pTagInfo) {
+VkResult DispatchDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT *pTagInfo) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
     safe_VkDebugMarkerObjectTagInfoEXT local_tag_info(pTagInfo);
     {
@@ -926,8 +935,8 @@ VkResult DispatchDebugMarkerSetObjectTagEXT(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchDebugMarkerSetObjectNameEXT(ValidationObject *layer_data,
-                                             VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+VkResult DispatchDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
     safe_VkDebugMarkerObjectNameInfoEXT local_name_info(pNameInfo);
     {
@@ -943,8 +952,8 @@ VkResult DispatchDebugMarkerSetObjectNameEXT(ValidationObject *layer_data,
 }
 
 // VK_EXT_debug_utils
-VkResult DispatchSetDebugUtilsObjectTagEXT(ValidationObject *layer_data,
-                                           VkDevice device, const VkDebugUtilsObjectTagInfoEXT *pTagInfo) {
+VkResult DispatchSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT *pTagInfo) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.SetDebugUtilsObjectTagEXT(device, pTagInfo);
     safe_VkDebugUtilsObjectTagInfoEXT local_tag_info(pTagInfo);
     {
@@ -959,8 +968,8 @@ VkResult DispatchSetDebugUtilsObjectTagEXT(ValidationObject *layer_data,
     return result;
 }
 
-VkResult DispatchSetDebugUtilsObjectNameEXT(ValidationObject *layer_data,
-                                            VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+VkResult DispatchSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);
     safe_VkDebugUtilsObjectNameInfoEXT local_name_info(pNameInfo);
     {
@@ -1725,7 +1734,6 @@ VkResult DispatchSetDebugUtilsObjectNameEXT(ValidationObject *layer_data,
         func_sig = decls[0][:-1]
         func_sig = func_sig.replace("VKAPI_ATTR ", "")
         func_sig = func_sig.replace("VKAPI_CALL ", "Dispatch")
-        func_sig = func_sig.replace("(", "(ValidationObject *layer_data, ")
         func_sig += ';'
         dispatch_prototype = ''
         if ifdef_text is not None:
@@ -1769,7 +1777,6 @@ VkResult DispatchSetDebugUtilsObjectNameEXT(ValidationObject *layer_data,
             func_sig = decls[0][:-1]
             func_sig = func_sig.replace("VKAPI_ATTR ", "")
             func_sig = func_sig.replace("VKAPI_CALL ", "Dispatch")
-            func_sig = func_sig.replace("(", "(ValidationObject *layer_data, ")
             self.appendSection('source_file', '')
             self.appendSection('source_file', func_sig)
             self.appendSection('source_file', '{')
@@ -1797,7 +1804,8 @@ VkResult DispatchSetDebugUtilsObjectNameEXT(ValidationObject *layer_data,
                 dispatch_table_type = "instance_dispatch_table"
 
             api_func = cmdinfo.elem.attrib.get('name').replace('vk','layer_data->%s.',1) % dispatch_table_type
-
+            # Call to get the layer_data pointer
+            self.appendSection('source_file', '    auto layer_data = GetLayerDataPtr(get_dispatch_key(%s), layer_data_map);' % dispatchable_name)
             # Put all this together for the final down-chain call
             if not down_chain_call_only:
                 unwrapped_dispatch_call = api_func + '(' + paramstext + ')'

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1010,7 +1010,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         intercept->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &cgpl_state);
     }
 
-    VkResult result = DispatchCreateGraphicsPipelines(layer_data, device, pipelineCache, createInfoCount, cgpl_state.pCreateInfos, pAllocator, pPipelines);
+    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, cgpl_state.pCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
@@ -1045,7 +1045,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     }
-    VkResult result = DispatchCreateComputePipelines(layer_data, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &pipe_state);
@@ -1078,7 +1078,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     }
-    VkResult result = DispatchCreateRayTracingPipelinesNV(layer_data, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+    VkResult result = DispatchCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &pipe_state);
@@ -1112,7 +1112,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, &cpl_state);
     }
-    VkResult result = DispatchCreatePipelineLayout(layer_data, device, &cpl_state.modified_create_info, pAllocator, pPipelineLayout);
+    VkResult result = DispatchCreatePipelineLayout(device, &cpl_state.modified_create_info, pAllocator, pPipelineLayout);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, result);
@@ -1146,7 +1146,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, &csm_state);
     }
-    VkResult result = DispatchCreateShaderModule(layer_data, device, &csm_state.instrumented_create_info, pAllocator, pShaderModule);
+    VkResult result = DispatchCreateShaderModule(device, &csm_state.instrumented_create_info, pAllocator, pShaderModule);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, result, &csm_state);
@@ -1176,7 +1176,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
         auto lock = intercept->write_lock();
         intercept->PreCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
     }
-    VkResult result = DispatchAllocateDescriptorSets(layer_data, device, pAllocateInfo, pDescriptorSets);
+    VkResult result = DispatchAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, result, &ads_state);
@@ -1583,7 +1583,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         api_function_name = cmdinfo.elem.attrib.get('name')
         params = cmdinfo.elem.findall('param/name')
         paramstext = ', '.join([str(param.text) for param in params])
-        API = api_function_name.replace('vk','Dispatch') + '(layer_data, '
+        API = api_function_name.replace('vk','Dispatch') + '('
 
         # Declare result variable, if any.
         return_map = {


### PR DESCRIPTION
In preparation for gpu assisted validation moving to vma, change dispatch routines to get their own validation object pointer instead of requiring them to be passed as a parameter