### PR TITLE
chassis: Fix calldown logic in device extensions

### DIFF
--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -760,7 +760,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
     if (pLayerName && !strcmp(pLayerName, global_layer.layerName)) return util_GetExtensionProperties(0, NULL, pCount, pProperties);
     assert(physicalDevice);
     auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-    return layer_data->instance_dispatch_table.EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
+    return layer_data->instance_dispatch_table.EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,


### PR DESCRIPTION
This fixes a bug where the layer chassis did not call down properly in `vkEnumerateDeviceExtensionProperties` if `pLayerName` was null. This prevented other layers from ever seeing the call.

This bug wasn't causing problems in the past (though it was technically still bugged), but it will start causing problems once KhronosGroup/Vulkan-Loader#194 is merged.