### PR TITLE
core_validation: bug: CoreChecks::GpuAllocateValidationResources doesn't use "bind_point" parameter

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1038,6 +1038,10 @@ void CoreChecks::GpuPostCallQueueSubmit(VkQueue queue, uint32_t submitCount, con
 }
 
 void CoreChecks::GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point) {
+    // Does GPUAV support VK_PIPELINE_BIND_POINT_RAY_TRACING_NV?
+    if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE) {
+        return;
+    }
     VkResult result;
 
     if (!(GetEnables()->gpu_validation)) return;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1098,7 +1098,7 @@ void CoreChecks::GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer
     desc_write.dstSet = desc_sets[0];
     DispatchUpdateDescriptorSets(device, 1, &desc_write, 0, NULL);
 
-    auto iter = cb_node->lastBound.find(VK_PIPELINE_BIND_POINT_GRAPHICS);  // find() allows read-only access to cb_state
+    auto iter = cb_node->lastBound.find(bind_point);  // find() allows read-only access to cb_state
     if (iter != cb_node->lastBound.end()) {
         auto pipeline_state = iter->second.pipeline_state;
         if (pipeline_state && (pipeline_state->pipeline_layout.set_layouts.size() <= gpu_validation_state->desc_set_bind_index)) {


### PR DESCRIPTION
Hi! I have bug during using Validation layers:

```
vkCmdBindPipeline(..., VK_PIPELINE_BIND_POINT_COMPUTE, ...);
vkCmdDispatch(...)
```
After calling  vkCmdDispatch, i got error "Unable to find pipeline state",. I think there is a problem of using 
VK_PIPELINE_BIND_POINT_GRAPHICS instead of "bind_point" parameter.

BR, Andrey
