### PR TITLE
Add ray tracing shader descriptor indexing validation

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -10,7 +10,7 @@
       "name" : "glslang",
       "url" : "https://github.com/KhronosGroup/glslang.git",
       "sub_dir" : "shaderc/third_party/glslang",
-      "commit" : "21eebe74214488264bbf0d19323a03c13a9e53a7"
+      "commit" : "74426f7570fdd23a3bcf7ac0987347197f44c92e"
     },
     {
       "name" : "Vulkan-Headers",
@@ -28,13 +28,13 @@
       "name" : "SPIRV-Tools",
       "url" : "https://github.com/KhronosGroup/SPIRV-Tools.git",
       "sub_dir" : "shaderc/third_party/spirv-tools",
-      "commit" : "d01a3c3b4b76e942e1c22adca5a9713197dde901"
+      "commit" : "1fedf72e500b7cf72098a3f800c8ef4b9d9dc84f"
     },
     {
       "name" : "SPIRV-Headers",
       "url" : "https://github.com/KhronosGroup/SPIRV-Headers.git",
       "sub_dir" : "shaderc/third_party/spirv-tools/external/spirv-headers",
-      "commit" : "8b911bd2ba37677037b38c9bd286c7c05701bcda"
+      "commit" : "dcce859e34cf0c23625ec75ac44df750aa2f4d70"
     }
   ]
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2005,6 +2005,7 @@ void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
         memset(&pCB->beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
         memset(&pCB->inheritanceInfo, 0, sizeof(VkCommandBufferInheritanceInfo));
         pCB->hasDrawCmd = false;
+        pCB->hasTraceRaysCmd = false;
         pCB->state = CB_NEW;
         pCB->submitCount = 0;
         pCB->image_layout_change_count = 1;  // Start at 1. 0 is insert value for validation cache versions, s.t. new == dirty
@@ -5069,7 +5070,6 @@ bool ValidationStateTracker::PreCallValidateCreateComputePipelines(VkDevice devi
                                                                    const VkComputePipelineCreateInfo *pCreateInfos,
                                                                    const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                                    void *ccpl_state_data) {
-    bool skip = false;
     auto *ccpl_state = reinterpret_cast<create_compute_pipeline_api_state *>(ccpl_state_data);
     ccpl_state->pCreateInfos = pCreateInfos;  // GPU validation can alter this, so we have to set a default value for the Chassis
     ccpl_state->pipe_state.reserve(count);
@@ -5079,7 +5079,7 @@ bool ValidationStateTracker::PreCallValidateCreateComputePipelines(VkDevice devi
         ccpl_state->pipe_state.back()->initComputePipeline(this, &pCreateInfos[i]);
         ccpl_state->pipe_state.back()->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
     }
-    return skip;
+    return false;
 }
 
 bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -5145,18 +5145,14 @@ bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesNV(VkDevice
                                                                         uint32_t count,
                                                                         const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                                         const VkAllocationCallbacks *pAllocator,
-                                                                        VkPipeline *pPipelines, void *pipe_state_data) {
-    // The order of operations here is a little convoluted but gets the job done
-    //  1. Pipeline create state is first shadowed into PIPELINE_STATE struct
-    //  2. Create state is then validated (which uses flags setup during shadowing)
-    //  3. If everything looks good, we'll then create the pipeline and add NODE to pipelineMap
-    vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
-        reinterpret_cast<vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
-    pipe_state->reserve(count);
+                                                                        VkPipeline *pPipelines, void *crtpl_state_data) {
+    auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
+    crtpl_state->pipe_state.reserve(count);
     for (uint32_t i = 0; i < count; i++) {
-        pipe_state->push_back(std::unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
-        (*pipe_state)[i]->initRayTracingPipelineNV(this, &pCreateInfos[i]);
-        (*pipe_state)[i]->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
+        // Create and initialize internal tracking data structure
+        crtpl_state->pipe_state.push_back(unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
+        crtpl_state->pipe_state.back()->initRayTracingPipelineNV(this, &pCreateInfos[i]);
+        crtpl_state->pipe_state.back()->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
     }
     return false;
 }
@@ -5164,31 +5160,56 @@ bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesNV(VkDevice
 bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                             const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                            void *pipe_state_data) {
+                                                            void *crtpl_state_data) {
     bool skip = StateTracker::PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, count, pCreateInfos, pAllocator,
-                                                                         pPipelines, pipe_state_data);
-    vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
-        reinterpret_cast<vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
-    for (uint32_t i = 0; i < count; i++) {
-        skip |= ValidateRayTracingPipelineNV((*pipe_state)[i].get());
-    }
+                                                                         pPipelines, crtpl_state_data);
 
+    auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
+    for (uint32_t i = 0; i < count; i++) {
+        skip |= ValidateRayTracingPipelineNV(crtpl_state->pipe_state[i].get());
+    }
     return skip;
+}
+
+void CoreChecks::PreCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                                          const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
+                                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
+                                                          void *crtpl_state_data) {
+    // GPU Validation may replace instrumented shaders with non-instrumented ones, so allow it to modify the createinfos.
+    if (enabled.gpu_validation) {
+        auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
+        crtpl_state->gpu_create_infos = GpuPreCallRecordCreateRayTracingPipelinesNV(pipelineCache, count, pCreateInfos, pAllocator,
+                                                                                    pPipelines, crtpl_state->pipe_state);
+        crtpl_state->pCreateInfos = reinterpret_cast<VkRayTracingPipelineCreateInfoNV *>(crtpl_state->gpu_create_infos.data());
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(
     VkDevice device, VkPipelineCache pipelineCache, uint32_t count, const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-    const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, VkResult result, void *pipe_state_data) {
-    vector<std::unique_ptr<PIPELINE_STATE>> *pipe_state =
-        reinterpret_cast<vector<std::unique_ptr<PIPELINE_STATE>> *>(pipe_state_data);
+    const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines, VkResult result, void *crtpl_state_data) {
+    auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
-            (*pipe_state)[i]->pipeline = pPipelines[i];
-            pipelineMap[pPipelines[i]] = std::move((*pipe_state)[i]);
+            (crtpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            pipelineMap[pPipelines[i]] = std::move((crtpl_state->pipe_state)[i]);
         }
     }
-    pipe_state->clear();
+    crtpl_state->pipe_state.clear();
+}
+
+void CoreChecks::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                                           const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
+                                                           const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
+                                                           VkResult result, void *crtpl_state_data) {
+    StateTracker::PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines,
+                                                            result, crtpl_state_data);
+    // GPU val needs clean up regardless of result
+    if (enabled.gpu_validation) {
+        auto *crtpl_state = reinterpret_cast<create_ray_tracing_pipeline_api_state *>(crtpl_state_data);
+        GpuPostCallRecordCreateRayTracingPipelinesNV(count, pCreateInfos, pAllocator, pPipelines);
+        crtpl_state->gpu_create_infos.clear();
+    }
 }
 
 void CoreChecks::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1398,6 +1398,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     VkCommandBufferInheritanceInfo inheritanceInfo;
     VkDevice device;  // device this CB belongs to
     bool hasDrawCmd;
