### PR TITLE
build: Remove unneeded gtest include dir from VLT

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,8 +15,6 @@
 # limitations under the License.
 # ~~~
 
-set(GTEST_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest)
-
 # Needed to make structure definitions match with glslang libraries
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
@@ -113,9 +111,9 @@ add_dependencies(vk_layer_validation_tests Vulkan::Vulkan)
 if(NOT GTEST_IS_STATIC_LIB)
     set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 endif()
+# Note that there is no need to add GTEST directories here due to googletest exporting them via the gtest target.
 target_include_directories(vk_layer_validation_tests
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                  ${GTEST_LOCATION}/googletest/include
                                   ${PROJECT_SOURCE_DIR}/layers
                                   ${GLSLANG_SPIRV_INCLUDE_DIR}
                                   ${SPIRV_TOOLS_INCLUDE_DIR}


### PR DESCRIPTION
The gtest project exports its include directories as
"INTERFACE SYSTEM" which means when including the gtest target
in another target, it is unnecessary to explictly list the
gtest include directories in the target's include directory
search path.  The target in this case is the validation layer tests (VLT).

Further, it is somewhat misleading to add the gtest include dir in the
search path on Linux-like systems because gtest exports the include
dir as "SYSTEM" which means it is moved from the location specified in the
CMake code to the end of the search path, along with other system includes.
So placing it in the include path in the CMake code gives the misleading
impression of its position in the final include search path.

Motivated by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/821.