### PR TITLE
layers: Split thread-safety locking into buckets to reduce contention

### DIFF
--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -39,7 +39,7 @@ void ThreadSafety::PostCallRecordAllocateCommandBuffers(VkDevice device, const V
     // Record mapping from command buffer to command pool
     if(pCommandBuffers) {
         for (uint32_t index = 0; index < pAllocateInfo->commandBufferCount; index++) {
-            auto &bucket = getBucket(pCommandBuffers[index]);
+            auto &bucket = GetBucket(pCommandBuffers[index]);
             std::lock_guard<std::mutex> lock(bucket.command_pool_lock);
             bucket.command_pool_map[pCommandBuffers[index]] = pAllocateInfo->commandPool;
         }
@@ -78,7 +78,7 @@ void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPoo
         }
         // Holding the lock for the shortest time while we update the map
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            auto &bucket = getBucket(pCommandBuffers[index]);
+            auto &bucket = GetBucket(pCommandBuffers[index]);
             std::lock_guard<std::mutex> lock(bucket.command_pool_lock);
             bucket.command_pool_map.erase(pCommandBuffers[index]);
         }

--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -38,9 +38,10 @@ void ThreadSafety::PostCallRecordAllocateCommandBuffers(VkDevice device, const V
 
     // Record mapping from command buffer to command pool
     if(pCommandBuffers) {
-        std::lock_guard<std::mutex> lock(command_pool_lock);
         for (uint32_t index = 0; index < pAllocateInfo->commandBufferCount; index++) {
-            command_pool_map[pCommandBuffers[index]] = pAllocateInfo->commandPool;
+            uint32_t h = ThreadSafetyHashObject(pCommandBuffers[index]);
+            std::lock_guard<std::mutex> lock(command_pool_lock[h]);
+            command_pool_map[h][pCommandBuffers[index]] = pAllocateInfo->commandPool;
         }
     }
 }
@@ -76,9 +77,10 @@ void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPoo
             FinishWriteObject(pCommandBuffers[index], lockCommandPool);
         }
         // Holding the lock for the shortest time while we update the map
-        std::lock_guard<std::mutex> lock(command_pool_lock);
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            command_pool_map.erase(pCommandBuffers[index]);
+            uint32_t h = ThreadSafetyHashObject(pCommandBuffers[index]);
+            std::lock_guard<std::mutex> lock(command_pool_lock[h]);
+            command_pool_map[h].erase(pCommandBuffers[index]);
         }
     }
 }

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -143,7 +143,7 @@ public:
     };
 
     CounterBucket buckets[THREAD_SAFETY_BUCKETS];
-    CounterBucket &getBucket(T object)
+    CounterBucket &GetBucket(T object)
     {
         return buckets[ThreadSafetyHashObject(object)];
     }
@@ -152,7 +152,7 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
         std::unique_lock<std::mutex> lock(bucket.counter_lock);
@@ -173,14 +173,7 @@ public:
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
-                        // Wait for thread-safe access to object instead of skipping call.
-                        // Don't use condition_variable to wait because it should be extremely
-                        // rare to have collisions, but signaling would be very frequent.
-                        while (bucket.uses.contains(object)) {
-                            lock.unlock();
-                            std::this_thread::sleep_for(std::chrono::microseconds(1));
-                            lock.lock();
-                        }
+                        WaitForObjectIdle(bucket, object, lock);
                         // There is now no current use of the object.  Record writer thread.
                         struct object_use_data *new_use_data = &bucket.uses[object];
                         new_use_data->thread = tid;
@@ -205,14 +198,7 @@ public:
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
-                        // Wait for thread-safe access to object instead of skipping call.
-                        // Don't use condition_variable to wait because it should be extremely
-                        // rare to have collisions, but signaling would be very frequent.
-                        while (bucket.uses.contains(object)) {
-                            lock.unlock();
-                            std::this_thread::sleep_for(std::chrono::microseconds(1));
-                            lock.lock();
-                        }
+                        WaitForObjectIdle(bucket, object, lock);
                         // There is now no current use of the object.  Record writer thread.
                         struct object_use_data *new_use_data = &bucket.uses[object];
                         new_use_data->thread = tid;
@@ -236,7 +222,7 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         // Object is no longer in use
         std::unique_lock<std::mutex> lock(bucket.counter_lock);
         struct object_use_data *use_data = &bucket.uses[object];
