### PR TITLE
Fix vkBindImageMemory doesn't check swapchain

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -65,10 +65,10 @@ IMAGE_STATE::IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo)
       has_ahb_format(false),
       ahb_format(0),
       full_range{},
-      sparse_requirements{},
       create_from_swapchain(VK_NULL_HANDLE),
       bind_swapchain(VK_NULL_HANDLE),
-      bind_swapchain_imageIndex(0) {
+      bind_swapchain_imageIndex(0),
+      sparse_requirements{} {
     if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
         uint32_t *pQueueFamilyIndices = new uint32_t[createInfo.queueFamilyIndexCount];
         for (uint32_t i = 0; i < createInfo.queueFamilyIndexCount; i++) {

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -65,7 +65,10 @@ IMAGE_STATE::IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo)
       has_ahb_format(false),
       ahb_format(0),
       full_range{},
-      sparse_requirements{} {
+      sparse_requirements{},
+      create_from_swapchain(VK_NULL_HANDLE),
+      bind_swapchain(VK_NULL_HANDLE),
+      bind_swapchain_imageIndex(0) {
     if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
         uint32_t *pQueueFamilyIndices = new uint32_t[createInfo.queueFamilyIndexCount];
         for (uint32_t i = 0; i < createInfo.queueFamilyIndexCount; i++) {
@@ -1463,6 +1466,10 @@ void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateI
     IMAGE_STATE *is_node = new IMAGE_STATE(*pImage, pCreateInfo);
     if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
         RecordCreateImageANDROID(pCreateInfo, is_node);
+    }
+    const auto swapchain_info = lvl_find_in_chain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
+    if (swapchain_info) {
+        is_node->create_from_swapchain = swapchain_info->swapchain;
     }
     imageMap.insert(std::make_pair(*pImage, std::unique_ptr<IMAGE_STATE>(is_node)));
     ImageSubresourcePair subpair{*pImage, false, VkImageSubresource()};

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -421,7 +421,16 @@ bool CoreChecks::VerifyBoundMemoryIsValid(VkDeviceMemory mem, const VulkanTypedH
 // Check to see if memory was ever bound to this image
 bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, const char *api_name, const char *error_code) {
     bool result = false;
-    if (0 == (static_cast<uint32_t>(image_state->createInfo.flags) & VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
+    if (image_state->create_from_swapchain != VK_NULL_HANDLE) {
+        if (image_state->bind_swapchain == VK_NULL_HANDLE) {
+            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                    HandleToUint64(image_state->image), error_code,
+                    "%s: %s is created by %s, and the image should be bound by calling vkBindImageMemory2(), and the pNext chain "
+                    "includes VkBindImageMemorySwapchainInfoKHR.",
+                    api_name, report_data->FormatHandle(image_state->image).c_str(),
+                    report_data->FormatHandle(image_state->create_from_swapchain).c_str());
+        }
+    } else if (0 == (static_cast<uint32_t>(image_state->createInfo.flags) & VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
         result = VerifyBoundMemoryIsValid(image_state->binding.mem, VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage),
                                           api_name, error_code);
     }
@@ -10482,13 +10491,13 @@ bool CoreChecks::PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDev
     return skip;
 }
 
-bool CoreChecks::ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset, const char *api_name) {
+bool CoreChecks::ValidateBindImageMemory(const VkBindImageMemoryInfo &bindInfo, const char *api_name) {
     bool skip = false;
-    IMAGE_STATE *image_state = GetImageState(image);
+    IMAGE_STATE *image_state = GetImageState(bindInfo.image);
     if (image_state) {
         // Track objects tied to memory
-        uint64_t image_handle = HandleToUint64(image);
-        skip = ValidateSetMemBinding(mem, VulkanTypedHandle(image, kVulkanObjectTypeImage), api_name);
+        uint64_t image_handle = HandleToUint64(bindInfo.image);
+        skip = ValidateSetMemBinding(bindInfo.memory, VulkanTypedHandle(bindInfo.image, kVulkanObjectTypeImage), api_name);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         if (image_state->external_format_android) {
             if (image_state->memory_requirements_checked) {
@@ -10496,7 +10505,7 @@ bool CoreChecks::ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDe
                                 kVUID_Core_DrawState_InvalidImage,
                                 "%s: Must not call vkGetImageMemoryRequirements on %s that will be bound to an external "
                                 "Android hardware buffer.",
-                                api_name, report_data->FormatHandle(image).c_str());
+                                api_name, report_data->FormatHandle(bindInfo.image).c_str());
             }
             return skip;
         }
@@ -10508,55 +10517,84 @@ bool CoreChecks::ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDe
             skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
                             kVUID_Core_DrawState_InvalidImage,
                             "%s: Binding memory to %s but vkGetImageMemoryRequirements() has not been called on that image.",
-                            api_name, report_data->FormatHandle(image).c_str());
+                            api_name, report_data->FormatHandle(bindInfo.image).c_str());
             // Make the call for them so we can verify the state
-            DispatchGetImageMemoryRequirements(device, image, &image_state->requirements);
+            DispatchGetImageMemoryRequirements(device, bindInfo.image, &image_state->requirements);
         }
 
         // Validate bound memory range information
-        auto mem_info = GetDevMemState(mem);
+        auto mem_info = GetDevMemState(bindInfo.memory);
         if (mem_info) {
-            skip |= ValidateInsertImageMemoryRange(image, mem_info, memoryOffset, image_state->requirements,
+            skip |= ValidateInsertImageMemoryRange(bindInfo.image, mem_info, bindInfo.memoryOffset, image_state->requirements,
                                                    image_state->createInfo.tiling == VK_IMAGE_TILING_LINEAR, api_name);
             skip |= ValidateMemoryTypes(mem_info, image_state->requirements.memoryTypeBits, api_name,
                                         "VUID-vkBindImageMemory-memory-01047");
         }
 
         // Validate memory requirements alignment
-        if (SafeModulo(memoryOffset, image_state->requirements.alignment) != 0) {
+        if (SafeModulo(bindInfo.memoryOffset, image_state->requirements.alignment) != 0) {
             skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
                             "VUID-vkBindImageMemory-memoryOffset-01048",
                             "%s: memoryOffset is 0x%" PRIxLEAST64
                             " but must be an integer multiple of the VkMemoryRequirements::alignment value 0x%" PRIxLEAST64
                             ", returned from a call to vkGetImageMemoryRequirements with image.",
-                            api_name, memoryOffset, image_state->requirements.alignment);
+                            api_name, bindInfo.memoryOffset, image_state->requirements.alignment);
         }
 
         if (mem_info) {
             // Validate memory requirements size
-            if (image_state->requirements.size > mem_info->alloc_info.allocationSize - memoryOffset) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                                "VUID-vkBindImageMemory-size-01049",
-                                "%s: memory size minus memoryOffset is 0x%" PRIxLEAST64
-                                " but must be at least as large as VkMemoryRequirements::size value 0x%" PRIxLEAST64
-                                ", returned from a call to vkGetImageMemoryRequirements with image.",
-                                api_name, mem_info->alloc_info.allocationSize - memoryOffset, image_state->requirements.size);
+            if (image_state->requirements.size > mem_info->alloc_info.allocationSize - bindInfo.memoryOffset) {
+                skip |=
+                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
+                            "VUID-vkBindImageMemory-size-01049",
+                            "%s: memory size minus memoryOffset is 0x%" PRIxLEAST64
+                            " but must be at least as large as VkMemoryRequirements::size value 0x%" PRIxLEAST64
+                            ", returned from a call to vkGetImageMemoryRequirements with image.",
+                            api_name, mem_info->alloc_info.allocationSize - bindInfo.memoryOffset, image_state->requirements.size);
             }
 
             // Validate dedicated allocation
-            if (mem_info->is_dedicated && ((mem_info->dedicated_image != image) || (memoryOffset != 0))) {
+            if (mem_info->is_dedicated && ((mem_info->dedicated_image != bindInfo.image) || (bindInfo.memoryOffset != 0))) {
                 // TODO: Add vkBindImageMemory2KHR error message when added to spec.
                 auto validation_error = kVUIDUndefined;
                 if (strcmp(api_name, "vkBindImageMemory()") == 0) {
                     validation_error = "VUID-vkBindImageMemory-memory-01509";
                 }
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, image_handle,
+                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
                                 validation_error,
-                                "%s: for dedicated memory allocation %s, VkMemoryDedicatedAllocateInfoKHR::%s must be equal "
+                                "%s: for dedicated memory allocation %s, VkMemoryDedicatedAllocateInfoKHR:: %s must be equal "
                                 "to %s and memoryOffset 0x%" PRIxLEAST64 " must be zero.",
-                                api_name, report_data->FormatHandle(mem).c_str(),
+                                api_name, report_data->FormatHandle(bindInfo.memory).c_str(),
                                 report_data->FormatHandle(mem_info->dedicated_image).c_str(),
-                                report_data->FormatHandle(image).c_str(), memoryOffset);
+                                report_data->FormatHandle(bindInfo.image).c_str(), bindInfo.memoryOffset);
+            }
+        }
+
+        const auto swapchain_info = lvl_find_in_chain<VkBindImageMemorySwapchainInfoKHR>(bindInfo.pNext);
+        if (swapchain_info) {
+            if (bindInfo.memory != VK_NULL_HANDLE) {
+                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
+                                "VUID-VkBindImageMemoryInfo-pNext-01631", "%s: %s is not VK_NULL_HANDLE.", api_name,
+                                report_data->FormatHandle(bindInfo.memory).c_str());
+            }
+            const auto swapchain_state = GetSwapchainState(swapchain_info->swapchain);
+            if (swapchain_state && swapchain_state->images.size() <= swapchain_info->imageIndex) {
+                skip |=
+                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
+                            "VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644",
+                            "%s: imageIndex (%i) is out of bounds of %s images (size: %i)", api_name, swapchain_info->imageIndex,
+                            report_data->FormatHandle(swapchain_info->swapchain).c_str(), (int)swapchain_state->images.size());
+            }
+        } else {
+            if (image_state->create_from_swapchain) {
+                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
+                                "VUID-VkBindImageMemoryInfo-image-01630",
+                                "%s: pNext of VkBindImageMemoryInfo doesn't include VkBindImageMemorySwapchainInfoKHR.", api_name);
+            }
+            if (!mem_info) {
+                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
+                                "VUID-VkBindImageMemoryInfo-pNext-01632", "%s: %s is invalid.", api_name,
+                                report_data->FormatHandle(bindInfo.memory).c_str());
             }
         }
     }
