### PR TITLE
scripts: Modify val stats script for helper fxns

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -278,6 +278,8 @@ class ValidationSource:
                         line = prepend[:-2] + line.lstrip().lstrip('"') # join lines skipping CR, whitespace and trailing/leading quote char
                         prepend = None
                     if any(prefix in line for prefix in vuid_prefixes):
+                        # Replace the '(' of lines containing validation helper functions with ' ' to make them easier to parse
+                        line = line.replace("(", " ")
                         line_list = line.split()
 
                         # A VUID string that has been broken by clang will start with a vuid prefix and end with -, and will be last in the list


### PR DESCRIPTION
`vk_validation_stats.py` could not handle the case when a validation
helper function's first parameter is a VUID string.