### PR TITLE
[WIP] layers: portability validation layer (for review only)

### DIFF
--- a/RUN_PORTABILITY_VALIDATION.sh
+++ b/RUN_PORTABILITY_VALIDATION.sh
@@ -1,0 +1,24 @@
+#! /bin/bash -x
+# Run vkcube with portability validation
+# mikew@lunarg.com
+
+set -o nounset
+
+echo "DISPLAY = ${DISPLAY:=:0}"
+export DISPLAY
+
+GITHUB="${HOME}/gits/github.com"
+
+# Location of .json manifest files (shared libraries to be searched using PATH)
+export VK_LAYER_PATH="${GITHUB}/KhronosGroup/Vulkan-ValidationLayers/BUILD/layers"
+
+export VK_INSTANCE_LAYERS="VK_LAYER_LUNARG_portability_validation"
+
+# error, warn, info, debug, all
+#export VK_LOADER_DEBUG="debug"
+
+APP="${GITHUB}/KhronosGroup/Vulkan-Tools/BUILD/cube/vkcube"
+
+$APP
+
+# vim: set sw=4 ts=8 et ic ai:

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -91,7 +91,8 @@ set(TARGET_NAMES
     VkLayer_unique_objects
     VkLayer_stateless_validation
     VkLayer_standard_validation
-    VkLayer_thread_safety)
+    VkLayer_thread_safety
+    VkLayer_portability_validation)
 
 if(BUILD_LAYERS)
     # Install the layer json files
@@ -222,6 +223,11 @@ set(STATELESS_VALIDATION_LIBRARY_FILES
     parameter_validation.h
     parameter_validation_utils.cpp)
 
