### PR TITLE
Improve component counting in ValidateShaderStageInputOutputLimits

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -615,7 +615,7 @@ class CoreChecks : public ValidationObject {
                                       VkShaderStageFlagBits stage);
     bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage, bool has_writable_descriptor);
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
-                                              PIPELINE_STATE* pipeline);
+                                              PIPELINE_STATE* pipeline, spirv_inst_iter entrypoint);
     bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                    PIPELINE_STATE* pipeline);
     bool ValidateExecutionModes(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint);

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -453,13 +453,12 @@ static unsigned GetComponentsConsumedByType(SHADER_MODULE_STATE const *src, unsi
             }
             return sum;
         }
-        case spv::OpTypeArray: {
-            uint32_t sum = 0;
-            for (uint32_t i = 2; i < insn.len(); i++) {
-                sum += GetComponentsConsumedByType(src, insn.word(i), false);
+        case spv::OpTypeArray:
+            if (strip_array_level) {
+                return GetComponentsConsumedByType(src, insn.word(2), false);
+            } else {
+                return GetConstantValue(src, insn.word(3)) * GetComponentsConsumedByType(src, insn.word(2), false);
             }
-            return sum;
-        }
         case spv::OpTypeMatrix:
             // Num locations is the dimension * element size
             return insn.word(3) * GetComponentsConsumedByType(src, insn.word(2), false);
@@ -1719,44 +1718,8 @@ bool CoreChecks::ValidateShaderCapabilities(SHADER_MODULE_STATE const *src, VkSh
     return skip;
 }
 
-static bool VariableIsBuiltIn(SHADER_MODULE_STATE const *src, const uint32_t ID, std::vector<uint32_t> const &builtInBlockIDs,
-                              std::vector<uint32_t> const &builtInIDs) {
-    auto insn = src->get_def(ID);
-
-    switch (insn.opcode()) {
-        case spv::OpVariable: {
-            // First check if the variable is a "pure" built-in type, e.g. gl_ViewportIndex
-            uint32_t ID = insn.word(2);
-            for (auto builtInID : builtInIDs) {
-                if (ID == builtInID) {
-                    return true;
-                }
-            }
-
-            return VariableIsBuiltIn(src, insn.word(1), builtInBlockIDs, builtInIDs);
-        }
-        case spv::OpTypePointer:
-            return VariableIsBuiltIn(src, insn.word(3), builtInBlockIDs, builtInIDs);
-        case spv::OpTypeArray:
-            return VariableIsBuiltIn(src, insn.word(2), builtInBlockIDs, builtInIDs);
-        case spv::OpTypeStruct: {
-            uint32_t ID = insn.word(1);  // We only need to check the first member as either all will be, or none will be built-in
-            for (auto builtInBlockID : builtInBlockIDs) {
-                if (ID == builtInBlockID) {
-                    return true;
-                }
-            }
-            return false;
-        }
-        default:
-            return false;
-    }
-
-    return false;
-}
-
 bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const *src, VkPipelineShaderStageCreateInfo const *pStage,
-                                                      PIPELINE_STATE *pipeline) {
+                                                      PIPELINE_STATE *pipeline, spirv_inst_iter entrypoint) {
     if (pStage->stage == VK_SHADER_STAGE_COMPUTE_BIT || pStage->stage == VK_SHADER_STAGE_ALL_GRAPHICS ||
         pStage->stage == VK_SHADER_STAGE_ALL) {
         return false;
@@ -1765,8 +1728,7 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
     bool skip = false;
     auto const &limits = phys_dev_props.limits;
 
-    std::vector<uint32_t> builtInBlockIDs;
-    std::vector<uint32_t> builtInIDs;
+    std::set<uint32_t> patchIDs;
     struct Variable {
         uint32_t baseTypePtrID;
         uint32_t ID;
@@ -1774,31 +1736,17 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
     };
     std::vector<Variable> variables;
 
+    uint32_t numVertices = 0;
+
     for (auto insn : *src) {
         switch (insn.opcode()) {
-            // Find all built-in member decorations
-            case spv::OpMemberDecorate:
-                if (insn.word(3) == spv::DecorationBuiltIn) {
-                    builtInBlockIDs.push_back(insn.word(1));
-                }
-                break;
-            // Find all built-in decorations
+            // Find all Patch decorations
             case spv::OpDecorate:
                 switch (insn.word(2)) {
-                    case spv::DecorationBlock: {
-                        uint32_t blockID = insn.word(1);
-                        for (auto builtInBlockID : builtInBlockIDs) {
-                            // Check if one of the members of the block are built-in -> the block is built-in
-                            if (blockID == builtInBlockID) {
-                                builtInIDs.push_back(blockID);
-                                break;
-                            }
-                        }
+                    case spv::DecorationPatch: {
+                        patchIDs.insert(insn.word(1));
                         break;
                     }
-                    case spv::DecorationBuiltIn:
-                        builtInIDs.push_back(insn.word(1));
-                        break;
                     default:
                         break;
                 }
@@ -1814,26 +1762,39 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
                 }
                 break;
             }
+            case spv::OpExecutionMode:
+                if (insn.word(1) == entrypoint.word(2)) {
+                    switch (insn.word(2)) {
+                        default:
+                            break;
+                        case spv::ExecutionModeOutputVertices:
+                            numVertices = insn.word(3);
+                            break;
+                    }
+                }
+                break;
             default:
                 break;
         }
     }
 
+    bool strip_output_array_level =
+        (pStage->stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT || pStage->stage == VK_SHADER_STAGE_MESH_BIT_NV);
+    bool strip_input_array_level =
+        (pStage->stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+         pStage->stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT || pStage->stage == VK_SHADER_STAGE_GEOMETRY_BIT);
+
     uint32_t numCompIn = 0, numCompOut = 0;
     for (auto &var : variables) {
-        // Check the variable's ID
-        if (VariableIsBuiltIn(src, var.ID, builtInBlockIDs, builtInIDs)) {
-            continue;
-        }
-        // Check the variable's type's ID - e.g. gl_PerVertex is made of basic types, not built-in types
-        if (VariableIsBuiltIn(src, src->get_def(var.baseTypePtrID).word(3), builtInBlockIDs, builtInIDs)) {
-            continue;
-        }
+        // Check if the variable is a patch. Patches can also be members of blocks,
+        // but if they are then the top-level arrayness has already been stripped
+        // by the time GetComponentsConsumedByType gets to it.
+        bool isPatch = patchIDs.find(var.ID) != patchIDs.end();
 
         if (var.storageClass == spv::StorageClassInput) {
-            numCompIn += GetComponentsConsumedByType(src, var.baseTypePtrID, false);
+            numCompIn += GetComponentsConsumedByType(src, var.baseTypePtrID, strip_input_array_level && !isPatch);
         } else {  // var.storageClass == spv::StorageClassOutput
-            numCompOut += GetComponentsConsumedByType(src, var.baseTypePtrID, false);
+            numCompOut += GetComponentsConsumedByType(src, var.baseTypePtrID, strip_output_array_level && !isPatch);
         }
     }
 
@@ -1907,6 +1868,15 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
                                 "VkPhysicalDeviceLimits::maxGeometryOutputComponents of %u "
                                 "components by %u components",
                                 limits.maxGeometryOutputComponents, numCompOut - limits.maxGeometryOutputComponents);
