### PR TITLE
Fix Android Hardware Buffer tests fail

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1343,9 +1343,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     VkImageFormatProperties format_limits = {};
     VkResult res = GetPDImageFormatProperties(pCreateInfo, &format_limits);
     if (res == VK_ERROR_FORMAT_NOT_SUPPORTED) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUIDUndefined,
-                        "vkCreateImage(): Format %s is not supported for this combination of parameters.",
-                        string_VkFormat(pCreateInfo->format));
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+        if (!lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo->pNext))
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUIDUndefined,
+                            "vkCreateImage(): Format %s is not supported for this combination of parameters.",
+                            string_VkFormat(pCreateInfo->format));
     } else {
         if (pCreateInfo->mipLevels > format_limits.maxMipLevels) {
             const char *format_string = string_VkFormat(pCreateInfo->format);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3428,8 +3428,8 @@ std::map<VkImageCreateFlags, uint64_t> ahb_create_map_v2a = {
 //
 // AHB-extension new APIs
 //
-bool CoreChecks::PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer *buffer,
-                                                                   VkAndroidHardwareBufferPropertiesANDROID *pProperties) {
+bool CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer *buffer,
+                                                                          VkAndroidHardwareBufferPropertiesANDROID *pProperties) {
     bool skip = false;
     //  buffer must be a valid Android hardware buffer object with at least one of the AHARDWAREBUFFER_USAGE_GPU_* usage flags.
     AHardwareBuffer_Desc ahb_desc;
@@ -3447,9 +3447,9 @@ bool CoreChecks::PreCallValidateGetAndroidHardwareBufferProperties(VkDevice devi
     return skip;
 }
 
-void CoreChecks::PostCallRecordGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer *buffer,
-                                                                  VkAndroidHardwareBufferPropertiesANDROID *pProperties,
-                                                                  VkResult result) {
+void CoreChecks::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer *buffer,
+                                                                         VkAndroidHardwareBufferPropertiesANDROID *pProperties,
+                                                                         VkResult result) {
     if (VK_SUCCESS != result) return;
     auto ahb_format_props = lvl_find_in_chain<VkAndroidHardwareBufferFormatPropertiesANDROID>(pProperties->pNext);
     if (ahb_format_props) {
@@ -3457,9 +3457,9 @@ void CoreChecks::PostCallRecordGetAndroidHardwareBufferProperties(VkDevice devic
     }
 }
 
-bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBuffer(VkDevice device,
-                                                               const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
-                                                               struct AHardwareBuffer **pBuffer) {
+bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
+                                                                      const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
+                                                                      struct AHardwareBuffer **pBuffer) {
     bool skip = false;
     DEVICE_MEM_INFO *mem_info = GetMemObjInfo(pInfo->memory);
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3618,16 +3618,15 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         if ((nullptr == mem_ded_alloc_info) || (VK_NULL_HANDLE == mem_ded_alloc_info->image)) {
             // the Android hardware buffer must have a format of AHARDWAREBUFFER_FORMAT_BLOB and a usage that includes
             // AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER
-            if (((uint64_t)AHARDWAREBUFFER_FORMAT_BLOB != ahb_format_props.externalFormat) ||
+            if (((uint64_t)AHARDWAREBUFFER_FORMAT_BLOB != ahb_desc.format) ||
                 (0 == (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER))) {
                 skip |= log_msg(
                     report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device),
                     "VUID-VkMemoryAllocateInfo-pNext-02384",
                     "vkAllocateMemory: VkMemoryAllocateInfo struct with chained VkImportAndroidHardwareBufferInfoANDROID "
-                    "struct without a dedicated allocation requirement, while the AHardwareBuffer's external format (0x%" PRIx64
-                    ") is not AHARDWAREBUFFER_FORMAT_BLOB or usage (0x%" PRIx64
-                    ") does not include AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER.",
-                    ahb_format_props.externalFormat, ahb_desc.usage);
+                    "struct without a dedicated allocation requirement, while the AHardwareBuffer_Desc's format ( %u ) is not "
+                    "AHARDWAREBUFFER_FORMAT_BLOB or usage (0x%" PRIx64 ") does not include AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER.",
+                    ahb_desc.format, ahb_desc.usage);
             }
         } else {  // Checks specific to import with a dedicated allocation requirement
             VkImageCreateInfo *ici = &(GetImageState(mem_ded_alloc_info->image)->createInfo);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1531,12 +1531,14 @@ class CoreChecks : public ValidationObject {
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    bool PreCallValidateGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
-                                                           VkAndroidHardwareBufferPropertiesANDROID* pProperties);
-    void PostCallRecordGetAndroidHardwareBufferProperties(VkDevice device, const struct AHardwareBuffer* buffer,
-                                                          VkAndroidHardwareBufferPropertiesANDROID* pProperties, VkResult result);
-    bool PreCallValidateGetMemoryAndroidHardwareBuffer(VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
-                                                       struct AHardwareBuffer** pBuffer);
+    bool PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                                  VkAndroidHardwareBufferPropertiesANDROID* pProperties);
+    void PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                                 VkAndroidHardwareBufferPropertiesANDROID* pProperties,
+                                                                 VkResult result);
+    bool PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
+                                                              const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
+                                                              struct AHardwareBuffer** pBuffer);
     void PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface, VkResult result);
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -37781,6 +37781,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
 
     // undefined format
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageCreateInfo-pNext-01975");
+    m_errorMonitor->SetUnexpectedError("VUID_Undefined");
     vkCreateImage(dev, &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
@@ -37825,7 +37826,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
 
     // a defined image format with a non-zero external format
     ici.format = VK_FORMAT_R8G8B8A8_UNORM;
-    efa.externalFormat = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+    efa.externalFormat = ahb_fmt_props.externalFormat;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageCreateInfo-pNext-01974");
     vkCreateImage(dev, &ici, NULL, &img);
     m_errorMonitor->VerifyFound();

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38360,7 +38360,26 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     // Give image an external format
     VkExternalFormatANDROID efa = {};
     efa.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID;
-    efa.externalFormat = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
+    efa.externalFormat = ahb_fmt_props.externalFormat;
+
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    ahb_desc.width = 64;
+    ahb_desc.height = 1;
+    ahb_desc.layers = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props_Ycbcr = {};
+    ahb_fmt_props_Ycbcr.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID;
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props_Ycbcr = {};
+    ahb_props_Ycbcr.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
+    ahb_props_Ycbcr.pNext = &ahb_fmt_props_Ycbcr;
+    pfn_GetAHBProps(dev, ahb, &ahb_props_Ycbcr);
+    AHardwareBuffer_release(ahb);
+
+    VkExternalFormatANDROID efa_Ycbcr = {};
+    efa_Ycbcr.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID;
+    efa_Ycbcr.externalFormat = ahb_fmt_props_Ycbcr.externalFormat;
 
     // Create the image
     VkImage img = VK_NULL_HANDLE;
@@ -38392,9 +38411,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     // Create a YCbCr conversion, with different external format, chain to view
     VkSamplerYcbcrConversion ycbcr_conv = VK_NULL_HANDLE;
     VkSamplerYcbcrConversionCreateInfo sycci = {};
-    efa.externalFormat = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
     sycci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
-    sycci.pNext = &efa;
+    sycci.pNext = &efa_Ycbcr;
     sycci.format = VK_FORMAT_UNDEFINED;
     sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
@@ -38430,7 +38448,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
 
     reset_view();
     vkDestroySamplerYcbcrConversion(dev, ycbcr_conv, NULL);
-    efa.externalFormat = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
+    sycci.pNext = &efa;
     vkCreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
     syci.conversion = ycbcr_conv;
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38332,9 +38332,6 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     VkDevice dev = m_device->device();
 
-    // Expect no validation errors during setup
-    m_errorMonitor->ExpectSuccess();
-
     // Allocate an AHB and fetch its properties
     AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
@@ -38369,6 +38366,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ahb_desc.layers = 1;
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
+    // Create another VkExternalFormatANDROID for test VUID-VkImageViewCreateInfo-image-02400
     VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props_Ycbcr = {};
     ahb_fmt_props_Ycbcr.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID;
     VkAndroidHardwareBufferPropertiesANDROID ahb_props_Ycbcr = {};
@@ -38405,7 +38403,18 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     mai.memoryTypeIndex = 0;
     vkAllocateMemory(dev, &mai, NULL, &img_mem);
 
+    // It shouldn't use vkGetImageMemoryRequirements for AndroidHardwareBuffer.
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "UNASSIGNED-CoreValidation-DrawState-InvalidImage");
+    VkMemoryRequirements img_mem_reqs = {};
+    vkGetImageMemoryRequirements(m_device->device(), img, &img_mem_reqs);
+    vkBindImageMemory(dev, img, img_mem, 0);
+    m_errorMonitor->VerifyFound();
+
     // Bind image to memory
