### PR TITLE
Mattrusch/perf

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -40,6 +40,7 @@
 #include <vector>
 #include <list>
 #include <deque>
+#include <map>
 
 enum SyncScope {
     kSyncScopeInternal,
@@ -79,7 +80,7 @@ class QUEUE_STATE {
     VkQueue queue;
     uint32_t queueFamilyIndex;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
-    std::unordered_map<QueryObject, QueryState> queryToStateMap;
+    std::map<QueryObject, QueryState> queryToStateMap;
 
     uint64_t seq;
     std::deque<CB_SUBMISSION> submissions;
@@ -203,7 +204,7 @@ class ValidationStateTracker : public ValidationObject {
 
     std::unordered_set<VkQueue> queues;  // All queues under given device
     unordered_map<VkImage, std::vector<ImageSubresourcePair>> imageSubresourceMap;
-    unordered_map<QueryObject, QueryState> queryToStateMap;
+    std::map<QueryObject, QueryState> queryToStateMap;
     unordered_map<VkSamplerYcbcrConversion, uint64_t> ycbcr_conversion_ahb_fmt_map;
 
     // Traits for State function resolution.  Specializations defined in the macro.

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -975,6 +975,9 @@ struct QueryObject {
     bool indexed;
     QueryObject(VkQueryPool pool_, uint32_t query_) : pool(pool_), query(query_), index(0), indexed(false) {}
     QueryObject(VkQueryPool pool_, uint32_t query_, uint32_t index_) : pool(pool_), query(query_), index(index_), indexed(true) {}
+    bool operator<(const QueryObject& rhs) const {
+        return (pool == rhs.pool) ? index < rhs.index : pool < rhs.pool;
+    }
 };
 
 enum QueryState {
@@ -1477,7 +1480,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::unordered_set<VkEvent> waitedEvents;
     std::vector<VkEvent> writeEventsBeforeWait;
     std::vector<VkEvent> events;
-    std::unordered_map<QueryObject, QueryState> queryToStateMap;
+    std::map<QueryObject, QueryState> queryToStateMap;
     std::unordered_set<QueryObject> activeQueries;
     std::unordered_set<QueryObject> startedQueries;
     typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> ImageLayoutMap;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -975,7 +975,7 @@ struct QueryObject {
     bool indexed;
     QueryObject(VkQueryPool pool_, uint32_t query_) : pool(pool_), query(query_), index(0), indexed(false) {}
     QueryObject(VkQueryPool pool_, uint32_t query_, uint32_t index_) : pool(pool_), query(query_), index(index_), indexed(true) {}
-    bool operator<(const QueryObject& rhs) const {
+    bool operator<(const QueryObject &rhs) const {
         return (pool == rhs.pool) ? index < rhs.index : pool < rhs.pool;
     }
 };

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -958,11 +958,12 @@ static inline int vasprintf(char **strp, char const *fmt, va_list ap) {
 // needs to be logged
 #ifndef WIN32
 static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkDebugReportObjectTypeEXT object_type,
-                           uint64_t src_object, std::string vuid_text, const char *format, ...)
+                           uint64_t src_object, const std::string &vuid_text, const char *format, ...)
     __attribute__((format(printf, 6, 7)));
 #endif
 static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkDebugReportObjectTypeEXT object_type,
-                           uint64_t src_object, std::string vuid_text, const char *format, ...) {
+                           uint64_t src_object, const std::string &vuid_text, const char *format, ...) {
+    return false;
     if (!debug_data) return false;
     std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
     VkFlags local_severity = 0;

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -963,7 +963,6 @@ static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flag
 #endif
 static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkDebugReportObjectTypeEXT object_type,
                            uint64_t src_object, const std::string &vuid_text, const char *format, ...) {
-    return false;
     if (!debug_data) return false;
     std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
     VkFlags local_severity = 0;


### PR DESCRIPTION
Gives 30% performance increase in my pathological case sample app. Using unordered_map<VkQueryPool, vector> to query would also run faster, but with very different memory footprint characteristics. Also fixes a pass by reference oversight.