+            }
+            if (numCompOut * numVertices > limits.maxGeometryTotalOutputComponents) {
+                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
+                                HandleToUint64(pipeline->pipeline), kVUID_Core_Shader_ExceedDeviceLimit,
+                                "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
+                                "VkPhysicalDeviceLimits::maxGeometryTotalOutputComponents of %u "
+                                "components by %u components",
+                                limits.maxGeometryTotalOutputComponents,
+                                numCompOut * numVertices - limits.maxGeometryTotalOutputComponents);
             }
             break;
 
@@ -2219,6 +2189,9 @@ bool CoreChecks::ValidateExecutionModes(SHADER_MODULE_STATE const *src, spirv_in
 
     bool skip = false;
 
+    uint32_t verticesOut = 0;
+    uint32_t invocations = 0;
+
     for (auto insn : *src) {
         if (insn.opcode() == spv::OpExecutionMode && insn.word(1) == entrypoint_id) {
             auto mode = insn.word(2);
@@ -2332,10 +2305,41 @@ bool CoreChecks::ValidateExecutionModes(SHADER_MODULE_STATE const *src, spirv_in
                     }
                     break;
                 }
+
+                case spv::ExecutionModeOutputVertices: {
+                    verticesOut = insn.word(3);
+                    break;
+                }
+
+                case spv::ExecutionModeInvocations: {
+                    invocations = insn.word(3);
+                    break;
+                }
             }
         }
     }
 
+    if (entrypoint.word(1) == spv::ExecutionModelGeometry) {
+        if (verticesOut == 0 || verticesOut > phys_dev_props.limits.maxGeometryOutputVertices) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkPipelineShaderStageCreateInfo-stage-00714",
+                            "Geometry shader entry point must have an OpExecutionMode instruction that "
+                            "specifies a maximum output vertex count that is greater than 0 and less "
+                            "than or equal to maxGeometryOutputVertices. "
+                            "OutputVertices=%d, maxGeometryOutputVertices=%d",
+                            verticesOut, phys_dev_props.limits.maxGeometryOutputVertices);
+        }
+
+        if (invocations == 0 || invocations > phys_dev_props.limits.maxGeometryShaderInvocations) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkPipelineShaderStageCreateInfo-stage-00715",
+                            "Geometry shader entry point must have an OpExecutionMode instruction that "
+                            "specifies an invocation count that is greater than 0 and less "
+                            "than or equal to maxGeometryShaderInvocations. "
+                            "Invocations=%d, maxGeometryShaderInvocations=%d",
+                            invocations, phys_dev_props.limits.maxGeometryShaderInvocations);
+        }
+    }
     return skip;
 }
 
