### PR TITLE
layers: Fix incorrect feature requirement

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1562,6 +1562,7 @@ bool CoreChecks::ValidateShaderCapabilities(SHADER_MODULE_STATE const *src, VkSh
         {spv::CapabilitySampled1D, {nullptr}},
         {spv::CapabilityImage1D, {nullptr}},
         {spv::CapabilitySampledBuffer, {nullptr}},
+        {spv::CapabilityStorageImageExtendedFormats, {nullptr}},
         {spv::CapabilityImageQuery, {nullptr}},
         {spv::CapabilityDerivativeControl, {nullptr}},
 
@@ -1587,7 +1588,6 @@ bool CoreChecks::ValidateShaderCapabilities(SHADER_MODULE_STATE const *src, VkSh
         {spv::CapabilityMinLod, {"VkPhysicalDeviceFeatures::shaderResourceMinLod", &VkPhysicalDeviceFeatures::shaderResourceMinLod}},
         {spv::CapabilitySampledCubeArray, {"VkPhysicalDeviceFeatures::imageCubeArray", &VkPhysicalDeviceFeatures::imageCubeArray}},
         {spv::CapabilityImageMSArray, {"VkPhysicalDeviceFeatures::shaderStorageImageMultisample", &VkPhysicalDeviceFeatures::shaderStorageImageMultisample}},
-        {spv::CapabilityStorageImageExtendedFormats, {"VkPhysicalDeviceFeatures::shaderStorageImageExtendedFormats", &VkPhysicalDeviceFeatures::shaderStorageImageExtendedFormats}},
         {spv::CapabilityInterpolationFunction, {"VkPhysicalDeviceFeatures::sampleRateShading", &VkPhysicalDeviceFeatures::sampleRateShading}},
         {spv::CapabilityStorageImageReadWithoutFormat, {"VkPhysicalDeviceFeatures::shaderStorageImageReadWithoutFormat", &VkPhysicalDeviceFeatures::shaderStorageImageReadWithoutFormat}},
         {spv::CapabilityStorageImageWriteWithoutFormat, {"VkPhysicalDeviceFeatures::shaderStorageImageWriteWithoutFormat", &VkPhysicalDeviceFeatures::shaderStorageImageWriteWithoutFormat}},


### PR DESCRIPTION
Do not require shaderStorageImageExtendedFormats Vulkan
feature when declaring the StorageImageExtendedFormats
OpCapability in SPIR-V shader. Validation now only requires
that the VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT is found in
image view's format features when usage contains
VK_IMAGE_USAGE_STORAGE_BIT in image view creation.

Fixes #925