### PR TITLE
layers: Reset command buffers in PreCallRecordDestroyDevice

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2572,7 +2572,13 @@ void ValidationStateTracker::PreCallRecordDestroyDevice(VkDevice device, const V
 
     pipelineMap.clear();
     renderPassMap.clear();
+
+    // Reset all command buffers before destroying them, to unlink object_bindings.
+    for (auto &commandBuffer : commandBufferMap) {
+        ResetCommandBufferState(commandBuffer.first);
+    }
     commandBufferMap.clear();
+
     // This will also delete all sets in the pool & remove them from setMap
     DeleteDescriptorSetPools();
     // All sets should be removed


### PR DESCRIPTION
Without this, I was seeing cases during device destroy where freeing descriptor
sets would crash trying to access command buffers that had already been freed.
There's an app bug here where the app isn't freeing all its objects before destroying
the device, but still nicer not to crash.