### PR TITLE
Remove unsubmitted fence warning

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1178,7 +1178,6 @@ class CoreChecks : public ValidationStateTracker {
                                       uint64_t timeout);
     void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                      uint64_t timeout, VkResult result);
-    bool PreCallValidateGetFenceStatus(VkDevice device, VkFence fence);
     void PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, VkResult result);
     bool PreCallValidateQueueWaitIdle(VkQueue queue);
     void PostCallRecordQueueWaitIdle(VkQueue queue, VkResult result);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2306,15 +2306,12 @@ TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
 }
 
 TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
-    TEST_DESCRIPTION(
-        "Call VkQueueSubmit with a semaphore that is already signaled but not waited on by the queue. Wait on a fence that has not "
-        "yet been submitted to a queue.");
+    TEST_DESCRIPTION("Call VkQueueSubmit with a semaphore that is already signaled but not waited on by the queue.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const char *queue_forward_progress_message = " that was previously signaled by queue 0x";
-    const char *invalid_fence_wait_message = " which has not been submitted on a Queue or during acquire next image.";
 
     VkCommandBufferObj cb1(m_device, m_commandPool);
     cb1.begin();
@@ -2339,17 +2336,7 @@ TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
     vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
-    VkFenceCreateInfo fence_create_info = {};
-    fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    VkFence fence;
-    ASSERT_VK_SUCCESS(vkCreateFence(m_device->device(), &fence_create_info, nullptr, &fence));
-
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT, invalid_fence_wait_message);
-    vkWaitForFences(m_device->device(), 1, &fence, VK_TRUE, UINT64_MAX);
-    m_errorMonitor->VerifyFound();
-
     vkDeviceWaitIdle(m_device->device());
-    vkDestroyFence(m_device->device(), fence, nullptr);
     vkDestroySemaphore(m_device->device(), semaphore, nullptr);
 }
 


### PR DESCRIPTION
Fixes #255.  This warning was invalid, confusing, and as part of the move to separate warnings from valid usage, being removed from CoreChecks.