### PR TITLE
cmake: Fix CMAKE_INSTALL_PREFIX on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,6 @@ endif()
 if(APPLE)
     # CMake versions 3 or later need CMAKE_MACOSX_RPATH defined. This avoids the CMP0042 policy message.
     set(CMAKE_MACOSX_RPATH 1)
-    # The "install" target for MacOS fixes up bundles in place.
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 endif()
 
 # Enable IDE GUI folders


### PR DESCRIPTION
Remove line of code that prevented CMAKE_INSTALL_PREFIX
from being set on MacOS.

Previously, CMAKE_INSTALL_PREFIX would always be
set to CMAKE_BINARY_DIR.