### PR TITLE
Validate maxComputeWorkGroupSize & maxComputeWorkGroupInvocations of Compute shader

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1530,6 +1530,7 @@ class CoreChecks : public ValidationObject {
                                                         const VkAllocationCallbacks* pAllocator);
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
+    bool ValidateComputeWorkGroupSizes(const shader_module* shader);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
                                                            VkAndroidHardwareBufferPropertiesANDROID* pProperties);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1531,6 +1531,8 @@ class CoreChecks : public ValidationObject {
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
     bool ValidateComputeWorkGroupSizes(const shader_module* shader);
+    bool ValidateComputeWorkGroupInvocations(GLOBAL_CB_NODE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
+                                             uint32_t groupCountZ);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
                                                            VkAndroidHardwareBufferPropertiesANDROID* pProperties);

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -190,9 +190,15 @@ void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
-    return ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCH, "vkCmdDispatch()",
-                               VK_QUEUE_COMPUTE_BIT, "VUID-vkCmdDispatch-commandBuffer-cmdpool", "VUID-vkCmdDispatch-renderpass",
-                               "VUID-vkCmdDispatch-None-00391", kVUIDUndefined);
+    bool skip = false;
+    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    if (cb_state) {
+        skip |= ValidateComputeWorkGroupInvocations(cb_state, x, y, z);
+    }
+    skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCH, "vkCmdDispatch()",
+                                VK_QUEUE_COMPUTE_BIT, "VUID-vkCmdDispatch-commandBuffer-cmdpool", "VUID-vkCmdDispatch-renderpass",
+                                "VUID-vkCmdDispatch-None-00391", kVUIDUndefined);
+    return skip;
 }
 
 void CoreChecks::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2971,3 +2971,67 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const shader_module *shader) {
     }
     return skip;
 }
+
+bool CoreChecks::ValidateComputeWorkGroupInvocations(GLOBAL_CB_NODE *cb_state, uint32_t groupCountX, uint32_t groupCountY,
+                                                     uint32_t groupCountZ) {
+    auto const &state = cb_state->lastBound[VK_PIPELINE_BIND_POINT_COMPUTE];
+    PIPELINE_STATE *pPipe = state.pipeline_state;
+    if (!pPipe) return false;
+    auto pCreateInfo = pPipe->computePipelineCI.ptr();
+    if (!pCreateInfo) return false;
+
+    unordered_map<VkShaderModule, std::unique_ptr<shader_module>>::iterator it = shaderModuleMap.find(pCreateInfo->stage.module);
+    if (it != shaderModuleMap.end()) {
+        uint32_t local_size_x = 0;
+        uint32_t local_size_y = 0;
+        uint32_t local_size_z = 0;
+        if (FindLocalSize(&(*it->second), local_size_x, local_size_y, local_size_z)) {
+            uint32_t limit = phys_dev_props.limits.maxComputeWorkGroupInvocations;
+            uint64_t invocations = local_size_x * local_size_y;
+            // Prevent overflow.
+            bool overflow = false;
+            if (invocations > UINT32_MAX) {
+                overflow = true;
+            }
+            if (!overflow) {
+                invocations *= local_size_z;
+                if (invocations > UINT32_MAX) {
+                    overflow = true;
+                }
+            }
+            if (!overflow) {
+                invocations *= groupCountX;
+                if (invocations > UINT32_MAX) {
+                    overflow = true;
+                }
+            }
+            if (!overflow) {
+                invocations *= groupCountY;
+                if (invocations > UINT32_MAX) {
+                    overflow = true;
+                }
+            }
+            if (!overflow) {
+                invocations *= groupCountZ;
+                if (invocations > UINT32_MAX) {
+                    overflow = true;
+                }
+            }
+            if (overflow) {
+                return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT,
+                               HandleToUint64(it->first), "UNASSIGNED-features-limits-maxComputeWorkGroupInvocations",
+                               "ShaderMdoule %s invocations (>%" PRIu32
+                               ") exceeds device limit maxComputeWorkGroupInvocations (%" PRIu32 ").",
+                               report_data->FormatHandle(it->first).c_str(), UINT32_MAX, limit);
+            }
+            if (invocations > limit) {
+                return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT,
+                               HandleToUint64(it->first), "UNASSIGNED-features-limits-maxComputeWorkGroupInvocations",
+                               "ShaderMdoule %s invocations (%" PRIu64
+                               ") exceeds device limit maxComputeWorkGroupInvocations (%" PRIu32 ").",
+                               report_data->FormatHandle(it->first).c_str(), invocations, limit);
+            }
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
[Issue #698](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/698)
Validate `maxComputeWorkGroupSize` in `vkCreateComputePipelines()` and `maxComputeWorkGroupInvocations` in `vkCmdDispatc()`