### PR TITLE
Fixes a bug where the maxComputeWorkGroupInvocations limit is incorrectly validated

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1592,8 +1592,7 @@ class CoreChecks : public ValidationObject {
     bool PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo);
     bool PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
     bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* shader);
-    bool ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE* cb_state, uint32_t groupCountX, uint32_t groupCountY,
-                                             uint32_t groupCountZ);
+    bool ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE* cb_state);
     bool ValidateQueryRange(VkDevice device, VkQueryPool queryPool, uint32_t totalCount, uint32_t firstQuery, uint32_t queryCount,
                             const char* vuid_badfirst, const char* vuid_badrange);
     bool PreCallValidateResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -193,7 +193,7 @@ bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint3
     bool skip = false;
     auto *cb_state = GetCBState(commandBuffer);
     if (cb_state) {
-        skip |= ValidateComputeWorkGroupInvocations(cb_state, x, y, z);
+        skip |= ValidateComputeWorkGroupInvocations(cb_state);
     }
     skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCH, "vkCmdDispatch()",
                                 VK_QUEUE_COMPUTE_BIT, "VUID-vkCmdDispatch-commandBuffer-cmdpool", "VUID-vkCmdDispatch-renderpass",

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2979,8 +2979,7 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE *shader
     return skip;
 }
 
-bool CoreChecks::ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE *cb_state, uint32_t groupCountX, uint32_t groupCountY,
-                                                     uint32_t groupCountZ) {
+bool CoreChecks::ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE *cb_state) {
     auto const &state = cb_state->lastBound[VK_PIPELINE_BIND_POINT_COMPUTE];
     PIPELINE_STATE *pPipe = state.pipeline_state;
     if (!pPipe) return false;
@@ -3003,24 +3002,6 @@ bool CoreChecks::ValidateComputeWorkGroupInvocations(CMD_BUFFER_STATE *cb_state,
             }
             if (!overflow) {
                 invocations *= local_size_z;
-                if (invocations > UINT32_MAX) {
-                    overflow = true;
-                }
-            }
-            if (!overflow) {
-                invocations *= groupCountX;
-                if (invocations > UINT32_MAX) {
-                    overflow = true;
-                }
-            }
-            if (!overflow) {
-                invocations *= groupCountY;
-                if (invocations > UINT32_MAX) {
-                    overflow = true;
-                }
-            }
-            if (!overflow) {
-                invocations *= groupCountZ;
                 if (invocations > UINT32_MAX) {
                     overflow = true;
                 }

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -1518,7 +1518,7 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "features-limits-maxComputeWorkGroupInvocations");
     vkCmdDispatch(m_commandBuffer->handle(), x_count_limit, y_count_limit, z_count_limit);
-    m_errorMonitor->VerifyFound();
+    m_errorMonitor->VerifyNotFound();
 
     // Dispatch counts that exceed device limits
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDispatch-groupCountX-00386");
@@ -1840,10 +1840,10 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
 
     // clang-format off
     vector<TestCase> test_cases = {
-        {   0, 
-            1, 
-            0, 
-            VK_VERTEX_INPUT_RATE_VERTEX, 
+        {   0,
+            1,
+            0,
+            VK_VERTEX_INPUT_RATE_VERTEX,
             {"VUID-VkVertexInputBindingDivisorDescriptionEXT-inputRate-01871"}
         },
         {   dev_limits.maxVertexInputBindings + 1,


### PR DESCRIPTION
The CoreChecks::ValidateComputeWorkGroupInvocations() validates the
maxComputeWorkGroupInvocations against the workgroup count as well which is
incorrect. According to the spec only the local size must be taken into
account and nothing from the dispatch command.

Change-Id: Ic1cca566ff956759c3361f1151199c1a83d8baf6