### PR TITLE
Implement some VK_IMAGE_CREATE_ALIAS_BIT features

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -119,6 +119,9 @@ bool IMAGE_STATE::IsCompatibleAliasing(IMAGE_STATE *other_image_state) {
         IsCreateInfoEqual(other_image_state->createInfo)) {
         return true;
     }
+    if ((bind_swapchain == other_image_state->bind_swapchain) && (bind_swapchain != VK_NULL_HANDLE)) {
+        return true;
+    }
     return false;
 }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1599,7 +1599,7 @@ void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage 
     for (auto mem_binding : image_state->GetBoundMemory()) {
         auto mem_info = GetDevMemState(mem_binding);
         if (mem_info) {
-            RemoveImageMemoryRange(obj_struct.handle, mem_info);
+            RemoveImageMemoryRange(image, mem_info);
         }
     }
     ClearMemoryObjectBindings(obj_struct);
@@ -4695,7 +4695,7 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
     for (auto mem_binding : buffer_state->GetBoundMemory()) {
         auto mem_info = GetDevMemState(mem_binding);
         if (mem_info) {
-            RemoveBufferMemoryRange(HandleToUint64(buffer), mem_info);
+            RemoveBufferMemoryRange(buffer, mem_info);
         }
     }
     ClearMemoryObjectBindings(obj_struct);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -110,10 +110,7 @@ using std::unordered_map;
 using std::unordered_set;
 using std::vector;
 
-// WSI Image Objects bypass usual Image Object creation methods.  A special Memory
-// Object value will be used to identify them internally.
-static const VkDeviceMemory MEMTRACKER_SWAP_CHAIN_IMAGE_KEY = (VkDeviceMemory)(-1);
-// 2nd special memory handle used to flag object as unbound from memory
+// A special memory handle used to flag object as unbound from memory
 static const VkDeviceMemory MEMORY_UNBOUND = VkDeviceMemory(~((uint64_t)(0)) - 1);
 
 // Get the global maps of pending releases
@@ -386,7 +383,7 @@ void ValidationStateTracker::AddCommandBufferBindingImage(CMD_BUFFER_STATE *cb_n
         return;
     }
     // Skip validation if this image was created through WSI
-    if (image_state->binding.mem != MEMTRACKER_SWAP_CHAIN_IMAGE_KEY) {
+    if (image_state->create_from_swapchain == VK_NULL_HANDLE) {
         // First update cb binding for image
         auto image_inserted = cb_node->object_bindings.emplace(image_state->image, kVulkanObjectTypeImage);
         if (image_inserted.second) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13003,8 +13003,8 @@ void CoreChecks::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchai
             // Add imageMap entries for each swapchain image
             VkImageCreateInfo image_ci;
             image_ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-            image_ci.pNext = nullptr;  // to be set later
-            image_ci.flags = 0;        // to be set later
+            image_ci.pNext = nullptr;                    // to be set later
+            image_ci.flags = VK_IMAGE_CREATE_ALIAS_BIT;  // to be updated below
             image_ci.imageType = VK_IMAGE_TYPE_2D;
             image_ci.format = swapchain_state->createInfo.imageFormat;
             image_ci.extent.width = swapchain_state->createInfo.imageExtent.width;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -894,10 +894,10 @@ class ValidationStateTracker : public ValidationObject {
     void RecordRenderPassDAG(RenderPassCreateVersion rp_version, const VkRenderPassCreateInfo2KHR* pCreateInfo,
                              RENDER_PASS_STATE* render_pass);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
-    void RemoveAccelerationStructureMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
+    void RemoveAccelerationStructureMemoryRange(VkAccelerationStructureNV as, DEVICE_MEMORY_STATE* mem_info);
     void RemoveCommandBufferBinding(const VulkanTypedHandle& object, CMD_BUFFER_STATE* cb_node);
-    void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
-    void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEMORY_STATE* mem_info);
+    void RemoveBufferMemoryRange(VkBuffer buffer, DEVICE_MEMORY_STATE* mem_info);
+    void RemoveImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info);
     void ResetCommandBufferState(const VkCommandBuffer cb);
     void RetireFence(VkFence fence);
     void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq, bool switch_finished_queries);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1487,6 +1487,9 @@ class CoreChecks : public ValidationStateTracker {
 
     void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t memBarrierCount, const VkImageMemoryBarrier* pImgMemBarriers);
 
