### PR TITLE
Add subgroup validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2407,6 +2407,14 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
         instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(gpu, &numCooperativeMatrixProperties,
                                                                                core_checks->cooperative_matrix_properties.data());
     }
+    if (core_checks->phys_dev_props.apiVersion >= VK_API_VERSION_1_1) {
+        // Get the needed subgroup limits
+        auto subgroup_prop = lvl_init_struct<VkPhysicalDeviceSubgroupProperties>();
+        auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&subgroup_prop);
+        instance_dispatch_table.GetPhysicalDeviceProperties2(gpu, &prop2);
+
+        core_checks->phys_dev_ext_props.subgroup_props = subgroup_prop;
+    }
 
     // Store queue family data
     if ((pCreateInfo != nullptr) && (pCreateInfo->pQueueCreateInfos != nullptr)) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -367,6 +367,7 @@ class CoreChecks : public ValidationStateTracker {
         VkPhysicalDeviceDepthStencilResolvePropertiesKHR depth_stencil_resolve_props;
         VkPhysicalDeviceCooperativeMatrixPropertiesNV cooperative_matrix_props;
         VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props;
+        VkPhysicalDeviceSubgroupProperties subgroup_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;
@@ -718,9 +719,12 @@ class CoreChecks : public ValidationStateTracker {
                                      bool check_point_size);
     bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint,
                                       VkShaderStageFlagBits stage);
-    bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage, bool has_writable_descriptor);
+    bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage);
+    bool ValidateShaderStageWritableDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor);
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                               PIPELINE_STATE* pipeline, spirv_inst_iter entrypoint);
+    bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage,
+                                            std::unordered_set<uint32_t> const& accessible_ids);
     bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                    PIPELINE_STATE* pipeline);
     bool ValidateExecutionModes(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -122,6 +122,14 @@ VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstan
     return push_descriptor_prop;
 }
 
+VkPhysicalDeviceSubgroupProperties GetSubgroupProperties(VkInstance instance, VkPhysicalDevice gpu) {
+    auto subgroup_prop = lvl_init_struct<VkPhysicalDeviceSubgroupProperties>();
+
+    auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2>(&subgroup_prop);
+    vkGetPhysicalDeviceProperties2(gpu, &prop2);
+    return subgroup_prop;
+}
+
 bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs) {
     bool is_equal = (rhs.color[0] == lhs.color[0]) && (rhs.color[1] == lhs.color[1]) && (rhs.color[2] == lhs.color[2]) &&
                     (rhs.color[3] == lhs.color[3]);

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -662,6 +662,9 @@ class ExtensionChain {
 // PushDescriptorProperties helper
 VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstance instance, VkPhysicalDevice gpu);
 
+// Subgroup properties helper
+VkPhysicalDeviceSubgroupProperties GetSubgroupProperties(VkInstance instance, VkPhysicalDevice gpu);
+
 class BarrierQueueFamilyTestHelper {
    public:
     struct QueueFamilyObjs {


### PR DESCRIPTION
Add subgroup (aka GroupNonUniform) validation. Most of the code was originally written by @sheredom in #888. His description:

 * Checks that capabilities are only used if the feature flags are present.
 * Checks the shader stage that subgroup operations were used in were valid.
 * Checks that if quadOperationsInAllStages is false, that quad operations are not used in banned stages.

I've just added the missing stage validation and fixed the tests.