@@ -10564,28 +10602,45 @@ bool CoreChecks::ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDe
 }
 
 bool CoreChecks::PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
-    return ValidateBindImageMemory(image, mem, memoryOffset, "vkBindImageMemory()");
+    VkBindImageMemoryInfo bindInfo = {};
+    bindInfo.sType = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
+    bindInfo.image = image;
+    bindInfo.memory = mem;
+    bindInfo.memoryOffset = memoryOffset;
+    return ValidateBindImageMemory(bindInfo, "vkBindImageMemory()");
 }
 
-void CoreChecks::UpdateBindImageMemoryState(VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
-    IMAGE_STATE *image_state = GetImageState(image);
+void CoreChecks::UpdateBindImageMemoryState(const VkBindImageMemoryInfo &bindInfo) {
+    IMAGE_STATE *image_state = GetImageState(bindInfo.image);
     if (image_state) {
-        // Track bound memory range information
-        auto mem_info = GetDevMemState(mem);
-        if (mem_info) {
-            InsertImageMemoryRange(image, mem_info, memoryOffset, image_state->requirements,
-                                   image_state->createInfo.tiling == VK_IMAGE_TILING_LINEAR);
-        }
+        const auto swapchain_info = lvl_find_in_chain<VkBindImageMemorySwapchainInfoKHR>(bindInfo.pNext);
+        if (swapchain_info) {
+            image_state->bind_swapchain = swapchain_info->swapchain;
+            image_state->bind_swapchain_imageIndex = swapchain_info->imageIndex;
+        } else {
+            // Track bound memory range information
+            auto mem_info = GetDevMemState(bindInfo.memory);
+            if (mem_info) {
+                InsertImageMemoryRange(bindInfo.image, mem_info, bindInfo.memoryOffset, image_state->requirements,
+                                       image_state->createInfo.tiling == VK_IMAGE_TILING_LINEAR);
+            }
 
-        // Track objects tied to memory
-        SetMemBinding(mem, image_state, memoryOffset, VulkanTypedHandle(image, kVulkanObjectTypeImage));
+            // Track objects tied to memory
+            SetMemBinding(bindInfo.memory, image_state, bindInfo.memoryOffset,
+                          VulkanTypedHandle(bindInfo.image, kVulkanObjectTypeImage));
+        }
     }
 }
 
 void CoreChecks::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset,
                                                VkResult result) {
     if (VK_SUCCESS != result) return;
-    UpdateBindImageMemoryState(image, mem, memoryOffset);
+    VkBindImageMemoryInfo bindInfo = {};
+    bindInfo.sType = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
+    bindInfo.image = image;
+    bindInfo.memory = mem;
+    bindInfo.memoryOffset = memoryOffset;
+    UpdateBindImageMemoryState(bindInfo);
 }
 
 bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount,
