### PR TITLE
layers: Skip SetImageViewInitialLayout if image_layout_validation is disabled

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -311,6 +311,9 @@ void CoreChecks::SetImageLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_STATE &im
 
 // Set the initial image layout for all slices of an image view
 void CoreChecks::SetImageViewInitialLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_VIEW_STATE &view_state, VkImageLayout layout) {
+    if (disabled.image_layout_validation) {
+        return;
+    }
     IMAGE_STATE *image_state = GetImageState(view_state.create_info.image);
     if (image_state) {
         auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, *image_state);


### PR DESCRIPTION
This significantly improves the effectiveness of disabling image layout validation in the app I'm looking at. Takes it from a 25% reduction in overall time to a 55% reduction in overall time.
