### PR TITLE
tests: Remove SetUp()\TearDown() functions

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -932,7 +932,9 @@ ErrorMonitor *VkLayerTest::Monitor() { return m_errorMonitor; }
 
 VkCommandBufferObj *VkLayerTest::CommandBuffer() { return m_commandBuffer; }
 
-void VkLayerTest::SetUp() {
+VkLayerTest::VkLayerTest() {
+    m_enableWSI = false;
+
     m_instance_layer_names.clear();
     m_instance_extension_names.clear();
     m_device_extension_names.clear();
@@ -1030,13 +1032,10 @@ bool VkLayerTest::LoadDeviceProfileLayer(
     return 1;
 }
 
-void VkLayerTest::TearDown() {
+VkLayerTest::~VkLayerTest() {
     // Clean up resources before we reset
-    ShutdownFramework();
     delete m_errorMonitor;
 }
-
-VkLayerTest::VkLayerTest() { m_enableWSI = false; }
 
 bool VkBufferTest::GetTestConditionValid(VkDeviceObj *aVulkanDevice, eTestEnFlags aTestFlag, VkBufferUsageFlags aBufferUsage) {
     if (eInvalidDeviceOffset != aTestFlag && eInvalidMemoryOffset != aTestFlag) {

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -300,14 +300,15 @@ class VkLayerTest : public VkRenderFramework {
     uint32_t m_instance_api_version = 0;
     uint32_t m_target_api_version = 0;
     bool m_enableWSI;
-    virtual void SetUp();
+
     uint32_t SetTargetApiVersion(uint32_t target_api_version);
     uint32_t DeviceValidationVersion();
     bool LoadDeviceProfileLayer(
         PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
         PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT);
-    virtual void TearDown();
+
     VkLayerTest();
+    ~VkLayerTest();
 };
 
 class VkPositiveLayerTest : public VkLayerTest {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -61,7 +61,7 @@ VkRenderFramework::VkRenderFramework()
     m_clear_color.float32[3] = 0.0f;
 }
 
-VkRenderFramework::~VkRenderFramework() {}
+VkRenderFramework::~VkRenderFramework() { ShutdownFramework(); }
 
 VkPhysicalDevice VkRenderFramework::gpu() {
     EXPECT_NE((VkInstance)0, inst);  // Invalid to request gpu before instance exists

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -163,24 +163,6 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_instance_layer_names;
     std::vector<const char *> m_instance_extension_names;
     std::vector<const char *> m_device_extension_names;
-
-    /*
-     * SetUp and TearDown are called by the Google Test framework
-     * to initialize a test framework based on this class.
-     */
-    virtual void SetUp() {
-        this->app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-        this->app_info.pNext = NULL;
-        this->app_info.pApplicationName = "base";
-        this->app_info.applicationVersion = 1;
-        this->app_info.pEngineName = "unittest";
-        this->app_info.engineVersion = 1;
-        this->app_info.apiVersion = VK_API_VERSION_1_0;
-
-        InitFramework();
-    }
-
-    virtual void TearDown() { ShutdownFramework(); }
 };
 
 class VkDescriptorSetObj;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -77,9 +77,6 @@ class VkDepthStencilObj;
 
 class VkRenderFramework : public VkTestFramework {
    public:
-    VkRenderFramework();
-    ~VkRenderFramework();
-
     VkInstance instance() { return inst; }
     VkDevice device() { return m_device->device(); }
     VkDeviceObj *DeviceObj() const { return m_device; }
@@ -118,6 +115,9 @@ class VkRenderFramework : public VkTestFramework {
     bool DeviceCanDraw();
 
    protected:
+    VkRenderFramework();
+    virtual ~VkRenderFramework() = 0;
+
     VkApplicationInfo app_info;
     VkInstance inst;
     VkPhysicalDevice objs[16];

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -59,9 +59,6 @@ class VkImageObj;
 
 class VkTestFramework : public ::testing::Test {
    public:
-    VkTestFramework();
-    ~VkTestFramework();
-
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
     static bool optionMatch(const char *option, char *optionLine);
     static void InitArgs(int *argc, char *argv[]);
@@ -78,6 +75,10 @@ class VkTestFramework : public ::testing::Test {
 
     char **ReadFileData(const char *fileName);
     void FreeFileData(char **data);
+
+   protected:
+    VkTestFramework();
+    virtual ~VkTestFramework() = 0;
 
    private:
     int m_compile_options;


### PR DESCRIPTION
https://github.com/google/googletest/blob/master/googletest/docs/faq.md#should-i-use-the-constructordestructor-of-the-test-fixture-or-setupteardown

This cleans up bit of confusion of Constructor vs SetUp(). Only one of those should be used for clarity. This PR chooses Constructor per above.

Not sure what the deal with the middleman classes are. Their division of labour seem blurry. So I at least made the `VkRenderFramework` and `VkTestFramework` abstract, to make sure they are not used outside `VkLayerTest`.