### PR TITLE
cmake: Always use a known CMake version for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,10 +17,17 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
+  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:
     - master
+
+install:
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\cmake > nul
+  - set path=C:\cmake\bin;%path%
+  - cmake --version
 
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,18 @@ cache: ccache
 
 before_install:
   - set -e
+  - CMAKE_VERSION=3.10.2
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      # Upgrade to the desired version of CMake
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      echo CMAKE_URL=${CMAKE_URL}
+      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
+      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+    cmake --version
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "GN" ]]; then
       # Install the appropriate Linux packages.
@@ -177,7 +189,6 @@ script:
 notifications:
   email:
     recipients:
-      - karl@lunarg.com
       - cnorthrop@google.com
       - tobine@google.com
       - chrisforbes@google.com


### PR DESCRIPTION
Add the ability to specify a specific version of CMake to be used
for CI builds.  Currently, use CMake 3.10.2 for all CI builds.

Also, removed Karl from the Travis distribution list, at his request.