### PR TITLE
tests: Fix Intel GPU fail

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38687,7 +38687,7 @@ TEST_F(VkLayerTest, CreateImageYcbcrArrayLayers) {
 
     // Enable KHR multiplane req'd extensions
     bool mp_extensions = InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-                                                    VK_KHR_GET_MEMORY_REQUIREMENTS_2_SPEC_VERSION);
+                                                    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION);
     if (mp_extensions) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
@@ -38721,6 +38721,12 @@ TEST_F(VkLayerTest, CreateImageYcbcrArrayLayers) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+    bool supported = ImageFormatAndFeaturesSupported(instance(), gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    if (!supported) {
+        printf("%s Multiplane image format not supported.  Skipping test.\n", kSkipPrefix);
+        return;
+    }
 
     VkImageFormatProperties img_limits;
     ASSERT_VK_SUCCESS(GPDIFPHelper(gpu(), &image_create_info, &img_limits));

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -30090,6 +30090,9 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
         return;
     }
 
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 2;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -30097,10 +30100,16 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     dsl_binding.pImmutableSamplers = NULL;
 
-    const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
+    const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
+    // Create push descriptor set layout
+    const VkDescriptorSetLayoutObj push_ds_layout(m_device, {dsl_binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
 
-    // Now use the descriptor layout to create a pipeline layout
-    const VkPipelineLayoutObj pipeline_layout(m_device, {&ds_layout});
+    // Use helper to create graphics pipeline
+    CreatePipelineHelper helper(*this);
+    helper.InitInfo();
+    helper.InitState();
+    helper.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&push_ds_layout, &ds_layout});
+    helper.CreateGraphicsPipeline();
 
     static const float vbo_data[3] = {1.f, 0.f, 1.f};
     VkConstantBufferObj vbo(m_device, sizeof(vbo_data), (const void *)&vbo_data, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
@@ -30123,8 +30132,12 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
         (PFN_vkCmdPushDescriptorSetKHR)vkGetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
     assert(vkCmdPushDescriptorSetKHR != nullptr);
+
     m_commandBuffer->begin();
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+
+    // In Intel GPU, it needs to bind pipeline before push descriptor set.
+    vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_);
+    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
                               &descriptor_write);
 
     m_errorMonitor->VerifyNotFound();


### PR DESCRIPTION
[LunarHub-Doc issue #212 ](https://github.com/LunarG/LunarHub-Doc/issues/212)
Two tests fail in Intel GPU.

**VkLayerTest.CreateImageYcbcrArrayLayers**
```
C:\Users\Locke\Works\Vulkan-ValidationLayers\tests\layer_validation_tests.cpp(38539): error: Expected equality of these values:
  VK_SUCCESS
    Which is: 0
  GPDIFPHelper(gpu(), &image_create_info, &img_limits)
    Which is: -11
UNKNOWN_RESULT
```
Check if it supports multiplane image 


**VkPositiveLayerTest.PushDescriptorNullDstSetTest**
```
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
VUID-vkDestroyDevice-device-00378(ERROR / SPEC): msgNum: 0 - OBJ ERROR : For device 0x22f6408f5b8, DeviceMemory object 0x6 has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyDevice-device-00378)
    Objects: 1
        [0] 0x6, type: 8, name: NULL
VUID-vkDestroyDevice-device-00378(ERROR / SPEC): msgNum: 0 - OBJ ERROR : For device 0x22f6408f5b8, Buffer object 0x5 has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyDevice-device-00378)
    Objects: 1
        [0] 0x5, type: 9, name: NULL
VUID-vkDestroyDevice-device-00378(ERROR / SPEC): msgNum: 0 - OBJ ERROR : For device 0x22f6408f5b8, PipelineLayout object 0x4 has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyDevice-device-00378)
    Objects: 1
        [0] 0x4, type: 17, name: NULL
VUID-vkDestroyDevice-device-00378(ERROR / SPEC): msgNum: 0 - OBJ ERROR : For device 0x22f6408f5b8, DescriptorSetLayout object 0x3 has not been destroyed. The Vulkan spec states: All child objects created on device must have been destroyed prior to destroying device (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyDevice-device-00378)
    Objects: 1
        [0] 0x3, type: 20, name: NULL
```
In Intel GPU, we need to bind pipeline before push descriptor set.