### PR TITLE
Refactor first tranche of validation functions out of DescriptorSet* classes.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5219,7 +5219,7 @@ void CoreChecks::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCre
 bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                                           const VkAllocationCallbacks *pAllocator,
                                                           VkDescriptorSetLayout *pSetLayout) {
-    return cvdescriptorset::DescriptorSetLayout::ValidateCreateInfo(
+    return cvdescriptorset::ValidateDescriptorSetLayoutCreateInfo(
         report_data, pCreateInfo, device_extensions.vk_khr_push_descriptor, phys_dev_ext_props.max_push_descriptors,
         device_extensions.vk_ext_descriptor_indexing, &enabled_features.descriptor_indexing, &enabled_features.inline_uniform_block,
         &phys_dev_ext_props.inline_uniform_block_props);
@@ -7003,7 +7003,8 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandB
                     // TODO move the validation (like this) that doesn't need descriptor set state to the DSL object so we
                     // don't have to do this.
                     cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, VK_NULL_HANDLE, dsl, 0, this);
-                    skip |= proxy_ds.ValidatePushDescriptorsUpdate(report_data, descriptorWriteCount, pDescriptorWrites, func_name);
+                    skip |=
+                        ValidatePushDescriptorsUpdate(&proxy_ds, report_data, descriptorWriteCount, pDescriptorWrites, func_name);
                 }
             }
         } else {
@@ -12592,8 +12593,8 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuf
         cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state, pData,
                                                                 dsl->GetDescriptorSetLayout());
         // Validate the decoded update against the proxy_ds
-        skip |= proxy_ds.ValidatePushDescriptorsUpdate(report_data, static_cast<uint32_t>(decoded_template.desc_writes.size()),
-                                                       decoded_template.desc_writes.data(), func_name);
+        skip |= ValidatePushDescriptorsUpdate(&proxy_ds, report_data, static_cast<uint32_t>(decoded_template.desc_writes.size()),
+                                              decoded_template.desc_writes.data(), func_name);
     }
 
     return skip;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1203,7 +1203,7 @@ static bool VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorSet *d
     }
     if (descriptor_set->IsPushDescriptor()) return true;
     auto layout_node = pipeline_layout->set_layouts[layoutIndex];
-    return descriptor_set->IsCompatible(layout_node.get(), &errorMsg);
+    return cvdescriptorset::VerifySetLayoutCompatibility(layout_node.get(), descriptor_set->GetLayout().get(), &errorMsg);
 }
 
 // Validate overall state at the time of a draw call

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1885,143 +1885,6 @@ bool cvdescriptorset::DescriptorSet::ValidatePushDescriptorsUpdate(const debug_r
     return skip;
 }
 
