### PR TITLE
tests: Skip Android test

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6967,6 +6967,14 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
 TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     TEST_DESCRIPTION("Transfer an image to a swapchain's image with a invalid layout between device group");
 
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    printf(
+        "%s According to VUID-01631, VkBindImageMemoryInfo-memory should be NULL. But Android will crash if memory is NULL, "
+        "skipping test\n",
+        kSkipPrefix);
+    return;
+#endif
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     if (!AddSurfaceInstanceExtension()) {

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -7386,6 +7386,14 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
 TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     TEST_DESCRIPTION("Transfer an image to a swapchain's image  between device group");
 
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    printf(
+        "%s According to VUID-01631, VkBindImageMemoryInfo-memory should be NULL. But Android will crash if memory is NULL, "
+        "skipping test\n",
+        kSkipPrefix);
+    return;
+#endif
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     if (!AddSurfaceInstanceExtension()) {


### PR DESCRIPTION
Android doesn't support bindimagememory2 with swapchain

Change-Id: I0fe192665b14cb8fbab00bf0e6a8d88f5378302e