@@ -2548,7 +2552,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
 
     // Validate shader capabilities against enabled device features
     skip |= ValidateShaderCapabilities(module, pStage->stage, has_writable_descriptor);
-    skip |= ValidateShaderStageInputOutputLimits(module, pStage, pipeline);
+    skip |= ValidateShaderStageInputOutputLimits(module, pStage, pipeline, entrypoint);
     skip |= ValidateExecutionModes(module, entrypoint);
     skip |= ValidateSpecializationOffsets(report_data, pStage);
     skip |= ValidatePushConstantUsage(report_data, pipeline->pipeline_layout.push_constant_ranges.get(), module, accessible_ids,

--- a/tests/vklayertests.cpp
+++ b/tests/vklayertests.cpp
@@ -19907,502 +19907,647 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
 TEST_F(VkLayerTest, CreatePipelineExceedMaxVertexOutputComponents) {
     TEST_DESCRIPTION(
         "Test that an error is produced when the number of output components from the vertex stage exceeds the device limit");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Vertex shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxVertexOutputComponents");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    const uint32_t maxVsOutComp = m_device->props.limits.maxVertexOutputComponents;
-    std::string vsSourceStr = "#version 450\n\n";
-    const uint32_t numVec4 = maxVsOutComp / 4;
-    uint32_t location = 0;
-    for (uint32_t i = 0; i < numVec4; i++) {
-        vsSourceStr += "layout(location=" + std::to_string(location) + ") out vec4 v" + std::to_string(i) + ";\n";
-        location += 1;
-    }
-    const uint32_t remainder = maxVsOutComp % 4;
-    if (remainder != 0) {
-        if (remainder == 1) {
-            vsSourceStr += "layout(location=" + std::to_string(location) + ") out float" + " vn;\n";
-        } else {
-            vsSourceStr += "layout(location=" + std::to_string(location) + ") out vec" + std::to_string(remainder) + " vn;\n";
-        }
-        location += 1;
-    }
-    vsSourceStr += "layout(location=" + std::to_string(location) +
-                   ") out vec4 exceedLimit;\n"
-                   "\n"
-                   "void main(){\n"
-                   "    gl_Position = vec4(1);\n"
-                   "}\n";
-
-    std::string fsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(location=0) out vec4 color;\n"
-        "\n"
-        "void main(){\n"
-        "    color = vec4(1);\n"
-        "}\n";
-
-    VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
-    VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&fs);
-
-    // Set up CB 0; type is UNORM by default
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkDescriptorSetObj descriptorSet(m_device);
-    descriptorSet.AppendDummy();
-    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+        const uint32_t maxVsOutComp = m_device->props.limits.maxVertexOutputComponents + overflow;
+        std::string vsSourceStr = "#version 450\n\n";
+        const uint32_t numVec4 = maxVsOutComp / 4;
+        uint32_t location = 0;
+        for (uint32_t i = 0; i < numVec4; i++) {
+            vsSourceStr += "layout(location=" + std::to_string(location) + ") out vec4 v" + std::to_string(i) + ";\n";
+            location += 1;
+        }
+        const uint32_t remainder = maxVsOutComp % 4;
+        if (remainder != 0) {
+            if (remainder == 1) {
+                vsSourceStr += "layout(location=" + std::to_string(location) + ") out float" + " vn;\n";
+            } else {
+                vsSourceStr += "layout(location=" + std::to_string(location) + ") out vec" + std::to_string(remainder) + " vn;\n";
+            }
+            location += 1;
+        }
+        vsSourceStr +=
+            "void main(){\n"
+            "}\n";
 
-    m_errorMonitor->VerifyFound();
+        std::string fsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(location=0) out vec4 color;\n"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Vertex shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxVertexOutputComponents");
+        }
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of per-vertex input and/or output components to the tessellation control "
         "stage exceeds the device limit");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Tessellation control shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxTessellationControlPerVertexInputComponents");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Tessellation control shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxTessellationControlPerVertexOutputComponents");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    VkPhysicalDeviceFeatures feat;
