### PR TITLE
Remove special cases for in-use tracking of vertex/index buffers

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1995,7 +1995,7 @@ void CoreChecks::ResetCommandBufferState(const VkCommandBuffer cb) {
         pCB->startedQueries.clear();
         pCB->image_layout_map.clear();
         pCB->eventToStageMap.clear();
-        pCB->draw_data.clear();
+        pCB->cb_vertex_buffer_binding_info.clear();
         pCB->current_draw_data.vertex_buffer_bindings.clear();
         pCB->vertex_buffer_used = false;
         pCB->primaryCommandBuffer = VK_NULL_HANDLE;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2539,14 +2539,6 @@ void CoreChecks::IncrementResources(CMD_BUFFER_STATE *cb_node) {
     // TODO : We should be able to remove the NULL look-up checks from the code below as long as
     //  all the corresponding cases are verified to cause CB_INVALID state and the CB_INVALID state
     //  should then be flagged prior to calling this function
-    for (auto draw_data_element : cb_node->draw_data) {
-        for (auto &vertex_buffer : draw_data_element.vertex_buffer_bindings) {
-            auto buffer_state = GetBufferState(vertex_buffer.buffer);
-            if (buffer_state) {
-                buffer_state->in_use.fetch_add(1);
-            }
-        }
-    }
     for (auto event : cb_node->writeEventsBeforeWait) {
         auto event_state = GetEventState(event);
         if (event_state) event_state->write_in_use++;
@@ -2657,14 +2649,6 @@ void CoreChecks::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq) {
             }
             // First perform decrement on general case bound objects
             DecrementBoundResources(cb_node);
-            for (auto draw_data_element : cb_node->draw_data) {
-                for (auto &vertex_buffer_binding : draw_data_element.vertex_buffer_bindings) {
-                    auto buffer_state = GetBufferState(vertex_buffer_binding.buffer);
-                    if (buffer_state) {
-                        buffer_state->in_use.fetch_sub(1);
-                    }
-                }
-            }
             for (auto event : cb_node->writeEventsBeforeWait) {
                 auto eventNode = eventMap.find(event);
                 if (eventNode != eventMap.end()) {
@@ -2756,26 +2740,6 @@ bool CoreChecks::ValidateCommandBufferState(CMD_BUFFER_STATE *cb_state, const ch
     return skip;
 }
 
-bool CoreChecks::ValidateResources(CMD_BUFFER_STATE *cb_node) {
-    bool skip = false;
-
-    // TODO : We should be able to remove the NULL look-up checks from the code below as long as
-    //  all the corresponding cases are verified to cause CB_INVALID state and the CB_INVALID state
-    //  should then be flagged prior to calling this function
-    for (const auto &draw_data_element : cb_node->draw_data) {
-        for (const auto &vertex_buffer_binding : draw_data_element.vertex_buffer_bindings) {
-            auto buffer_state = GetBufferState(vertex_buffer_binding.buffer);
-            if ((vertex_buffer_binding.buffer != VK_NULL_HANDLE) && (!buffer_state)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                                HandleToUint64(vertex_buffer_binding.buffer), kVUID_Core_DrawState_InvalidBuffer,
-                                "Cannot submit cmd buffer using deleted %s.",
-                                report_data->FormatHandle(vertex_buffer_binding.buffer).c_str());
-            }
-        }
-    }
-    return skip;
-}
-
 // Check that the queue family index of 'queue' matches one of the entries in pQueueFamilyIndices
 bool CoreChecks::ValidImageBufferQueue(CMD_BUFFER_STATE *cb_node, const VulkanTypedHandle &object, VkQueue queue, uint32_t count,
                                        const uint32_t *indices) {
@@ -2846,15 +2810,12 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(CMD_BUFFER_STATE *pCB, int cu
     // Track in-use for resources off of primary and any secondary CBs
     bool skip = false;
 
-    // If USAGE_SIMULTANEOUS_USE_BIT not set then CB cannot already be executing
-    // on device
+    // If USAGE_SIMULTANEOUS_USE_BIT not set then CB cannot already be executing on device
     skip |= ValidateCommandBufferSimultaneousUse(pCB, current_submit_count);
 
-    skip |= ValidateResources(pCB);
     skip |= ValidateQueuedQFOTransfers(pCB, qfo_image_scoreboards, qfo_buffer_scoreboards);
 
     for (auto pSubCB : pCB->linkedCommandBuffers) {
-        skip |= ValidateResources(pSubCB);
         skip |= ValidateQueuedQFOTransfers(pSubCB, qfo_image_scoreboards, qfo_buffer_scoreboards);
         // TODO: replace with InvalidateCommandBuffers() at recording.
         if ((pSubCB->primaryCommandBuffer != pCB->commandBuffer) &&
@@ -6147,6 +6108,7 @@ bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer) 
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/165
         skip |= InsideRenderPass(cb_state, "vkEndCommandBuffer()", "VUID-vkEndCommandBuffer-commandBuffer-00060");
     }
+
     skip |= ValidateCmd(cb_state, CMD_ENDCOMMANDBUFFER, "vkEndCommandBuffer()");
     for (auto query : cb_state->activeQueries) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
@@ -7038,6 +7000,8 @@ void CoreChecks::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer
         auto &vertex_buffer_binding = cb_state->current_draw_data.vertex_buffer_bindings[i + firstBinding];
         vertex_buffer_binding.buffer = pBuffers[i];
         vertex_buffer_binding.offset = pOffsets[i];
+        // Add binding for this vertex buffer to this commandbuffer
+        AddCommandBufferBindingBuffer(cb_state, GetBufferState(pBuffers[i]));
     }
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6953,13 +6953,15 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer
 void CoreChecks::PreCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                  VkIndexType indexType) {
     auto buffer_state = GetBufferState(buffer);
-    auto cb_node = GetCBState(commandBuffer);
+    auto cb_state = GetCBState(commandBuffer);
 
-    cb_node->status |= CBSTATUS_INDEX_BUFFER_BOUND;
-    cb_node->index_buffer_binding.buffer = buffer;
-    cb_node->index_buffer_binding.size = buffer_state->createInfo.size;
-    cb_node->index_buffer_binding.offset = offset;
-    cb_node->index_buffer_binding.index_type = indexType;
+    cb_state->status |= CBSTATUS_INDEX_BUFFER_BOUND;
+    cb_state->index_buffer_binding.buffer = buffer;
+    cb_state->index_buffer_binding.size = buffer_state->createInfo.size;
+    cb_state->index_buffer_binding.offset = offset;
+    cb_state->index_buffer_binding.index_type = indexType;
+    // Add binding for this index buffer to this commandbuffer
+    AddCommandBufferBindingBuffer(cb_state, buffer_state);
 }
 
 bool CoreChecks::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -831,7 +831,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateEventStageMask(VkQueue queue, CMD_BUFFER_STATE* pCB, uint32_t eventCount, size_t firstEventIndex,
                                 VkPipelineStageFlags sourceStageMask);
     void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq);
-    bool ValidateResources(CMD_BUFFER_STATE* cb_node);
     bool ValidateQueueFamilyIndices(CMD_BUFFER_STATE* pCB, VkQueue queue);
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);
@@ -1149,7 +1148,6 @@ class CoreChecks : public ValidationStateTracker {
 
     bool PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer);
-
 
     bool PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkBufferView* pView);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1418,7 +1418,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     ImageLayoutMap image_layout_map;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
     std::vector<CBVertexBufferBindingInfo> cb_vertex_buffer_binding_info;