+    vkDestroyImage(dev, img, NULL);
+    vkFreeMemory(dev, img_mem, NULL);
+    vkCreateImage(dev, &ici, NULL, &img);
+    vkAllocateMemory(dev, &mai, NULL, &img_mem);
     vkBindImageMemory(dev, img, img_mem, 0);
 
     // Create a YCbCr conversion, with different external format, chain to view

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38011,8 +38011,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
         if (ahb) AHardwareBuffer_release(ahb);
         ahb = nullptr;
         AHardwareBuffer_allocate(&ahb_desc, &ahb);
-        pfn_GetAHBProps(dev, ahb, &ahb_props);
-        iahbi.buffer = ahb;
+        if (ahb) {
+            pfn_GetAHBProps(dev, ahb, &ahb_props);
+            iahbi.buffer = ahb;
+        }
     };
 
     // Allocate an AHardwareBuffer
@@ -38026,7 +38028,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     // Create an image w/ external format
     VkExternalFormatANDROID efa = {};
     efa.sType = VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID;
-    efa.externalFormat = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+    efa.externalFormat = ahb_fmt_props.externalFormat;
 
     VkImageCreateInfo ici = {};
     ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -38037,7 +38039,6 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     ici.format = VK_FORMAT_UNDEFINED;
     ici.mipLevels = 1;
     ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    ici.mipLevels = 1;
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -38068,7 +38069,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
 
     // Allocation size mismatch
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
+    ahb_desc.height = 1;
     recreate_ahb();
     mai.allocationSize = ahb_props.allocationSize + 1;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