+set(PORTABILITY_VALIDATION_LIBRARY_FILES
+    portability_validation.cpp
+    portability_validation.h
+)
+
 # Inter-layer dependencies are temporarily necessary to serialize layer builds which avoids contention for common generated files
 if(BUILD_LAYERS)
     AddVkLayer(core_validation "BUILD_CORE_VALIDATION"
@@ -236,12 +242,15 @@ if(BUILD_LAYERS)
     add_dependencies(VkLayer_stateless_validation VkLayer_thread_safety)
     AddVkLayer(unique_objects "LAYER_CHASSIS_CAN_WRAP_HANDLES" ${CHASSIS_LIBRARY_FILES})
     add_dependencies(VkLayer_unique_objects VkLayer_stateless_validation)
-    AddVkLayer(khronos_validation "BUILD_KHRONOS_VALIDATION;BUILD_CORE_VALIDATION;BUILD_OBJECT_TRACKER;BUILD_THREAD_SAFETY;BUILD_PARAMETER_VALIDATION;LAYER_CHASSIS_CAN_WRAP_HANDLES"
+    AddVkLayer(portability_validation "BUILD_PORTABILITY_VALIDATION" ${CHASSIS_LIBRARY_FILES} ${PORTABILITY_VALIDATION_LIBRARY_FILES})
+    add_dependencies(VkLayer_portability_validation VkLayer_stateless_validation)
+    AddVkLayer(khronos_validation "BUILD_KHRONOS_VALIDATION;BUILD_CORE_VALIDATION;BUILD_OBJECT_TRACKER;BUILD_THREAD_SAFETY;BUILD_PARAMETER_VALIDATION;BUILD_PORTABILITY_VALIDATION;LAYER_CHASSIS_CAN_WRAP_HANDLES"
         ${CHASSIS_LIBRARY_FILES}
         ${CORE_VALIDATION_LIBRARY_FILES}
         ${OBJECT_LIFETIMES_LIBRARY_FILES}
         ${THREAD_SAFETY_LIBRARY_FILES}
-        ${STATELESS_VALIDATION_LIBRARY_FILES})
+        ${STATELESS_VALIDATION_LIBRARY_FILES}
+        ${PORTABILITY_VALIDATION_LIBRARY_FILES})
     add_dependencies(VkLayer_khronos_validation VkLayer_unique_objects)
 
     # Core validation and Khronos validation have additional dependencies

--- a/layers/VkLayer_portability_validation.def
+++ b/layers/VkLayer_portability_validation.def
@@ -1,0 +1,30 @@
+
+;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Copyright (c) 2015-2019 The Khronos Group Inc.
+; Copyright (c) 2015-2019 Valve Corporation
+; Copyright (c) 2015-2019 LunarG, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+;  Author: Mike Weiblen <mikew@LunarG.com>
+;
+;;;;  End Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+LIBRARY VkLayer_portability_validation
+EXPORTS
+vkGetInstanceProcAddr
+vkGetDeviceProcAddr
+vkEnumerateInstanceLayerProperties
+vkEnumerateInstanceExtensionProperties
+vkNegotiateLoaderLayerInterfaceVersion

--- a/layers/json/VkLayer_portability_validation.json.in
+++ b/layers/json/VkLayer_portability_validation.json.in
@@ -1,0 +1,18 @@
+{
+    "file_format_version" : "1.1.0",
+    "layer" : {
+        "name": "VK_LAYER_LUNARG_portability_validation",
+        "type": "GLOBAL",
+        "library_path": "@RELATIVE_LAYER_BINARY@",
+        "api_version": "@VK_VERSION@",
+        "implementation_version": "1",
+        "description": "LunarG Portability Validation Layer",
+        "device_extensions": [
+             {
+                 "name": "VK_EXTX_portability_subset",
+                 "spec_version": "1",
+                 "entrypoints": []
+             }
+         ]
+    }
+}

--- a/layers/libVkLayer_portability_validation.map
+++ b/layers/libVkLayer_portability_validation.map
@@ -1,0 +1,10 @@
+{
+  global:
+    vkGetInstanceProcAddr;
+    vkGetDeviceProcAddr;
+    vkEnumerateInstanceLayerProperties;
+    vkEnumerateInstanceExtensionProperties;
+    vkNegotiateLoaderLayerInterfaceVersion;
+  local:
+    *;
+};

--- a/layers/portability_validation.cpp
+++ b/layers/portability_validation.cpp
@@ -1,0 +1,383 @@
+/* Copyright (c) 2019 The Khronos Group Inc.
+ * Copyright (c) 2019 Valve Corporation
+ * Copyright (c) 2019 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mike Weiblen <mikew@lunarg.com>
+ */
+
+//#pragma message( "this is : #pragma message1")
+
+#include <stdio.h>
+#include "chassis.h"
+#include "portability_validation.h"
+
+bool PortabilityValidation::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkInstance* pInstance,
+                                                         VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                                    VkPhysicalDevice* pPhysicalDevices) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                                  VkPhysicalDevice* pPhysicalDevices) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                                   VkPhysicalDevice* pPhysicalDevices, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                                       VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                                                VkExtensionProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                                              VkExtensionProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                                               VkExtensionProperties* pProperties,
+                                                                               VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                              const char* pLayerName, uint32_t* pPropertyCount,
+                                                                              VkExtensionProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
+                                                                            uint32_t* pPropertyCount,
+                                                                            VkExtensionProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                             const char* pLayerName, uint32_t* pPropertyCount,
+                                                                             VkExtensionProperties* pProperties, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
+                                                                            VkLayerProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
+                                                                          VkLayerProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties,
+                                                                           VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                          VkLayerProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                        VkLayerProperties* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                         VkLayerProperties* pProperties, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
+                                                                         VkPhysicalDeviceFeatures2* pFeatures) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
+                                                                       VkPhysicalDeviceFeatures2* pFeatures) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
+                                                                        VkPhysicalDeviceFeatures2* pFeatures) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                           VkPhysicalDeviceProperties2* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                         VkPhysicalDeviceProperties2* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                          VkPhysicalDeviceProperties2* pProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordGetPhysicalDeviceImageFormatProperties2KHR(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordGetPhysicalDeviceImageFormatProperties2KHR(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkEvent* pEvent) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkEvent* pEvent) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkEvent* pEvent, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateGetEventStatus(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordGetEventStatus(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordGetEventStatus(VkDevice device, VkEvent event, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateSetEvent(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordSetEvent(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordSetEvent(VkDevice device, VkEvent event, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateResetEvent(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordResetEvent(VkDevice device, VkEvent event) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordResetEvent(VkDevice device, VkEvent event, VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
+                                                       VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
+                                                      VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
+                                                         VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
+                                                       VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
+                                                        VkPipelineStageFlags stageMask) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                         VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                                         uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                                         uint32_t bufferMemoryBarrierCount,
+                                                         const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                                         uint32_t imageMemoryBarrierCount,
+                                                         const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                       VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                                       uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                                       uint32_t bufferMemoryBarrierCount,
+                                                       const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                                       uint32_t imageMemoryBarrierCount,
+                                                       const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                        VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                                        uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                                        uint32_t bufferMemoryBarrierCount,
+                                                        const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                                        uint32_t imageMemoryBarrierCount,
+                                                        const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
+                                                                   uint32_t createInfoCount,
+                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkPipeline* pPipelines) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
+                                                                 uint32_t createInfoCount,
+                                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
+                                                                  uint32_t createInfoCount,
+                                                                  const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                  const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                  VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator, VkImageView* pView) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkImageView* pView) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkImageView* pView,
+                                                          VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+bool PortabilityValidation::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkSampler* pSampler) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+    return false;
+}
+
+void PortabilityValidation::PreCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkSampler* pSampler) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+void PortabilityValidation::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
+                                                        VkResult result) {
+    printf("%s @ %d\n", __FUNCTION__, __LINE__);
+}
+
+// vim: set sw=4 ts=8 et ic ai:

