### PR TITLE
If layouts are read-only in subpasses, it doesn't need dependencies.

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -177,6 +177,11 @@ struct SURFACE_STATE {
     SURFACE_STATE(VkSurfaceKHR surface) : surface(surface) {}
 };
 
+struct SubpassLayout {
+    uint32_t index;
+    VkImageLayout layout;
+};
+
 using std::unordered_map;
 struct GpuValidationState;
 
@@ -981,8 +986,10 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo* pCreateInfo) const;
     bool MatchUsage(uint32_t count, const VkAttachmentReference2KHR* attachments, const VkFramebufferCreateInfo* fbci,
                     VkImageUsageFlagBits usage_flag, const char* error_code) const;
-    bool CheckDependencyExists(const uint32_t subpass, const std::vector<uint32_t>& dependent_subpasses,
-                               const std::vector<DAGNode>& subpass_to_node, bool& skip) const;
+    bool IsImageLayoutReadOnly(VkImageLayout layout) const;
+    bool CheckDependencyExists(const uint32_t subpass, const VkImageLayout layout,
+                               const std::vector<SubpassLayout>& dependent_subpasses, const std::vector<DAGNode>& subpass_to_node,
+                               bool& skip) const;
     bool CheckPreserved(const VkRenderPassCreateInfo2KHR* pCreateInfo, const int index, const uint32_t attachment,
                         const std::vector<DAGNode>& subpass_to_node, int depth, bool& skip) const;
     bool ValidateBindImageMemory(const VkBindImageMemoryInfo& bindInfo, const char* api_name) const;


### PR DESCRIPTION
[issue #948 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/948)

vkspec: `If two subpasses use the same attachment in different layouts, and both layouts are read-only, no subpass dependency needs to be specified between those subpasses.`

But even in same layouts, they should be treated in the same way, thus `if two subpasses are the same attachment, and their layouts are read-only, they don't need dependency, whatever they are in the same or different layouts.`

@liufachen 