-    vkGetPhysicalDeviceFeatures(gpu(), &feat);
-    if (!feat.tessellationShader) {
-        printf("%s tessellation shader stage(s) unsupported.\n", kSkipPrefix);
-        return;
-    }
-
-    std::string vsSourceStr =
-        "#version 450\n"
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    // Tessellation control stage
-    std::string tcsSourceStr =
-        "#version 450\n"
-        "\n";
-    // Input components
-    const uint32_t maxTescInComp = m_device->props.limits.maxTessellationControlPerVertexInputComponents;
-    const uint32_t numInVec4 = maxTescInComp / 4;
-    uint32_t inLocation = 0;
-    for (uint32_t i = 0; i < numInVec4; i++) {
-        tcsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
-        inLocation += 1;
-    }
-    const uint32_t inRemainder = maxTescInComp % 4;
-    if (inRemainder != 0) {
-        if (inRemainder == 1) {
-            tcsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
-        } else {
-            tcsSourceStr +=
-                "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
-        }
-        inLocation += 1;
-    }
-    tcsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 exceedLimitIn[];\n\n";
-    // Output components
-    const uint32_t maxTescOutComp = m_device->props.limits.maxTessellationControlPerVertexOutputComponents;
-    const uint32_t numOutVec4 = maxTescOutComp / 4;
-    uint32_t outLocation = 0;
-    for (uint32_t i = 0; i < numOutVec4; i++) {
-        tcsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out[3];\n";
-        outLocation += 1;
-    }
-    const uint32_t outRemainder = maxTescOutComp % 4;
-    if (outRemainder != 0) {
-        if (outRemainder == 1) {
-            tcsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut[3];\n";
-        } else {
-            tcsSourceStr +=
-                "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut[3];\n";
-        }
-        outLocation += 1;
-    }
-    tcsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 exceedLimitOut[3];\n";
-    tcsSourceStr += "layout(vertices=3) out;\n";
-    // Finalize
-    tcsSourceStr +=
-        "\n"
-        "void main(){\n"
-        "    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;\n"
-        "}\n";
-
-    std::string tesSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(triangles) in;"
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    std::string fsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(location=0) out vec4 color;"
-        "\n"
-        "void main(){\n"
-        "    color = vec4(1);\n"
-        "}\n";
-
-    VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
-    VkShaderObj tcs(m_device, tcsSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
-    VkShaderObj tes(m_device, tesSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
-    VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&tcs);
-    pipe.AddShader(&tes);
-    pipe.AddShader(&fs);
-
-    // Set up CB 0; type is UNORM by default
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkDescriptorSetObj descriptorSet(m_device);
-    descriptorSet.AppendDummy();
-    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
+        VkPhysicalDeviceFeatures feat;
+        vkGetPhysicalDeviceFeatures(gpu(), &feat);
+        if (!feat.tessellationShader) {
+            printf("%s tessellation shader stage(s) unsupported.\n", kSkipPrefix);
+            return;
+        }
 
-    VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo = {};
-    inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    inputAssemblyInfo.pNext = NULL;
-    inputAssemblyInfo.flags = 0;
-    inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-    inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
-    pipe.SetInputAssembly(&inputAssemblyInfo);
+        std::string vsSourceStr =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "    gl_Position = vec4(1);\n"
+            "}\n";
 
-    VkPipelineTessellationStateCreateInfo tessInfo = {};
-    tessInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
-    tessInfo.pNext = NULL;
-    tessInfo.flags = 0;
-    tessInfo.patchControlPoints = 3;
-    pipe.SetTessellation(&tessInfo);
+        // Tessellation control stage
+        std::string tcsSourceStr =
+            "#version 450\n"
+            "\n";
+        // Input components
+        const uint32_t maxTescInComp = m_device->props.limits.maxTessellationControlPerVertexInputComponents + overflow;
+        const uint32_t numInVec4 = maxTescInComp / 4;
+        uint32_t inLocation = 0;
+        for (uint32_t i = 0; i < numInVec4; i++) {
+            tcsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
+            inLocation += 1;
+        }
+        const uint32_t inRemainder = maxTescInComp % 4;
+        if (inRemainder != 0) {
+            if (inRemainder == 1) {
+                tcsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
+            } else {
+                tcsSourceStr +=
+                    "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
+            }
+            inLocation += 1;
+        }
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+        // Output components
+        const uint32_t maxTescOutComp = m_device->props.limits.maxTessellationControlPerVertexOutputComponents + overflow;
+        const uint32_t numOutVec4 = maxTescOutComp / 4;
+        uint32_t outLocation = 0;
+        for (uint32_t i = 0; i < numOutVec4; i++) {
+            tcsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out[3];\n";
+            outLocation += 1;
+        }
+        const uint32_t outRemainder = maxTescOutComp % 4;
+        if (outRemainder != 0) {
+            if (outRemainder == 1) {
+                tcsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut[3];\n";
+            } else {
+                tcsSourceStr +=
+                    "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut[3];\n";
+            }
+            outLocation += 1;
+        }
 
-    m_errorMonitor->VerifyFound();
+        tcsSourceStr += "layout(vertices=3) out;\n";
+        // Finalize
+        tcsSourceStr +=
+            "\n"
+            "void main(){\n"
+            "}\n";
+
+        std::string tesSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(triangles) in;"
+            "\n"
+            "void main(){\n"
+            "}\n";
+
+        std::string fsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(location=0) out vec4 color;"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj tcs(m_device, tcsSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
+        VkShaderObj tes(m_device, tesSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&tcs);
+        pipe.AddShader(&tes);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo = {};
+        inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+        inputAssemblyInfo.pNext = NULL;
+        inputAssemblyInfo.flags = 0;
+        inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+        inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
+        pipe.SetInputAssembly(&inputAssemblyInfo);
+
+        VkPipelineTessellationStateCreateInfo tessInfo = {};
+        tessInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
+        tessInfo.pNext = NULL;
+        tessInfo.flags = 0;
+        tessInfo.patchControlPoints = 3;
+        pipe.SetTessellation(&tessInfo);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Tessellation control shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxTessellationControlPerVertexInputComponents");
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Tessellation control shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxTessellationControlPerVertexOutputComponents");
+        }
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the tessellation evaluation stage "
         "exceeds the device limit");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Tessellation evaluation shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxTessellationEvaluationInputComponents");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Tessellation evaluation shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxTessellationEvaluationOutputComponents");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    VkPhysicalDeviceFeatures feat;