-// Validate the state for a given write update but don't actually perform the update
-//  If an error would occur for this update, return false and fill in details in error_msg string
-bool cvdescriptorset::ValidateWriteUpdate(const DescriptorSet *dest_set, const debug_report_data *report_data,
-                                          const VkWriteDescriptorSet *update, const char *func_name, std::string *error_code,
-                                          std::string *error_msg) {
-    const auto dest_layout = dest_set->GetLayout();
-
-    // Verify dst layout still valid
-    if (dest_layout->IsDestroyed()) {
-        *error_code = "VUID-VkWriteDescriptorSet-dstSet-00320";
-        string_sprintf(error_msg, "Cannot call %s to perform write update on %s which has been destroyed", func_name,
-                       dest_set->StringifySetAndLayout().c_str());
-        return false;
-    }
-    // Verify dst binding exists
-    if (!dest_layout->HasBinding(update->dstBinding)) {
-        *error_code = "VUID-VkWriteDescriptorSet-dstBinding-00315";
-        std::stringstream error_str;
-        error_str << dest_set->StringifySetAndLayout() << " does not have binding " << update->dstBinding;
-        *error_msg = error_str.str();
-        return false;
-    }
-
-    DescriptorSetLayout::ConstBindingIterator dest(dest_layout.get(), update->dstBinding);
-    // Make sure binding isn't empty
-    if (0 == dest.GetDescriptorCount()) {
-        *error_code = "VUID-VkWriteDescriptorSet-dstBinding-00316";
-        std::stringstream error_str;
-        error_str << dest_set->StringifySetAndLayout() << " cannot updated binding " << update->dstBinding
-                  << " that has 0 descriptors";
-        *error_msg = error_str.str();
-        return false;
-    }
-
-    // Verify idle ds
-    if (dest_set->in_use.load() && !(dest.GetDescriptorBindingFlags() & (VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT_EXT |
-                                                                         VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT))) {
-        // TODO : Re-using Free Idle error code, need write update idle error code
-        *error_code = "VUID-vkFreeDescriptorSets-pDescriptorSets-00309";
-        std::stringstream error_str;
-        error_str << "Cannot call " << func_name << " to perform write update on " << dest_set->StringifySetAndLayout()
-                  << " that is in use by a command buffer";
-        *error_msg = error_str.str();
-        return false;
-    }
-    // We know that binding is valid, verify update and do update on each descriptor
-    auto start_idx = dest.GetGlobalIndexRange().start + update->dstArrayElement;
-    auto type = dest.GetType();
-    if (type != update->descriptorType) {
-        *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00319";
-        std::stringstream error_str;
-        error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                  << " with type " << string_VkDescriptorType(type) << " but update type is "
-                  << string_VkDescriptorType(update->descriptorType);
-        *error_msg = error_str.str();
-        return false;
-    }
-    auto total_descriptors = dest_layout->GetTotalDescriptorCount();
-    if (update->descriptorCount > (total_descriptors - start_idx)) {
-        *error_code = "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
-        std::stringstream error_str;
-        error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                  << " with " << total_descriptors - start_idx
-                  << " descriptors in that binding and all successive bindings of the set, but update of "
-                  << update->descriptorCount << " descriptors combined with update array element offset of "
-                  << update->dstArrayElement << " oversteps the available number of consecutive descriptors";
-        *error_msg = error_str.str();
-        return false;
-    }
-    if (type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-        if ((update->dstArrayElement % 4) != 0) {
-            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02219";
-            std::stringstream error_str;
-            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                      << " with "
-                      << "dstArrayElement " << update->dstArrayElement << " not a multiple of 4";
-            *error_msg = error_str.str();
-            return false;
-        }
-        if ((update->descriptorCount % 4) != 0) {
-            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02220";
-            std::stringstream error_str;
-            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                      << " with "
-                      << "descriptorCount  " << update->descriptorCount << " not a multiple of 4";
-            *error_msg = error_str.str();
-            return false;
-        }
-        const auto *write_inline_info = lvl_find_in_chain<VkWriteDescriptorSetInlineUniformBlockEXT>(update->pNext);
-        if (!write_inline_info || write_inline_info->dataSize != update->descriptorCount) {
-            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02221";
-            std::stringstream error_str;
-            if (!write_inline_info) {
-                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #"
-                          << update->dstBinding << " with "
-                          << "VkWriteDescriptorSetInlineUniformBlockEXT missing";
-            } else {
-                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #"
-                          << update->dstBinding << " with "
-                          << "VkWriteDescriptorSetInlineUniformBlockEXT dataSize " << write_inline_info->dataSize
-                          << " not equal to "
-                          << "VkWriteDescriptorSet descriptorCount " << update->descriptorCount;
-            }
-            *error_msg = error_str.str();
-            return false;
-        }
-        // This error is probably unreachable due to the previous two errors
-        if (write_inline_info && (write_inline_info->dataSize % 4) != 0) {
-            *error_code = "VUID-VkWriteDescriptorSetInlineUniformBlockEXT-dataSize-02222";
-            std::stringstream error_str;
-            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                      << " with "
-                      << "VkWriteDescriptorSetInlineUniformBlockEXT dataSize " << write_inline_info->dataSize
-                      << " not a multiple of 4";
-            *error_msg = error_str.str();
-            return false;
-        }
-    }
-    // Verify consecutive bindings match (if needed)
-    if (!VerifyUpdateConsistency(DescriptorSetLayout::ConstBindingIterator(dest_layout.get(), update->dstBinding),
-                                 update->dstArrayElement, update->descriptorCount, "write update to", dest_set->GetSet(),
-                                 error_msg)) {
-        // TODO : Should break out "consecutive binding updates" language into valid usage statements
-        *error_code = "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
-        return false;
-    }
-    // Update is within bounds and consistent so last step is to validate update contents
-    if (!dest_set->VerifyWriteUpdateContents(update, start_idx, func_name, error_code, error_msg)) {
-        std::stringstream error_str;
-        error_str << "Write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
-                  << " failed with error message: " << error_msg->c_str();
-        *error_msg = error_str.str();
-        return false;
-    }
-    // All checks passed, update is clean
-    return true;
-}
 // For the given buffer, verify that its creation parameters are appropriate for the given type
 //  If there's an error, update the error_msg string with details and return false, else return true
 bool cvdescriptorset::DescriptorSet::ValidateBufferUsage(BUFFER_STATE const *buffer_node, VkDescriptorType type,
@@ -2601,5 +2464,143 @@ bool cvdescriptorset::VerifyUpdateConsistency(DescriptorSetLayout::ConstBindingI
         update_count -= binding_remaining;
         binding_remaining = current_binding.GetDescriptorCount();
     }
+    return true;
+}
+
+// Validate the state for a given write update but don't actually perform the update
+//  If an error would occur for this update, return false and fill in details in error_msg string
+bool cvdescriptorset::ValidateWriteUpdate(const DescriptorSet *dest_set, const debug_report_data *report_data,
+                                          const VkWriteDescriptorSet *update, const char *func_name, std::string *error_code,
+                                          std::string *error_msg) {
+    const auto dest_layout = dest_set->GetLayout();
+
+    // Verify dst layout still valid
+    if (dest_layout->IsDestroyed()) {
+        *error_code = "VUID-VkWriteDescriptorSet-dstSet-00320";
+        string_sprintf(error_msg, "Cannot call %s to perform write update on %s which has been destroyed", func_name,
+                       dest_set->StringifySetAndLayout().c_str());
+        return false;
+    }
+    // Verify dst binding exists
+    if (!dest_layout->HasBinding(update->dstBinding)) {
+        *error_code = "VUID-VkWriteDescriptorSet-dstBinding-00315";
+        std::stringstream error_str;
+        error_str << dest_set->StringifySetAndLayout() << " does not have binding " << update->dstBinding;
+        *error_msg = error_str.str();
+        return false;
+    }
+
+    DescriptorSetLayout::ConstBindingIterator dest(dest_layout.get(), update->dstBinding);
+    // Make sure binding isn't empty
+    if (0 == dest.GetDescriptorCount()) {
+        *error_code = "VUID-VkWriteDescriptorSet-dstBinding-00316";
+        std::stringstream error_str;
+        error_str << dest_set->StringifySetAndLayout() << " cannot updated binding " << update->dstBinding
+                  << " that has 0 descriptors";
+        *error_msg = error_str.str();
+        return false;
+    }
+
+    // Verify idle ds
+    if (dest_set->in_use.load() && !(dest.GetDescriptorBindingFlags() & (VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT_EXT |
+                                                                         VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT))) {
+        // TODO : Re-using Free Idle error code, need write update idle error code
+        *error_code = "VUID-vkFreeDescriptorSets-pDescriptorSets-00309";
+        std::stringstream error_str;
+        error_str << "Cannot call " << func_name << " to perform write update on " << dest_set->StringifySetAndLayout()
+                  << " that is in use by a command buffer";
+        *error_msg = error_str.str();
+        return false;
+    }
+    // We know that binding is valid, verify update and do update on each descriptor
+    auto start_idx = dest.GetGlobalIndexRange().start + update->dstArrayElement;
+    auto type = dest.GetType();
+    if (type != update->descriptorType) {
+        *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00319";
+        std::stringstream error_str;
+        error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                  << " with type " << string_VkDescriptorType(type) << " but update type is "
+                  << string_VkDescriptorType(update->descriptorType);
+        *error_msg = error_str.str();
+        return false;
+    }
+    auto total_descriptors = dest_layout->GetTotalDescriptorCount();
+    if (update->descriptorCount > (total_descriptors - start_idx)) {
+        *error_code = "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
+        std::stringstream error_str;
+        error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                  << " with " << total_descriptors - start_idx
+                  << " descriptors in that binding and all successive bindings of the set, but update of "
+                  << update->descriptorCount << " descriptors combined with update array element offset of "
+                  << update->dstArrayElement << " oversteps the available number of consecutive descriptors";
+        *error_msg = error_str.str();
+        return false;
+    }
+    if (type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        if ((update->dstArrayElement % 4) != 0) {
+            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02219";
+            std::stringstream error_str;
+            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                      << " with "
+                      << "dstArrayElement " << update->dstArrayElement << " not a multiple of 4";
+            *error_msg = error_str.str();
+            return false;
+        }
+        if ((update->descriptorCount % 4) != 0) {
+            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02220";
+            std::stringstream error_str;
+            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                      << " with "
+                      << "descriptorCount  " << update->descriptorCount << " not a multiple of 4";
+            *error_msg = error_str.str();
+            return false;
+        }
+        const auto *write_inline_info = lvl_find_in_chain<VkWriteDescriptorSetInlineUniformBlockEXT>(update->pNext);
+        if (!write_inline_info || write_inline_info->dataSize != update->descriptorCount) {
+            *error_code = "VUID-VkWriteDescriptorSet-descriptorType-02221";
+            std::stringstream error_str;
+            if (!write_inline_info) {
+                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #"
+                          << update->dstBinding << " with "
+                          << "VkWriteDescriptorSetInlineUniformBlockEXT missing";
+            } else {
+                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #"
+                          << update->dstBinding << " with "
+                          << "VkWriteDescriptorSetInlineUniformBlockEXT dataSize " << write_inline_info->dataSize
+                          << " not equal to "
+                          << "VkWriteDescriptorSet descriptorCount " << update->descriptorCount;
+            }
+            *error_msg = error_str.str();
+            return false;
+        }
+        // This error is probably unreachable due to the previous two errors
+        if (write_inline_info && (write_inline_info->dataSize % 4) != 0) {
+            *error_code = "VUID-VkWriteDescriptorSetInlineUniformBlockEXT-dataSize-02222";
+            std::stringstream error_str;
+            error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                      << " with "
+                      << "VkWriteDescriptorSetInlineUniformBlockEXT dataSize " << write_inline_info->dataSize
+                      << " not a multiple of 4";
+            *error_msg = error_str.str();
+            return false;
+        }
+    }
+    // Verify consecutive bindings match (if needed)
+    if (!VerifyUpdateConsistency(DescriptorSetLayout::ConstBindingIterator(dest_layout.get(), update->dstBinding),
+                                 update->dstArrayElement, update->descriptorCount, "write update to", dest_set->GetSet(),
+                                 error_msg)) {
+        // TODO : Should break out "consecutive binding updates" language into valid usage statements
+        *error_code = "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
+        return false;
+    }
+    // Update is within bounds and consistent so last step is to validate update contents
+    if (!dest_set->VerifyWriteUpdateContents(update, start_idx, func_name, error_code, error_msg)) {
+        std::stringstream error_str;
+        error_str << "Write update to " << dest_set->StringifySetAndLayout() << " binding #" << update->dstBinding
+                  << " failed with error message: " << error_msg->c_str();
+        *error_msg = error_str.str();
+        return false;
+    }
+    // All checks passed, update is clean
     return true;
 }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -100,9 +100,6 @@ class DescriptorSetLayoutDef {
     const std::set<uint32_t> &GetSortedBindingSet() const { return non_empty_bindings_; }
     // Return true if given binding is present in this layout
     bool HasBinding(const uint32_t binding) const { return binding_to_index_map_.count(binding) > 0; };
-    // Return true if this DSL Def (referenced by the 1st layout) is compatible with another DSL Def (ref'd from the 2nd layout)
-    // else return false and update error_msg with description of incompatibility
-    bool IsCompatible(VkDescriptorSetLayout, VkDescriptorSetLayout, DescriptorSetLayoutDef const *const, std::string *) const;
     // Return true if binding 1 beyond given exists and has same type, stageFlags & immutable sampler use
     bool IsNextBindingConsistent(const uint32_t) const;
     uint32_t GetIndexFromBinding(uint32_t binding) const;
@@ -198,7 +195,8 @@ class DescriptorSetLayout {
     bool HasBinding(const uint32_t binding) const { return layout_id_->HasBinding(binding); }
     // Return true if this layout is compatible with passed in layout from a pipelineLayout,
     //   else return false and update error_msg with description of incompatibility
-    bool IsCompatible(DescriptorSetLayout const *const, std::string *) const;
+    // Return true if this layout is compatible with passed in layout
+    bool IsCompatible(DescriptorSetLayout const *rh_ds_layout) const;
     // Straightforward Get functions
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return layout_; };
     bool IsDestroyed() const { return layout_destroyed_; }
@@ -371,6 +369,10 @@ class Descriptor {
 bool ValidateSampler(const VkSampler, CoreChecks *);
 bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, CoreChecks *, const char *func_name, std::string *,
                          std::string *);
+// Return true if this layout is compatible with passed in layout from a pipelineLayout,
+//   else return false and update error_msg with description of incompatibility
+bool VerifySetLayoutCompatibility(DescriptorSetLayout const *lh_ds_layout, DescriptorSetLayout const *rh_ds_layout,
+                                  std::string *error_msg);
 bool ValidateDescriptorSetLayoutCreateInfo(const debug_report_data *report_data, const VkDescriptorSetLayoutCreateInfo *create_info,
                                            const bool push_descriptor_ext, const uint32_t max_push_descriptors,
                                            const bool descriptor_indexing_ext,
@@ -571,8 +573,6 @@ class DescriptorSet : public BASE_NODE {
     }
     // Return true if given binding is present in this set
     bool HasBinding(const uint32_t binding) const { return p_layout_->HasBinding(binding); };
-    // Is this set compatible with the given layout?
-    bool IsCompatible(DescriptorSetLayout const *const, std::string *) const;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const std::map<uint32_t, descriptor_req> &, const std::vector<uint32_t> &, CMD_BUFFER_STATE *,
                            const char *caller, std::string *) const;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -505,6 +505,8 @@ bool VerifyUpdateConsistency(DescriptorSetLayout::ConstBindingIterator current_b
 bool ValidateWriteUpdate(const DescriptorSet *descriptor_set, const debug_report_data *report_data,
                          const VkWriteDescriptorSet *update, const char *func_name, std::string *error_code,
                          std::string *error_msg);
+bool VerifyWriteUpdateContents(const DescriptorSet *dest_set, const VkWriteDescriptorSet *update, const uint32_t index,
+                               const char *func_name, std::string *error_code, std::string *error_msg);
 
 // Helper class to encapsulate the descriptor update template decoding logic
 struct DecodedTemplateUpdate {
@@ -632,14 +634,16 @@ class DescriptorSet : public BASE_NODE {
     DESCRIPTOR_POOL_STATE *GetPoolState() const { return pool_state_; }
     const Descriptor *GetDescriptorFromGlobalIndex(const uint32_t index) const { return descriptors_[index].get(); }
 
+    // TODO: Clean up the const cleaness here.  Getting  non-const CoreChecks from a const DescriptorSet is probably not okay.
+    CoreChecks *GetDeviceData() const { return device_data_; }
+
     // TODO -- remove from DescriptorSet
-    bool VerifyWriteUpdateContents(const VkWriteDescriptorSet *, const uint32_t, const char *, std::string *, std::string *) const;
+    bool ValidateBufferUsage(BUFFER_STATE const *, VkDescriptorType, std::string *, std::string *) const;
+    bool ValidateBufferUpdate(VkDescriptorBufferInfo const *, VkDescriptorType, const char *, std::string *, std::string *) const;
 
    private:
     bool VerifyCopyUpdateContents(const VkCopyDescriptorSet *, const DescriptorSet *, VkDescriptorType, uint32_t, const char *,
                                   std::string *, std::string *) const;
-    bool ValidateBufferUsage(BUFFER_STATE const *, VkDescriptorType, std::string *, std::string *) const;
-    bool ValidateBufferUpdate(VkDescriptorBufferInfo const *, VkDescriptorType, const char *, std::string *, std::string *) const;
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers();
     bool some_update_;  // has any part of the set ever been updated?


### PR DESCRIPTION
In order to make state tracking reusable in various ValidationObject subclasses, the objects that track state must be distinct from the CoreChecks validation functionality.

This is the first piece of that refactor.  Note that for functions that I moved to the end of file, the move is a separate change.  Later refactors I left in situ, but will move as a separate PR to improve reviewability.