### PR TITLE
Be more careful cleaning up gpu-av resources

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -122,13 +122,6 @@ void GpuDescriptorSetManager::PutBackDescriptorSet(VkDescriptorPool desc_pool, V
     return;
 }
 
-void GpuDescriptorSetManager::DestroyDescriptorPools() {
-    for (auto &pool : desc_pool_map_) {
-        DispatchDestroyDescriptorPool(dev_data_->device, pool.first, NULL);
-    }
-    desc_pool_map_.clear();
-}
-
 // Trampolines to make VMA call Dispatch for Vulkan calls
 static VKAPI_ATTR void VKAPI_CALL gpuVkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                                    VkPhysicalDeviceProperties *pProperties) {
@@ -249,11 +242,6 @@ void CoreChecks::GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, std::unique_
 // Perform initializations that can be done at Create Device time.
 void CoreChecks::GpuPostCallRecordCreateDevice(const CHECK_ENABLED *enables) {
     gpu_validation_state = std::unique_ptr<GpuValidationState>(new GpuValidationState);
-
-    gpu_validation_state->aborted = false;
-    gpu_validation_state->reserve_binding_slot = false;
-    gpu_validation_state->barrier_command_pool = VK_NULL_HANDLE;
-    gpu_validation_state->barrier_command_buffer = VK_NULL_HANDLE;
     gpu_validation_state->reserve_binding_slot = enables->gpu_validation_reserve_binding_slot;
 
     if (GetPDProperties()->apiVersion < VK_API_VERSION_1_1) {
@@ -344,8 +332,10 @@ void CoreChecks::GpuPreCallRecordDestroyDevice() {
         DispatchDestroyDescriptorSetLayout(device, gpu_validation_state->dummy_desc_layout, NULL);
         gpu_validation_state->dummy_desc_layout = VK_NULL_HANDLE;
     }
-    gpu_validation_state->desc_set_manager->DestroyDescriptorPools();
-    vmaDestroyAllocator(gpu_validation_state->vmaAllocator);
+    gpu_validation_state->desc_set_manager.reset();
+    if (gpu_validation_state->vmaAllocator) {
+        vmaDestroyAllocator(gpu_validation_state->vmaAllocator);
+    }
 }
 
 // Modify the pipeline layout to include our debug descriptor set and any needed padding with the dummy descriptor set.

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -44,7 +44,6 @@ class GpuDescriptorSetManager {
 
     VkResult GetDescriptorSets(uint32_t count, VkDescriptorPool *pool, std::vector<VkDescriptorSet> *desc_sets);
     void PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDescriptorSet desc_set);
-    void DestroyDescriptorPools();
 
    private:
     static const uint32_t kItemsPerChunk = 512;
@@ -72,6 +71,13 @@ struct GpuValidationState {
     std::unordered_map<VkCommandBuffer, std::vector<GpuBufferInfo>> command_buffer_map;  // gpu_buffer_list;
     uint32_t output_buffer_size;
     VmaAllocator vmaAllocator;
+    GpuValidationState(bool aborted = false, bool reserve_binding_slot = false, VkCommandPool barrier_command_pool = VK_NULL_HANDLE,
+                       VkCommandBuffer barrier_command_buffer = VK_NULL_HANDLE, VmaAllocator vmaAllocator = {})
+        : aborted(aborted),
+          reserve_binding_slot(reserve_binding_slot),
+          barrier_command_pool(barrier_command_pool),
+          barrier_command_buffer(barrier_command_buffer),
+          vmaAllocator(vmaAllocator){};
 
     std::vector<GpuBufferInfo> &GetGpuBufferInfo(const VkCommandBuffer command_buffer) {
         auto buffer_list = command_buffer_map.find(command_buffer);


### PR DESCRIPTION
If we abort gpu-av in CreateDevice because of Vulkan < 1.1 (or any other reason), don't try to cleanup vma or the descriptor set manager in DestroyDevice