### PR TITLE
Remove wrong maxComputeWorkGroupInvocations check

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1565,8 +1565,6 @@ class CoreChecks : public ValidationObject {
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
     bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* shader);
-    bool ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
-                                             uint32_t groupCountZ);
     bool ValidateQueryRange(VkDevice device, VkQueryPool queryPool, uint32_t totalCount, uint32_t firstQuery, uint32_t queryCount,
                             const char* vuid_badfirst, const char* vuid_badrange);
     bool PreCallValidateResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -191,10 +191,6 @@ void CoreChecks::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuf
 
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
     bool skip = false;
-    auto *cb_state = GetCBState(commandBuffer);
-    if (cb_state) {
-        skip |= ValidateComputeWorkGroupInvocations(cb_state, x, y, z);
-    }
     skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCH, "vkCmdDispatch()",
                                 VK_QUEUE_COMPUTE_BIT, "VUID-vkCmdDispatch-commandBuffer-cmdpool", "VUID-vkCmdDispatch-renderpass",
                                 "VUID-vkCmdDispatch-None-02700", kVUIDUndefined);

--- a/tests/vklayertests.cpp
+++ b/tests/vklayertests.cpp
@@ -10087,10 +10087,6 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
     m_commandBuffer->begin();
     vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline);
 
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "features-limits-maxComputeWorkGroupInvocations");
-    vkCmdDispatch(m_commandBuffer->handle(), x_count_limit, y_count_limit, z_count_limit);
-    m_errorMonitor->VerifyFound();
-
     // Dispatch counts that exceed device limits
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDispatch-groupCountX-00386");
     vkCmdDispatch(m_commandBuffer->handle(), x_count_limit + 1, y_count_limit, z_count_limit);
@@ -11557,10 +11553,10 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
 
     // clang-format off
     vector<TestCase> test_cases = {
-        {   0, 
-            1, 
-            0, 
-            VK_VERTEX_INPUT_RATE_VERTEX, 
+        {   0,
+            1,
+            0,
+            VK_VERTEX_INPUT_RATE_VERTEX,
             {"VUID-VkVertexInputBindingDivisorDescriptionEXT-inputRate-01871"}
         },
         {   dev_limits.maxVertexInputBindings + 1,


### PR DESCRIPTION
The correct check for maxComputeWorkGroupInvocations is already done so we can simply remove this wrong check (the standard is a bit confusing here but this check makes no sense, see #923).
Also fix ShaderModule spelling.
Closes #923 