+    bool hasTraceRaysCmd;
     CB_STATE state;        // Track cmd buffer update state
     uint64_t submitCount;  // Number of times CB has been submitted
     typedef uint64_t ImageLayoutUpdateCount;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -361,6 +361,28 @@ void CoreChecks::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer com
     AddCommandBufferBindingBuffer(cb_state, count_buffer_state);
 }
 
+void CoreChecks::PreCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
+                                             VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
+                                             VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
+                                             VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
+                                             VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
+                                             VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
+                                             uint32_t width, uint32_t height, uint32_t depth) {
+    GpuAllocateValidationResources(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV);
+}
+
+void CoreChecks::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
+                                              VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
+                                              VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
+                                              VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
+                                              VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
+                                              VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
+                                              uint32_t width, uint32_t height, uint32_t depth) {
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    UpdateStateCmdDrawDispatchType(cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV);
+    cb_state->hasTraceRaysCmd = true;
+}
+
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
     bool skip = ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWMESHTASKSNV,
                                     "vkCmdDrawMeshTasksNV()", VK_QUEUE_GRAPHICS_BIT,

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3619,7 +3619,7 @@ class ValidationObject {
         virtual VkResult CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount, const VkValidationCacheEXT* pSrcCaches)  { return VK_SUCCESS; };
         virtual VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData)  { return VK_SUCCESS; };
 
-        // Allow additional parameter for CreateGraphicsPipelines
+        // Allow additional state parameter for CreateGraphicsPipelines
         virtual bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* cgpl_state) {
             return PreCallValidateCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
         };
@@ -3629,12 +3629,13 @@ class ValidationObject {
         virtual void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result, void* cgpl_state) {
             PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result);
         };
-        virtual void PreCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* ccpl_state) {
-            PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-        };
+
         // Allow additional state parameter for CreateComputePipelines
         virtual bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* pipe_state)  {
             return PreCallValidateCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+        };
+        virtual void PreCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* ccpl_state) {
+            PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
         };
         virtual void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result, void* pipe_state) {
             PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result);
@@ -3643,6 +3644,9 @@ class ValidationObject {
         // Allow additional state parameter for CreateRayTracingPipelinesNV
         virtual bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoNV* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* pipe_state)  {
             return PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+        };
+        virtual void PreCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoNV* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* ccpl_state) {
+            PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
         };
         virtual void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoNV* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, VkResult result, void* pipe_state) {
             PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result);

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "3a1bf2cb47845cd27db1a89f1b75b71cf7ec92f7"
+#define SPIRV_TOOLS_COMMIT_ID "9773b4a008ed92341b308d3902215ea37e2c59a3"

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -43,6 +43,11 @@ struct GpuBufferInfo {
           pipeline_bind_point(pipeline_bind_point){};
 };
 