@@ -250,7 +236,7 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
         std::unique_lock<std::mutex> lock(bucket.counter_lock);
@@ -268,14 +254,7 @@ public:
                 "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                 typeName, (uint64_t)bucket.uses[object].thread, (uint64_t)tid);
             if (skip) {
-                // Wait for thread-safe access to object instead of skipping call.
-                // Don't use condition_variable to wait because it should be extremely
-                // rare to have collisions, but signaling would be very frequent.
-                while (bucket.uses.contains(object)) {
-                    lock.unlock();
-                    std::this_thread::sleep_for(std::chrono::microseconds(1));
-                    lock.lock();
-                }
+                WaitForObjectIdle(bucket, object, lock);
                 // There is no current use of the object.  Record reader count
                 struct object_use_data *use_data = &bucket.uses[object];
                 use_data->reader_count = 1;
@@ -293,7 +272,7 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         std::unique_lock<std::mutex> lock(bucket.counter_lock);
         struct object_use_data *use_data = &bucket.uses[object];
         use_data->reader_count -= 1;
@@ -305,6 +284,18 @@ public:
         typeName = name;
         objectType = type;
         report_data = rep_data;
+    }
+
+private:
+    void WaitForObjectIdle(CounterBucket &bucket, T object, std::unique_lock<std::mutex> &lock) {
+        // Wait for thread-safe access to object instead of skipping call.
+        // Don't use condition_variable to wait because it should be extremely
+        // rare to have collisions, but signaling would be very frequent.
+        while (bucket.uses.contains(object)) {
+            lock.unlock();
+            std::this_thread::sleep_for(std::chrono::microseconds(1));
+            lock.lock();
+        }
     }
 };
 
@@ -326,7 +317,7 @@ public:
     };
 
     CommandBufferBucket buckets[THREAD_SAFETY_BUCKETS];
-    CommandBufferBucket &getBucket(VkCommandBuffer object)
+    CommandBufferBucket &GetBucket(VkCommandBuffer object)
     {
         return buckets[ThreadSafetyHashObject(object)];
     }