-    vkGetPhysicalDeviceFeatures(gpu(), &feat);
-    if (!feat.tessellationShader) {
-        printf("%s tessellation shader stage(s) unsupported.\n", kSkipPrefix);
-        return;
-    }
-
-    std::string vsSourceStr =
-        "#version 450\n"
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    std::string tcsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout (vertices = 3) out;\n"
-        "\n"
-        "void main(){\n"
-        "    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;\n"
-        "}\n";
-
-    // Tessellation evaluation stage
-    std::string tesSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout (triangles) in;\n"
-        "\n";
-    // Input components
-    const uint32_t maxTeseInComp = m_device->props.limits.maxTessellationEvaluationInputComponents;
-    const uint32_t numInVec4 = maxTeseInComp / 4;
-    uint32_t inLocation = 0;
-    for (uint32_t i = 0; i < numInVec4; i++) {
-        tesSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
-        inLocation += 1;
-    }
-    const uint32_t inRemainder = maxTeseInComp % 4;
-    if (inRemainder != 0) {
-        if (inRemainder == 1) {
-            tesSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
-        } else {
-            tesSourceStr +=
-                "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
-        }
-        inLocation += 1;
-    }
-    tesSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 exceedLimitIn[];\n\n";
-    // Output components
-    const uint32_t maxTeseOutComp = m_device->props.limits.maxTessellationEvaluationOutputComponents;
-    const uint32_t numOutVec4 = maxTeseOutComp / 4;
-    uint32_t outLocation = 0;
-    for (uint32_t i = 0; i < numOutVec4; i++) {
-        tesSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out;\n";
-        outLocation += 1;
-    }
-    const uint32_t outRemainder = maxTeseOutComp % 4;
-    if (outRemainder != 0) {
-        if (outRemainder == 1) {
-            tesSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut;\n";
-        } else {
-            tesSourceStr +=
-                "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut;\n";
-        }
-        outLocation += 1;
-    }
-    tesSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 exceedLimitOut;\n";
-    // Finalize
-    tesSourceStr +=
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    std::string fsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(location=0) out vec4 color;"
-        "\n"
-        "void main(){\n"
-        "    color = vec4(1);\n"
-        "}\n";
-
-    VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
-    VkShaderObj tcs(m_device, tcsSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
-    VkShaderObj tes(m_device, tesSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
-    VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&tcs);
-    pipe.AddShader(&tes);
-    pipe.AddShader(&fs);
-
-    // Set up CB 0; type is UNORM by default
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkDescriptorSetObj descriptorSet(m_device);
-    descriptorSet.AppendDummy();
-    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
+        VkPhysicalDeviceFeatures feat;
+        vkGetPhysicalDeviceFeatures(gpu(), &feat);
+        if (!feat.tessellationShader) {
+            printf("%s tessellation shader stage(s) unsupported.\n", kSkipPrefix);
+            return;
+        }
 
-    VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo = {};
-    inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    inputAssemblyInfo.pNext = NULL;
-    inputAssemblyInfo.flags = 0;
-    inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-    inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
-    pipe.SetInputAssembly(&inputAssemblyInfo);
+        std::string vsSourceStr =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "    gl_Position = vec4(1);\n"
+            "}\n";
 
-    VkPipelineTessellationStateCreateInfo tessInfo = {};
-    tessInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
-    tessInfo.pNext = NULL;
-    tessInfo.flags = 0;
-    tessInfo.patchControlPoints = 3;
-    pipe.SetTessellation(&tessInfo);
+        std::string tcsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout (vertices = 3) out;\n"
+            "\n"
+            "void main(){\n"
+            "    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;\n"
+            "}\n";
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+        // Tessellation evaluation stage
+        std::string tesSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout (triangles) in;\n"
+            "\n";
+        // Input components
+        const uint32_t maxTeseInComp = m_device->props.limits.maxTessellationEvaluationInputComponents + overflow;
+        const uint32_t numInVec4 = maxTeseInComp / 4;
+        uint32_t inLocation = 0;
+        for (uint32_t i = 0; i < numInVec4; i++) {
+            tesSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
+            inLocation += 1;
+        }
+        const uint32_t inRemainder = maxTeseInComp % 4;
+        if (inRemainder != 0) {
+            if (inRemainder == 1) {
+                tesSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
+            } else {
+                tesSourceStr +=
+                    "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
+            }
+            inLocation += 1;
+        }
 
-    m_errorMonitor->VerifyFound();
+        // Output components
+        const uint32_t maxTeseOutComp = m_device->props.limits.maxTessellationEvaluationOutputComponents + overflow;
+        const uint32_t numOutVec4 = maxTeseOutComp / 4;
+        uint32_t outLocation = 0;
+        for (uint32_t i = 0; i < numOutVec4; i++) {
+            tesSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out;\n";
+            outLocation += 1;
+        }
+        const uint32_t outRemainder = maxTeseOutComp % 4;
+        if (outRemainder != 0) {
+            if (outRemainder == 1) {
+                tesSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut;\n";
+            } else {
+                tesSourceStr +=
+                    "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut;\n";
+            }
+            outLocation += 1;
+        }
+
+        // Finalize
+        tesSourceStr +=
+            "\n"
+            "void main(){\n"
+            "}\n";
+
+        std::string fsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(location=0) out vec4 color;"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj tcs(m_device, tcsSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
+        VkShaderObj tes(m_device, tesSourceStr.c_str(), VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&tcs);
+        pipe.AddShader(&tes);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        VkPipelineInputAssemblyStateCreateInfo inputAssemblyInfo = {};
+        inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+        inputAssemblyInfo.pNext = NULL;
+        inputAssemblyInfo.flags = 0;
+        inputAssemblyInfo.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+        inputAssemblyInfo.primitiveRestartEnable = VK_FALSE;
+        pipe.SetInputAssembly(&inputAssemblyInfo);
+
+        VkPipelineTessellationStateCreateInfo tessInfo = {};
+        tessInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
+        tessInfo.pNext = NULL;
+        tessInfo.flags = 0;
+        tessInfo.patchControlPoints = 3;
+        pipe.SetTessellation(&tessInfo);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Tessellation evaluation shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxTessellationEvaluationInputComponents");
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Tessellation evaluation shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxTessellationEvaluationOutputComponents");
+        }
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the geometry stage exceeds the device "
         "limit");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Geometry shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxGeometryInputComponents");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Geometry shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxGeometryOutputComponents");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    VkPhysicalDeviceFeatures feat;
