### PR TITLE
layers: Fix plane compatibility validation

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4120,24 +4120,24 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         // Validate VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT state, if view/image formats differ
         if ((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) && (image_format != view_format)) {
             if (FormatIsMultiplane(image_format)) {
-                // View format must match the multiplane compatible format
-                uint32_t plane = 3;  // invalid
-                switch (aspect_mask) {
-                    case VK_IMAGE_ASPECT_PLANE_0_BIT:
-                        plane = 0;
-                        break;
-                    case VK_IMAGE_ASPECT_PLANE_1_BIT:
-                        plane = 1;
-                        break;
-                    case VK_IMAGE_ASPECT_PLANE_2_BIT:
-                        plane = 2;
-                        break;
-                    default:
-                        break;
-                }
-
-                VkFormat compat_format = FindMultiplaneCompatibleFormat(image_format, plane);
+                VkFormat compat_format = FindMultiplaneCompatibleFormat(image_format, aspect_mask);
                 if (view_format != compat_format) {
+                    // View format must match the multiplane compatible format
+                    uint32_t plane = 3;  // invalid
+                    switch (aspect_mask) {
+                        case VK_IMAGE_ASPECT_PLANE_0_BIT:
+                            plane = 0;
+                            break;
+                        case VK_IMAGE_ASPECT_PLANE_1_BIT:
+                            plane = 1;
+                            break;
+                        case VK_IMAGE_ASPECT_PLANE_2_BIT:
+                            plane = 2;
+                            break;
+                        default:
+                            break;
+                    }
+
                     std::stringstream ss;
                     ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)
                        << " is not compatible with plane " << plane << " of underlying image format "

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4123,24 +4123,9 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                 VkFormat compat_format = FindMultiplaneCompatibleFormat(image_format, aspect_mask);
                 if (view_format != compat_format) {
                     // View format must match the multiplane compatible format
-                    uint32_t plane = 3;  // invalid
-                    switch (aspect_mask) {
-                        case VK_IMAGE_ASPECT_PLANE_0_BIT:
-                            plane = 0;
-                            break;
-                        case VK_IMAGE_ASPECT_PLANE_1_BIT:
-                            plane = 1;
-                            break;
-                        case VK_IMAGE_ASPECT_PLANE_2_BIT:
-                            plane = 2;
-                            break;
-                        default:
-                            break;
-                    }
-
                     std::stringstream ss;
                     ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)
-                       << " is not compatible with plane " << plane << " of underlying image format "
+                       << " is not compatible with plane " << GetPlaneIndex(aspect_mask) << " of underlying image format "
                        << string_VkFormat(image_format) << ", must be " << string_VkFormat(compat_format) << ".";
                     skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                                     HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01586", "%s",

--- a/layers/vk_format_utils.h
+++ b/layers/vk_format_utils.h
@@ -173,6 +173,7 @@ VK_LAYER_EXPORT uint32_t FormatElementSize(VkFormat format, VkImageAspectFlags a
 VK_LAYER_EXPORT double FormatTexelSize(VkFormat format);
 VK_LAYER_EXPORT VkFormatCompatibilityClass FormatCompatibilityClass(VkFormat format);
 VK_LAYER_EXPORT VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor);
+VK_LAYER_EXPORT uint32_t GetPlaneIndex(VkImageAspectFlags aspect);
 VK_LAYER_EXPORT VkFormat FindMultiplaneCompatibleFormat(VkFormat fmt, VkImageAspectFlags plane_aspect);
 VK_LAYER_EXPORT VkExtent2D FindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspectFlags plane_aspect);
 


### PR DESCRIPTION
The plane index was being confused with the aspect mask which meant that
the check was failing incorrectly.