### PR TITLE
Validate YCrCb conversion

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -896,6 +896,15 @@ bool cvdescriptorset::DescriptorSet::ValidateDrawState(const std::map<uint32_t, 
                                   << " that has been destroyed.";
                         *error = error_str.str();
                         return false;
+                    } else {
+                        SAMPLER_STATE *sampler_state = device_data_->GetSamplerState(sampler);
+                        if (sampler_state->samplerConversion && !descriptors_[i].get()->IsImmutableSampler()) {
+                            std::stringstream error_str;
+                            error_str << "sampler (" << sampler << ") in the descriptor set (" << set_
+                                      << ") contains a YCBCR conversion (" << sampler_state->samplerConversion
+                                      << ") , then the sampler MUST also exists as an immutable sampler.";
+                            *error = error_str.str();
+                        }
                     }
                 }
             }
@@ -2193,6 +2202,21 @@ bool cvdescriptorset::DescriptorSet::VerifyWriteUpdateContents(const VkWriteDesc
                                 error_str << "Attempted write update to combined image sampler and image view and sampler ycbcr "
                                              "conversions are not identical, sampler: "
                                           << desc->GetSampler() << " image view: " << iv_state->image_view << ".";
+                                *error_msg = error_str.str();
+                                return false;
+                            }
+                        }
+                    } else {
+                        auto iv_state = device_data_->GetImageViewState(image_view);
+                        if (iv_state) {
+                            auto ycbcr_info = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(iv_state->create_info.pNext);
+                            if (ycbcr_info) {
+                                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-01947";
+                                std::stringstream error_str;
+                                error_str << "Because dstSet (" << update->dstSet << ") is bound to image view ("
+                                          << iv_state->image_view
+                                          << ") that includes a YCBCR conversion, it must have been allocated with a layout that "
+                                             "includes an immutable sampler.";
                                 *error_msg = error_str.str();
                                 return false;
                             }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -25959,7 +25959,8 @@ TEST_F(VkLayerTest, CopyImageSinglePlane422Alignment) {
 }
 
 TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
-    TEST_DESCRIPTION("Create sampler with ycbcr conversion and use with an image created without ycrcb conversion");
+    TEST_DESCRIPTION(
+        "Create sampler with ycbcr conversion and use with an image created without ycrcb conversion or immutable sampler");
 
     // Enable KHR multiplane req'd extensions
     bool mp_extensions = InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
@@ -25987,7 +25988,9 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_features = {};
     ycbcr_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
     ycbcr_features.samplerYcbcrConversion = VK_TRUE;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ycbcr_features));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ycbcr_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkImageCreateInfo ci = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                   NULL,
@@ -26054,10 +26057,10 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
 
     // Use the image and sampler together in a descriptor set
     OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler},
+                                         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, &sampler},
                                      });
 
-    VkDescriptorImageInfo image_info{};
+    VkDescriptorImageInfo image_info = {};
     image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     image_info.imageView = view;
     image_info.sampler = sampler;
@@ -26073,8 +26076,64 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkWriteDescriptorSet-descriptorType-01948");
     vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
     m_errorMonitor->VerifyFound();
+
+    VkImageView view_1947;
+    ivci.pNext = &ycbcr_info;
+    vkCreateImageView(m_device->device(), &ivci, nullptr, &view_1947);
+    OneOffDescriptorSet ds_1947(m_device, {
+                                              {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                          });
+    image_info.imageView = view_1947;
+    descriptor_write.dstSet = ds_1947.set_;
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkWriteDescriptorSet-descriptorType-01947");
+    vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    m_errorMonitor->VerifyFound();
+
+    descriptor_write.dstSet = ds.set_;
+    vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+
+    char const *vsSource =
+        "#version 450\n"
+        "\n"
+        "void main(){\n"
+        "   gl_Position = vec4(1);\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "\n"
+        "layout(set=0, binding=0) uniform sampler2D s;\n"
+        "layout(location=0) out vec4 x;\n"
+        "void main(){\n"
+        "   x = texture(s, vec2(1));\n"
+        "}\n";
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddDefaultColorAttachment();
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+
+    const VkPipelineLayoutObj pl(m_device, {&ds.layout_});
+    pipe.CreateVKPipeline(pl.handle(), renderPass());
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    VkViewport viewport = {0, 0, 16, 16, 0, 1};
+    VkRect2D scissor = {{0, 0}, {16, 16}};
+    vkCmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
+    vkCmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
+    vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    vkCmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pl.handle(), 0, 1, &ds.set_, 0, NULL);
+
+    m_commandBuffer->Draw(1, 0, 0, 0);
+
+    vkCmdEndRenderPass(m_commandBuffer->handle());
+    m_commandBuffer->end();
+
     vkDestroySamplerYcbcrConversion(m_device->device(), conversion, nullptr);
     vkDestroyImageView(m_device->device(), view, NULL);
+    vkDestroyImageView(m_device->device(), view_1947, NULL);
     vkDestroySampler(m_device->device(), sampler, nullptr);
 }
 


### PR DESCRIPTION
[Issue #726 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/726)

> Based on this text the primary check that we'd like added is to verify at draw time that, if any samplers in the descriptor set contain a YCBCR conversion, then those samplers MUST also exists as immutable samplers in the currently bound pipeline.

The above validation might not work.

Because if it wants to update and bind a descriptor set that contain a YCBCR conversion, it has to pass VUID-VkWriteDescriptorSet-descriptorType-01947 & 01948.

But in the case, the error that a sampler in the descriptor set contain a YCBCR conversion, but it is not an immutable sampler at draw time will not happen.