### PR TITLE
Cache and precompute some image view descriptor state

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -113,6 +113,8 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const IMAGE_STATE *image_state, VkImageView i
 
         // Cache a full normalization (for "full image/whole image" comparisons)
         normalized_subresource_range = NormalizeSubresourceRange(*image_state, ci->subresourceRange);
+        samples = image_state->createInfo.samples;
+        descriptor_format_bits = DescriptorRequirementsBitsFromFormat(create_info.format);
     }
 }
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -146,6 +146,8 @@ enum descriptor_req {
     DESCRIPTOR_REQ_COMPONENT_TYPE_UINT = DESCRIPTOR_REQ_COMPONENT_TYPE_SINT << 1,
 };
 
+extern unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt);
+
 struct DESCRIPTOR_POOL_STATE : BASE_NODE {
     VkDescriptorPool pool;
     uint32_t maxSets;        // Max descriptor sets allowed in this pool
@@ -327,6 +329,8 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     VkImageView image_view;
     VkImageViewCreateInfo create_info;
     VkImageSubresourceRange normalized_subresource_range;
+    VkSampleCountFlagBits samples;
+    unsigned descriptor_format_bits;
     VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
     IMAGE_VIEW_STATE(const IMAGE_STATE *image_state, VkImageView iv, const VkImageViewCreateInfo *ci);
     IMAGE_VIEW_STATE(const IMAGE_VIEW_STATE &rh_obj) = delete;


### PR DESCRIPTION
I have some changes in progress to improve performance for large (bindless) descriptor sets. This is a few minor optimizations that aren't related to the other changes, and were easy to split out into their own PR.

- Precompute descriptor format bits and save image samples in IMAGE_VIEW_STATE.
- Avoid finding and accessing IMAGE_STATE entirely when image layout validation
is disabled.
- Don't copy image view create info onto the stack.
