### PR TITLE
Add missing newline in param val gen

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -199,6 +199,7 @@ const std::vector<VkCoverageReductionModeNV> AllVkCoverageReductionModeNVEnums =
 const std::vector<VkFullScreenExclusiveEXT> AllVkFullScreenExclusiveEXTEnums = {VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT, VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT, VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT, VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT, };
 #endif // VK_USE_PLATFORM_WIN32_KHR
 
+
 bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) {
     bool skip = false;
     switch(header->sType) {

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -611,7 +611,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                         enum_entry += '%s, ' % name
                 enum_entry += '};\n'
                 if self.featureExtraProtect is not None:
-                    enum_entry += '#endif // %s' % self.featureExtraProtect
+                    enum_entry += '#endif // %s\n' % self.featureExtraProtect
                 self.enumValueLists += enum_entry
     #
     # Capture command parameter info to be used for param check code generation.


### PR DESCRIPTION
Before this change, trying to update the latest known good vulkan headers
produces compiler errors because the parameter validation generated code
ends up with a constant defined on the same line as the endif comment:

#endif // VK_USE_PLATFORM_WIN32_KHRconst std::vector<VkLineRaster...