+struct GpuQueueBarrierCommandInfo {
+    VkCommandPool barrier_command_pool = VK_NULL_HANDLE;
+    VkCommandBuffer barrier_command_buffer = VK_NULL_HANDLE;
+};
+
 // Class to encapsulate Descriptor Set allocation.  This manager creates and destroys Descriptor Pools
 // as needed to satisfy requests for descriptor sets.
 class GpuDescriptorSetManager {
@@ -74,20 +79,16 @@ struct GpuValidationState {
     uint32_t unique_shader_module_id;
     std::unordered_map<uint32_t, ShaderTracker> shader_map;
     std::unique_ptr<GpuDescriptorSetManager> desc_set_manager;
-    VkCommandPool barrier_command_pool;
-    VkCommandBuffer barrier_command_buffer;
+    std::map<VkQueue, GpuQueueBarrierCommandInfo> queue_barrier_command_infos;
     std::unordered_map<VkCommandBuffer, std::vector<GpuBufferInfo>> command_buffer_map;  // gpu_buffer_list;
     uint32_t output_buffer_size;
     VmaAllocator vmaAllocator;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
     GpuValidationState(bool aborted = false, bool reserve_binding_slot = false, uint32_t unique_shader_module_id = 0,
-                       VkCommandPool barrier_command_pool = VK_NULL_HANDLE, VkCommandBuffer barrier_command_buffer = VK_NULL_HANDLE,
                        VmaAllocator vmaAllocator = {})
         : aborted(aborted),
           reserve_binding_slot(reserve_binding_slot),
           unique_shader_module_id(unique_shader_module_id),
-          barrier_command_pool(barrier_command_pool),
-          barrier_command_buffer(barrier_command_buffer),
           vmaAllocator(vmaAllocator){};
 
     std::vector<GpuBufferInfo> &GetGpuBufferInfo(const VkCommandBuffer command_buffer) {

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -33,9 +33,14 @@ struct GpuBufferInfo {
     GpuDeviceMemoryBlock input_mem_block;
     VkDescriptorSet desc_set;
     VkDescriptorPool desc_pool;
+    VkPipelineBindPoint pipeline_bind_point;
     GpuBufferInfo(GpuDeviceMemoryBlock output_mem_block, GpuDeviceMemoryBlock input_mem_block, VkDescriptorSet desc_set,
-                  VkDescriptorPool desc_pool)
-        : output_mem_block(output_mem_block), input_mem_block(input_mem_block), desc_set(desc_set), desc_pool(desc_pool){};
+                  VkDescriptorPool desc_pool, VkPipelineBindPoint pipeline_bind_point)
+        : output_mem_block(output_mem_block),
+          input_mem_block(input_mem_block),
+          desc_set(desc_set),
+          desc_pool(desc_pool),
+          pipeline_bind_point(pipeline_bind_point){};
 };
 
 // Class to encapsulate Descriptor Set allocation.  This manager creates and destroys Descriptor Pools

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "21eebe74214488264bbf0d19323a03c13a9e53a7",
+      "commit" : "74426f7570fdd23a3bcf7ac0987347197f44c92e",
       "prebuild" : [
         "python update_glslang_sources.py"
       ],

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -27,7 +27,7 @@
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
 
-TEST_F(VkLayerTest, GpuValidationArrayOOB) {
+TEST_F(VkLayerTest, GpuValidationArrayOOBGraphicsShaders) {
     TEST_DESCRIPTION(
         "GPU validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors.");
     if (!VkRenderFramework::DeviceCanDraw()) {
@@ -364,6 +364,836 @@ TEST_F(VkLayerTest, GpuValidationArrayOOB) {
     }
     return;
 }
+
+TEST_F(VkLayerTest, GpuValidationArrayOOBRayTracingShaders) {
+    TEST_DESCRIPTION(
+        "GPU validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors for "
+        "ray tracing shaders.");
+
+    std::array<const char *, 1> required_instance_extensions = {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME};
+    for (auto instance_extension : required_instance_extensions) {
+        if (InstanceExtensionSupported(instance_extension)) {
+            m_instance_extension_names.push_back(instance_extension);
+        } else {
+            printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix, instance_extension);
+            return;
+        }
+    }
+
+    VkValidationFeatureEnableEXT validation_feature_enables[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
+    VkValidationFeaturesEXT validation_features = {};
+    validation_features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    validation_features.enabledValidationFeatureCount = 1;
+    validation_features.pEnabledValidationFeatures = validation_feature_enables;
+    bool descriptor_indexing = CheckDescriptorIndexingSupportAndInitFramework(
+        this, m_instance_extension_names, m_device_extension_names, &validation_features, m_errorMonitor);
+
+    if (DeviceIsMockICD() || DeviceSimulation()) {
+        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
+    std::array<const char *, 2> required_device_extensions = {VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
+                                                              VK_NV_RAY_TRACING_EXTENSION_NAME};
+    for (auto device_extension : required_device_extensions) {
+        if (DeviceExtensionSupported(gpu(), nullptr, device_extension)) {
+            m_device_extension_names.push_back(device_extension);
+        } else {
+            printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, device_extension);
+            return;
+        }
+    }
+
+    VkPhysicalDeviceFeatures2KHR features2 = {};
+    auto indexing_features = lvl_init_struct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    if (descriptor_indexing) {
+        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
+            (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+
+        features2 = lvl_init_struct<VkPhysicalDeviceFeatures2KHR>(&indexing_features);
+        vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+
+        if (!indexing_features.runtimeDescriptorArray || !indexing_features.descriptorBindingPartiallyBound ||
+            !indexing_features.descriptorBindingSampledImageUpdateAfterBind ||
+            !indexing_features.descriptorBindingVariableDescriptorCount) {
+            printf("Not all descriptor indexing features supported, skipping descriptor indexing tests\n");
+            descriptor_indexing = false;
+        }
+    }
+    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
+
+    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
+        (PFN_vkGetPhysicalDeviceProperties2KHR)vkGetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+
+    auto ray_tracing_properties = lvl_init_struct<VkPhysicalDeviceRayTracingPropertiesNV>();
+    auto properties2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);
+    vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    if (ray_tracing_properties.maxTriangleCount == 0) {
+        printf("%s Did not find required ray tracing properties; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    struct AABB {
+        float min_x;
+        float min_y;
+        float min_z;
+        float max_x;
+        float max_y;
+        float max_z;
+    };
+
+    const std::vector<AABB> aabbs = {{-1.0f, -1.0f, -1.0f, +1.0f, +1.0f, +1.0f}};
+
+    struct VkGeometryInstanceNV {
+        float transform[12];
+        uint32_t instanceCustomIndex : 24;
+        uint32_t mask : 8;
+        uint32_t instanceOffset : 24;
+        uint32_t flags : 8;
+        uint64_t accelerationStructureHandle;
+    };
+
+    VkDeviceSize aabb_buffer_size = sizeof(AABB) * aabbs.size();
+    VkBufferObj aabb_buffer;
+    aabb_buffer.init(*m_device, aabb_buffer_size, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                     VK_BUFFER_USAGE_RAY_TRACING_BIT_NV);
+
+    uint8_t *mapped_aabb_buffer_data = (uint8_t *)aabb_buffer.memory().map();
+    std::memcpy(mapped_aabb_buffer_data, (uint8_t *)aabbs.data(), static_cast<std::size_t>(aabb_buffer_size));
+    aabb_buffer.memory().unmap();
+
+    VkGeometryNV geometry = {};
+    geometry.sType = VK_STRUCTURE_TYPE_GEOMETRY_NV;
+    geometry.geometryType = VK_GEOMETRY_TYPE_AABBS_NV;
+    geometry.geometry.triangles = {};
+    geometry.geometry.triangles.sType = VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV;
+    geometry.geometry.aabbs = {};
+    geometry.geometry.aabbs.sType = VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV;
+    geometry.geometry.aabbs.aabbData = aabb_buffer.handle();
+    geometry.geometry.aabbs.numAABBs = static_cast<uint32_t>(aabbs.size());
+    geometry.geometry.aabbs.offset = 0;
+    geometry.geometry.aabbs.stride = static_cast<VkDeviceSize>(sizeof(AABB));
+    geometry.flags = 0;
+
+    VkAccelerationStructureInfoNV bot_level_as_info = {};
+    bot_level_as_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
+    bot_level_as_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;
+    bot_level_as_info.instanceCount = 0;
+    bot_level_as_info.geometryCount = 1;
+    bot_level_as_info.pGeometries = &geometry;
+
+    VkAccelerationStructureCreateInfoNV bot_level_as_create_info = {};
+    bot_level_as_create_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV;
+    bot_level_as_create_info.info = bot_level_as_info;
+
+    VkAccelerationStructureObj bot_level_as(*m_device, bot_level_as_create_info);
+
+    const std::vector<VkGeometryInstanceNV> instances = {
+        VkGeometryInstanceNV{
+            {
+                // clang-format off
+                1.0f, 0.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f, 0.0f,
+                0.0f, 0.0f, 1.0f, 0.0f,
+                // clang-format on
+            },
+            0,
+            0xFF,
+            0,
+            VK_GEOMETRY_INSTANCE_TRIANGLE_CULL_DISABLE_BIT_NV,
+            bot_level_as.opaque_handle(),
+        },
+    };
+
+    VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV) * instances.size();
+    VkBufferObj instance_buffer;
+    instance_buffer.init(*m_device, instance_buffer_size,
+                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                         VK_BUFFER_USAGE_RAY_TRACING_BIT_NV);
+
+    uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
+    std::memcpy(mapped_instance_buffer_data, (uint8_t *)instances.data(), static_cast<std::size_t>(instance_buffer_size));
+    instance_buffer.memory().unmap();
+
+    VkAccelerationStructureInfoNV top_level_as_info = {};
+    top_level_as_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
+    top_level_as_info.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
+    top_level_as_info.instanceCount = 1;
+    top_level_as_info.geometryCount = 0;
+
+    VkAccelerationStructureCreateInfoNV top_level_as_create_info = {};
+    top_level_as_create_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV;
+    top_level_as_create_info.info = top_level_as_info;
+
+    VkAccelerationStructureObj top_level_as(*m_device, top_level_as_create_info);
+
+    VkDeviceSize scratch_buffer_size = std::max(bot_level_as.build_scratch_memory_requirements().memoryRequirements.size,
+                                                top_level_as.build_scratch_memory_requirements().memoryRequirements.size);
+    VkBufferObj scratch_buffer;
+    scratch_buffer.init(*m_device, scratch_buffer_size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV);
+
+    m_commandBuffer->begin();
+
+    // Build bot level acceleration structure
+    m_commandBuffer->BuildAccelerationStructure(&bot_level_as, scratch_buffer.handle());
+
+    // Barrier to prevent using scratch buffer for top level build before bottom level build finishes
+    VkMemoryBarrier memory_barrier = {};
+    memory_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    memory_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_NV | VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_NV;
+    memory_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_NV | VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_NV;
+    m_commandBuffer->PipelineBarrier(VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV,
+                                     VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV, 0, 1, &memory_barrier, 0, nullptr, 0,
+                                     nullptr);
+
+    // Build top level acceleration structure
+    m_commandBuffer->BuildAccelerationStructure(&top_level_as, scratch_buffer.handle(), instance_buffer.handle());
+
+    m_commandBuffer->end();
+
+    VkSubmitInfo submit_info = {};
+    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+    vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vkQueueWaitIdle(m_device->m_queue);
+    m_errorMonitor->VerifyNotFound();
+
+    VkTextureObj texture(m_device, nullptr);
+    VkSamplerObj sampler(m_device);
+
+    VkDeviceSize storage_buffer_size = 1024;
+    VkBufferObj storage_buffer;
+    storage_buffer.init(*m_device, storage_buffer_size, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
+
+    VkDeviceSize shader_binding_table_buffer_size = ray_tracing_properties.shaderGroupHandleSize * 4ull;
+    VkBufferObj shader_binding_table_buffer;
+    shader_binding_table_buffer.init(*m_device, shader_binding_table_buffer_size,
+                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                     VK_BUFFER_USAGE_RAY_TRACING_BIT_NV);
+
+    // Setup descriptors!
+    const VkShaderStageFlags kAllRayTracingStages = VK_SHADER_STAGE_RAYGEN_BIT_NV | VK_SHADER_STAGE_ANY_HIT_BIT_NV |
+                                                    VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV | VK_SHADER_STAGE_MISS_BIT_NV |
+                                                    VK_SHADER_STAGE_INTERSECTION_BIT_NV | VK_SHADER_STAGE_CALLABLE_BIT_NV;
+
+    void *layout_pnext = nullptr;
+    void *allocate_pnext = nullptr;
+    VkDescriptorPoolCreateFlags pool_create_flags = 0;
+    VkDescriptorSetLayoutCreateFlags layout_create_flags = 0;
+    VkDescriptorBindingFlagsEXT ds_binding_flags[3] = {};
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT layout_createinfo_binding_flags[1] = {};
+    if (descriptor_indexing) {
+        ds_binding_flags[0] = 0;
+        ds_binding_flags[1] = 0;
+        ds_binding_flags[2] = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT;
+
+        layout_createinfo_binding_flags[0].sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
+        layout_createinfo_binding_flags[0].pNext = NULL;
+        layout_createinfo_binding_flags[0].bindingCount = 3;
+        layout_createinfo_binding_flags[0].pBindingFlags = ds_binding_flags;
+        layout_create_flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT;
+        pool_create_flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT;
+        layout_pnext = layout_createinfo_binding_flags;
+    }
+
+    // Prepare descriptors
+    OneOffDescriptorSet ds(m_device,
+                           {
+                               {0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, 1, kAllRayTracingStages, nullptr},
+                               {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, kAllRayTracingStages, nullptr},
+                               {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 6, kAllRayTracingStages, nullptr},
+                           },
+                           layout_create_flags, layout_pnext, pool_create_flags);
+
+    VkDescriptorSetVariableDescriptorCountAllocateInfoEXT variable_count = {};
+    uint32_t desc_counts;
+    if (descriptor_indexing) {
+        layout_create_flags = 0;
+        pool_create_flags = 0;
+        ds_binding_flags[2] =
+            VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT | VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT_EXT;
+        desc_counts = 6;  // We'll reserve 8 spaces in the layout, but the descriptor will only use 6
+        variable_count.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT;
+        variable_count.descriptorSetCount = 1;
+        variable_count.pDescriptorCounts = &desc_counts;
+        allocate_pnext = &variable_count;
+    }
+
+    OneOffDescriptorSet ds_variable(m_device,
+                                    {
+                                        {0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, 1, kAllRayTracingStages, nullptr},
+                                        {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, kAllRayTracingStages, nullptr},
+                                        {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 8, kAllRayTracingStages, nullptr},
+                                    },
+                                    layout_create_flags, layout_pnext, pool_create_flags, allocate_pnext);
+
+    VkAccelerationStructureNV top_level_as_handle = top_level_as.handle();
+    VkWriteDescriptorSetAccelerationStructureNV write_descript_set_as = {};
+    write_descript_set_as.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV;
+    write_descript_set_as.accelerationStructureCount = 1;
+    write_descript_set_as.pAccelerationStructures = &top_level_as_handle;
+
+    VkDescriptorBufferInfo descriptor_buffer_info = {};
+    descriptor_buffer_info.buffer = storage_buffer.handle();
+    descriptor_buffer_info.offset = 0;
+    descriptor_buffer_info.range = storage_buffer_size;
+
+    VkDescriptorImageInfo descriptor_image_infos[6] = {};
+    for (int i = 0; i < 6; i++) {
+        descriptor_image_infos[i] = texture.DescriptorImageInfo();
+        descriptor_image_infos[i].sampler = sampler.handle();
+        descriptor_image_infos[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+
+    VkWriteDescriptorSet descriptor_writes[3] = {};
+    descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    descriptor_writes[0].dstSet = ds.set_;
+    descriptor_writes[0].dstBinding = 0;
+    descriptor_writes[0].descriptorCount = 1;
+    descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
+    descriptor_writes[0].pNext = &write_descript_set_as;
+
+    descriptor_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    descriptor_writes[1].dstSet = ds.set_;
+    descriptor_writes[1].dstBinding = 1;
+    descriptor_writes[1].descriptorCount = 1;
+    descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    descriptor_writes[1].pBufferInfo = &descriptor_buffer_info;
+
+    descriptor_writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    descriptor_writes[2].dstSet = ds.set_;
+    descriptor_writes[2].dstBinding = 2;
+    if (descriptor_indexing) {
+        descriptor_writes[2].descriptorCount = 5;  // Intentionally don't write index 5
+    } else {
+        descriptor_writes[2].descriptorCount = 6;
+    }
+    descriptor_writes[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    descriptor_writes[2].pImageInfo = descriptor_image_infos;
+    vkUpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, NULL);
+    if (descriptor_indexing) {
+        descriptor_writes[0].dstSet = ds_variable.set_;
+        descriptor_writes[1].dstSet = ds_variable.set_;
+        descriptor_writes[2].dstSet = ds_variable.set_;
+        vkUpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, NULL);
+    }
+
+    const VkPipelineLayoutObj pipeline_layout(m_device, {&ds.layout_});
+    const VkPipelineLayoutObj pipeline_layout_variable(m_device, {&ds_variable.layout_});
+
+    const auto SetImagesArrayLength = [](const std::string &shader_template, const std::string &length_str) {
+        const std::string to_replace = "IMAGES_ARRAY_LENGTH";
+
+        std::string result = shader_template;
+        auto position = result.find(to_replace);
+        assert(position != std::string::npos);
+        result.replace(position, to_replace.length(), length_str);
+        return result;
+    };
+
+    const std::string rgen_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : require
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 0) uniform accelerationStructureNV topLevelAS;
+        layout(set = 0, binding = 1, std430) buffer RayTracingSbo {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        layout(location = 0) rayPayloadNV vec3 payload;
+        layout(location = 3) callableDataNV vec3 callableData;
+
+        void main() {
+            sbo.rgen_ran = 1;
+
+	        executeCallableNV(0, 3);
+	        sbo.result1 = callableData.x;
+
+	        vec3 origin = vec3(0.0f, 0.0f, -2.0f);
+	        vec3 direction = vec3(0.0f, 0.0f, 1.0f);
+
+	        traceNV(topLevelAS, gl_RayFlagsNoneNV, 0xFF, 0, 1, 0, origin, 0.001, direction, 10000.0, 0);
+	        sbo.result2 = payload.x;
+
+	        traceNV(topLevelAS, gl_RayFlagsNoneNV, 0xFF, 0, 1, 0, origin, 0.001, -direction, 10000.0, 0);
+	        sbo.result3 = payload.x;
+
+            if (sbo.rgen_index > 0) {
+                // OOB here:
+                sbo.result3 = texelFetch(textures[sbo.rgen_index], ivec2(0, 0), 0).x;
+            }
+        }
+        )";
+
+    const std::string rgen_source = SetImagesArrayLength(rgen_source_template, "6");
+    const std::string rgen_source_runtime = SetImagesArrayLength(rgen_source_template, "");
+
+    const std::string ahit_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : require
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 1, std430) buffer StorageBuffer {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        hitAttributeNV vec3 hitValue;
+
+        layout(location = 0) rayPayloadInNV vec3 payload;
+
+        void main() {
+	        sbo.ahit_ran = 2;
+
+	        payload = vec3(0.1234f);
+
+            if (sbo.ahit_index > 0) {
+                // OOB here:
+                payload.x = texelFetch(textures[sbo.ahit_index], ivec2(0, 0), 0).x;
+            }
+        }
+    )";
+    const std::string ahit_source = SetImagesArrayLength(ahit_source_template, "6");
+    const std::string ahit_source_runtime = SetImagesArrayLength(ahit_source_template, "");
+
+    const std::string chit_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : require
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 1, std430) buffer RayTracingSbo {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        layout(location = 0) rayPayloadInNV vec3 payload;
+
+        hitAttributeNV vec3 attribs;
+
+        void main() {
+            sbo.chit_ran = 3;
+
+            payload = attribs;
+            if (sbo.chit_index > 0) {
+                // OOB here:
+                payload.x = texelFetch(textures[sbo.chit_index], ivec2(0, 0), 0).x;
+            }
+        }
+        )";
+    const std::string chit_source = SetImagesArrayLength(chit_source_template, "6");
+    const std::string chit_source_runtime = SetImagesArrayLength(chit_source_template, "");
+
+    const std::string miss_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : enable
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 1, std430) buffer RayTracingSbo {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        layout(location = 0) rayPayloadInNV vec3 payload;
+
+        void main() {
+            sbo.miss_ran = 4;
+
+            payload = vec3(1.0, 0.0, 0.0);
+
+            if (sbo.miss_index > 0) {
+                // OOB here:
+                payload.x = texelFetch(textures[sbo.miss_index], ivec2(0, 0), 0).x;
+            }
+        }
+    )";
+    const std::string miss_source = SetImagesArrayLength(miss_source_template, "6");
+    const std::string miss_source_runtime = SetImagesArrayLength(miss_source_template, "");
+
+    const std::string intr_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : require
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 1, std430) buffer StorageBuffer {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        hitAttributeNV vec3 hitValue;
+
+        void main() {
+	        sbo.intr_ran = 5;
+
+	        hitValue = vec3(0.0f, 0.5f, 0.0f);
+
+	        reportIntersectionNV(1.0f, 0);
+
+            if (sbo.intr_index > 0) {
+                // OOB here:
+                hitValue.x = texelFetch(textures[sbo.intr_index], ivec2(0, 0), 0).x;
+            }
+        }
+    )";
+    const std::string intr_source = SetImagesArrayLength(intr_source_template, "6");
+    const std::string intr_source_runtime = SetImagesArrayLength(intr_source_template, "");
+
+    const std::string call_source_template = R"(#version 460
+        #extension GL_EXT_nonuniform_qualifier : require
+        #extension GL_EXT_samplerless_texture_functions : require
+        #extension GL_NV_ray_tracing : require
+
+        layout(set = 0, binding = 1, std430) buffer StorageBuffer {
+	        uint rgen_index;
+	        uint ahit_index;
+	        uint chit_index;
+	        uint miss_index;
+	        uint intr_index;
+	        uint call_index;
+
+	        uint rgen_ran;
+	        uint ahit_ran;
+	        uint chit_ran;
+	        uint miss_ran;
+	        uint intr_ran;
+	        uint call_ran;
+
+	        float result1;
+	        float result2;
+	        float result3;
+        } sbo;
+        layout(set = 0, binding = 2) uniform texture2D textures[IMAGES_ARRAY_LENGTH];
+
+        layout(location = 3) callableDataInNV vec3 callableData;
+
+        void main() {
+	        sbo.call_ran = 6;
+
+	        callableData = vec3(0.1234f);
+
+            if (sbo.call_index > 0) {
+                // OOB here:
+                callableData.x = texelFetch(textures[sbo.call_index], ivec2(0, 0), 0).x;
+            }
+        }
+    )";
+    const std::string call_source = SetImagesArrayLength(call_source_template, "6");
+    const std::string call_source_runtime = SetImagesArrayLength(call_source_template, "");
+
+    struct TestCase {
+        const std::string &rgen_shader_source;
+        const std::string &ahit_shader_source;
+        const std::string &chit_shader_source;
+        const std::string &miss_shader_source;
+        const std::string &intr_shader_source;
+        const std::string &call_shader_source;
+        bool variable_length;
+        uint32_t rgen_index;
+        uint32_t ahit_index;
+        uint32_t chit_index;
+        uint32_t miss_index;
+        uint32_t intr_index;
+        uint32_t call_index;
+        const char *expected_error;
+    };
+
+    std::vector<TestCase> tests;
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 25, 0, 0, 0, 0, 0,
+                     "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 0, 25, 0, 0, 0, 0,
+                     "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 0, 0, 25, 0, 0, 0,
+                     "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 0, 0, 0, 25, 0, 0,
+                     "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 0, 0, 0, 0, 25, 0,
+                     "Index of 25 used to index descriptor array of length 6."});
+    tests.push_back({rgen_source, ahit_source, chit_source, miss_source, intr_source, call_source, false, 0, 0, 0, 0, 0, 25,
+                     "Index of 25 used to index descriptor array of length 6."});
+
+    if (descriptor_indexing) {
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 25, 0, 0, 0, 0, 0, "Index of 25 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 25, 0, 0, 0, 0, "Index of 25 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 25, 0, 0, 0, "Index of 25 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 25, 0, 0, "Index of 25 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 25, 0, "Index of 25 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 0, 25, "Index of 25 used to index descriptor array of length 6."});
+
+        // For this group, 6 is less than max specified (max specified is 8) but more than actual specified (actual specified is 5)
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 6, 0, 0, 0, 0, 0, "Index of 6 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 6, 0, 0, 0, 0, "Index of 6 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 6, 0, 0, 0, "Index of 6 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 6, 0, 0, "Index of 6 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 6, 0, "Index of 6 used to index descriptor array of length 6."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 0, 6, "Index of 6 used to index descriptor array of length 6."});
+
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 5, 0, 0, 0, 0, 0, "Descriptor index 5 is uninitialized."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 5, 0, 0, 0, 0, "Descriptor index 5 is uninitialized."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 5, 0, 0, 0, "Descriptor index 5 is uninitialized."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 5, 0, 0, "Descriptor index 5 is uninitialized."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 5, 0, "Descriptor index 5 is uninitialized."});
+        tests.push_back({rgen_source_runtime, ahit_source_runtime, chit_source_runtime, miss_source_runtime, intr_source_runtime,
+                         call_source_runtime, true, 0, 0, 0, 0, 0, 5, "Descriptor index 5 is uninitialized."});
+    }
+
+    PFN_vkCreateRayTracingPipelinesNV vkCreateRayTracingPipelinesNV = reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(
+        vkGetDeviceProcAddr(m_device->handle(), "vkCreateRayTracingPipelinesNV"));
+    ASSERT_TRUE(vkCreateRayTracingPipelinesNV != nullptr);
+
+    PFN_vkGetRayTracingShaderGroupHandlesNV vkGetRayTracingShaderGroupHandlesNV =
+        reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesNV>(
+            vkGetDeviceProcAddr(m_device->handle(), "vkGetRayTracingShaderGroupHandlesNV"));
+    ASSERT_TRUE(vkGetRayTracingShaderGroupHandlesNV != nullptr);
+
+    PFN_vkCmdTraceRaysNV vkCmdTraceRaysNV =
+        reinterpret_cast<PFN_vkCmdTraceRaysNV>(vkGetDeviceProcAddr(m_device->handle(), "vkCmdTraceRaysNV"));
+    ASSERT_TRUE(vkCmdTraceRaysNV != nullptr);
+
+    for (const auto &test : tests) {
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, test.expected_error);
+
+        VkShaderObj rgen_shader(m_device, test.rgen_shader_source.c_str(), VK_SHADER_STAGE_RAYGEN_BIT_NV, this, "main");
+        VkShaderObj ahit_shader(m_device, test.ahit_shader_source.c_str(), VK_SHADER_STAGE_ANY_HIT_BIT_NV, this, "main");
+        VkShaderObj chit_shader(m_device, test.chit_shader_source.c_str(), VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV, this, "main");
+        VkShaderObj miss_shader(m_device, test.miss_shader_source.c_str(), VK_SHADER_STAGE_MISS_BIT_NV, this, "main");
+        VkShaderObj intr_shader(m_device, test.intr_shader_source.c_str(), VK_SHADER_STAGE_INTERSECTION_BIT_NV, this, "main");
+        VkShaderObj call_shader(m_device, test.call_shader_source.c_str(), VK_SHADER_STAGE_CALLABLE_BIT_NV, this, "main");
+
+        VkPipelineShaderStageCreateInfo stage_create_infos[6] = {};
+        stage_create_infos[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[0].stage = VK_SHADER_STAGE_RAYGEN_BIT_NV;
+        stage_create_infos[0].module = rgen_shader.handle();
+        stage_create_infos[0].pName = "main";
+
+        stage_create_infos[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[1].stage = VK_SHADER_STAGE_ANY_HIT_BIT_NV;
+        stage_create_infos[1].module = ahit_shader.handle();
+        stage_create_infos[1].pName = "main";
+
+        stage_create_infos[2].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[2].stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV;
+        stage_create_infos[2].module = chit_shader.handle();
+        stage_create_infos[2].pName = "main";
+
+        stage_create_infos[3].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[3].stage = VK_SHADER_STAGE_MISS_BIT_NV;
+        stage_create_infos[3].module = miss_shader.handle();
+        stage_create_infos[3].pName = "main";
+
+        stage_create_infos[4].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[4].stage = VK_SHADER_STAGE_INTERSECTION_BIT_NV;
+        stage_create_infos[4].module = intr_shader.handle();
+        stage_create_infos[4].pName = "main";
+
+        stage_create_infos[5].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_create_infos[5].stage = VK_SHADER_STAGE_CALLABLE_BIT_NV;
+        stage_create_infos[5].module = call_shader.handle();
+        stage_create_infos[5].pName = "main";
+
+        VkRayTracingShaderGroupCreateInfoNV group_create_infos[4] = {};
+        group_create_infos[0].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;
+        group_create_infos[0].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_NV;
+        group_create_infos[0].generalShader = 0;  // rgen
+        group_create_infos[0].closestHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[0].anyHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[0].intersectionShader = VK_SHADER_UNUSED_NV;
+
+        group_create_infos[1].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;
+        group_create_infos[1].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_NV;
+        group_create_infos[1].generalShader = 3;  // miss
+        group_create_infos[1].closestHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[1].anyHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[1].intersectionShader = VK_SHADER_UNUSED_NV;
+
+        group_create_infos[2].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;
+        group_create_infos[2].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV;
+        group_create_infos[2].generalShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[2].closestHitShader = 2;
+        group_create_infos[2].anyHitShader = 1;
+        group_create_infos[2].intersectionShader = 4;
+
+        group_create_infos[3].sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV;
+        group_create_infos[3].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV;
+        group_create_infos[3].generalShader = 5;  // call
+        group_create_infos[3].closestHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[3].anyHitShader = VK_SHADER_UNUSED_NV;
+        group_create_infos[3].intersectionShader = VK_SHADER_UNUSED_NV;
+
+        VkRayTracingPipelineCreateInfoNV pipeline_ci = {};
+        pipeline_ci.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV;
+        pipeline_ci.stageCount = 6;
+        pipeline_ci.pStages = stage_create_infos;
+        pipeline_ci.groupCount = 4;
+        pipeline_ci.pGroups = group_create_infos;
+        pipeline_ci.maxRecursionDepth = 2;
+        pipeline_ci.layout = test.variable_length ? pipeline_layout_variable.handle() : pipeline_layout.handle();
+
+        VkPipeline pipeline = VK_NULL_HANDLE;
+        ASSERT_VK_SUCCESS(vkCreateRayTracingPipelinesNV(m_device->handle(), VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline));
+
+        std::vector<uint8_t> shader_binding_table_data;
+        shader_binding_table_data.resize(static_cast<std::size_t>(shader_binding_table_buffer_size), 0);
+        ASSERT_VK_SUCCESS(vkGetRayTracingShaderGroupHandlesNV(m_device->handle(), pipeline, 0, 4,
+                                                              static_cast<std::size_t>(shader_binding_table_buffer_size),
+                                                              shader_binding_table_data.data()));
+
+        uint8_t *mapped_shader_binding_table_data = (uint8_t *)shader_binding_table_buffer.memory().map();
+        std::memcpy(mapped_shader_binding_table_data, shader_binding_table_data.data(), shader_binding_table_data.size());
+        shader_binding_table_buffer.memory().unmap();
+
+        m_commandBuffer->begin();
+
+        vkCmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, pipeline);
+        vkCmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV,
+                                test.variable_length ? pipeline_layout_variable.handle() : pipeline_layout.handle(), 0, 1,
+                                test.variable_length ? &ds_variable.set_ : &ds.set_, 0, nullptr);
+
+        vkCmdTraceRaysNV(m_commandBuffer->handle(), shader_binding_table_buffer.handle(),
+                         ray_tracing_properties.shaderGroupHandleSize * 0ull, shader_binding_table_buffer.handle(),
+                         ray_tracing_properties.shaderGroupHandleSize * 1ull, ray_tracing_properties.shaderGroupHandleSize,
+                         shader_binding_table_buffer.handle(), ray_tracing_properties.shaderGroupHandleSize * 2ull,
+                         ray_tracing_properties.shaderGroupHandleSize, shader_binding_table_buffer.handle(),
+                         ray_tracing_properties.shaderGroupHandleSize * 3ull, ray_tracing_properties.shaderGroupHandleSize,
+                         /*width=*/1, /*height=*/1, /*depth=*/1);
+
+        m_commandBuffer->end();
+
+        // Update the index of the texture that the shaders should read
+        uint32_t *mapped_storage_buffer_data = (uint32_t *)storage_buffer.memory().map();
+        mapped_storage_buffer_data[0] = test.rgen_index;
+        mapped_storage_buffer_data[1] = test.ahit_index;
+        mapped_storage_buffer_data[2] = test.chit_index;
+        mapped_storage_buffer_data[3] = test.miss_index;
+        mapped_storage_buffer_data[4] = test.intr_index;
+        mapped_storage_buffer_data[5] = test.call_index;
+        mapped_storage_buffer_data[6] = 0;
+        mapped_storage_buffer_data[7] = 0;
+        mapped_storage_buffer_data[8] = 0;
+        mapped_storage_buffer_data[9] = 0;
+        mapped_storage_buffer_data[10] = 0;
+        mapped_storage_buffer_data[11] = 0;
+        storage_buffer.memory().unmap();
+
+        vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+        vkQueueWaitIdle(m_device->m_queue);
+        m_errorMonitor->VerifyFound();
+
+        mapped_storage_buffer_data = (uint32_t *)storage_buffer.memory().map();
+        ASSERT_TRUE(mapped_storage_buffer_data[6] == 1);
+        ASSERT_TRUE(mapped_storage_buffer_data[7] == 2);
+        ASSERT_TRUE(mapped_storage_buffer_data[8] == 3);
+        ASSERT_TRUE(mapped_storage_buffer_data[9] == 4);
+        ASSERT_TRUE(mapped_storage_buffer_data[10] == 5);
+        ASSERT_TRUE(mapped_storage_buffer_data[11] == 6);
+        storage_buffer.memory().unmap();
+
+        vkDestroyPipeline(m_device->handle(), pipeline, nullptr);
+    }
+}
+
 TEST_F(VkLayerTest, InvalidDescriptorPoolConsistency) {
     VkResult err;
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1845,6 +1845,19 @@ void VkCommandBufferObj::ClearDepthStencilImage(VkImage image, VkImageLayout ima
     vkCmdClearDepthStencilImage(handle(), image, imageLayout, pColor, rangeCount, pRanges);
 }
 
+void VkCommandBufferObj::BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer) {
+    BuildAccelerationStructure(as, scratchBuffer, VK_NULL_HANDLE);
+}
+
+void VkCommandBufferObj::BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer, VkBuffer instanceData) {
+    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
+        (PFN_vkCmdBuildAccelerationStructureNV)vkGetDeviceProcAddr(as->dev(), "vkCmdBuildAccelerationStructureNV");
+    assert(vkCmdBuildAccelerationStructureNV != nullptr);
+
+    vkCmdBuildAccelerationStructureNV(handle(), &as->info(), instanceData, 0, VK_FALSE, as->handle(), VK_NULL_HANDLE, scratchBuffer,
+                                      0);
+}
+
 void VkCommandBufferObj::PrepareAttachments(const vector<std::unique_ptr<VkImageObj>> &color_atts,
                                             VkDepthStencilObj *depth_stencil_att) {
     for (const auto &color_att : color_atts) {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -215,6 +215,8 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
                          const VkImageSubresourceRange *pRanges);
     void ClearDepthStencilImage(VkImage image, VkImageLayout imageLayout, const VkClearDepthStencilValue *pColor,
                                 uint32_t rangeCount, const VkImageSubresourceRange *pRanges);
+    void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer);
+    void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer, VkBuffer instanceData);
 
    protected:
     VkDeviceObj *m_device;

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -669,6 +669,11 @@ void AccelerationStructure::init(const Device &dev, const VkAccelerationStructur
         bind_info.accelerationStructure = handle();
         bind_info.memory = memory_.handle();
         EXPECT(vkBindAccelerationStructureMemoryNV(dev.handle(), 1, &bind_info) == VK_SUCCESS);
+
+        PFN_vkGetAccelerationStructureHandleNV vkGetAccelerationStructureHandleNV =
+            (PFN_vkGetAccelerationStructureHandleNV)vkGetDeviceProcAddr(dev.handle(), "vkGetAccelerationStructureHandleNV");
+        assert(vkGetAccelerationStructureHandleNV != nullptr);
+        EXPECT(vkGetAccelerationStructureHandleNV(dev.handle(), handle(), sizeof(uint64_t), &opaque_handle_) == VK_SUCCESS);
     }
 }
 

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -569,6 +569,8 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
     VkMemoryRequirements2 memory_requirements() const;
     VkMemoryRequirements2 build_scratch_memory_requirements() const;
 
+    uint64_t opaque_handle() const { return opaque_handle_; }
+
     const VkAccelerationStructureInfoNV &info() const { return info_; }
 
     const VkDevice &dev() const { return device(); }
@@ -578,6 +580,7 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
    private:
     VkAccelerationStructureInfoNV info_;
     DeviceMemory memory_;
+    uint64_t opaque_handle_;
 };
 
 class ShaderModule : public internal::NonDispHandle<VkShaderModule> {

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -388,8 +388,8 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     void init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props);
     void init(const Device &dev, const VkBufferCreateInfo &info) { init(dev, info, 0); }
     void init(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags mem_props,
-              VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
-        init(dev, create_info(size, usage), mem_props);
+              VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, const std::vector<uint32_t> &queue_families = {}) {
+        init(dev, create_info(size, usage, &queue_families), mem_props);
     }
     void init(const Device &dev, VkDeviceSize size) { init(dev, size, 0); }
     void init_as_src(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,


### PR DESCRIPTION
Updates gpu validation to support descriptor indexing shader checks for
ray tracing ray generation, intersection, any hit, closest hit, miss, and callable shaders.

Note this PR depends on https://github.com/KhronosGroup/SPIRV-Tools/pull/2733 - just want to start review process to get feedback.