### PR TITLE
ci: Relax summary limit to 64 from 54

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ a good reason is "This violates the style guide, but it improves type safety."
 >        $ git commit
 
 * **Commit Messages**
-    * Limit the subject line to 50 characters -- this allows the information to display correctly in git/Github logs
+    * Limit the subject line to 64 characters -- this allows the information to display correctly in git/GitHub logs
     * Begin subject line with a one-word component description followed by a colon (e.g. build, docs, layers, tests, etc.)
     * Separate subject from body with a blank line
     * Wrap the body at 72 characters

--- a/scripts/check_commit_message_format.sh
+++ b/scripts/check_commit_message_format.sh
@@ -55,9 +55,9 @@ printf %s "$COMMIT_TEXT" | while IFS='' read -r line; do
   fi
   chars=${#line}
   if [ $current_line -eq 1 ]; then
-    # Subject line should be 50 chars or less (but give some slack here)
-    if [ $chars -gt 54 ]; then
-      echo "The following subject line exceeds 50 characters in length."
+    # Subject line should be 64 chars or less
+    if [ $chars -gt 64 ]; then
+      echo "The following subject line exceeds 64 characters in length."
       echo "     '$line'"
       success=0
     fi

--- a/scripts/check_commit_message_format.sh
+++ b/scripts/check_commit_message_format.sh
@@ -30,6 +30,7 @@ NC='\033[0m' # No Color
 # Get user-supplied commit message text for applicable commits and insert
 # a unique separator string identifier. The git command returns ONLY the
 # subject line and body for each of the commits.
+TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}"
 COMMIT_TEXT=$(git log ${TRAVIS_COMMIT_RANGE} --pretty=format:"XXXNEWLINEXXX"%n%B)
 
 # Bail if there are none


### PR DESCRIPTION
Any limit I could find on GitHub is 72. 64 for blame page.

The 50 limit arguments always seem to link back to some obsolete article on some personal blog, which actually says:

> shoot **for about** 50 characters (though this **isn’t a hard maximum**)

Not that it matters that much, as we are all obviously ignoring the rule anyway:
![obrazek](https://user-images.githubusercontent.com/3791331/62984324-0354a800-be33-11e9-8c6d-c62db8263435.png)
Ye without sin, throw the first stone!
