### PR TITLE
Add correct VUID for Depth&Stencil aspectbits check

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1412,6 +1412,7 @@ bool cvdescriptorset::ValidateImageUpdate(VkImageView image_view, VkImageLayout 
                                      "image in a descriptor set, please only set either VK_IMAGE_ASPECT_DEPTH_BIT or "
                                      "VK_IMAGE_ASPECT_STENCIL_BIT depending on whether it will be used for depth reads or stencil "
                                      "reads respectively.";
+                        *error_code = "VUID-VkDescriptorImageInfo-imageView-01976";
                         *error_msg = error_str.str();
                         return false;
                     }

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4377,7 +4377,7 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
 
     // TODO(whenning42): Update this check to look for a VUID when this error is
     // assigned one.
-    const char *error_msg = " please only set either VK_IMAGE_ASPECT_DEPTH_BIT or VK_IMAGE_ASPECT_STENCIL_BIT ";
+    const char *error_msg = "VUID-VkDescriptorImageInfo-imageView-01976";
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, error_msg);
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Check was present in the layer and had a test, but was not using the correct VUID.

Fixes #422.