### PR TITLE
Make khronos validation layer a dependency for the layer validation tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,7 +109,7 @@ add_executable(vk_layer_validation_tests
                ${PROJECT_BINARY_DIR}/vk_safe_struct.cpp
                ${COMMON_CPP})
 add_test(NAME vk_layer_validation_tests COMMAND vk_layer_validation_tests)
-add_dependencies(vk_layer_validation_tests Vulkan::Vulkan)
+add_dependencies(vk_layer_validation_tests Vulkan::Vulkan VkLayer_khronos_validation VkLayer_khronos_validation-json)
 if(NOT GTEST_IS_STATIC_LIB)
     set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 endif()


### PR DESCRIPTION
Causes validation layers to get rebuilt if layer source is modified but only the layer validation tests target is built. 

Makes sense to me that LVTs go hand-in-hand with a new validation layer -- AFAICT we don't build standalone LVTs in any peer repository.

Fixes #1045.

