### PR TITLE
Make GetDeviceProcAddress return NULL for non-existent APIs

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -330,7 +330,7 @@ void ProcessConfigAndEnvSettings(const char* layer_description, CHECK_ENABLED* e
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char *funcName) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    if (!ApiParentExtensionEnabled(funcName, layer_data->device_extensions.device_extension_set)) {
+    if (!ApiParentExtensionEnabled(funcName, &layer_data->device_extensions)) {
         return nullptr;
     }
     const auto &item = name_to_funcptr_map.find(funcName);

--- a/layers/generated/vk_dispatch_table_helper.h
+++ b/layers/generated/vk_dispatch_table_helper.h
@@ -212,6 +212,22 @@ static VKAPI_ATTR void VKAPI_CALL StubResetQueryPoolEXT(VkDevice device, VkQuery
 
 
 const std::unordered_map<std::string, std::string> api_extension_map {
+    {"vkBindBufferMemory2", "VK_VERSION_1_1"},
+    {"vkBindImageMemory2", "VK_VERSION_1_1"},
+    {"vkGetDeviceGroupPeerMemoryFeatures", "VK_VERSION_1_1"},
+    {"vkCmdSetDeviceMask", "VK_VERSION_1_1"},
+    {"vkCmdDispatchBase", "VK_VERSION_1_1"},
+    {"vkGetImageMemoryRequirements2", "VK_VERSION_1_1"},
+    {"vkGetBufferMemoryRequirements2", "VK_VERSION_1_1"},
+    {"vkGetImageSparseMemoryRequirements2", "VK_VERSION_1_1"},
+    {"vkTrimCommandPool", "VK_VERSION_1_1"},
+    {"vkGetDeviceQueue2", "VK_VERSION_1_1"},
+    {"vkCreateSamplerYcbcrConversion", "VK_VERSION_1_1"},
+    {"vkDestroySamplerYcbcrConversion", "VK_VERSION_1_1"},
+    {"vkCreateDescriptorUpdateTemplate", "VK_VERSION_1_1"},
+    {"vkDestroyDescriptorUpdateTemplate", "VK_VERSION_1_1"},
+    {"vkUpdateDescriptorSetWithTemplate", "VK_VERSION_1_1"},
+    {"vkGetDescriptorSetLayoutSupport", "VK_VERSION_1_1"},
     {"vkCreateSwapchainKHR", "VK_KHR_swapchain"},
     {"vkDestroySwapchainKHR", "VK_KHR_swapchain"},
     {"vkGetSwapchainImagesKHR", "VK_KHR_swapchain"},

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <utility>
 #include <set>
+#include <vector>
 
 #include <vulkan/vulkan.h>
 
@@ -72,8 +73,6 @@ struct InstanceExtensions {
     bool vk_mvk_macos_surface{false};
     bool vk_nn_vi_surface{false};
     bool vk_nv_external_memory_capabilities{false};
-
-    std::unordered_set<std::string> device_extension_set;
 
     struct InstanceReq {
         const bool InstanceExtensions::* enabled;
@@ -183,11 +182,6 @@ struct InstanceExtensions {
     }
 
     uint32_t InitFromInstanceCreateInfo(uint32_t requested_api_version, const VkInstanceCreateInfo *pCreateInfo) {
-
-        // Save pCreateInfo device extension list
-        for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
-           device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);
-        }
 
         static const std::vector<const char *> V_1_0_promoted_instance_extensions = {
             VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME,
@@ -720,11 +714,6 @@ struct DeviceExtensions : public InstanceExtensions {
         assert(instance_extensions);
         *this = DeviceExtensions(*instance_extensions);
 
-
-        // Save pCreateInfo device extension list
-        for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {
-           device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);
-        }
 
         static const std::vector<const char *> V_1_0_promoted_device_extensions = {
             VK_KHR_16BIT_STORAGE_EXTENSION_NAME,

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -42,6 +42,7 @@
 #include <vulkan/vulkan.h>
 
 struct InstanceExtensions {
+    bool vk_feature_version_1_1{false};
     bool vk_ext_acquire_xlib_display{false};
     bool vk_ext_debug_report{false};
     bool vk_ext_debug_utils{false};
@@ -88,6 +89,7 @@ struct InstanceExtensions {
     typedef std::unordered_map<std::string,InstanceInfo> InstanceInfoMap;
     static const InstanceInfo &get_info(const char *name) {
         static const InstanceInfoMap info_map = {
+            std::make_pair("VK_VERSION_1_1", InstanceInfo(&InstanceExtensions::vk_feature_version_1_1, {})),
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
             std::make_pair(VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME, InstanceInfo(&InstanceExtensions::vk_ext_acquire_xlib_display, {{
                            {&InstanceExtensions::vk_ext_direct_mode_display, VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME}}})),
@@ -189,6 +191,7 @@ struct InstanceExtensions {
             VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+            "VK_VERSION_1_1",
         };
 
         // Initialize struct data, robust to invalid pCreateInfo
@@ -270,6 +273,7 @@ static const std::set<std::string> kInstanceExtensionNames = {
 };
 
 struct DeviceExtensions : public InstanceExtensions {
+    bool vk_feature_version_1_1{false};
     bool vk_amd_buffer_marker{false};
     bool vk_amd_display_native_hdr{false};
     bool vk_amd_draw_indirect_count{false};
@@ -427,6 +431,7 @@ struct DeviceExtensions : public InstanceExtensions {
     typedef std::unordered_map<std::string,DeviceInfo> DeviceInfoMap;
     static const DeviceInfo &get_info(const char *name) {
         static const DeviceInfoMap info_map = {
+            std::make_pair("VK_VERSION_1_1", DeviceInfo(&DeviceExtensions::vk_feature_version_1_1, {})),
             std::make_pair(VK_AMD_BUFFER_MARKER_EXTENSION_NAME, DeviceInfo(&DeviceExtensions::vk_amd_buffer_marker, {})),
             std::make_pair(VK_AMD_DISPLAY_NATIVE_HDR_EXTENSION_NAME, DeviceInfo(&DeviceExtensions::vk_amd_display_native_hdr, {{
                            {&DeviceExtensions::vk_khr_get_physical_device_properties_2, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME},
@@ -734,6 +739,7 @@ struct DeviceExtensions : public InstanceExtensions {
             VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,
             VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME,
             VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME,
+            "VK_VERSION_1_1",
         };
 
         // Initialize struct data, robust to invalid pCreateInfo

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -185,7 +185,7 @@ struct InstanceExtensions {
 
     uint32_t InitFromInstanceCreateInfo(uint32_t requested_api_version, const VkInstanceCreateInfo *pCreateInfo) {
 
-        static const std::vector<const char *> V_1_0_promoted_instance_extensions = {
+        static const std::vector<const char *> V_1_1_promoted_instance_apis = {
             VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME,
             VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
@@ -204,7 +204,7 @@ struct InstanceExtensions {
         }
         uint32_t api_version = NormalizeApiVersion(requested_api_version);
         if (api_version >= VK_API_VERSION_1_1) {
-            for (auto promoted_ext : V_1_0_promoted_instance_extensions) {
+            for (auto promoted_ext : V_1_1_promoted_instance_apis) {
                 auto info = get_info(promoted_ext);
                 assert(info.state);
                 if (info.state) this->*(info.state) = true;
@@ -720,7 +720,7 @@ struct DeviceExtensions : public InstanceExtensions {
         *this = DeviceExtensions(*instance_extensions);
 
 
-        static const std::vector<const char *> V_1_0_promoted_device_extensions = {
+        static const std::vector<const char *> V_1_1_promoted_device_apis = {
             VK_KHR_16BIT_STORAGE_EXTENSION_NAME,
             VK_KHR_BIND_MEMORY_2_EXTENSION_NAME,
             VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
@@ -752,7 +752,7 @@ struct DeviceExtensions : public InstanceExtensions {
         }
         uint32_t api_version = NormalizeApiVersion(requested_api_version);
         if (api_version >= VK_API_VERSION_1_1) {
-            for (auto promoted_ext : V_1_0_promoted_device_extensions) {
+            for (auto promoted_ext : V_1_1_promoted_device_apis) {
                 auto info = get_info(promoted_ext);
                 assert(info.state);
                 if (info.state) this->*(info.state) = true;

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -123,6 +123,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         preamble += '#include <unordered_set>\n'
         preamble += '#include <unordered_map>\n'
         preamble += '#include "vk_layer_dispatch_table.h"\n'
+        preamble += '#include "vk_extension_helper.h"\n'
 
         write(copyright, file=self.outFile)
         write(preamble, file=self.outFile)
@@ -231,12 +232,13 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         ext_fcn += '//   o  Determine if the API has an associated extension\n'
         ext_fcn += '//   o  If it does, determine if that extension name is present in the passed-in set of enabled_ext_names \n'
         ext_fcn += '//   If the APIname has no parent extension, OR its parent extension name is IN the set, return TRUE, else FALSE\n'
-        ext_fcn += 'static inline bool ApiParentExtensionEnabled(const std::string api_name, const std::unordered_set<std::string> &enabled_ext_names) {\n'
+        ext_fcn += 'static inline bool ApiParentExtensionEnabled(const std::string api_name, const DeviceExtensions *device_extension_info) {\n'
         ext_fcn += '    auto has_ext = api_extension_map.find(api_name);\n'
-        ext_fcn += '    // Is this API part of an extension?\n'
+        ext_fcn += '    // Is this API part of an extension or feature group?\n'
         ext_fcn += '    if (has_ext != api_extension_map.end()) {\n'
         ext_fcn += '        // Was the extension for this API enabled in the CreateDevice call?\n'
-        ext_fcn += '        if (enabled_ext_names.find(has_ext->second) == enabled_ext_names.end()) {\n'
+        ext_fcn += '        auto info = device_extension_info->get_info(has_ext->second.c_str());\n'
+        ext_fcn += '        if ((!info.state) || (device_extension_info->*(info.state) != true)) {\n'
         ext_fcn += '            return false;\n'
         ext_fcn += '        }\n'
         ext_fcn += '    }\n'

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -180,9 +180,9 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
             extension = "VK_VERSION" not in self.featureName
             promoted = not extension and "VK_VERSION_1_0" != self.featureName
             if promoted or extension:
+                # We want feature written for all promoted entrypoints, in addition to extensions
                 self.device_stub_list.append([name, self.featureName])
-                if extension:
-                    self.device_extension_list.append([name, self.featureName])
+                self.device_extension_list.append([name, self.featureName])
                 # Build up stub function
                 return_type = ''
                 decl = self.makeCDecls(cmdinfo.elem)[1]

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -492,7 +492,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             'VK_VERSION_1_1',
             ]
 
-        V_1_0_instance_extensions_promoted_to_core = [
+        V_1_0_instance_extensions_promoted_to_V_1_1_core = [
             'vk_khr_device_group_creation',
             'vk_khr_external_fence_capabilities',
             'vk_khr_external_memory_capabilities',
@@ -500,7 +500,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             'vk_khr_get_physical_device_properties_2',
             ]
 
-        V_1_0_device_extensions_promoted_to_core = [
+        V_1_0_device_extensions_promoted_to_V_1_1_core = [
             'vk_khr_16bit_storage',
             'vk_khr_bind_memory_2',
             'vk_khr_dedicated_allocation',
@@ -545,12 +545,12 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct_type = '%sExtensions' % type
             if type == 'Instance':
                 extension_dict = self.instance_extension_info
-                promoted_ext_list = V_1_0_instance_extensions_promoted_to_core
+                promoted_ext_list = V_1_0_instance_extensions_promoted_to_V_1_1_core
                 struct_decl = 'struct %s {' % struct_type
                 instance_struct_type = struct_type
             else:
                 extension_dict = self.device_extension_info
-                promoted_ext_list = V_1_0_device_extensions_promoted_to_core
+                promoted_ext_list = V_1_0_device_extensions_promoted_to_V_1_1_core
                 struct_decl = 'struct %s : public %s {' % (struct_type, instance_struct_type)
 
             extension_items = sorted(extension_dict.items())
@@ -639,7 +639,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                     '']),
             struct.extend([
                 '',
-                '        static const std::vector<const char *> V_1_0_promoted_%s_extensions = {' % type.lower() ])
+                '        static const std::vector<const char *> V_1_1_promoted_%s_apis = {' % type.lower() ])
             struct.extend(['            %s_EXTENSION_NAME,' % ext_name.upper() for ext_name in promoted_ext_list])
             struct.extend(['            "VK_VERSION_1_1",'])
             struct.extend([
@@ -655,7 +655,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 '        }',
                 '        uint32_t api_version = NormalizeApiVersion(requested_api_version);',
                 '        if (api_version >= VK_API_VERSION_1_1) {',
-                '            for (auto promoted_ext : V_1_0_promoted_%s_extensions) {' % type.lower(),
+                '            for (auto promoted_ext : V_1_1_promoted_%s_apis) {' % type.lower(),
                 '                auto info = get_info(promoted_ext);',
                 '                assert(info.state);',
                 '                if (info.state) this->*(info.state) = true;',

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -526,6 +526,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             '#include <unordered_map>',
             '#include <utility>',
             '#include <set>',
+            '#include <vector>',
             '',
             '#include <vulkan/vulkan.h>',
             '']
@@ -563,12 +564,6 @@ class HelperFileOutputGenerator(OutputGenerator):
             # Output the data member list
             struct  = [struct_decl]
             struct.extend([ '    bool %s{false};' % field_name[ext_name] for ext_name, info in extension_items])
-
-            # Create struct entries for saving extension count and extension list from Instance, DeviceCreateInfo
-            if type == 'Instance':
-                struct.extend([
-                    '',
-                    '    std::unordered_set<std::string> device_extension_set;'])
 
             # Construct the extension information map -- mapping name to data member (field), and required extensions
             # The map is contained within a static function member for portability reasons.
@@ -635,11 +630,6 @@ class HelperFileOutputGenerator(OutputGenerator):
                     '        *this = %s(*instance_extensions);' % struct_type,
                     '']),
             struct.extend([
-                    '',
-                    '        // Save pCreateInfo device extension list',
-                    '        for (uint32_t extn = 0; extn < pCreateInfo->enabledExtensionCount; extn++) {',
-                    '           device_extension_set.insert(pCreateInfo->ppEnabledExtensionNames[extn]);',
-                    '        }',
                 '',
                 '        static const std::vector<const char *> V_1_0_promoted_%s_extensions = {' % type.lower() ])
             struct.extend(['            %s_EXTENSION_NAME,' % ext_name.upper() for ext_name in promoted_ext_list])

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -488,6 +488,10 @@ class HelperFileOutputGenerator(OutputGenerator):
     # Generate extension helper header file
     def GenerateExtensionHelperHeader(self):
 
+        V_1_1_level_feature_set = [
+            'VK_VERSION_1_1',
+            ]
+
         V_1_0_instance_extensions_promoted_to_core = [
             'vk_khr_device_group_creation',
             'vk_khr_external_fence_capabilities',
@@ -552,6 +556,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             extension_items = sorted(extension_dict.items())
 
             field_name = { ext_name: re.sub('_extension_name', '', info['define'].lower()) for ext_name, info in extension_items }
+
             if type == 'Instance':
                 instance_field_name = field_name
                 instance_extension_dict = extension_dict
@@ -563,6 +568,7 @@ class HelperFileOutputGenerator(OutputGenerator):
 
             # Output the data member list
             struct  = [struct_decl]
+            struct.extend([ '    bool vk_feature_version_1_1{false};'])
             struct.extend([ '    bool %s{false};' % field_name[ext_name] for ext_name, info in extension_items])
 
             # Construct the extension information map -- mapping name to data member (field), and required extensions
@@ -587,6 +593,8 @@ class HelperFileOutputGenerator(OutputGenerator):
                 '    typedef std::unordered_map<std::string,%s> %s;' % (info_type, info_map_type),
                 '    static const %s &get_info(const char *name) {' %info_type,
                 '        static const %s info_map = {' % info_map_type ])
+            struct.extend([
+                '            std::make_pair("VK_VERSION_1_1", %sInfo(&%sExtensions::vk_feature_version_1_1, {})),' % (type, type)])
 
             field_format = '&' + struct_type + '::%s'
             req_format = '{' + field_format+ ', %s}'
@@ -633,6 +641,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 '',
                 '        static const std::vector<const char *> V_1_0_promoted_%s_extensions = {' % type.lower() ])
             struct.extend(['            %s_EXTENSION_NAME,' % ext_name.upper() for ext_name in promoted_ext_list])
+            struct.extend(['            "VK_VERSION_1_1",'])
             struct.extend([
                 '        };',
                 '',

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -723,7 +723,7 @@ void ProcessConfigAndEnvSettings(const char* layer_description, CHECK_ENABLED* e
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char *funcName) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
-    if (!ApiParentExtensionEnabled(funcName, layer_data->device_extensions.device_extension_set)) {
+    if (!ApiParentExtensionEnabled(funcName, &layer_data->device_extensions)) {
         return nullptr;
     }
     const auto &item = name_to_funcptr_map.find(funcName);

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -31,6 +31,30 @@
 //
 // These tests do not expect to encounter ANY validation errors pass only if this is true
 
+TEST_F(VkPositiveLayerTest, NullFunctionPointer) {
+    TEST_DESCRIPTION("On 1_0 instance , call GetDeviceProcAddr on promoted 1_1 device-level entrypoint");
+    SetTargetApiVersion(VK_API_VERSION_1_0);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+
+    if (DeviceExtensionSupported(gpu(), nullptr, "VK_KHR_get_memory_requirements2")) {
+        m_device_extension_names.push_back("VK_KHR_get_memory_requirements2");
+    } else {
+        printf("%s VK_KHR_get_memory_reqirements2 extension not supported, skipping NullFunctionPointer test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    m_errorMonitor->ExpectSuccess();
+    auto fpGetBufferMemoryRequirements =
+        (PFN_vkGetBufferMemoryRequirements2)vkGetDeviceProcAddr(m_device->device(), "vkGetBufferMemoryRequirements2");
+    if (fpGetBufferMemoryRequirements) {
+        m_errorMonitor->SetError("Null was expected!");
+    }
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkPositiveLayerTest, SecondaryCommandBufferBarrier) {
     TEST_DESCRIPTION("Add a pipeline barrier in a secondary command buffer");
     ASSERT_NO_FATAL_FAILURE(Init());


### PR DESCRIPTION
On a 1.0 Vulkan instance, calling `GetDeviceProcAddr `on a promoted API should return NULL.  For example, on a 1_0 Vulkan instance, even with the `VK_KHR_bind_memory2 `extension enabled, calling `GetDeviceProcAddr` on `vkBindImageMemory2 `should return nullptr.  

Also consolidated the enabled-extension tracking methods, and added a test. 🥇 First PR with generated files!

Fixes #579.