+    void RecordTransitionImageLayout(CMD_BUFFER_STATE* cb_state, const IMAGE_STATE* image_state,
+                                     const VkImageMemoryBarrier& mem_barrier);
+
     void TransitionFinalSubpassLayouts(CMD_BUFFER_STATE* pCB, const VkRenderPassBeginInfo* pRenderPassBegin,
                                        FRAMEBUFFER_STATE* framebuffer_state);
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -256,6 +256,10 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE, accelerationStructureMap)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
 
+    void AddAliasingImage(IMAGE_STATE* image_state);
+    void RemoveAliasingImage(IMAGE_STATE* image_state);
+    void RemoveAliasingImages(const std::unordered_set<VkImage>& bound_images);
+
   public:
     template <typename State>
     typename AccessorTraits<State>::ReturnType Get(typename AccessorTraits<State>::Handle handle) {

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -207,6 +207,7 @@ static const char DECORATE_UNUSED *kVUID_Core_Swapchain_GetSupportedDisplaysWith
 static const char DECORATE_UNUSED *kVUID_Core_Swapchain_InvalidCount = "UNASSIGNED-CoreValidation-SwapchainInvalidCount";
 static const char DECORATE_UNUSED *kVUID_Core_Swapchain_PriorCount = "UNASSIGNED-CoreValidation-SwapchainPriorCount";
 static const char DECORATE_UNUSED *kVUID_Core_Swapchain_PreTransform = "UNASSIGNED-CoreValidation-SwapchainPreTransform";
+static const char DECORATE_UNUSED *kVUID_Core_BindImageMemory_Swapchain = "UNASSIGNED-CoreValidation-BindImageMemory-Swapchain";
 
 // Previously defined but unused - uncomment as needed
 //static const char DECORATE_UNUSED *kVUID_Core_Swapchain_BadBool = "UNASSIGNED-CoreValidation-SwapchainBadBool";

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -320,6 +320,48 @@ class IMAGE_STATE : public BINDABLE {
     IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo);
     IMAGE_STATE(IMAGE_STATE const &rh_obj) = delete;
 
+    std::unordered_set<VkImage> aliasing_images;
+    bool IsCompatibleAliasing(IMAGE_STATE *other_image_state);
+
+    bool IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const;
+
+    inline bool IsImageTypeEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.imageType == other_createInfo.imageType;
+    }
+    inline bool IsFormatEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.format == other_createInfo.format;
+    }
+    inline bool IsMipLevelsEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.mipLevels == other_createInfo.mipLevels;
+    }
+    inline bool IsUsageEqual(const VkImageCreateInfo &other_createInfo) const { return createInfo.usage == other_createInfo.usage; }
+    inline bool IsSamplesEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.samples == other_createInfo.samples;
+    }
+    inline bool IsTilingEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.tiling == other_createInfo.tiling;
+    }
+    inline bool IsArrayLayersEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.arrayLayers == other_createInfo.arrayLayers;
+    }
+    inline bool IsInitialLayoutEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.initialLayout == other_createInfo.initialLayout;
+    }
+    inline bool IsSharingModeEqual(const VkImageCreateInfo &other_createInfo) const {
+        return createInfo.sharingMode == other_createInfo.sharingMode;
+    }
+    inline bool IsExtentEqual(const VkImageCreateInfo &other_createInfo) const {
+        return (createInfo.extent.width == other_createInfo.extent.width) &&
+               (createInfo.extent.height == other_createInfo.extent.height) &&
+               (createInfo.extent.depth == other_createInfo.extent.depth);
+    }
+    inline bool IsQueueFamilyIndicesEqual(const VkImageCreateInfo &other_createInfo) const {
+        return (createInfo.queueFamilyIndexCount == other_createInfo.queueFamilyIndexCount) &&
+               (createInfo.queueFamilyIndexCount == 0 ||
+                memcmp(createInfo.pQueueFamilyIndices, other_createInfo.pQueueFamilyIndices,
+                       createInfo.queueFamilyIndexCount * sizeof(createInfo.pQueueFamilyIndices[0])) == 0);
+    }
+
     ~IMAGE_STATE() {
         if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
             delete[] createInfo.pQueueFamilyIndices;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -453,6 +453,7 @@ class SWAPCHAIN_NODE {
     safe_VkSwapchainCreateInfoKHR createInfo;
     VkSwapchainKHR swapchain;
     std::vector<VkImage> images;
+    std::unordered_set<VkImage> bound_images;
     bool retired = false;
     bool shared_presentable = false;
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -378,7 +378,8 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
     VkExternalMemoryHandleTypeFlags export_handle_type_flags;
     std::unordered_set<VulkanTypedHandle> obj_bindings;  // objects bound to this memory
     // Convenience vectors of handles to speed up iterating over objects independently
-    std::unordered_set<uint64_t> bound_images;
+    std::unordered_set<VkImage> bound_images;
+    // TODO: Convert the two sets to the correct types.
     std::unordered_set<uint64_t> bound_buffers;
     std::unordered_set<uint64_t> bound_acceleration_structures;
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4173,6 +4173,7 @@ TEST_F(VkLayerTest, WarningSwapchainCreateInfoPreTransform) {
     m_errorMonitor->SetUnexpectedError("VUID-VkSwapchainCreateInfoKHR-preTransform-01279");
     InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR);
     m_errorMonitor->VerifyFound();
+    DestroySwapchain();
 }
 
 bool InitFrameworkForRayTracingTest(VkRenderFramework *renderFramework, std::vector<const char *> &instance_extension_names,

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -7779,7 +7779,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     create_device_pnext.sType = VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO;
     create_device_pnext.physicalDeviceCount = physical_device_group[0].physicalDeviceCount;
     create_device_pnext.pPhysicalDevices = physical_device_group[0].physicalDevices;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &create_device_pnext, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &create_device_pnext));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     if (!InitSwapchain(VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
         printf("%s Cannot create surface or swapchain, skipping test\n", kSkipPrefix);
@@ -7852,12 +7852,6 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     img_barrier.subresourceRange.levelCount = 1;
     vkCmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0,
                          nullptr, 0, nullptr, 1, &img_barrier);
-
-    m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
-
-    m_commandBuffer->reset();
-    m_commandBuffer->begin();
 
     VkImageCopy copy_region = {};
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -676,7 +676,7 @@ bool VkRenderFramework::InitSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags i
     swapchain_create_info.imageFormat = formats[0].format;
     swapchain_create_info.imageColorSpace = formats[0].colorSpace;
     swapchain_create_info.imageExtent = {capabilities.minImageExtent.width, capabilities.minImageExtent.height};
-    swapchain_create_info.imageArrayLayers = capabilities.maxImageArrayLayers;
+    swapchain_create_info.imageArrayLayers = 1;
     swapchain_create_info.imageUsage = imageUsage;
     swapchain_create_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchain_create_info.preTransform = preTransform;


### PR DESCRIPTION
Fixed [issue #750](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/750) & [issue #1020](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1020)

This PR implements vkspec `If two aliases are both images that were created with identical creation parameters, both were created with the VK_IMAGE_CREATE_ALIAS_BIT flag set, and both are bound identically to memory except for VkBindImageMemoryDeviceGroupInfo::pDeviceIndices and VkBindImageMemoryDeviceGroupInfo::pSplitInstanceBindRegions, then they interpret the contents of the memory in consistent ways, and data written to one alias can be read by the other alias.`

For `data written to one alias can be read by the other alias`, this PR only does setting layout. When one image sets layout, it will set it to the whole aliasing images. We might have more stuff need to do. 