### PR TITLE
layers: Skip descriptor set UpdateDrawState if image layout and command buffer state validation are disabled

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1204,6 +1204,13 @@ void cvdescriptorset::DescriptorSet::UpdateDrawState(ValidationStateTracker *dev
     cb_node->object_bindings.emplace(set_, kVulkanObjectTypeDescriptorSet);
     pool_state_->cb_bindings.insert(cb_node);
     cb_node->object_bindings.emplace(pool_state_->pool, kVulkanObjectTypeDescriptorPool);
+
+    // Descriptor UpdateDrawState functions do two things - associate resources to the command buffer,
+    // and call image layout validation callbacks. If both are disabled, skip the entire loop.
+    if (device_data->disabled.command_buffer_state && device_data->disabled.image_layout_validation) {
+        return;
+    }
+
     // For the active slots, use set# to look up descriptorSet from boundDescriptorSets, and bind all of that descriptor set's
     // resources
     for (auto binding_req_pair : binding_req_map) {


### PR DESCRIPTION
This reduces core validation time by around 25% when both disables are on, in the test app I'm using.