--- a/layers/portability_validation.h
+++ b/layers/portability_validation.h
@@ -1,0 +1,172 @@
+/* Copyright (c) 2019 The Khronos Group Inc.
+ * Copyright (c) 2019 Valve Corporation
+ * Copyright (c) 2019 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mike Weiblen <mikew@lunarg.com>
+ */
+
+#ifndef VULKAN_PORTABILITY_VALIDATION_H
+#define VULKAN_PORTABILITY_VALIDATION_H
+
+#include "vulkan/vulkan.h"
+#include "vulkan/vk_layer.h"
+#include "vk_extx_portability_subset.h"
+
+class PortabilityValidation : public ValidationObject {
+   public:
+    bool PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                       VkInstance* pInstance);
+    void PreCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                     VkInstance* pInstance);
+    void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                      VkInstance* pInstance, VkResult result);
+
+    bool PreCallValidateEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                 VkPhysicalDevice* pPhysicalDevices);
+    void PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                               VkPhysicalDevice* pPhysicalDevices);
+    void PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                VkPhysicalDevice* pPhysicalDevices, VkResult result);
+
+    bool PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice);
+    void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice);
+    void PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
+
+    bool PreCallValidateEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                             VkExtensionProperties* pProperties);
+    void PreCallRecordEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                           VkExtensionProperties* pProperties);
+    void PostCallRecordEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                            VkExtensionProperties* pProperties, VkResult result);
+
+    bool PreCallValidateEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
+                                                           uint32_t* pPropertyCount, VkExtensionProperties* pProperties);
+    void PreCallRecordEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
+                                                         uint32_t* pPropertyCount, VkExtensionProperties* pProperties);
+    void PostCallRecordEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
+                                                          uint32_t* pPropertyCount, VkExtensionProperties* pProperties,
+                                                          VkResult result);
+
+    bool PreCallValidateEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties);
+    void PreCallRecordEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties);
+    void PostCallRecordEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties, VkResult result);
+
+    bool PreCallValidateEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                       VkLayerProperties* pProperties);
+    void PreCallRecordEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                     VkLayerProperties* pProperties);
+    void PostCallRecordEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                      VkLayerProperties* pProperties, VkResult result);
+
+    bool PreCallValidateGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
+    void PreCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
+    void PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
+
+    bool PreCallValidateGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2* pProperties);
+    void PreCallRecordGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2* pProperties);
+    void PostCallRecordGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2* pProperties);
+
+    bool PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                   const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+                                                                   VkImageFormatProperties2* pImageFormatProperties);
+    void PreCallRecordGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                 const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+                                                                 VkImageFormatProperties2* pImageFormatProperties);
+    void PostCallRecordGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                  const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+                                                                  VkImageFormatProperties2* pImageFormatProperties,
+                                                                  VkResult result);
+
+    bool PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                    VkEvent* pEvent);
+    void PreCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                  VkEvent* pEvent);
+    void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                   VkEvent* pEvent, VkResult result);
+
+    bool PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator);
+    void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator);
+    void PostCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator);
+
+    bool PreCallValidateGetEventStatus(VkDevice device, VkEvent event);
+    void PreCallRecordGetEventStatus(VkDevice device, VkEvent event);
+    void PostCallRecordGetEventStatus(VkDevice device, VkEvent event, VkResult result);
+
+    bool PreCallValidateSetEvent(VkDevice device, VkEvent event);
+    void PreCallRecordSetEvent(VkDevice device, VkEvent event);
+    void PostCallRecordSetEvent(VkDevice device, VkEvent event, VkResult result);
+
+    bool PreCallValidateResetEvent(VkDevice device, VkEvent event);
+    void PreCallRecordResetEvent(VkDevice device, VkEvent event);
+    void PostCallRecordResetEvent(VkDevice device, VkEvent event, VkResult result);
+
+    bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    void PreCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    void PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+
+    bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    void PreCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+
+    bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                      VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                      uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                      uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                      uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+    void PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                    VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                    uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                    uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+    void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                     VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                     uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+
+    bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
+                                                const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
+    void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
+                                              const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
+    void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
+                                               const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result);
+
+    bool PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks* pAllocator, VkImageView* pView);
+    void PreCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkImageView* pView);
+    void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkImageView* pView, VkResult result);
+
+    bool PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkSampler* pSampler);
+    void PreCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkSampler* pSampler);
+    void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkSampler* pSampler, VkResult result);
+
+   private:
+
+};  // class PortabilityValidation
+
+#endif  // VULKAN_PORTABILITY_VALIDATION_H
+
+// vim: set sw=4 ts=8 et ic ai:

