### PR TITLE
Fix one layer and two test issues found in testing vs. updated drivers

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2412,7 +2412,7 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
         instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(gpu, &numCooperativeMatrixProperties,
                                                                                core_checks->cooperative_matrix_properties.data());
     }
-    if (core_checks->phys_dev_props.apiVersion >= VK_API_VERSION_1_1) {
+    if (core_checks->api_version >= VK_API_VERSION_1_1) {
         // Get the needed subgroup limits
         auto subgroup_prop = lvl_init_struct<VkPhysicalDeviceSubgroupProperties>();
         auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&subgroup_prop);


### PR DESCRIPTION
The layers were making an incorrect/illegal downchain call when the instance api version was less than the device api version.  An updated driver on one platform exposed this by causing a crash inside the loader.

To tests were also shown not to be robust to valid platform differences.  In one case, further work is needed inside the layers relocate validation eariler s.t. our testing doesn't drive invalid content that can't be caught before the driver could take exception to it. (Will open an issue to track.)