### PR TITLE
appveyor: Capture layer binaries as artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,3 +74,7 @@ build:
   parallel: true                              # enable MSBuild parallel builds
   project: build/Vulkan-ValidationLayers.sln  # path to Visual Studio solution or project
   verbosity: quiet                            # quiet|minimal|normal|detailed
+
+artifacts:
+  - path: build\layers\$(configuration)
+    name: Vulkan-ValidationLayers-$(platform)-$(configuration)


### PR DESCRIPTION
Related to #1134. This does not however switch the build type, so Release builds have no symbol information yet, but it shows that AppVeyor will do this for open source accounts.

Tested in a fork using my personal AppVeyor account. Sample link showing artifacts for download: https://ci.appveyor.com/project/NunoSubtil/vulkan-validationlayers/builds/26758820/job/gv1udp0dyhk30i45/artifacts