### PR TITLE
Skip building most of VulkanTools for Travis VVL builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,8 @@ script:
       mkdir build
       cd build
       cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_VIA=NO -DBUILD_VKTRACE=NO -DBUILD_VLF=NO -DBUILD_TESTS=NO -DBUILD_LAYERMGR=NO \
+            -DBUILD_VKTRACEVIEWER=NO -DBUILD_VKTRACE_LAYER=NO -DBUILD_VKTRACE_REPLAY=NO \
             -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Headers/build/install \
             -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install \
             -DVULKAN_VALIDATIONLAYERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/build/install \


### PR DESCRIPTION
Seems like only DevSim is needed, so the only necessary target should be 'layersvt'.  Skip building VLF, VKTRACE, and related items.