### PR TITLE
Check extension support before feature test

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -5489,6 +5489,16 @@ TEST_F(VkLayerTest, CreatePipelineCheckFragmentShaderInterlockEnabled) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     std::vector<const char *> device_extension_names;
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME)) {
+        // Note: we intentionally do not add the required extension to the device extension list.
+        //       in order to create the error below
+    } else {
+        // We skip this test if the extension is not supported by the driver as in some cases this will cause
+        // the vkCreateShaderModule to fail without generating an error message
+        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
+        return;
+    }
+
     auto features = m_device->phy().features();
 
     // Disable the fragment shader interlock feature.


### PR DESCRIPTION
Test was checking for required feature enable without first seeing if
extension that supports feature was supported.

Add extension supported check and else skip logic to test.  This is a workaround to avoid a driver specific CreateShaderModule failure because an unsupported feature is required by the passed shader source.  The driver fails the CSM call, and the test framework asserts success. 

This is another example of #1022 where a driver is detecting and failing a create based on unsupported extensions/features/capabilities, but validation isn't checking at CreateShaderModule time.

@mikes-lunarg  -- Also it feels likes there's a missing class of VU's. There are features or capabilities that require extensions, but I don't see VU that states that an feature that is added as part of an extension requires the extension to be enabled to enable the feature, or that calls that require the feature to also require that the extension be enabled.  Is this something I'm missing in the spec or something to clarify with the WG?