### PR TITLE
Add config support for ValidationFeatureDisables and internal layer disables

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -1,7 +1,8 @@
 /**************************************************************************
  *
- * Copyright 2014 Valve Software
- * Copyright 2015 Google Inc.
+ * Copyright 2014-2019 Valve Software
+ * Copyright 2015-2019 Google Inc.
+ * Copyright 2019 LunarG, Inc.
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +46,7 @@ class ConfigFile {
 
     const char *getOption(const std::string &_option);
     void setOption(const std::string &_option, const std::string &_val);
+    std::string vk_layer_disables_env_var{};
 
    private:
     bool m_fileIsParsed;
@@ -76,6 +78,10 @@ std::string getEnvironment(const char *variable) {
 }
 
 VK_LAYER_EXPORT const char *getLayerOption(const char *_option) { return g_configFileObj.getOption(_option); }
+VK_LAYER_EXPORT const char *GetLayerEnvVar(const char *_option) {
+    g_configFileObj.vk_layer_disables_env_var = getEnvironment(_option);
+    return g_configFileObj.vk_layer_disables_env_var.c_str();
+}
 
 // If option is NULL or stdout, return stdout, otherwise try to open option
 // as a filename. If successful, return file handle, otherwise stdout

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@ const std::unordered_map<std::string, VkFlags> report_flags_option_definitions =
     {std::string("debug"), VK_DEBUG_REPORT_DEBUG_BIT_EXT}};
 
 VK_LAYER_EXPORT const char *getLayerOption(const char *_option);
+VK_LAYER_EXPORT const char *GetLayerEnvVar(const char *_option);
+
 VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *_option, const char *layerName);
 VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string, VkFlags> const &enum_data,
                                             uint32_t option_default);

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -52,11 +52,38 @@
 #      filename is specified or if filename has invalid path, then stdout
 #      is used by default.
 #
+#   DISABLES:
+#   =============
+#   <LayerIdentifier>.disables : comma separated list of feature/flag/disable enums
+#      These can include VkValidationFeatureDisableEXT flags defined in the Vulkan
+#      specification, or ValidationCheckDisables enums defined in chassis.h.
+#      Effects of setting these flags are described in the specification (or the
+#      source code in the case of the ValidationCheckDisables). The most useful
+#      flags are briefly described here:
+#      VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT - disables handle wrapping.
+#          Disable this feature if you are running into crashes when authoring new extensions
+#          or developing new Vulkan objects/structures
+#      VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT - disables thread checks. It may
+#          help with performance to run with thread-checking disabled most of the time,
+#          enabling it occasionally for a quick sanity check, or when debugging difficult
+#          application behaviors.
+#      VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT - disables the main, heavy-duty
+#          validation checks. This may be valuable early in the development cycle to
+#          reduce validation output while correcting paramter/object usage errors.
+#      VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT - disables stateless parameter
+#          checks. This may not always be necessary late in a development cycle.
+#      VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT - disables object tracking.
+#          This may not always be necessary late in a development cycle.
+#
+
+
 
 # VK_LAYER_KHRONOS_validation Settings
 khronos_validation.debug_action = VK_DBG_LAYER_ACTION_LOG_MSG
 khronos_validation.report_flags = error,warn,perf
 khronos_validation.log_filename = stdout
+# Example entry showing how to disable threading checks and validation at DestroyPipeline time
+#khronos_validation.disables = VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,VALIDATION_CHECK_DISABLE_DESTROY_PIPELINE
 
 # VK_LAYER_LUNARG_core_validation Settings
 lunarg_core_validation.debug_action = VK_DBG_LAYER_ACTION_LOG_MSG

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -75,8 +75,15 @@
 #      VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT - disables object tracking.
 #          This may not always be necessary late in a development cycle.
 #
-
-
+#   ENABLES:
+#   =============
+#   <LayerIdentifier>.enables : comma separated list of feature enable enums
+#      These can include VkValidationFeatureEnableEXT flags defined in the Vulkan
+#      specification, where their effects are described.  The most useful
+#      flags are briefly described here:
+#      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT - enables heavy-weight GPU-assisted
+#      shader validation in core/khronos validation layers
+#
 
 # VK_LAYER_KHRONOS_validation Settings
 khronos_validation.debug_action = VK_DBG_LAYER_ACTION_LOG_MSG


### PR DESCRIPTION
Hooked up `vk_layer_settings.txt` support for the spec-defined `VK_VALIDATION_FEATURE_* `flags, and defined new enums for existing internal-only disables. Also added env vars for development use.  This'll allow a user to easily disable validation functionality (which we used to do by just not loading a layer) or to enable gpu validation.

For example, in layer_settings to disable unique objects, 
`khronos_validation.disables = VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT`

or, using the env var:
`VK_LAYER_DISABLES = VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT`

Added new commits supporting the `VK_VALIDATION_FEATURE_ENABLE `flags -- this will not interfere with the existing gpu validation config settings keys.