### PR TITLE
Validate using VkPhysicalDeviceFeatures2 & VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT without enabling the extensions.

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -209,6 +209,35 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
         }
     }
 
+    auto features2 = lvl_find_in_chain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
+    if (features2) {
+        if (!instance_extensions.vk_khr_get_physical_device_properties_2) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            kVUID_PVError_ExtensionNotEnabled,
+                            "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceFeatures2 struct, "
+                            "VK_KHR_get_physical_device_properties2 must be enabled when it creates an instance.");
+        }
+    }
+
+    auto vertex_attribute_divisor_features =
+        lvl_find_in_chain<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>(pCreateInfo->pNext);
+    if (vertex_attribute_divisor_features) {
+        bool extension_found = false;
+        for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; ++i) {
+            if (0 == strncmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,
+                             VK_MAX_EXTENSION_NAME_SIZE)) {
+                extension_found = true;
+                break;
+            }
+        }
+        if (!extension_found) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            kVUID_PVError_ExtensionNotEnabled,
+                            "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT "
+                            "struct, VK_EXT_vertex_attribute_divisor must be enabled when it creates a device.");
+        }
+    }
+
     // Validate pCreateInfo->pQueueCreateInfos
     if (pCreateInfo->pQueueCreateInfos) {
         std::unordered_set<uint32_t> set;

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -63,11 +63,6 @@ extern const std::vector<VkLogicOp> AllVkLogicOpEnums;
 extern const std::vector<VkBorderColor> AllVkBorderColorEnums;
 extern const std::vector<VkImageLayout> AllVkImageLayoutEnums;
 
-struct GenericHeader {
-    VkStructureType sType;
-    const void *pNext;
-};
-
 // String returned by string_VkStructureType for an unrecognized type.
 const std::string UnsupportedStructureTypeString = "Unhandled VkStructureType";
 
@@ -474,7 +469,7 @@ class StatelessValidation : public ValidationObject {
     }
 
     // Forward declaration for pNext validation
-    bool ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const GenericHeader *header);
+    bool ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure *header);
 
     /**
      * Validate a structure's pNext member.
@@ -521,7 +516,7 @@ class StatelessValidation : public ValidationObject {
             } else {
                 const VkStructureType *start = allowed_types;
                 const VkStructureType *end = allowed_types + allowed_type_count;
-                const GenericHeader *current = reinterpret_cast<const GenericHeader *>(next);
+                const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
 
                 cycle_check.insert(next);
 
@@ -574,7 +569,7 @@ class StatelessValidation : public ValidationObject {
                         }
                         skip_call |= ValidatePnextStructContents(api_name, parameter_name, current);
                     }
-                    current = reinterpret_cast<const GenericHeader *>(current->pNext);
+                    current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
                 }
             }
         }

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -1136,7 +1136,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         type_member = 'Type'
         id_member = 'kSType'
         id_decl = 'static const VkStructureType '
-        generic_header = prefix + 'GenericHeader'
+        generic_header = 'VkBaseOutStructure'
         typename_func = fprefix + 'typename'
         idname_func = fprefix + 'stype_name'
         find_func = fprefix + 'find_in_chain'
@@ -1160,12 +1160,6 @@ class HelperFileOutputGenerator(OutputGenerator):
 
         # Define the utilities (here so any renaming stays consistent), if this grows large, refactor to a fixed .h file
         utilities_format = '\n'.join((
-            '// Header "base class" for pNext chain traversal',
-            'struct {header} {{',
-            '   VkStructureType sType;',
-            '   const {header} *pNext;',
-            '}};',
-            '',
             '// Find an entry of the given type in the pNext chain',
             'template <typename T> const T *{find_func}(const void *next) {{',
             '    const {header} *current = reinterpret_cast<const {header} *>(next);',

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -337,7 +337,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             write(self.enumValueLists, file=self.outFile)
             self.newline()
 
-            pnext_handler  = 'bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const GenericHeader* header) {\n'
+            pnext_handler  = 'bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) {\n'
             pnext_handler += '    bool skip = false;\n'
             pnext_handler += '    switch(header->sType) {\n'
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13362,6 +13362,35 @@ TEST_F(VkLayerTest, InvalidPipelineSamplePNext) {
                                       "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
 }
 
+TEST_F(VkLayerTest, DeviceFeature2AndVertexAttributeDivisorExtensionUnenabled) {
+    TEST_DESCRIPTION(
+        "Test unenabled VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME & "
+        "VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME.");
+
+    VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vadf = {};
+    vadf.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT;
+    VkPhysicalDeviceFeatures2 pd_features2 = {};
+    pd_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    pd_features2.pNext = &vadf;
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
+    VkDeviceCreateInfo device_create_info = {};
+    device_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    device_create_info.pNext = &pd_features2;
+    device_create_info.queueCreateInfoCount = queue_info.size();
+    device_create_info.pQueueCreateInfos = queue_info.data();
+    VkDevice testDevice;
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                         "VK_KHR_get_physical_device_properties2 must be enabled when it creates an instance");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                         "VK_EXT_vertex_attribute_divisor must be enabled when it creates a device");
+    m_errorMonitor->SetUnexpectedError("Failed to create device chain");
+    vkCreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
     TEST_DESCRIPTION("Test VUIDs added with VK_EXT_vertex_attribute_divisor extension.");
 


### PR DESCRIPTION
[issue #855 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/855)
@ShabbyX 
The PR also replaces the whole `GenericHeader` into `VkBaseOutStructure`.