--- a/layers/vk_extx_portability_subset.h
+++ b/layers/vk_extx_portability_subset.h
@@ -1,0 +1,76 @@
+#ifndef VK_EXTX_PORTABILITY_SUBSET_H_
+#define VK_EXTX_PORTABILITY_SUBSET_H_ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+ Please Note:  This extension is currently defined as "EXTX", meaning "multivendor experimental".
+ That means the definition of this extension is in active development, and may break compatibility
+ between point releases (defined as any increment of VK_EXTX_PORTABILITY_SUBSET_SPEC_VERSION).
+ You are free to explore the extension and provide feedback, but it is not recommended to use this
+ extension for shipping applications, particularly applications that require the driver implementing this
+ extension to be linked dynamically and potentially "dropped-in" to the application execution environment.
+ */
+
+#include "vulkan/vulkan.h"
+
+#define VK_EXTX_PORTABILITY_SUBSET_SPEC_VERSION       1
+#define VK_EXTX_PORTABILITY_SUBSET_EXTENSION_NAME     "VK_EXTX_portability_subset"
+
+#define VK_EXTX_PORTABILITY_SUBSET_EXTENSION_ID 164
+// See enum_offset() from https://www.khronos.org/registry/vulkan/specs/1.1/styleguide.html#_assigning_extension_token_values
+#define VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(x) \
+    ((VkStructureType)(1000000000 + 1000 * (VK_EXTX_PORTABILITY_SUBSET_EXTENSION_ID - 1) + x))
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_EXTX      VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(0)
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_EXTX    VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(1)
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_SUPPORT_EXTX               VK_EXTX_PORTABILITY_SUBSET_STYPE_ID(2)
+
+typedef struct VkPhysicalDevicePortabilitySubsetFeaturesEXTX {
+     VkStructureType    sType;
+     void*              pNext;
+     VkBool32           triangleFans;
+     VkBool32           separateStencilMaskRef;
+     VkBool32           events;
+     VkBool32           standardImageViews;
+     VkBool32           samplerMipLodBias;
+} VkPhysicalDevicePortabilitySubsetFeaturesEXTX;
+
+typedef struct VkPhysicalDevicePortabilitySubsetPropertiesEXTX {
+     VkStructureType    sType;
+     void*              pNext;
+     uint32_t           minVertexInputBindingStrideAlignment;
+} VkPhysicalDevicePortabilitySubsetPropertiesEXTX;
+
+typedef struct VkPhysicalDeviceImageViewSupportEXTX {
+     VkStructureType        sType;
+     void*                  pNext;
+     VkImageViewCreateFlags flags;
+     VkImageViewType        viewType;
+     VkFormat               format;
+     VkComponentMapping     components;
+     VkImageAspectFlags     aspectMask;
+} VkPhysicalDeviceImageViewSupportEXTX;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VK_EXTX_PORTABILITY_SUBSET_H_

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -83,6 +83,8 @@
 #      flags are briefly described here:
 #      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT - enables intrusive GPU-assisted
 #      shader validation in core/khronos validation layers
