### PR TITLE
Image Layout tracking refactor for performance & low hanging fruit perf changes for object binding

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -37,6 +37,7 @@ uint32_t FullMipChainLevels(VkExtent2D);
 uint32_t ResolveRemainingLevels(const VkImageSubresourceRange *range, uint32_t mip_levels);
 
 uint32_t ResolveRemainingLayers(const VkImageSubresourceRange *range, uint32_t layers);
+VkImageSubresourceRange NormalizeSubresourceRange(const IMAGE_STATE &image_state, const VkImageSubresourceRange &range);
 
 bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap, ImageSubresourcePair imgpair,
                 VkImageLayout &layout, const VkImageAspectFlags aspectMask);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -376,66 +376,87 @@ void CoreChecks::AddMemObjInfo(void *object, const VkDeviceMemory mem, const VkM
 
 // Create binding link between given sampler and command buffer node
 void CoreChecks::AddCommandBufferBindingSampler(GLOBAL_CB_NODE *cb_node, SAMPLER_STATE *sampler_state) {
-    sampler_state->cb_bindings.insert(cb_node);
-    cb_node->object_bindings.insert({HandleToUint64(sampler_state->sampler), kVulkanObjectTypeSampler});
+    auto inserted = cb_node->object_bindings.insert({HandleToUint64(sampler_state->sampler), kVulkanObjectTypeSampler});
+    if (inserted.second) {
+        // Only need to complete the cross-reference if this is a new item
+        sampler_state->cb_bindings.insert(cb_node);
+    }
 }
 
 // Create binding link between given image node and command buffer node
 void CoreChecks::AddCommandBufferBindingImage(GLOBAL_CB_NODE *cb_node, IMAGE_STATE *image_state) {
     // Skip validation if this image was created through WSI
     if (image_state->binding.mem != MEMTRACKER_SWAP_CHAIN_IMAGE_KEY) {
-        // First update CB binding in MemObj mini CB list
-        for (auto mem_binding : image_state->GetBoundMemory()) {
-            DEVICE_MEM_INFO *pMemInfo = GetMemObjInfo(mem_binding);
-            if (pMemInfo) {
-                pMemInfo->cb_bindings.insert(cb_node);
-                // Now update CBInfo's Mem reference list
-                cb_node->memObjs.insert(mem_binding);
+        // First update cb binding for image
+        auto image_inserted = cb_node->object_bindings.insert({HandleToUint64(image_state->image), kVulkanObjectTypeImage});
+        if (image_inserted.second) {
+            // Only need to continue if this is a new item (the rest of the work would have be done previous)
+            image_state->cb_bindings.insert(cb_node);
+            // Now update CB binding in MemObj mini CB list
+            for (auto mem_binding : image_state->GetBoundMemory()) {
+                DEVICE_MEM_INFO *pMemInfo = GetMemObjInfo(mem_binding);
+                if (pMemInfo) {
+                    // Now update CBInfo's Mem reference list
+                    auto mem_inserted = cb_node->memObjs.insert(mem_binding);
+                    if (mem_inserted.second) {
+                        // Only need to complete the cross-reference if this is a new item
+                        pMemInfo->cb_bindings.insert(cb_node);
+                    }
+                }
             }
         }
-        // Now update cb binding for image
-        cb_node->object_bindings.insert({HandleToUint64(image_state->image), kVulkanObjectTypeImage});
-        image_state->cb_bindings.insert(cb_node);
     }
 }
 
 // Create binding link between given image view node and its image with command buffer node
 void CoreChecks::AddCommandBufferBindingImageView(GLOBAL_CB_NODE *cb_node, IMAGE_VIEW_STATE *view_state) {
     // First add bindings for imageView
-    view_state->cb_bindings.insert(cb_node);
-    cb_node->object_bindings.insert({HandleToUint64(view_state->image_view), kVulkanObjectTypeImageView});
-    auto image_state = GetImageState(view_state->create_info.image);
-    // Add bindings for image within imageView
-    if (image_state) {
-        AddCommandBufferBindingImage(cb_node, image_state);
+    auto inserted = cb_node->object_bindings.insert({HandleToUint64(view_state->image_view), kVulkanObjectTypeImageView});
+    if (inserted.second) {
+        // Only need to continue if this is a new item
+        view_state->cb_bindings.insert(cb_node);
+        auto image_state = GetImageState(view_state->create_info.image);
+        // Add bindings for image within imageView
+        if (image_state) {
+            AddCommandBufferBindingImage(cb_node, image_state);
+        }
     }
 }
 
 // Create binding link between given buffer node and command buffer node
 void CoreChecks::AddCommandBufferBindingBuffer(GLOBAL_CB_NODE *cb_node, BUFFER_STATE *buffer_state) {
-    // First update CB binding in MemObj mini CB list
-    for (auto mem_binding : buffer_state->GetBoundMemory()) {
-        DEVICE_MEM_INFO *pMemInfo = GetMemObjInfo(mem_binding);
-        if (pMemInfo) {
-            pMemInfo->cb_bindings.insert(cb_node);
-            // Now update CBInfo's Mem reference list
-            cb_node->memObjs.insert(mem_binding);
+    // First update cb binding for buffer
+    auto buffer_inserted = cb_node->object_bindings.insert({HandleToUint64(buffer_state->buffer), kVulkanObjectTypeBuffer});
+    if (buffer_inserted.second) {
+        // Only need to continue if this is a new item
+        buffer_state->cb_bindings.insert(cb_node);
+        // Now update CB binding in MemObj mini CB list
+        for (auto mem_binding : buffer_state->GetBoundMemory()) {
+            DEVICE_MEM_INFO *pMemInfo = GetMemObjInfo(mem_binding);
+            if (pMemInfo) {
+                // Now update CBInfo's Mem reference list
+                auto inserted = cb_node->memObjs.insert(mem_binding);
+                if (inserted.second) {
+                    // Only need to complete the cross-reference if this is a new item
+                    pMemInfo->cb_bindings.insert(cb_node);
+                }
+            }
         }
     }
-    // Now update cb binding for buffer
-    cb_node->object_bindings.insert({HandleToUint64(buffer_state->buffer), kVulkanObjectTypeBuffer});
-    buffer_state->cb_bindings.insert(cb_node);
 }
 
 // Create binding link between given buffer view node and its buffer with command buffer node
 void CoreChecks::AddCommandBufferBindingBufferView(GLOBAL_CB_NODE *cb_node, BUFFER_VIEW_STATE *view_state) {
     // First add bindings for bufferView
-    view_state->cb_bindings.insert(cb_node);
-    cb_node->object_bindings.insert({HandleToUint64(view_state->buffer_view), kVulkanObjectTypeBufferView});
-    auto buffer_state = GetBufferState(view_state->create_info.buffer);
-    // Add bindings for buffer within bufferView
-    if (buffer_state) {
-        AddCommandBufferBindingBuffer(cb_node, buffer_state);
+    auto inserted = cb_node->object_bindings.insert({HandleToUint64(view_state->buffer_view), kVulkanObjectTypeBufferView});
+    if (inserted.second) {
+        // Only need to complete the cross-reference if this is a new item
+        view_state->cb_bindings.insert(cb_node);
+        auto buffer_state = GetBufferState(view_state->create_info.buffer);
+        // Add bindings for buffer within bufferView
+        if (buffer_state) {
+            AddCommandBufferBindingBuffer(cb_node, buffer_state);
+        }
     }
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -280,6 +280,71 @@ std::unordered_map<VkSamplerYcbcrConversion, uint64_t> *CoreChecks::GetYcbcrConv
 
 std::unordered_set<uint64_t> *CoreChecks::GetAHBExternalFormatsSet() { return &ahb_ext_formats_set; }
 
+// the ImageLayoutMap implementation bakes in the number of valid aspects -- we have to choose the correct one at construction time
+template <uint32_t kThreshold>
+static std::unique_ptr<ImageSubresourceLayoutMap> LayoutMapFactoryByAspect(const IMAGE_STATE &image_state) {
+    ImageSubresourceLayoutMap *map = nullptr;
+    switch (image_state.full_range.aspectMask) {
+        case VK_IMAGE_ASPECT_COLOR_BIT:
+            map = new ImageSubresourceLayoutMapImpl<ColorAspectTraits, kThreshold>(image_state);
+            break;
+        case VK_IMAGE_ASPECT_DEPTH_BIT:
+            map = new ImageSubresourceLayoutMapImpl<DepthAspectTraits, kThreshold>(image_state);
+            break;
+        case VK_IMAGE_ASPECT_STENCIL_BIT:
+            map = new ImageSubresourceLayoutMapImpl<StencilAspectTraits, kThreshold>(image_state);
+            break;
+        case VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT:
+            map = new ImageSubresourceLayoutMapImpl<DepthStencilAspectTraits, kThreshold>(image_state);
+            break;
+        case VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT:
+            map = new ImageSubresourceLayoutMapImpl<Multiplane2AspectTraits, kThreshold>(image_state);
+            break;
+        case VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT:
+            map = new ImageSubresourceLayoutMapImpl<Multiplane3AspectTraits, kThreshold>(image_state);
+            break;
+    }
+
+    assert(map);  // We shouldn't be able to get here null unless the traits cases are incomplete
+    return std::unique_ptr<ImageSubresourceLayoutMap>(map);
+}
+
+static std::unique_ptr<ImageSubresourceLayoutMap> LayoutMapFactory(const IMAGE_STATE &image_state) {
+    std::unique_ptr<ImageSubresourceLayoutMap> map;
+    const uint32_t kAlwaysDenseLimit = 16;  // About a cacheline on deskop architectures
+    if (image_state.full_range.layerCount <= kAlwaysDenseLimit) {
+        // Create a dense row map
+        map = LayoutMapFactoryByAspect<0>(image_state);
+    } else {
+        // Create an initially sparse row map
+        map = LayoutMapFactoryByAspect<kAlwaysDenseLimit>(image_state);
+    }
+    return map;
+}
+
+// The const variant only need the image as it is the key for the map
+const ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(const GLOBAL_CB_NODE *cb_state, VkImage image) {
+    auto it = cb_state->image_layout_map.find(image);
+    if (it == cb_state->image_layout_map.cend()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+// The non-const variant only needs the image state, as the factory requires it to construct a new entry
+ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(GLOBAL_CB_NODE *cb_state, const IMAGE_STATE &image_state) {
+    auto it = cb_state->image_layout_map.find(image_state.image);
+    if (it == cb_state->image_layout_map.end()) {
+        // Empty slot... fill it in.
+        auto insert_pair = cb_state->image_layout_map.insert(std::make_pair(image_state.image, LayoutMapFactory(image_state)));
+        assert(insert_pair.second);
+        ImageSubresourceLayoutMap *new_map = insert_pair.first->second.get();
+        assert(new_map);
+        return new_map;
+    }
+    return it->second.get();
+}
+
 // Return ptr to info in map container containing mem, or NULL if not found
 //  Calls to this function should be wrapped in mutex
 DEVICE_MEM_INFO *CoreChecks::GetMemObjInfo(const VkDeviceMemory mem) {
@@ -2088,7 +2153,7 @@ void CoreChecks::ResetCommandBufferState(const VkCommandBuffer cb) {
         pCB->queryToStateMap.clear();
         pCB->activeQueries.clear();
         pCB->startedQueries.clear();
-        pCB->imageLayoutMap.clear();
+        pCB->image_layout_map.clear();
         pCB->eventToStageMap.clear();
         pCB->draw_data.clear();
         pCB->current_draw_data.vertex_buffer_bindings.clear();
@@ -10256,45 +10321,46 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             "inherited queries not supported on this device.",
                             report_data->FormatHandle(pCommandBuffers[i]).c_str());
         }
-        // Propagate layout transitions to the primary cmd buffer
+        // Validate initial layout uses vs. the primary cmd buffer state
         // Novel Valid usage: "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001"
         // initial layout usage of secondary command buffers resources must match parent command buffer
-        for (const auto &ilm_entry : sub_cb_state->imageLayoutMap) {
-            auto cb_entry = cb_state->imageLayoutMap.find(ilm_entry.first);
-            if (cb_entry != cb_state->imageLayoutMap.end()) {
-                // For exact matches ImageSubresourcePair matches, validate and update the parent entry
-                if ((VK_IMAGE_LAYOUT_UNDEFINED != ilm_entry.second.initialLayout) &&
-                    (cb_entry->second.layout != ilm_entry.second.initialLayout)) {
-                    const VkImageSubresource &subresource = ilm_entry.first.subresource;
-                    log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(pCommandBuffers[i]), "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
-                        "%s: Executed secondary command buffer using image %s (subresource: aspectMask 0x%X array layer %u, "
-                        "mip level %u) which expects layout %s--instead, image %s's current layout is %s.",
-                        "vkCmdExecuteCommands():", report_data->FormatHandle(ilm_entry.first.image).c_str(), subresource.aspectMask,
-                        subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(ilm_entry.second.initialLayout),
-                        report_data->FormatHandle(ilm_entry.first.image).c_str(), string_VkImageLayout(cb_entry->second.layout));
+        const auto *const_cb_state = static_cast<const GLOBAL_CB_NODE *>(cb_state);
+        for (const auto &sub_layout_map_entry : sub_cb_state->image_layout_map) {
+            const auto image = sub_layout_map_entry.first;
+            const auto *image_state = GetImageState(image);
+            if (!image_state) continue;  // Can't set layouts of a dead image
+
+            const auto *cb_subres_map = GetImageSubresourceLayoutMap(const_cb_state, image);
+            // Const getter can be null in which case we have nothing to check against for this image...
+            if (!cb_subres_map) continue;
+
+            const auto &sub_cb_subres_map = sub_layout_map_entry.second;
+            // Validate the initial_uses, that they match the current state of the primary cb, or absent a current state,
+            // that the match any initial_layout.
+            for (auto it_init = sub_cb_subres_map->BeginInitialUse(); !it_init.AtEnd(); ++it_init) {
+                const auto &sub_layout = (*it_init).layout;
+                if (VK_IMAGE_LAYOUT_UNDEFINED == sub_layout) continue;  // secondary doesn't care about current or initial
+                const auto &subresource = (*it_init).subresource;
+                // Look up the current layout (if any)
+                VkImageLayout cb_layout = cb_subres_map->GetSubresourceLayout(subresource);
+                const char *layout_type = "current";
+                if (cb_layout == kInvalidLayout) {
+                    // Find initial layout (if any)
+                    cb_layout = cb_subres_map->GetSubresourceInitialLayout(subresource);
+                    layout_type = "initial";
                 }
-            } else {
-                // Look for partial matches (in aspectMask), and update or create parent map entry in SetLayout
-                assert(ilm_entry.first.hasSubresource);
-                IMAGE_CMD_BUF_LAYOUT_NODE node;
-                if (FindCmdBufLayout(cb_state, ilm_entry.first.image, ilm_entry.first.subresource, node)) {
-                    if ((VK_IMAGE_LAYOUT_UNDEFINED != ilm_entry.second.initialLayout) &&
-                        (node.layout != ilm_entry.second.initialLayout)) {
-                        const VkImageSubresource &subresource = ilm_entry.first.subresource;
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(pCommandBuffers[i]), "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
-                                "%s: Executed secondary command buffer using image %s (subresource: aspectMask 0x%X array layer "
-                                "%u, mip level %u) which expects layout %s--instead, image %s's current layout is %s.",
-                                "vkCmdExecuteCommands():", report_data->FormatHandle(ilm_entry.first.image).c_str(),
-                                subresource.aspectMask, subresource.arrayLayer, subresource.mipLevel,
-                                string_VkImageLayout(ilm_entry.second.initialLayout),
-                                report_data->FormatHandle(ilm_entry.first.image).c_str(), string_VkImageLayout(node.layout));
-                    }
+                if ((cb_layout != kInvalidLayout) && (cb_layout != sub_layout)) {
+                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
+                            HandleToUint64(pCommandBuffers[i]), "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
+                            "%s: Executed secondary command buffer using image %s (subresource: aspectMask 0x%X array layer %u, "
+                            "mip level %u) which expects layout %s--instead, image %s layout is %s.",
+                            "vkCmdExecuteCommands():", report_data->FormatHandle(image).c_str(), subresource.aspectMask,
+                            subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(sub_layout), layout_type,
+                            string_VkImageLayout(cb_layout));
                 }
             }
         }
+
         linked_command_buffers.insert(sub_cb_state);
     }
     skip |= ValidatePrimaryCommandBuffer(cb_state, "vkCmdExecuteCommands()", "VUID-vkCmdExecuteCommands-bufferlevel");
@@ -10320,25 +10386,19 @@ void CoreChecks::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffer, 
                 cb_state->beginInfo.flags &= ~VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
             }
         }
-        // Propagate layout transitions to the primary cmd buffer
-        // Novel Valid usage: "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001"
-        //  initial layout usage of secondary command buffers resources must match parent command buffer
-        for (const auto &ilm_entry : sub_cb_state->imageLayoutMap) {
-            auto cb_entry = cb_state->imageLayoutMap.find(ilm_entry.first);
-            if (cb_entry != cb_state->imageLayoutMap.end()) {
-                // For exact matches ImageSubresourcePair matches, update the parent entry
-                cb_entry->second.layout = ilm_entry.second.layout;
-            } else {
-                // Look for partial matches (in aspectMask), and update or create parent map entry in SetLayout
-                assert(ilm_entry.first.hasSubresource);
-                IMAGE_CMD_BUF_LAYOUT_NODE node;
-                if (!FindCmdBufLayout(cb_state, ilm_entry.first.image, ilm_entry.first.subresource, node)) {
-                    node.initialLayout = ilm_entry.second.initialLayout;
-                }
-                node.layout = ilm_entry.second.layout;
-                SetLayout(cb_state, ilm_entry.first, node);
-            }
+
+        // Propagate inital layout and current layout state to the primary cmd buffer
+        for (const auto &sub_layout_map_entry : sub_cb_state->image_layout_map) {
+            const auto image = sub_layout_map_entry.first;
+            const auto *image_state = GetImageState(image);
+            if (!image_state) continue;  // Can't set layouts of a dead image
+
+            auto *cb_subres_map = GetImageSubresourceLayoutMap(cb_state, *image_state);
+            const auto *sub_cb_subres_map = sub_layout_map_entry.second.get();
+            assert(cb_subres_map && sub_cb_subres_map);  // Non const get and map traversal should never be null
+            cb_subres_map->UpdateFrom(*sub_cb_subres_map);
         }
+
         sub_cb_state->primaryCommandBuffer = cb_state->commandBuffer;
         cb_state->linkedCommandBuffers.insert(sub_cb_state);
         sub_cb_state->linkedCommandBuffers.insert(cb_state);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -481,8 +481,6 @@ class CoreChecks : public ValidationObject {
     bool InsideRenderPass(const GLOBAL_CB_NODE* pCB, const char* apiName, const char* msgCode);
     bool OutsideRenderPass(GLOBAL_CB_NODE* pCB, const char* apiName, const char* msgCode);
 
-    void SetLayout(GLOBAL_CB_NODE* pCB, ImageSubresourcePair imgpair, const VkImageLayout& layout);
-    void SetLayout(GLOBAL_CB_NODE* pCB, ImageSubresourcePair imgpair, const IMAGE_CMD_BUF_LAYOUT_NODE& node);
     void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& imageLayoutMap, ImageSubresourcePair imgpair,
                    VkImageLayout layout);
 
@@ -649,10 +647,11 @@ class CoreChecks : public ValidationObject {
                                        const VkImageSubresourceRange& subresourceRange, const char* cmd_name,
                                        const char* param_name, const char* image_layer_count_var_name, const uint64_t image_handle,
                                        SubresourceRangeErrorCodes errorCodes);
-    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* image_state, VkImageSubresourceRange image_subresource_range,
-                        const VkImageLayout& layout);
-    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* image_state, VkImageSubresourceLayers image_subresource_layers,
-                        const VkImageLayout& layout);
+    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state,
+                        const VkImageSubresourceRange& image_subresource_range, VkImageLayout layout,
+                        VkImageLayout expected_layout = kInvalidLayout);
+    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state,
+                        const VkImageSubresourceLayers& image_subresource_layers, VkImageLayout layout);
     bool ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPassCreateVersion rp_version, VkImageLayout layout,
                                                               VkImage image, VkImageView image_view, VkFramebuffer framebuffer,
                                                               VkRenderPass renderpass, uint32_t attachment_index,
@@ -683,8 +682,11 @@ class CoreChecks : public ValidationObject {
 
     bool VerifyClearImageLayout(GLOBAL_CB_NODE* cb_node, IMAGE_STATE* image_state, VkImageSubresourceRange range,
                                 VkImageLayout dest_image_layout, const char* func_name);
+    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
+                           VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
+                           const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error);
 
-    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, VkImageSubresourceLayers subLayers,
+    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceLayers& subLayers,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
                            const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error);
 
@@ -721,12 +723,7 @@ class CoreChecks : public ValidationObject {
                                                 const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                 const VkImageSubresourceRange* pRanges);
 
-    bool FindLayoutVerifyNode(GLOBAL_CB_NODE const* pCB, ImageSubresourcePair imgpair, IMAGE_CMD_BUF_LAYOUT_NODE& node,
-                              const VkImageAspectFlags aspectMask);
-
     bool FindLayoutVerifyLayout(ImageSubresourcePair imgpair, VkImageLayout& layout, const VkImageAspectFlags aspectMask);
-
-    bool FindCmdBufLayout(GLOBAL_CB_NODE const* pCB, VkImage image, VkImageSubresource range, IMAGE_CMD_BUF_LAYOUT_NODE& node);
 
     bool FindGlobalLayout(ImageSubresourcePair imgpair, VkImageLayout& layout);
 
@@ -742,7 +739,14 @@ class CoreChecks : public ValidationObject {
 
     void SetImageViewLayout(GLOBAL_CB_NODE* pCB, VkImageView imageView, const VkImageLayout& layout);
 
-    void SetImageViewLayout(GLOBAL_CB_NODE* cb_node, IMAGE_VIEW_STATE* view_state, const VkImageLayout& layout);
+    void SetImageViewLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
+    void SetImageViewInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
+
+    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, VkImage image, const VkImageSubresourceRange& range, VkImageLayout layout);
+    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceRange& range,
+                               VkImageLayout layout);
+    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceLayers& layers,
+                               VkImageLayout layout);
 
     bool VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion rp_version, GLOBAL_CB_NODE* pCB,
                                                const VkRenderPassBeginInfo* pRenderPassBegin,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -25,6 +25,7 @@
 #define CORE_VALIDATION_TYPES_H_
 
 #include "hash_vk_types.h"
+#include "sparse_containers.h"
 #include "vk_safe_struct.h"
 #include "vulkan/vulkan.h"
 #include "vk_layer_logging.h"
@@ -33,6 +34,8 @@
 #include "vk_typemap_helper.h"
 #include "convert_to_renderpass2.h"
 #include "layer_chassis_dispatch.h"
+
+#include <array>
 #include <atomic>
 #include <functional>
 #include <list>
@@ -298,34 +301,9 @@ class IMAGE_STATE : public BINDABLE {
     bool imported_ahb;              // True if image was imported from an Android Hardware Buffer
     bool has_ahb_format;            // True if image was created with an external Android format
     uint64_t ahb_format;            // External Android format, if provided
+    VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers (slices), and aspects
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
-    IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo)
-        : image(img),
-          createInfo(*pCreateInfo),
-          valid(false),
-          acquired(false),
-          shared_presentable(false),
-          layout_locked(false),
-          get_sparse_reqs_called(false),
-          sparse_metadata_required(false),
-          sparse_metadata_bound(false),
-          imported_ahb(false),
-          has_ahb_format(false),
-          ahb_format(0),
-          sparse_requirements{} {
-        if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
-            uint32_t *pQueueFamilyIndices = new uint32_t[createInfo.queueFamilyIndexCount];
-            for (uint32_t i = 0; i < createInfo.queueFamilyIndexCount; i++) {
-                pQueueFamilyIndices[i] = pCreateInfo->pQueueFamilyIndices[i];
-            }
-            createInfo.pQueueFamilyIndices = pQueueFamilyIndices;
-        }
-
-        if (createInfo.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
-            sparse = true;
-        }
-    };
-
+    IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo);
     IMAGE_STATE(IMAGE_STATE const &rh_obj) = delete;
 
     ~IMAGE_STATE() {
@@ -340,12 +318,9 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
    public:
     VkImageView image_view;
     VkImageViewCreateInfo create_info;
+    VkImageSubresourceRange normalized_subresource_range;
     VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
-    IMAGE_VIEW_STATE(VkImageView iv, const VkImageViewCreateInfo *ci)
-        : image_view(iv), create_info(*ci), samplerConversion(VK_NULL_HANDLE) {
-        auto *conversionInfo = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(create_info.pNext);
-        if (conversionInfo) samplerConversion = conversionInfo->conversion;
-    };
+    IMAGE_VIEW_STATE(const IMAGE_STATE *image_state, VkImageView iv, const VkImageViewCreateInfo *ci);
     IMAGE_VIEW_STATE(const IMAGE_VIEW_STATE &rh_obj) = delete;
 };
 
