### PR TITLE
aligned_alloc() is only defined for glibc>=2.16

### DIFF
--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -3177,6 +3177,15 @@ void *aligned_alloc(size_t alignment, size_t size)
     return memalign(alignment, size);
 }
 #elif defined(__APPLE__) || defined(__ANDROID__)
+#  define ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
+#elif defined(__GNU_LIBRARY__)
+#  if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 16)
+// aligned_alloc() is defined in glibc only for version >= 2.16
+#    define ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
+#  endif
+#endif
+
+#ifdef ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
 #include <cstdlib>
 void *aligned_alloc(size_t alignment, size_t size)
 {


### PR DESCRIPTION
Kudos to Tor Colvin for finding the root cause.

There is a build error on CentOS6 because CentOS6 comes with glibc is 2.12.
As seen on the "Versions" section of the aligned_alloc() manpage: https://linux.die.net/man/3/aligned_alloc, "The function aligned_alloc() was added to glibc in version 2.16. ".

This patch reuses the implementation for Apple and Android (using posix_memalign()) when it is detected that glibc<2.16. For the use of __GLIBC_PREREQ(major,minor) in the patch, this macro is defined since 1999-06-18: https://github.molgen.mpg.de/git-mirror/glibc/blob/master/ChangeLog.10

This was discovered while trying to build the 1.1.106 Vulkan SDK on CentOS6.

Note that this has nothing to do with the gcc/g++ version but only with the glibc version: on CentOS6, I used gcc 6.4.0 and aligned_alloc() is not defined, but for comparison on Ubuntu 18.10 I used gcc 6.5.0 and aligned_alloc() is defined because Ubuntu comes with glibc 2.28.