### PR TITLE
Check sampler type when shader code uses sampler and descriptor type is COMBINED_IMAGE_SAMPLER. 

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -768,24 +768,27 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                     }
                     const auto &image_view_ci = image_view_state->create_info;
 
-                    if ((reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) && (~reqs & (1 << image_view_ci.viewType))) {
-                        // bad view type
-                        std::stringstream error_str;
-                        error_str << "Descriptor in binding #" << binding << " index " << index
-                                  << " requires an image view of type " << StringDescriptorReqViewType(reqs) << " but got "
-                                  << string_VkImageViewType(image_view_ci.viewType) << ".";
-                        *error = error_str.str();
-                        return false;
-                    }
+                    if (reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
+                        if (~reqs & (1 << image_view_ci.viewType)) {
+                            // bad view type
+                            std::stringstream error_str;
+                            error_str << "Descriptor in binding #" << binding << " index " << index
+                                      << " requires an image view of type " << StringDescriptorReqViewType(reqs) << " but got "
+                                      << string_VkImageViewType(image_view_ci.viewType) << ".";
+                            *error = error_str.str();
+                            return false;
+                        }
 
-                    if (!(reqs & image_view_state->descriptor_format_bits)) {
-                        // bad component type
-                        std::stringstream error_str;
-                        error_str << "Descriptor in binding #" << binding << " index " << index << " requires "
-                                  << StringDescriptorReqComponentType(reqs) << " component type, but bound descriptor format is "
-                                  << string_VkFormat(image_view_ci.format) << ".";
-                        *error = error_str.str();
-                        return false;
+                        if (!(reqs & image_view_state->descriptor_format_bits)) {
+                            // bad component type
+                            std::stringstream error_str;
+                            error_str << "Descriptor in binding #" << binding << " index " << index << " requires "
+                                      << StringDescriptorReqComponentType(reqs)
+                                      << " component type, but bound descriptor format is " << string_VkFormat(image_view_ci.format)
+                                      << ".";
+                            *error = error_str.str();
+                            return false;
+                        }
                     }
 
                     if (!disabled.image_layout_validation) {


### PR DESCRIPTION
[issue #385 ](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/385)

The issue happens that is because of shader code: binding #0 includes image and sampler.
```
OpDecorate %InputData DescriptorSet 0
OpDecorate %InputData Binding 0
OpDecorate %SamplerData DescriptorSet 0
OpDecorate %SamplerData Binding 0
```
But this shader only uses sampler, not image, so in shader validation, it doesn't have image information.
`%call_smp = OpLoad %Sampler %SamplerData`

It causes shader validation's image format is 0 and mismatches descriptor's image format.

@gnl21 