@@ -10594,7 +10649,7 @@ bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindI
     char api_name[128];
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         sprintf(api_name, "vkBindImageMemory2() pBindInfos[%u]", i);
-        skip |= ValidateBindImageMemory(pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset, api_name);
+        skip |= ValidateBindImageMemory(pBindInfos[i], api_name);
     }
     return skip;
 }
@@ -10605,7 +10660,7 @@ bool CoreChecks::PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bi
     char api_name[128];
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         sprintf(api_name, "vkBindImageMemory2KHR() pBindInfos[%u]", i);
-        skip |= ValidateBindImageMemory(pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset, api_name);
+        skip |= ValidateBindImageMemory(pBindInfos[i], api_name);
     }
     return skip;
 }
@@ -10614,7 +10669,7 @@ void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindIn
                                                 VkResult result) {
     if (VK_SUCCESS != result) return;
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        UpdateBindImageMemoryState(pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset);
+        UpdateBindImageMemoryState(pBindInfos[i]);
     }
 }
 
@@ -10622,7 +10677,7 @@ void CoreChecks::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bin
                                                    const VkBindImageMemoryInfoKHR *pBindInfos, VkResult result) {
     if (VK_SUCCESS != result) return;
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        UpdateBindImageMemoryState(pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset);
+        UpdateBindImageMemoryState(pBindInfos[i]);
     }
 }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -522,8 +522,8 @@ class CoreChecks : public ValidationStateTracker {
                                const std::vector<DAGNode>& subpass_to_node, bool& skip);
     bool CheckPreserved(const VkRenderPassCreateInfo2KHR* pCreateInfo, const int index, const uint32_t attachment,
                         const std::vector<DAGNode>& subpass_to_node, int depth, bool& skip);
