### PR TITLE
CoreChecks object map name normalization

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -820,7 +820,7 @@ bool CoreChecks::ValidateBarriersToImages(CMD_BUFFER_STATE const *cb_state, uint
 bool CoreChecks::IsReleaseOp(CMD_BUFFER_STATE *cb_state, VkImageMemoryBarrier const *barrier) {
     if (!IsTransferOp(barrier)) return false;
 
-    auto pool = GetCommandPoolNode(cb_state->createInfo.commandPool);
+    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
     return pool && TempIsReleaseOp<VkImageMemoryBarrier, true>(pool, barrier);
 }
 
@@ -829,7 +829,7 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const char *func_name, CMD
                                                       const Barrier *barriers) {
     using BarrierRecord = QFOTransferBarrier<Barrier>;
     bool skip = false;
-    auto pool = GetCommandPoolNode(cb_state->createInfo.commandPool);
+    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
     auto &barrier_sets = GetQFOBarrierSets(cb_state, typename BarrierRecord::Tag());
     const char *barrier_name = BarrierRecord::BarrierName();
     const char *handle_name = BarrierRecord::HandleName();
@@ -867,7 +867,7 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const char *func_name, CMD
 
 template <typename Barrier>
 void CoreChecks::RecordQFOTransferBarriers(CMD_BUFFER_STATE *cb_state, uint32_t barrier_count, const Barrier *barriers) {
-    auto pool = GetCommandPoolNode(cb_state->createInfo.commandPool);
+    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
     auto &barrier_sets = GetQFOBarrierSets(cb_state, typename QFOTransferBarrier<Barrier>::Tag());
     for (uint32_t b = 0; b < barrier_count; b++) {
         if (!IsTransferOp(&barriers[b])) continue;
@@ -1857,7 +1857,7 @@ static inline bool IsExtentSizeZero(const VkExtent3D *extent) {
 VkExtent3D CoreChecks::GetScaledItg(const CMD_BUFFER_STATE *cb_node, const IMAGE_STATE *img) {
     // Default to (0, 0, 0) granularity in case we can't find the real granularity for the physical device.
     VkExtent3D granularity = {0, 0, 0};
-    auto pPool = GetCommandPoolNode(cb_node->createInfo.commandPool);
+    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
     if (pPool) {
         granularity = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
         if (FormatIsCompressed(img->createInfo.format)) {
@@ -4737,7 +4737,7 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuff
     skip |= ValidateCmd(cb_node, CMD_COPYIMAGETOBUFFER, "vkCmdCopyImageToBuffer()");
 
     // Command pool must support graphics, compute, or transfer operations
-    auto pPool = GetCommandPoolNode(cb_node->createInfo.commandPool);
+    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
 
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
 
@@ -4821,7 +4821,7 @@ bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuff
     skip |= ValidateCmd(cb_node, CMD_COPYBUFFERTOIMAGE, "vkCmdCopyBufferToImage()");
 
     // Command pool must support graphics, compute, or transfer operations
-    auto pPool = GetCommandPoolNode(cb_node->createInfo.commandPool);
+    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1471,7 +1471,7 @@ void CoreChecks::PreCallRecordDestroyImage(VkDevice device, VkImage image, const
     InvalidateCommandBuffers(image_state->cb_bindings, obj_struct);
     // Clean up memory mapping, bindings and range references for image
     for (auto mem_binding : image_state->GetBoundMemory()) {
-        auto mem_info = GetMemObjInfo(mem_binding);
+        auto mem_info = GetDevMemState(mem_binding);
         if (mem_info) {
             RemoveImageMemoryRange(obj_struct.handle, mem_info);
         }
@@ -4404,7 +4404,7 @@ void CoreChecks::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, co
 
     InvalidateCommandBuffers(buffer_state->cb_bindings, obj_struct);
     for (auto mem_binding : buffer_state->GetBoundMemory()) {
-        auto mem_info = GetMemObjInfo(mem_binding);
+        auto mem_info = GetDevMemState(mem_binding);
         if (mem_info) {
             RemoveBufferMemoryRange(HandleToUint64(buffer), mem_info);
         }

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1613,7 +1613,7 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
                                                    const VkImageSubresourceRange *pRanges) {
     bool skip = false;
     // TODO : Verify memory is in VK_IMAGE_STATE_CLEAR state
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
         skip |= ValidateMemoryIsBoundToImage(image_state, "vkCmdClearColorImage()", "VUID-vkCmdClearColorImage-image-00003");
@@ -1639,7 +1639,7 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
 void CoreChecks::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                  const VkClearColorValue *pColor, uint32_t rangeCount,
                                                  const VkImageSubresourceRange *pRanges) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
         AddCommandBufferBindingImage(cb_node, image_state);
@@ -1655,7 +1655,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     bool skip = false;
 
     // TODO : Verify memory is in VK_IMAGE_STATE_CLEAR state
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
         skip |= ValidateMemoryIsBoundToImage(image_state, "vkCmdClearDepthStencilImage()",
@@ -1702,7 +1702,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
 void CoreChecks::PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                         const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
                                                         const VkImageSubresourceRange *pRanges) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
         AddCommandBufferBindingImage(cb_node, image_state);
@@ -2363,7 +2363,7 @@ bool CoreChecks::CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, c
 bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                              const VkImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
     bool skip = false;
@@ -2634,7 +2634,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
 void CoreChecks::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                            VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                            const VkImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -2694,7 +2694,7 @@ bool CoreChecks::ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, u
 bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                     const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                     const VkClearRect *pRects) {
-    CMD_BUFFER_STATE *cb_node = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_node = GetCBState(commandBuffer);
 
     bool skip = false;
     if (cb_node) {
@@ -2821,7 +2821,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 bool CoreChecks::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                 const VkImageResolve *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -2915,7 +2915,7 @@ bool CoreChecks::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, V
 void CoreChecks::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                               const VkImageResolve *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -2927,7 +2927,7 @@ void CoreChecks::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkI
 bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                              const VkImageBlit *pRegions, VkFilter filter) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -3243,7 +3243,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
 void CoreChecks::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                            VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                            const VkImageBlit *pRegions, VkFilter filter) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -4315,7 +4315,7 @@ void CoreChecks::PostCallRecordCreateImageView(VkDevice device, const VkImageVie
 
 bool CoreChecks::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                               uint32_t regionCount, const VkBufferCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
@@ -4339,7 +4339,7 @@ bool CoreChecks::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkB
 
 void CoreChecks::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                             uint32_t regionCount, const VkBufferCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
@@ -4438,7 +4438,7 @@ void CoreChecks::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bu
 
 bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                               VkDeviceSize size, uint32_t data) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto buffer_state = GetBufferState(dstBuffer);
     bool skip = false;
     skip |= ValidateMemoryIsBoundToBuffer(buffer_state, "vkCmdFillBuffer()", "VUID-vkCmdFillBuffer-dstBuffer-00031");
@@ -4455,7 +4455,7 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
 
 void CoreChecks::PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                             VkDeviceSize size, uint32_t data) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto buffer_state = GetBufferState(dstBuffer);
     // Update bindings between buffer and cmd buffer
     AddCommandBufferBindingBuffer(cb_node, buffer_state);
@@ -4727,7 +4727,7 @@ static inline bool ValidateBufferBounds(const debug_report_data *report_data, IM
 
 bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                      VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
@@ -4795,7 +4795,7 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuff
 
 void CoreChecks::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                    VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
@@ -4811,7 +4811,7 @@ void CoreChecks::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer
 bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
                                                      const VkBufferImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_image_state = GetImageState(dstImage);
 
@@ -4875,7 +4875,7 @@ bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuff
 void CoreChecks::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                    VkImageLayout dstImageLayout, uint32_t regionCount,
                                                    const VkBufferImageCopy *pRegions) {
-    auto cb_node = GetCBNode(commandBuffer);
+    auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_image_state = GetImageState(dstImage);
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -161,7 +161,7 @@ void CoreChecks::SetLayout(OBJECT *pObject, ImageSubresourcePair imgpair, const 
 }
 
 // Set the layout in supplied map
-void CoreChecks::SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap,
+void CoreChecks::SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &imageLayoutMap,
                            ImageSubresourcePair imgpair, VkImageLayout layout) {
     auto it = imageLayoutMap.find(imgpair);
     if (it != imageLayoutMap.end()) {
@@ -233,7 +233,7 @@ bool CoreChecks::FindLayouts(VkImage image, std::vector<VkImageLayout> &layouts)
     return true;
 }
 
-bool CoreChecks::FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap,
+bool CoreChecks::FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &imageLayoutMap,
                             ImageSubresourcePair imgpair, VkImageLayout &layout, const VkImageAspectFlags aspectMask) {
     if (!(imgpair.subresource.aspectMask & aspectMask)) {
         return false;
@@ -248,7 +248,7 @@ bool CoreChecks::FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE
 }
 
 // find layout in supplied map
-bool CoreChecks::FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap,
+bool CoreChecks::FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &imageLayoutMap,
                             ImageSubresourcePair imgpair, VkImageLayout &layout) {
     layout = VK_IMAGE_LAYOUT_MAX_ENUM;
     FindLayout(imageLayoutMap, imgpair, layout, VK_IMAGE_ASPECT_COLOR_BIT);
@@ -1440,7 +1440,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage, VkResult result) {
     if (VK_SUCCESS != result) return;
-    IMAGE_LAYOUT_NODE image_state;
+    IMAGE_LAYOUT_STATE image_state;
     image_state.layout = pCreateInfo->initialLayout;
     image_state.format = pCreateInfo->format;
     IMAGE_STATE *is_node = new IMAGE_STATE(*pImage, pCreateInfo);
@@ -3258,9 +3258,9 @@ void CoreChecks::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImag
 }
 
 // This validates that the initial layout specified in the command buffer for the IMAGE is the same as the global IMAGE layout
-bool CoreChecks::ValidateCmdBufImageLayouts(CMD_BUFFER_STATE *pCB,
-                                            std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> const &globalImageLayoutMap,
-                                            std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &overlayLayoutMap) {
+bool CoreChecks::ValidateCmdBufImageLayouts(
+    CMD_BUFFER_STATE *pCB, std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> const &globalImageLayoutMap,
+    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &overlayLayoutMap) {
     bool skip = false;
     // Iterate over the layout maps for each referenced image
     for (const auto &layout_map_entry : pCB->image_layout_map) {

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3585,7 +3585,7 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 }
 
 // For any image objects that overlap mapped memory, verify that their layouts are PREINIT or GENERAL
-bool CoreChecks::ValidateMapImageLayouts(VkDevice device, DEVICE_MEM_INFO const *mem_info, VkDeviceSize offset,
+bool CoreChecks::ValidateMapImageLayouts(VkDevice device, DEVICE_MEMORY_STATE const *mem_info, VkDeviceSize offset,
                                          VkDeviceSize end_offset) {
     bool skip = false;
     // Iterate over all bound image ranges and verify that for any that overlap the map ranges, the layouts are

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -39,10 +39,10 @@ uint32_t ResolveRemainingLevels(const VkImageSubresourceRange *range, uint32_t m
 uint32_t ResolveRemainingLayers(const VkImageSubresourceRange *range, uint32_t layers);
 VkImageSubresourceRange NormalizeSubresourceRange(const IMAGE_STATE &image_state, const VkImageSubresourceRange &range);
 
-bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap, ImageSubresourcePair imgpair,
+bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &imageLayoutMap, ImageSubresourcePair imgpair,
                 VkImageLayout &layout, const VkImageAspectFlags aspectMask);
 
-void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap, ImageSubresourcePair imgpair,
+void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> &imageLayoutMap, ImageSubresourcePair imgpair,
                VkImageLayout layout);
 
 #endif  // CORE_VALIDATION_BUFFER_VALIDATION_H_

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -748,7 +748,7 @@ std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorS
     return it->second;
 }
 
-PIPELINE_LAYOUT_NODE const *CoreChecks::GetPipelineLayout(VkPipelineLayout pipeLayout) {
+PIPELINE_LAYOUT_STATE const *CoreChecks::GetPipelineLayout(VkPipelineLayout pipeLayout) {
     auto it = pipelineLayoutMap.find(pipeLayout);
     if (it == pipelineLayoutMap.end()) {
         return nullptr;
@@ -1196,7 +1196,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(LAST_BOUND_STATE const &state, co
 // For given cvdescriptorset::DescriptorSet, verify that its Set is compatible w/ the setLayout corresponding to
 // pipelineLayout[layoutIndex]
 static bool VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorSet *descriptor_set,
-                                         PIPELINE_LAYOUT_NODE const *pipeline_layout, const uint32_t layoutIndex,
+                                         PIPELINE_LAYOUT_STATE const *pipeline_layout, const uint32_t layoutIndex,
                                          string &errorMsg) {
     auto num_sets = pipeline_layout->set_layouts.size();
     if (layoutIndex >= num_sets) {
@@ -6008,7 +6008,7 @@ void CoreChecks::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPip
     }
     if (VK_SUCCESS != result) return;
 
-    PIPELINE_LAYOUT_NODE &plNode = pipelineLayoutMap[*pPipelineLayout];
+    PIPELINE_LAYOUT_STATE &plNode = pipelineLayoutMap[*pPipelineLayout];
     plNode.layout = *pPipelineLayout;
     plNode.set_layouts.resize(pCreateInfo->setLayoutCount);
     PipelineLayoutSetLayoutsDef set_layouts(pCreateInfo->setLayoutCount);
@@ -6795,7 +6795,7 @@ void CoreChecks::PreCallRecordCmdSetStencilReference(VkCommandBuffer commandBuff
 
 // Update pipeline_layout bind points applying the "Pipeline Layout Compatibility" rules
 void CoreChecks::UpdateLastBoundDescriptorSets(CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint pipeline_bind_point,
-                                               const PIPELINE_LAYOUT_NODE *pipeline_layout, uint32_t first_set, uint32_t set_count,
+                                               const PIPELINE_LAYOUT_STATE *pipeline_layout, uint32_t first_set, uint32_t set_count,
                                                const std::vector<cvdescriptorset::DescriptorSet *> descriptor_sets,
                                                uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets) {
     // Defensive
@@ -12560,8 +12560,8 @@ void CoreChecks::PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device
     RecordUpdateDescriptorSetWithTemplateState(descriptorSet, descriptorUpdateTemplate, pData);
 }
 
-static std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> GetDslFromPipelineLayout(PIPELINE_LAYOUT_NODE const *layout_data,
-                                                                                            uint32_t set) {
+static std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> GetDslFromPipelineLayout(
+    PIPELINE_LAYOUT_STATE const *layout_data, uint32_t set) {
     std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> dsl = nullptr;
     if (layout_data && (set < layout_data->set_layouts.size())) {
         dsl = layout_data->set_layouts[set];

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -199,7 +199,7 @@ EVENT_STATE *CoreChecks::GetEventNode(VkEvent event) {
     return &it->second;
 }
 
-QUERY_POOL_NODE *CoreChecks::GetQueryPoolNode(VkQueryPool query_pool) {
+QUERY_POOL_STATE *CoreChecks::GetQueryPoolNode(VkQueryPool query_pool) {
     auto it = queryPoolMap.find(query_pool);
     if (it == queryPoolMap.end()) {
         return nullptr;
@@ -4200,7 +4200,7 @@ void CoreChecks::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const
 
 bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks *pAllocator) {
     if (disabled.query_validation) return false;
-    QUERY_POOL_NODE *qp_state = GetQueryPoolNode(queryPool);
+    QUERY_POOL_STATE *qp_state = GetQueryPoolNode(queryPool);
     VK_OBJECT obj_struct = {HandleToUint64(queryPool), kVulkanObjectTypeQueryPool};
     bool skip = false;
     if (qp_state) {
@@ -4211,7 +4211,7 @@ bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool qu
 
 void CoreChecks::PreCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks *pAllocator) {
     if (!queryPool) return;
-    QUERY_POOL_NODE *qp_state = GetQueryPoolNode(queryPool);
+    QUERY_POOL_STATE *qp_state = GetQueryPoolNode(queryPool);
     VK_OBJECT obj_struct = {HandleToUint64(queryPool), kVulkanObjectTypeQueryPool};
     InvalidateCommandBuffers(qp_state->cb_bindings, obj_struct);
     queryPoolMap.erase(queryPool);
@@ -4906,7 +4906,7 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
 void CoreChecks::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool, VkResult result) {
     if (VK_SUCCESS != result) return;
-    QUERY_POOL_NODE *qp_node = &queryPoolMap[*pQueryPool];
+    QUERY_POOL_STATE *qp_node = &queryPoolMap[*pQueryPool];
     qp_node->createInfo = *pCreateInfo;
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -756,7 +756,7 @@ PIPELINE_LAYOUT_NODE const *CoreChecks::GetPipelineLayout(VkPipelineLayout pipeL
     return &it->second;
 }
 
-shader_module const *CoreChecks::GetShaderModuleState(VkShaderModule module) {
+SHADER_MODULE_STATE const *CoreChecks::GetShaderModuleState(VkShaderModule module) {
     auto it = shaderModuleMap.find(module);
     if (it == shaderModuleMap.end()) {
         return nullptr;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3255,7 +3255,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
     unordered_set<VkSemaphore> unsignaled_semaphores;
     unordered_set<VkSemaphore> internal_semaphores;
     vector<VkCommandBuffer> current_cmds;
-    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> localImageLayoutMap;
+    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> localImageLayoutMap;
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
@@ -11626,7 +11626,7 @@ void CoreChecks::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchai
         for (uint32_t i = 0; i < *pSwapchainImageCount; ++i) {
             if (swapchain_state->images[i] != VK_NULL_HANDLE) continue;  // Already retrieved this.
 
-            IMAGE_LAYOUT_NODE image_layout_node;
+            IMAGE_LAYOUT_STATE image_layout_node;
             image_layout_node.layout = VK_IMAGE_LAYOUT_UNDEFINED;
             image_layout_node.format = swapchain_state->createInfo.imageFormat;
             // Add imageMap entries for each swapchain image

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -61,7 +61,7 @@ class FENCE_STATE {
     FENCE_STATE() : state(FENCE_UNSIGNALED), scope(kSyncScopeInternal) {}
 };
 
-class SEMAPHORE_NODE : public BASE_NODE {
+class SEMAPHORE_STATE : public BASE_NODE {
    public:
     std::pair<VkQueue, uint64_t> signaler;
     bool signaled;
@@ -190,7 +190,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
     unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;
-    unordered_map<VkSemaphore, SEMAPHORE_NODE> semaphoreMap;
+    unordered_map<VkSemaphore, SEMAPHORE_STATE> semaphoreMap;
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> imageLayoutMap;
     unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
 
@@ -258,7 +258,7 @@ class CoreChecks : public ValidationObject {
     EVENT_STATE* GetEventNode(VkEvent event);
     QUERY_POOL_STATE* GetQueryPoolNode(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);
-    SEMAPHORE_NODE* GetSemaphoreNode(VkSemaphore semaphore);
+    SEMAPHORE_STATE* GetSemaphoreNode(VkSemaphore semaphore);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(VkPhysicalDevice phys);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState();
     SURFACE_STATE* GetSurfaceState(VkSurfaceKHR surface);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -185,7 +185,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
 
     unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;
-    unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
+    unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_STATE> pipelineLayoutMap;
     unordered_map<VkFence, FENCE_NODE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
@@ -279,7 +279,7 @@ class CoreChecks : public ValidationObject {
     bool ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset, const char* api_name);
     void RecordGetBufferMemoryRequirementsState(VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
     void UpdateBindBufferMemoryState(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
-    PIPELINE_LAYOUT_NODE const* GetPipelineLayout(VkPipelineLayout pipeLayout);
+    PIPELINE_LAYOUT_STATE const* GetPipelineLayout(VkPipelineLayout pipeLayout);
     const TEMPLATE_STATE* GetDescriptorTemplateState(VkDescriptorUpdateTemplateKHR descriptor_update_template);
     bool ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2* pInfo);
     void RecordGetImageMemoryRequiementsState(VkImage image, VkMemoryRequirements* pMemoryRequirements);
@@ -355,7 +355,7 @@ class CoreChecks : public ValidationObject {
                                          uint32_t set, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites);
     void UpdateLastBoundDescriptorSets(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint pipeline_bind_point,
-                                       const PIPELINE_LAYOUT_NODE* pipeline_layout, uint32_t first_set, uint32_t set_count,
+                                       const PIPELINE_LAYOUT_STATE* pipeline_layout, uint32_t first_set, uint32_t set_count,
                                        const std::vector<cvdescriptorset::DescriptorSet*> descriptor_sets,
                                        uint32_t dynamic_offset_count, const uint32_t* p_dynamic_offsets);
     bool ValidatePipelineBindPoint(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point, const char* func_name,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -255,8 +255,8 @@ class CoreChecks : public ValidationObject {
     COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_STATE* GetFenceState(VkFence fence);
-    EVENT_STATE* GetEventNode(VkEvent event);
-    QUERY_POOL_STATE* GetQueryPoolNode(VkQueryPool query_pool);
+    EVENT_STATE* GetEventState(VkEvent event);
+    QUERY_POOL_STATE* GetQueryPoolState(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);
     SEMAPHORE_STATE* GetSemaphoreNode(VkSemaphore semaphore);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(VkPhysicalDevice phys);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -47,18 +47,18 @@ enum SyncScope {
     kSyncScopeExternalPermanent,
 };
 
-enum FENCE_STATE { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
+enum FENCE_STATUS { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
 
-class FENCE_NODE {
+class FENCE_STATE {
    public:
     VkFence fence;
     VkFenceCreateInfo createInfo;
     std::pair<VkQueue, uint64_t> signaler;
-    FENCE_STATE state;
+    FENCE_STATUS state;
     SyncScope scope;
 
     // Default constructor
-    FENCE_NODE() : state(FENCE_UNSIGNALED), scope(kSyncScopeInternal) {}
+    FENCE_STATE() : state(FENCE_UNSIGNALED), scope(kSyncScopeInternal) {}
 };
 
 class SEMAPHORE_NODE : public BASE_NODE {
@@ -186,7 +186,7 @@ class CoreChecks : public ValidationObject {
 
     unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_STATE> pipelineLayoutMap;
-    unordered_map<VkFence, FENCE_NODE> fenceMap;
+    unordered_map<VkFence, FENCE_STATE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
     unordered_map<VkQueryPool, QUERY_POOL_NODE> queryPoolMap;
@@ -254,7 +254,7 @@ class CoreChecks : public ValidationObject {
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
     COMMAND_POOL_STATE* GetCommandPoolNode(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
-    FENCE_NODE* GetFenceNode(VkFence fence);
+    FENCE_STATE* GetFenceNode(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);
     QUERY_POOL_NODE* GetQueryPoolNode(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);
@@ -300,7 +300,7 @@ class CoreChecks : public ValidationObject {
     void DeletePools();
     bool ValidImageBufferQueue(CMD_BUFFER_STATE* cb_node, const VK_OBJECT* object, VkQueue queue, uint32_t count,
                                const uint32_t* indices);
-    bool ValidateFenceForSubmit(FENCE_NODE* pFence);
+    bool ValidateFenceForSubmit(FENCE_STATE* pFence);
     void AddMemObjInfo(void* object, const VkDeviceMemory mem, const VkMemoryAllocateInfo* pAllocateInfo);
     bool ValidateStatus(CMD_BUFFER_STATE* pNode, CBStatusFlags status_mask, VkFlags msg_flags, const char* fail_msg,
                         const char* msg_code);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -182,7 +182,7 @@ class CoreChecks : public ValidationObject {
 
     unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE*> descriptorPoolMap;
     unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
-    unordered_map<VkCommandBuffer, GLOBAL_CB_NODE*> commandBufferMap;
+    unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
 
     unordered_map<VkCommandPool, COMMAND_POOL_NODE> commandPoolMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
@@ -247,7 +247,7 @@ class CoreChecks : public ValidationObject {
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView);
     SWAPCHAIN_NODE* GetSwapchainNode(VkSwapchainKHR);
-    GLOBAL_CB_NODE* GetCBNode(const VkCommandBuffer cb);
+    CMD_BUFFER_STATE* GetCBNode(const VkCommandBuffer cb);
     PIPELINE_STATE* GetPipelineState(VkPipeline pipeline);
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
@@ -265,7 +265,7 @@ class CoreChecks : public ValidationObject {
     BINDABLE* GetObjectMemBinding(uint64_t handle, VulkanObjectType type);
 
     bool VerifyQueueStateToSeq(QUEUE_STATE* initial_queue, uint64_t initial_seq);
-    void ClearCmdBufAndMemReferences(GLOBAL_CB_NODE* cb_node);
+    void ClearCmdBufAndMemReferences(CMD_BUFFER_STATE* cb_node);
     void ClearMemoryObjectBinding(uint64_t handle, VulkanObjectType type, VkDeviceMemory mem);
     void ResetCommandBufferState(const VkCommandBuffer cb);
     void SetMemBinding(VkDeviceMemory mem, BINDABLE* mem_binding, VkDeviceSize memory_offset, uint64_t handle,
@@ -275,7 +275,7 @@ class CoreChecks : public ValidationObject {
     bool ValidateDeviceQueueFamily(uint32_t queue_family, const char* cmd_name, const char* parameter_name, const char* error_code,
                                    bool optional);
     BASE_NODE* GetStateStructPtrFromObject(VK_OBJECT object_struct);
-    void RemoveCommandBufferBinding(VK_OBJECT const* object, GLOBAL_CB_NODE* cb_node);
+    void RemoveCommandBufferBinding(VK_OBJECT const* object, CMD_BUFFER_STATE* cb_node);
     bool ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset, const char* api_name);
     void RecordGetBufferMemoryRequirementsState(VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
     void UpdateBindBufferMemoryState(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
@@ -286,9 +286,9 @@ class CoreChecks : public ValidationObject {
     void FreeCommandBufferStates(COMMAND_POOL_NODE* pool_state, const uint32_t command_buffer_count,
                                  const VkCommandBuffer* command_buffers);
     bool CheckCommandBuffersInFlight(COMMAND_POOL_NODE* pPool, const char* action, const char* error_code);
-    bool CheckCommandBufferInFlight(const GLOBAL_CB_NODE* cb_node, const char* action, const char* error_code);
+    bool CheckCommandBufferInFlight(const CMD_BUFFER_STATE* cb_node, const char* action, const char* error_code);
     bool VerifyQueueStateToFence(VkFence fence);
-    void DecrementBoundResources(GLOBAL_CB_NODE const* cb_node);
+    void DecrementBoundResources(CMD_BUFFER_STATE const* cb_node);
     bool VerifyWaitFenceState(VkFence fence, const char* apiCall);
     void RetireFence(VkFence fence);
     void StoreMemRanges(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size);
@@ -298,13 +298,13 @@ class CoreChecks : public ValidationObject {
     bool ValidatePipelineUnlocked(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex);
     void FreeDescriptorSet(cvdescriptorset::DescriptorSet* descriptor_set);
     void DeletePools();
-    bool ValidImageBufferQueue(GLOBAL_CB_NODE* cb_node, const VK_OBJECT* object, VkQueue queue, uint32_t count,
+    bool ValidImageBufferQueue(CMD_BUFFER_STATE* cb_node, const VK_OBJECT* object, VkQueue queue, uint32_t count,
                                const uint32_t* indices);
     bool ValidateFenceForSubmit(FENCE_NODE* pFence);
     void AddMemObjInfo(void* object, const VkDeviceMemory mem, const VkMemoryAllocateInfo* pAllocateInfo);
-    bool ValidateStatus(GLOBAL_CB_NODE* pNode, CBStatusFlags status_mask, VkFlags msg_flags, const char* fail_msg,
+    bool ValidateStatus(CMD_BUFFER_STATE* pNode, CBStatusFlags status_mask, VkFlags msg_flags, const char* fail_msg,
                         const char* msg_code);
-    bool ValidateDrawStateFlags(GLOBAL_CB_NODE* pCB, const PIPELINE_STATE* pPipe, bool indexed, const char* msg_code);
+    bool ValidateDrawStateFlags(CMD_BUFFER_STATE* pCB, const PIPELINE_STATE* pPipe, bool indexed, const char* msg_code);
     bool LogInvalidAttachmentMessage(const char* type1_string, const RENDER_PASS_STATE* rp1_state, const char* type2_string,
                                      const RENDER_PASS_STATE* rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                      const char* msg, const char* caller, const char* error_code);
@@ -322,8 +322,8 @@ class CoreChecks : public ValidationObject {
                                       const char* error_code);
     bool ValidateRenderPassCompatibility(const char* type1_string, const RENDER_PASS_STATE* rp1_state, const char* type2_string,
                                          const RENDER_PASS_STATE* rp2_state, const char* caller, const char* error_code);
-    void UpdateDrawState(GLOBAL_CB_NODE* cb_state, const VkPipelineBindPoint bind_point);
-    bool ReportInvalidCommandBuffer(const GLOBAL_CB_NODE* cb_state, const char* call_source);
+    void UpdateDrawState(CMD_BUFFER_STATE* cb_state, const VkPipelineBindPoint bind_point);
+    bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE* cb_state, const char* call_source);
     void InitGpuValidation();
     bool ValidatePhysicalDeviceQueueFamily(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family,
                                            const char* err_code, const char* cmd_name, const char* queue_family_var_name);
@@ -332,8 +332,8 @@ class CoreChecks : public ValidationObject {
 
     bool ValidatePipelineVertexDivisors(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis);
-    void AddFramebufferBinding(GLOBAL_CB_NODE* cb_state, FRAMEBUFFER_STATE* fb_state);
-    bool ValidateImageBarrierImage(const char* funcName, GLOBAL_CB_NODE const* cb_state, VkFramebuffer framebuffer,
+    void AddFramebufferBinding(CMD_BUFFER_STATE* cb_state, FRAMEBUFFER_STATE* fb_state);
+    bool ValidateImageBarrierImage(const char* funcName, CMD_BUFFER_STATE const* cb_state, VkFramebuffer framebuffer,
                                    uint32_t active_subpass, const safe_VkSubpassDescription2KHR& sub_desc, uint64_t rp_handle,
                                    uint32_t img_index, const VkImageMemoryBarrier& img_barrier);
     void RecordCmdBeginRenderPassState(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
@@ -341,45 +341,45 @@ class CoreChecks : public ValidationObject {
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, RenderPassCreateVersion rp_version,
                                     const VkRenderPassBeginInfo* pRenderPassBegin);
     bool ValidateDependencies(FRAMEBUFFER_STATE const* framebuffer, RENDER_PASS_STATE const* renderPass);
-    bool ValidateBarriers(const char* funcName, GLOBAL_CB_NODE* cb_state, VkPipelineStageFlags src_stage_mask,
+    bool ValidateBarriers(const char* funcName, CMD_BUFFER_STATE* cb_state, VkPipelineStageFlags src_stage_mask,
                           VkPipelineStageFlags dst_stage_mask, uint32_t memBarrierCount, const VkMemoryBarrier* pMemBarriers,
                           uint32_t bufferBarrierCount, const VkBufferMemoryBarrier* pBufferMemBarriers,
                           uint32_t imageMemBarrierCount, const VkImageMemoryBarrier* pImageMemBarriers);
-    bool ValidateBarrierQueueFamilies(const char* func_name, GLOBAL_CB_NODE* cb_state, const VkImageMemoryBarrier* barrier,
+    bool ValidateBarrierQueueFamilies(const char* func_name, CMD_BUFFER_STATE* cb_state, const VkImageMemoryBarrier* barrier,
                                       const IMAGE_STATE* state_data);
-    bool ValidateBarrierQueueFamilies(const char* func_name, GLOBAL_CB_NODE* cb_state, const VkBufferMemoryBarrier* barrier,
+    bool ValidateBarrierQueueFamilies(const char* func_name, CMD_BUFFER_STATE* cb_state, const VkBufferMemoryBarrier* barrier,
                                       const BUFFER_STATE* state_data);
     bool ValidateCreateSwapchain(const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo, SURFACE_STATE* surface_state,
                                  SWAPCHAIN_NODE* old_swapchain_state);
-    void RecordCmdPushDescriptorSetState(GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
+    void RecordCmdPushDescriptorSetState(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                          uint32_t set, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites);
-    void UpdateLastBoundDescriptorSets(GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint pipeline_bind_point,
+    void UpdateLastBoundDescriptorSets(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint pipeline_bind_point,
                                        const PIPELINE_LAYOUT_NODE* pipeline_layout, uint32_t first_set, uint32_t set_count,
                                        const std::vector<cvdescriptorset::DescriptorSet*> descriptor_sets,
                                        uint32_t dynamic_offset_count, const uint32_t* p_dynamic_offsets);
-    bool ValidatePipelineBindPoint(GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint bind_point, const char* func_name,
+    bool ValidatePipelineBindPoint(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point, const char* func_name,
                                    const std::map<VkPipelineBindPoint, std::string>& bind_errors);
     bool ValidateMemoryIsMapped(const char* funcName, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
     bool ValidateAndCopyNoncoherentMemoryToDriver(uint32_t mem_range_count, const VkMappedMemoryRange* mem_ranges);
     void CopyNoncoherentMemoryFromDriver(uint32_t mem_range_count, const VkMappedMemoryRange* mem_ranges);
     bool ValidateMappedMemoryRangeDeviceLimits(const char* func_name, uint32_t mem_range_count,
                                                const VkMappedMemoryRange* mem_ranges);
-    BarrierOperationsType ComputeBarrierOperationsType(GLOBAL_CB_NODE* cb_state, uint32_t buffer_barrier_count,
+    BarrierOperationsType ComputeBarrierOperationsType(CMD_BUFFER_STATE* cb_state, uint32_t buffer_barrier_count,
                                                        const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
                                                        const VkImageMemoryBarrier* image_barriers);
-    bool ValidateStageMasksAgainstQueueCapabilities(GLOBAL_CB_NODE const* cb_state, VkPipelineStageFlags source_stage_mask,
+    bool ValidateStageMasksAgainstQueueCapabilities(CMD_BUFFER_STATE const* cb_state, VkPipelineStageFlags source_stage_mask,
                                                     VkPipelineStageFlags dest_stage_mask, BarrierOperationsType barrier_op_type,
                                                     const char* function, const char* error_code);
     bool SetEventStageMask(VkQueue queue, VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
-    bool ValidateRenderPassImageBarriers(const char* funcName, GLOBAL_CB_NODE* cb_state, uint32_t active_subpass,
+    bool ValidateRenderPassImageBarriers(const char* funcName, CMD_BUFFER_STATE* cb_state, uint32_t active_subpass,
                                          const safe_VkSubpassDescription2KHR& sub_desc, uint64_t rp_handle,
                                          const safe_VkSubpassDependency2KHR* dependencies,
                                          const std::vector<uint32_t>& self_dependencies, uint32_t image_mem_barrier_count,
                                          const VkImageMemoryBarrier* image_barriers);
-    bool ValidateSecondaryCommandBufferState(GLOBAL_CB_NODE* pCB, GLOBAL_CB_NODE* pSubCB);
-    bool ValidateFramebuffer(VkCommandBuffer primaryBuffer, const GLOBAL_CB_NODE* pCB, VkCommandBuffer secondaryBuffer,
-                             const GLOBAL_CB_NODE* pSubCB, const char* caller);
+    bool ValidateSecondaryCommandBufferState(CMD_BUFFER_STATE* pCB, CMD_BUFFER_STATE* pSubCB);
+    bool ValidateFramebuffer(VkCommandBuffer primaryBuffer, const CMD_BUFFER_STATE* pCB, VkCommandBuffer secondaryBuffer,
+                             const CMD_BUFFER_STATE* pSubCB, const char* caller);
     bool ValidateDescriptorUpdateTemplate(const char* func_name, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo);
     bool ValidateCreateSamplerYcbcrConversion(const char* func_name, const VkSamplerYcbcrConversionCreateInfo* create_info);
     void RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo* create_info,
@@ -392,7 +392,7 @@ class CoreChecks : public ValidationObject {
     void RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
                                      VkFence fence, uint32_t* pImageIndex);
     bool VerifyRenderAreaBounds(const VkRenderPassBeginInfo* pRenderPassBegin);
-    bool ValidatePrimaryCommandBuffer(const GLOBAL_CB_NODE* pCB, char const* cmd_name, const char* error_code);
+    bool ValidatePrimaryCommandBuffer(const CMD_BUFFER_STATE* pCB, char const* cmd_name, const char* error_code);
     void RecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents);
     bool ValidateCmdEndRenderPass(RenderPassCreateVersion rp_version, VkCommandBuffer commandBuffer);
     void RecordCmdEndRenderPassState(VkCommandBuffer commandBuffer);
@@ -409,7 +409,7 @@ class CoreChecks : public ValidationObject {
                                                             void* pProperties);
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                  const char* api_name);
-    bool ValidateQuery(VkQueue queue, GLOBAL_CB_NODE* pCB, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);
+    bool ValidateQuery(VkQueue queue, CMD_BUFFER_STATE* pCB, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);
     bool IsQueryInvalid(QUEUE_STATE* queue_data, VkQueryPool queryPool, uint32_t queryIndex);
     bool ValidateImportSemaphore(VkSemaphore semaphore, const char* caller_name);
     void RecordImportSemaphoreState(VkSemaphore semaphore, VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type,
@@ -419,8 +419,8 @@ class CoreChecks : public ValidationObject {
     bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, VkPipelineBindPoint bind_point, CMD_TYPE cmd_type,
                              const char* caller, VkQueueFlags queue_flags, const char* queue_flag_code,
                              const char* renderpass_msg_code, const char* pipebound_msg_code, const char* dynamic_state_msg_code);
-    void UpdateStateCmdDrawDispatchType(GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint bind_point);
-    void UpdateStateCmdDrawType(GLOBAL_CB_NODE* cb_state, VkPipelineBindPoint bind_point);
+    void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
+    void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     bool ValidateCmdNextSubpass(RenderPassCreateVersion rp_version, VkCommandBuffer commandBuffer);
     bool RangesIntersect(MEMORY_RANGE const* range1, VkDeviceSize offset, VkDeviceSize end);
     bool RangesIntersect(MEMORY_RANGE const* range1, MEMORY_RANGE const* range2, bool* skip, bool skip_checks);
@@ -445,8 +445,9 @@ class CoreChecks : public ValidationObject {
                              const char* msgCode);
     void RecordCreateDescriptorUpdateTemplateState(const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
                                                    VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
-    bool ValidateCommandBufferState(GLOBAL_CB_NODE* cb_state, const char* call_source, int current_submit_count, const char* vu_id);
-    bool ValidateCommandBufferSimultaneousUse(GLOBAL_CB_NODE* pCB, int current_submit_count);
+    bool ValidateCommandBufferState(CMD_BUFFER_STATE* cb_state, const char* call_source, int current_submit_count,
+                                    const char* vu_id);
+    bool ValidateCommandBufferSimultaneousUse(CMD_BUFFER_STATE* pCB, int current_submit_count);
     bool ValidateGetDeviceQueue(uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue, const char* valid_qfi_vuid,
                                 const char* qfi_in_range_vuid);
     void RecordGetDeviceQueueState(uint32_t queue_family_index, VkQueue queue);
@@ -458,7 +459,7 @@ class CoreChecks : public ValidationObject {
                                  const char* type);
     bool ValidateCreateRenderPass(VkDevice device, RenderPassCreateVersion rp_version,
                                   const VkRenderPassCreateInfo2KHR* pCreateInfo, RENDER_PASS_STATE* render_pass);
-    bool ValidateRenderPassPipelineBarriers(const char* funcName, GLOBAL_CB_NODE* cb_state, VkPipelineStageFlags src_stage_mask,
+    bool ValidateRenderPassPipelineBarriers(const char* funcName, CMD_BUFFER_STATE* cb_state, VkPipelineStageFlags src_stage_mask,
                                             VkPipelineStageFlags dst_stage_mask, VkDependencyFlags dependency_flags,
                                             uint32_t mem_barrier_count, const VkMemoryBarrier* mem_barriers,
                                             uint32_t buffer_mem_barrier_count, const VkBufferMemoryBarrier* buffer_mem_barriers,
@@ -471,35 +472,36 @@ class CoreChecks : public ValidationObject {
                                                  VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
     bool ValidateMemoryIsBoundToBuffer(const BUFFER_STATE*, const char*, const char*);
     bool ValidateMemoryIsBoundToImage(const IMAGE_STATE*, const char*, const char*);
-    void AddCommandBufferBindingSampler(GLOBAL_CB_NODE*, SAMPLER_STATE*);
-    void AddCommandBufferBindingImage(GLOBAL_CB_NODE*, IMAGE_STATE*);
-    void AddCommandBufferBindingImageView(GLOBAL_CB_NODE*, IMAGE_VIEW_STATE*);
-    void AddCommandBufferBindingBuffer(GLOBAL_CB_NODE*, BUFFER_STATE*);
-    void AddCommandBufferBindingBufferView(GLOBAL_CB_NODE*, BUFFER_VIEW_STATE*);
+    void AddCommandBufferBindingSampler(CMD_BUFFER_STATE*, SAMPLER_STATE*);
+    void AddCommandBufferBindingImage(CMD_BUFFER_STATE*, IMAGE_STATE*);
+    void AddCommandBufferBindingImageView(CMD_BUFFER_STATE*, IMAGE_VIEW_STATE*);
+    void AddCommandBufferBindingBuffer(CMD_BUFFER_STATE*, BUFFER_STATE*);
+    void AddCommandBufferBindingBufferView(CMD_BUFFER_STATE*, BUFFER_VIEW_STATE*);
     bool ValidateObjectNotInUse(BASE_NODE* obj_node, VK_OBJECT obj_struct, const char* caller_name, const char* error_code);
-    void InvalidateCommandBuffers(std::unordered_set<GLOBAL_CB_NODE*> const& cb_nodes, VK_OBJECT obj);
+    void InvalidateCommandBuffers(std::unordered_set<CMD_BUFFER_STATE*> const& cb_nodes, VK_OBJECT obj);
     void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
     void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
     void ClearMemoryObjectBindings(uint64_t handle, VulkanObjectType type);
-    bool ValidateCmdQueueFlags(const GLOBAL_CB_NODE* cb_node, const char* caller_name, VkQueueFlags flags, const char* error_code);
-    bool InsideRenderPass(const GLOBAL_CB_NODE* pCB, const char* apiName, const char* msgCode);
-    bool OutsideRenderPass(GLOBAL_CB_NODE* pCB, const char* apiName, const char* msgCode);
+    bool ValidateCmdQueueFlags(const CMD_BUFFER_STATE* cb_node, const char* caller_name, VkQueueFlags flags,
+                               const char* error_code);
+    bool InsideRenderPass(const CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode);
+    bool OutsideRenderPass(CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode);
 
     void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& imageLayoutMap, ImageSubresourcePair imgpair,
                    VkImageLayout layout);
 
     bool ValidateImageSampleCount(IMAGE_STATE* image_state, VkSampleCountFlagBits sample_count, const char* location,
                                   const std::string& msgCode);
-    bool ValidateCmdSubpassState(const GLOBAL_CB_NODE* pCB, const CMD_TYPE cmd_type);
-    bool ValidateCmd(const GLOBAL_CB_NODE* cb_state, const CMD_TYPE cmd, const char* caller_name);
+    bool ValidateCmdSubpassState(const CMD_BUFFER_STATE* pCB, const CMD_TYPE cmd_type);
+    bool ValidateCmd(const CMD_BUFFER_STATE* cb_state, const CMD_TYPE cmd, const char* caller_name);
 
     bool ValidateDeviceMaskToPhysicalDeviceCount(uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type,
                                                  uint64_t VUID_handle, const char* VUID);
     bool ValidateDeviceMaskToZero(uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type, uint64_t VUID_handle,
                                   const char* VUID);
-    bool ValidateDeviceMaskToCommandBuffer(GLOBAL_CB_NODE* pCB, uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type,
+    bool ValidateDeviceMaskToCommandBuffer(CMD_BUFFER_STATE* pCB, uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type,
                                            uint64_t VUID_handle, const char* VUID);
-    bool ValidateDeviceMaskToRenderPass(GLOBAL_CB_NODE* pCB, uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type,
+    bool ValidateDeviceMaskToRenderPass(CMD_BUFFER_STATE* pCB, uint32_t deviceMask, VkDebugReportObjectTypeEXT VUID_handle_type,
                                         uint64_t VUID_handle, const char* VUID);
 
     // Prototypes for CoreChecks accessor functions
@@ -513,41 +515,42 @@ class CoreChecks : public ValidationObject {
     GlobalQFOTransferBarrierMap<VkBufferMemoryBarrier>& GetGlobalQFOReleaseBarrierMap(
         const QFOTransferBarrier<VkBufferMemoryBarrier>::Tag& type_tag);
     template <typename Barrier>
-    void RecordQueuedQFOTransferBarriers(GLOBAL_CB_NODE* cb_state);
+    void RecordQueuedQFOTransferBarriers(CMD_BUFFER_STATE* cb_state);
     template <typename Barrier>
-    bool ValidateQueuedQFOTransferBarriers(GLOBAL_CB_NODE* cb_state, QFOTransferCBScoreboards<Barrier>* scoreboards);
-    bool ValidateQueuedQFOTransfers(GLOBAL_CB_NODE* cb_state, QFOTransferCBScoreboards<VkImageMemoryBarrier>* qfo_image_scoreboards,
+    bool ValidateQueuedQFOTransferBarriers(CMD_BUFFER_STATE* cb_state, QFOTransferCBScoreboards<Barrier>* scoreboards);
+    bool ValidateQueuedQFOTransfers(CMD_BUFFER_STATE* cb_state,
+                                    QFOTransferCBScoreboards<VkImageMemoryBarrier>* qfo_image_scoreboards,
                                     QFOTransferCBScoreboards<VkBufferMemoryBarrier>* qfo_buffer_scoreboards);
     template <typename BarrierRecord, typename Scoreboard>
-    bool ValidateAndUpdateQFOScoreboard(const debug_report_data* report_data, const GLOBAL_CB_NODE* cb_state, const char* operation,
-                                        const BarrierRecord& barrier, Scoreboard* scoreboard);
+    bool ValidateAndUpdateQFOScoreboard(const debug_report_data* report_data, const CMD_BUFFER_STATE* cb_state,
+                                        const char* operation, const BarrierRecord& barrier, Scoreboard* scoreboard);
     template <typename Barrier>
-    void RecordQFOTransferBarriers(GLOBAL_CB_NODE* cb_state, uint32_t barrier_count, const Barrier* barriers);
-    void RecordBarriersQFOTransfers(GLOBAL_CB_NODE* cb_state, uint32_t bufferBarrierCount,
+    void RecordQFOTransferBarriers(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const Barrier* barriers);
+    void RecordBarriersQFOTransfers(CMD_BUFFER_STATE* cb_state, uint32_t bufferBarrierCount,
                                     const VkBufferMemoryBarrier* pBufferMemBarriers, uint32_t imageMemBarrierCount,
                                     const VkImageMemoryBarrier* pImageMemBarriers);
     template <typename Barrier>
-    bool ValidateQFOTransferBarrierUniqueness(const char* func_name, GLOBAL_CB_NODE* cb_state, uint32_t barrier_count,
+    bool ValidateQFOTransferBarrierUniqueness(const char* func_name, CMD_BUFFER_STATE* cb_state, uint32_t barrier_count,
                                               const Barrier* barriers);
-    bool IsReleaseOp(GLOBAL_CB_NODE* cb_state, VkImageMemoryBarrier const* barrier);
-    bool ValidateBarriersQFOTransferUniqueness(const char* func_name, GLOBAL_CB_NODE* cb_state, uint32_t bufferBarrierCount,
+    bool IsReleaseOp(CMD_BUFFER_STATE* cb_state, VkImageMemoryBarrier const* barrier);
+    bool ValidateBarriersQFOTransferUniqueness(const char* func_name, CMD_BUFFER_STATE* cb_state, uint32_t bufferBarrierCount,
                                                const VkBufferMemoryBarrier* pBufferMemBarriers, uint32_t imageMemBarrierCount,
                                                const VkImageMemoryBarrier* pImageMemBarriers);
-    bool ValidatePrimaryCommandBufferState(GLOBAL_CB_NODE* pCB, int current_submit_count,
+    bool ValidatePrimaryCommandBufferState(CMD_BUFFER_STATE* pCB, int current_submit_count,
                                            QFOTransferCBScoreboards<VkImageMemoryBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<VkBufferMemoryBarrier>* qfo_buffer_scoreboards);
-    bool ValidatePipelineDrawtimeState(LAST_BOUND_STATE const& state, const GLOBAL_CB_NODE* pCB, CMD_TYPE cmd_type,
+    bool ValidatePipelineDrawtimeState(LAST_BOUND_STATE const& state, const CMD_BUFFER_STATE* pCB, CMD_TYPE cmd_type,
                                        PIPELINE_STATE const* pPipeline, const char* caller);
-    bool ValidateCmdBufDrawState(GLOBAL_CB_NODE* cb_node, CMD_TYPE cmd_type, const bool indexed,
+    bool ValidateCmdBufDrawState(CMD_BUFFER_STATE* cb_node, CMD_TYPE cmd_type, const bool indexed,
                                  const VkPipelineBindPoint bind_point, const char* function, const char* pipe_err_code,
                                  const char* state_err_code);
-    void IncrementBoundObjects(GLOBAL_CB_NODE const* cb_node);
-    void IncrementResources(GLOBAL_CB_NODE* cb_node);
-    bool ValidateEventStageMask(VkQueue queue, GLOBAL_CB_NODE* pCB, uint32_t eventCount, size_t firstEventIndex,
+    void IncrementBoundObjects(CMD_BUFFER_STATE const* cb_node);
+    void IncrementResources(CMD_BUFFER_STATE* cb_node);
+    bool ValidateEventStageMask(VkQueue queue, CMD_BUFFER_STATE* pCB, uint32_t eventCount, size_t firstEventIndex,
                                 VkPipelineStageFlags sourceStageMask);
     void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq);
-    bool ValidateResources(GLOBAL_CB_NODE* cb_node);
-    bool ValidateQueueFamilyIndices(GLOBAL_CB_NODE* pCB, VkQueue queue);
+    bool ValidateResources(CMD_BUFFER_STATE* cb_node);
+    bool ValidateQueueFamilyIndices(CMD_BUFFER_STATE* pCB, VkQueue queue);
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);
     void CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
@@ -618,9 +621,9 @@ class CoreChecks : public ValidationObject {
                                                   const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
     void GpuPreCallRecordDestroyPipeline(const VkPipeline pipeline);
     void GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point);
-    void AnalyzeAndReportError(GLOBAL_CB_NODE* cb_node, VkQueue queue, uint32_t draw_index, uint32_t* const debug_output_buffer);
-    void ProcessInstrumentationBuffer(VkQueue queue, GLOBAL_CB_NODE* cb_node);
-    void UpdateInstrumentationBuffer(GLOBAL_CB_NODE* cb_node);
+    void AnalyzeAndReportError(CMD_BUFFER_STATE* cb_node, VkQueue queue, uint32_t draw_index, uint32_t* const debug_output_buffer);
+    void ProcessInstrumentationBuffer(VkQueue queue, CMD_BUFFER_STATE* cb_node);
+    void UpdateInstrumentationBuffer(CMD_BUFFER_STATE* cb_node);
     void SubmitBarrier(VkQueue queue);
     bool GpuInstrumentShader(const VkShaderModuleCreateInfo* pCreateInfo, std::vector<unsigned int>& new_pgm,
                              uint32_t* unique_shader_id);
@@ -641,7 +644,7 @@ class CoreChecks : public ValidationObject {
             GetGlobalQFOReleaseBarrierMap(typename BarrierRecord::Tag());
         global_release_barriers.erase(handle);
     }
-    bool ValidateCopyImageTransferGranularityRequirements(const GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* src_img,
+    bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* src_img,
                                                           const IMAGE_STATE* dst_img, const VkImageCopy* region, const uint32_t i,
                                                           const char* function);
     bool ValidateIdleBuffer(VkBuffer buffer);
@@ -651,10 +654,10 @@ class CoreChecks : public ValidationObject {
                                        const VkImageSubresourceRange& subresourceRange, const char* cmd_name,
                                        const char* param_name, const char* image_layer_count_var_name, const uint64_t image_handle,
                                        SubresourceRangeErrorCodes errorCodes);
-    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state,
+    void SetImageLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state,
                         const VkImageSubresourceRange& image_subresource_range, VkImageLayout layout,
                         VkImageLayout expected_layout = kInvalidLayout);
-    void SetImageLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state,
+    void SetImageLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state,
                         const VkImageSubresourceLayers& image_subresource_layers, VkImageLayout layout);
     bool ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPassCreateVersion rp_version, VkImageLayout layout,
                                                               VkImage image, VkImageView image_view, VkFramebuffer framebuffer,
@@ -684,32 +687,32 @@ class CoreChecks : public ValidationObject {
     bool ValidateImageCopyData(const uint32_t regionCount, const VkImageCopy* ic_regions, const IMAGE_STATE* src_state,
                                const IMAGE_STATE* dst_state);
 
-    bool VerifyClearImageLayout(GLOBAL_CB_NODE* cb_node, IMAGE_STATE* image_state, VkImageSubresourceRange range,
+    bool VerifyClearImageLayout(CMD_BUFFER_STATE* cb_node, IMAGE_STATE* image_state, VkImageSubresourceRange range,
                                 VkImageLayout dest_image_layout, const char* func_name);
 
-    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
+    bool VerifyImageLayout(CMD_BUFFER_STATE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                            VkImageAspectFlags view_aspect, VkImageLayout explicit_layout, VkImageLayout optimal_layout,
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,
                            bool* error);
 
-    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
+    bool VerifyImageLayout(CMD_BUFFER_STATE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
                            const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error) {
         return VerifyImageLayout(cb_node, image_state, range, 0, explicit_layout, optimal_layout, caller, layout_invalid_msg_code,
                                  layout_mismatch_msg_code, error);
     }
 
-    bool VerifyImageLayout(GLOBAL_CB_NODE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceLayers& subLayers,
+    bool VerifyImageLayout(CMD_BUFFER_STATE const* cb_node, IMAGE_STATE* image_state, const VkImageSubresourceLayers& subLayers,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
                            const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error);
 
-    bool CheckItgExtent(const GLOBAL_CB_NODE* cb_node, const VkExtent3D* extent, const VkOffset3D* offset,
+    bool CheckItgExtent(const CMD_BUFFER_STATE* cb_node, const VkExtent3D* extent, const VkOffset3D* offset,
                         const VkExtent3D* granularity, const VkExtent3D* subresource_extent, const VkImageType image_type,
                         const uint32_t i, const char* function, const char* member, const char* vuid);
 
-    bool CheckItgOffset(const GLOBAL_CB_NODE* cb_node, const VkOffset3D* offset, const VkExtent3D* granularity, const uint32_t i,
+    bool CheckItgOffset(const CMD_BUFFER_STATE* cb_node, const VkOffset3D* offset, const VkExtent3D* granularity, const uint32_t i,
                         const char* function, const char* member, const char* vuid);
-    VkExtent3D GetScaledItg(const GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* img);
+    VkExtent3D GetScaledItg(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img);
     bool CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, const IMAGE_STATE* src_image_state,
                                        const IMAGE_STATE* dst_image_state, const VkImageCopy region);
     void RecordRenderPassDAG(RenderPassCreateVersion rp_version, const VkRenderPassCreateInfo2KHR* pCreateInfo,
@@ -717,7 +720,7 @@ class CoreChecks : public ValidationObject {
     void RecordCreateRenderPassState(RenderPassCreateVersion rp_version, std::shared_ptr<RENDER_PASS_STATE>& render_pass,
                                      VkRenderPass* pRenderPass);
 
-    void RecordClearImageLayout(GLOBAL_CB_NODE* cb_node, VkImage image, VkImageSubresourceRange range,
+    void RecordClearImageLayout(CMD_BUFFER_STATE* cb_node, VkImage image, VkImageSubresourceRange range,
                                 VkImageLayout dest_image_layout);
 
     bool PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
@@ -750,46 +753,47 @@ class CoreChecks : public ValidationObject {
 
     void SetGlobalLayout(ImageSubresourcePair imgpair, const VkImageLayout& layout);
 
-    void SetImageViewLayout(GLOBAL_CB_NODE* pCB, VkImageView imageView, const VkImageLayout& layout);
+    void SetImageViewLayout(CMD_BUFFER_STATE* pCB, VkImageView imageView, const VkImageLayout& layout);
 
-    void SetImageViewLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
-    void SetImageViewInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
+    void SetImageViewLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
+    void SetImageViewInitialLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
 
-    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, VkImage image, const VkImageSubresourceRange& range, VkImageLayout layout);
-    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceRange& range,
+    void SetImageInitialLayout(CMD_BUFFER_STATE* cb_node, VkImage image, const VkImageSubresourceRange& range,
                                VkImageLayout layout);
-    void SetImageInitialLayout(GLOBAL_CB_NODE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceLayers& layers,
+    void SetImageInitialLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceRange& range,
+                               VkImageLayout layout);
+    void SetImageInitialLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceLayers& layers,
                                VkImageLayout layout);
 
-    bool VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion rp_version, GLOBAL_CB_NODE* pCB,
+    bool VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion rp_version, CMD_BUFFER_STATE* pCB,
                                                const VkRenderPassBeginInfo* pRenderPassBegin,
                                                const FRAMEBUFFER_STATE* framebuffer_state);
 
-    void TransitionAttachmentRefLayout(GLOBAL_CB_NODE* pCB, FRAMEBUFFER_STATE* pFramebuffer,
+    void TransitionAttachmentRefLayout(CMD_BUFFER_STATE* pCB, FRAMEBUFFER_STATE* pFramebuffer,
                                        const safe_VkAttachmentReference2KHR& ref);
 
-    void TransitionSubpassLayouts(GLOBAL_CB_NODE*, const RENDER_PASS_STATE*, const int, FRAMEBUFFER_STATE*);
+    void TransitionSubpassLayouts(CMD_BUFFER_STATE*, const RENDER_PASS_STATE*, const int, FRAMEBUFFER_STATE*);
 
-    void TransitionBeginRenderPassLayouts(GLOBAL_CB_NODE*, const RENDER_PASS_STATE*, FRAMEBUFFER_STATE*);
+    void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE*, const RENDER_PASS_STATE*, FRAMEBUFFER_STATE*);
 
-    bool ValidateImageAspectLayout(GLOBAL_CB_NODE const* pCB, const VkImageMemoryBarrier* mem_barrier, uint32_t level,
+    bool ValidateImageAspectLayout(CMD_BUFFER_STATE const* pCB, const VkImageMemoryBarrier* mem_barrier, uint32_t level,
                                    uint32_t layer, VkImageAspectFlags aspect);
 
-    void TransitionImageAspectLayout(GLOBAL_CB_NODE* pCB, const VkImageMemoryBarrier* mem_barrier, uint32_t level, uint32_t layer,
+    void TransitionImageAspectLayout(CMD_BUFFER_STATE* pCB, const VkImageMemoryBarrier* mem_barrier, uint32_t level, uint32_t layer,
                                      VkImageAspectFlags aspect_mask, VkImageAspectFlags aspect);
 
     bool ValidateBarrierLayoutToImageUsage(const VkImageMemoryBarrier* img_barrier, bool new_not_old, VkImageUsageFlags usage,
                                            const char* func_name);
 
-    bool ValidateBarriersToImages(GLOBAL_CB_NODE const* cb_state, uint32_t imageMemoryBarrierCount,
+    bool ValidateBarriersToImages(CMD_BUFFER_STATE const* cb_state, uint32_t imageMemoryBarrierCount,
                                   const VkImageMemoryBarrier* pImageMemoryBarriers, const char* func_name);
 
-    void RecordQueuedQFOTransfers(GLOBAL_CB_NODE* pCB);
+    void RecordQueuedQFOTransfers(CMD_BUFFER_STATE* pCB);
     void EraseQFOImageRelaseBarriers(const VkImage& image);
 
-    void TransitionImageLayouts(GLOBAL_CB_NODE* cb_state, uint32_t memBarrierCount, const VkImageMemoryBarrier* pImgMemBarriers);
+    void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t memBarrierCount, const VkImageMemoryBarrier* pImgMemBarriers);
 
-    void TransitionFinalSubpassLayouts(GLOBAL_CB_NODE* pCB, const VkRenderPassBeginInfo* pRenderPassBegin,
+    void TransitionFinalSubpassLayouts(CMD_BUFFER_STATE* pCB, const VkRenderPassBeginInfo* pRenderPassBegin,
                                        FRAMEBUFFER_STATE* framebuffer_state);
 
     bool PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
@@ -815,11 +819,11 @@ class CoreChecks : public ValidationObject {
                                    VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageBlit* pRegions,
                                    VkFilter filter);
 
-    bool ValidateCmdBufImageLayouts(GLOBAL_CB_NODE* pCB,
+    bool ValidateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB,
                                     std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> const& globalImageLayoutMap,
                                     std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& overlayLayoutMap);
 
-    void UpdateCmdBufImageLayouts(GLOBAL_CB_NODE* pCB);
+    void UpdateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB);
 
     bool VerifyBoundMemoryIsValid(VkDeviceMemory mem, uint64_t handle, const char* api_name, const char* type_name,
                                   const char* error_code);
@@ -839,7 +843,7 @@ class CoreChecks : public ValidationObject {
     bool ValidateImageFormatFeatureFlags(IMAGE_STATE const* image_state, VkFormatFeatureFlags desired, char const* func_name,
                                          const char* linear_vuid, const char* optimal_vuid);
 
-    bool ValidateImageSubresourceLayers(const GLOBAL_CB_NODE* cb_node, const VkImageSubresourceLayers* subresource_layers,
+    bool ValidateImageSubresourceLayers(const CMD_BUFFER_STATE* cb_node, const VkImageSubresourceLayers* subresource_layers,
                                         char const* func_name, char const* member, uint32_t i);
 
     bool ValidateBufferUsageFlags(BUFFER_STATE const* buffer_state, VkFlags desired, bool strict, const char* msgCode,
@@ -878,14 +882,14 @@ class CoreChecks : public ValidationObject {
     void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkImageView* pView, VkResult result);
 
-    bool ValidateCopyBufferImageTransferGranularityRequirements(const GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* img,
+    bool ValidateCopyBufferImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img,
                                                                 const VkBufferImageCopy* region, const uint32_t i,
                                                                 const char* function, const char* vuid);
 
-    bool ValidateImageMipLevel(const GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* img, uint32_t mip_level, const uint32_t i,
+    bool ValidateImageMipLevel(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img, uint32_t mip_level, const uint32_t i,
                                const char* function, const char* member, const char* vuid);
 
-    bool ValidateImageArrayLayerRange(const GLOBAL_CB_NODE* cb_node, const IMAGE_STATE* img, const uint32_t base_layer,
+    bool ValidateImageArrayLayerRange(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img, const uint32_t base_layer,
                                       const uint32_t layer_count, const uint32_t i, const char* function, const char* member,
                                       const char* vuid);
 
@@ -1537,7 +1541,7 @@ class CoreChecks : public ValidationObject {
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
     bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* shader);
-    bool ValidateComputeWorkGroupInvocations(GLOBAL_CB_NODE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
+    bool ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
                                              uint32_t groupCountZ);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -258,7 +258,7 @@ class CoreChecks : public ValidationObject {
     EVENT_STATE* GetEventState(VkEvent event);
     QUERY_POOL_STATE* GetQueryPoolState(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);
-    SEMAPHORE_STATE* GetSemaphoreNode(VkSemaphore semaphore);
+    SEMAPHORE_STATE* GetSemaphoreState(VkSemaphore semaphore);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(VkPhysicalDevice phys);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState();
     SURFACE_STATE* GetSurfaceState(VkSurfaceKHR surface);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -191,7 +191,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkEvent, EVENT_STATE> eventMap;
     unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;
     unordered_map<VkSemaphore, SEMAPHORE_STATE> semaphoreMap;
-    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> imageLayoutMap;
+    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> imageLayoutMap;
     unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
 
     unordered_map<VkRenderPass, std::shared_ptr<RENDER_PASS_STATE>> renderPassMap;
@@ -487,7 +487,7 @@ class CoreChecks : public ValidationObject {
     bool InsideRenderPass(const CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode);
     bool OutsideRenderPass(CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode);
 
-    void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& imageLayoutMap, ImageSubresourcePair imgpair,
+    void SetLayout(std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE>& imageLayoutMap, ImageSubresourcePair imgpair,
                    VkImageLayout layout);
 
     bool ValidateImageSampleCount(IMAGE_STATE* image_state, VkSampleCountFlagBits sample_count, const char* location,
@@ -745,11 +745,11 @@ class CoreChecks : public ValidationObject {
 
     bool FindLayouts(VkImage image, std::vector<VkImageLayout>& layouts);
 
-    bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& imageLayoutMap, ImageSubresourcePair imgpair,
-                    VkImageLayout& layout);
+    bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE>& imageLayoutMap,
+                    ImageSubresourcePair imgpair, VkImageLayout& layout);
 
-    bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& imageLayoutMap, ImageSubresourcePair imgpair,
-                    VkImageLayout& layout, const VkImageAspectFlags aspectMask);
+    bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE>& imageLayoutMap,
+                    ImageSubresourcePair imgpair, VkImageLayout& layout, const VkImageAspectFlags aspectMask);
 
     void SetGlobalLayout(ImageSubresourcePair imgpair, const VkImageLayout& layout);
 
@@ -820,8 +820,8 @@ class CoreChecks : public ValidationObject {
                                    VkFilter filter);
 
     bool ValidateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB,
-                                    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> const& globalImageLayoutMap,
-                                    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE>& overlayLayoutMap);
+                                    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> const& globalImageLayoutMap,
+                                    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE>& overlayLayoutMap);
 
     void UpdateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB);
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -168,33 +168,38 @@ struct GpuValidationState;
 
 class CoreChecks : public ValidationObject {
    public:
-    std::unordered_set<VkQueue> queues;  // All queues under given device
     unordered_map<VkSampler, std::unique_ptr<SAMPLER_STATE>> samplerMap;
     unordered_map<VkImageView, std::unique_ptr<IMAGE_VIEW_STATE>> imageViewMap;
     unordered_map<VkImage, std::unique_ptr<IMAGE_STATE>> imageMap;
     unordered_map<VkBufferView, std::unique_ptr<BUFFER_VIEW_STATE>> bufferViewMap;
     unordered_map<VkBuffer, std::unique_ptr<BUFFER_STATE>> bufferMap;
     unordered_map<VkPipeline, std::unique_ptr<PIPELINE_STATE>> pipelineMap;
-    unordered_map<VkCommandPool, COMMAND_POOL_NODE> commandPoolMap;
-    unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE*> descriptorPoolMap;
-    unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
-    unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> descriptorSetLayoutMap;
-    unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
     unordered_map<VkDeviceMemory, std::unique_ptr<DEVICE_MEM_INFO>> memObjMap;
-    unordered_map<VkFence, FENCE_NODE> fenceMap;
-    unordered_map<VkQueue, QUEUE_STATE> queueMap;
-    unordered_map<VkEvent, EVENT_STATE> eventMap;
-    unordered_map<QueryObject, bool> queryToStateMap;
-    unordered_map<VkQueryPool, QUERY_POOL_NODE> queryPoolMap;
-    unordered_map<VkSemaphore, SEMAPHORE_NODE> semaphoreMap;
-    unordered_map<VkCommandBuffer, GLOBAL_CB_NODE*> commandBufferMap;
     unordered_map<VkFramebuffer, std::unique_ptr<FRAMEBUFFER_STATE>> frameBufferMap;
-    unordered_map<VkImage, std::vector<ImageSubresourcePair>> imageSubresourceMap;
-    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> imageLayoutMap;
-    unordered_map<VkRenderPass, std::shared_ptr<RENDER_PASS_STATE>> renderPassMap;
     unordered_map<VkShaderModule, std::unique_ptr<shader_module>> shaderModuleMap;
     unordered_map<VkDescriptorUpdateTemplateKHR, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
     unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
+
+    unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE*> descriptorPoolMap;
+    unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
+    unordered_map<VkCommandBuffer, GLOBAL_CB_NODE*> commandBufferMap;
+
+    unordered_map<VkCommandPool, COMMAND_POOL_NODE> commandPoolMap;
+    unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
+    unordered_map<VkFence, FENCE_NODE> fenceMap;
+    unordered_map<VkQueue, QUEUE_STATE> queueMap;
+    unordered_map<VkEvent, EVENT_STATE> eventMap;
+    unordered_map<VkQueryPool, QUERY_POOL_NODE> queryPoolMap;
+    unordered_map<VkSemaphore, SEMAPHORE_NODE> semaphoreMap;
+    unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> imageLayoutMap;
+    unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
+
+    unordered_map<VkRenderPass, std::shared_ptr<RENDER_PASS_STATE>> renderPassMap;
+    unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> descriptorSetLayoutMap;
+
+    std::unordered_set<VkQueue> queues;  // All queues under given device
+    unordered_map<VkImage, std::vector<ImageSubresourcePair>> imageSubresourceMap;
+    unordered_map<QueryObject, bool> queryToStateMap;
     unordered_map<VkSamplerYcbcrConversion, uint64_t> ycbcr_conversion_ahb_fmt_map;
     std::unordered_set<uint64_t> ahb_ext_formats_set;
     GlobalQFOTransferBarrierMap<VkImageMemoryBarrier> qfo_release_image_barrier_map;
@@ -206,7 +211,6 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkPhysicalDevice, PHYSICAL_DEVICE_STATE> physical_device_map;
     // Link to the device's physical-device data
     PHYSICAL_DEVICE_STATE* physical_device_state;
-    unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
 
     // Link for derived device objects back to their parent instance object
     CoreChecks* instance_state;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -176,7 +176,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkPipeline, std::unique_ptr<PIPELINE_STATE>> pipelineMap;
     unordered_map<VkDeviceMemory, std::unique_ptr<DEVICE_MEMORY_STATE>> memObjMap;
     unordered_map<VkFramebuffer, std::unique_ptr<FRAMEBUFFER_STATE>> frameBufferMap;
-    unordered_map<VkShaderModule, std::unique_ptr<shader_module>> shaderModuleMap;
+    unordered_map<VkShaderModule, std::unique_ptr<SHADER_MODULE_STATE>> shaderModuleMap;
     unordered_map<VkDescriptorUpdateTemplateKHR, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
     unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
 
@@ -253,7 +253,7 @@ class CoreChecks : public ValidationObject {
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
     COMMAND_POOL_NODE* GetCommandPoolNode(VkCommandPool pool);
-    shader_module const* GetShaderModuleState(VkShaderModule module);
+    SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_NODE* GetFenceNode(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);
     QUERY_POOL_NODE* GetQueryPoolNode(VkQueryPool query_pool);
@@ -583,15 +583,16 @@ class CoreChecks : public ValidationObject {
                                           const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, VkResult result,
                                           void* csm_state);
     bool ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo const* pStage, PIPELINE_STATE* pipeline,
-                                     shader_module const** out_module, spirv_inst_iter* out_entrypoint, bool check_point_size);
-    bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, shader_module const* src, spirv_inst_iter entrypoint,
+                                     SHADER_MODULE_STATE const** out_module, spirv_inst_iter* out_entrypoint,
+                                     bool check_point_size);
+    bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint,
                                       VkShaderStageFlagBits stage);
-    bool ValidateShaderCapabilities(shader_module const* src, VkShaderStageFlagBits stage, bool has_writable_descriptor);
-    bool ValidateShaderStageInputOutputLimits(shader_module const* src, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage, bool has_writable_descriptor);
+    bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                               PIPELINE_STATE* pipeline);
-    bool ValidateCooperativeMatrix(shader_module const* src, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                    PIPELINE_STATE* pipeline);
-    bool ValidateExecutionModes(shader_module const* src, spirv_inst_iter entrypoint);
+    bool ValidateExecutionModes(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint);
 
     // Gpu Validation Functions
     void GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, std::unique_ptr<safe_VkDeviceCreateInfo>& modified_create_info,
@@ -1535,7 +1536,7 @@ class CoreChecks : public ValidationObject {
                                                         const VkAllocationCallbacks* pAllocator);
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
-    bool ValidateComputeWorkGroupSizes(const shader_module* shader);
+    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* shader);
     bool ValidateComputeWorkGroupInvocations(GLOBAL_CB_NODE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
                                              uint32_t groupCountZ);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -184,7 +184,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
     unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
 
-    unordered_map<VkCommandPool, COMMAND_POOL_NODE> commandPoolMap;
+    unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
     unordered_map<VkFence, FENCE_NODE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
@@ -252,7 +252,7 @@ class CoreChecks : public ValidationObject {
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
-    COMMAND_POOL_NODE* GetCommandPoolNode(VkCommandPool pool);
+    COMMAND_POOL_STATE* GetCommandPoolNode(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_NODE* GetFenceNode(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);
@@ -283,9 +283,9 @@ class CoreChecks : public ValidationObject {
     const TEMPLATE_STATE* GetDescriptorTemplateState(VkDescriptorUpdateTemplateKHR descriptor_update_template);
     bool ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2* pInfo);
     void RecordGetImageMemoryRequiementsState(VkImage image, VkMemoryRequirements* pMemoryRequirements);
-    void FreeCommandBufferStates(COMMAND_POOL_NODE* pool_state, const uint32_t command_buffer_count,
+    void FreeCommandBufferStates(COMMAND_POOL_STATE* pool_state, const uint32_t command_buffer_count,
                                  const VkCommandBuffer* command_buffers);
-    bool CheckCommandBuffersInFlight(COMMAND_POOL_NODE* pPool, const char* action, const char* error_code);
+    bool CheckCommandBuffersInFlight(COMMAND_POOL_STATE* pPool, const char* action, const char* error_code);
     bool CheckCommandBufferInFlight(const CMD_BUFFER_STATE* cb_node, const char* action, const char* error_code);
     bool VerifyQueueStateToFence(VkFence fence);
     void DecrementBoundResources(CMD_BUFFER_STATE const* cb_node);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -86,7 +86,7 @@ class QUEUE_STATE {
     std::deque<CB_SUBMISSION> submissions;
 };
 
-class QUERY_POOL_NODE : public BASE_NODE {
+class QUERY_POOL_STATE : public BASE_NODE {
    public:
     VkQueryPoolCreateInfo createInfo;
 };
@@ -189,7 +189,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkFence, FENCE_STATE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
-    unordered_map<VkQueryPool, QUERY_POOL_NODE> queryPoolMap;
+    unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;
     unordered_map<VkSemaphore, SEMAPHORE_NODE> semaphoreMap;
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> imageLayoutMap;
     unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
@@ -256,7 +256,7 @@ class CoreChecks : public ValidationObject {
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_STATE* GetFenceNode(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);
-    QUERY_POOL_NODE* GetQueryPoolNode(VkQueryPool query_pool);
+    QUERY_POOL_STATE* GetQueryPoolNode(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);
     SEMAPHORE_NODE* GetSemaphoreNode(VkSemaphore semaphore);
     PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(VkPhysicalDevice phys);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -247,7 +247,7 @@ class CoreChecks : public ValidationObject {
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView);
     SWAPCHAIN_NODE* GetSwapchainState(VkSwapchainKHR);
-    CMD_BUFFER_STATE* GetCBNode(const VkCommandBuffer cb);
+    CMD_BUFFER_STATE* GetCBState(const VkCommandBuffer cb);
     PIPELINE_STATE* GetPipelineState(VkPipeline pipeline);
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -174,7 +174,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkBufferView, std::unique_ptr<BUFFER_VIEW_STATE>> bufferViewMap;
     unordered_map<VkBuffer, std::unique_ptr<BUFFER_STATE>> bufferMap;
     unordered_map<VkPipeline, std::unique_ptr<PIPELINE_STATE>> pipelineMap;
-    unordered_map<VkDeviceMemory, std::unique_ptr<DEVICE_MEM_INFO>> memObjMap;
+    unordered_map<VkDeviceMemory, std::unique_ptr<DEVICE_MEMORY_STATE>> memObjMap;
     unordered_map<VkFramebuffer, std::unique_ptr<FRAMEBUFFER_STATE>> frameBufferMap;
     unordered_map<VkShaderModule, std::unique_ptr<shader_module>> shaderModuleMap;
     unordered_map<VkDescriptorUpdateTemplateKHR, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
@@ -241,7 +241,7 @@ class CoreChecks : public ValidationObject {
     DESCRIPTOR_POOL_STATE* GetDescriptorPoolState(const VkDescriptorPool);
     BUFFER_STATE* GetBufferState(VkBuffer);
     IMAGE_STATE* GetImageState(VkImage);
-    DEVICE_MEM_INFO* GetMemObjInfo(VkDeviceMemory);
+    DEVICE_MEMORY_STATE* GetMemObjInfo(VkDeviceMemory);
     BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView);
     SAMPLER_STATE* GetSamplerState(VkSampler);
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);
@@ -429,19 +429,19 @@ class CoreChecks : public ValidationObject {
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
     void PostRecordEnumeratePhysicalDeviceGroupsState(uint32_t* pPhysicalDeviceGroupCount,
                                                       VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);
-    bool ValidateInsertMemoryRange(uint64_t handle, DEVICE_MEM_INFO* mem_info, VkDeviceSize memoryOffset,
+    bool ValidateInsertMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize memoryOffset,
                                    VkMemoryRequirements memRequirements, bool is_image, bool is_linear, const char* api_name);
-    void InsertMemoryRange(uint64_t handle, DEVICE_MEM_INFO* mem_info, VkDeviceSize memoryOffset,
+    void InsertMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize memoryOffset,
                            VkMemoryRequirements memRequirements, bool is_image, bool is_linear);
-    bool ValidateInsertImageMemoryRange(VkImage image, DEVICE_MEM_INFO* mem_info, VkDeviceSize mem_offset,
+    bool ValidateInsertImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset,
                                         VkMemoryRequirements mem_reqs, bool is_linear, const char* api_name);
-    void InsertImageMemoryRange(VkImage image, DEVICE_MEM_INFO* mem_info, VkDeviceSize mem_offset, VkMemoryRequirements mem_reqs,
-                                bool is_linear);
-    bool ValidateInsertBufferMemoryRange(VkBuffer buffer, DEVICE_MEM_INFO* mem_info, VkDeviceSize mem_offset,
+    void InsertImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset,
+                                VkMemoryRequirements mem_reqs, bool is_linear);
+    bool ValidateInsertBufferMemoryRange(VkBuffer buffer, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset,
                                          VkMemoryRequirements mem_reqs, const char* api_name);
-    void InsertBufferMemoryRange(VkBuffer buffer, DEVICE_MEM_INFO* mem_info, VkDeviceSize mem_offset,
+    void InsertBufferMemoryRange(VkBuffer buffer, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset,
                                  VkMemoryRequirements mem_reqs);
-    bool ValidateMemoryTypes(const DEVICE_MEM_INFO* mem_info, const uint32_t memory_type_bits, const char* funcName,
+    bool ValidateMemoryTypes(const DEVICE_MEMORY_STATE* mem_info, const uint32_t memory_type_bits, const char* funcName,
                              const char* msgCode);
     void RecordCreateDescriptorUpdateTemplateState(const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
                                                    VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
@@ -478,8 +478,8 @@ class CoreChecks : public ValidationObject {
     void AddCommandBufferBindingBufferView(GLOBAL_CB_NODE*, BUFFER_VIEW_STATE*);
     bool ValidateObjectNotInUse(BASE_NODE* obj_node, VK_OBJECT obj_struct, const char* caller_name, const char* error_code);
     void InvalidateCommandBuffers(std::unordered_set<GLOBAL_CB_NODE*> const& cb_nodes, VK_OBJECT obj);
-    void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEM_INFO* mem_info);
-    void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEM_INFO* mem_info);
+    void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
+    void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
     void ClearMemoryObjectBindings(uint64_t handle, VulkanObjectType type);
     bool ValidateCmdQueueFlags(const GLOBAL_CB_NODE* cb_node, const char* caller_name, VkQueueFlags flags, const char* error_code);
     bool InsideRenderPass(const GLOBAL_CB_NODE* pCB, const char* apiName, const char* msgCode);
@@ -829,7 +829,8 @@ class CoreChecks : public ValidationObject {
 
     bool ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice device, const VkRenderPassCreateInfo2KHR* pCreateInfo);
 
-    bool ValidateMapImageLayouts(VkDevice device, DEVICE_MEM_INFO const* mem_info, VkDeviceSize offset, VkDeviceSize end_offset);
+    bool ValidateMapImageLayouts(VkDevice device, DEVICE_MEMORY_STATE const* mem_info, VkDeviceSize offset,
+                                 VkDeviceSize end_offset);
 
     bool ValidateImageUsageFlags(IMAGE_STATE const* image_state, VkFlags desired, bool strict, const char* msgCode,
                                  char const* func_name, char const* usage_string);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -252,7 +252,7 @@ class CoreChecks : public ValidationObject {
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
-    COMMAND_POOL_STATE* GetCommandPoolNode(VkCommandPool pool);
+    COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_STATE* GetFenceNode(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -246,7 +246,7 @@ class CoreChecks : public ValidationObject {
     SAMPLER_STATE* GetSamplerState(VkSampler);
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView);
-    SWAPCHAIN_NODE* GetSwapchainNode(VkSwapchainKHR);
+    SWAPCHAIN_NODE* GetSwapchainState(VkSwapchainKHR);
     CMD_BUFFER_STATE* GetCBNode(const VkCommandBuffer cb);
     PIPELINE_STATE* GetPipelineState(VkPipeline pipeline);
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -241,7 +241,7 @@ class CoreChecks : public ValidationObject {
     DESCRIPTOR_POOL_STATE* GetDescriptorPoolState(const VkDescriptorPool);
     BUFFER_STATE* GetBufferState(VkBuffer);
     IMAGE_STATE* GetImageState(VkImage);
-    DEVICE_MEMORY_STATE* GetMemObjInfo(VkDeviceMemory);
+    DEVICE_MEMORY_STATE* GetDevMemState(VkDeviceMemory);
     BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView);
     SAMPLER_STATE* GetSamplerState(VkSampler);
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -254,7 +254,7 @@ class CoreChecks : public ValidationObject {
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
     COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
-    FENCE_STATE* GetFenceNode(VkFence fence);
+    FENCE_STATE* GetFenceState(VkFence fence);
     EVENT_STATE* GetEventNode(VkEvent event);
     QUERY_POOL_STATE* GetQueryPoolNode(VkQueryPool query_pool);
     QUEUE_STATE* GetQueueState(VkQueue queue);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -84,7 +84,7 @@ class BASE_NODE {
 };
 
 // Track command pools and their command buffers
-struct COMMAND_POOL_NODE : public BASE_NODE {
+struct COMMAND_POOL_STATE : public BASE_NODE {
     VkCommandPoolCreateFlags createFlags;
     uint32_t queueFamilyIndex;
     // Cmd buffers allocated from this pool
@@ -98,12 +98,12 @@ static bool IsTransferOp(const Barrier *barrier) {
 }
 
 template <typename Barrier, bool assume_transfer = false>
-static bool TempIsReleaseOp(const COMMAND_POOL_NODE *pool, const Barrier *barrier) {
+static bool TempIsReleaseOp(const COMMAND_POOL_STATE *pool, const Barrier *barrier) {
     return (assume_transfer || IsTransferOp(barrier)) && (pool->queueFamilyIndex == barrier->srcQueueFamilyIndex);
 }
 
 template <typename Barrier, bool assume_transfer = false>
-static bool IsAcquireOp(const COMMAND_POOL_NODE *pool, const Barrier *barrier) {
+static bool IsAcquireOp(const COMMAND_POOL_STATE *pool, const Barrier *barrier) {
     return (assume_transfer || IsTransferOp(barrier)) && (pool->queueFamilyIndex == barrier->dstQueueFamilyIndex);
 }
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1100,13 +1100,13 @@ using PipelineLayoutCompatDict = hash_util::Dictionary<PipelineLayoutCompatDef, 
 using PipelineLayoutCompatId = PipelineLayoutCompatDict::Id;
 
 // Store layouts and pushconstants for PipelineLayout
-struct PIPELINE_LAYOUT_NODE {
+struct PIPELINE_LAYOUT_STATE {
     VkPipelineLayout layout;
     std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> set_layouts;
     PushConstantRangesId push_constant_ranges;
     std::vector<PipelineLayoutCompatId> compat_for_set;
 
-    PIPELINE_LAYOUT_NODE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{}, compat_for_set{} {}
+    PIPELINE_LAYOUT_STATE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{}, compat_for_set{} {}
 
     void reset() {
         layout = VK_NULL_HANDLE;
@@ -1122,7 +1122,7 @@ static inline bool CompatForSet(uint32_t set, const std::vector<PipelineLayoutCo
     return result;
 }
 
-static inline bool CompatForSet(uint32_t set, const PIPELINE_LAYOUT_NODE *a, const PIPELINE_LAYOUT_NODE *b) {
+static inline bool CompatForSet(uint32_t set, const PIPELINE_LAYOUT_STATE *a, const PIPELINE_LAYOUT_STATE *b) {
     // Intentionally have a result variable to simplify debugging
     bool result = a && b && CompatForSet(set, a->compat_for_set, b->compat_for_set);
     return result;
@@ -1147,7 +1147,7 @@ class PIPELINE_STATE : public BASE_NODE {
     std::unordered_map<uint32_t, uint32_t> vertex_binding_to_index_map_;
     std::vector<VkPipelineColorBlendAttachmentState> attachments;
     bool blendConstantsEnabled;  // Blend constants enabled for any attachments
-    PIPELINE_LAYOUT_NODE pipeline_layout;
+    PIPELINE_LAYOUT_STATE pipeline_layout;
     VkPrimitiveTopology topology_at_rasterizer;
 
     // Default constructor

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1560,7 +1560,7 @@ class FRAMEBUFFER_STATE : public BASE_NODE {
         : framebuffer(fb), createInfo(pCreateInfo), rp_state(rpstate){};
 };
 
-struct shader_module;
+struct SHADER_MODULE_STATE;
 struct DeviceExtensions;
 
 struct DeviceFeatures {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1542,7 +1542,7 @@ struct CB_SUBMISSION {
     VkFence fence;
 };
 
-struct IMAGE_LAYOUT_NODE {
+struct IMAGE_LAYOUT_STATE {
     VkImageLayout layout;
     VkFormat format;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -293,16 +293,16 @@ class IMAGE_STATE : public BINDABLE {
    public:
     VkImage image;
     VkImageCreateInfo createInfo;
-    bool valid;                   // If this is a swapchain image backing memory track valid here as it doesn't have DEVICE_MEM_INFO
-    bool acquired;                // If this is a swapchain image, has it been acquired by the app.
-    bool shared_presentable;      // True for a front-buffered swapchain image
-    bool layout_locked;           // A front-buffered image that has been presented can never have layout transitioned
-    bool get_sparse_reqs_called;  // Track if GetImageSparseMemoryRequirements() has been called for this image
-    bool sparse_metadata_required;  // Track if sparse metadata aspect is required for this image
-    bool sparse_metadata_bound;     // Track if sparse metadata aspect is bound to this image
-    bool imported_ahb;              // True if image was imported from an Android Hardware Buffer
-    bool has_ahb_format;            // True if image was created with an external Android format
-    uint64_t ahb_format;            // External Android format, if provided
+    bool valid;               // If this is a swapchain image backing memory track valid here as it doesn't have DEVICE_MEMORY_STATE
+    bool acquired;            // If this is a swapchain image, has it been acquired by the app.
+    bool shared_presentable;  // True for a front-buffered swapchain image
+    bool layout_locked;       // A front-buffered image that has been presented can never have layout transitioned
+    bool get_sparse_reqs_called;         // Track if GetImageSparseMemoryRequirements() has been called for this image
+    bool sparse_metadata_required;       // Track if sparse metadata aspect is required for this image
+    bool sparse_metadata_bound;          // Track if sparse metadata aspect is bound to this image
+    bool imported_ahb;                   // True if image was imported from an Android Hardware Buffer
+    bool has_ahb_format;                 // True if image was created with an external Android format
+    uint64_t ahb_format;                 // External Android format, if provided
     VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers (slices), and aspects
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
     IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo);
@@ -344,7 +344,7 @@ struct MEMORY_RANGE {
 };
 
 // Data struct for tracking memory object
-struct DEVICE_MEM_INFO : public BASE_NODE {
+struct DEVICE_MEMORY_STATE : public BASE_NODE {
     void *object;  // Dispatchable object used to create this memory (device of swapchain)
     VkDeviceMemory mem;
     VkMemoryAllocateInfo alloc_info;
@@ -366,7 +366,7 @@ struct DEVICE_MEM_INFO : public BASE_NODE {
                                // multiple of limits.minMemoryMapAlignment
     void *p_driver_data;       // Pointer to application's actual memory
 
-    DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
+    DEVICE_MEMORY_STATE(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
         : object(disp_object),
           mem(in_mem),
           alloc_info(*p_alloc_info),
@@ -487,7 +487,7 @@ class ImageSubresourceLayoutMap {
    public:
     typedef std::function<bool(const VkImageSubresource &, VkImageLayout, VkImageLayout)> Callback;
     struct InitialLayoutState {
-        VkImageView image_view;  // For relaxed matching rule evaluation, else VK_NULL_HANDLE
+        VkImageView image_view;          // For relaxed matching rule evaluation, else VK_NULL_HANDLE
         VkImageAspectFlags aspect_mask;  // For relaxed matching rules... else 0
         LoggingLabel label;
         InitialLayoutState(const GLOBAL_CB_NODE &cb_state_, const IMAGE_VIEW_STATE *view_state);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -751,7 +751,7 @@ bool cvdescriptorset::DescriptorSet::ValidateDrawState(const std::map<uint32_t, 
                         return false;
                     } else if (!buffer_node->sparse) {
                         for (auto mem_binding : buffer_node->GetBoundMemory()) {
-                            if (!device_data_->GetMemObjInfo(mem_binding)) {
+                            if (!device_data_->GetDevMemState(mem_binding)) {
                                 std::stringstream error_str;
                                 error_str << "Descriptor in binding #" << binding << " index " << index << " uses buffer " << buffer
                                           << " that references invalid memory " << mem_binding << ".";

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -49,7 +49,7 @@ bool CoreChecks::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, V
                                      const char *renderpass_msg_code, const char *pipebound_msg_code,
                                      const char *dynamic_state_msg_code) {
     bool skip = false;
-    CMD_BUFFER_STATE *cb_state = GetCBNode(cmd_buffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(cmd_buffer);
     if (cb_state) {
         skip |= ValidateCmdQueueFlags(cb_state, caller, queue_flags, queue_flag_code);
         skip |= ValidateCmd(cb_state, cmd_type, caller);
@@ -87,7 +87,7 @@ void CoreChecks::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t ve
 
 void CoreChecks::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                        uint32_t firstVertex, uint32_t firstInstance) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -97,7 +97,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
                                     VK_QUEUE_GRAPHICS_BIT, "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
                                     "VUID-vkCmdDrawIndexed-renderpass", "VUID-vkCmdDrawIndexed-None-00461",
                                     "VUID-vkCmdDrawIndexed-None-00462");
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     if (!skip && (cb_state->status & CBSTATUS_INDEX_BUFFER_BOUND)) {
         unsigned int index_size = 0;
         const auto &index_buffer_binding = cb_state->index_buffer_binding;
@@ -127,7 +127,7 @@ void CoreChecks::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint
 
 void CoreChecks::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                               uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -153,7 +153,7 @@ void CoreChecks::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkB
 
 void CoreChecks::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                                uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -183,7 +183,7 @@ void CoreChecks::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuff
 
 void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       uint32_t count, uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -191,7 +191,7 @@ void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuf
 
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
     bool skip = false;
-    auto *cb_state = GetCBNode(commandBuffer);
+    auto *cb_state = GetCBState(commandBuffer);
     if (cb_state) {
         skip |= ValidateComputeWorkGroupInvocations(cb_state, x, y, z);
     }
@@ -206,7 +206,7 @@ void CoreChecks::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_
 }
 
 void CoreChecks::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawDispatchType(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
 }
 
@@ -228,7 +228,7 @@ void CoreChecks::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer,
 }
 
 void CoreChecks::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawDispatchType(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -283,7 +283,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCountKHR(VkCommandBuffer commandB
 void CoreChecks::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                       uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
@@ -342,7 +342,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffer c
 void CoreChecks::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                              uint32_t maxDrawCount, uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
@@ -359,7 +359,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer
 }
 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -381,7 +381,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          uint32_t drawCount, uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     if (buffer_state) {
@@ -415,7 +415,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride) {
-    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -41,7 +41,7 @@
 #include "chassis.h"
 #include "core_validation.h"
 
-static inline void UpdateResourceTrackingOnDraw(GLOBAL_CB_NODE *pCB) { pCB->draw_data.push_back(pCB->current_draw_data); }
+static inline void UpdateResourceTrackingOnDraw(CMD_BUFFER_STATE *pCB) { pCB->draw_data.push_back(pCB->current_draw_data); }
 
 // Generic function to handle validation for all CmdDraw* type functions
 bool CoreChecks::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, VkPipelineBindPoint bind_point, CMD_TYPE cmd_type,
@@ -49,7 +49,7 @@ bool CoreChecks::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, V
                                      const char *renderpass_msg_code, const char *pipebound_msg_code,
                                      const char *dynamic_state_msg_code) {
     bool skip = false;
-    GLOBAL_CB_NODE *cb_state = GetCBNode(cmd_buffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(cmd_buffer);
     if (cb_state) {
         skip |= ValidateCmdQueueFlags(cb_state, caller, queue_flags, queue_flag_code);
         skip |= ValidateCmd(cb_state, cmd_type, caller);
@@ -62,12 +62,12 @@ bool CoreChecks::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, V
 }
 
 // Generic function to handle state update for all CmdDraw* and CmdDispatch* type functions
-void CoreChecks::UpdateStateCmdDrawDispatchType(GLOBAL_CB_NODE *cb_state, VkPipelineBindPoint bind_point) {
+void CoreChecks::UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint bind_point) {
     UpdateDrawState(cb_state, bind_point);
 }
 
 // Generic function to handle state update for all CmdDraw* type functions
-void CoreChecks::UpdateStateCmdDrawType(GLOBAL_CB_NODE *cb_state, VkPipelineBindPoint bind_point) {
+void CoreChecks::UpdateStateCmdDrawType(CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint bind_point) {
     UpdateStateCmdDrawDispatchType(cb_state, bind_point);
     UpdateResourceTrackingOnDraw(cb_state);
     cb_state->hasDrawCmd = true;
@@ -87,7 +87,7 @@ void CoreChecks::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t ve
 
 void CoreChecks::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                        uint32_t firstVertex, uint32_t firstInstance) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -97,7 +97,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
                                     VK_QUEUE_GRAPHICS_BIT, "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
                                     "VUID-vkCmdDrawIndexed-renderpass", "VUID-vkCmdDrawIndexed-None-00461",
                                     "VUID-vkCmdDrawIndexed-None-00462");
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     if (!skip && (cb_state->status & CBSTATUS_INDEX_BUFFER_BOUND)) {
         unsigned int index_size = 0;
         const auto &index_buffer_binding = cb_state->index_buffer_binding;
@@ -127,7 +127,7 @@ void CoreChecks::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint
 
 void CoreChecks::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                               uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -153,7 +153,7 @@ void CoreChecks::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkB
 
 void CoreChecks::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                                uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -183,7 +183,7 @@ void CoreChecks::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuff
 
 void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       uint32_t count, uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -191,7 +191,7 @@ void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuf
 
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
     bool skip = false;
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    auto *cb_state = GetCBNode(commandBuffer);
     if (cb_state) {
         skip |= ValidateComputeWorkGroupInvocations(cb_state, x, y, z);
     }
@@ -206,7 +206,7 @@ void CoreChecks::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_
 }
 
 void CoreChecks::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawDispatchType(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
 }
 
@@ -228,7 +228,7 @@ void CoreChecks::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer,
 }
 
 void CoreChecks::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawDispatchType(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
@@ -283,7 +283,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCountKHR(VkCommandBuffer commandB
 void CoreChecks::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                       uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
@@ -342,7 +342,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffer c
 void CoreChecks::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                              uint32_t maxDrawCount, uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
@@ -359,7 +359,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer
 }
 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
@@ -381,7 +381,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          uint32_t drawCount, uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     if (buffer_state) {
@@ -415,7 +415,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
 void CoreChecks::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride) {
-    GLOBAL_CB_NODE *cb_state = GetCBNode(commandBuffer);
+    CMD_BUFFER_STATE *cb_state = GetCBNode(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1039,7 +1039,7 @@ void CoreChecks::GpuPreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            auto cb_node = GetCBNode(submit->pCommandBuffers[i]);
+            auto cb_node = GetCBState(submit->pCommandBuffers[i]);
             UpdateInstrumentationBuffer(cb_node);
             for (auto secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
                 UpdateInstrumentationBuffer(secondaryCmdBuffer);
@@ -1061,7 +1061,7 @@ void CoreChecks::GpuPostCallQueueSubmit(VkQueue queue, uint32_t submitCount, con
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            auto cb_node = GetCBNode(submit->pCommandBuffers[i]);
+            auto cb_node = GetCBState(submit->pCommandBuffers[i]);
             ProcessInstrumentationBuffer(queue, cb_node);
             for (auto secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
                 ProcessInstrumentationBuffer(queue, secondaryCmdBuffer);
@@ -1095,7 +1095,7 @@ void CoreChecks::GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer
     VkDescriptorBufferInfo output_desc_buffer_info = {};
     output_desc_buffer_info.range = gpu_validation_state->output_buffer_size;
 
-    auto cb_node = GetCBNode(cmd_buffer);
+    auto cb_node = GetCBState(cmd_buffer);
     if (!cb_node) {
         ReportSetupProblem(VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device), "Unrecognized command buffer");
         gpu_validation_state->aborted = true;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -447,7 +447,7 @@ std::vector<safe_VkGraphicsPipelineCreateInfo> CoreChecks::GpuPreCallRecordCreat
 
         if (replace_shaders) {
             for (uint32_t stage = 0; stage < pCreateInfos[pipeline].stageCount; ++stage) {
-                const shader_module *shader = GetShaderModuleState(pCreateInfos[pipeline].pStages[stage].module);
+                const SHADER_MODULE_STATE *shader = GetShaderModuleState(pCreateInfos[pipeline].pStages[stage].module);
                 VkShaderModuleCreateInfo create_info = {};
                 VkShaderModule shader_module;
                 create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -658,7 +658,8 @@ static void GenerateCommonMessage(const debug_report_data *report_data, const GL
 
 // Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
 // Split the single string into a vector of strings, one for each line, for easier processing.
-static void ReadOpSource(const shader_module &shader, const uint32_t reported_file_id, std::vector<std::string> &opsource_lines) {
+static void ReadOpSource(const SHADER_MODULE_STATE &shader, const uint32_t reported_file_id,
+                         std::vector<std::string> &opsource_lines) {
     for (auto insn : shader) {
         if ((insn.opcode() == spv::OpSource) && (insn.len() >= 5) && (insn.word(3) == reported_file_id)) {
             std::istringstream in_stream;
@@ -760,7 +761,7 @@ static void GenerateSourceMessages(const std::vector<unsigned int> &pgm, const u
     using namespace spvtools;
     std::ostringstream filename_stream;
     std::ostringstream source_stream;
-    shader_module shader;
+    SHADER_MODULE_STATE shader;
     shader.words = pgm;
     // Find the OpLine just before the failing instruction indicated by the debug info.
     // SPIR-V can only be iterated in the forward direction due to its opcode/length encoding.

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -631,9 +631,9 @@ static std::string LookupDebugUtilsName(const debug_report_data *report_data, co
 }
 
 // Generate message from the common portion of the debug report record.
-static void GenerateCommonMessage(const debug_report_data *report_data, const GLOBAL_CB_NODE *cb_node, const uint32_t *debug_record,
-                                  const VkShaderModule shader_module_handle, const VkPipeline pipeline_handle,
-                                  const uint32_t draw_index, std::string &msg) {
+static void GenerateCommonMessage(const debug_report_data *report_data, const CMD_BUFFER_STATE *cb_node,
+                                  const uint32_t *debug_record, const VkShaderModule shader_module_handle,
+                                  const VkPipeline pipeline_handle, const uint32_t draw_index, std::string &msg) {
     using namespace spvtools;
     std::ostringstream strm;
     if (shader_module_handle == VK_NULL_HANDLE) {
@@ -872,7 +872,7 @@ static void GenerateSourceMessages(const std::vector<unsigned int> &pgm, const u
 // sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
 // keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
 //
-void CoreChecks::AnalyzeAndReportError(GLOBAL_CB_NODE *cb_node, VkQueue queue, uint32_t draw_index,
+void CoreChecks::AnalyzeAndReportError(CMD_BUFFER_STATE *cb_node, VkQueue queue, uint32_t draw_index,
                                        uint32_t *const debug_output_buffer) {
     using namespace spvtools;
     const uint32_t total_words = debug_output_buffer[0];
@@ -923,7 +923,7 @@ void CoreChecks::AnalyzeAndReportError(GLOBAL_CB_NODE *cb_node, VkQueue queue, u
 }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void CoreChecks::ProcessInstrumentationBuffer(VkQueue queue, GLOBAL_CB_NODE *cb_node) {
+void CoreChecks::ProcessInstrumentationBuffer(VkQueue queue, CMD_BUFFER_STATE *cb_node) {
     auto gpu_buffer_list = gpu_validation_state->GetGpuBufferInfo(cb_node->commandBuffer);
     if (cb_node && cb_node->hasDrawCmd && gpu_buffer_list.size() > 0) {
         VkResult result;
@@ -943,7 +943,7 @@ void CoreChecks::ProcessInstrumentationBuffer(VkQueue queue, GLOBAL_CB_NODE *cb_
 }
 
 // For the given command buffer, map its debug data buffers and update the status of any update after bind descriptors
-void CoreChecks::UpdateInstrumentationBuffer(GLOBAL_CB_NODE *cb_node) {
+void CoreChecks::UpdateInstrumentationBuffer(CMD_BUFFER_STATE *cb_node) {
     auto gpu_buffer_list = gpu_validation_state->GetGpuBufferInfo(cb_node->commandBuffer);
     uint32_t *pData;
     for (auto &buffer_info : gpu_buffer_list) {

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2974,7 +2974,7 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE *shader
     return skip;
 }
 
-bool CoreChecks::ValidateComputeWorkGroupInvocations(GLOBAL_CB_NODE *cb_state, uint32_t groupCountX, uint32_t groupCountY,
+bool CoreChecks::ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE *cb_state, uint32_t groupCountX, uint32_t groupCountY,
                                                      uint32_t groupCountZ) {
     auto const &state = cb_state->lastBound[VK_PIPELINE_BIND_POINT_COMPUTE];
     PIPELINE_STATE *pPipe = state.pipeline_state;

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2400,7 +2400,7 @@ static uint32_t DescriptorTypeToReqs(SHADER_MODULE_STATE const *module, uint32_t
 
 // For given pipelineLayout verify that the set_layout_node at slot.first
 //  has the requested binding at slot.second and return ptr to that binding
-static VkDescriptorSetLayoutBinding const *GetDescriptorBinding(PIPELINE_LAYOUT_NODE const *pipelineLayout,
+static VkDescriptorSetLayoutBinding const *GetDescriptorBinding(PIPELINE_LAYOUT_STATE const *pipelineLayout,
                                                                 descriptor_slot_t slot) {
     if (!pipelineLayout) return nullptr;
 

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -69,7 +69,7 @@ struct spirv_inst_iter {
     spirv_inst_iter const &operator*() const { return *this; }
 };
 
-struct shader_module {
+struct SHADER_MODULE_STATE {
     // The spirv image itself
     std::vector<uint32_t> words;
     // A mapping of <id> to the first word of its def. this is useful because walking type
@@ -124,8 +124,8 @@ struct shader_module {
         return src;
     }
 
-    shader_module(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env,
-                  uint32_t unique_shader_id)
+    SHADER_MODULE_STATE(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env,
+                        uint32_t unique_shader_id)
         : words(PreprocessShaderBinary((uint32_t *)pCreateInfo->pCode, pCreateInfo->codeSize, env)),
           def_index(),
           has_valid_spirv(true),
@@ -134,7 +134,7 @@ struct shader_module {
         BuildDefIndex();
     }
 
-    shader_module() : has_valid_spirv(false), vk_shader_module(VK_NULL_HANDLE) {}
+    SHADER_MODULE_STATE() : has_valid_spirv(false), vk_shader_module(VK_NULL_HANDLE) {}
 
     // Expose begin() / end() to enable range-based for
     spirv_inst_iter begin() const { return spirv_inst_iter(words.begin(), words.begin() + 5); }  // First insn


### PR DESCRIPTION
Finally got rid of all the old 'node' names for the maps and accessor functions in preparation for moving more of the maps to use unique_ptrs.