### PR TITLE
layers: Fix build race condition

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -231,9 +231,9 @@ if(BUILD_LAYERS)
     AddVkLayer(thread_safety "BUILD_THREAD_SAFETY" ${CHASSIS_LIBRARY_FILES} ${THREAD_SAFETY_LIBRARY_FILES})
     add_dependencies(VkLayer_thread_safety VkLayer_object_lifetimes)
     AddVkLayer(stateless_validation "BUILD_PARAMETER_VALIDATION" ${CHASSIS_LIBRARY_FILES} ${STATELESS_VALIDATION_LIBRARY_FILES})
-    add_dependencies(VkLayer_stateless_validation VkLayer_unique_objects)
+    add_dependencies(VkLayer_stateless_validation VkLayer_thread_safety)
     AddVkLayer(unique_objects "LAYER_CHASSIS_CAN_WRAP_HANDLES" ${CHASSIS_LIBRARY_FILES})
-    add_dependencies(VkLayer_unique_objects VkLayer_thread_safety)
+    add_dependencies(VkLayer_unique_objects VkLayer_stateless_validation)
     AddVkLayer(khronos_validation "BUILD_KHRONOS_VALIDATION;BUILD_CORE_VALIDATION;BUILD_OBJECT_TRACKER;BUILD_THREAD_SAFETY;BUILD_PARAMETER_VALIDATION;LAYER_CHASSIS_CAN_WRAP_HANDLES"
         ${CHASSIS_LIBRARY_FILES}
         ${CORE_VALIDATION_LIBRARY_FILES}


### PR DESCRIPTION
Both VkLayer_thread_safety and VkLayer_khronos_validation depend
on the generation of parameter_validation.cpp and parameter_validation.h.
In a parallel build, it's possible for one thread to create these files and
attempt to compile them, while another thread erases and attempts to recreate
them, leading to bizarre compile errors.

This fixes the issue by adding a dependency between VkLayer_khronos_validation
and VkLayer_thread_safety.