@@ -477,7 +468,7 @@ WRAPPER(uint64_t)
     // VkCommandBuffer needs check for implicit use of command pool
     void StartWriteObject(VkCommandBuffer object, bool lockPool = true) {
         if (lockPool) {
-            auto &bucket = getBucket(object);
+            auto &bucket = GetBucket(object);
             std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
             VkCommandPool pool = bucket.command_pool_map[object];
             lock.unlock();
@@ -488,7 +479,7 @@ WRAPPER(uint64_t)
     void FinishWriteObject(VkCommandBuffer object, bool lockPool = true) {
         c_VkCommandBuffer.FinishWrite(object);
         if (lockPool) {
-            auto &bucket = getBucket(object);
+            auto &bucket = GetBucket(object);
             std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
             VkCommandPool pool = bucket.command_pool_map[object];
             lock.unlock();
@@ -496,7 +487,7 @@ WRAPPER(uint64_t)
         }
     }
     void StartReadObject(VkCommandBuffer object) {
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
         VkCommandPool pool = bucket.command_pool_map[object];
         lock.unlock();
@@ -507,7 +498,7 @@ WRAPPER(uint64_t)
         c_VkCommandBuffer.StartRead(object);
     }
     void FinishReadObject(VkCommandBuffer object) {
-        auto &bucket = getBucket(object);
+        auto &bucket = GetBucket(object);
         c_VkCommandBuffer.FinishRead(object);
         std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
         VkCommandPool pool = bucket.command_pool_map[object];

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -116,32 +116,45 @@ public:
     }
 };
 
+#define THREAD_SAFETY_BUCKETS_LOG2 6
+#define THREAD_SAFETY_BUCKETS (1 << THREAD_SAFETY_BUCKETS_LOG2)
+
+template <typename T> inline uint32_t ThreadSafetyHashObject(T object)
+{
+    uint32_t hash = (uint32_t)(uint64_t)object;
+    hash ^= (hash >> THREAD_SAFETY_BUCKETS_LOG2) ^ (hash >> (2*THREAD_SAFETY_BUCKETS_LOG2));
+    hash &= (THREAD_SAFETY_BUCKETS-1);
+    return hash;
+}
+
 template <typename T>
 class counter {
 public:
     const char *typeName;
     VkDebugReportObjectTypeEXT objectType;
     debug_report_data **report_data;
-    small_unordered_map<T, object_use_data> uses;
-    std::mutex counter_lock;
-    std::condition_variable counter_condition;
 
+    // Per-bucket locking, to reduce contention.
+    small_unordered_map<T, object_use_data> uses[THREAD_SAFETY_BUCKETS];
+    std::mutex counter_lock[THREAD_SAFETY_BUCKETS];
+    std::condition_variable counter_condition[THREAD_SAFETY_BUCKETS];
 
     void StartWrite(T object) {
         if (object == VK_NULL_HANDLE) {
             return;
         }
+        uint32_t h = ThreadSafetyHashObject(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
-        std::unique_lock<std::mutex> lock(counter_lock);
-        if (!uses.contains(object)) {
+        std::unique_lock<std::mutex> lock(counter_lock[h]);
+        if (!uses[h].contains(object)) {
             // There is no current use of the object.  Record writer thread.
-            struct object_use_data *use_data = &uses[object];
+            struct object_use_data *use_data = &uses[h][object];
             use_data->reader_count = 0;
             use_data->writer_count = 1;
             use_data->thread = tid;
         } else {
-            struct object_use_data *use_data = &uses[object];
+            struct object_use_data *use_data = &uses[h][object];
             if (use_data->reader_count == 0) {
                 // There are no readers.  Two writers just collided.
                 if (use_data->thread != tid) {
@@ -152,11 +165,11 @@ public:
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
                         // Wait for thread-safe access to object instead of skipping call.
-                        while (uses.contains(object)) {
-                            counter_condition.wait(lock);
+                        while (uses[h].contains(object)) {
+                            counter_condition[h].wait(lock);
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *new_use_data = &uses[object];
+                        struct object_use_data *new_use_data = &uses[h][object];
                         new_use_data->thread = tid;
                         new_use_data->reader_count = 0;
                         new_use_data->writer_count = 1;
@@ -180,11 +193,11 @@ public:
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
                         // Wait for thread-safe access to object instead of skipping call.
-                        while (uses.contains(object)) {
-                            counter_condition.wait(lock);
+                        while (uses[h].contains(object)) {
+                            counter_condition[h].wait(lock);
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *new_use_data = &uses[object];
+                        struct object_use_data *new_use_data = &uses[h][object];
                         new_use_data->thread = tid;
                         new_use_data->reader_count = 0;
                         new_use_data->writer_count = 1;
@@ -206,67 +219,70 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
+        uint32_t h = ThreadSafetyHashObject(object);
         // Object is no longer in use
-        std::unique_lock<std::mutex> lock(counter_lock);
-        uses[object].writer_count -= 1;
-        if ((uses[object].reader_count == 0) && (uses[object].writer_count == 0)) {
-            uses.erase(object);
+        std::unique_lock<std::mutex> lock(counter_lock[h]);
+        uses[h][object].writer_count -= 1;
+        if ((uses[h][object].reader_count == 0) && (uses[h][object].writer_count == 0)) {
+            uses[h].erase(object);
         }
         // Notify any waiting threads that this object may be safe to use
         lock.unlock();
-        counter_condition.notify_all();
+        counter_condition[h].notify_all();
     }
 
     void StartRead(T object) {
         if (object == VK_NULL_HANDLE) {
             return;
         }
+        uint32_t h = ThreadSafetyHashObject(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
-        std::unique_lock<std::mutex> lock(counter_lock);
-        if (!uses.contains(object)) {
+        std::unique_lock<std::mutex> lock(counter_lock[h]);
+        if (!uses[h].contains(object)) {
             // There is no current use of the object.  Record reader count
-            struct object_use_data *use_data = &uses[object];
+            struct object_use_data *use_data = &uses[h][object];
             use_data->reader_count = 1;
             use_data->writer_count = 0;
             use_data->thread = tid;
-        } else if (uses[object].writer_count > 0 && uses[object].thread != tid) {
+        } else if (uses[h][object].writer_count > 0 && uses[h][object].thread != tid) {
             // There is a writer of the object.
             skip |= log_msg(*report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
                 kVUID_Threading_MultipleThreads,
                 "THREADING ERROR : object of type %s is simultaneously used in "
                 "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
-                typeName, (uint64_t)uses[object].thread, (uint64_t)tid);
+                typeName, (uint64_t)uses[h][object].thread, (uint64_t)tid);
             if (skip) {
                 // Wait for thread-safe access to object instead of skipping call.
-                while (uses.contains(object)) {
-                    counter_condition.wait(lock);
+                while (uses[h].contains(object)) {
+                    counter_condition[h].wait(lock);
                 }
                 // There is no current use of the object.  Record reader count
-                struct object_use_data *use_data = &uses[object];
+                struct object_use_data *use_data = &uses[h][object];
                 use_data->reader_count = 1;
                 use_data->writer_count = 0;
                 use_data->thread = tid;
             } else {
-                uses[object].reader_count += 1;
+                uses[h][object].reader_count += 1;
             }
         } else {
             // There are other readers of the object.  Increase reader count
-            uses[object].reader_count += 1;
+            uses[h][object].reader_count += 1;
         }
     }
     void FinishRead(T object) {
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        std::unique_lock<std::mutex> lock(counter_lock);
-        uses[object].reader_count -= 1;
-        if ((uses[object].reader_count == 0) && (uses[object].writer_count == 0)) {
-            uses.erase(object);
+        uint32_t h = ThreadSafetyHashObject(object);
+        std::unique_lock<std::mutex> lock(counter_lock[h]);
+        uses[h][object].reader_count -= 1;
+        if ((uses[h][object].reader_count == 0) && (uses[h][object].writer_count == 0)) {
+            uses[h].erase(object);
         }
         // Notify any waiting threads that this object may be safe to use
         lock.unlock();
-        counter_condition.notify_all();
+        counter_condition[h].notify_all();
     }
     counter(const char *name = "", VkDebugReportObjectTypeEXT type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, debug_report_data **rep_data = nullptr) {
         typeName = name;
@@ -286,8 +302,8 @@ public:
         return std::unique_lock<std::mutex>(validation_object_mutex, std::defer_lock);
     }
 
-    std::mutex command_pool_lock;
-    std::unordered_map<VkCommandBuffer, VkCommandPool> command_pool_map;
+    std::mutex command_pool_lock[THREAD_SAFETY_BUCKETS];
+    std::unordered_map<VkCommandBuffer, VkCommandPool> command_pool_map[THREAD_SAFETY_BUCKETS];
 
     counter<VkCommandBuffer> c_VkCommandBuffer;
     counter<VkDevice> c_VkDevice;
@@ -435,8 +451,9 @@ WRAPPER(uint64_t)
     // VkCommandBuffer needs check for implicit use of command pool
     void StartWriteObject(VkCommandBuffer object, bool lockPool = true) {
         if (lockPool) {
-            std::unique_lock<std::mutex> lock(command_pool_lock);
-            VkCommandPool pool = command_pool_map[object];
+            uint32_t h = ThreadSafetyHashObject(object);
+            std::unique_lock<std::mutex> lock(command_pool_lock[h]);
+            VkCommandPool pool = command_pool_map[h][object];
             lock.unlock();
             StartWriteObject(pool);
         }
@@ -445,15 +462,17 @@ WRAPPER(uint64_t)
     void FinishWriteObject(VkCommandBuffer object, bool lockPool = true) {
         c_VkCommandBuffer.FinishWrite(object);
         if (lockPool) {
-            std::unique_lock<std::mutex> lock(command_pool_lock);
-            VkCommandPool pool = command_pool_map[object];
+            uint32_t h = ThreadSafetyHashObject(object);
+            std::unique_lock<std::mutex> lock(command_pool_lock[h]);
+            VkCommandPool pool = command_pool_map[h][object];
             lock.unlock();
             FinishWriteObject(pool);
         }
     }
     void StartReadObject(VkCommandBuffer object) {
-        std::unique_lock<std::mutex> lock(command_pool_lock);
-        VkCommandPool pool = command_pool_map[object];
+        uint32_t h = ThreadSafetyHashObject(object);
+        std::unique_lock<std::mutex> lock(command_pool_lock[h]);
+        VkCommandPool pool = command_pool_map[h][object];
         lock.unlock();
         // We set up a read guard against the "Contents" counter to catch conflict vs. vkResetCommandPool and vkDestroyCommandPool
         // while *not* establishing a read guard against the command pool counter itself to avoid false postives for
@@ -462,9 +481,10 @@ WRAPPER(uint64_t)
         c_VkCommandBuffer.StartRead(object);
     }
     void FinishReadObject(VkCommandBuffer object) {
+        uint32_t h = ThreadSafetyHashObject(object);
         c_VkCommandBuffer.FinishRead(object);
-        std::unique_lock<std::mutex> lock(command_pool_lock);
-        VkCommandPool pool = command_pool_map[object];
+        std::unique_lock<std::mutex> lock(command_pool_lock[h]);
+        VkCommandPool pool = command_pool_map[h][object];
         lock.unlock();
         c_VkCommandPoolContents.FinishRead(pool);
     } 

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -150,6 +150,7 @@ class ThreadOutputGenerator(OutputGenerator):
 #pragma once
 
 #include <chrono>
+#include <thread>
 #include <mutex>
 #include <vector>
 #include <unordered_set>
@@ -247,7 +248,8 @@ public:
 
 template <typename T> inline uint32_t ThreadSafetyHashObject(T object)
 {
-    uint32_t hash = (uint32_t)(uint64_t)object;
+    uint64_t u64 = (uint64_t)(uintptr_t)object;
+    uint32_t hash = (uint32_t)(u64 >> 32) + (uint32_t)u64;
     hash ^= (hash >> THREAD_SAFETY_BUCKETS_LOG2) ^ (hash >> (2*THREAD_SAFETY_BUCKETS_LOG2));
     hash &= (THREAD_SAFETY_BUCKETS-1);
     return hash;
@@ -261,25 +263,33 @@ public:
     debug_report_data **report_data;
 
     // Per-bucket locking, to reduce contention.
-    small_unordered_map<T, object_use_data> uses[THREAD_SAFETY_BUCKETS];
-    std::mutex counter_lock[THREAD_SAFETY_BUCKETS];
+    struct CounterBucket {
+        small_unordered_map<T, object_use_data> uses;
+        std::mutex counter_lock;
+    };
+
+    CounterBucket buckets[THREAD_SAFETY_BUCKETS];
+    CounterBucket &getBucket(T object)
+    {
+        return buckets[ThreadSafetyHashObject(object)];
+    }
 
     void StartWrite(T object) {
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        uint32_t h = ThreadSafetyHashObject(object);
+        auto &bucket = getBucket(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
-        std::unique_lock<std::mutex> lock(counter_lock[h]);
-        if (!uses[h].contains(object)) {
+        std::unique_lock<std::mutex> lock(bucket.counter_lock);
+        if (!bucket.uses.contains(object)) {
             // There is no current use of the object.  Record writer thread.
-            struct object_use_data *use_data = &uses[h][object];
+            struct object_use_data *use_data = &bucket.uses[object];
             use_data->reader_count = 0;
             use_data->writer_count = 1;
             use_data->thread = tid;
         } else {
-            struct object_use_data *use_data = &uses[h][object];
+            struct object_use_data *use_data = &bucket.uses[object];
             if (use_data->reader_count == 0) {
                 // There are no readers.  Two writers just collided.
                 if (use_data->thread != tid) {
@@ -292,13 +302,13 @@ public:
                         // Wait for thread-safe access to object instead of skipping call.
                         // Don't use condition_variable to wait because it should be extremely
                         // rare to have collisions, but signaling would be very frequent.
-                        while (uses[h].contains(object)) {
+                        while (bucket.uses.contains(object)) {
                             lock.unlock();
                             std::this_thread::sleep_for(std::chrono::microseconds(1));
                             lock.lock();
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *new_use_data = &uses[h][object];
+                        struct object_use_data *new_use_data = &bucket.uses[object];
                         new_use_data->thread = tid;
                         new_use_data->reader_count = 0;
                         new_use_data->writer_count = 1;
@@ -324,13 +334,13 @@ public:
                         // Wait for thread-safe access to object instead of skipping call.
                         // Don't use condition_variable to wait because it should be extremely
                         // rare to have collisions, but signaling would be very frequent.
-                        while (uses[h].contains(object)) {
+                        while (bucket.uses.contains(object)) {
                             lock.unlock();
                             std::this_thread::sleep_for(std::chrono::microseconds(1));
                             lock.lock();
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *new_use_data = &uses[h][object];
+                        struct object_use_data *new_use_data = &bucket.uses[object];
                         new_use_data->thread = tid;
                         new_use_data->reader_count = 0;
                         new_use_data->writer_count = 1;
@@ -352,13 +362,13 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        uint32_t h = ThreadSafetyHashObject(object);
+        auto &bucket = getBucket(object);
         // Object is no longer in use
-        std::unique_lock<std::mutex> lock(counter_lock[h]);
-        struct object_use_data *use_data = &uses[h][object];
+        std::unique_lock<std::mutex> lock(bucket.counter_lock);
+        struct object_use_data *use_data = &bucket.uses[object];
         use_data->writer_count -= 1;
         if ((use_data->reader_count == 0) && (use_data->writer_count == 0)) {
-            uses[h].erase(object);
+            bucket.uses.erase(object);
         }
     }
 
@@ -366,55 +376,55 @@ public:
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        uint32_t h = ThreadSafetyHashObject(object);
+        auto &bucket = getBucket(object);
         bool skip = false;
         loader_platform_thread_id tid = loader_platform_get_thread_id();
-        std::unique_lock<std::mutex> lock(counter_lock[h]);
-        if (!uses[h].contains(object)) {
+        std::unique_lock<std::mutex> lock(bucket.counter_lock);
+        if (!bucket.uses.contains(object)) {
             // There is no current use of the object.  Record reader count
-            struct object_use_data *use_data = &uses[h][object];
+            struct object_use_data *use_data = &bucket.uses[object];
             use_data->reader_count = 1;
             use_data->writer_count = 0;
             use_data->thread = tid;
-        } else if (uses[h][object].writer_count > 0 && uses[h][object].thread != tid) {
+        } else if (bucket.uses[object].writer_count > 0 && bucket.uses[object].thread != tid) {
             // There is a writer of the object.
             skip |= log_msg(*report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
                 kVUID_Threading_MultipleThreads,
                 "THREADING ERROR : object of type %s is simultaneously used in "
                 "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
-                typeName, (uint64_t)uses[h][object].thread, (uint64_t)tid);
+                typeName, (uint64_t)bucket.uses[object].thread, (uint64_t)tid);
             if (skip) {
                 // Wait for thread-safe access to object instead of skipping call.
                 // Don't use condition_variable to wait because it should be extremely
                 // rare to have collisions, but signaling would be very frequent.
-                while (uses[h].contains(object)) {
+                while (bucket.uses.contains(object)) {
                     lock.unlock();
                     std::this_thread::sleep_for(std::chrono::microseconds(1));
                     lock.lock();
                 }
                 // There is no current use of the object.  Record reader count
-                struct object_use_data *use_data = &uses[h][object];
+                struct object_use_data *use_data = &bucket.uses[object];
                 use_data->reader_count = 1;
                 use_data->writer_count = 0;
                 use_data->thread = tid;
             } else {
-                uses[h][object].reader_count += 1;
+                bucket.uses[object].reader_count += 1;
             }
         } else {
             // There are other readers of the object.  Increase reader count
-            uses[h][object].reader_count += 1;
+            bucket.uses[object].reader_count += 1;
         }
     }
     void FinishRead(T object) {
         if (object == VK_NULL_HANDLE) {
             return;
         }
-        uint32_t h = ThreadSafetyHashObject(object);
-        std::unique_lock<std::mutex> lock(counter_lock[h]);
-        struct object_use_data *use_data = &uses[h][object];
+        auto &bucket = getBucket(object);
+        std::unique_lock<std::mutex> lock(bucket.counter_lock);
+        struct object_use_data *use_data = &bucket.uses[object];
         use_data->reader_count -= 1;
         if ((use_data->reader_count == 0) && (use_data->writer_count == 0)) {
-            uses[h].erase(object);
+            bucket.uses.erase(object);
         }
     }
     counter(const char *name = "", VkDebugReportObjectTypeEXT type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, debug_report_data **rep_data = nullptr) {
@@ -435,8 +445,17 @@ public:
         return std::unique_lock<std::mutex>(validation_object_mutex, std::defer_lock);
     }
 
-    std::mutex command_pool_lock[THREAD_SAFETY_BUCKETS];
-    std::unordered_map<VkCommandBuffer, VkCommandPool> command_pool_map[THREAD_SAFETY_BUCKETS];
+    // Per-bucket locking, to reduce contention.
+    struct CommandBufferBucket {
+        std::mutex command_pool_lock;
+        small_unordered_map<VkCommandBuffer, VkCommandPool> command_pool_map;
+    };
+
+    CommandBufferBucket buckets[THREAD_SAFETY_BUCKETS];
+    CommandBufferBucket &getBucket(VkCommandBuffer object)
+    {
+        return buckets[ThreadSafetyHashObject(object)];
+    }
 
     counter<VkCommandBuffer> c_VkCommandBuffer;
     counter<VkDevice> c_VkDevice;
@@ -498,9 +517,9 @@ WRAPPER(uint64_t)
     // VkCommandBuffer needs check for implicit use of command pool
     void StartWriteObject(VkCommandBuffer object, bool lockPool = true) {
         if (lockPool) {
-            uint32_t h = ThreadSafetyHashObject(object);
-            std::unique_lock<std::mutex> lock(command_pool_lock[h]);
-            VkCommandPool pool = command_pool_map[h][object];
+            auto &bucket = getBucket(object);
+            std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
+            VkCommandPool pool = bucket.command_pool_map[object];
             lock.unlock();
             StartWriteObject(pool);
         }
@@ -509,17 +528,17 @@ WRAPPER(uint64_t)
     void FinishWriteObject(VkCommandBuffer object, bool lockPool = true) {
         c_VkCommandBuffer.FinishWrite(object);
         if (lockPool) {
-            uint32_t h = ThreadSafetyHashObject(object);
-            std::unique_lock<std::mutex> lock(command_pool_lock[h]);
-            VkCommandPool pool = command_pool_map[h][object];
+            auto &bucket = getBucket(object);
+            std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
+            VkCommandPool pool = bucket.command_pool_map[object];
             lock.unlock();
             FinishWriteObject(pool);
         }
     }
     void StartReadObject(VkCommandBuffer object) {
-        uint32_t h = ThreadSafetyHashObject(object);
-        std::unique_lock<std::mutex> lock(command_pool_lock[h]);
-        VkCommandPool pool = command_pool_map[h][object];
+        auto &bucket = getBucket(object);
+        std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
+        VkCommandPool pool = bucket.command_pool_map[object];
         lock.unlock();
         // We set up a read guard against the "Contents" counter to catch conflict vs. vkResetCommandPool and vkDestroyCommandPool
         // while *not* establishing a read guard against the command pool counter itself to avoid false postives for
@@ -528,10 +547,10 @@ WRAPPER(uint64_t)
         c_VkCommandBuffer.StartRead(object);
     }
     void FinishReadObject(VkCommandBuffer object) {
-        uint32_t h = ThreadSafetyHashObject(object);
+        auto &bucket = getBucket(object);
         c_VkCommandBuffer.FinishRead(object);
-        std::unique_lock<std::mutex> lock(command_pool_lock[h]);
-        VkCommandPool pool = command_pool_map[h][object];
+        std::unique_lock<std::mutex> lock(bucket.command_pool_lock);
+        VkCommandPool pool = bucket.command_pool_map[object];
         lock.unlock();
         c_VkCommandPoolContents.FinishRead(pool);
     } """
@@ -552,9 +571,9 @@ void ThreadSafety::PostCallRecordAllocateCommandBuffers(VkDevice device, const V
     // Record mapping from command buffer to command pool
     if(pCommandBuffers) {
         for (uint32_t index = 0; index < pAllocateInfo->commandBufferCount; index++) {
-            uint32_t h = ThreadSafetyHashObject(pCommandBuffers[index]);
-            std::lock_guard<std::mutex> lock(command_pool_lock[h]);
-            command_pool_map[h][pCommandBuffers[index]] = pAllocateInfo->commandPool;
+            auto &bucket = getBucket(pCommandBuffers[index]);
+            std::lock_guard<std::mutex> lock(bucket.command_pool_lock);
+            bucket.command_pool_map[pCommandBuffers[index]] = pAllocateInfo->commandPool;
         }
     }
 }
@@ -591,9 +610,9 @@ void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPoo
         }
         // Holding the lock for the shortest time while we update the map
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            uint32_t h = ThreadSafetyHashObject(pCommandBuffers[index]);
-            std::lock_guard<std::mutex> lock(command_pool_lock[h]);
-            command_pool_map[h].erase(pCommandBuffers[index]);
+            auto &bucket = getBucket(pCommandBuffers[index]);
+            std::lock_guard<std::mutex> lock(bucket.command_pool_lock);
+            bucket.command_pool_map.erase(pCommandBuffers[index]);
         }
     }
 }

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -149,7 +149,7 @@ class ThreadOutputGenerator(OutputGenerator):
     inline_custom_header_preamble = """
 #pragma once
 
-#include <condition_variable>
+#include <chrono>
 #include <mutex>
 #include <vector>
 #include <unordered_set>
@@ -263,7 +263,6 @@ public:
     // Per-bucket locking, to reduce contention.
     small_unordered_map<T, object_use_data> uses[THREAD_SAFETY_BUCKETS];
     std::mutex counter_lock[THREAD_SAFETY_BUCKETS];
-    std::condition_variable counter_condition[THREAD_SAFETY_BUCKETS];
 
     void StartWrite(T object) {
         if (object == VK_NULL_HANDLE) {
@@ -291,8 +290,12 @@ public:
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
                         // Wait for thread-safe access to object instead of skipping call.
+                        // Don't use condition_variable to wait because it should be extremely
+                        // rare to have collisions, but signaling would be very frequent.
                         while (uses[h].contains(object)) {
-                            counter_condition[h].wait(lock);
+                            lock.unlock();
+                            std::this_thread::sleep_for(std::chrono::microseconds(1));
+                            lock.lock();
                         }
                         // There is now no current use of the object.  Record writer thread.
                         struct object_use_data *new_use_data = &uses[h][object];
@@ -319,8 +322,12 @@ public:
                         typeName, (uint64_t)use_data->thread, (uint64_t)tid);
                     if (skip) {
                         // Wait for thread-safe access to object instead of skipping call.
+                        // Don't use condition_variable to wait because it should be extremely
+                        // rare to have collisions, but signaling would be very frequent.
                         while (uses[h].contains(object)) {
-                            counter_condition[h].wait(lock);
+                            lock.unlock();
+                            std::this_thread::sleep_for(std::chrono::microseconds(1));
+                            lock.lock();
                         }
                         // There is now no current use of the object.  Record writer thread.
                         struct object_use_data *new_use_data = &uses[h][object];
@@ -348,13 +355,11 @@ public:
         uint32_t h = ThreadSafetyHashObject(object);
         // Object is no longer in use
         std::unique_lock<std::mutex> lock(counter_lock[h]);
-        uses[h][object].writer_count -= 1;
-        if ((uses[h][object].reader_count == 0) && (uses[h][object].writer_count == 0)) {
+        struct object_use_data *use_data = &uses[h][object];
+        use_data->writer_count -= 1;
+        if ((use_data->reader_count == 0) && (use_data->writer_count == 0)) {
             uses[h].erase(object);
         }
-        // Notify any waiting threads that this object may be safe to use
-        lock.unlock();
-        counter_condition[h].notify_all();
     }
 
     void StartRead(T object) {
@@ -380,8 +385,12 @@ public:
                 typeName, (uint64_t)uses[h][object].thread, (uint64_t)tid);
             if (skip) {
                 // Wait for thread-safe access to object instead of skipping call.
+                // Don't use condition_variable to wait because it should be extremely
+                // rare to have collisions, but signaling would be very frequent.
                 while (uses[h].contains(object)) {
-                    counter_condition[h].wait(lock);
+                    lock.unlock();
+                    std::this_thread::sleep_for(std::chrono::microseconds(1));
+                    lock.lock();
                 }
                 // There is no current use of the object.  Record reader count
                 struct object_use_data *use_data = &uses[h][object];
@@ -402,13 +411,11 @@ public:
         }
         uint32_t h = ThreadSafetyHashObject(object);
         std::unique_lock<std::mutex> lock(counter_lock[h]);
-        uses[h][object].reader_count -= 1;
-        if ((uses[h][object].reader_count == 0) && (uses[h][object].writer_count == 0)) {
+        struct object_use_data *use_data = &uses[h][object];
+        use_data->reader_count -= 1;
+        if ((use_data->reader_count == 0) && (use_data->writer_count == 0)) {
             uses[h].erase(object);
         }
-        // Notify any waiting threads that this object may be safe to use
-        lock.unlock();
-        counter_condition[h].notify_all();
     }
     counter(const char *name = "", VkDebugReportObjectTypeEXT type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, debug_report_data **rep_data = nullptr) {
         typeName = name;


### PR DESCRIPTION
Reduces thread_safety-only time by 45% in my test app.

It's tempting to try to change the object_use_data to be atomic and only do a read/write lock on a hash table lookup, but rewriting to use atomics is a much more subtle change, and this shows pretty good gains.