### PR TITLE
Misc codegen cleanup

### DIFF
--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "3f7888a58593e74f6429518196ed597dc5775f66"
+#define SPIRV_TOOLS_COMMIT_ID "333d1c95792692205472c457d7bec915a94c8000"

--- a/scripts/external_revision_generator.py
+++ b/scripts/external_revision_generator.py
@@ -24,6 +24,7 @@ import argparse
 import hashlib
 import subprocess
 import uuid
+import json
 
 def generate(symbol_name, commit_id, output_header_file):
     # Write commit ID to output header file
@@ -85,20 +86,35 @@ def get_commit_id_from_file(rev_file):
         return sha1.hexdigest()
 
 def get_commit_id_from_uuid():
-        unique_uuid = str(uuid.uuid4())
-        sha1 = hashlib.sha1();
-        sha1.update(unique_uuid.encode())
-        return sha1.hexdigest()
+    unique_uuid = str(uuid.uuid4())
+    sha1 = hashlib.sha1();
+    sha1.update(unique_uuid.encode())
+    return sha1.hexdigest()
+
+def get_commit_id_from_json(json_file, json_keys):
+    with open(json_file) as json_stream:
+        json_data = json.load(json_stream)
+    for key in json_keys.split(','):
+        if type(json_data) == list:
+            json_data = json_data[int(key)]
+        else:
+            json_data = json_data[key]
+    return json_data
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--symbol_name", metavar="SYMBOL_NAME", required=True, help="C symbol name")
-    parser.add_argument("-o", "--output_header_file", metavar="OUTPUT_HEADER_FILE", required=True, help="output header file path")
     rev_method_group = parser.add_mutually_exclusive_group(required=True)
     rev_method_group.add_argument("--git_dir", metavar="SOURCE_DIR", help="git working copy directory")
     rev_method_group.add_argument("--rev_file", metavar="REVISION_FILE", help="source revision file path (must contain a SHA1 hash")
     rev_method_group.add_argument("--from_uuid", action='store_true', help="base SHA1 on a dynamically generated UUID")
+    rev_method_group.add_argument("--json_file", metavar="JSON_FILE", help="path to json file")
+    parser.add_argument("-s", "--symbol_name", metavar="SYMBOL_NAME", required=True, help="C symbol name")
+    parser.add_argument("-o", "--output_header_file", metavar="OUTPUT_HEADER_FILE", required=True, help="output header file path")
+    parser.add_argument("--json_keys", action='store', metavar="JSON_KEYS", help="comma-separated list of keys specifying SHA1 location in root json object for --json_file option")
     args = parser.parse_args()
+
+    if ('json_file' in args) != ('json_keys' in args):
+        parser.error('--json_file and --json_keys must be provided together')
 
     # We can either parse the latest Git commit ID out of the specified repository (preferred where possible),
     # or computing the SHA1 hash of the contents of a file passed on the command line and (where necessary --
@@ -113,7 +129,9 @@ def main():
     elif args.rev_file is not None:
         # Read the commit ID from a file.
         commit_id = get_commit_id_from_file(args.rev_file)
-    elif args.from_uuid is not None:
+    elif args.json_file is not None:
+        commit_id = get_commit_id_from_json(args.json_file, args.json_keys)
+    elif args.from_uuid:
         commit_id = get_commit_id_from_uuid()
 
     if not is_sha1(commit_id):

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -63,7 +63,8 @@ def main(argv):
                  os.path.abspath(os.path.join(args.registry, 'validusage.json')),
                  '-export_header'],
                 [common_codegen.repo_relative('scripts/external_revision_generator.py'),
-                 '--rev_file', common_codegen.repo_relative('scripts/known_good.json'),
+                 '--json_file', common_codegen.repo_relative('scripts/known_good.json'),
+                 '--json_keys', 'repos,0,commit',
                  '-s', 'SPIRV_TOOLS_COMMIT_ID',
                  '-o', 'spirv_tools_commit_id.h']]
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -19,13 +19,14 @@
 # Author: Mike Schuchardt <mikes@lunarg.com>
 
 import argparse
-import common_codegen
 import filecmp
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+
+import common_codegen
 
 # files to exclude from --verify check
 verify_exclude = ['.clang-format']
@@ -84,10 +85,7 @@ def main(argv):
     for cmd in gen_cmds:
         print(' '.join(cmd))
         try:
-            subprocess.check_call([sys.executable] + cmd,
-                                  # ignore generator output, vk_validation_stats.py is especially noisy
-                                  stdout=subprocess.DEVNULL,
-                                  cwd=gen_dir)
+            subprocess.check_call([sys.executable] + cmd, cwd=gen_dir)
         except Exception as e:
             print('ERROR:', str(e))
             return 1

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -144,6 +144,7 @@ def printHelp():
     print ("                                [ -csv  [ <csv_out_filename>]  ]")
     print ("                                [ -html [ <html_out_filename>] ]")
     print ("                                [ -export_header ]")
+    print ("                                [ -summary ]")
     print ("                                [ -verbose ]")
     print ("                                [ -help ]")
     print ("\n  The vk_validation_stats script parses validation layer source files to")