-    vkGetPhysicalDeviceFeatures(gpu(), &feat);
-    if (!feat.geometryShader) {
-        printf("%s geometry shader stage unsupported.\n", kSkipPrefix);
-        return;
-    }
-
-    std::string vsSourceStr =
-        "#version 450\n"
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    std::string gsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(triangles) in;\n"
-        "layout(invocations=1) in;\n";
-    // Input components
-    const uint32_t maxGeomInComp = m_device->props.limits.maxGeometryInputComponents;
-    const uint32_t numInVec4 = maxGeomInComp / 4;
-    uint32_t inLocation = 0;
-    for (uint32_t i = 0; i < numInVec4; i++) {
-        gsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
-        inLocation += 1;
-    }
-    const uint32_t inRemainder = maxGeomInComp % 4;
-    if (inRemainder != 0) {
-        if (inRemainder == 1) {
-            gsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
-        } else {
-            gsSourceStr +=
-                "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
-        }
-        inLocation += 1;
-    }
-    gsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 exceedLimitIn[];\n\n";
-    // Output components
-    const uint32_t maxGeomOutComp = m_device->props.limits.maxGeometryOutputComponents;
-    const uint32_t numOutVec4 = maxGeomOutComp / 4;
-    uint32_t outLocation = 0;
-    for (uint32_t i = 0; i < numOutVec4; i++) {
-        gsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out;\n";
-        outLocation += 1;
-    }
-    const uint32_t outRemainder = maxGeomOutComp % 4;
-    if (outRemainder != 0) {
-        if (outRemainder == 1) {
-            gsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut;\n";
-        } else {
-            gsSourceStr +=
-                "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut;\n";
-        }
-        outLocation += 1;
-    }
-    gsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 exceedLimitOut;\n";
-    // Finalize
-    gsSourceStr +=
-        "layout(triangle_strip, max_vertices=3) out;\n"
-        "\n"
-        "void main(){\n"
-        "    exceedLimitOut = vec4(1);\n"
-        "}\n";
-
-    std::string fsSourceStr =
-        "#version 450\n"
-        "\n"
-        "layout(location=0) out vec4 color;"
-        "\n"
-        "void main(){\n"
-        "    color = vec4(1);\n"
-        "}\n";
-
-    VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
-    VkShaderObj gs(m_device, gsSourceStr.c_str(), VK_SHADER_STAGE_GEOMETRY_BIT, this);
-    VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&gs);
-    pipe.AddShader(&fs);
-
-    // Set up CB 0; type is UNORM by default
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkDescriptorSetObj descriptorSet(m_device);
-    descriptorSet.AppendDummy();
-    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
+        VkPhysicalDeviceFeatures feat;
+        vkGetPhysicalDeviceFeatures(gpu(), &feat);
+        if (!feat.geometryShader) {
+            printf("%s geometry shader stage unsupported.\n", kSkipPrefix);
+            return;
+        }
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
-    m_errorMonitor->VerifyFound();
+        std::string vsSourceStr =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "    gl_Position = vec4(1);\n"
+            "}\n";
+
+        std::string gsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(triangles) in;\n"
+            "layout(invocations=1) in;\n";
+
+        // Input components
+        const uint32_t maxGeomInComp = m_device->props.limits.maxGeometryInputComponents + overflow;
+        const uint32_t numInVec4 = maxGeomInComp / 4;
+        uint32_t inLocation = 0;
+        for (uint32_t i = 0; i < numInVec4; i++) {
+            gsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in vec4 v" + std::to_string(i) + "In[];\n";
+            inLocation += 1;
+        }
+        const uint32_t inRemainder = maxGeomInComp % 4;
+        if (inRemainder != 0) {
+            if (inRemainder == 1) {
+                gsSourceStr += "layout(location=" + std::to_string(inLocation) + ") in float" + " vnIn[];\n";
+            } else {
+                gsSourceStr +=
+                    "layout(location=" + std::to_string(inLocation) + ") in vec" + std::to_string(inRemainder) + " vnIn[];\n";
+            }
+            inLocation += 1;
+        }
+
+        // Output components
+        const uint32_t maxGeomOutComp = m_device->props.limits.maxGeometryOutputComponents + overflow;
+        const uint32_t numOutVec4 = maxGeomOutComp / 4;
+        uint32_t outLocation = 0;
+        for (uint32_t i = 0; i < numOutVec4; i++) {
+            gsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out vec4 v" + std::to_string(i) + "Out;\n";
+            outLocation += 1;
+        }
+        const uint32_t outRemainder = maxGeomOutComp % 4;
+        if (outRemainder != 0) {
+            if (outRemainder == 1) {
+                gsSourceStr += "layout(location=" + std::to_string(outLocation) + ") out float" + " vnOut;\n";
+            } else {
+                gsSourceStr +=
+                    "layout(location=" + std::to_string(outLocation) + ") out vec" + std::to_string(outRemainder) + " vnOut;\n";
+            }
+            outLocation += 1;
+        }
+
+        // Finalize
+        int max_vertices = overflow ? (m_device->props.limits.maxGeometryTotalOutputComponents / maxGeomOutComp + 1) : 1;
+        gsSourceStr += "layout(points, max_vertices = " + std::to_string(max_vertices) +
+                       ") out;\n"
+                       "\n"
+                       "void main(){\n"
+                       "}\n";
+
+        std::string fsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(location=0) out vec4 color;"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj gs(m_device, gsSourceStr.c_str(), VK_SHADER_STAGE_GEOMETRY_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&gs);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Geometry shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxGeometryInputComponents");
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Geometry shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxGeometryOutputComponents");
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Geometry shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxGeometryTotalOutputComponents");
+        }
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
     TEST_DESCRIPTION(
         "Test that an error is produced when the number of input components from the fragment stage exceeds the device limit");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Fragment shader exceeds "
