### PR TITLE
layers:Clarify descriptor update error message

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -679,7 +679,7 @@ bool cvdescriptorset::ValidateDrawState(const DescriptorSet *descriptor_set, con
             } else if (!descriptor->updated) {
                 std::stringstream error_str;
                 error_str << "Descriptor in binding #" << binding << " index " << index
-                          << " is being used in draw but has not been updated.";
+                          << " is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.";
                 *error = error_str.str();
                 return false;
             } else {


### PR DESCRIPTION
The term "updated" on its own implies a previous write/copy action so
clarifying to indicate that descriptor has NEVER been updated by a call
to vkUpdateDescriptorSets() or similar calls.

For brevity and forward compatibility I went with "similar calls"
rather than listing every variant of descriptor update function.