### PR TITLE
Validate texel buffer view & buffer at draw time

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -869,6 +869,22 @@ bool cvdescriptorset::DescriptorSet::ValidateDrawState(const std::map<uint32_t, 
                     auto texel_buffer = static_cast<TexelDescriptor *>(descriptors_[i].get());
                     auto buffer_view = device_data_->GetBufferViewState(texel_buffer->GetBufferView());
 
+                    if (nullptr == buffer_view) {
+                        std::stringstream error_str;
+                        error_str << "Descriptor in binding #" << binding << " index " << index << " is using bufferView "
+                                  << buffer_view << " that has been destroyed.";
+                        *error = error_str.str();
+                        return false;
+                    }
+                    auto buffer = buffer_view->create_info.buffer;
+                    auto buffer_state = device_data_->GetBufferState(buffer);
+                    if (!buffer_state) {
+                        std::stringstream error_str;
+                        error_str << "Descriptor in binding #" << binding << " index " << index << " is using buffer "
+                                  << buffer_state << " that has been destroyed.";
+                        *error = error_str.str();
+                        return false;
+                    }
                     auto reqs = binding_pair.second;
                     auto format_bits = DescriptorRequirementsBitsFromFormat(buffer_view->create_info.format);
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -11952,10 +11952,15 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
     VkResult err;
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkWriteDescriptorSet-descriptorType-00323");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+    VkPhysicalDeviceFeatures device_features = {};
+    ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&device_features));
+    device_features.fragmentStoresAndAtomics = VK_TRUE;
+    ASSERT_NO_FATAL_FAILURE(InitState(&device_features));
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     VkDescriptorPoolSize ds_type_count = {};
-    ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    ds_type_count.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     ds_type_count.descriptorCount = 1;
 
     VkDescriptorPoolCreateInfo ds_pool_ci = {};
@@ -11971,7 +11976,7 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
-    dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
     dsl_binding.pImmutableSamplers = NULL;
@@ -12037,7 +12042,7 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
     descriptor_write.dstSet = descriptorSet;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
-    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     descriptor_write.pTexelBufferView = &view;
 
     vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
@@ -12049,6 +12054,64 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
     vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
     m_errorMonitor->VerifyFound();
 
+    if (m_device->phy().features().fragmentStoresAndAtomics) {
+        err = vkCreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+        ASSERT_VK_SUCCESS(err);
+        err = vkBindBufferMemory(m_device->device(), buffer, buffer_memory, 0);
+        ASSERT_VK_SUCCESS(err);
+        bvci.buffer = buffer;
+        err = vkCreateBufferView(m_device->device(), &bvci, NULL, &view);
+        ASSERT_VK_SUCCESS(err);
+        vkUpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+
+        char const *vsSource =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "   gl_Position = vec4(1);\n"
+            "}\n";
+        char const *fsSource =
+            "#version 450\n"
+            "\n"
+            "layout(set=0, binding=0, r32f) uniform imageBuffer texelBuffer;\n"
+            "layout(location=0) out vec4 x;\n"
+            "void main(){\n"
+            "   x = imageLoad( texelBuffer, 0 );\n"
+            "}\n";
+        VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+        VkPipelineObj pipe(m_device);
+        pipe.AddDefaultColorAttachment();
+        pipe.AddShader(&vs);
+        pipe.AddShader(&fs);
+        const VkPipelineLayoutObj pl(m_device, {&ds_layout});
+        pipe.CreateVKPipeline(pl.handle(), renderPass());
+
+        m_commandBuffer->begin();
+        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+        VkViewport viewport = {0, 0, 16, 16, 0, 1};
+        VkRect2D scissor = {{0, 0}, {16, 16}};
+        vkCmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
+        vkCmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
+        vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+        vkCmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pl.handle(), 0, 1, &descriptorSet, 0,
+                                NULL);
+
+        vkDestroyBuffer(m_device->device(), buffer, NULL);
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "Descriptor in binding #0 index 0 is using buffer");
+        m_commandBuffer->Draw(1, 0, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        vkDestroyBufferView(m_device->device(), view, NULL);
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "Descriptor in binding #0 index 0 is using bufferView");
+        m_commandBuffer->Draw(1, 0, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        vkCmdEndRenderPass(m_commandBuffer->handle());
+        m_commandBuffer->end();
+    } else {
+        printf("%s fragmentStoresAndAtomics feature is disabled -- skipping test at draw time.\n", kSkipPrefix);
+    }
     vkFreeMemory(m_device->device(), buffer_memory, NULL);
     vkDestroyDescriptorPool(m_device->device(), ds_pool, NULL);
 }


### PR DESCRIPTION
[issue #50 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/50)

That validate image at descriptor sets update and draw time 
and texel buffer view & buffer at descriptor sets update 
had been added. 

I only added validate texel buffer view & buffer at draw time.