### PR TITLE
gpu: Ignore if maxBoundDescriptorSets == 0

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12845,7 +12845,9 @@ bool CoreChecks::PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const
 
 void CoreChecks::PreCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                           VkPhysicalDeviceProperties *pPhysicalDeviceProperties) {
-    if (enabled.gpu_validation && enabled.gpu_validation_reserve_binding_slot) {
+    // There is an implicit layer that can cause this call to return 0 for maxBoundDescriptorSets - Ignore such calls
+    if (enabled.gpu_validation && enabled.gpu_validation_reserve_binding_slot &&
+        pPhysicalDeviceProperties->limits.maxBoundDescriptorSets > 0) {
         if (pPhysicalDeviceProperties->limits.maxBoundDescriptorSets > 1) {
             pPhysicalDeviceProperties->limits.maxBoundDescriptorSets -= 1;
         } else {


### PR DESCRIPTION
For GPU-AV purposes, ignore GetPhysicalDeviceProperties calls if maxBoundDescriptorSets == 0