### PR TITLE
layers: Avoid crash when pNext is invalid in update combined image of descriptor set

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2225,18 +2225,15 @@ bool cvdescriptorset::DescriptorSet::VerifyWriteUpdateContents(const VkWriteDesc
                         }
                     } else {
                         auto iv_state = device_data_->GetImageViewState(image_view);
-                        if (iv_state) {
-                            auto ycbcr_info = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(iv_state->create_info.pNext);
-                            if (ycbcr_info) {
-                                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-01947";
-                                std::stringstream error_str;
-                                error_str << "Because dstSet (" << update->dstSet << ") is bound to image view ("
-                                          << iv_state->image_view
-                                          << ") that includes a YCBCR conversion, it must have been allocated with a layout that "
-                                             "includes an immutable sampler.";
-                                *error_msg = error_str.str();
-                                return false;
-                            }
+                        if (iv_state && (iv_state->samplerConversion != VK_NULL_HANDLE)) {
+                            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-01947";
+                            std::stringstream error_str;
+                            error_str << "Because dstSet (" << update->dstSet << ") is bound to image view ("
+                                      << iv_state->image_view
+                                      << ") that includes a YCBCR conversion, it must have been allocated with a layout that "
+                                         "includes an immutable sampler.";
+                            *error_msg = error_str.str();
+                            return false;
                         }
                     }
                 }


### PR DESCRIPTION
Sometimes, `pNext`'s pointer is invalid. If it tries to get the struct of a `pNext`, it will crash. So I check `samplerConversion`, instead of `pNext`.
[issue #905 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/905)