-    bool ValidateBindImageMemory(VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset, const char* api_name);
-    void UpdateBindImageMemoryState(VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset);
+    bool ValidateBindImageMemory(const VkBindImageMemoryInfo& bindInfo, const char* api_name);
+    void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bindInfo);
     void RecordGetPhysicalDeviceDisplayPlanePropertiesState(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
                                                             void* pProperties);
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -301,6 +301,9 @@ class IMAGE_STATE : public BINDABLE {
     bool has_ahb_format;                 // True if image was created with an external Android format
     uint64_t ahb_format;                 // External Android format, if provided
     VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers (slices), and aspects
+    VkSwapchainKHR create_from_swapchain;
+    VkSwapchainKHR bind_swapchain;
+    uint32_t bind_swapchain_imageIndex;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     uint64_t external_format_android;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -980,26 +980,6 @@ VkLayerTest::VkLayerTest() {
             printf("             Did not find VK_LAYER_LUNARG_device_simulation layer so it will not be enabled.\n");
         }
     }
-    if (m_enableWSI) {
-        m_instance_extension_names.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-#ifdef NEED_TO_TEST_THIS_ON_PLATFORM
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-        m_instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-        m_instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-#endif  // VK_USE_PLATFORM_WAYLAND_KHR
-#if defined(VK_USE_PLATFORM_WIN32_KHR)
-        m_instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#endif  // VK_USE_PLATFORM_WIN32_KHR
-#endif  // NEED_TO_TEST_THIS_ON_PLATFORM
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-        m_instance_extension_names.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-        m_instance_extension_names.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-#endif  // VK_USE_PLATFORM_XLIB_KHR
-    }
 
     this->app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     this->app_info.pNext = NULL;