@@ -418,14 +393,447 @@ class SWAPCHAIN_NODE {
         : createInfo(pCreateInfo), swapchain(swapchain) {}
 };
 
-class IMAGE_CMD_BUF_LAYOUT_NODE {
-   public:
-    IMAGE_CMD_BUF_LAYOUT_NODE() = default;
-    IMAGE_CMD_BUF_LAYOUT_NODE(VkImageLayout initialLayoutInput, VkImageLayout layoutInput)
-        : initialLayout(initialLayoutInput), layout(layoutInput) {}
+struct ColorAspectTraits {
+    static const uint32_t kAspectCount = 1;
+    static int Index(VkImageAspectFlags mask) { return 0; };
+    static VkImageAspectFlags AspectMask() { return VK_IMAGE_ASPECT_COLOR_BIT; }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_COLOR_BIT};
+        return kAspectBits;
+    }
+};
 
-    VkImageLayout initialLayout;
-    VkImageLayout layout;
+struct DepthAspectTraits {
+    static const uint32_t kAspectCount = 1;
+    static int Index(VkImageAspectFlags mask) { return 0; };
+    static VkImageAspectFlags AspectMask() { return VK_IMAGE_ASPECT_DEPTH_BIT; }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_DEPTH_BIT};
+        return kAspectBits;
+    }
+};
+
+struct StencilAspectTraits {
+    static const uint32_t kAspectCount = 1;
+    static int Index(VkImageAspectFlags mask) { return 0; };
+    static VkImageAspectFlags AspectMask() { return VK_IMAGE_ASPECT_STENCIL_BIT; }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_STENCIL_BIT};
+        return kAspectBits;
+    }
+};
+
+struct DepthStencilAspectTraits {
+    // VK_IMAGE_ASPECT_DEPTH_BIT = 0x00000002,  >> 1 -> 1 -1 -> 0
+    // VK_IMAGE_ASPECT_STENCIL_BIT = 0x00000004, >> 1 -> 2 -1 = 1
+    static const uint32_t kAspectCount = 2;
+    static uint32_t Index(VkImageAspectFlags mask) {
+        uint32_t index = (mask >> 1) - 1;
+        assert((index == 0) || (index == 1));
+        return index;
+    };
+    static VkImageAspectFlags AspectMask() { return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT; }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_ASPECT_STENCIL_BIT};
+        return kAspectBits;
+    }
+};
+
+struct Multiplane2AspectTraits {
+    // VK_IMAGE_ASPECT_PLANE_0_BIT = 0x00000010, >> 4 - 1 -> 0
+    // VK_IMAGE_ASPECT_PLANE_1_BIT = 0x00000020, >> 4 - 1 -> 1
+    static const uint32_t kAspectCount = 2;
+    static uint32_t Index(VkImageAspectFlags mask) {
+        uint32_t index = (mask >> 4) - 1;
+        assert((index == 0) || (index == 1));
+        return index;
+    };
+    static VkImageAspectFlags AspectMask() { return VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT; }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_PLANE_0_BIT,
+                                                                           VK_IMAGE_ASPECT_PLANE_1_BIT};
+        return kAspectBits;
+    }
+};
+
+struct Multiplane3AspectTraits {
+    // VK_IMAGE_ASPECT_PLANE_0_BIT = 0x00000010, >> 4 - 1 -> 0
+    // VK_IMAGE_ASPECT_PLANE_1_BIT = 0x00000020, >> 4 - 1 -> 1
+    // VK_IMAGE_ASPECT_PLANE_2_BIT = 0x00000040, >> 4 - 1 -> 3
+    static const uint32_t kAspectCount = 3;
+    static uint32_t Index(VkImageAspectFlags mask) {
+        uint32_t index = (mask >> 4) - 1;
+        index = index > 2 ? 2 : index;
+        assert((index == 0) || (index == 1) || (index == 2));
+        return index;
+    };
+    static VkImageAspectFlags AspectMask() {
+        return VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+    }
+    static const std::array<VkImageAspectFlagBits, kAspectCount> &AspectBits() {
+        static std::array<VkImageAspectFlagBits, kAspectCount> kAspectBits{VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT,
+                                                                           VK_IMAGE_ASPECT_PLANE_2_BIT};
+        return kAspectBits;
+    }
+};
+
+const static VkImageLayout kInvalidLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
+// Interface class.
+class ImageSubresourceLayoutMap {
+   public:
+    typedef std::function<bool(const VkImageSubresource &, VkImageLayout, VkImageLayout)> Callback;
+
+    struct SubresourceLayout {
+        VkImageSubresource subresource;
+        VkImageLayout layout;
+    };
+
+    struct SubresourceRangeLayout {
+        VkImageSubresourceRange range;
+        VkImageLayout layout;
+    };
+
+    class ConstIteratorInterface {
+       public:
+        // Make the value accessor non virtual
+        const SubresourceLayout &operator*() const { return value_; }
+
+        virtual ConstIteratorInterface &operator++() = 0;
+        virtual bool AtEnd() const = 0;
+        virtual ~ConstIteratorInterface(){};
+
+       protected:
+        SubresourceLayout value_;
+    };
+
+    class ConstIterator {
+       public:
+        ConstIterator &operator++() {
+            ++(*it_);
+            return *this;
+        }
+        const SubresourceLayout &operator*() const { return *(*it_); }
+        ConstIterator(ConstIteratorInterface *it) : it_(it){};
+        bool AtEnd() const { return it_->AtEnd(); }
+
+       protected:
+        std::unique_ptr<ConstIteratorInterface> it_;
+    };
+
+    virtual ConstIterator BeginInitialUse() const = 0;
+    virtual ConstIterator BeginSetLayout() const = 0;
+
+    virtual bool SetSubresourceRangeLayout(const VkImageSubresourceRange &range, VkImageLayout layout,
+                                           VkImageLayout expected_layout = kInvalidLayout) = 0;
+    virtual bool SetSubresourceRangeInitialLayout(const VkImageSubresourceRange &range, VkImageLayout layout) = 0;
+    virtual bool ForRange(const VkImageSubresourceRange &range, const Callback &callback, bool skip_invalid = true,
+                          bool always_get_initial = false) const = 0;
+    virtual VkImageLayout GetSubresourceLayout(const VkImageSubresource subresource) const = 0;
+    virtual VkImageLayout GetSubresourceInitialLayout(const VkImageSubresource subresource) const = 0;
+    virtual bool UpdateFrom(const ImageSubresourceLayoutMap &from) = 0;
+    virtual uintptr_t CompatibilityKey() const = 0;
+    ImageSubresourceLayoutMap() {}
+    virtual ~ImageSubresourceLayoutMap() {}
+};
+
+template <typename AspectTraits_, size_t kSparseThreshold = 64U>
+class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
+   public:
+    typedef ImageSubresourceLayoutMap Base;
+    typedef AspectTraits_ AspectTraits;
+    typedef Base::SubresourceLayout SubresourceLayout;
+    typedef sparse_container::SparseVector<size_t, VkImageLayout, true, kInvalidLayout, kSparseThreshold> LayoutMap;
+    typedef sparse_container::SparseVector<size_t, VkImageLayout, false, kInvalidLayout, kSparseThreshold> InitialLayoutMap;
+
+    struct Layouts {
+        LayoutMap current;
+        InitialLayoutMap initial;
+        Layouts(size_t size) : current(0, size), initial(0, size) {}
+    };
+
+    template <typename Container>
+    class ConstIteratorImpl : public Base::ConstIteratorInterface {
+       public:
+        ConstIteratorImpl &operator++() override {
+            ++it_;
+            UpdateValue();
+            return *this;
+        }
+        // Just good enough for cend checks
+        ConstIteratorImpl(const ImageSubresourceLayoutMapImpl &map, const Container &container)
+            : map_(&map), container_(&container), the_end_(false) {
+            it_ = container_->cbegin();
+            UpdateValue();
+        }
+        ~ConstIteratorImpl() override {}
+        virtual bool AtEnd() const override { return the_end_; }
+
+       protected:
+        void UpdateValue() {
+            if (it_ != container_->cend()) {
+                value_.subresource = map_->Decode((*it_).first);
+                value_.layout = (*it_).second;
+            } else {
+                the_end_ = true;
+                value_.layout = kInvalidLayout;
+            }
+        }
+
+        typedef typename Container::const_iterator ContainerIterator;
+        const ImageSubresourceLayoutMapImpl *map_;
+        const Container *container_;
+        bool the_end_;
+        ContainerIterator it_;
+    };
+
+    Base::ConstIterator BeginInitialUse() const override {
+        return Base::ConstIterator(new ConstIteratorImpl<InitialLayoutMap>(*this, layouts_.initial));
+    }
+
+    Base::ConstIterator BeginSetLayout() const override {
+        return Base::ConstIterator(new ConstIteratorImpl<LayoutMap>(*this, layouts_.current));
+    }
+
+    bool SetSubresourceRangeLayout(const VkImageSubresourceRange &range, VkImageLayout layout,
+                                   VkImageLayout expected_layout = kInvalidLayout) override {
+        bool updated = false;
+        if (expected_layout == kInvalidLayout) {
+            // Set the initial layout to the set layout as we had no other layout to reference
+            expected_layout = layout;
+        }
+        if (!InRange(range)) return false;  // Don't even try to track bogus subreources
+
+        const uint32_t end_mip = range.baseMipLevel + range.levelCount;
+        const auto &aspects = AspectTraits::AspectBits();
+        for (uint32_t aspect_index = 0; aspect_index < AspectTraits::kAspectCount; aspect_index++) {
+            if (0 == (range.aspectMask & aspects[aspect_index])) continue;
+            size_t array_offset = Encode(aspect_index, range.baseMipLevel);
+            for (uint32_t mip_level = range.baseMipLevel; mip_level < end_mip; ++mip_level, array_offset += mip_size_) {
+                size_t start = array_offset + range.baseArrayLayer;
+                size_t end = start + range.layerCount;
+                BoundsCheck(start, end);
+                bool updated_level = layouts_.current.SetRange(start, end, layout);
+                if (updated_level) {
+                    // We only need to try setting the initial layout, if we changed any of the layout values above
+                    layouts_.initial.SetRange(start, end, expected_layout);
+                    updated = true;
+                }
+            }
+        }
+        if (updated) version_++;
+        return updated;
+    }
+
+    bool SetSubresourceRangeInitialLayout(const VkImageSubresourceRange &range, VkImageLayout layout) override {
+        bool updated = false;
+        if (!InRange(range)) return false;  // Don't even try to track bogus subreources
+
+        const uint32_t end_mip = range.baseMipLevel + range.levelCount;
+        const auto &aspects = AspectTraits::AspectBits();
+        for (uint32_t aspect_index = 0; aspect_index < AspectTraits::kAspectCount; aspect_index++) {
+            if (0 == (range.aspectMask & aspects[aspect_index])) continue;
+            size_t array_offset = Encode(aspect_index, range.baseMipLevel);
+            for (uint32_t mip_level = range.baseMipLevel; mip_level < end_mip; ++mip_level, array_offset += mip_size_) {
+                size_t start = array_offset + range.baseArrayLayer;
+                size_t end = start + range.layerCount;
+                BoundsCheck(start, end);
+                updated |= layouts_.initial.SetRange(start, end, layout);
+            }
+        }
+        if (updated) version_++;
+        return updated;
+    }
+
+    // Loop over the given range calling the callback, primarily for
+    // validation checks.  By default the initial_value is only looked
+    // up if the set value isn't found.
+    bool ForRange(const VkImageSubresourceRange &range, const Callback &callback, bool skip_invalid = true,
+                  bool always_get_initial = false) const override {
+        if (!InRange(range)) return false;  // Don't even try to process bogus subreources
+
+        VkImageSubresource subres;
+        auto &level = subres.mipLevel;
+        auto &layer = subres.arrayLayer;
+        auto &aspect = subres.aspectMask;
+        const auto &aspects = AspectTraits::AspectBits();
+        bool keep_on = true;
+        const uint32_t end_mip = range.baseMipLevel + range.levelCount;
+        const uint32_t end_layer = range.baseArrayLayer + range.layerCount;
+        for (uint32_t aspect_index = 0; aspect_index < AspectTraits::kAspectCount; aspect_index++) {
+            if (0 == (range.aspectMask & aspects[aspect_index])) continue;
+            aspect = aspects[aspect_index];  // noting that this and the following loop indices are references
+            size_t array_offset = Encode(aspect_index, range.baseMipLevel);
+            for (level = range.baseMipLevel; level < end_mip; ++level, array_offset += mip_size_) {
+                for (layer = range.baseArrayLayer; layer < end_layer; layer++) {
+                    // TODO -- would an interator with range check be faster?
+                    size_t index = array_offset + layer;
+                    BoundsCheck(index);
+                    VkImageLayout layout = layouts_.current.Get(index);
+                    VkImageLayout initial_layout = kInvalidLayout;
+                    if (always_get_initial || (layout == kInvalidLayout)) {
+                        initial_layout = layouts_.initial.Get(index);
+                    }
+
+                    if (!skip_invalid || (layout != kInvalidLayout) || (initial_layout != kInvalidLayout)) {
+                        keep_on = callback(subres, layout, initial_layout);
+                        if (!keep_on) return keep_on;  // False value from the callback aborts the range traversal
+                    }
+                }
+            }
+        }
+        return keep_on;
+    }
+    VkImageLayout GetSubresourceInitialLayout(const VkImageSubresource subresource) const override {
+        if (!InRange(subresource)) return kInvalidLayout;
+        uint32_t aspect_index = AspectTraits::Index(subresource.aspectMask);
+        size_t index = Encode(aspect_index, subresource.mipLevel, subresource.arrayLayer);
+        BoundsCheck(index);
+        return layouts_.initial.Get(index);
+    }
+
+    VkImageLayout GetSubresourceLayout(const VkImageSubresource subresource) const override {
+        if (!InRange(subresource)) return kInvalidLayout;
+        uint32_t aspect_index = AspectTraits::Index(subresource.aspectMask);
+        size_t index = Encode(aspect_index, subresource.mipLevel, subresource.arrayLayer);
+        BoundsCheck(index);
+        return layouts_.current.Get(index);
+    }
+
+    // TODO: make sure this paranoia check is sufficient and not too much.
+    uintptr_t CompatibilityKey() const override {
+        return (reinterpret_cast<const uintptr_t>(&image_state_) ^ AspectTraits::AspectMask() ^ kSparseThreshold);
+    }
+
+    bool UpdateFrom(const ImageSubresourceLayoutMap &other) override {
+        // Must be from matching images for the reinterpret cast to be valid
+        assert(CompatibilityKey() == other.CompatibilityKey());
+        if (CompatibilityKey() != other.CompatibilityKey()) return false;
+
+        const auto &from = reinterpret_cast<const ImageSubresourceLayoutMapImpl &>(other);
+        bool updated = false;
+        updated |= layouts_.initial.Merge(from.layouts_.initial);
+        updated |= layouts_.current.Merge(from.layouts_.current);
+
+        return updated;
+    }
+
+    ImageSubresourceLayoutMapImpl() : Base() {}
+    ImageSubresourceLayoutMapImpl(const IMAGE_STATE &image_state)
+        : Base(),
+          image_state_(image_state),
+          mip_size_(image_state.full_range.layerCount),
+          aspect_size_(mip_size_ * image_state.full_range.levelCount),
+          version_(0),
+          layouts_(aspect_size_ * AspectTraits::kAspectCount) {
+        // Setup the row <-> aspect/mip_level base Encode/Decode LUT...
+        aspect_offsets_[0] = 0;
+        for (size_t i = 1; i < aspect_offsets_.size(); ++i) {  // Size is a compile time constant
+            aspect_offsets_[i] = aspect_offsets_[i - 1] + aspect_size_;
+        }
+    }
+    ~ImageSubresourceLayoutMapImpl() override {}
+
+   protected:
+//#define IMAGE_LAYOUT_MAP_BOUNDS_CHECK
+#ifdef IMAGE_LAYOUT_MAP_BOUNDS_CHECK
+    // Optional bounds checking
+    __declspec(noinline) void BoundsCheck(size_t inclusive) const {
+        if (inclusive >= layouts_.current.RangeMax()) {
+            error_count_++;
+            std::cout << "Bounds Error:" << error_count_ << std::endl;
+        }
+    }
+    // Optional bounds checking
+    __declspec(noinline) void BoundsCheck(size_t inclusive, size_t exclusive) const {
+        if ((inclusive >= layouts_.current.RangeMax()) || (exclusive > layouts_.current.RangeMax())) {
+            error_count_++;
+            std::cout << "Bounds Error:" << error_count_ << std::endl;
+        }
+    }
+    mutable size_t error_count_ = 0;
+#else
+    void BoundsCheck(size_t inclusive) const {}
+    void BoundsCheck(size_t inclusive, size_t exclusive) const {}
+#endif
+
+    // This looks a bit ponderous but kAspectCount is a compile time constant
+    VkImageSubresource Decode(size_t index) const {
+        VkImageSubresource subres;
+        // find aspect index
+        uint32_t aspect_index = 0;
+        if (AspectTraits::kAspectCount == 2) {
+            if (index >= aspect_offsets_[1]) {
+                aspect_index = 1;
+                index = index - aspect_offsets_[aspect_index];
+            }
+        } else if (AspectTraits::kAspectCount == 3) {
+            if (index >= aspect_offsets_[2]) {
+                aspect_index = 2;
+            } else if (index >= aspect_offsets_[1]) {
+                aspect_index = 1;
+            }
+            index = index - aspect_offsets_[aspect_index];
+        } else {
+            assert(AspectTraits::kAspectCount == 1);  // Only aspect counts of 1, 2, and 3 supported
+        }
+
+        subres.aspectMask = AspectTraits::AspectBits()[aspect_index];
+        subres.mipLevel =
+            static_cast<uint32_t>(index / mip_size_);  // One hopes the compiler with optimize this pair of divisions...
+        subres.arrayLayer = static_cast<uint32_t>(index % mip_size_);
+
+        return subres;
+    }
+
+    uint32_t LevelLimit(uint32_t level) const { return std::min(image_state_.full_range.levelCount, level); }
+    uint32_t LayerLimit(uint32_t layer) const { return std::min(image_state_.full_range.layerCount, layer); }
+
+    bool InRange(const VkImageSubresource &subres) const {
+        bool in_range = (subres.mipLevel < image_state_.full_range.levelCount) &&
+                        (subres.arrayLayer < image_state_.full_range.layerCount) &&
+                        (subres.aspectMask & AspectTraits::AspectMask());
+        return in_range;
+    }
+
+    bool InRange(const VkImageSubresourceRange &range) const {
+        bool in_range = (range.baseMipLevel < image_state_.full_range.levelCount) &&
+                        ((range.baseMipLevel + range.levelCount) <= image_state_.full_range.levelCount) &&
+                        (range.baseArrayLayer < image_state_.full_range.layerCount) &&
+                        ((range.baseArrayLayer + range.layerCount) <= image_state_.full_range.layerCount) &&
+                        (range.aspectMask & AspectTraits::AspectMask());
+        return in_range;
+    }
+
+    inline size_t Encode(uint32_t aspect_index) const {
+        return (AspectTraits::kAspectCount == 1) ? 0 : aspect_offsets_[aspect_index];
+    }
+    inline size_t Encode(uint32_t aspect_index, uint32_t mip_level) const { return Encode(aspect_index) + mip_level * mip_size_; }
+    inline size_t Encode(uint32_t aspect_index, uint32_t mip_level, uint32_t array_layer) const {
+        return Encode(aspect_index, mip_level) + array_layer;
+    }
+
+    const IMAGE_STATE &image_state_;
+    const size_t mip_size_;
+    const size_t aspect_size_;
+    uint64_t version_ = 0;
+    Layouts layouts_;
+    std::array<size_t, AspectTraits::kAspectCount> aspect_offsets_;
+};
+
+// Utility type for ForRange callbacks
+struct LayoutUseCheckAndMessage {
+    const char *message = nullptr;
+    VkImageLayout layout = kInvalidLayout;
+    LayoutUseCheckAndMessage(VkImageLayout check, VkImageLayout current_layout, VkImageLayout initial_layout) {
+        if (current_layout != kInvalidLayout && check != current_layout) {
+            message = "previous known";
+            layout = current_layout;
+        } else if (initial_layout != kInvalidLayout && check != initial_layout) {
+            message = "previously used";
+            layout = initial_layout;
+        }
+    }
+    bool CheckFailed() const { return layout != kInvalidLayout; }
 };
 
 // Store the DAG.
