### PR TITLE
build:Add missing dependency to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -141,25 +141,25 @@ layers = [
   [
     "object_lifetimes",
     object_lifetimes_sources + chassis_sources + thread_safety_sources + core_validation_sources,
-    [],
+    [ ":vulkan_core_validation_glslang" ],
     [ "BUILD_OBJECT_TRACKER" ],
   ],
   [
     "stateless_validation",
     stateless_validation_sources + chassis_sources + core_validation_sources,
-    [],
+    [ ":vulkan_core_validation_glslang" ],
     [ "BUILD_PARAMETER_VALIDATION" ],
   ],
   [
     "thread_safety",
     thread_safety_sources + chassis_sources + core_validation_sources,
-    [],
+    [ ":vulkan_core_validation_glslang" ],
     [ "BUILD_THREAD_SAFETY" ],
   ],
   [
     "unique_objects",
     unique_objects_sources + chassis_sources + core_validation_sources,
-    [],
+    [ ":vulkan_core_validation_glslang" ],
     [ "LAYER_CHASSIS_CAN_WRAP_HANDLES" ],
   ],
   [


### PR DESCRIPTION
The individual layers include shader_validation in their dependency
chain which includes <SPIRV/spirv.hpp>. Adding appropriate glslang dep
to fix strict build.
This is a follow-on to #1068.