### PR TITLE
layers: reduce dynamic memory allocation in UpdateLastBoundDescriptorSets and UpdateDrawState

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -764,7 +764,7 @@ class ValidationStateTracker : public ValidationObject {
     void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bindInfo);
     void UpdateLastBoundDescriptorSets(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint pipeline_bind_point,
                                        const PIPELINE_LAYOUT_STATE* pipeline_layout, uint32_t first_set, uint32_t set_count,
-                                       const std::vector<cvdescriptorset::DescriptorSet*> descriptor_sets,
+                                       const VkDescriptorSet* pDescriptorSets, cvdescriptorset::DescriptorSet* push_descriptor_set,
                                        uint32_t dynamic_offset_count, const uint32_t* p_dynamic_offsets);
     void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);


### PR DESCRIPTION
Skip map assignment in UpdateDrawState if it's not needed.

Change UpdateLastBoundDescriptorSets to not take a vector parameter (passed
by value).

I saw these memory allocations stand out in profiling, but didn't measure a significant performance benefit. Still, I think it's worthwhile to remove dynamic memory allocation when possible.