### PR TITLE
Add more filtering of large descriptor set validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1247,8 +1247,6 @@ void ValidationStateTracker::UpdateDrawState(CMD_BUFFER_STATE *cb_state, const V
 
                 // Bind this set and its active descriptor resources to the command buffer
                 descriptor_set->UpdateDrawState(this, cb_state, binding_req_map);
-                // For given active slots record updated images & buffers
-                descriptor_set->GetStorageUpdates(binding_req_map, &cb_state->updateBuffers, &cb_state->updateImages);
             }
         }
     }
@@ -2131,8 +2129,6 @@ void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
             pSubCB->linkedCommandBuffers.erase(pCB);
         }
         pCB->linkedCommandBuffers.clear();
-        pCB->updateImages.clear();
-        pCB->updateBuffers.clear();
         ClearCmdBufAndMemReferences(pCB);
         pCB->queue_submit_functions.clear();
         pCB->cmd_execute_commands_functions.clear();

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1429,9 +1429,6 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     CBVertexBufferBindingInfo current_vertex_buffer_binding_info;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;
-    // Track images and buffers that are updated by this CB at the point of a draw
-    std::unordered_set<VkImageView> updateImages;
-    std::unordered_set<VkBuffer> updateBuffers;
     // If primary, the secondary command buffers we will call.
     // If secondary, the primary command buffers we will be called by.
     std::unordered_set<CMD_BUFFER_STATE *> linkedCommandBuffers;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -48,7 +48,6 @@ struct IndexRange {
     uint32_t start;
     uint32_t end;
 };
-typedef std::map<uint32_t, descriptor_req> BindingReqMap;
 
 /*
  * DescriptorSetLayoutDef/DescriptorSetLayout classes
@@ -619,6 +618,7 @@ class DescriptorSet : public BASE_NODE {
     uint32_t GetVariableDescriptorCount() const { return variable_count_; }
     DESCRIPTOR_POOL_STATE *GetPoolState() const { return pool_state_; }
     const Descriptor *GetDescriptorFromGlobalIndex(const uint32_t index) const { return descriptors_[index].get(); }
+    uint64_t GetChangeCount() const { return change_count_; }
 
    private:
     // Private helper to set all bound cmd buffers to INVALID state
@@ -630,6 +630,7 @@ class DescriptorSet : public BASE_NODE {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     StateTracker *state_data_;
     uint32_t variable_count_;
+    uint64_t change_count_;
 
     // Cached binding and validation support:
     //
@@ -639,9 +640,9 @@ class DescriptorSet : public BASE_NODE {
     // Track the validation caching of bindings vs. the command buffer and draw state
     typedef std::unordered_map<uint32_t, CMD_BUFFER_STATE::ImageLayoutUpdateCount> VersionedBindings;
     struct CachedValidation {
-        TrackedBindings command_binding_and_usage;                               // Persistent for the life of the recording
-        TrackedBindings non_dynamic_buffers;                                     // Persistent for the life of the recording
-        TrackedBindings dynamic_buffers;                                         // Dirtied (flushed) each BindDescriptorSet
+        TrackedBindings command_binding_and_usage;                                     // Persistent for the life of the recording
+        TrackedBindings non_dynamic_buffers;                                           // Persistent for the life of the recording
+        TrackedBindings dynamic_buffers;                                               // Dirtied (flushed) each BindDescriptorSet
         std::unordered_map<const PIPELINE_STATE *, VersionedBindings> image_samplers;  // Tested vs. changes to CB's ImageLayout
     };
     typedef std::unordered_map<const CMD_BUFFER_STATE *, CachedValidation> CachedValidationMap;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -559,10 +559,6 @@ class DescriptorSet : public BASE_NODE {
     }
     // Return true if given binding is present in this set
     bool HasBinding(const uint32_t binding) const { return p_layout_->HasBinding(binding); };
-    // For given set of bindings, add any buffers and images that will be updated to their respective unordered_sets & return number
-    // of objects inserted
-    uint32_t GetStorageUpdates(const std::map<uint32_t, descriptor_req> &, std::unordered_set<VkBuffer> *,
-                               std::unordered_set<VkImageView> *) const;
 
     std::string StringifySetAndLayout() const;
 

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1338,14 +1338,15 @@ void CoreChecks::GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer
     VkWriteDescriptorSet desc_writes[2] = {};
     uint32_t desc_count = 1;
     auto const &state = cb_node->lastBound[bind_point];
-    uint32_t number_of_sets = (uint32_t)state.boundDescriptorSets.size();
+    uint32_t number_of_sets = (uint32_t)state.per_set.size();
 
     // Figure out how much memory we need for the input block based on how many sets and bindings there are
     // and how big each of the bindings is
     if (number_of_sets > 0 && device_extensions.vk_ext_descriptor_indexing) {
         uint32_t descriptor_count = 0;  // Number of descriptors, including all array elements
         uint32_t binding_count = 0;     // Number of bindings based on the max binding number used
-        for (auto desc : state.boundDescriptorSets) {
+        for (auto s : state.per_set) {
+            auto desc = s.bound_descriptor_set;
             auto bindings = desc->GetLayout()->GetSortedBindingSet();
             if (bindings.size() > 0) {
                 binding_count += desc->GetLayout()->GetMaxBinding() + 1;
@@ -1395,7 +1396,8 @@ void CoreChecks::GpuAllocateValidationResources(const VkCommandBuffer cmd_buffer
         // Index of the start of the sets_to_bindings array
         pData[0] = number_of_sets + binding_count + 1;
 
-        for (auto desc : state.boundDescriptorSets) {
+        for (auto s : state.per_set) {
+            auto desc = s.bound_descriptor_set;
             auto layout = desc->GetLayout();
             auto bindings = layout->GetSortedBindingSet();
             if (bindings.size() > 0) {


### PR DESCRIPTION
This adds new descriptor set validation filtering that IMO is complementary to the existing filtering. The existing filtering caches whether a descriptor set has been validated against a particular pipeline. This new filtering additionally skips validating against a new pipeline when the new pipeline doesn't have any additional requirements over the old pipeline.

This will be simpler to review by looking at the commits separately. The first commit is the same as #1121, second commit is just dead code removal, third commit is refactoring, fourth commit is the actual filtering.

This reduces core validation time by about 40% in the app I'm looking at.
