### PR TITLE
build: Fix test build to use loader as imported target

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 # ~~~
 set(VULKAN_LOADER_INSTALL_DIR "LOADER-NOTFOUND" CACHE PATH "Absolute path to a Vulkan-Loader install directory")
 
-if(NOT TARGET vulkan)
+if (NOT TARGET vulkan)
     if(VULKAN_LOADER_INSTALL_DIR)
         message(STATUS "VULKAN_LOADER_INSTALL_DIR specified, using find_package to locate Vulkan")
     elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
@@ -100,6 +100,18 @@ if(NOT TARGET vulkan)
         ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR}
         )
     find_package(Vulkan)
+    add_library(vulkan STATIC IMPORTED)
+
+    set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${Vulkan_LIBRARY}")
+    target_include_directories(vulkan INTERFACE "${Vulkan_INCLUDE_DIR}")
+endif()
+
+if (NOT TARGET Vulkan::Vulkan)
+    if (TARGET vulkan)
+        add_library(Vulkan::Vulkan ALIAS vulkan)
+    else()
+        message(FATAL_ERROR "Vulkan loader target not found")
+    endif()
 endif()
 
 set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
@@ -109,6 +121,7 @@ add_executable(vk_layer_validation_tests
                ../layers/convert_to_renderpass2.cpp
                ${PROJECT_BINARY_DIR}/vk_safe_struct.cpp
                ${COMMON_CPP})
+target_link_libraries(vk_layer_validation_tests PRIVATE Vulkan::Headers)
 add_dependencies(vk_layer_validation_tests Vulkan::Vulkan)
 if(NOT GTEST_IS_STATIC_LIB)
     set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,7 +103,11 @@ if (NOT TARGET vulkan)
     add_library(vulkan STATIC IMPORTED)
 
     set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION "${Vulkan_LIBRARY}")
-    target_include_directories(vulkan INTERFACE "${Vulkan_INCLUDE_DIR}")
+    # cmake <= 3.10.2 can't attach include paths to imported targets
+    # remove this check once we settle on a newer version
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.11.0")
+        target_include_directories(vulkan INTERFACE "${Vulkan_INCLUDE_DIR}")
+    endif()
 endif()
 
 if (NOT TARGET Vulkan::Vulkan)
@@ -123,6 +127,12 @@ add_executable(vk_layer_validation_tests
                ${COMMON_CPP})
 target_link_libraries(vk_layer_validation_tests PRIVATE Vulkan::Headers)
 add_dependencies(vk_layer_validation_tests Vulkan::Vulkan)
+# cmake <= 3.10.2 can't attach include paths to imported targets
+# remove this once we settle on a newer version
+if (CMAKE_VERSION VERSION_LESS "3.11.0")
+    target_include_directories(vk_layer_validation_tests INTERFACE "${Vulkan_INCLUDE_DIR}")
+endif()
+
 if(NOT GTEST_IS_STATIC_LIB)
     set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 endif()
@@ -163,6 +173,12 @@ else()
                                       gtest_main
                                       ${GLSLANG_LIBRARIES})
     endif()
+endif()
+
+# cmake <= 3.10.2 can't attach include paths to imported targets
+# remove this once we settle on a newer version
+if (CMAKE_VERSION VERSION_LESS "3.11.0")
+    target_include_directories(vk_layer_validation_tests INTERFACE "${Vulkan_INCLUDE_DIR}")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Updates the test build to consume the Vulkan loader as an imported
target in a nested project build. If the imported target is not found,
the existing logic and search path is used instead.