### PR TITLE
layers: Refine query state tracking and errors

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -830,7 +830,7 @@ class CoreChecks : public ValidationStateTracker {
     void IncrementResources(CMD_BUFFER_STATE* cb_node);
     bool ValidateEventStageMask(VkQueue queue, CMD_BUFFER_STATE* pCB, uint32_t eventCount, size_t firstEventIndex,
                                 VkPipelineStageFlags sourceStageMask);
-    void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq);
+    void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq, bool switch_finished_queries = false);
     bool ValidateResources(CMD_BUFFER_STATE* cb_node);
     bool ValidateQueueFamilyIndices(CMD_BUFFER_STATE* pCB, VkQueue queue);
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -984,6 +984,7 @@ enum QueryState {
     QUERYSTATE_UNKNOWN,    // Initial state.
     QUERYSTATE_RESET,      // After resetting.
     QUERYSTATE_RUNNING,    // Query running.
+    QUERYSTATE_ENDED,      // Query ended but results may not be available.
     QUERYSTATE_AVAILABLE,  // Results available.
 };
 


### PR DESCRIPTION
This PR is a small follow-up to my query state tracking PR https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/942 that was merged a month ago.

This commit removes query-state-related errors generated from calls to vkGetQueryPoolResults(). The reasoning is that this function operates asynchronously to work done on the GPU.

For example, if a query is reset from the host using vkResetQueryPoolEXT(), then work is submitted to a queue beginning and ending this query, then vkGetQueryPoolResults() is called using the wait bit without waiting for the queue or device to be idle, the validation layers would emit an error indicating the code is waiting on a query that has been reset and not issued. This error is spurious because what would happen is that the call to vkGetQueryPoolResults() succeeds after waiting until the GPU finishes the query and makes results available for it.

Similar circumstances surround other types of errors related to query states and vkGetQueryPoolResults(). It's possible to get spurious errors for any of them. Some of these happen in a subset of VK-GL-CTS tests when enabling validation.

However, this commit does *not* remove similar errors for vkCmdCopyQueryPoolResults(), which is submitted to command buffers and does not have this kind of problems.

In addition, this commit adds one more state to queries, allowing the validation layers to make a distinction between ended queries and available queries. Queries are switched from the ended state to the available state when retiring work on queues after waiting for the queue or device to be idle, or when waiting on a fence.

This refinement fixes more spurious errors in some VK-GL-CTS tests.
