### PR TITLE
layers: Allow using 0th Queue Family and 1 queue

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -103,7 +103,7 @@ struct PHYSICAL_DEVICE_STATE {
     CALL_STATE vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = UNCALLED;
     safe_VkPhysicalDeviceFeatures2 features2 = {};
     VkPhysicalDevice phys_device = VK_NULL_HANDLE;
-    uint32_t queue_family_count = 0;
+    uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported
     std::vector<VkQueueFamilyProperties> queue_family_properties;
     VkSurfaceCapabilitiesKHR surfaceCapabilities = {};
     std::vector<VkPresentModeKHR> present_modes;
@@ -443,8 +443,8 @@ class CoreChecks : public ValidationStateTracker {
     void UpdateDrawState(CMD_BUFFER_STATE* cb_state, const VkPipelineBindPoint bind_point);
     bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE* cb_state, const char* call_source);
     void InitGpuValidation();
-    bool ValidatePhysicalDeviceQueueFamily(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family,
-                                           const char* err_code, const char* cmd_name, const char* queue_family_var_name);
+    bool ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family, const char* err_code,
+                                  const char* cmd_name, const char* queue_family_var_name);
     bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,
                                         const VkDeviceQueueCreateInfo* infos);
 

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -7236,3 +7236,28 @@ TEST_F(VkPositiveLayerTest, CreatePipelineFragmentOutputNotConsumedButAlphaToCov
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, "", true);
 }
+
+TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
+    TEST_DESCRIPTION("Use first queue family and one queue without first querying with vkGetPhysicalDeviceQueueFamilyProperties");
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+
+    const float q_priority[] = {1.0f};
+    VkDeviceQueueCreateInfo queue_ci = {};
+    queue_ci.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_ci.queueFamilyIndex = 0;
+    queue_ci.queueCount = 1;
+    queue_ci.pQueuePriorities = q_priority;
+
+    VkDeviceCreateInfo device_ci = {};
+    device_ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    device_ci.queueCreateInfoCount = 1;
+    device_ci.pQueueCreateInfos = &queue_ci;
+
+    m_errorMonitor->ExpectSuccess();
+    VkDevice test_device;
+    vkCreateDevice(gpu(), &device_ci, nullptr, &test_device);
+    m_errorMonitor->VerifyNotFound();
+
+    vkDestroyDevice(test_device, nullptr);
+}


### PR DESCRIPTION
despite the strict VU wording, the counts can be infered:

> Implementations **must** support at least one queue family.

> Each queue family **must** support at least one queue.