### PR TITLE
docs: Bump minimums to Ubuntu 16.04 and gcc 5.4.0

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -428,8 +428,8 @@ layer validation tests use the "googletest" testing framework.)
 ### Linux Build Requirements
 
 This repository has been built and tested on the two most recent Ubuntu LTS
-versions. Currently, the oldest supported version is Ubuntu 14.04, meaning
-that the minimum supported compiler versions are GCC 4.8.2 and Clang 3.4,
+versions. Currently, the oldest supported version is Ubuntu 16.04, meaning
+that the minimum officially supported C++11 compiler version is GCC 5.4.0,
 although earlier versions may work. It should be straightforward to adapt this
 repository to other Linux distributions.
 


### PR DESCRIPTION
Change-Id: Ic40bf1485efed0bcd7cef8b039154ba5828fb59f