+#      VK_VALIDATION_FEATURE_ENABLE_PORTABILITY_VALIDATION_EXTX - enable validation for
+#      the work-in-progress VK_EXTX_portability_subset extension.
 #
 
 # VK_LAYER_KHRONOS_validation Settings
@@ -116,4 +118,10 @@ google_threading.log_filename = stdout
 google_unique_objects.debug_action = VK_DBG_LAYER_ACTION_LOG_MSG
 google_unique_objects.report_flags = error,warn,perf
 google_unique_objects.log_filename = stdout
+
+# VK_LAYER_LUNARG_portability_validation Settings
+lunarg_portability_validation.debug_action = VK_DBG_LAYER_ACTION_LOG_MSG
+lunarg_portability_validation.report_flags = error,warn,perf
+lunarg_portability_validation.log_filename = stdout
+
 ################################################################################

--- a/layers/vk_validation_error_messages.h
+++ b/layers/vk_validation_error_messages.h
@@ -1,3 +1,10 @@
+/******************************************************************************
+** README README README README README README README README README README README
+** Because the "VK_EXTX_portability_subset" extension is not yet part of
+** Vulkan XML registry, this file has been deliberately hand-edited to add
+** the "VUID-vkPortability-*" messages.
+******************************************************************************/
+
 /* THIS FILE IS GENERATED - DO NOT EDIT (scripts/vk_validation_stats.py) */
 /* Vulkan specification version: 1.1.107 */
 /* Header generated: 2019-04-30 12:00:30 */
