### PR TITLE
tests: Add instance creation\destruction tests

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -71,12 +71,13 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayerValidationTests
 LOCAL_SRC_FILES += $(SRC_DIR)/tests/layer_validation_tests.cpp \
-				   $(SRC_DIR)/tests/vklayertests_pipeline_shader.cpp \
-				   $(SRC_DIR)/tests/vklayertests_buffer_image_memory_sampler.cpp \
-				   $(SRC_DIR)/tests/vklayertests_others.cpp \
-				   $(SRC_DIR)/tests/vklayertests_descriptor_renderpass_framebuffer.cpp \
-				   $(SRC_DIR)/tests/vklayertests_command.cpp \
-				   $(SRC_DIR)/tests/vkpositivelayertests.cpp \
+                   $(SRC_DIR)/tests/vklayertests_instanceless.cpp \
+                   $(SRC_DIR)/tests/vklayertests_pipeline_shader.cpp \
+                   $(SRC_DIR)/tests/vklayertests_buffer_image_memory_sampler.cpp \
+                   $(SRC_DIR)/tests/vklayertests_others.cpp \
+                   $(SRC_DIR)/tests/vklayertests_descriptor_renderpass_framebuffer.cpp \
+                   $(SRC_DIR)/tests/vklayertests_command.cpp \
+                   $(SRC_DIR)/tests/vkpositivelayertests.cpp \
                    $(SRC_DIR)/tests/vktestbinding.cpp \
                    $(SRC_DIR)/tests/vktestframeworkandroid.cpp \
                    $(SRC_DIR)/tests/vkrenderframework.cpp \
@@ -101,12 +102,13 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 LOCAL_MODULE := VulkanLayerValidationTests
 LOCAL_SRC_FILES += $(SRC_DIR)/tests/layer_validation_tests.cpp \
-				   $(SRC_DIR)/tests/vklayertests_pipeline_shader.cpp \
-				   $(SRC_DIR)/tests/vklayertests_buffer_image_memory_sampler.cpp \
-				   $(SRC_DIR)/tests/vklayertests_others.cpp \
-				   $(SRC_DIR)/tests/vklayertests_descriptor_renderpass_framebuffer.cpp \
-				   $(SRC_DIR)/tests/vklayertests_command.cpp \
-				   $(SRC_DIR)/tests/vkpositivelayertests.cpp \
+                   $(SRC_DIR)/tests/vklayertests_instanceless.cpp \
+                   $(SRC_DIR)/tests/vklayertests_pipeline_shader.cpp \
+                   $(SRC_DIR)/tests/vklayertests_buffer_image_memory_sampler.cpp \
+                   $(SRC_DIR)/tests/vklayertests_others.cpp \
+                   $(SRC_DIR)/tests/vklayertests_descriptor_renderpass_framebuffer.cpp \
+                   $(SRC_DIR)/tests/vklayertests_command.cpp \
+                   $(SRC_DIR)/tests/vkpositivelayertests.cpp \
                    $(SRC_DIR)/tests/vktestbinding.cpp \
                    $(SRC_DIR)/tests/vktestframeworkandroid.cpp \
                    $(SRC_DIR)/tests/vkrenderframework.cpp \

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -468,23 +468,19 @@ static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags ms
     return bail;
 }
 
-static inline void DebugAnnotFlagsToReportFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,
-                                                VkDebugUtilsMessageTypeFlagsEXT da_type, VkDebugReportFlagsEXT *dr_flags) {
-    *dr_flags = 0;
-
-    if ((da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0) {
-        *dr_flags |= VK_DEBUG_REPORT_ERROR_BIT_EXT;
-    } else if ((da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0) {
-        if ((da_type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) != 0) {
-            *dr_flags |= VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
-        } else {
-            *dr_flags |= VK_DEBUG_REPORT_WARNING_BIT_EXT;
-        }
-    } else if ((da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) != 0) {
-        *dr_flags |= VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-    } else if ((da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) != 0) {
-        *dr_flags |= VK_DEBUG_REPORT_DEBUG_BIT_EXT;
+static inline VkDebugReportFlagsEXT DebugAnnotFlagsToReportFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,
+                                                                 VkDebugUtilsMessageTypeFlagsEXT da_type) {
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) return VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+        if (da_type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+            return VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
+        else
+            return VK_DEBUG_REPORT_WARNING_BIT_EXT;
     }
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
+
+    return 0;
 }
 
 static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ endif()
 set(LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
 
 set(COMMON_CPP
+    vklayertests_instanceless.cpp
     vklayertests_pipeline_shader.cpp
     vklayertests_buffer_image_memory_sampler.cpp
     vklayertests_others.cpp

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -126,27 +126,6 @@ bool ImageFormatAndFeaturesSupported(const VkInstance inst, const VkPhysicalDevi
     return true;
 }
 
-VKAPI_ATTR VkBool32 VKAPI_CALL LvtDebugReportFunc(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType, uint64_t srcObject,
-                                                  size_t location, int32_t msgCode, const char *pLayerPrefix, const char *pMsg,
-                                                  void *pUserData) {
-    ErrorMonitor *errMonitor = (ErrorMonitor *)pUserData;
-    if (msgFlags & errMonitor->GetMessageFlags()) {
-        return errMonitor->CheckForDesiredMsg(pMsg);
-    }
-    return VK_FALSE;
-}
-
-VKAPI_ATTR VkBool32 VKAPI_CALL LvtDebugUtilsFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                                                 VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-                                                 const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData) {
-    ErrorMonitor *errMonitor = (ErrorMonitor *)pUserData;
-    auto msg_flags = DebugAnnotFlagsToMsgTypeFlags(messageSeverity, messageTypes);
-    if (msg_flags & errMonitor->GetMessageFlags()) {
-        return errMonitor->CheckForDesiredMsg(pCallbackData->pMessage);
-    }
-    return VK_FALSE;
-}
-
 VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstance instance, VkPhysicalDevice gpu) {
     // Find address of extension call and make the call -- assumes needed extensions are enabled.
     PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
@@ -535,15 +514,15 @@ void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *pCreateInfo
     VkResult err;
     VkSampler sampler = VK_NULL_HANDLE;
     if (code.length())
-        test.Monitor()->SetDesiredFailureMsg(kErrorBit | kWarningBit, code);
+        test.Monitor().SetDesiredFailureMsg(kErrorBit | kWarningBit, code);
     else
-        test.Monitor()->ExpectSuccess();
+        test.Monitor().ExpectSuccess();
 
     err = vk::CreateSampler(test.device(), pCreateInfo, NULL, &sampler);
     if (code.length())
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     else
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
         vk::DestroySampler(test.device(), sampler, NULL);
@@ -554,15 +533,15 @@ void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, 
     VkResult err;
     VkBuffer buffer = VK_NULL_HANDLE;
     if (code.length())
-        test.Monitor()->SetDesiredFailureMsg(kErrorBit, code);
+        test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     else
-        test.Monitor()->ExpectSuccess();
+        test.Monitor().ExpectSuccess();
 
     err = vk::CreateBuffer(test.device(), pCreateInfo, NULL, &buffer);
     if (code.length())
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     else
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
         vk::DestroyBuffer(test.device(), buffer, NULL);
@@ -573,15 +552,15 @@ void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, st
     VkResult err;
     VkImage image = VK_NULL_HANDLE;
     if (code.length())
-        test.Monitor()->SetDesiredFailureMsg(kErrorBit, code);
+        test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     else
-        test.Monitor()->ExpectSuccess();
+        test.Monitor().ExpectSuccess();
 
     err = vk::CreateImage(test.device(), pCreateInfo, NULL, &image);
     if (code.length())
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     else
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
         vk::DestroyImage(test.device(), image, NULL);
@@ -592,16 +571,15 @@ void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCrea
     VkResult err;
     VkBufferView view = VK_NULL_HANDLE;
     if (codes.size())
-        std::for_each(codes.begin(), codes.end(),
-                      [&](const std::string &s) { test.Monitor()->SetDesiredFailureMsg(kErrorBit, s); });
+        std::for_each(codes.begin(), codes.end(), [&](const std::string &s) { test.Monitor().SetDesiredFailureMsg(kErrorBit, s); });
     else
-        test.Monitor()->ExpectSuccess();
+        test.Monitor().ExpectSuccess();
 
     err = vk::CreateBufferView(test.device(), pCreateInfo, NULL, &view);
     if (codes.size())
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     else
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
         vk::DestroyBufferView(test.device(), view, NULL);
@@ -612,15 +590,15 @@ void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreate
     VkResult err;
     VkImageView view = VK_NULL_HANDLE;
     if (code.length())
-        test.Monitor()->SetDesiredFailureMsg(kErrorBit, code);
+        test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     else
-        test.Monitor()->ExpectSuccess();
+        test.Monitor().ExpectSuccess();
 
     err = vk::CreateImageView(test.device(), pCreateInfo, NULL, &view);
     if (code.length())
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     else
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
         vk::DestroyImageView(test.device(), view, NULL);
@@ -937,32 +915,32 @@ VkCommandBufferObj *VkLayerTest::CommandBuffer() { return m_commandBuffer; }
 VkLayerTest::VkLayerTest() {
     m_enableWSI = false;
 
-    m_instance_layer_names.clear();
-    m_instance_extension_names.clear();
-    m_device_extension_names.clear();
+    // TODO: not quite sure why most of this is here instead of in super
 
     // Add default instance extensions to the list
-    m_instance_extension_names.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-    m_instance_extension_names.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    instance_extensions_.push_back(debug_reporter_.debug_extension_name);
 
-    m_instance_layer_names.push_back("VK_LAYER_KHRONOS_validation");
+    instance_layers_.push_back(kValidationLayerName);
 
     if (VkTestFramework::m_devsim_layer) {
         if (InstanceLayerSupported("VK_LAYER_LUNARG_device_simulation")) {
-            m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_simulation");
+            instance_layers_.push_back("VK_LAYER_LUNARG_device_simulation");
         } else {
             VkTestFramework::m_devsim_layer = false;
             printf("             Did not find VK_LAYER_LUNARG_device_simulation layer so it will not be enabled.\n");
         }
+    } else {
+        if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api"))
+            instance_layers_.push_back("VK_LAYER_LUNARG_device_profile_api");
     }
 
-    this->app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    this->app_info.pNext = NULL;
-    this->app_info.pApplicationName = "layer_tests";
-    this->app_info.applicationVersion = 1;
-    this->app_info.pEngineName = "unittest";
-    this->app_info.engineVersion = 1;
-    this->app_info.apiVersion = VK_API_VERSION_1_0;
+    app_info_.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info_.pNext = NULL;
+    app_info_.pApplicationName = "layer_tests";
+    app_info_.applicationVersion = 1;
+    app_info_.pEngineName = "unittest";
+    app_info_.engineVersion = 1;
+    app_info_.apiVersion = VK_API_VERSION_1_0;
 
     // Find out what version the instance supports and record the default target instance
     auto enumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vk::GetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion");
@@ -971,7 +949,7 @@ VkLayerTest::VkLayerTest() {
     } else {
         m_instance_api_version = VK_API_VERSION_1_0;
     }
-    m_target_api_version = app_info.apiVersion;
+    m_target_api_version = app_info_.apiVersion;
 }
 
 bool VkLayerTest::AddSurfaceInstanceExtension() {
@@ -980,7 +958,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         printf("%s %s extension not supported\n", kSkipPrefix, VK_KHR_SURFACE_EXTENSION_NAME);
         return false;
     }
-    m_instance_extension_names.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+    instance_extensions_.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
 
     bool bSupport = false;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -988,7 +966,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         printf("%s %s extension not supported\n", kSkipPrefix, VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
         return false;
     }
-    m_instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+    instance_extensions_.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
     bSupport = true;
 #endif
 
@@ -997,7 +975,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         printf("%s %s extension not supported\n", kSkipPrefix, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
         return false;
     }
-    m_instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+    instance_extensions_.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
     bSupport = true;
 #endif
 
@@ -1007,7 +985,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         return false;
     }
     if (XOpenDisplay(NULL)) {
-        m_instance_extension_names.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+        instance_extensions_.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
         bSupport = true;
     }
 #endif
@@ -1018,7 +996,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         return false;
     }
     if (!bSupport && xcb_connect(NULL, NULL)) {
-        m_instance_extension_names.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+        instance_extensions_.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
         bSupport = true;
     }
 #endif
@@ -1041,7 +1019,7 @@ uint32_t VkLayerTest::SetTargetApiVersion(uint32_t target_api_version) {
     if (target_api_version == 0) target_api_version = VK_API_VERSION_1_0;
     if (target_api_version <= m_instance_api_version) {
         m_target_api_version = target_api_version;
-        app_info.apiVersion = m_target_api_version;
+        app_info_.apiVersion = m_target_api_version;
     }
     return m_target_api_version;
 }
@@ -1877,9 +1855,9 @@ BarrierQueueFamilyTestHelper::QueueFamilyObjs *BarrierQueueFamilyTestHelper::Get
 
 void BarrierQueueFamilyTestHelper::operator()(std::string img_err, std::string buf_err, uint32_t src, uint32_t dst, bool positive,
                                               uint32_t queue_family_index, Modifier mod) {
-    auto monitor = context_->layer_test->Monitor();
-    if (img_err.length()) monitor->SetDesiredFailureMsg(kErrorBit | kWarningBit, img_err);
-    if (buf_err.length()) monitor->SetDesiredFailureMsg(kErrorBit | kWarningBit, buf_err);
+    auto &monitor = context_->layer_test->Monitor();
+    if (img_err.length()) monitor.SetDesiredFailureMsg(kErrorBit | kWarningBit, img_err);
+    if (buf_err.length()) monitor.SetDesiredFailureMsg(kErrorBit | kWarningBit, buf_err);
 
     image_barrier_.srcQueueFamilyIndex = src;
     image_barrier_.dstQueueFamilyIndex = dst;
@@ -1909,9 +1887,9 @@ void BarrierQueueFamilyTestHelper::operator()(std::string img_err, std::string b
     }
 
     if (positive) {
-        monitor->VerifyNotFound();
+        monitor.VerifyNotFound();
     } else {
-        monitor->VerifyFound();
+        monitor.VerifyFound();
     }
     context_->Reset();
 };

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -55,7 +55,12 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <string>
 #include <unordered_set>
+#include <vector>
+
+using std::string;
+using std::vector;
 
 //--------------------------------------------------------------------------------------
 // Mesh and VertexFormat Data
@@ -226,6 +231,7 @@ T NearestSmaller(const T from) {
 class VkLayerTest : public VkRenderFramework {
   public:
     const char *kValidationLayerName = "VK_LAYER_KHRONOS_validation";
+
     void VKTriangleTest(BsoFailSelect failCase);
 
     void GenericDrawPreparation(VkCommandBufferObj *commandBuffer, VkPipelineObj &pipelineobj, VkDescriptorSetObj &descriptorSet,
@@ -423,13 +429,13 @@ struct CreatePipelineHelper {
         info_override(helper);
         helper.InitState();
 
-        for (const auto &error : errors) test.Monitor()->SetDesiredFailureMsg(flags, error);
+        for (const auto &error : errors) test.Monitor().SetDesiredFailureMsg(flags, error);
         helper.CreateGraphicsPipeline();
 
         if (positive_test) {
-            test.Monitor()->VerifyNotFound();
+            test.Monitor().VerifyNotFound();
         } else {
-            test.Monitor()->VerifyFound();
+            test.Monitor().VerifyFound();
         }
     }
 
@@ -479,13 +485,13 @@ struct CreateComputePipelineHelper {
         info_override(helper);
         helper.InitState();
 
-        for (const auto &error : errors) test.Monitor()->SetDesiredFailureMsg(flags, error);
+        for (const auto &error : errors) test.Monitor().SetDesiredFailureMsg(flags, error);
         helper.CreateComputePipeline();
 
         if (positive_test) {
-            test.Monitor()->VerifyNotFound();
+            test.Monitor().VerifyNotFound();
         } else {
-            test.Monitor()->VerifyFound();
+            test.Monitor().VerifyFound();
         }
     }
 
@@ -544,9 +550,9 @@ struct CreateNVRayTracingPipelineHelper {
         info_override(helper);
         helper.InitState();
 
-        for (const auto &error : errors) test.Monitor()->SetDesiredFailureMsg(flags, error);
+        for (const auto &error : errors) test.Monitor().SetDesiredFailureMsg(flags, error);
         helper.CreateNVRayTracingPipeline();
-        test.Monitor()->VerifyFound();
+        test.Monitor().VerifyFound();
     }
 
     template <typename Test, typename OverrideFunc, typename Error>
@@ -561,9 +567,9 @@ struct CreateNVRayTracingPipelineHelper {
         info_override(helper);
         helper.InitState();
 
-        test.Monitor()->ExpectSuccess(message_flag_mask);
+        test.Monitor().ExpectSuccess(message_flag_mask);
         ASSERT_VK_SUCCESS(helper.CreateNVRayTracingPipeline());
-        test.Monitor()->VerifyNotFound();
+        test.Monitor().VerifyNotFound();
     }
 };
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -24,6 +24,8 @@
  * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
+#include <type_traits>
+
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
 
@@ -6898,7 +6900,7 @@ TEST_F(VkLayerTest, CreateImageMinLimitsViolation) {
 
     enum Dimension { kWidth = 0x1, kHeight = 0x2, kDepth = 0x4 };
 
-    for (underlying_type<Dimension>::type bad_dimensions = 0x1; bad_dimensions < 0x8; ++bad_dimensions) {
+    for (std::underlying_type<Dimension>::type bad_dimensions = 0x1; bad_dimensions < 0x8; ++bad_dimensions) {
         VkExtent3D extent = {1, 1, 1};
 
         if (bad_dimensions & kWidth) {

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -49,9 +49,6 @@ TEST_F(VkLayerTest, InstanceExtensionDependencies) {
     const auto ici = GetInstanceCreateInfo();
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
-
-    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-    vk::DestroyInstance(dummy_instance, nullptr);
 }
 
 TEST_F(VkLayerTest, InstanceBadStype) {
@@ -63,9 +60,6 @@ TEST_F(VkLayerTest, InstanceBadStype) {
     ici.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
-
-    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-    vk::DestroyInstance(dummy_instance, nullptr);
 }
 
 TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
@@ -85,9 +79,6 @@ TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
     ici.pNext = &first_pnext;
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
-
-    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-    vk::DestroyInstance(dummy_instance, nullptr);
 }
 
 TEST_F(VkLayerTest, InstanceFlags) {
@@ -99,9 +90,6 @@ TEST_F(VkLayerTest, InstanceFlags) {
     ici.flags = (VkInstanceCreateFlags)1;
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
-
-    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-    vk::DestroyInstance(dummy_instance, nullptr);
 }
 
 TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
@@ -117,9 +105,6 @@ TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
     Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkApplicationInfo-sType-sType");
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
-
-    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-    vk::DestroyInstance(dummy_instance, nullptr);
 }
 
 TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
@@ -154,7 +139,6 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
-        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
 
     {
@@ -168,7 +152,6 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
-        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
 }
 
@@ -204,7 +187,6 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
-        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
 
     {
@@ -216,7 +198,6 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
         Monitor().SetDesiredFailureMsg(kErrorBit, "parameter disabledValidationCheckCount must be greater than 0");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
-        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
 }
 

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -24,8 +24,6 @@
 // Note: testing pCreateInfo pointer, the sType of a debug struct, the debug callback pointer, the ppEnabledLayerNames pointer, and
 //       the ppEnabledExtensionNames would require extenally enabled debug layers, so this is currently not performed.
 //
-// TODO: some check are disabled because they are failing
-// TODO: some checks have problems with the loader requiring a workaround
 // TODO: VkDebugReportCallbackCreateInfoEXT::flags and VkDebugUtilsMessengerCreateInfoEXT various Flags could theoretically be
 //       tested if the debug extensions are made robust enough
 
@@ -56,102 +54,6 @@ TEST_F(VkLayerTest, InstanceExtensionDependencies) {
     vk::DestroyInstance(dummy_instance, nullptr);
 }
 
-// TODO: Defunct because of the instance bug, and we cannot workaround by destroying the instance because we pass NULL
-// TEST_F(VkLayerTest, InstanceNullReturnPtr) {
-//    TEST_DESCRIPTION("Test creating instance with NULL pInstance.");
-//
-//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-pInstance-parameter");
-//    vk::CreateInstance(&GetInstanceCreateInfo(), nullptr, nullptr);
-//    Monitor().VerifyFound();
-//}
-
-void* VKAPI_PTR DummyAlloc(void*, size_t size, size_t alignment, VkSystemAllocationScope) {
-    size_t space = size + alignment - 1;
-    void* mem_ptr = std::malloc(space);
-    return std::align(alignment, size, mem_ptr, space);
-}
-void VKAPI_PTR DummyFree(void*, void* pMemory) {
-    // just leak it
-}
-void* VKAPI_PTR DummyRealloc(void* pUserData, void* pOriginal, size_t size, size_t alignment,
-                             VkSystemAllocationScope allocationScope) {
-    DummyFree(pUserData, pOriginal);
-    return DummyAlloc(pUserData, size, alignment, allocationScope);
-}
-void VKAPI_PTR DummyInfoAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
-void VKAPI_PTR DummyInfoFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
-
-// TODO: Loader hates this; if it can, it should call layers first before using allocators
-// TEST_F(VkLayerTest, InstanceAllocationCallbacks) {
-//    TEST_DESCRIPTION("Test creating instance with invalid allocation callbacks.");
-//
-//    const auto ici = GetInstanceCreateInfo();
-//    const VkAllocationCallbacks alloc_callbacks = {nullptr,    &DummyAlloc,     &DummyRealloc,
-//                                                   &DummyFree, &DummyInfoAlloc, &DummyInfoFree};
-//
-//    enum TestedFn { kCreate, kDestroy };
-//    struct TestCase {
-//        const char* vuid;
-//        TestedFn tested_fn;
-//        VkAllocationCallbacks test_ac;
-//    };
-//
-//    const std::vector<TestCase> test_cases = {
-//        {"VUID-VkAllocationCallbacks-pfnAllocation-00632",
-//         kCreate,
-//         {nullptr, nullptr, &DummyRealloc, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnAllocation-00632",
-//         kDestroy,
-//         {nullptr, nullptr, &DummyRealloc, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnReallocation-00633",
-//         kCreate,
-//         {nullptr, &DummyAlloc, nullptr, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnReallocation-00633",
-//         kDestroy,
-//         {nullptr, &DummyAlloc, nullptr, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnFree-00634",
-//         kCreate,
-//         {nullptr, &DummyAlloc, &DummyRealloc, nullptr, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnFree-00634",
-//         kDestroy,
-//         {nullptr, &DummyAlloc, &DummyRealloc, nullptr, &DummyInfoAlloc, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
-//         kCreate,
-//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, nullptr, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
-//         kDestroy,
-//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, nullptr, &DummyInfoFree}},
-//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-006352",
-//         kCreate,
-//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, &DummyInfoAlloc, nullptr}},
-//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
-//         kDestroy,
-//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, &DummyInfoAlloc, nullptr}},
-//    };
-//
-//    for (const auto& test_case : test_cases) {
-//        if (test_case.tested_fn == kCreate) {
-//            Monitor().SetDesiredFailureMsg(kErrorBit, test_case.vuid);
-//            vk::CreateInstance(&ici, &test_case.test_ac, &dummy_instance);
-//            Monitor().VerifyFound();
-//
-//            //vk::DestroyInstance(dummy_instance, &alloc_callbacks); // WORKAROUND
-//        }
-//
-//        if (test_case.tested_fn == kDestroy) {
-//            VkInstance instance;
-//            ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, &alloc_callbacks, &instance));
-//
-//            Monitor().SetDesiredFailureMsg(kErrorBit, test_case.vuid);
-//            vk::DestroyInstance(instance, &test_case.test_ac);
-//            Monitor().VerifyFound();
-//
-//            // cleanup
-//            vk::DestroyInstance(instance, &alloc_callbacks);
-//        }
-//    }
-//}
-
 TEST_F(VkLayerTest, InstanceBadStype) {
     TEST_DESCRIPTION("Test creating instance with bad sType.");
 
@@ -165,25 +67,6 @@ TEST_F(VkLayerTest, InstanceBadStype) {
     // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
     vk::DestroyInstance(dummy_instance, nullptr);
 }
-
-// TODO: Fails
-// TEST_F(VkLayerTest, InstanceBadPnextStype) {
-//    TEST_DESCRIPTION("Test creating instance with bad sType in the pNext chain.");
-//
-//    auto ici = GetInstanceCreateInfo();
-//
-//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-pNext-pNext");
-//    VkBaseInStructure invalid_struct = {
-//        VK_STRUCTURE_TYPE_APPLICATION_INFO,
-//        reinterpret_cast<const VkBaseInStructure* >(ici.pNext)
-//    };
-//    ici.pNext = &invalid_struct;
-//    vk::CreateInstance(&ici, nullptr, &dummy_instance);
-//    Monitor().VerifyFound();
-//
-//    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-//    vk::DestroyInstance(dummy_instance, nullptr);
-//}
 
 TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
     TEST_DESCRIPTION("Test creating instance with duplicate sType in the pNext chain.");
@@ -239,26 +122,6 @@ TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
     vk::DestroyInstance(dummy_instance, nullptr);
 }
 
-// TODO: fails
-// TEST_F(VkLayerTest, InstanceAppInfoBadPnext) {
-//    TEST_DESCRIPTION("Test creating instance with invalid pNext in VkApplicationInfo.");
-//
-//    auto ici = GetInstanceCreateInfo();
-//
-//    VkApplicationInfo bad_app_info = {};
-//    if( ici.pApplicationInfo ) bad_app_info = *ici.pApplicationInfo;
-//    ASSERT_TRUE(!ici.pApplicationInfo || ici.pApplicationInfo->pNext == nullptr); // test framework should not be using the pNext
-//    bad_app_info.pNext = reinterpret_cast<void*>(0x1);
-//    ici.pApplicationInfo = &bad_app_info;
-//
-//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkApplicationInfo-pNext-pNext");
-//    vk::CreateInstance(&ici, nullptr, &dummy_instance);
-//    Monitor().VerifyFound();
-//
-//    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
-//    vk::DestroyInstance(dummy_instance, nullptr);
-//}
-
 TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
     TEST_DESCRIPTION("Test creating instance with invalid flags in VkValidationFeaturesEXT.");
 
@@ -276,28 +139,18 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
         ASSERT_NE(traversable_pnext->sType, VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT);
     }
 
-    VkValidationFeaturesEXT validation_features = {};
-    validation_features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
-    validation_features.pNext = ici.pNext;
-    ici.pNext = &validation_features;
+    VkValidationFeaturesEXT validation_features_template = {};
+    validation_features_template.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    validation_features_template.pNext = ici.pNext;
 
     {
-        validation_features.enabledValidationFeatureCount = 1;
-        validation_features.pEnabledValidationFeatures = nullptr;
-        validation_features.disabledValidationFeatureCount = 0;
-        validation_features.pDisabledValidationFeatures = nullptr;
-
-        // TODO: Crashes
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
-        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
-        // Monitor().VerifyFound();
-        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
-
         const VkValidationFeatureEnableEXT bad_enable = (VkValidationFeatureEnableEXT)0x42;
+        VkValidationFeaturesEXT validation_features = validation_features_template;
+        validation_features.enabledValidationFeatureCount = 1;
         validation_features.pEnabledValidationFeatures = &bad_enable;
+        ici.pNext = &validation_features;
 
-        // TODO: Does not have a proper VUID
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        // VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
@@ -305,31 +158,18 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
     }
 
     {
-        validation_features.enabledValidationFeatureCount = 0;
-        validation_features.pEnabledValidationFeatures = nullptr;
-        validation_features.disabledValidationFeatureCount = 1;
-        validation_features.pDisabledValidationFeatures = nullptr;
-
-        // TODO: Crashes
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
-        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
-        // Monitor().VerifyFound();
-        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
-
         const VkValidationFeatureDisableEXT bad_disable = (VkValidationFeatureDisableEXT)0x42;
+        VkValidationFeaturesEXT validation_features = validation_features_template;
+        validation_features.disabledValidationFeatureCount = 1;
         validation_features.pDisabledValidationFeatures = &bad_disable;
+        ici.pNext = &validation_features;
 
-        // TODO: Does not have a proper VUID
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        // VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
         vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
-
-    // TODO: some new VUs soon
-    // VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT vs VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT
-    // VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT + VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT dependency
 }
 
 TEST_F(VkLayerTest, InstanceBadValidationFlags) {
@@ -349,26 +189,18 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
         ASSERT_NE(traversable_pnext->sType, VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT);
     }
 
-    VkValidationFlagsEXT validation_flags = {};
-    validation_flags.sType = VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT;
-    validation_flags.pNext = ici.pNext;
-    ici.pNext = &validation_flags;
+    VkValidationFlagsEXT validation_flags_template = {};
+    validation_flags_template.sType = VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT;
+    validation_flags_template.pNext = ici.pNext;
 
     {
-        validation_flags.disabledValidationCheckCount = 1;
-        validation_flags.pDisabledValidationChecks = nullptr;
-
-        // TODO: Crashes
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-pDisabledValidationChecks-parameter");
-        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
-        // Monitor().VerifyFound();
-        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
-
         const VkValidationCheckEXT bad_disable = (VkValidationCheckEXT)0x42;
+        VkValidationFlagsEXT validation_flags = validation_flags_template;
+        validation_flags.disabledValidationCheckCount = 1;
         validation_flags.pDisabledValidationChecks = &bad_disable;
+        ici.pNext = &validation_flags;
 
-        // TODO: Does not have a proper VUID
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-pDisabledValidationChecks-parameter");
+        // VUID-VkValidationFlagsEXT-pDisabledValidationChecks-parameter
         Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
@@ -376,20 +208,33 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
     }
 
     {
+        VkValidationFlagsEXT validation_flags = validation_flags_template;
         validation_flags.disabledValidationCheckCount = 0;
+        ici.pNext = &validation_flags;
 
-        // TODO: Does not have a proper VUID
-        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-disabledValidationCheckCount-arraylength");
+        // VUID-VkValidationFlagsEXT-disabledValidationCheckCount-arraylength
         Monitor().SetDesiredFailureMsg(kErrorBit, "parameter disabledValidationCheckCount must be greater than 0");
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
         vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
     }
-
-    // TODO: some new VUs soon
-    // VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT vs VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT
-    // VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT + VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT dependency
 }
+
+void* VKAPI_PTR DummyAlloc(void*, size_t size, size_t alignment, VkSystemAllocationScope) {
+    size_t space = size + alignment - 1;
+    void* mem_ptr = std::malloc(space);
+    return std::align(alignment, size, mem_ptr, space);
+}
+void VKAPI_PTR DummyFree(void*, void* pMemory) {
+    // just leak it
+}
+void* VKAPI_PTR DummyRealloc(void* pUserData, void* pOriginal, size_t size, size_t alignment,
+                             VkSystemAllocationScope allocationScope) {
+    DummyFree(pUserData, pOriginal);
+    return DummyAlloc(pUserData, size, alignment, allocationScope);
+}
+void VKAPI_PTR DummyInfoAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
+void VKAPI_PTR DummyInfoFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
 
 TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
     TEST_DESCRIPTION("Test vkDestroyInstance with incompatible allocation callbacks.");
@@ -397,16 +242,6 @@ TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
     const auto ici = GetInstanceCreateInfo();
     const VkAllocationCallbacks alloc_callbacks = {nullptr,    &DummyAlloc,     &DummyRealloc,
                                                    &DummyFree, &DummyInfoAlloc, &DummyInfoFree};
-
-    // TODO: also crashes Loader
-    //{
-    //    VkInstance instance;
-    //    ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, &alloc_callbacks, &instance));
-
-    //    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyInstance-instance-00630");
-    //    vk::DestroyInstance(instance, nullptr);
-    //    Monitor().VerifyFound();
-    //}
 
     {
         VkInstance instance;
@@ -445,8 +280,7 @@ TEST_F(VkLayerTest, DestroyInstanceHandleLeak) {
     VkDevice leaked_device;
     ASSERT_VK_SUCCESS(vk::CreateDevice(physical_device, &dci, nullptr, &leaked_device));
 
-    // TODO: Does not have a proper VUID assigned in object tracker
-    // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyInstance-instance-00629");
+    // VUID-vkDestroyInstance-instance-00629
     Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ObjectTracker-ObjectLeak");
     vk::DestroyInstance(instance, nullptr);
     Monitor().VerifyFound();

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -262,7 +262,8 @@ TEST_F(VkLayerTest, DestroyInstanceHandleLeak) {
     ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance));
     uint32_t physical_device_count = 1;
     VkPhysicalDevice physical_device;
-    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance, &physical_device_count, &physical_device));
+    const VkResult err = vk::EnumeratePhysicalDevices(instance, &physical_device_count, &physical_device);
+    ASSERT_TRUE(err == VK_SUCCESS || err == VK_INCOMPLETE) << vk_result_string(err);
     ASSERT_EQ(physical_device_count, 1);
 
     float dqci_priorities[] = {1.0};

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -1,0 +1,453 @@
+/* Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//   Instanceless tests
+// Tests of validation of vkCreateInstance and vkDestroyInstance via the pNext debug callback.
+//
+// This set of test should ideally be as complete as possible. Most of the VUs are Implicit (i.e. automatically generated), but any
+// of the parameters could expose a bug or inadequacy in the Loader or the debug extension.
+//
+// Note: testing pCreateInfo pointer, the sType of a debug struct, the debug callback pointer, the ppEnabledLayerNames pointer, and
+//       the ppEnabledExtensionNames would require extenally enabled debug layers, so this is currently not performed.
+//
+// TODO: some check are disabled because they are failing
+// TODO: some checks have problems with the loader requiring a workaround
+// TODO: VkDebugReportCallbackCreateInfoEXT::flags and VkDebugUtilsMessengerCreateInfoEXT various Flags could theoretically be
+//       tested if the debug extensions are made robust enough
+
+#include <memory>
+#include <vector>
+
+#include "cast_utils.h"
+#include "layer_validation_tests.h"
+
+static VkInstance dummy_instance;
+
+TEST_F(VkLayerTest, InstanceExtensionDependencies) {
+    TEST_DESCRIPTION("Test enabling instance extension without dependencies met.");
+
+    if (!InstanceExtensionSupported(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)) {
+        printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+        return;
+    }
+    ASSERT_TRUE(InstanceExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME));  // Driver should always provide dependencies
+
+    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-ppEnabledExtensionNames-01388");
+    instance_extensions_.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    const auto ici = GetInstanceCreateInfo();
+    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+    Monitor().VerifyFound();
+
+    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+    vk::DestroyInstance(dummy_instance, nullptr);
+}
+
+// TODO: Defunct because of the instance bug, and we cannot workaround by destroying the instance because we pass NULL
+// TEST_F(VkLayerTest, InstanceNullReturnPtr) {
+//    TEST_DESCRIPTION("Test creating instance with NULL pInstance.");
+//
+//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-pInstance-parameter");
+//    vk::CreateInstance(&GetInstanceCreateInfo(), nullptr, nullptr);
+//    Monitor().VerifyFound();
+//}
+
+void* VKAPI_PTR DummyAlloc(void*, size_t size, size_t alignment, VkSystemAllocationScope) {
+    size_t space = size + alignment - 1;
+    void* mem_ptr = std::malloc(space);
+    return std::align(alignment, size, mem_ptr, space);
+}
+void VKAPI_PTR DummyFree(void*, void* pMemory) {
+    // just leak it
+}
+void* VKAPI_PTR DummyRealloc(void* pUserData, void* pOriginal, size_t size, size_t alignment,
+                             VkSystemAllocationScope allocationScope) {
+    DummyFree(pUserData, pOriginal);
+    return DummyAlloc(pUserData, size, alignment, allocationScope);
+}
+void VKAPI_PTR DummyInfoAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
+void VKAPI_PTR DummyInfoFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
+
+// TODO: Loader hates this; if it can, it should call layers first before using allocators
+// TEST_F(VkLayerTest, InstanceAllocationCallbacks) {
+//    TEST_DESCRIPTION("Test creating instance with invalid allocation callbacks.");
+//
+//    const auto ici = GetInstanceCreateInfo();
+//    const VkAllocationCallbacks alloc_callbacks = {nullptr,    &DummyAlloc,     &DummyRealloc,
+//                                                   &DummyFree, &DummyInfoAlloc, &DummyInfoFree};
+//
+//    enum TestedFn { kCreate, kDestroy };
+//    struct TestCase {
+//        const char* vuid;
+//        TestedFn tested_fn;
+//        VkAllocationCallbacks test_ac;
+//    };
+//
+//    const std::vector<TestCase> test_cases = {
+//        {"VUID-VkAllocationCallbacks-pfnAllocation-00632",
+//         kCreate,
+//         {nullptr, nullptr, &DummyRealloc, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnAllocation-00632",
+//         kDestroy,
+//         {nullptr, nullptr, &DummyRealloc, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnReallocation-00633",
+//         kCreate,
+//         {nullptr, &DummyAlloc, nullptr, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnReallocation-00633",
+//         kDestroy,
+//         {nullptr, &DummyAlloc, nullptr, &DummyFree, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnFree-00634",
+//         kCreate,
+//         {nullptr, &DummyAlloc, &DummyRealloc, nullptr, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnFree-00634",
+//         kDestroy,
+//         {nullptr, &DummyAlloc, &DummyRealloc, nullptr, &DummyInfoAlloc, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
+//         kCreate,
+//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, nullptr, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
+//         kDestroy,
+//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, nullptr, &DummyInfoFree}},
+//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-006352",
+//         kCreate,
+//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, &DummyInfoAlloc, nullptr}},
+//        {"VUID-VkAllocationCallbacks-pfnInternalAllocation-00635",
+//         kDestroy,
+//         {nullptr, &DummyAlloc, &DummyRealloc, &DummyFree, &DummyInfoAlloc, nullptr}},
+//    };
+//
+//    for (const auto& test_case : test_cases) {
+//        if (test_case.tested_fn == kCreate) {
+//            Monitor().SetDesiredFailureMsg(kErrorBit, test_case.vuid);
+//            vk::CreateInstance(&ici, &test_case.test_ac, &dummy_instance);
+//            Monitor().VerifyFound();
+//
+//            //vk::DestroyInstance(dummy_instance, &alloc_callbacks); // WORKAROUND
+//        }
+//
+//        if (test_case.tested_fn == kDestroy) {
+//            VkInstance instance;
+//            ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, &alloc_callbacks, &instance));
+//
+//            Monitor().SetDesiredFailureMsg(kErrorBit, test_case.vuid);
+//            vk::DestroyInstance(instance, &test_case.test_ac);
+//            Monitor().VerifyFound();
+//
+//            // cleanup
+//            vk::DestroyInstance(instance, &alloc_callbacks);
+//        }
+//    }
+//}
+
+TEST_F(VkLayerTest, InstanceBadStype) {
+    TEST_DESCRIPTION("Test creating instance with bad sType.");
+
+    auto ici = GetInstanceCreateInfo();
+
+    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-sType-sType");
+    ici.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+    Monitor().VerifyFound();
+
+    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+    vk::DestroyInstance(dummy_instance, nullptr);
+}
+
+// TODO: Fails
+// TEST_F(VkLayerTest, InstanceBadPnextStype) {
+//    TEST_DESCRIPTION("Test creating instance with bad sType in the pNext chain.");
+//
+//    auto ici = GetInstanceCreateInfo();
+//
+//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-pNext-pNext");
+//    VkBaseInStructure invalid_struct = {
+//        VK_STRUCTURE_TYPE_APPLICATION_INFO,
+//        reinterpret_cast<const VkBaseInStructure* >(ici.pNext)
+//    };
+//    ici.pNext = &invalid_struct;
+//    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+//    Monitor().VerifyFound();
+//
+//    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+//    vk::DestroyInstance(dummy_instance, nullptr);
+//}
+
+TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
+    TEST_DESCRIPTION("Test creating instance with duplicate sType in the pNext chain.");
+
+    if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
+        printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+        return;
+    }
+    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+
+    auto ici = GetInstanceCreateInfo();
+
+    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-sType-unique");
+    const VkValidationFeaturesEXT duplicate_pnext = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, ici.pNext};
+    const VkValidationFeaturesEXT first_pnext = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, &duplicate_pnext};
+    ici.pNext = &first_pnext;
+    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+    Monitor().VerifyFound();
+
+    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+    vk::DestroyInstance(dummy_instance, nullptr);
+}
+
+TEST_F(VkLayerTest, InstanceFlags) {
+    TEST_DESCRIPTION("Test creating instance with invalid flags.");
+
+    auto ici = GetInstanceCreateInfo();
+
+    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-flags-zerobitmask");
+    ici.flags = (VkInstanceCreateFlags)1;
+    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+    Monitor().VerifyFound();
+
+    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+    vk::DestroyInstance(dummy_instance, nullptr);
+}
+
+TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
+    TEST_DESCRIPTION("Test creating instance with invalid sType in VkApplicationInfo.");
+
+    auto ici = GetInstanceCreateInfo();
+
+    VkApplicationInfo bad_app_info = {};
+    if (ici.pApplicationInfo) bad_app_info = *ici.pApplicationInfo;
+    bad_app_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    ici.pApplicationInfo = &bad_app_info;
+
+    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkApplicationInfo-sType-sType");
+    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+    Monitor().VerifyFound();
+
+    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+    vk::DestroyInstance(dummy_instance, nullptr);
+}
+
+// TODO: fails
+// TEST_F(VkLayerTest, InstanceAppInfoBadPnext) {
+//    TEST_DESCRIPTION("Test creating instance with invalid pNext in VkApplicationInfo.");
+//
+//    auto ici = GetInstanceCreateInfo();
+//
+//    VkApplicationInfo bad_app_info = {};
+//    if( ici.pApplicationInfo ) bad_app_info = *ici.pApplicationInfo;
+//    ASSERT_TRUE(!ici.pApplicationInfo || ici.pApplicationInfo->pNext == nullptr); // test framework should not be using the pNext
+//    bad_app_info.pNext = reinterpret_cast<void*>(0x1);
+//    ici.pApplicationInfo = &bad_app_info;
+//
+//    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkApplicationInfo-pNext-pNext");
+//    vk::CreateInstance(&ici, nullptr, &dummy_instance);
+//    Monitor().VerifyFound();
+//
+//    // WORKAROUND: Subsequent tests crash when this is not called. MockICD or Loader bug?
+//    vk::DestroyInstance(dummy_instance, nullptr);
+//}
+
+TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
+    TEST_DESCRIPTION("Test creating instance with invalid flags in VkValidationFeaturesEXT.");
+
+    if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
+        printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+        return;
+    }
+    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+
+    auto ici = GetInstanceCreateInfo();
+
+    // the test framework should not be using VkValidationFeatureEnableEXT itself
+    for (auto traversable_pnext = reinterpret_cast<const VkBaseInStructure*>(ici.pNext); traversable_pnext;
+         traversable_pnext = traversable_pnext->pNext) {
+        ASSERT_NE(traversable_pnext->sType, VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT);
+    }
+
+    VkValidationFeaturesEXT validation_features = {};
+    validation_features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    validation_features.pNext = ici.pNext;
+    ici.pNext = &validation_features;
+
+    {
+        validation_features.enabledValidationFeatureCount = 1;
+        validation_features.pEnabledValidationFeatures = nullptr;
+        validation_features.disabledValidationFeatureCount = 0;
+        validation_features.pDisabledValidationFeatures = nullptr;
+
+        // TODO: Crashes
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        // Monitor().VerifyFound();
+        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
+
+        const VkValidationFeatureEnableEXT bad_enable = (VkValidationFeatureEnableEXT)0x42;
+        validation_features.pEnabledValidationFeatures = &bad_enable;
+
+        // TODO: Does not have a proper VUID
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
+    }
+
+    {
+        validation_features.enabledValidationFeatureCount = 0;
+        validation_features.pEnabledValidationFeatures = nullptr;
+        validation_features.disabledValidationFeatureCount = 1;
+        validation_features.pDisabledValidationFeatures = nullptr;
+
+        // TODO: Crashes
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        // Monitor().VerifyFound();
+        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
+
+        const VkValidationFeatureDisableEXT bad_disable = (VkValidationFeatureDisableEXT)0x42;
+        validation_features.pDisabledValidationFeatures = &bad_disable;
+
+        // TODO: Does not have a proper VUID
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter");
+        Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
+    }
+
+    // TODO: some new VUs soon
+    // VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT vs VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT
+    // VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT + VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT dependency
+}
+
+TEST_F(VkLayerTest, InstanceBadValidationFlags) {
+    TEST_DESCRIPTION("Test creating instance with invalid VkValidationFlagsEXT.");
+
+    if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME)) {
+        printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
+        return;
+    }
+    instance_extensions_.push_back(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
+
+    auto ici = GetInstanceCreateInfo();
+
+    // the test framework should not be using VkValidationFlagsEXT itself
+    for (auto traversable_pnext = reinterpret_cast<const VkBaseInStructure*>(ici.pNext); traversable_pnext;
+         traversable_pnext = traversable_pnext->pNext) {
+        ASSERT_NE(traversable_pnext->sType, VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT);
+    }
+
+    VkValidationFlagsEXT validation_flags = {};
+    validation_flags.sType = VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT;
+    validation_flags.pNext = ici.pNext;
+    ici.pNext = &validation_flags;
+
+    {
+        validation_flags.disabledValidationCheckCount = 1;
+        validation_flags.pDisabledValidationChecks = nullptr;
+
+        // TODO: Crashes
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-pDisabledValidationChecks-parameter");
+        // vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        // Monitor().VerifyFound();
+        // vk::DestroyInstance(dummy_instance, nullptr); // WORKAROUND
+
+        const VkValidationCheckEXT bad_disable = (VkValidationCheckEXT)0x42;
+        validation_flags.pDisabledValidationChecks = &bad_disable;
+
+        // TODO: Does not have a proper VUID
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-pDisabledValidationChecks-parameter");
+        Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
+    }
+
+    {
+        validation_flags.disabledValidationCheckCount = 0;
+
+        // TODO: Does not have a proper VUID
+        // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-VkValidationFlagsEXT-disabledValidationCheckCount-arraylength");
+        Monitor().SetDesiredFailureMsg(kErrorBit, "parameter disabledValidationCheckCount must be greater than 0");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+        vk::DestroyInstance(dummy_instance, nullptr);  // WORKAROUND
+    }
+
+    // TODO: some new VUs soon
+    // VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT vs VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT
+    // VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT + VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT dependency
+}
+
+TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
+    TEST_DESCRIPTION("Test vkDestroyInstance with incompatible allocation callbacks.");
+
+    const auto ici = GetInstanceCreateInfo();
+    const VkAllocationCallbacks alloc_callbacks = {nullptr,    &DummyAlloc,     &DummyRealloc,
+                                                   &DummyFree, &DummyInfoAlloc, &DummyInfoFree};
+
+    // TODO: also crashes Loader
+    //{
+    //    VkInstance instance;
+    //    ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, &alloc_callbacks, &instance));
+
+    //    Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyInstance-instance-00630");
+    //    vk::DestroyInstance(instance, nullptr);
+    //    Monitor().VerifyFound();
+    //}
+
+    {
+        VkInstance instance;
+        ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance));
+
+        Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyInstance-instance-00631");
+        vk::DestroyInstance(instance, &alloc_callbacks);
+        Monitor().VerifyFound();
+    }
+}
+
+TEST_F(VkLayerTest, DestroyInstanceHandleLeak) {
+    TEST_DESCRIPTION("Test vkDestroyInstance while leaking a VkDevice object.");
+
+    const auto ici = GetInstanceCreateInfo();
+
+    VkInstance instance;
+    ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance));
+    uint32_t physical_device_count = 1;
+    VkPhysicalDevice physical_device;
+    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance, &physical_device_count, &physical_device));
+    ASSERT_EQ(physical_device_count, 1);
+
+    float dqci_priorities[] = {1.0};
+    VkDeviceQueueCreateInfo dqci = {};
+    dqci.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    dqci.queueFamilyIndex = 0;
+    dqci.queueCount = 1;
+    dqci.pQueuePriorities = dqci_priorities;
+
+    VkDeviceCreateInfo dci = {};
+    dci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dci.queueCreateInfoCount = 1;
+    dci.pQueueCreateInfos = &dqci;
+
+    VkDevice leaked_device;
+    ASSERT_VK_SUCCESS(vk::CreateDevice(physical_device, &dci, nullptr, &leaked_device));
+
+    // TODO: Does not have a proper VUID assigned in object tracker
+    // Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyInstance-instance-00629");
+    Monitor().SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ObjectTracker-ObjectLeak");
+    vk::DestroyInstance(instance, nullptr);
+    Monitor().VerifyFound();
+}

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3099,23 +3099,6 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InstanceDebugReportCallback) {
-    TEST_DESCRIPTION("Test that a pNext-installed debug callback will catch a CreateInstance-time error.");
-
-    // This instance extension requires that the VK_KHR_get_surface_capabilities2 also be enabled
-    if (!InstanceExtensionSupported(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME)) {
-        printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix,
-               VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME);
-        return;
-    }
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-ppEnabledExtensionNames-01388");
-    // Enable the instance extension, but none of the extensions it depends on
-    m_instance_extension_names.push_back(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(VkLayerTest, HostQueryResetNotEnabled) {
     TEST_DESCRIPTION("Use vkResetQueryPoolEXT without enabling the feature");
 

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -7948,7 +7948,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
 TEST_F(VkPositiveLayerTest, ApiVersionZero) {
     TEST_DESCRIPTION("Check that apiVersion = 0 is valid.");
     m_errorMonitor->ExpectSuccess();
-    app_info.apiVersion = 0U;
+    app_info_.apiVersion = 0U;
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     m_errorMonitor->VerifyNotFound();
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -511,10 +511,7 @@ void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *
 void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *create_device_pnext,
                                   const VkCommandPoolCreateFlags flags) {
     const auto ExtensionNotSupportedWithReporting = [this](const char *extension) {
-        std::vector<const char *> layers = {nullptr};
-        layers.insert(layers.end(), instance_layers_.begin(), instance_layers_.end());
-        if (std::any_of(layers.begin(), layers.end(),
-                        [this, extension](const char *l) { return DeviceExtensionSupported(gpu(), l, extension); }))
+        if (DeviceExtensionSupported(extension))
             return false;
         else {
             ADD_FAILURE() << "InitState(): Requested device extension \"" << extension

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -455,7 +455,8 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
     if (instance_pnext) reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext = nullptr;  // reset back borrowed pNext chain
 
     uint32_t gpu_count = 1;
-    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance_, &gpu_count, &gpu_));
+    const VkResult err = vk::EnumeratePhysicalDevices(instance_, &gpu_count, &gpu_);
+    ASSERT_TRUE(err == VK_SUCCESS || err == VK_INCOMPLETE) << vk_result_string(err);
     ASSERT_GT(gpu_count, (uint32_t)0) << "No GPU (i.e. VkPhysicalDevice) available";
 
     debug_reporter_.Create(instance_);

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -42,7 +42,6 @@ typename C::iterator RemoveIf(C &container, F &&fn) {
 
 ErrorMonitor::ErrorMonitor() {
     test_platform_thread_create_mutex(&mutex_);
-    // TODO: why even lock in constructor
     test_platform_thread_lock_mutex(&mutex_);
     Reset();
     test_platform_thread_unlock_mutex(&mutex_);
@@ -51,7 +50,6 @@ ErrorMonitor::ErrorMonitor() {
 ErrorMonitor::~ErrorMonitor() NOEXCEPT { test_platform_thread_delete_mutex(&mutex_); }
 
 void ErrorMonitor::Reset() {
-    // TODO: thread lock?
     message_flags_ = 0;
     bailout_ = NULL;
     message_found_ = VK_FALSE;
@@ -223,7 +221,6 @@ void DebugReporter::Create(VkInstance instance) NOEXCEPT {
     assert(instance);
     assert(!debug_obj_);
 
-    // TODO: the lvl loader should perhaps do this
     auto DebugCreate = reinterpret_cast<DebugCreateFnType>(vk::GetInstanceProcAddr(instance, debug_create_fn_name_));
     if (!DebugCreate) return;
 
@@ -443,7 +440,6 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
     auto ici = GetInstanceCreateInfo();
 
     // concatenate pNexts
-    // TODO: There HAS to be some utility function for this somewhere
     void *last_pnext = nullptr;
     if (instance_pnext) {
         last_pnext = instance_pnext;
@@ -514,7 +510,6 @@ void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *
 void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *create_device_pnext,
                                   const VkCommandPoolCreateFlags flags) {
     const auto ExtensionNotSupportedWithReporting = [this](const char *extension) {
-        // TODO: could be simplified with better DeviceExtensionSupported()
         std::vector<const char *> layers = {nullptr};
         layers.insert(layers.end(), instance_layers_.begin(), instance_layers_.end());
         if (std::any_of(layers.begin(), layers.end(),

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -22,12 +22,27 @@
  */
 
 #include "vkrenderframework.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <utility>
+#include <vector>
+
 #include "vk_format_utils.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+using std::string;
+using std::strncmp;
+using std::vector;
+
+template <typename C, typename F>
+typename C::iterator RemoveIf(C &container, F &&fn) {
+    return container.erase(std::remove_if(container.begin(), container.end(), std::forward<F>(fn)), container.end());
+}
 
 ErrorMonitor::ErrorMonitor() {
     test_platform_thread_create_mutex(&mutex_);
+    // TODO: why even lock in constructor
     test_platform_thread_lock_mutex(&mutex_);
     Reset();
     test_platform_thread_unlock_mutex(&mutex_);
@@ -36,6 +51,7 @@ ErrorMonitor::ErrorMonitor() {
 ErrorMonitor::~ErrorMonitor() NOEXCEPT { test_platform_thread_delete_mutex(&mutex_); }
 
 void ErrorMonitor::Reset() {
+    // TODO: thread lock?
     message_flags_ = 0;
     bailout_ = NULL;
     message_found_ = VK_FALSE;
@@ -46,9 +62,7 @@ void ErrorMonitor::Reset() {
     other_messages_.clear();
 }
 
-void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const std::string msg) {
-    SetDesiredFailureMsg(msgFlags, msg.c_str());
-}
+void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const string msg) { SetDesiredFailureMsg(msgFlags, msg.c_str()); }
 
 void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const char *const msgString) {
     test_platform_thread_lock_mutex(&mutex_);
@@ -141,9 +155,9 @@ void ErrorMonitor::SetBailout(bool *bailout) { bailout_ = bailout; }
 void ErrorMonitor::DumpFailureMsgs() const {
     vector<string> otherMsgs = GetOtherFailureMsgs();
     if (otherMsgs.size()) {
-        cout << "Other error messages logged for this test were:" << endl;
+        std::cout << "Other error messages logged for this test were:" << std::endl;
         for (auto iter = otherMsgs.begin(); iter != otherMsgs.end(); iter++) {
-            cout << "     " << *iter << endl;
+            std::cout << "     " << *iter << std::endl;
         }
     }
 }
@@ -196,18 +210,60 @@ void ErrorMonitor::VerifyNotFound() {
     Reset();
 }
 
-bool ErrorMonitor::IgnoreMessage(std::string const &msg) const {
+bool ErrorMonitor::IgnoreMessage(string const &msg) const {
     if (ignore_message_strings_.empty()) {
         return false;
     }
 
-    return std::find_if(ignore_message_strings_.begin(), ignore_message_strings_.end(), [&msg](std::string const &str) {
-               return msg.find(str) != std::string::npos;
-           }) != ignore_message_strings_.end();
+    return std::find_if(ignore_message_strings_.begin(), ignore_message_strings_.end(),
+                        [&msg](string const &str) { return msg.find(str) != string::npos; }) != ignore_message_strings_.end();
+}
+
+void DebugReporter::Create(VkInstance instance) NOEXCEPT {
+    assert(instance);
+    assert(!debug_obj_);
+
+    // TODO: the lvl loader should perhaps do this
+    auto DebugCreate = reinterpret_cast<DebugCreateFnType>(vk::GetInstanceProcAddr(instance, debug_create_fn_name_));
+    if (!DebugCreate) return;
+
+    const VkResult err = DebugCreate(instance, &debug_create_info_, nullptr, &debug_obj_);
+    if (err) debug_obj_ = VK_NULL_HANDLE;
+}
+
+void DebugReporter::Destroy(VkInstance instance) NOEXCEPT {
+    assert(instance);
+    assert(debug_obj_);  // valid to call with null object, but probably bug
+
+    auto DebugDestroy = reinterpret_cast<DebugDestroyFnType>(vk::GetInstanceProcAddr(instance, debug_destroy_fn_name_));
+    assert(DebugDestroy);
+
+    DebugDestroy(instance, debug_obj_, nullptr);
+    debug_obj_ = VK_NULL_HANDLE;
+}
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugReporter::DebugCallback(VkDebugReportFlagsEXT message_flags, VkDebugReportObjectTypeEXT,
+                                                            uint64_t, size_t, int32_t, const char *, const char *message,
+                                                            void *user_data) {
+#else
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugReporter::DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                            VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                                            const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                            void *user_data) {
+    const auto message_flags = DebugAnnotFlagsToReportFlags(message_severity, message_types);
+    const char *message = callback_data->pMessage;
+#endif
+    ErrorMonitor *errMonitor = (ErrorMonitor *)user_data;
+
+    if (message_flags & errMonitor->GetMessageFlags()) {
+        return errMonitor->CheckForDesiredMsg(message);
+    }
+    return VK_FALSE;
 }
 
 VkRenderFramework::VkRenderFramework()
-    : inst(VK_NULL_HANDLE),
+    : instance_(NULL),
       m_device(NULL),
       m_commandPool(VK_NULL_HANDLE),
       m_commandBuffer(NULL),
@@ -223,17 +279,9 @@ VkRenderFramework::VkRenderFramework()
       m_clear_via_load_op(true),
       m_depth_clear_color(1.0),
       m_stencil_clear_color(0),
-      m_depthStencil(NULL),
-      m_CreateDebugReportCallback(VK_NULL_HANDLE),
-      m_DestroyDebugReportCallback(VK_NULL_HANDLE),
-      m_globalMsgCallback(VK_NULL_HANDLE),
-      m_CreateDebugUtilsCallback(VK_NULL_HANDLE),
-      m_DestroyDebugUtilsCallback(VK_NULL_HANDLE),
-      m_global_message_callback(VK_NULL_HANDLE) {
+      m_depthStencil(NULL) {
     memset(&m_renderPassBeginInfo, 0, sizeof(m_renderPassBeginInfo));
     m_renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-
-    m_errorMonitor = new ErrorMonitor;
 
     // clear the back buffer to dark grey
     m_clear_color.float32[0] = 0.25f;
@@ -245,40 +293,48 @@ VkRenderFramework::VkRenderFramework()
 VkRenderFramework::~VkRenderFramework() { ShutdownFramework(); }
 
 VkPhysicalDevice VkRenderFramework::gpu() {
-    EXPECT_NE((VkInstance)0, inst);  // Invalid to request gpu before instance exists
-    return objs[0];
+    EXPECT_NE((VkInstance)0, instance_);  // Invalid to request gpu before instance exists
+    return gpu_;
 }
 
 // Return true if layer name is found and spec+implementation values are >= requested values
-bool VkRenderFramework::InstanceLayerSupported(const char *name, uint32_t spec, uint32_t implementation) {
-    uint32_t layer_count = 0;
-    std::vector<VkLayerProperties> layer_props;
+bool VkRenderFramework::InstanceLayerSupported(const char *const layer_name, const uint32_t spec_version,
+                                               const uint32_t impl_version) {
+    const auto layers = vk_testing::GetGlobalLayers();
 
-    VkResult res = vk::EnumerateInstanceLayerProperties(&layer_count, NULL);
-    if (VK_SUCCESS != res) return false;
-    if (0 == layer_count) return false;
-
-    layer_props.resize(layer_count);
-    res = vk::EnumerateInstanceLayerProperties(&layer_count, layer_props.data());
-    if (VK_SUCCESS != res) return false;
-
-    for (auto &it : layer_props) {
-        if (0 == strncmp(name, it.layerName, VK_MAX_EXTENSION_NAME_SIZE)) {
-            return ((it.specVersion >= spec) && (it.implementationVersion >= implementation));
+    for (const auto &layer : layers) {
+        if (0 == strncmp(layer_name, layer.layerName, VK_MAX_EXTENSION_NAME_SIZE)) {
+            return layer.specVersion >= spec_version && layer.implementationVersion >= impl_version;
         }
     }
     return false;
+}
+
+// Return true if extension name is found and spec value is >= requested spec value
+// WARNING: for simplicity, does not cover layers' extensions
+bool VkRenderFramework::InstanceExtensionSupported(const char *const extension_name, const uint32_t spec_version) {
+    // WARNING: assume debug extensions are always supported, which are usually provided by layers
+    if (0 == strncmp(extension_name, VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE)) return true;
+    if (0 == strncmp(extension_name, VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE)) return true;
+
+    const auto extensions = vk_testing::GetGlobalExtensions();
+
+    const auto IsTheQueriedExtension = [extension_name, spec_version](const VkExtensionProperties &extension) {
+        return strncmp(extension_name, extension.extensionName, VK_MAX_EXTENSION_NAME_SIZE) == 0 &&
+               extension.specVersion >= spec_version;
+    };
+
+    return std::any_of(extensions.begin(), extensions.end(), IsTheQueriedExtension);
 }
 
 // Enable device profile as last layer on stack overriding devsim if there, or return if not available
 bool VkRenderFramework::EnableDeviceProfileLayer() {
     if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {
         if (VkTestFramework::m_devsim_layer) {
-            assert(0 == strcmp(m_instance_layer_names.back(), "VK_LAYER_LUNARG_device_simulation"));
-            m_instance_layer_names.pop_back();
-            m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_profile_api");
+            assert(0 == strncmp(instance_layers_.back(), "VK_LAYER_LUNARG_device_simulation", VK_MAX_EXTENSION_NAME_SIZE));
+            instance_layers_.back() = "VK_LAYER_LUNARG_device_profile_api";
         } else {
-            m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_profile_api");
+            instance_layers_.push_back("VK_LAYER_LUNARG_device_profile_api");
         }
     } else {
         printf("             Did not find VK_LAYER_LUNARG_device_profile_api layer; skipped.\n");
@@ -287,54 +343,24 @@ bool VkRenderFramework::EnableDeviceProfileLayer() {
     return true;
 }
 
-// Return true if extension name is found and spec value is >= requested spec value
-bool VkRenderFramework::InstanceExtensionSupported(const char *ext_name, uint32_t spec) {
-    // Debug utils is explicitly supported by the validation layer, no need to check for it
-    if (0 == strncmp(ext_name, VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE)) {
-        return true;
-    }
-    uint32_t ext_count = 0;
-    std::vector<VkExtensionProperties> ext_props;
-    VkResult res = vk::EnumerateInstanceExtensionProperties(nullptr, &ext_count, nullptr);
-    if (VK_SUCCESS != res) return false;
-    if (0 == ext_count) return false;
-
-    ext_props.resize(ext_count);
-    res = vk::EnumerateInstanceExtensionProperties(nullptr, &ext_count, ext_props.data());
-    if (VK_SUCCESS != res) return false;
-
-    for (auto &it : ext_props) {
-        if (0 == strncmp(ext_name, it.extensionName, VK_MAX_EXTENSION_NAME_SIZE)) {
-            return (it.specVersion >= spec);
-        }
-    }
-    return false;
-}
-
 // Return true if instance exists and extension name is in the list
 bool VkRenderFramework::InstanceExtensionEnabled(const char *ext_name) {
-    if (!inst) return false;
+    if (!instance_) return false;
 
-    bool ext_found = false;
-    for (auto ext : m_instance_extension_names) {
-        if (!strcmp(ext, ext_name)) {
-            ext_found = true;
-            break;
-        }
-    }
-    return ext_found;
+    return std::any_of(instance_extensions_.begin(), instance_extensions_.end(),
+                       [ext_name](const char *e) { return 0 == strncmp(ext_name, e, VK_MAX_EXTENSION_NAME_SIZE); });
 }
 // Return true if extension name is found and spec value is >= requested spec value
 bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, const uint32_t spec_version) const {
-    if (!inst || !objs[0]) {
-        EXPECT_NE((VkInstance)0, inst);  // Complain, not cool without an instance
-        EXPECT_NE((VkPhysicalDevice)0, objs[0]);
+    if (!instance_ || !gpu_) {
+        EXPECT_NE((VkInstance)0, instance_);  // Complain, not cool without an instance
+        EXPECT_NE((VkPhysicalDevice)0, gpu_);
         return false;
     }
 
-    const vk_testing::PhysicalDevice device_obj(objs[0]);
+    const vk_testing::PhysicalDevice device_obj(gpu_);
 
-    const auto enabled_layers = m_instance_layer_names;  // assumes m_instance_layer_names contains enabled layers
+    const auto enabled_layers = instance_layers_;  // assumes instance_layers_ contains enabled layers
 
     auto extensions = device_obj.extensions();
     for (const auto &layer : enabled_layers) {
@@ -356,7 +382,7 @@ bool VkRenderFramework::DeviceExtensionEnabled(const char *ext_name) {
 
     bool ext_found = false;
     for (auto ext : m_device_extension_names) {
-        if (!strcmp(ext, ext_name)) {
+        if (!strncmp(ext, ext_name, VK_MAX_EXTENSION_NAME_SIZE)) {
             ext_found = true;
             break;
         }
@@ -368,7 +394,8 @@ bool VkRenderFramework::DeviceExtensionEnabled(const char *ext_name) {
 // this function dubious when DevSim is active.
 bool VkRenderFramework::DeviceIsMockICD() {
     VkPhysicalDeviceProperties props = vk_testing::PhysicalDevice(gpu()).properties();
-    if ((props.vendorID == 0xba5eba11) && (props.deviceID == 0xf005ba11) && (0 == strcmp("Vulkan Mock Device", props.deviceName))) {
+    if ((props.vendorID == 0xba5eba11) && (props.deviceID == 0xf005ba11) &&
+        (0 == strncmp("Vulkan Mock Device", props.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE))) {
         return true;
     }
     return false;
@@ -377,185 +404,72 @@ bool VkRenderFramework::DeviceIsMockICD() {
 // Some tests may need to be skipped if the devsim layer is in use.
 bool VkRenderFramework::DeviceSimulation() { return m_devsim_layer; }
 
-// Debug Report-based framework initialization
-void VkRenderFramework::InitFrameworkDebugReport(PFN_vkDebugReportCallbackEXT dbgFunction, void *userData, void *instance_pnext) {
-    // Only enable device profile layer by default if devsim is not enabled
-    if (!VkTestFramework::m_devsim_layer && InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {
-        m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_profile_api");
-    }
-
-    // Assert not already initialized
-    ASSERT_EQ((VkInstance)0, inst);
-
-    // Remove any unsupported layer names from list
-    for (auto layer = m_instance_layer_names.begin(); layer != m_instance_layer_names.end();) {
-        if (!InstanceLayerSupported(*layer)) {
-            ADD_FAILURE() << "InitFramework(): Requested layer " << *layer << " was not found. Disabled.";
-            layer = m_instance_layer_names.erase(layer);
-        } else {
-            ++layer;
-        }
-    }
-
-    // Remove any unsupported instance extension names from list
-    for (auto ext = m_instance_extension_names.begin(); ext != m_instance_extension_names.end();) {
-        if (!InstanceExtensionSupported(*ext)) {
-            ADD_FAILURE() << "InitFramework(): Requested extension " << *ext << " was not found. Disabled.";
-            ext = m_instance_extension_names.erase(ext);
-        } else {
-            ++ext;
-        }
-    }
-
-    VkInstanceCreateInfo instInfo = {};
-    instInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    instInfo.pNext = instance_pnext;
-    instInfo.pApplicationInfo = &app_info;
-    instInfo.enabledLayerCount = m_instance_layer_names.size();
-    instInfo.ppEnabledLayerNames = m_instance_layer_names.data();
-    instInfo.enabledExtensionCount = m_instance_extension_names.size();
-    instInfo.ppEnabledExtensionNames = m_instance_extension_names.data();
-
-    VkDebugReportCallbackCreateInfoEXT dbgCreateInfo;
-    if (dbgFunction) {
-        // Enable create time debug messages
-        memset(&dbgCreateInfo, 0, sizeof(dbgCreateInfo));
-        dbgCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
-        dbgCreateInfo.flags = kErrorBit | kWarningBit | kPerformanceWarningBit;
-        dbgCreateInfo.pfnCallback = dbgFunction;
-        dbgCreateInfo.pUserData = userData;
-
-        dbgCreateInfo.pNext = instInfo.pNext;
-        instInfo.pNext = &dbgCreateInfo;
-    }
-
-    VkResult err;
-
-    err = vk::CreateInstance(&instInfo, NULL, &this->inst);
-    ASSERT_VK_SUCCESS(err);
-
-    err = vk::EnumeratePhysicalDevices(inst, &this->gpu_count, NULL);
-    ASSERT_LE(this->gpu_count, ARRAY_SIZE(objs)) << "Too many gpus";
-    ASSERT_VK_SUCCESS(err);
-    err = vk::EnumeratePhysicalDevices(inst, &this->gpu_count, objs);
-    ASSERT_VK_SUCCESS(err);
-    ASSERT_GE(this->gpu_count, (uint32_t)1) << "No GPU available";
-
-    if (dbgFunction) {
-        m_CreateDebugReportCallback =
-            (PFN_vkCreateDebugReportCallbackEXT)vk::GetInstanceProcAddr(this->inst, "vkCreateDebugReportCallbackEXT");
-        ASSERT_NE(m_CreateDebugReportCallback, (PFN_vkCreateDebugReportCallbackEXT)NULL)
-            << "Did not get function pointer for CreateDebugReportCallback";
-        if (m_CreateDebugReportCallback) {
-            dbgCreateInfo.pNext = nullptr;  // clean up from usage in CreateInstance above
-            err = m_CreateDebugReportCallback(this->inst, &dbgCreateInfo, NULL, &m_globalMsgCallback);
-            ASSERT_VK_SUCCESS(err);
-
-            m_DestroyDebugReportCallback =
-                (PFN_vkDestroyDebugReportCallbackEXT)vk::GetInstanceProcAddr(this->inst, "vkDestroyDebugReportCallbackEXT");
-            ASSERT_NE(m_DestroyDebugReportCallback, (PFN_vkDestroyDebugReportCallbackEXT)NULL)
-                << "Did not get function pointer for DestroyDebugReportCallback";
-        }
-    }
+VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
+    return {
+        VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        &debug_reporter_.debug_create_info_,
+        0,
+        &app_info_,
+        static_cast<uint32_t>(instance_layers_.size()),
+        instance_layers_.data(),
+        static_cast<uint32_t>(instance_extensions_.size()),
+        instance_extensions_.data(),
+    };
 }
 
-// Debug Utils-based framework initialization
-void VkRenderFramework::InitFrameworkDebugUtils(PFN_vkDebugUtilsMessengerCallbackEXT debug_function, void *userData,
-                                                void *instance_pnext) {
-    // Only enable device profile layer by default if devsim is not enabled
-    if (!VkTestFramework::m_devsim_layer && InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {
-        m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_profile_api");
-    }
+void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/, void *instance_pnext) {
+    ASSERT_EQ((VkInstance)0, instance_);
 
-    // Assert not already initialized
-    ASSERT_EQ((VkInstance)0, inst);
-
-    // Remove any unsupported layer names from list
-    for (auto layer = m_instance_layer_names.begin(); layer != m_instance_layer_names.end();) {
-        if (!InstanceLayerSupported(*layer)) {
-            ADD_FAILURE() << "InitFramework(): Requested layer " << *layer << " was not found. Disabled.";
-            layer = m_instance_layer_names.erase(layer);
-        } else {
-            ++layer;
+    const auto LayerNotSupportedWithReporting = [](const char *layer) {
+        if (InstanceLayerSupported(layer))
+            return false;
+        else {
+            ADD_FAILURE() << "InitFramework(): Requested layer \"" << layer << "\" is not supported. It will be disabled.";
+            return true;
         }
-    }
-
-    // Remove any unsupported instance extension names from list
-    for (auto ext = m_instance_extension_names.begin(); ext != m_instance_extension_names.end();) {
-        if (!InstanceExtensionSupported(*ext)) {
-            ADD_FAILURE() << "InitFramework(): Requested extension " << *ext << " was not found. Disabled.";
-            ext = m_instance_extension_names.erase(ext);
-        } else {
-            ++ext;
+    };
+    const auto ExtensionNotSupportedWithReporting = [](const char *extension) {
+        if (InstanceExtensionSupported(extension))
+            return false;
+        else {
+            ADD_FAILURE() << "InitFramework(): Requested extension \"" << extension << "\" is not supported. It will be disabled.";
+            return true;
         }
+    };
+
+    RemoveIf(instance_layers_, LayerNotSupportedWithReporting);
+    RemoveIf(instance_extensions_, ExtensionNotSupportedWithReporting);
+
+    auto ici = GetInstanceCreateInfo();
+
+    // concatenate pNexts
+    // TODO: There HAS to be some utility function for this somewhere
+    void *last_pnext = nullptr;
+    if (instance_pnext) {
+        last_pnext = instance_pnext;
+        while (reinterpret_cast<const VkBaseOutStructure *>(last_pnext)->pNext)
+            last_pnext = reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext;
+
+        void *&link = reinterpret_cast<void *&>(reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext);
+        link = const_cast<void *>(ici.pNext);
+        ici.pNext = instance_pnext;
     }
 
-    VkInstanceCreateInfo instInfo = {};
-    instInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    instInfo.pNext = instance_pnext;
-    instInfo.pApplicationInfo = &app_info;
-    instInfo.enabledLayerCount = m_instance_layer_names.size();
-    instInfo.ppEnabledLayerNames = m_instance_layer_names.data();
-    instInfo.enabledExtensionCount = m_instance_extension_names.size();
-    instInfo.ppEnabledExtensionNames = m_instance_extension_names.data();
+    ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance_));
+    if (instance_pnext) reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext = nullptr;  // reset back borrowed pNext chain
 
-    VkDebugUtilsMessengerCreateInfoEXT debug_create_info{};
-    if (debug_function) {
-        // Enable create time debug messages
-        debug_create_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-        debug_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT |
-                                            VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                                            VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-        debug_create_info.messageType =
-            VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-        debug_create_info.pfnUserCallback = debug_function;
-        debug_create_info.pUserData = userData;
+    uint32_t gpu_count = 1;
+    ASSERT_VK_SUCCESS(vk::EnumeratePhysicalDevices(instance_, &gpu_count, &gpu_));
+    ASSERT_GT(gpu_count, (uint32_t)0) << "No GPU (i.e. VkPhysicalDevice) available";
 
-        debug_create_info.pNext = instInfo.pNext;
-        instInfo.pNext = &debug_create_info;
-    }
-
-    VkResult err;
-
-    err = vk::CreateInstance(&instInfo, NULL, &this->inst);
-    ASSERT_VK_SUCCESS(err);
-
-    err = vk::EnumeratePhysicalDevices(inst, &this->gpu_count, NULL);
-    ASSERT_LE(this->gpu_count, ARRAY_SIZE(objs)) << "Too many gpus";
-    ASSERT_VK_SUCCESS(err);
-    err = vk::EnumeratePhysicalDevices(inst, &this->gpu_count, objs);
-    ASSERT_VK_SUCCESS(err);
-    ASSERT_GE(this->gpu_count, (uint32_t)1) << "No GPU available";
-
-    if (debug_function) {
-        m_CreateDebugUtilsCallback =
-            (PFN_vkCreateDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(this->inst, "vkCreateDebugUtilsMessengerEXT");
-        ASSERT_NE(m_CreateDebugUtilsCallback, (PFN_vkCreateDebugUtilsMessengerEXT)NULL)
-            << "Did not get function pointer for CreateDebugUtilsMessengerEXT";
-        if (m_CreateDebugUtilsCallback) {
-            debug_create_info.pNext = nullptr;  // clean up from usage in CreateInstance above
-            err = m_CreateDebugUtilsCallback(this->inst, &debug_create_info, NULL, &m_global_message_callback);
-            ASSERT_VK_SUCCESS(err);
-
-            m_DestroyDebugUtilsCallback =
-                (PFN_vkDestroyDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(this->inst, "vkDestroyDebugUtilsMessengerEXT");
-            ASSERT_NE(m_DestroyDebugUtilsCallback, (PFN_vkDestroyDebugUtilsMessengerEXT)NULL)
-                << "Did not get function pointer for DestroyDebugUtilsMessengerEXT";
-        }
-    }
-}
-
-void VkRenderFramework::InitFramework(void *userData, void *instance_pnext) {
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-    InitFrameworkDebugReport(LvtDebugReportFunc, userData, instance_pnext);
-#else
-    InitFrameworkDebugUtils(LvtDebugUtilsFunc, userData, instance_pnext);
-#endif
+    debug_reporter_.Create(instance_);
 }
 
 void VkRenderFramework::ShutdownFramework() {
+    debug_reporter_.error_monitor_.Reset();
+
     // Nothing to shut down without a VkInstance
-    if (!this->inst) return;
+    if (!instance_) return;
 
     delete m_commandBuffer;
     m_commandBuffer = nullptr;
@@ -566,12 +480,6 @@ void VkRenderFramework::ShutdownFramework() {
     if (m_renderPass) vk::DestroyRenderPass(device(), m_renderPass, NULL);
     m_renderPass = VK_NULL_HANDLE;
 
-    if (m_globalMsgCallback) m_DestroyDebugReportCallback(this->inst, m_globalMsgCallback, NULL);
-    m_globalMsgCallback = VK_NULL_HANDLE;
-
-    if (m_global_message_callback) m_DestroyDebugUtilsCallback(this->inst, m_global_message_callback, NULL);
-    m_global_message_callback = VK_NULL_HANDLE;
-
     m_renderTargets.clear();
 
     delete m_depthStencil;
@@ -581,16 +489,17 @@ void VkRenderFramework::ShutdownFramework() {
     delete m_device;
     m_device = nullptr;
 
-    if (this->inst) vk::DestroyInstance(this->inst, NULL);
-    delete m_errorMonitor;
-    this->inst = (VkInstance)0;  // In case we want to re-initialize
+    debug_reporter_.Destroy(instance_);
+
+    vk::DestroyInstance(instance_, nullptr);
+    instance_ = NULL;  // In case we want to re-initialize
 }
 
-ErrorMonitor *VkRenderFramework::Monitor() { return m_errorMonitor; }
+ErrorMonitor &VkRenderFramework::Monitor() { return debug_reporter_.error_monitor_; }
 
 void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features) {
     if (NULL == m_device) {
-        VkDeviceObj *temp_device = new VkDeviceObj(0, objs[0], m_device_extension_names);
+        VkDeviceObj *temp_device = new VkDeviceObj(0, gpu_, m_device_extension_names);
         *features = temp_device->phy().features();
         delete (temp_device);
     } else {
@@ -604,33 +513,28 @@ void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *
 
 void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *create_device_pnext,
                                   const VkCommandPoolCreateFlags flags) {
-    // Remove any unsupported device extension names from list
-    for (auto ext = m_device_extension_names.begin(); ext != m_device_extension_names.end();) {
-        if (!DeviceExtensionSupported(objs[0], nullptr, *ext)) {
-            bool found = false;
-            for (auto layer = m_instance_layer_names.begin(); layer != m_instance_layer_names.end(); ++layer) {
-                if (DeviceExtensionSupported(objs[0], *layer, *ext)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                ADD_FAILURE() << "InitState(): The requested device extension " << *ext << " was not found. Disabled.";
-                ext = m_device_extension_names.erase(ext);
-            } else {
-                ++ext;
-            }
-        } else {
-            ++ext;
+    const auto ExtensionNotSupportedWithReporting = [this](const char *extension) {
+        // TODO: could be simplified with better DeviceExtensionSupported()
+        std::vector<const char *> layers = {nullptr};
+        layers.insert(layers.end(), instance_layers_.begin(), instance_layers_.end());
+        if (std::any_of(layers.begin(), layers.end(),
+                        [this, extension](const char *l) { return DeviceExtensionSupported(gpu(), l, extension); }))
+            return false;
+        else {
+            ADD_FAILURE() << "InitState(): Requested device extension \"" << extension
+                          << "\" is not supported. It will be disabled.";
+            return true;
         }
-    }
+    };
 
-    m_device = new VkDeviceObj(0, objs[0], m_device_extension_names, features, create_device_pnext);
+    RemoveIf(m_device_extension_names, ExtensionNotSupportedWithReporting);
+
+    m_device = new VkDeviceObj(0, gpu_, m_device_extension_names, features, create_device_pnext);
     m_device->SetDeviceQueue();
 
     m_depthStencil = new VkDepthStencilObj(m_device);
 
-    m_render_target_fmt = VkTestFramework::GetFormat(inst, m_device);
+    m_render_target_fmt = VkTestFramework::GetFormat(instance_, m_device);
 
     m_lineWidth = 1.0f;
 
@@ -761,7 +665,7 @@ bool VkRenderFramework::InitSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags i
 
     uint32_t format_count;
     vk::GetPhysicalDeviceSurfaceFormatsKHR(m_device->phy().handle(), surface, &format_count, nullptr);
-    std::vector<VkSurfaceFormatKHR> formats;
+    vector<VkSurfaceFormatKHR> formats;
     if (format_count != 0) {
         formats.resize(format_count);
         vk::GetPhysicalDeviceSurfaceFormatsKHR(m_device->phy().handle(), surface, &format_count, formats.data());
@@ -769,7 +673,7 @@ bool VkRenderFramework::InitSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags i
 
     uint32_t present_mode_count;
     vk::GetPhysicalDeviceSurfacePresentModesKHR(m_device->phy().handle(), surface, &present_mode_count, nullptr);
-    std::vector<VkPresentModeKHR> present_modes;
+    vector<VkPresentModeKHR> present_modes;
     if (present_mode_count != 0) {
         present_modes.resize(present_mode_count);
         vk::GetPhysicalDeviceSurfacePresentModesKHR(m_device->phy().handle(), surface, &present_mode_count, present_modes.data());
@@ -802,7 +706,7 @@ bool VkRenderFramework::InitSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags i
     }
     uint32_t imageCount = 0;
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &imageCount, nullptr);
-    std::vector<VkImage> swapchainImages;
+    vector<VkImage> swapchainImages;
     swapchainImages.resize(imageCount);
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &imageCount, swapchainImages.data());
     return true;
@@ -826,9 +730,9 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets) { InitRenderTarget(ta
 void VkRenderFramework::InitRenderTarget(VkImageView *dsBinding) { InitRenderTarget(1, dsBinding); }
 
 void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBinding) {
-    std::vector<VkAttachmentDescription> attachments;
-    std::vector<VkAttachmentReference> color_references;
-    std::vector<VkImageView> bindings;
+    vector<VkAttachmentDescription> attachments;
+    vector<VkAttachmentReference> color_references;
+    vector<VkImageView> bindings;
     attachments.reserve(targets + 1);  // +1 for dsBinding
     color_references.reserve(targets);
     bindings.reserve(targets + 1);  // +1 for dsBinding
@@ -987,7 +891,7 @@ VkDeviceObj::VkDeviceObj(uint32_t id, VkPhysicalDevice obj) : vk_testing::Device
     queue_props = phy().queue_properties();
 }
 
-VkDeviceObj::VkDeviceObj(uint32_t id, VkPhysicalDevice obj, std::vector<const char *> &extension_names,
+VkDeviceObj::VkDeviceObj(uint32_t id, VkPhysicalDevice obj, vector<const char *> &extension_names,
                          VkPhysicalDeviceFeatures *features, void *create_device_pnext)
     : vk_testing::Device(obj), id(id) {
     init(extension_names, features, create_device_pnext);
@@ -1024,7 +928,7 @@ VkQueueObj *VkDeviceObj::GetDefaultComputeQueue() {
 }
 
 VkDescriptorSetLayoutObj::VkDescriptorSetLayoutObj(const VkDeviceObj *device,
-                                                   const std::vector<VkDescriptorSetLayoutBinding> &descriptor_set_bindings,
+                                                   const vector<VkDescriptorSetLayoutBinding> &descriptor_set_bindings,
                                                    VkDescriptorSetLayoutCreateFlags flags, void *pNext) {
     VkDescriptorSetLayoutCreateInfo dsl_ci = {};
     dsl_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -1149,7 +1053,7 @@ void VkDescriptorSetObj::CreateVKDescriptorSet(VkCommandBufferObj *commandBuffer
 
         // build the update array
         size_t imageSamplerCount = 0;
-        for (std::vector<VkWriteDescriptorSet>::iterator it = m_writes.begin(); it != m_writes.end(); it++) {
+        for (vector<VkWriteDescriptorSet>::iterator it = m_writes.begin(); it != m_writes.end(); it++) {
             it->dstSet = m_set->handle();
             if (it->descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
                 it->pImageInfo = &m_imageSamplerDescriptors[imageSamplerCount++];
@@ -1364,7 +1268,7 @@ bool VkImageObj::IsCompatible(const VkImageUsageFlags usages, const VkFormatFeat
 
 void VkImageObj::InitNoLayout(uint32_t const width, uint32_t const height, uint32_t const mipLevels, VkFormat const format,
                               VkFlags const usage, VkImageTiling const requested_tiling, VkMemoryPropertyFlags const reqs,
-                              const std::vector<uint32_t> *queue_families, bool memory) {
+                              const vector<uint32_t> *queue_families, bool memory) {
     VkFormatProperties image_fmt;
     VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
 
@@ -1414,7 +1318,7 @@ void VkImageObj::InitNoLayout(uint32_t const width, uint32_t const height, uint3
 
 void VkImageObj::Init(uint32_t const width, uint32_t const height, uint32_t const mipLevels, VkFormat const format,
                       VkFlags const usage, VkImageTiling const requested_tiling, VkMemoryPropertyFlags const reqs,
-                      const std::vector<uint32_t> *queue_families, bool memory) {
+                      const vector<uint32_t> *queue_families, bool memory) {
     InitNoLayout(width, height, mipLevels, format, usage, requested_tiling, reqs, queue_families, memory);
 
     if (!initialized() || !memory) return;  // We don't have a valid handle from early stage init, and thus SetLayout will fail
@@ -1721,7 +1625,7 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderS
     m_stage_info.pName = name;
     m_stage_info.pSpecializationInfo = specInfo;
 
-    std::vector<unsigned int> spv;
+    vector<unsigned int> spv;
     framework->GLSLtoSPV(&device->props.limits, stage, shader_code, spv, debug, spirv_minor_version);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
@@ -1733,8 +1637,8 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderS
     m_stage_info.module = handle();
 }
 
-VkShaderObj::VkShaderObj(VkDeviceObj *device, const std::string spv_source, VkShaderStageFlagBits stage,
-                         VkRenderFramework *framework, char const *name, VkSpecializationInfo *specInfo) {
+VkShaderObj::VkShaderObj(VkDeviceObj *device, const string spv_source, VkShaderStageFlagBits stage, VkRenderFramework *framework,
+                         char const *name, VkSpecializationInfo *specInfo) {
     m_device = device;
     m_stage_info.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     m_stage_info.pNext = nullptr;
@@ -1744,7 +1648,7 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const std::string spv_source, VkSh
     m_stage_info.pName = name;
     m_stage_info.pSpecializationInfo = specInfo;
 
-    std::vector<unsigned int> spv;
+    vector<unsigned int> spv;
     framework->ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, spv_source.data(), spv);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
@@ -1756,9 +1660,8 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const std::string spv_source, VkSh
     m_stage_info.module = handle();
 }
 
-VkPipelineLayoutObj::VkPipelineLayoutObj(VkDeviceObj *device,
-                                         const std::vector<const VkDescriptorSetLayoutObj *> &descriptor_layouts,
-                                         const std::vector<VkPushConstantRange> &push_constant_ranges) {
+VkPipelineLayoutObj::VkPipelineLayoutObj(VkDeviceObj *device, const vector<const VkDescriptorSetLayoutObj *> &descriptor_layouts,
+                                         const vector<VkPushConstantRange> &push_constant_ranges) {
     VkPipelineLayoutCreateInfo pl_ci = {};
     pl_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     pl_ci.pushConstantRangeCount = static_cast<uint32_t>(push_constant_ranges.size());

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -104,20 +104,21 @@ VkPhysicalDeviceFeatures PhysicalDevice::features() const {
  */
 std::vector<VkLayerProperties> GetGlobalLayers() {
     VkResult err;
-    std::vector<VkLayerProperties> layers;
     uint32_t layer_count;
+    std::vector<VkLayerProperties> layers;
 
     do {
-        layer_count = 0;
-        err = vk::EnumerateInstanceLayerProperties(&layer_count, NULL);
+        err = vk::EnumerateInstanceLayerProperties(&layer_count, nullptr);
+        assert(!err);
+        if (err || 0 == layer_count) return {};
 
-        if (err == VK_SUCCESS) {
-            layers.reserve(layer_count);
-            err = vk::EnumerateInstanceLayerProperties(&layer_count, layers.data());
-        }
-    } while (err == VK_INCOMPLETE);
+        layers.resize(layer_count);
+        err = vk::EnumerateInstanceLayerProperties(&layer_count, layers.data());
+    } while (VK_INCOMPLETE == err);
 
-    assert(err == VK_SUCCESS);
+    assert(!err);
+    if (err) return {};
+    layers.resize(layer_count);
 
     return layers;
 }
@@ -125,7 +126,7 @@ std::vector<VkLayerProperties> GetGlobalLayers() {
 /*
  * Return list of Global extensions provided by the ICD / Loader
  */
-std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExtensions(NULL); }
+std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExtensions(nullptr); }
 
 /*
  * Return list of Global extensions provided by the specified layer
@@ -133,23 +134,24 @@ std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExten
  * ICDs
  */
 std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
-    std::vector<VkExtensionProperties> exts;
-    uint32_t ext_count;
     VkResult err;
+    uint32_t extension_count;
+    std::vector<VkExtensionProperties> extensions;
 
     do {
-        ext_count = 0;
-        err = vk::EnumerateInstanceExtensionProperties(pLayerName, &ext_count, NULL);
+        err = vk::EnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
+        assert(!err);
+        if (err || 0 == extension_count) return {};
 
-        if (err == VK_SUCCESS) {
-            exts.resize(ext_count);
-            err = vk::EnumerateInstanceExtensionProperties(pLayerName, &ext_count, exts.data());
-        }
-    } while (err == VK_INCOMPLETE);
+        extensions.resize(extension_count);
+        err = vk::EnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data());
+    } while (VK_INCOMPLETE == err);
 
-    assert(err == VK_SUCCESS);
+    assert(!err);
+    if (err) return {};
+    extensions.resize(extension_count);
 
-    return exts;
+    return extensions;
 }
 
 /*


### PR DESCRIPTION
Add tests for `vkCreateInstance` and `vkDestroyInstance`.

Unfortunatelly requires some considerable framework work; I want to be able to directly call `vkCreateInstance` to maximize the amount of tests I can do without worrying about the framework internals.

There are some problems discovered during this (those tests are not part of this PR, and there is a workaround that has to be on all the tests). There are probably some problems with Loader, Layer, or MockICD, where those are buggy or not as robust as they could be. Directory to emergent Issues or fixes:

- #1677 (demonstrated by #1676) -- creating two instances without destroy in between crashes subsequent destroy. This necessitates the workarounds in this PR.
  - fixed by https://github.com/KhronosGroup/Vulkan-Tools/pull/365 and https://github.com/KhronosGroup/Vulkan-Tools/pull/368
- #1678 -- these tests do not seem to work if the layers are instead enabled by `VK_INSTANCE_LAYERS`.
- [TBD]