@@ -162,6 +163,7 @@ def printHelp():
     print (" -html [filename]  output the error database in html to <html_database_filename>,")
     print ("                   defaults to 'validation_error_database.html'")
     print (" -export_header    export a new VUID error text header file to <%s>" % header_filename)
+    print (" -summary          output summary of VUID coverage")
     print (" -verbose          show your work (to stdout)")
 
 class ValidationJSON:
@@ -571,7 +573,8 @@ static const vuid_spec_text_pair vuid_spec_text[] = {
             hfile.write('</table>\n</body>\n</html>\n')
 
     def export_header(self):
-        print("\n Exporting header file to: %s" % header_filename)
+        if verbose_mode:
+            print("\n Exporting header file to: %s" % header_filename)
         with open (header_filename, 'w') as hfile:
             hfile.write(self.header_version)
             hfile.write(self.header_preamble)
@@ -632,6 +635,7 @@ def main(argv):
     csv_out = False
     html_out = False
     header_out = False
+    show_summary = False
 
     if (1 > len(argv)):
         printHelp()
@@ -672,6 +676,8 @@ def main(argv):
             header_out = True
         elif (arg in ['-verbose']):
             verbose_mode = True
+        elif (arg in ['-summary']):
+            show_summary = True
         elif (arg in ['-help', '-h']):
             printHelp()
             sys.exit()
@@ -725,20 +731,21 @@ def main(argv):
         print("  %d unassigned" % len(val_tests.unassigned_vuids))
 
     # Process stats
-    print("\nValidation Statistics (using validusage.json version %s)" % val_json.apiversion)
-    print("  VUIDs defined in JSON file:  %04d explicit, %04d implicit, %04d total." % (exp_json, imp_json, all_json))
-    print("  VUIDs checked in layer code: %04d explicit, %04d implicit, %04d total." % (exp_checks, imp_checks, all_checks))
-    print("  VUIDs tested in layer tests: %04d explicit, %04d implicit, %04d total." % (exp_tests, imp_tests, all_tests))
+    if show_summary:
+        print("\nValidation Statistics (using validusage.json version %s)" % val_json.apiversion)
+        print("  VUIDs defined in JSON file:  %04d explicit, %04d implicit, %04d total." % (exp_json, imp_json, all_json))
+        print("  VUIDs checked in layer code: %04d explicit, %04d implicit, %04d total." % (exp_checks, imp_checks, all_checks))
+        print("  VUIDs tested in layer tests: %04d explicit, %04d implicit, %04d total." % (exp_tests, imp_tests, all_tests))
 
-    print("\nVUID check coverage")
-    print("  Explicit VUIDs checked: %.1f%% (%d checked vs %d defined)" % ((100.0 * exp_checks / exp_json), exp_checks, exp_json))
-    print("  Implicit VUIDs checked: %.1f%% (%d checked vs %d defined)" % ((100.0 * imp_checks / imp_json), imp_checks, imp_json))
-    print("  Overall VUIDs checked:  %.1f%% (%d checked vs %d defined)" % ((100.0 * all_checks / all_json), all_checks, all_json))
+        print("\nVUID check coverage")
+        print("  Explicit VUIDs checked: %.1f%% (%d checked vs %d defined)" % ((100.0 * exp_checks / exp_json), exp_checks, exp_json))
+        print("  Implicit VUIDs checked: %.1f%% (%d checked vs %d defined)" % ((100.0 * imp_checks / imp_json), imp_checks, imp_json))
+        print("  Overall VUIDs checked:  %.1f%% (%d checked vs %d defined)" % ((100.0 * all_checks / all_json), all_checks, all_json))
 
-    print("\nVUID test coverage")
-    print("  Explicit VUIDs tested: %.1f%% (%d tested vs %d checks)" % ((100.0 * exp_tests / exp_checks), exp_tests, exp_checks))
-    print("  Implicit VUIDs tested: %.1f%% (%d tested vs %d checks)" % ((100.0 * imp_tests / imp_checks), imp_tests, imp_checks))
-    print("  Overall VUIDs tested:  %.1f%% (%d tested vs %d checks)" % ((100.0 * all_tests / all_checks), all_tests, all_checks))
+        print("\nVUID test coverage")
+        print("  Explicit VUIDs tested: %.1f%% (%d tested vs %d checks)" % ((100.0 * exp_tests / exp_checks), exp_tests, exp_checks))
+        print("  Implicit VUIDs tested: %.1f%% (%d tested vs %d checks)" % ((100.0 * imp_tests / imp_checks), imp_tests, imp_checks))
+        print("  Overall VUIDs tested:  %.1f%% (%d tested vs %d checks)" % ((100.0 * all_tests / all_checks), all_tests, all_checks))
 
     # Report status of a single VUID
     if len(get_vuid_status) > 1:


### PR DESCRIPTION
- Make spirv_tools_commit_id.h depend only on glslang revision from known_good.json instead of hash of entire file
- Make vk_validation_stats.py quiet instead of squashing stdout for all code generators
- Merge generate_source.py tweaks from Vulkan-Tools code review back to VVL