### PR TITLE
Update secondary command buffer's initial layout map

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -753,6 +753,7 @@ class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
         bool updated = false;
         updated |= layouts_.initial.Merge(from.layouts_.initial);
         updated |= layouts_.current.Merge(from.layouts_.current);
+        initial_layout_state_map_.Merge(from.initial_layout_state_map_);
 
         return updated;
     }


### PR DESCRIPTION
When image layout state data was propagated to secondary command buffers, the initial layout state map was not updated, resulting in stale data which led to segmentation faults.

Fixes #1011.   