-                                         "VkPhysicalDeviceLimits::maxFragmentInputComponents");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    std::string vsSourceStr =
-        "#version 450\n"
-        "\n"
-        "void main(){\n"
-        "    gl_Position = vec4(1);\n"
-        "}\n";
-
-    const uint32_t maxFsInComp = m_device->props.limits.maxFragmentInputComponents;
-    std::string fsSourceStr = "#version 450\n\n";
-    const uint32_t numVec4 = maxFsInComp / 4;
-    uint32_t location = 0;
-    for (uint32_t i = 0; i < numVec4; i++) {
-        fsSourceStr += "layout(location=" + std::to_string(location) + ") in vec4 v" + std::to_string(i) + ";\n";
-        location += 1;
-    }
-    const uint32_t remainder = maxFsInComp % 4;
-    if (remainder != 0) {
-        if (remainder == 1) {
-            fsSourceStr += "layout(location=" + std::to_string(location) + ") in float" + " vn;\n";
-        } else {
-            fsSourceStr += "layout(location=" + std::to_string(location) + ") in vec" + std::to_string(remainder) + " vn;\n";
-        }
-        location += 1;
-    }
-    fsSourceStr += "layout(location=" + std::to_string(location) +
-                   ") in vec4 exceedLimit;\n"
-                   "\n"
-                   "layout(location=0) out vec4 color;"
-                   "\n"
-                   "void main(){\n"
-                   "    color = vec4(1);\n"
-                   "}\n";
-
-    VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
-    VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&fs);
-
-    // Set up CB 0; type is UNORM by default
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkDescriptorSetObj descriptorSet(m_device);
-    descriptorSet.AppendDummy();
-    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
+        std::string vsSourceStr =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "    gl_Position = vec4(1);\n"
+            "}\n";
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+        const uint32_t maxFsInComp = m_device->props.limits.maxFragmentInputComponents + overflow;
+        std::string fsSourceStr = "#version 450\n\n";
+        const uint32_t numVec4 = maxFsInComp / 4;
+        uint32_t location = 0;
+        for (uint32_t i = 0; i < numVec4; i++) {
+            fsSourceStr += "layout(location=" + std::to_string(location) + ") in vec4 v" + std::to_string(i) + ";\n";
+            location += 1;
+        }
+        const uint32_t remainder = maxFsInComp % 4;
+        if (remainder != 0) {
+            if (remainder == 1) {
+                fsSourceStr += "layout(location=" + std::to_string(location) + ") in float" + " vn;\n";
+            } else {
+                fsSourceStr += "layout(location=" + std::to_string(location) + ") in vec" + std::to_string(remainder) + " vn;\n";
+            }
+            location += 1;
+        }
+        fsSourceStr +=
+            "layout(location=0) out vec4 color;"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
 
