### PR TITLE
layers: Return error if >1 plane in mask

### DIFF
--- a/layers/vk_format_utils.cpp
+++ b/layers/vk_format_utils.cpp
@@ -1290,6 +1290,7 @@ const std::map<VkFormat, VULKAN_MULTIPLANE_COMPATIBILITY> vk_multiplane_compatib
 // clang-format on
 
 uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
+    // Returns an out of bounds index on error
     switch (aspect) {
         case VK_IMAGE_ASPECT_PLANE_0_BIT:
             return 0;
@@ -1301,7 +1302,8 @@ uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
             return 2;
             break;
         default:
-            return 0;
+            // If more than one plane bit is set, return error condition
+            return VK_MULTIPLANE_FORMAT_MAX_PLANES;
             break;
     }
 }

--- a/tests/vklayertests.cpp
+++ b/tests/vklayertests.cpp
@@ -23526,6 +23526,7 @@ TEST_F(VkLayerTest, CopyImageMultiplaneAspectBits) {
                                &copy_region);
     m_errorMonitor->VerifyFound();
 
+    m_errorMonitor->SetUnexpectedError("VUID-vkCmdCopyImage-srcImage-00135");
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT_KHR;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageCopy-srcImage-01553");


### PR DESCRIPTION
Addresses #850 - callers check for >= VK_MULTIPLANE_FORMAT_MAX_PLANES and will treat as an error