### PR TITLE
WIP: dehandle example

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -820,7 +820,7 @@ bool CoreChecks::ValidateBarriersToImages(CMD_BUFFER_STATE const *cb_state, uint
 bool CoreChecks::IsReleaseOp(CMD_BUFFER_STATE *cb_state, VkImageMemoryBarrier const *barrier) {
     if (!IsTransferOp(barrier)) return false;
 
-    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
+    auto pool = cb_state->command_pool.get();
     return pool && TempIsReleaseOp<VkImageMemoryBarrier, true>(pool, barrier);
 }
 
@@ -829,7 +829,7 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const char *func_name, CMD
                                                       const Barrier *barriers) {
     using BarrierRecord = QFOTransferBarrier<Barrier>;
     bool skip = false;
-    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
+    auto pool = cb_state->command_pool.get();
     auto &barrier_sets = GetQFOBarrierSets(cb_state, typename BarrierRecord::Tag());
     const char *barrier_name = BarrierRecord::BarrierName();
     const char *handle_name = BarrierRecord::HandleName();
@@ -867,7 +867,7 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const char *func_name, CMD
 
 template <typename Barrier>
 void CoreChecks::RecordQFOTransferBarriers(CMD_BUFFER_STATE *cb_state, uint32_t barrier_count, const Barrier *barriers) {
-    auto pool = GetCommandPoolState(cb_state->createInfo.commandPool);
+    auto pool = cb_state->command_pool.get();
     auto &barrier_sets = GetQFOBarrierSets(cb_state, typename QFOTransferBarrier<Barrier>::Tag());
     for (uint32_t b = 0; b < barrier_count; b++) {
         if (!IsTransferOp(&barriers[b])) continue;
@@ -1857,7 +1857,7 @@ static inline bool IsExtentSizeZero(const VkExtent3D *extent) {
 VkExtent3D CoreChecks::GetScaledItg(const CMD_BUFFER_STATE *cb_node, const IMAGE_STATE *img) {
     // Default to (0, 0, 0) granularity in case we can't find the real granularity for the physical device.
     VkExtent3D granularity = {0, 0, 0};
-    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
+    auto pPool = cb_node->command_pool.get();
     if (pPool) {
         granularity = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
         if (FormatIsCompressed(img->createInfo.format)) {
@@ -4737,7 +4737,7 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuff
     skip |= ValidateCmd(cb_node, CMD_COPYIMAGETOBUFFER, "vkCmdCopyImageToBuffer()");
 
     // Command pool must support graphics, compute, or transfer operations
-    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
+    auto pPool = cb_node->command_pool.get();
 
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
 
@@ -4821,7 +4821,7 @@ bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuff
     skip |= ValidateCmd(cb_node, CMD_COPYBUFFERTOIMAGE, "vkCmdCopyBufferToImage()");
 
     // Command pool must support graphics, compute, or transfer operations
-    auto pPool = GetCommandPoolState(cb_node->createInfo.commandPool);
+    auto pPool = cb_node->command_pool.get();
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -182,7 +182,7 @@ class CoreChecks : public ValidationObject {
     unordered_map<VkDescriptorPool, std::unique_ptr<DESCRIPTOR_POOL_STATE>> descriptorPoolMap;
     unordered_map<VkDescriptorSet, std::unique_ptr<cvdescriptorset::DescriptorSet>> setMap;
     unordered_map<VkCommandBuffer, std::unique_ptr<CMD_BUFFER_STATE>> commandBufferMap;
-    unordered_map<VkCommandPool, std::unique_ptr<COMMAND_POOL_STATE>> commandPoolMap;
+    unordered_map<VkCommandPool, COMMAND_POOL_SHARED> commandPoolMap;
     unordered_map<VkPipelineLayout, std::unique_ptr<PIPELINE_LAYOUT_STATE>> pipelineLayoutMap;
     unordered_map<VkFence, std::unique_ptr<FENCE_STATE>> fenceMap;
     unordered_map<VkQueue, std::unique_ptr<QUEUE_STATE>> queueMap;
@@ -252,6 +252,8 @@ class CoreChecks : public ValidationObject {
     RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
     std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
     FRAMEBUFFER_STATE* GetFramebufferState(VkFramebuffer framebuffer);
+
+    COMMAND_POOL_SHARED GetCommandPoolShared(VkCommandPool pool);
     COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool);
     SHADER_MODULE_STATE const* GetShaderModuleState(VkShaderModule module);
     FENCE_STATE* GetFenceState(VkFence fence);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1379,6 +1379,7 @@ struct QFOTransferCBScoreboards {
 struct CMD_BUFFER_STATE : public BASE_NODE {
     VkCommandBuffer commandBuffer;
     VkCommandBufferAllocateInfo createInfo = {};
+    COMMAND_POOL_SHARED command_pool;
     VkCommandBufferBeginInfo beginInfo;
     VkCommandBufferInheritanceInfo inheritanceInfo;
     VkDevice device;  // device this CB belongs to

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -79,8 +79,12 @@ class BASE_NODE {
     //  binding removed when command buffer is reset or destroyed
     // When an object is destroyed, any bound cbs are set to INVALID
     std::unordered_set<CMD_BUFFER_STATE *> cb_bindings;
+    bool destroyed;
 
-    BASE_NODE() { in_use.store(0); };
+    BASE_NODE() {
+        in_use.store(0);
+        destroyed = false;
+    };
 };
 
 // Track command pools and their command buffers
@@ -90,6 +94,7 @@ struct COMMAND_POOL_STATE : public BASE_NODE {
     // Cmd buffers allocated from this pool
     std::unordered_set<VkCommandBuffer> commandBuffers;
 };
+typedef std::shared_ptr<COMMAND_POOL_STATE> COMMAND_POOL_SHARED;
 
 // Utilities for barriers and the commmand pool
 template <typename Barrier>


### PR DESCRIPTION
Implemented "dehandling" for command pool state lookup from command buffer state.  For scope and examplar purposes.

Passes ULT -- but no performance or app testing has been done

@mark-lunarg  -- this is what I've been nattering about for hash eliminations  in a very simple case which is called once per vkCmd... call.