### PR TITLE
Fix use of 'is' operator for comparison

### DIFF
--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -230,7 +230,7 @@ class HelperFileOutputGenerator(OutputGenerator):
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if elem.tag == 'type' and elem.tail is not None and '*' in elem.tail:
                 ispointer = True
         return ispointer
     #

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1175,7 +1175,7 @@ VkResult DispatchSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsO
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if elem.tag == 'type' and elem.tail is not None and '*' in elem.tail:
                 ispointer = True
         return ispointer
     #

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1478,7 +1478,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if elem.tag == 'type' and elem.tail is not None and '*' in elem.tail:
                 ispointer = True
         return ispointer
 

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -491,7 +491,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if elem.tag == 'type' and elem.tail is not None and '*' in elem.tail:
                 ispointer = True
         return ispointer
     #

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -361,10 +361,10 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                 struct_validation_source = self.ScrubStructCode(expr)
                 pnext_case += '%s' % struct_validation_source
                 pnext_case += '        } break;\n'
-                if protect is not '':
+                if protect:
                     pnext_case += '#endif // %s\n' % protect
                 # Skip functions containing no validation
-                if struct_validation_source != '':
+                if struct_validation_source:
                     pnext_handler += pnext_case;
             pnext_handler += '        default:\n'
             pnext_handler += '            skip = false;\n'

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -677,7 +677,7 @@ void ThreadSafety::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapch
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if elem.tag == 'type' and elem.tail is not None and '*' in elem.tail:
                 ispointer = True
         return ispointer
 


### PR DESCRIPTION
The 'is' operator is not meant to be used for comparisons. It currently working is an implementation detail of CPython.
CPython 3.8 has added a SyntaxWarning for this.