@@ -38096,7 +38098,9 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     // Dedicated allocation with unmatched usage bits
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT;
+    ahb_desc.height = 64;
     recreate_ahb();
+    mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-02390");
     vkAllocateMemory(dev, &mai, NULL, &mem_handle);
     m_errorMonitor->VerifyFound();
@@ -38109,10 +38113,24 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     mdai.image = img;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE;
     recreate_ahb();
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-02389");
-    vkAllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    reset_mem();
+
+    if (ahb) {
+        mai.allocationSize = ahb_props.allocationSize;
+        for (int i = 0; i < 32; i++) {
+            if (ahb_props.memoryTypeBits & (1 << i)) {
+                mai.memoryTypeIndex = i;
+                break;
+            }
+        }
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-02389");
+        vkAllocateMemory(dev, &mai, NULL, &mem_handle);
+        m_errorMonitor->VerifyFound();
+        reset_mem();
+    } else {
+        // ERROR: AHardwareBuffer_allocate() with MIPMAP_COMPLETE fails. It returns -12, NO_MEMORY.
+        // The problem seems to happen in Pixel 2, not Pixel 3.
+        printf("%s AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE not supported, skipping tests\n", kSkipPrefix);
+    }
 
     // Dedicated allocation with mis-matched dimension
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
@@ -38151,12 +38169,11 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
 
     // Dedicated allocation with missing usage bits
     // Setting up this test also triggers a slew of others
+    mai.allocationSize = ahb_props.allocationSize + 1;
+    mai.memoryTypeIndex = 0;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-02390");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
-
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-02386");
     vkAllocateMemory(dev, &mai, NULL, &mem_handle);
     m_errorMonitor->VerifyFound();

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38534,11 +38534,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
 
     // Allocate an AHardwareBuffer
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA;
     ahb_desc.width = 512;
     ahb_desc.height = 1;
     ahb_desc.layers = 1;
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
+    m_errorMonitor->SetUnexpectedError("VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
     pfn_GetAHBProps(dev, ahb, &ahb_props);
     iahbi.buffer = ahb;
 
@@ -38561,6 +38562,22 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     // Allocation info
     VkMemoryAllocateInfo mai = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, mem_reqs, 0);
     mai.pNext = &iahbi;  // Chained import struct
+    VkPhysicalDeviceMemoryProperties memory_info;
+    vkGetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    unsigned int i;
+    for (i = 0; i < memory_info.memoryTypeCount; i++) {
+        if ((ahb_props.memoryTypeBits & (1 << i))) {
+            mai.memoryTypeIndex = i;
+            break;
+        }
+    }
+    if (i >= memory_info.memoryTypeCount) {
+        printf("%s No invalid memory type index could be found; skipped.\n", kSkipPrefix);
+        AHardwareBuffer_release(ahb);
+        reset_mem();
+        vkDestroyBuffer(dev, buf, NULL);
+        return;
+    }
 
     // Import as buffer requires format AHB_FMT_BLOB and usage AHB_USAGE_GPU_DATA_BUFFER
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,


### PR DESCRIPTION
Those tests require `Android Q`.

I resolved most problems about AHB tests, besides a test, `AndroidHardwareBufferMemoryAllocation`.

The test needs to `AHardwareBuffer_allocate()` for usage `AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE`.

I cannot allocate it successfully. It fails and returns `-12`. It means `NO_MEMORY`. 