-    CBVertexBufferBindingInfo current_draw_data;
+    CBVertexBufferBindingInfo current_vertex_buffer_binding_info;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;
     // Track images and buffers that are updated by this CB at the point of a draw

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1027,7 +1027,7 @@ struct hash<QueryObject> {
 };
 }  // namespace std
 
-struct DrawData {
+struct CBVertexBufferBindingInfo {
     std::vector<BufferBinding> vertex_buffer_bindings;
 };
 
@@ -1417,8 +1417,8 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> ImageLayoutMap;
     ImageLayoutMap image_layout_map;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
-    std::vector<DrawData> draw_data;
-    DrawData current_draw_data;
+    std::vector<CBVertexBufferBindingInfo> draw_data;
+    CBVertexBufferBindingInfo current_draw_data;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;
     // Track images and buffers that are updated by this CB at the point of a draw

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1417,7 +1417,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> ImageLayoutMap;
     ImageLayoutMap image_layout_map;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
-    std::vector<CBVertexBufferBindingInfo> draw_data;
+    std::vector<CBVertexBufferBindingInfo> cb_vertex_buffer_binding_info;
     CBVertexBufferBindingInfo current_draw_data;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -41,7 +41,9 @@
 #include "chassis.h"
 #include "core_validation.h"
 
-static inline void UpdateResourceTrackingOnDraw(CMD_BUFFER_STATE *pCB) { pCB->draw_data.push_back(pCB->current_draw_data); }
+static inline void UpdateResourceTrackingOnDraw(CMD_BUFFER_STATE *pCB) {
+    pCB->cb_vertex_buffer_binding_info.push_back(pCB->current_draw_data);
+}
 
 // Generic function to handle validation for all CmdDraw* type functions
 bool CoreChecks::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, VkPipelineBindPoint bind_point, CMD_TYPE cmd_type,

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -42,7 +42,7 @@
 #include "core_validation.h"
 
 static inline void UpdateResourceTrackingOnDraw(CMD_BUFFER_STATE *pCB) {
-    pCB->cb_vertex_buffer_binding_info.push_back(pCB->current_draw_data);
+    pCB->cb_vertex_buffer_binding_info.push_back(pCB->current_vertex_buffer_binding_info);
 }
 
 // Generic function to handle validation for all CmdDraw* type functions


### PR DESCRIPTION
These had been special-cased since the early days of the DrawState layer for no good reason. Normalized the tracking for in-flight command buffers and fixed up some names.

Fixes #29.