### PR TITLE
Add VU checks for CUBE_COMPATIBLE image sizes

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1326,11 +1326,21 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
     }
 
-    if ((pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) && (VK_IMAGE_TYPE_2D != pCreateInfo->imageType)) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-            "VUID-VkImageCreateInfo-flags-00949",
-            "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT flag bit is set");
+    if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
+        if (VK_IMAGE_TYPE_2D != pCreateInfo->imageType) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-flags-00949",
+                            "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT "
+                            "flag bit is set");
+        }
+
+        if ((pCreateInfo->extent.width != pCreateInfo->extent.height) || (pCreateInfo->arrayLayers < 6)) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkImageCreateInfo-imageType-00954",
+                            "vkCreateImage(): If VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT flag bit is set, width (%d) must equal "
+                            "height (%d) and arrayLayers (%d) must be >= 6.",
+                            pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->arrayLayers);
+        }
     }
 
     const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -5863,12 +5863,14 @@ TEST_F(VkLayerTest, CreateImageMiscErrors) {
         image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         image_ci.arrayLayers = 6;
         image_ci.imageType = VK_IMAGE_TYPE_1D;
+        m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00954");
         image_ci.extent = {64, 1, 1};
         CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-00949");
 
         image_ci = safe_image_ci;
         image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         image_ci.imageType = VK_IMAGE_TYPE_3D;
+        m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00954");
         image_ci.extent = {4, 4, 4};
         CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-00949");
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -5873,6 +5873,20 @@ TEST_F(VkLayerTest, CreateImageMiscErrors) {
         m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00954");
         image_ci.extent = {4, 4, 4};
         CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-00949");
+
+        image_ci = safe_image_ci;
+        image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+        image_ci.imageType = VK_IMAGE_TYPE_2D;
+        image_ci.extent = {8, 6, 1};
+        image_ci.arrayLayers = 6;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-imageType-00954");
+
+        image_ci = safe_image_ci;
+        image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+        image_ci.imageType = VK_IMAGE_TYPE_2D;
+        image_ci.extent = {8, 8, 1};
+        image_ci.arrayLayers = 4;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-imageType-00954");
     }
 
     {


### PR DESCRIPTION
Added check for `VUID-VkImageCreateInfo-imageType-00954`, width==height and arrayLayers >= 6, along with tests.

Fixes #410.