### PR TITLE
Support breakpoint debug actions for DebugUtils extension

### DIFF
--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -1066,6 +1066,19 @@ static inline VKAPI_ATTR VkBool32 VKAPI_CALL DebugBreakCallback(VkFlags msgFlags
     return false;
 }
 
+static inline VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                                    void *user_data) {
+#ifdef WIN32
+    DebugBreak();
+#else
+    raise(SIGTRAP);
+#endif
+
+    return false;
+}
+
 static inline VKAPI_ATTR VkBool32 VKAPI_CALL messenger_log_callback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                                     const VkDebugUtilsMessengerCallbackDataEXT *callback_data,

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -143,6 +143,15 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
         layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
         logging_messenger.push_back(messenger);
     }
+
+    messenger = VK_NULL_HANDLE;
+
+    if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {
+        dbgCreateInfo.pfnUserCallback = MessengerBreakCallback;
+        dbgCreateInfo.pUserData = NULL;
+        layer_create_messenger_callback(report_data, default_layer_callback, &dbgCreateInfo, pAllocator, &messenger);
+        logging_messenger.push_back(messenger);
+    }
 }
 
 // NOTE: This function has been deprecated, and the above function (layer_debug_messenger_actions) should be


### PR DESCRIPTION
DebugReport has this ability, added it to DebugUtils. 

Fixes #897.