@@ -1001,7 +1409,8 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::unordered_map<QueryObject, bool> queryToStateMap;  // 0 is unavailable, 1 is available
     std::unordered_set<QueryObject> activeQueries;
     std::unordered_set<QueryObject> startedQueries;
-    std::unordered_map<ImageSubresourcePair, IMAGE_CMD_BUF_LAYOUT_NODE> imageLayoutMap;
+    typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> ImageLayoutMap;
+    ImageLayoutMap image_layout_map;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
     std::vector<DrawData> draw_data;
     DrawData current_draw_data;
@@ -1117,5 +1526,8 @@ enum BarrierOperationsType {
 class CoreChecks;
 
 std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorSetLayout(CoreChecks const *, VkDescriptorSetLayout);
+
+ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(GLOBAL_CB_NODE *cb_state, const IMAGE_STATE &image_state);
+const ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(const GLOBAL_CB_NODE *cb_state, VkImage image);
 
 #endif  // CORE_VALIDATION_TYPES_H_

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -834,27 +834,19 @@ bool cvdescriptorset::DescriptorSet::ValidateDrawState(const std::map<uint32_t, 
                     auto image_node = device_data_->GetImageState(image_view_ci.image);
                     assert(image_node);
                     // Verify Image Layout
-                    // Copy first mip level into sub_layers and loop over each mip level to verify layout
-                    VkImageSubresourceLayers sub_layers;
-                    sub_layers.aspectMask = image_view_ci.subresourceRange.aspectMask;
-                    sub_layers.baseArrayLayer = image_view_ci.subresourceRange.baseArrayLayer;
-                    sub_layers.layerCount = image_view_ci.subresourceRange.layerCount;
+                    // No "invalid layout" VUID required for this call, since the optimal_layout parameter is UNDEFINED.
                     bool hit_error = false;
-                    for (auto cur_level = image_view_ci.subresourceRange.baseMipLevel;
-                         cur_level < image_view_ci.subresourceRange.levelCount; ++cur_level) {
-                        sub_layers.mipLevel = cur_level;
-                        // No "invalid layout" VUID required for this call, since the optimal_layout parameter is UNDEFINED.
-                        device_data_->VerifyImageLayout(cb_node, image_node, sub_layers, image_layout, VK_IMAGE_LAYOUT_UNDEFINED,
-                                                        caller, kVUIDUndefined, "VUID-VkDescriptorImageInfo-imageLayout-00344",
-                                                        &hit_error);
-                        if (hit_error) {
-                            *error =
-                                "Image layout specified at vkUpdateDescriptorSet* or vkCmdPushDescriptorSet* time "
-                                "doesn't match actual image layout at time descriptor is used. See previous error callback for "
-                                "specific details.";
-                            return false;
-                        }
+                    device_data_->VerifyImageLayout(cb_node, image_node, image_view_state->normalized_subresource_range,
+                                                    image_layout, VK_IMAGE_LAYOUT_UNDEFINED, caller, kVUIDUndefined,
+                                                    "VUID-VkDescriptorImageInfo-imageLayout-00344", &hit_error);
+                    if (hit_error) {
+                        *error =
+                            "Image layout specified at vkUpdateDescriptorSet* or vkCmdPushDescriptorSet* time "
+                            "doesn't match actual image layout at time descriptor is used. See previous error callback for "
+                            "specific details.";
+                        return false;
                     }
+
                     // Verify Sample counts
                     if ((reqs & DESCRIPTOR_REQ_SINGLE_SAMPLE) && image_node->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
                         std::stringstream error_str;
@@ -1610,9 +1602,7 @@ void cvdescriptorset::ImageSamplerDescriptor::UpdateDrawState(CoreChecks *dev_da
     auto iv_state = dev_data->GetImageViewState(image_view_);
     if (iv_state) {
         dev_data->AddCommandBufferBindingImageView(cb_node, iv_state);
-    }
-    if (image_view_) {
-        dev_data->SetImageViewLayout(cb_node, image_view_, image_layout_);
+        dev_data->SetImageViewInitialLayout(cb_node, *iv_state, image_layout_);
     }
 }
 
@@ -1643,9 +1633,7 @@ void cvdescriptorset::ImageDescriptor::UpdateDrawState(CoreChecks *dev_data, GLO
     auto iv_state = dev_data->GetImageViewState(image_view_);
     if (iv_state) {
         dev_data->AddCommandBufferBindingImageView(cb_node, iv_state);
-    }
-    if (image_view_) {
-        dev_data->SetImageViewLayout(cb_node, image_view_, image_layout_);
+        dev_data->SetImageViewInitialLayout(cb_node, *iv_state, image_layout_);
     }
 }
 

--- a/layers/sparse_containers.h
+++ b/layers/sparse_containers.h
@@ -1,0 +1,404 @@
+/* Copyright (c) 2019 The Khronos Group Inc.
+ * Copyright (c) 2019 Valve Corporation
+ * Copyright (c) 2019 LunarG, Inc.
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * John Zulauf <jzulauf@lunarg.com>
+ *
+ */
+#ifndef SPARSE_CONTAINERS_H_
+#define SPARSE_CONTAINERS_H_
+#define NOMINMAX
+#include <cassert>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace sparse_container {
+// SparseVector:
+//
+// Defines a sparse single-dimensional container which is targeted for three distinct use cases
+// 1) Large range of indices sparsely populated ("Sparse access" below)
+// 2) Large range of indices where all values are the same ("Sparse access" below)
+// 3) Large range of values densely populated (more that 1/4 full) ("Dense access" below)
+// 4) Small range of values where direct access is most efficient ("Dense access" below)
+//
+// To update semantics are supported bases on kSetReplaces:
+//    true -- updates to already set (valid) indices replace current value
+//    false -- updates to already set (valid) indicies are ignored.
+//
+// Theory of operation:
+//
+// When created, a sparse vector is created (based on size relative to
+// the kSparseThreshold) in either Sparse or Dense access mode.
+//
+// In "Sparse access" mode individual values are stored in a map keyed
+// by the index.  A "full range" value (if set) defines the value of all
+// entries not present in the map. Setting a full range value via
+//
+//     SetRange(range_min, range_max, full_range_value )
+//
+// either clears the map (kSetReplaces==true) or prevents further
+// updates to the vector (kSetReplaces==false).  If the map becomes
+// more than // 1/kConversionThreshold (4) full, the SparseVector is
+// converted into "Dense access" mode.  Entries are copied from map,
+// with non-present indices set to the default value (kDefaultValue)
+// or the full range value (if present).
+//
+// In "Dense access" mode, values are  stored in a vector the size of
+// the valid range indexed by the incoming index value minus range_min_.
+// The same upate semantic applies bases on kSetReplaces.
+//
+// Note that when kSparseThreshold
+//
+// Access:
+//
+// NOTE all "end" indices (in construction or access) are *exclusive*.
+//
+// Given the variable semantics and effective compression of Sparse
+// access mode, all access is through Get, Set, and SetRange functions
+// and a constant iterator. Get return either the value found (using
+// the current access mode) or the kDefaultValue.  Set and SetRange
+// return whether or not state was updated, in order to support dirty
+// bit updates for any dependent state.
+//
+// The iterator ConstIterator provides basic, "by value" access. The
+// "by value" nature of the access reflect the compressed nature
+// operators *, ++, ==, and != are provided, with the latter two only
+// suitable for comparisons vs. cend.  The iterator skips all
+// kDefaultValue entries in either access mode, returning a std::pair
+// containing {IndexType, ValueType}. The multiple access modes give
+// the iterator a bit more complexity than is optimal, but hides the
+// underlying complexity from the callers.
+//
+// TODO: Update iterator to use a reference (likely using
+// reference_wrapper...)
+
+template <typename IndexType_, typename T, bool kSetReplaces, T kDefaultValue = T(), size_t kSparseThreshold = 16>
+class SparseVector {
+   public:
+    typedef IndexType_ IndexType;
+    typedef T value_type;
+    typedef value_type ValueType;
+    typedef std::unordered_map<IndexType, ValueType> SparseType;
+    typedef std::vector<ValueType> DenseType;
+
+    SparseVector(IndexType start, IndexType end)
+        : range_min_(start), range_max_(end), threshold_((end - start) / kConversionThreshold) {
+        assert(end > start);
+        Reset();
+    }
+
+    // Initial access mode is set based on range size vs. kSparseThreshold.  Either sparse_ or dense_ is always set, but only
+    // ever one at a time
+    void Reset() {
+        has_full_range_value_ = false;
+        full_range_value_ = kDefaultValue;
+        size_t count = range_max_ - range_min_;
+        if (kSparseThreshold && (count > kSparseThreshold)) {
+            sparse_.reset(new SparseType());
+            dense_.reset();
+        } else {
+            sparse_.reset();
+            dense_.reset(new DenseType(count, kDefaultValue));
+        }
+    }
+
+    const ValueType &Get(const IndexType index) const {
+        // Note that here (and similarly below, the 'IsSparse' clause is
+        // eliminated as dead code in release builds if kSparseThreshold==0
+        if (IsSparse()) {
+            if (!sparse_->empty()) {  // Don't attempt lookup in empty map
+                auto it = sparse_->find(index);
+                if (it != sparse_->cend()) {
+                    return it->second;
+                }
+            }
+            // If there is a full_range_value, return it, but there isn't a full_range_value_, it's set to  kDefaultValue
+            // so it's still the correct this to return
+            return full_range_value_;
+        } else {
+            // Direct access
+            assert(dense_.get());
+            const ValueType &value = (*dense_)[index - range_min_];
+            return value;
+        }
+    }
+
+    // Set a indexes value, based on the access mode, update semantics are enforced within the access mode specific function
+    bool Set(const IndexType index, const ValueType &value) {
+        bool updated = false;
+        if (IsSparse()) {
+            updated = SetSparse(index, value);
+        } else {
+            assert(dense_.get());
+            updated = SetDense(index, value);
+        }
+        return updated;
+    }
+
+    // Set a range of values based on access mode, with some update semantics applied a the range level
+    bool SetRange(const IndexType start, IndexType end, ValueType value) {
+        bool updated = false;
+        if (IsSparse()) {
+            if (!kSetReplaces && HasFullRange()) return false;  // We have full coverage, we can change this no more
+
+            bool is_full_range = IsFullRange(start, end);
+            if (kSetReplaces && is_full_range) {
+                updated = value != full_range_value_;
+                full_range_value_ = value;
+                if (HasSparseSubranges()) {
+                    updated = true;
+                    sparse_->clear();  // full range replaces all subranges
+                }
+                // has_full_range_value_ state of the full_range_value_ to avoid ValueType comparisons
+                has_full_range_value_ = value != kDefaultValue;
+            } else if (!kSetReplaces && (value != kDefaultValue) && is_full_range && !HasFullRange()) {
+                // With the update only invalid semantics, the value becomes the fallback, and will prevent other updates
+                full_range_value_ = value;
+                has_full_range_value_ = true;
+                updated = true;
+                // Clean up the sparse map a bit
+                for (auto it = sparse_->begin(); it != sparse_->end();) {  // no increment clause because of erase below
+                    if (it->second == value) {
+                        it = sparse_->erase(it);  // remove redundant entries
+                    } else {
+                        ++it;
+                    }
+                }
+            } else {
+                for (IndexType index = start; index < end; ++index) {
+                    // NOTE: We can't use SetSparse here, because this may be converted to dense access mid update
+                    updated |= Set(index, value);
+                }
+            }
+        } else {
+            // Note that "Dense Access" does away with the full_range_value_ logic, storing empty entries using kDefaultValue
+            assert(dense_);
+            for (IndexType index = start; index < end; ++index) {
+                updated = SetDense(index, value);
+            }
+        }
+        return updated;
+    }
+
+    // Set only the non-default values from another sparse vector
+    bool Merge(const SparseVector &from) {
+        // Must not set from Sparse arracy with larger bounds...
+        assert((range_min_ <= from.range_min_) && (range_max_ >= from.range_max_));
+        bool updated = false;
+        if (from.IsSparse()) {
+            if (from.HasFullRange() && !from.HasSparseSubranges()) {
+                // Short cut to copy a full range if that's all we have
+                updated |= SetRange(from.range_min_, from.range_max_, from.full_range_value_);
+            } else {
+                // Have to do it the complete (potentially) slow way
+                // TODO add sorted keys to iterator to reduce hash lookups
+                for (auto it = from.cbegin(); it != from.cend(); ++it) {
+                    const IndexType index = (*it).first;
+                    const ValueType &value = (*it).second;
+                    Set(index, value);
+                }
+            }
+        } else {
+            assert(from.dense_);
+            DenseType &ray = *from.dense_;
+            for (IndexType entry = from.range_min_; entry < from.range_max_; ++entry) {
+                IndexType index = entry - from.range_min_;
+                if (ray[index] != kDefaultValue) {
+                    updated |= Set(entry, ray[index]);
+                }
+            }
+        }
+        return updated;
+    }
+
+    friend class ConstIterator;
+    class ConstIterator {
+       public:
+        using SparseType = typename SparseVector::SparseType;
+        using SparseIterator = typename SparseType::const_iterator;
+        using IndexType = typename SparseVector::IndexType;
+        using ValueType = typename SparseVector::ValueType;
+        using IteratorValueType = std::pair<IndexType, ValueType>;
+        const IteratorValueType &operator*() const { return current_value_; }
+
+        ConstIterator &operator++() {
+            if (delegated_) {  // implies sparse
+                ++it_sparse_;
+                if (it_sparse_ == vec_->sparse_->cend()) {
+                    the_end_ = true;
+                    current_value_.first = vec_->range_max_;
+                    current_value_.second = SparseVector::DefaultValue();
+                } else {
+                    current_value_.first = it_sparse_->first;
+                    current_value_.second = it_sparse_->second;
+                }
+            } else {
+                index_++;
+                SetCurrentValue();
+            }
+            return *this;
+        }
+        bool operator!=(const ConstIterator &rhs) const {
+            return (the_end_ != rhs.the_end_);  // Just good enough for cend checks
+        }
+
+        bool operator==(const ConstIterator &rhs) const {
+            return (the_end_ == rhs.the_end_);  // Just good enough for cend checks
+        }
+
+        // The iterator has two modes:
+        //     delegated:
+        //         where we are in sparse access mode and have no full_range_value
+        //         and thus can delegate our iteration to underlying map
+        //     non-delegated:
+        //         either dense mode or we have a full range value and thus
+        //         must iterate over the whole range
+        ConstIterator(const SparseVector &vec) : vec_(&vec) {
+            if (!vec_->IsSparse() || vec_->HasFullRange()) {
+                // Must iterated over entire ranges skipping (in the case of dense access), invalid entries
+                delegated_ = false;
+                index_ = vec_->range_min_;
+                SetCurrentValue();  // Skips invalid and sets the_end_
+            } else if (vec_->HasSparseSubranges()) {
+                // The subranges store the non-default values... and their is no full range value
+                delegated_ = true;
+                it_sparse_ = vec_->sparse_->cbegin();
+                current_value_.first = it_sparse_->first;
+                current_value_.second = it_sparse_->second;
+                the_end_ = false;  // the sparse map is non-empty (per HasSparseSubranges() above)
+            } else {
+                // Sparse, but with no subranges
+                the_end_ = true;
+            }
+        }
+
+        ConstIterator() : vec_(nullptr), the_end_(true) {}
+
+       protected:
+        const SparseVector *vec_;
+        bool the_end_;
+        SparseIterator it_sparse_;
+        bool delegated_;
+        IndexType index_;
+        ValueType value_;
+
+        IteratorValueType current_value_;
+
+        // in the non-delegated case we use normal accessors and skip default values.
+        void SetCurrentValue() {
+            the_end_ = true;
+            while (index_ < vec_->range_max_) {
+                value_ = vec_->Get(index_);
+                if (value_ != SparseVector::DefaultValue()) {
+                    the_end_ = false;
+                    current_value_ = IteratorValueType(index_, value_);
+                    break;
+                }
+                index_++;
+            }
+        }
+    };
+    typedef ConstIterator const_iterator;
+
+    ConstIterator cbegin() const { return ConstIterator(*this); }
+    ConstIterator cend() const { return ConstIterator(); }
+
+    IndexType RangeMax() const { return range_max_; }
+    IndexType RangeMin() const { return range_min_; }
+
+    static const unsigned kConversionThreshold = 4;
+    const IndexType range_min_;  // exclusive
+    const IndexType range_max_;  // exclusive
+    const IndexType threshold_;  // exclusive
+
+    // Data for sparse mode
+    // We have a short cut for full range values when in sparse mode
+    bool has_full_range_value_;
+    ValueType full_range_value_;
+    std::unique_ptr<SparseType> sparse_;
+
+    // Data for dense mode
+    std::unique_ptr<DenseType> dense_;
+
+    static const ValueType &DefaultValue() {
+        static ValueType value = kDefaultValue;
+        return value;
+    }
+    // Note that IsSparse is compile-time reducible if kSparseThreshold is zero...
+    inline bool IsSparse() const { return kSparseThreshold && sparse_.get(); }
+    bool IsFullRange(IndexType start, IndexType end) const { return (start == range_min_) && (end == range_max_); }
+    bool IsFullRangeValue(const ValueType &value) const { return has_full_range_value_ && (value == full_range_value_); }
+    bool HasFullRange() const { return IsSparse() && has_full_range_value_; }
+    bool HasSparseSubranges() const { return IsSparse() && !sparse_->empty(); }
+
+    // This is called unconditionally, to encapsulate the conversion criteria and logic here
+    void SparseToDenseConversion() {
+        // If we're using more threshold of the sparse range, convert to dense_
+        if (IsSparse() && (sparse_->size() > threshold_)) {
+            ValueType default_value = HasFullRange() ? full_range_value_ : kDefaultValue;
+            dense_.reset(new DenseType((range_max_ - range_min_), default_value));
+            DenseType &ray = *dense_;
+            for (auto const &item : *sparse_) {
+                ray[item.first - range_min_] = item.second;
+            }
+            sparse_.reset();
+            has_full_range_value_ = false;
+        }
+    }
+
+    // Dense access mode setter with update semantics implemented
+    bool SetDense(IndexType index, const ValueType &value) {
+        bool updated = false;
+        ValueType &current_value = (*dense_)[index - range_min_];
+        if ((kSetReplaces || current_value == kDefaultValue) && (value != current_value)) {
+            current_value = value;
+            updated = true;
+        }
+        return updated;
+    }
+
+    // Sparse access mode setter with update full range and update semantics implemented
+    bool SetSparse(IndexType index, const ValueType &value) {
+        if (!kSetReplaces && HasFullRange()) {
+            return false;  // We have full coverage, we can change this no more
+        }
+
+        if (kSetReplaces && IsFullRangeValue(value) && HasSparseSubranges()) {
+            auto erasure = sparse_->erase(index);  // Remove duplicate record from map
+            return erasure > 0;
+        }
+
+        // Use insert to reduce the number of hash lookups
+        auto map_pair = std::make_pair(index, value);
+        auto insert_pair = sparse_->insert(map_pair);
+        auto &it = insert_pair.first;  // use references to avoid nested pair accesses
+        const bool inserted = insert_pair.second;
+        bool updated = false;
+        if (inserted) {
+            updated = true;
+            SparseToDenseConversion();
+        } else if (kSetReplaces && value != it->second) {
+            // Only replace value if semantics allow it and it has changed.
+            it->second = value;
+            updated = true;
+        }
+        return updated;
+    }
+};
+
+}  // namespace sparse_container
+#endif

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -18010,7 +18010,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     // Final src error is due to bad layout type
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdCopyImage-srcImageLayout-00129");
     m_errorMonitor->SetUnexpectedError(
-        "with specific layout VK_IMAGE_LAYOUT_UNDEFINED that doesn't match the actual current layout VK_IMAGE_LAYOUT_GENERAL.");
+        "with specific layout VK_IMAGE_LAYOUT_UNDEFINED that doesn't match the previously used layout VK_IMAGE_LAYOUT_GENERAL.");
     m_commandBuffer->CopyImage(src_image, VK_IMAGE_LAYOUT_UNDEFINED, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
     // Now verify same checks for dst
@@ -18027,7 +18027,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     m_errorMonitor->VerifyFound();
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdCopyImage-dstImageLayout-00134");
     m_errorMonitor->SetUnexpectedError(
-        "with specific layout VK_IMAGE_LAYOUT_UNDEFINED that doesn't match the actual current layout VK_IMAGE_LAYOUT_GENERAL.");
+        "with specific layout VK_IMAGE_LAYOUT_UNDEFINED that doesn't match the previously used layout VK_IMAGE_LAYOUT_GENERAL.");
     m_commandBuffer->CopyImage(src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_UNDEFINED, 1, &copy_region);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
Based on profiling, the map used for tracking image layout state within command buffers was a hot spot.  A new two level (image, then subresource) map is construct where the second level is a specialized, adaptive sparse_vector that can function as a map for sparse usage, and as a vector for dense usage.  In testing, this yielded performance improvement.

Layout tracking was also changed semantically, such that only operations that *change* layout alter the current layout state.  This may cause additional layout incompatibility messages, as subsequent incorrect uses will not be (incorrectly) masked by a previous incorrect use.

Based on user feedback, record time reporting of layout incompatibility is preserved.

Plus low hanging fruit... making bindable resource tracking lazy. Change the command buffer to bindable resource logic to avoid duplication, by only continuing with insert activities when a new reference is inserted.
