### PR TITLE
Check VALIDATION_APK when add surface extension

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1019,7 +1019,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
     bSupport = true;
 #endif
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+#if defined(VK_USE_PLATFORM_ANDROID_KHR) && defined(VALIDATION_APK)
     if (!InstanceExtensionSupported(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME)) {
         printf("%s VK_KHR_ANDROID_SURFACE_EXTENSION_NAME extension not supported\n", kSkipPrefix);
         return false;


### PR DESCRIPTION
In Android native tests, it cannot create surface, so check VALIDATION_APK to skip the related tests.