### PR TITLE
Make settings consistent using old configs

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -241,6 +241,10 @@ void CoreChecks::GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, std::unique_
 
 // Perform initializations that can be done at Create Device time.
 void CoreChecks::GpuPostCallRecordCreateDevice(const CHECK_ENABLED *enables) {
+    // Set instance-level enables in device-enable data structure if using legacy settings
+    enabled.gpu_validation = enables->gpu_validation;
+    enabled.gpu_validation_reserve_binding_slot = enables->gpu_validation_reserve_binding_slot;
+
     gpu_validation_state = std::unique_ptr<GpuValidationState>(new GpuValidationState);
     gpu_validation_state->reserve_binding_slot = enables->gpu_validation_reserve_binding_slot;
 


### PR DESCRIPTION
Old GPUVAL config file settings were overwritten by the default instance settings. Copied instance settings to device in this case.  This'll allow enabling GpuVal using the original config settings.