@@ -5145,6 +5152,33 @@ static const vuid_spec_text_pair vuid_spec_text[] = {
     {"VUID-vkWaitForFences-fenceCount-arraylength", "fenceCount must be greater than 0 (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkWaitForFences-fenceCount-arraylength)"},
     {"VUID-vkWaitForFences-pFences-parameter", "pFences must be a valid pointer to an array of fenceCount valid VkFence handles (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkWaitForFences-pFences-parameter)"},
     {"VUID-vkWaitForFences-pFences-parent", "Each element of pFences must have been created, allocated, or retrieved from device (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkWaitForFences-pFences-parent)"},
+    {"VUID-vkPortability-001", "VK_EXTX_portability_subset requires Vulkan 1.0"},
+    {"VUID-vkPortability-002", "VK_EXTX_portability_subset requires VK_KHR_get_physical_device_properties2"},
+    {"VUID-vkPortability-003", "VK_EXTX_portability_subset exists, but has not be enabled"},
+    {"VUID-vkPortability-004", "vkGetPhysicalDeviceFeatures2KHR called with illegal sType in pNext chain"},
+    {"VUID-vkPortability-005", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX has not been queried using vkGetPhysicalDeviceFeatures2KHR"},
+    {"VUID-vkPortability-006", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.triangleFans is false, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN not permitted"},
+    {"VUID-vkPortability-007", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.separateStencilMaskRef is false, front and back stencil reference values must be equal"},
+    {"VUID-vkPortability-008", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkCreateEvent"},
+    {"VUID-vkPortability-009", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkDestroyEvent"},
+    {"VUID-vkPortability-010", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkGetEventStatus"},
+    {"VUID-vkPortability-011", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkSetEvent"},
+    {"VUID-vkPortability-012", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkResetEvent"},
+    {"VUID-vkPortability-013", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkCmdSetEvent"},
+    {"VUID-vkPortability-014", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkCmdResetEvent"},
+    {"VUID-vkPortability-015", "VkPhysicalDevicePortabilitySubsetFeaturesEXTX.events is false, must not call vkCmdWaitEvents"},
+    {"VUID-vkPortability-016", "vkGetPhysicalDeviceProperties2KHR called with illegal sType in pNext chain"},
+    {"VUID-vkPortability-017", "VkPhysicalDevicePortabilitySubsetPropertiesEXTX has not been queried using vkGetPhysicalDeviceProperties2KHR"},
+    {"VUID-vkPortability-018", "VkVertexInputBindingDescription.stride is not a non-zero multiple of VkPhysicalDevicePortabilitySubsetPropertiesEXTX.minVertexInputBindingStrideAlignment"},
+    {"VUID-vkPortability-019", "vkGetPhysicalDeviceImageFormatProperties2KHR called with illegal sType in pNext chain"},
+    {"VUID-vkPortability-020", "VkPhysicalDeviceImageViewSupportEXTX.flags must be 0"},
+    {"VUID-vkPortability-021", "VkPhysicalDeviceImageViewSupportEXTX.viewType is not a valid VkImageViewType value"},
+    {"VUID-vkPortability-022", "VkPhysicalDeviceImageViewSupportEXTX.format is not a valid VkFormat value"},
+    {"VUID-vkPortability-023", "VkPhysicalDeviceImageViewSupportEXTX.components is not a valid vkComponentMapping structure"},
+    {"VUID-vkPortability-024", "VkPhysicalDeviceImageViewSupportEXTX.aspectMask must not be 0"},
+    {"VUID-vkPortability-025", "VkPhysicalDeviceImageViewSupportEXTX.aspectMask must be a valid combination of VkImageAspectFlagBits values"},
+    {"VUID-vkPortability-026", "VkImageView used without first querying using VkPhysicalDeviceImageViewSupportEXTX"},
+    {"VUID-vkPortability-027", "VkImageView used, but VkPhysicalDeviceImageViewSupportEXTX reported VK_ERROR_FORMAT_NOT_SUPPORTED"},
 };
 
 // Defines to allow creating "must be recording" meta data


### PR DESCRIPTION
DO NOT MERGE, FOR REVIEW ONLY!

Initial implementation of a portability_subset v0.2 validation layer
using the new Validation Layer Chassis framework.

Includes a rough draft of the validation error messages to be reported,
as derived from the VK_EXTX_portability_subset.md specification.
Both the list of error messages and the contents of those messages need
review and refinement.

This frames out the layer for intercepting the necessary Vulkan calls
for implementing the validation logic.

Builds on Windows and Linux as a separate shared library.
When integrated into core Vulkan, this functionality can be incorporated
directly into the KHRONOS_validation layer.

The RUN_PORTABILITY_VALIDATION.sh script for Linux demonstrates the
layer using a modified portability-aware vkcube executable, see
https://github.com/KhronosGroup/Vulkan-Tools/pull/193

Due to the extension not existing in the Vulkan XML manifest, there
are several hacks to the Layer Chassis to temporarily bypass its code-generation.

Included is a verbatim local copy of vk_extx_portability_subset.h from the v0.2 release.

Change-Id: I6394adadb5330776110683404f74b76309a78592