-    m_errorMonitor->VerifyFound();
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                                 "Fragment shader exceeds "
+                                                 "VkPhysicalDeviceLimits::maxFragmentInputComponents");
+        }
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
+}
+
+TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInstanceVertexCount) {
+    TEST_DESCRIPTION(
+        "Test that errors are produced when the number of output vertices/instances in the geometry stage exceeds the device "
+        "limit");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    for (int overflow = 0; overflow < 2; ++overflow) {
+        m_errorMonitor->Reset();
+        VkPhysicalDeviceFeatures feat;
+        vkGetPhysicalDeviceFeatures(gpu(), &feat);
+        if (!feat.geometryShader) {
+            printf("%s geometry shader stage unsupported.\n", kSkipPrefix);
+            return;
+        }
+
+        std::string vsSourceStr =
+            "#version 450\n"
+            "\n"
+            "void main(){\n"
+            "    gl_Position = vec4(1);\n"
+            "}\n";
+
+        std::string gsSourceStr = R"(
+               OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Geometry %main "main"
+               OpExecutionMode %main InputPoints
+               OpExecutionMode %main OutputPoints
+               )";
+        if (overflow) {
+            gsSourceStr += "OpExecutionMode %main Invocations " +
+                           std::to_string(m_device->props.limits.maxGeometryShaderInvocations + 1) +
+                           "\n\
+                OpExecutionMode %main OutputVertices " +
+                           std::to_string(m_device->props.limits.maxGeometryOutputVertices + 1);
+        } else {
+            gsSourceStr += R"(
+               OpExecutionMode %main Invocations 1
+               OpExecutionMode %main OutputVertices 1
+               )";
+        }
+        gsSourceStr += R"(
+               OpSource GLSL 450
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+        )";
+
+        std::string fsSourceStr =
+            "#version 450\n"
+            "\n"
+            "layout(location=0) out vec4 color;"
+            "\n"
+            "void main(){\n"
+            "    color = vec4(1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSourceStr.c_str(), VK_SHADER_STAGE_VERTEX_BIT, this);
+        VkShaderObj gs(m_device, gsSourceStr, VK_SHADER_STAGE_GEOMETRY_BIT, this);
+        VkShaderObj fs(m_device, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        VkPipelineObj pipe(m_device);
+        pipe.AddShader(&vs);
+        pipe.AddShader(&gs);
+        pipe.AddShader(&fs);
+
+        // Set up CB 0; type is UNORM by default
+        pipe.AddDefaultColorAttachment();
+
+        VkDescriptorSetObj descriptorSet(m_device);
+        descriptorSet.AppendDummy();
+        descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+        if (overflow) {
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkPipelineShaderStageCreateInfo-stage-00714");
+            m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkPipelineShaderStageCreateInfo-stage-00715");
+        }
+
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+        if (overflow) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineUniformBlockNotProvided) {


### PR DESCRIPTION
Fixes #820.

Check for outermost array that shouldn't be counted for certain shader stages, for non-patch attributes. Implement maxGeometryTotalOutputComponents device limit check, and some related verticesout/invocations limits.

Update the tests to each run two iterations, one that is just under the limit and one that is just over the limit. Add a variant that tests OutputVertices/Invocations.
