### PR TITLE
Convert corechecks object maps to use smart pointers

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -957,7 +957,7 @@ cvdescriptorset::DescriptorSet *CoreChecks::GetSetNode(VkDescriptorSet set) {
     if (set_it == setMap.end()) {
         return NULL;
     }
-    return set_it->second;
+    return set_it->second.get();
 }
 
 // For given pipeline, return number of MSAA samples, or one if MSAA disabled
@@ -1895,10 +1895,8 @@ bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const char *func
 }
 
 // Remove set from setMap and delete the set
-void CoreChecks::FreeDescriptorSet(cvdescriptorset::DescriptorSet *descriptor_set) {
-    setMap.erase(descriptor_set->GetSet());
-    delete descriptor_set;
-}
+void CoreChecks::FreeDescriptorSet(cvdescriptorset::DescriptorSet *descriptor_set) { setMap.erase(descriptor_set->GetSet()); }
+
 // Free all DS Pools including their Sets & related sub-structs
 // NOTE : Calls to this function should be wrapped in mutex
 void CoreChecks::DeletePools() {
@@ -6123,7 +6121,7 @@ void CoreChecks::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPo
     // For each freed descriptor add its resources back into the pool as available and remove from pool and setMap
     for (uint32_t i = 0; i < count; ++i) {
         if (pDescriptorSets[i] != VK_NULL_HANDLE) {
-            auto descriptor_set = setMap[pDescriptorSets[i]];
+            auto descriptor_set = setMap[pDescriptorSets[i]].get();
             uint32_t type_index = 0, descriptor_count = 0;
             for (uint32_t j = 0; j < descriptor_set->GetBindingCount(); ++j) {
                 type_index = static_cast<uint32_t>(descriptor_set->GetTypeFromIndex(j));

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -228,7 +228,7 @@ COMMAND_POOL_STATE *CoreChecks::GetCommandPoolState(VkCommandPool pool) {
     if (it == commandPoolMap.end()) {
         return nullptr;
     }
-    return &it->second;
+    return it->second.get();
 }
 
 PHYSICAL_DEVICE_STATE *CoreChecks::GetPhysicalDeviceState(VkPhysicalDevice phys) {
@@ -4837,10 +4837,10 @@ void CoreChecks::FreeCommandBufferStates(COMMAND_POOL_STATE *pool_state, const u
             // reset prior to delete, removing various references to it.
             // TODO: fix this, it's insane.
             ResetCommandBufferState(cb_state->commandBuffer);
-            // Remove the cb_state's references from COMMAND_POOL_STATEs
+            // Remove CBState from CB map
             commandBufferMap.erase(cb_state->commandBuffer);
+            // Remove the cb_state's references from COMMAND_POOL_STATEs
             pool_state->commandBuffers.erase(command_buffers[i]);
-
             // Remove the cb debug labels
             EraseCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
         }
@@ -4876,8 +4876,10 @@ void CoreChecks::PostCallRecordCreateCommandPool(VkDevice device, const VkComman
                                                  const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
                                                  VkResult result) {
     if (VK_SUCCESS != result) return;
-    commandPoolMap[*pCommandPool].createFlags = pCreateInfo->flags;
-    commandPoolMap[*pCommandPool].queueFamilyIndex = pCreateInfo->queueFamilyIndex;
+    std::unique_ptr<COMMAND_POOL_STATE> cmd_pool_state(new COMMAND_POOL_STATE{});
+    cmd_pool_state->createFlags = pCreateInfo->flags;
+    cmd_pool_state->queueFamilyIndex = pCreateInfo->queueFamilyIndex;
+    commandPoolMap[*pCommandPool] = std::move(cmd_pool_state);
 }
 
 bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
@@ -8265,7 +8267,7 @@ bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(CMD_BUFFER_STATE con
                                                             BarrierOperationsType barrier_op_type, const char *function,
                                                             const char *error_code) {
     bool skip = false;
-    uint32_t queue_family_index = commandPoolMap[cb_state->createInfo.commandPool].queueFamilyIndex;
+    uint32_t queue_family_index = commandPoolMap[cb_state->createInfo.commandPool].get()->queueFamilyIndex;
     auto physical_device_state = GetPhysicalDeviceState();
 
     // Any pipeline stage included in srcStageMask or dstStageMask must be supported by the capabilities of the queue family

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -248,7 +248,7 @@ SURFACE_STATE *CoreChecks::GetSurfaceState(VkSurfaceKHR surface) {
     if (it == surf_map->end()) {
         return nullptr;
     }
-    return &it->second;
+    return it->second.get();
 }
 
 // Return ptr to memory binding for given handle of specified type
@@ -12107,7 +12107,9 @@ void CoreChecks::PreCallRecordValidateDestroySurfaceKHR(VkInstance instance, VkS
     surface_map.erase(surface);
 }
 
-void CoreChecks::RecordVulkanSurface(VkSurfaceKHR *pSurface) { surface_map[*pSurface] = SURFACE_STATE(*pSurface); }
+void CoreChecks::RecordVulkanSurface(VkSurfaceKHR *pSurface) {
+    surface_map[*pSurface] = std::unique_ptr<SURFACE_STATE>(new SURFACE_STATE{*pSurface});
+}
 
 void CoreChecks::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -753,7 +753,7 @@ PIPELINE_LAYOUT_STATE const *CoreChecks::GetPipelineLayout(VkPipelineLayout pipe
     if (it == pipelineLayoutMap.end()) {
         return nullptr;
     }
-    return &it->second;
+    return it->second.get();
 }
 
 SHADER_MODULE_STATE const *CoreChecks::GetShaderModuleState(VkShaderModule module) {
@@ -6002,24 +6002,26 @@ void CoreChecks::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPip
     }
     if (VK_SUCCESS != result) return;
 
-    PIPELINE_LAYOUT_STATE &plNode = pipelineLayoutMap[*pPipelineLayout];
-    plNode.layout = *pPipelineLayout;
-    plNode.set_layouts.resize(pCreateInfo->setLayoutCount);
+    std::unique_ptr<PIPELINE_LAYOUT_STATE> pipeline_layout_state(new PIPELINE_LAYOUT_STATE{});
+    pipeline_layout_state->layout = *pPipelineLayout;
+    pipeline_layout_state->set_layouts.resize(pCreateInfo->setLayoutCount);
     PipelineLayoutSetLayoutsDef set_layouts(pCreateInfo->setLayoutCount);
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        plNode.set_layouts[i] = GetDescriptorSetLayout(this, pCreateInfo->pSetLayouts[i]);
-        set_layouts[i] = plNode.set_layouts[i]->GetLayoutId();
+        pipeline_layout_state->set_layouts[i] = GetDescriptorSetLayout(this, pCreateInfo->pSetLayouts[i]);
+        set_layouts[i] = pipeline_layout_state->set_layouts[i]->GetLayoutId();
     }
 
     // Get canonical form IDs for the "compatible for set" contents
-    plNode.push_constant_ranges = GetCanonicalId(pCreateInfo);
+    pipeline_layout_state->push_constant_ranges = GetCanonicalId(pCreateInfo);
     auto set_layouts_id = pipeline_layout_set_layouts_dict.look_up(set_layouts);
-    plNode.compat_for_set.reserve(pCreateInfo->setLayoutCount);
+    pipeline_layout_state->compat_for_set.reserve(pCreateInfo->setLayoutCount);
 
     // Create table of "compatible for set N" cannonical forms for trivial accept validation
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        plNode.compat_for_set.emplace_back(GetCanonicalId(i, plNode.push_constant_ranges, set_layouts_id));
+        pipeline_layout_state->compat_for_set.emplace_back(
+            GetCanonicalId(i, pipeline_layout_state->push_constant_ranges, set_layouts_id));
     }
+    pipelineLayoutMap[*pPipelineLayout] = std::move(pipeline_layout_state);
 }
 
 void CoreChecks::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -188,7 +188,7 @@ FENCE_STATE *CoreChecks::GetFenceState(VkFence fence) {
     if (it == fenceMap.end()) {
         return nullptr;
     }
-    return &it->second;
+    return it->second.get();
 }
 
 EVENT_STATE *CoreChecks::GetEventState(VkEvent event) {
@@ -5053,10 +5053,11 @@ VkResult CoreChecks::GetPDImageFormatProperties2(const VkPhysicalDeviceImageForm
 void CoreChecks::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence, VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto &fence_node = fenceMap[*pFence];
-    fence_node.fence = *pFence;
-    fence_node.createInfo = *pCreateInfo;
-    fence_node.state = (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED;
+    std::unique_ptr<FENCE_STATE> fence_state(new FENCE_STATE{});
+    fence_state->fence = *pFence;
+    fence_state->createInfo = *pCreateInfo;
+    fence_state->state = (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED;
+    fenceMap[*pFence] = std::move(fence_state);
 }
 
 // Validation cache:

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1866,7 +1866,7 @@ DESCRIPTOR_POOL_STATE *CoreChecks::GetDescriptorPoolState(const VkDescriptorPool
     if (pool_it == descriptorPoolMap.end()) {
         return NULL;
     }
-    return pool_it->second;
+    return pool_it->second.get();
 }
 
 // Validate that given set is valid and that it's not being used by an in-flight CmdBuffer
@@ -1908,7 +1908,6 @@ void CoreChecks::DeletePools() {
             FreeDescriptorSet(ds);
         }
         ii->second->sets.clear();
-        delete ii->second;
         ii = descriptorPoolMap.erase(ii);
     }
 }
@@ -4804,7 +4803,6 @@ void CoreChecks::PreCallRecordDestroyDescriptorPool(VkDevice device, VkDescripto
             FreeDescriptorSet(ds);
         }
         descriptorPoolMap.erase(descriptorPool);
-        delete desc_pool_state;
     }
 }
 
@@ -6032,9 +6030,8 @@ void CoreChecks::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDes
                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool,
                                                     VkResult result) {
     if (VK_SUCCESS != result) return;
-    DESCRIPTOR_POOL_STATE *pNewNode = new DESCRIPTOR_POOL_STATE(*pDescriptorPool, pCreateInfo);
-    assert(pNewNode);
-    descriptorPoolMap[*pDescriptorPool] = pNewNode;
+    descriptorPoolMap[*pDescriptorPool] =
+        std::unique_ptr<DESCRIPTOR_POOL_STATE>(new DESCRIPTOR_POOL_STATE(*pDescriptorPool, pCreateInfo));
 }
 
 bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
@@ -6093,7 +6090,7 @@ void CoreChecks::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkD
     // All the updates are contained in a single cvdescriptorset function
     cvdescriptorset::AllocateDescriptorSetsData *ads_state =
         reinterpret_cast<cvdescriptorset::AllocateDescriptorSetsData *>(ads_state_data);
-    PerformAllocateDescriptorSets(pAllocateInfo, pDescriptorSets, ads_state, &descriptorPoolMap, &setMap);
+    PerformAllocateDescriptorSets(pAllocateInfo, pDescriptorSets, ads_state);
 }
 
 bool CoreChecks::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -204,7 +204,7 @@ QUERY_POOL_STATE *CoreChecks::GetQueryPoolState(VkQueryPool query_pool) {
     if (it == queryPoolMap.end()) {
         return nullptr;
     }
-    return &it->second;
+    return it->second.get();
 }
 
 QUEUE_STATE *CoreChecks::GetQueueState(VkQueue queue) {
@@ -4219,7 +4219,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
     bool skip = false;
     auto query_pool_state = queryPoolMap.find(queryPool);
     if (query_pool_state != queryPoolMap.end()) {
-        if ((query_pool_state->second.createInfo.queryType == VK_QUERY_TYPE_TIMESTAMP) && (flags & VK_QUERY_RESULT_PARTIAL_BIT)) {
+        if ((query_pool_state->second->createInfo.queryType == VK_QUERY_TYPE_TIMESTAMP) && (flags & VK_QUERY_RESULT_PARTIAL_BIT)) {
             skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT, 0,
                             "VUID-vkGetQueryPoolResults-queryType-00818",
                             "QueryPool %s was created with a queryType of VK_QUERY_TYPE_TIMESTAMP but flags contains "
@@ -4901,8 +4901,9 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
 void CoreChecks::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool, VkResult result) {
     if (VK_SUCCESS != result) return;
-    QUERY_POOL_STATE *qp_node = &queryPoolMap[*pQueryPool];
-    qp_node->createInfo = *pCreateInfo;
+    std::unique_ptr<QUERY_POOL_STATE> query_pool_state(new QUERY_POOL_STATE{});
+    query_pool_state->createInfo = *pCreateInfo;
+    queryPoolMap[*pQueryPool] = std::move(query_pool_state);
 }
 
 bool CoreChecks::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
@@ -10207,33 +10208,33 @@ bool CoreChecks::ValidateSecondaryCommandBufferState(CMD_BUFFER_STATE *pCB, CMD_
     unordered_set<int> activeTypes;
     if (!disabled.query_validation) {
         for (auto queryObject : pCB->activeQueries) {
-            auto queryPoolData = queryPoolMap.find(queryObject.pool);
-            if (queryPoolData != queryPoolMap.end()) {
-                if (queryPoolData->second.createInfo.queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS &&
+            auto query_pool_state = GetQueryPoolState(queryObject.pool);
+            if (query_pool_state) {
+                if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS &&
                     pSubCB->beginInfo.pInheritanceInfo) {
                     VkQueryPipelineStatisticFlags cmdBufStatistics = pSubCB->beginInfo.pInheritanceInfo->pipelineStatistics;
-                    if ((cmdBufStatistics & queryPoolData->second.createInfo.pipelineStatistics) != cmdBufStatistics) {
+                    if ((cmdBufStatistics & query_pool_state->createInfo.pipelineStatistics) != cmdBufStatistics) {
                         skip |= log_msg(
                             report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                             HandleToUint64(pCB->commandBuffer), "VUID-vkCmdExecuteCommands-commandBuffer-00104",
                             "vkCmdExecuteCommands() called w/ invalid Cmd Buffer %s which has invalid active query pool %s"
                             ". Pipeline statistics is being queried so the command buffer must have all bits set on the queryPool.",
                             report_data->FormatHandle(pCB->commandBuffer).c_str(),
-                            report_data->FormatHandle(queryPoolData->first).c_str());
+                            report_data->FormatHandle(queryObject.pool).c_str());
                     }
                 }
-                activeTypes.insert(queryPoolData->second.createInfo.queryType);
+                activeTypes.insert(query_pool_state->createInfo.queryType);
             }
         }
         for (auto queryObject : pSubCB->startedQueries) {
-            auto queryPoolData = queryPoolMap.find(queryObject.pool);
-            if (queryPoolData != queryPoolMap.end() && activeTypes.count(queryPoolData->second.createInfo.queryType)) {
+            auto query_pool_state = GetQueryPoolState(queryObject.pool);
+            if (query_pool_state && activeTypes.count(query_pool_state->createInfo.queryType)) {
                 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                                 HandleToUint64(pCB->commandBuffer), kVUID_Core_DrawState_InvalidSecondaryCommandBuffer,
                                 "vkCmdExecuteCommands() called w/ invalid Cmd Buffer %s which has invalid active query pool %s"
                                 " of type %d but a query of that type has been started on secondary Cmd Buffer %s.",
                                 report_data->FormatHandle(pCB->commandBuffer).c_str(),
-                                report_data->FormatHandle(queryPoolData->first).c_str(), queryPoolData->second.createInfo.queryType,
+                                report_data->FormatHandle(queryObject.pool).c_str(), query_pool_state->createInfo.queryType,
                                 report_data->FormatHandle(pSubCB->commandBuffer).c_str());
             }
         }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -187,8 +187,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkFence, std::unique_ptr<FENCE_STATE>> fenceMap;
     unordered_map<VkQueue, std::unique_ptr<QUEUE_STATE>> queueMap;
     unordered_map<VkEvent, std::unique_ptr<EVENT_STATE>> eventMap;
+    unordered_map<VkQueryPool, std::unique_ptr<QUERY_POOL_STATE>> queryPoolMap;
 
-    unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;
     unordered_map<VkSemaphore, SEMAPHORE_STATE> semaphoreMap;
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> imageLayoutMap;
     unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -188,8 +188,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkQueue, std::unique_ptr<QUEUE_STATE>> queueMap;
     unordered_map<VkEvent, std::unique_ptr<EVENT_STATE>> eventMap;
     unordered_map<VkQueryPool, std::unique_ptr<QUERY_POOL_STATE>> queryPoolMap;
+    unordered_map<VkSemaphore, std::unique_ptr<SEMAPHORE_STATE>> semaphoreMap;
 
-    unordered_map<VkSemaphore, SEMAPHORE_STATE> semaphoreMap;
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> imageLayoutMap;
     unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -183,8 +183,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkDescriptorSet, std::unique_ptr<cvdescriptorset::DescriptorSet>> setMap;
     unordered_map<VkCommandBuffer, std::unique_ptr<CMD_BUFFER_STATE>> commandBufferMap;
     unordered_map<VkCommandPool, std::unique_ptr<COMMAND_POOL_STATE>> commandPoolMap;
+    unordered_map<VkPipelineLayout, std::unique_ptr<PIPELINE_LAYOUT_STATE>> pipelineLayoutMap;
 
-    unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_STATE> pipelineLayoutMap;
     unordered_map<VkFence, FENCE_STATE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -182,7 +182,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkDescriptorPool, std::unique_ptr<DESCRIPTOR_POOL_STATE>> descriptorPoolMap;
     unordered_map<VkDescriptorSet, std::unique_ptr<cvdescriptorset::DescriptorSet>> setMap;
 
-    unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
+    unordered_map<VkCommandBuffer, std::unique_ptr<CMD_BUFFER_STATE>> commandBufferMap;
 
     unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_STATE> pipelineLayoutMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -181,10 +181,9 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     unordered_map<VkDescriptorPool, std::unique_ptr<DESCRIPTOR_POOL_STATE>> descriptorPoolMap;
     unordered_map<VkDescriptorSet, std::unique_ptr<cvdescriptorset::DescriptorSet>> setMap;
-
     unordered_map<VkCommandBuffer, std::unique_ptr<CMD_BUFFER_STATE>> commandBufferMap;
+    unordered_map<VkCommandPool, std::unique_ptr<COMMAND_POOL_STATE>> commandPoolMap;
 
-    unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_STATE> pipelineLayoutMap;
     unordered_map<VkFence, FENCE_STATE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -189,9 +189,9 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkEvent, std::unique_ptr<EVENT_STATE>> eventMap;
     unordered_map<VkQueryPool, std::unique_ptr<QUERY_POOL_STATE>> queryPoolMap;
     unordered_map<VkSemaphore, std::unique_ptr<SEMAPHORE_STATE>> semaphoreMap;
+    unordered_map<VkSurfaceKHR, std::unique_ptr<SURFACE_STATE>> surface_map;
 
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> imageLayoutMap;
-    unordered_map<VkSurfaceKHR, SURFACE_STATE> surface_map;
 
     unordered_map<VkRenderPass, std::shared_ptr<RENDER_PASS_STATE>> renderPassMap;
     unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> descriptorSetLayoutMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -184,8 +184,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkCommandBuffer, std::unique_ptr<CMD_BUFFER_STATE>> commandBufferMap;
     unordered_map<VkCommandPool, std::unique_ptr<COMMAND_POOL_STATE>> commandPoolMap;
     unordered_map<VkPipelineLayout, std::unique_ptr<PIPELINE_LAYOUT_STATE>> pipelineLayoutMap;
+    unordered_map<VkFence, std::unique_ptr<FENCE_STATE>> fenceMap;
 
-    unordered_map<VkFence, FENCE_STATE> fenceMap;
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
     unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -179,8 +179,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkShaderModule, std::unique_ptr<SHADER_MODULE_STATE>> shaderModuleMap;
     unordered_map<VkDescriptorUpdateTemplateKHR, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
     unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
+    unordered_map<VkDescriptorPool, std::unique_ptr<DESCRIPTOR_POOL_STATE>> descriptorPoolMap;
 
-    unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE*> descriptorPoolMap;
     unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
     unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
 
@@ -568,9 +568,7 @@ class CoreChecks : public ValidationObject {
     void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*);
     bool ValidateAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const cvdescriptorset::AllocateDescriptorSetsData*);
     void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const VkDescriptorSet*,
-                                       const cvdescriptorset::AllocateDescriptorSetsData*,
-                                       std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE*>*,
-                                       std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*>*);
+                                       const cvdescriptorset::AllocateDescriptorSetsData*);
     bool ValidateUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet* p_wds, uint32_t copy_count,
                                       const VkCopyDescriptorSet* p_cds, const char* func_name);
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -185,9 +185,9 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkCommandPool, std::unique_ptr<COMMAND_POOL_STATE>> commandPoolMap;
     unordered_map<VkPipelineLayout, std::unique_ptr<PIPELINE_LAYOUT_STATE>> pipelineLayoutMap;
     unordered_map<VkFence, std::unique_ptr<FENCE_STATE>> fenceMap;
+    unordered_map<VkQueue, std::unique_ptr<QUEUE_STATE>> queueMap;
+    unordered_map<VkEvent, std::unique_ptr<EVENT_STATE>> eventMap;
 
-    unordered_map<VkQueue, QUEUE_STATE> queueMap;
-    unordered_map<VkEvent, EVENT_STATE> eventMap;
     unordered_map<VkQueryPool, QUERY_POOL_STATE> queryPoolMap;
     unordered_map<VkSemaphore, SEMAPHORE_STATE> semaphoreMap;
     unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_STATE> imageLayoutMap;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -180,8 +180,8 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkDescriptorUpdateTemplateKHR, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
     unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     unordered_map<VkDescriptorPool, std::unique_ptr<DESCRIPTOR_POOL_STATE>> descriptorPoolMap;
+    unordered_map<VkDescriptorSet, std::unique_ptr<cvdescriptorset::DescriptorSet>> setMap;
 
-    unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet*> setMap;
     unordered_map<VkCommandBuffer, CMD_BUFFER_STATE*> commandBufferMap;
 
     unordered_map<VkCommandPool, COMMAND_POOL_STATE> commandPoolMap;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2563,12 +2563,11 @@ void CoreChecks::PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo
     for (uint32_t i = 0; i < p_alloc_info->descriptorSetCount; i++) {
         uint32_t variable_count = variable_count_valid ? variable_count_info->pDescriptorCounts[i] : 0;
 
-        auto new_ds = new cvdescriptorset::DescriptorSet(descriptor_sets[i], p_alloc_info->descriptorPool, ds_data->layout_nodes[i],
-                                                         variable_count, this);
-
-        pool_state->sets.insert(new_ds);
+        std::unique_ptr<cvdescriptorset::DescriptorSet> new_ds(new cvdescriptorset::DescriptorSet(
+            descriptor_sets[i], p_alloc_info->descriptorPool, ds_data->layout_nodes[i], variable_count, this));
+        pool_state->sets.insert(new_ds.get());
         new_ds->in_use.store(0);
-        setMap[descriptor_sets[i]] = new_ds;
+        setMap[descriptor_sets[i]] = std::move(new_ds);
     }
 }
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2548,10 +2548,8 @@ bool CoreChecks::ValidateAllocateDescriptorSets(const VkDescriptorSetAllocateInf
 // Decrement allocated sets from the pool and insert new sets into set_map
 void CoreChecks::PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *p_alloc_info,
                                                const VkDescriptorSet *descriptor_sets,
-                                               const cvdescriptorset::AllocateDescriptorSetsData *ds_data,
-                                               std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE *> *pool_map,
-                                               std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *set_map) {
-    auto pool_state = (*pool_map)[p_alloc_info->descriptorPool];
+                                               const cvdescriptorset::AllocateDescriptorSetsData *ds_data) {
+    auto pool_state = descriptorPoolMap[p_alloc_info->descriptorPool].get();
     // Account for sets and individual descriptors allocated from pool
     pool_state->availableSets -= p_alloc_info->descriptorSetCount;
     for (auto it = ds_data->required_descriptors_by_type.begin(); it != ds_data->required_descriptors_by_type.end(); ++it) {
@@ -2570,7 +2568,7 @@ void CoreChecks::PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo
 
         pool_state->sets.insert(new_ds);
         new_ds->in_use.store(0);
-        (*set_map)[descriptor_sets[i]] = new_ds;
+        setMap[descriptor_sets[i]] = new_ds;
     }
 }
 

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -971,7 +971,7 @@ void CoreChecks::SubmitBarrier(VkQueue queue) {
 
     auto it = queueMap.find(queue);
     if (it != queueMap.end()) {
-        queue_family_index = it->second.queueFamilyIndex;
+        queue_family_index = it->second->queueFamilyIndex;
     }
 
     // Pay attention only to queues that support graphics.


### PR DESCRIPTION
A step towards perhaps using std::shared_ptr in the future.