@@ -1019,6 +999,66 @@ VkLayerTest::VkLayerTest() {
         m_instance_api_version = VK_API_VERSION_1_0;
     }
     m_target_api_version = app_info.apiVersion;
+}
+
+bool VkLayerTest::AddSurfaceInstanceExtension() {
+    m_enableWSI = true;
+    if (!InstanceExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    if (!InstanceExtensionSupported(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_ANDROID_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+
+#elif defined(VK_USE_PLATFORM_WIN32_KHR)
+    if (!InstanceExtensionSupported(VK_KHR_WIN32_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_WIN32_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+    if (!InstanceExtensionSupported(VK_KHR_XLIB_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_XLIB_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+    if (!InstanceExtensionSupported(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_XCB_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    m_instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
+    if (!InstanceExtensionSupported(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+        printf("%s VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_instance_extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
+
+#else
+    printf("%s No platform's surface extension not supported\n", kSkipPrefix);
+    return false;
+#endif
+    return true;
+}
+
+bool VkLayerTest::AddSwapchainDeviceExtension() {
+    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+        printf("%s VK_KHR_SWAPCHAIN_EXTENSION_NAME extension not supported\n", kSkipPrefix);
+        return false;
+    }
+    m_device_extension_names.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    return true;
 }
 
 uint32_t VkLayerTest::SetTargetApiVersion(uint32_t target_api_version) {

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -300,6 +300,8 @@ class VkLayerTest : public VkRenderFramework {
 
     void Init(VkPhysicalDeviceFeatures *features = nullptr, VkPhysicalDeviceFeatures2 *features2 = nullptr,
               const VkCommandPoolCreateFlags flags = 0, void *instance_pnext = nullptr);
+    bool AddSurfaceInstanceExtension();
+    bool AddSwapchainDeviceExtension();
     ErrorMonitor *Monitor();
     VkCommandBufferObj *CommandBuffer();
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6867,3 +6867,99 @@ TEST_F(VkLayerTest, CreateImageYcbcrArrayLayers) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02653");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageCreateInfo-format-02653");
 }
+
+TEST_F(VkLayerTest, BindImageMemorySwapchain) {
+    TEST_DESCRIPTION("Invalid bind image with a swapchain");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    if (!AddSurfaceInstanceExtension()) {
+        printf("%s surface extensions not supported, skipping BindSwapchainImageMemory test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+
+    if (!AddSwapchainDeviceExtension()) {
+        printf("%s swapchain extensions not supported, skipping BindSwapchainImageMemory test\n", kSkipPrefix);
+        return;
+    }
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s VkBindImageMemoryInfo requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (!InitSwapchain()) {
+        printf("%s Cannot create surface or swapchain, skipping BindSwapchainImageMemory test\n", kSkipPrefix);
+        return;
+    }
+
+    auto image_create_info = lvl_init_struct<VkImageCreateInfo>();
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
+    image_create_info.extent.width = 64;
+    image_create_info.extent.height = 64;
+    image_create_info.extent.depth = 1;
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+    image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    auto image_swapchain_create_info = lvl_init_struct<VkImageSwapchainCreateInfoKHR>();
+    image_swapchain_create_info.swapchain = m_swapchain;
+    image_create_info.pNext = &image_swapchain_create_info;
+
+    VkImage image_from_swapchain;
+    vkCreateImage(device(), &image_create_info, NULL, &image_from_swapchain);
+
+    VkMemoryRequirements mem_reqs = {};
+    vkGetImageMemoryRequirements(device(), image_from_swapchain, &mem_reqs);
+
+    auto alloc_info = lvl_init_struct<VkMemoryAllocateInfo>();
+    alloc_info.memoryTypeIndex = 0;
+    alloc_info.allocationSize = mem_reqs.size;
+
+    bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    ASSERT_TRUE(pass);
+
+    VkDeviceMemory mem;
+    VkResult err = vkAllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    ASSERT_VK_SUCCESS(err);
+
+    auto bind_info = lvl_init_struct<VkBindImageMemoryInfo>();
+    bind_info.image = image_from_swapchain;
+    bind_info.memory = VK_NULL_HANDLE;
+    bind_info.memoryOffset = 0;
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBindImageMemoryInfo-image-01630");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBindImageMemoryInfo-pNext-01632");
+    vkBindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
+
+    auto bind_swapchain_info = lvl_init_struct<VkBindImageMemorySwapchainInfoKHR>();
+    bind_swapchain_info.swapchain = VK_NULL_HANDLE;
+    bind_swapchain_info.imageIndex = 0;
+    bind_info.pNext = &bind_swapchain_info;
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "UNASSIGNED-GeneralParameterError-RequiredParameter");
+    vkBindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
+
+    bind_info.memory = mem;
+    bind_swapchain_info.swapchain = m_swapchain;
+    bind_swapchain_info.imageIndex = UINT32_MAX;
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBindImageMemoryInfo-pNext-01631");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644");
+    vkBindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
+
+    vkDestroyImage(m_device->device(), image_from_swapchain, NULL);
+    vkFreeMemory(m_device->device(), mem, NULL);
+    DestroySwapchain();
+}

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -4115,7 +4115,7 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
     const uint32_t transfer_only_qfi =
         m_device->QueueFamilyMatching(VK_QUEUE_TRANSFER_BIT, (VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT));
     if ((UINT32_MAX == transfer_only_qfi) && (UINT32_MAX == no_gfx_qfi)) {
-        printf("%s No compute or transfer only queue family, skipping bindpoint and queue tests.", kSkipPrefix);
+        printf("%s No compute or transfer only queue family, skipping bindpoint and queue tests.\n", kSkipPrefix);
     } else {
         const uint32_t err_qfi = (UINT32_MAX == no_gfx_qfi) ? transfer_only_qfi : no_gfx_qfi;
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -5255,7 +5255,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
 
     if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, NULL,
                                                          m_errorMonitor))) {
-        printf("Descriptor indexing or one of its dependencies not supported, skipping tests\n");
+        printf("%s Descriptor indexing or one of its dependencies not supported, skipping tests\n.", kSkipPrefix);
         return;
     }
 

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -7032,15 +7032,15 @@ TEST_F(VkPositiveLayerTest, ViewportArray2NV) {
     ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&available_features));
 
     if (!available_features.multiViewport) {
-        printf("VkPhysicalDeviceFeatures::multiViewport is not supported, skipping tests\n");
+        printf("%s VkPhysicalDeviceFeatures::multiViewport is not supported, skipping tests\n", kSkipPrefix);
         return;
     }
     if (!available_features.tessellationShader) {
-        printf("VkPhysicalDeviceFeatures::tessellationShader is not supported, skipping tests\n");
+        printf("%s VkPhysicalDeviceFeatures::tessellationShader is not supported, skipping tests\n", kSkipPrefix);
         return;
     }
     if (!available_features.geometryShader) {
-        printf("VkPhysicalDeviceFeatures::geometryShader is not supported, skipping tests\n");
+        printf("%s VkPhysicalDeviceFeatures::geometryShader is not supported, skipping tests\n", kSkipPrefix);
         return;
     }
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -472,7 +472,7 @@ void VkRenderFramework::InitViewport(float width, float height) {
 
 void VkRenderFramework::InitViewport() { InitViewport(m_width, m_height); }
 
-void VkRenderFramework::InitSwapchain() { InitSwapchain(m_width, m_height); }
+bool VkRenderFramework::InitSwapchain() { return InitSwapchain(m_width, m_height); }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
@@ -480,10 +480,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-void VkRenderFramework::InitSwapchain(float width, float height) {
+bool VkRenderFramework::InitSwapchain(float width, float height) {
     VkResult err = VK_SUCCESS;
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
     HINSTANCE window_instance = GetModuleHandle(nullptr);
     const char class_name[] = "test";
     WNDCLASS wc = {};
@@ -499,10 +499,11 @@ void VkRenderFramework::InitSwapchain(float width, float height) {
     surface_create_info.hinstance = window_instance;
     surface_create_info.hwnd = window;
     err = vkCreateWin32SurfaceKHR(instance(), &surface_create_info, nullptr, &m_surface);
-    ASSERT_VK_SUCCESS(err);
+    if (err != VK_SUCCESS) return false;
 
-#elif VK_USE_PLATFORM_XLIB_KHR
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
     Display *d = XOpenDisplay(NULL);
+    if (!d) return false;
     int s = DefaultScreen(d);
     Window w = XCreateSimpleWindow(d, RootWindow(d, s), 0, 0, (int)m_width, (int)m_height, 1, BlackPixel(d, s), WhitePixel(d, s));
     VkXlibSurfaceCreateInfoKHR surface_create_info = {};
@@ -510,17 +511,45 @@ void VkRenderFramework::InitSwapchain(float width, float height) {
     surface_create_info.dpy = d;
     surface_create_info.window = w;
     err = vkCreateXlibSurfaceKHR(instance(), &surface_create_info, nullptr, &m_surface);
-    ASSERT_VK_SUCCESS(err);
+    if (err != VK_SUCCESS) return false;
+
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+    xcb_connection_t *connection = xcb_connect(NULL, NULL);
+    if (!connection) return false;
+    xcb_window_t window = xcb_generate_id(connection);
+
+    VkXcbSurfaceCreateInfoKHR surface_create_info = {};
+    surface_create_info.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+    surface_create_info.connection = connection;
+    surface_create_info.window = window;
+
+    err = vkCreateXcbSurfaceKHR(instance(), &surface_create_info, nullptr, &m_surface);
+    if (err != VK_SUCCESS) return false;
+
+#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    wl_display *display = wl_display_connect(NULL);
+    if (!display) return false;
+
+    wl_surface *surface = wl_compositor_create_surface(compositor);
+    if (!surface) return false;
+
+    VkWaylandSurfaceCreateInfoKHR surface_create_info = {};
+    surface_create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    surface_create_info.display = display;
+    surface_create_info.surface = surface;
+
+    err = vkCreateWaylandSurfaceKHR(instance(), &surface_create_info, nullptr, &m_surface);
+    if (err != VK_SUCCESS) return false;
 
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR) && defined(VALIDATION_APK)
     VkAndroidSurfaceCreateInfoKHR surface_create_info = {};
     surface_create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
     surface_create_info.window = VkTestFramework::window;
     err = vkCreateAndroidSurfaceKHR(instance(), &surface_create_info, nullptr, &m_surface);
-    ASSERT_VK_SUCCESS(err);
+    if (err != VK_SUCCESS) return false;
 
 #else
-    return;
+    return false;
 #endif
 
     for (size_t i = 0; i < m_device->queue_props.size(); ++i) {
@@ -567,8 +596,18 @@ void VkRenderFramework::InitSwapchain(float width, float height) {
     swapchain_create_info.presentMode = present_modes[0];
     swapchain_create_info.clipped = VK_FALSE;
     swapchain_create_info.oldSwapchain = 0;
+
     err = vkCreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
-    ASSERT_VK_SUCCESS(err);
+    if (err != VK_SUCCESS) {
+        vkDestroySurfaceKHR(instance(), m_surface, nullptr);
+        return false;
+    }
+    uint32_t imageCount = 0;
+    vkGetSwapchainImagesKHR(device(), m_swapchain, &imageCount, nullptr);
+    std::vector<VkImage> swapchainImages;
+    swapchainImages.resize(imageCount);
+    vkGetSwapchainImagesKHR(device(), m_swapchain, &imageCount, swapchainImages.data());
+    return true;
 }
 
 void VkRenderFramework::DestroySwapchain() {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -86,8 +86,8 @@ class VkRenderFramework : public VkTestFramework {
     VkFramebuffer framebuffer() { return m_framebuffer; }
     void InitViewport(float width, float height);
     void InitViewport();
-    void InitSwapchain(float width, float height);
-    void InitSwapchain();
+    bool InitSwapchain(float width, float height);
+    bool InitSwapchain();
     void DestroySwapchain();
     void InitRenderTarget();
     void InitRenderTarget(uint32_t targets);


### PR DESCRIPTION
[issue #749 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/749)

`Image_state` records if the image is created from a swapchain and bind with a swapchain.

And add checking swapchain when it validates if image binds memory.