### PR TITLE
Remove obsolete image layout warning

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10292,8 +10292,6 @@ bool CoreChecks::PreCallValidateMapMemory(VkDevice device, VkDeviceMemory mem, V
     bool skip = false;
     DEVICE_MEMORY_STATE *mem_info = GetDevMemState(mem);
     if (mem_info) {
-        auto end_offset = (VK_WHOLE_SIZE == size) ? mem_info->alloc_info.allocationSize - 1 : offset + size - 1;
-        skip |= ValidateMapImageLayouts(device, mem_info, offset, end_offset);
         if ((phys_dev_mem_props.memoryTypes[mem_info->alloc_info.memoryTypeIndex].propertyFlags &
              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
             skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -982,9 +982,6 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice device, const VkRenderPassCreateInfo2KHR* pCreateInfo);
 
-    bool ValidateMapImageLayouts(VkDevice device, DEVICE_MEMORY_STATE const* mem_info, VkDeviceSize offset,
-                                 VkDeviceSize end_offset);
-
     bool ValidateImageUsageFlags(IMAGE_STATE const* image_state, VkFlags desired, bool strict, const char* msgCode,
                                  char const* func_name, char const* usage_string);
 


### PR DESCRIPTION
Speculation was that the spec justification for this class of warnings had changed, and this particular warning is no longer useful, but this is not the case.

Fixes #990.