### PR TITLE
layers: Add missing compute shader stage flag to GPU-assisted layer

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -289,14 +289,14 @@ void CoreChecks::GpuPostCallRecordCreateDevice(const CHECK_ENABLED *enables, con
             0,  // output
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
             1,
-            VK_SHADER_STAGE_ALL_GRAPHICS,
+            VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT,
             NULL,
         },
         {
             1,  // input
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
             1,
-            VK_SHADER_STAGE_ALL_GRAPHICS,
+            VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT,
             NULL,
         },
     };


### PR DESCRIPTION
@Jasper-Bekkers reported a crash in our driver when compiling a compute pipeline with the GPU-assisted validation layer enabled. Our driver/compiler require accurate descriptor binding stageFlags, and the compute bit was missing.
