### PR TITLE
Use vl_concurrent_unordered_map in ObjectLifetimes

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12110,10 +12110,19 @@ void CoreChecks::PreCallRecordSetEvent(VkDevice device, VkEvent event) {
 
 bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
                                                 VkFence fence) {
+    auto queue_data = GetQueueState(queue);
     auto pFence = GetFenceState(fence);
     bool skip = ValidateFenceForSubmit(pFence);
     if (skip) {
         return true;
+    }
+
+    auto queueFlags = GetPhysicalDeviceState()->queue_family_properties[queue_data->queueFamilyIndex].queueFlags;
+    if (!(queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+        skip |= log_msg(
+            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, HandleToUint64(queue),
+            "VUID-vkQueueBindSparse-queuetype",
+            "Attempting vkQueueBindSparse on a non-memory-management capable queue -- VK_QUEUE_SPARSE_BINDING_BIT not set.");
     }
 
     unordered_set<VkSemaphore> signaled_semaphores;

--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -115,7 +115,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFeatures(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceFeatures*                   pFeatures) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFeatures-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -126,7 +125,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFormatProperties(
     VkFormat                                    format,
     VkFormatProperties*                         pFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFormatProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -141,7 +139,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceImageFormatProperties(
     VkImageCreateFlags                          flags,
     VkImageFormatProperties*                    pImageFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceImageFormatProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -151,7 +148,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceProperties(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceProperties*                 pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -161,7 +157,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceMemoryProperties(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceMemoryProperties*           pMemoryProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceMemoryProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -171,7 +166,6 @@ bool ObjectLifetimes::PreCallValidateGetInstanceProcAddr(
     VkInstance                                  instance,
     const char*                                 pName) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, true, "VUID-vkGetInstanceProcAddr-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -181,7 +175,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceProcAddr(
     VkDevice                                    device,
     const char*                                 pName) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceProcAddr-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -193,7 +186,6 @@ bool ObjectLifetimes::PreCallValidateCreateDevice(
     const VkAllocationCallbacks*                pAllocator,
     VkDevice*                                   pDevice) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkCreateDevice-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -206,7 +198,6 @@ void ObjectLifetimes::PostCallRecordCreateDevice(
     VkDevice*                                   pDevice,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(physicalDevice, *pDevice, kVulkanObjectTypeDevice, pAllocator);
 
 }
@@ -217,7 +208,6 @@ bool ObjectLifetimes::PreCallValidateEnumerateDeviceExtensionProperties(
     uint32_t*                                   pPropertyCount,
     VkExtensionProperties*                      pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkEnumerateDeviceExtensionProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -228,7 +218,6 @@ bool ObjectLifetimes::PreCallValidateEnumerateDeviceLayerProperties(
     uint32_t*                                   pPropertyCount,
     VkLayerProperties*                          pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkEnumerateDeviceLayerProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -240,7 +229,6 @@ bool ObjectLifetimes::PreCallValidateQueueSubmit(
     const VkSubmitInfo*                         pSubmits,
     VkFence                                     fence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueSubmit-queue-parameter", "VUID-vkQueueSubmit-commonparent");
     if (pSubmits) {
         for (uint32_t index0 = 0; index0 < submitCount; ++index0) {
@@ -269,7 +257,6 @@ bool ObjectLifetimes::PreCallValidateQueueSubmit(
 bool ObjectLifetimes::PreCallValidateQueueWaitIdle(
     VkQueue                                     queue) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueWaitIdle-queue-parameter", kVUIDUndefined);
 
     return skip;
@@ -278,7 +265,6 @@ bool ObjectLifetimes::PreCallValidateQueueWaitIdle(
 bool ObjectLifetimes::PreCallValidateDeviceWaitIdle(
     VkDevice                                    device) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDeviceWaitIdle-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -290,7 +276,6 @@ bool ObjectLifetimes::PreCallValidateAllocateMemory(
     const VkAllocationCallbacks*                pAllocator,
     VkDeviceMemory*                             pMemory) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkAllocateMemory-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -303,7 +288,6 @@ void ObjectLifetimes::PostCallRecordAllocateMemory(
     VkDeviceMemory*                             pMemory,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pMemory, kVulkanObjectTypeDeviceMemory, pAllocator);
 
 }
@@ -313,7 +297,6 @@ bool ObjectLifetimes::PreCallValidateFreeMemory(
     VkDeviceMemory                              memory,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkFreeMemory-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, true, "VUID-vkFreeMemory-memory-parameter", "VUID-vkFreeMemory-memory-parent");
     skip |= ValidateDestroyObject(device, memory, kVulkanObjectTypeDeviceMemory, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -325,7 +308,6 @@ void ObjectLifetimes::PreCallRecordFreeMemory(
     VkDevice                                    device,
     VkDeviceMemory                              memory,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, memory, kVulkanObjectTypeDeviceMemory);
 
 }
@@ -338,7 +320,6 @@ bool ObjectLifetimes::PreCallValidateMapMemory(
     VkMemoryMapFlags                            flags,
     void**                                      ppData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkMapMemory-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkMapMemory-memory-parameter", "VUID-vkMapMemory-memory-parent");
 
@@ -349,7 +330,6 @@ bool ObjectLifetimes::PreCallValidateUnmapMemory(
     VkDevice                                    device,
     VkDeviceMemory                              memory) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkUnmapMemory-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkUnmapMemory-memory-parameter", "VUID-vkUnmapMemory-memory-parent");
 
@@ -361,7 +341,6 @@ bool ObjectLifetimes::PreCallValidateFlushMappedMemoryRanges(
     uint32_t                                    memoryRangeCount,
     const VkMappedMemoryRange*                  pMemoryRanges) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkFlushMappedMemoryRanges-device-parameter", kVUIDUndefined);
     if (pMemoryRanges) {
         for (uint32_t index0 = 0; index0 < memoryRangeCount; ++index0) {
@@ -377,7 +356,6 @@ bool ObjectLifetimes::PreCallValidateInvalidateMappedMemoryRanges(
     uint32_t                                    memoryRangeCount,
     const VkMappedMemoryRange*                  pMemoryRanges) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkInvalidateMappedMemoryRanges-device-parameter", kVUIDUndefined);
     if (pMemoryRanges) {
         for (uint32_t index0 = 0; index0 < memoryRangeCount; ++index0) {
@@ -393,7 +371,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceMemoryCommitment(
     VkDeviceMemory                              memory,
     VkDeviceSize*                               pCommittedMemoryInBytes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceMemoryCommitment-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkGetDeviceMemoryCommitment-memory-parameter", "VUID-vkGetDeviceMemoryCommitment-memory-parent");
 
@@ -406,7 +383,6 @@ bool ObjectLifetimes::PreCallValidateBindBufferMemory(
     VkDeviceMemory                              memory,
     VkDeviceSize                                memoryOffset) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindBufferMemory-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkBindBufferMemory-buffer-parameter", "VUID-vkBindBufferMemory-buffer-parent");
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkBindBufferMemory-memory-parameter", "VUID-vkBindBufferMemory-memory-parent");
@@ -420,7 +396,6 @@ bool ObjectLifetimes::PreCallValidateBindImageMemory(
     VkDeviceMemory                              memory,
     VkDeviceSize                                memoryOffset) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindImageMemory-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, false, "VUID-vkBindImageMemory-image-parameter", "VUID-vkBindImageMemory-image-parent");
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkBindImageMemory-memory-parameter", "VUID-vkBindImageMemory-memory-parent");
@@ -433,7 +408,6 @@ bool ObjectLifetimes::PreCallValidateGetBufferMemoryRequirements(
     VkBuffer                                    buffer,
     VkMemoryRequirements*                       pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetBufferMemoryRequirements-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkGetBufferMemoryRequirements-buffer-parameter", "VUID-vkGetBufferMemoryRequirements-buffer-parent");
 
@@ -445,7 +419,6 @@ bool ObjectLifetimes::PreCallValidateGetImageMemoryRequirements(
     VkImage                                     image,
     VkMemoryRequirements*                       pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageMemoryRequirements-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, false, "VUID-vkGetImageMemoryRequirements-image-parameter", "VUID-vkGetImageMemoryRequirements-image-parent");
 
@@ -458,7 +431,6 @@ bool ObjectLifetimes::PreCallValidateGetImageSparseMemoryRequirements(
     uint32_t*                                   pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements*            pSparseMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageSparseMemoryRequirements-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, false, "VUID-vkGetImageSparseMemoryRequirements-image-parameter", "VUID-vkGetImageSparseMemoryRequirements-image-parent");
 
@@ -475,7 +447,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSparseImageFormatPropertie
     uint32_t*                                   pPropertyCount,
     VkSparseImageFormatProperties*              pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSparseImageFormatProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -487,7 +458,6 @@ bool ObjectLifetimes::PreCallValidateQueueBindSparse(
     const VkBindSparseInfo*                     pBindInfo,
     VkFence                                     fence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueBindSparse-queue-parameter", "VUID-vkQueueBindSparse-commonparent");
     if (pBindInfo) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -544,7 +514,6 @@ bool ObjectLifetimes::PreCallValidateCreateFence(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateFence-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -557,7 +526,6 @@ void ObjectLifetimes::PostCallRecordCreateFence(
     VkFence*                                    pFence,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pFence, kVulkanObjectTypeFence, pAllocator);
 
 }
@@ -567,7 +535,6 @@ bool ObjectLifetimes::PreCallValidateDestroyFence(
     VkFence                                     fence,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyFence-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, fence, kVulkanObjectTypeFence, true, "VUID-vkDestroyFence-fence-parameter", "VUID-vkDestroyFence-fence-parent");
     skip |= ValidateDestroyObject(device, fence, kVulkanObjectTypeFence, pAllocator, "VUID-vkDestroyFence-fence-01121", "VUID-vkDestroyFence-fence-01122");
@@ -579,7 +546,6 @@ void ObjectLifetimes::PreCallRecordDestroyFence(
     VkDevice                                    device,
     VkFence                                     fence,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, fence, kVulkanObjectTypeFence);
 
 }
@@ -589,7 +555,6 @@ bool ObjectLifetimes::PreCallValidateResetFences(
     uint32_t                                    fenceCount,
     const VkFence*                              pFences) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkResetFences-device-parameter", kVUIDUndefined);
     if (pFences) {
         for (uint32_t index0 = 0; index0 < fenceCount; ++index0) {
@@ -604,7 +569,6 @@ bool ObjectLifetimes::PreCallValidateGetFenceStatus(
     VkDevice                                    device,
     VkFence                                     fence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetFenceStatus-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, fence, kVulkanObjectTypeFence, false, "VUID-vkGetFenceStatus-fence-parameter", "VUID-vkGetFenceStatus-fence-parent");
 
@@ -618,7 +582,6 @@ bool ObjectLifetimes::PreCallValidateWaitForFences(
     VkBool32                                    waitAll,
     uint64_t                                    timeout) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkWaitForFences-device-parameter", kVUIDUndefined);
     if (pFences) {
         for (uint32_t index0 = 0; index0 < fenceCount; ++index0) {
@@ -635,7 +598,6 @@ bool ObjectLifetimes::PreCallValidateCreateSemaphore(
     const VkAllocationCallbacks*                pAllocator,
     VkSemaphore*                                pSemaphore) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSemaphore-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -648,7 +610,6 @@ void ObjectLifetimes::PostCallRecordCreateSemaphore(
     VkSemaphore*                                pSemaphore,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pSemaphore, kVulkanObjectTypeSemaphore, pAllocator);
 
 }
@@ -658,7 +619,6 @@ bool ObjectLifetimes::PreCallValidateDestroySemaphore(
     VkSemaphore                                 semaphore,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroySemaphore-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, semaphore, kVulkanObjectTypeSemaphore, true, "VUID-vkDestroySemaphore-semaphore-parameter", "VUID-vkDestroySemaphore-semaphore-parent");
     skip |= ValidateDestroyObject(device, semaphore, kVulkanObjectTypeSemaphore, pAllocator, "VUID-vkDestroySemaphore-semaphore-01138", "VUID-vkDestroySemaphore-semaphore-01139");
@@ -670,7 +630,6 @@ void ObjectLifetimes::PreCallRecordDestroySemaphore(
     VkDevice                                    device,
     VkSemaphore                                 semaphore,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, semaphore, kVulkanObjectTypeSemaphore);
 
 }
@@ -681,7 +640,6 @@ bool ObjectLifetimes::PreCallValidateCreateEvent(
     const VkAllocationCallbacks*                pAllocator,
     VkEvent*                                    pEvent) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateEvent-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -694,7 +652,6 @@ void ObjectLifetimes::PostCallRecordCreateEvent(
     VkEvent*                                    pEvent,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pEvent, kVulkanObjectTypeEvent, pAllocator);
 
 }
@@ -704,7 +661,6 @@ bool ObjectLifetimes::PreCallValidateDestroyEvent(
     VkEvent                                     event,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyEvent-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, event, kVulkanObjectTypeEvent, true, "VUID-vkDestroyEvent-event-parameter", "VUID-vkDestroyEvent-event-parent");
     skip |= ValidateDestroyObject(device, event, kVulkanObjectTypeEvent, pAllocator, "VUID-vkDestroyEvent-event-01146", "VUID-vkDestroyEvent-event-01147");
@@ -716,7 +672,6 @@ void ObjectLifetimes::PreCallRecordDestroyEvent(
     VkDevice                                    device,
     VkEvent                                     event,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, event, kVulkanObjectTypeEvent);
 
 }
@@ -725,7 +680,6 @@ bool ObjectLifetimes::PreCallValidateGetEventStatus(
     VkDevice                                    device,
     VkEvent                                     event) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetEventStatus-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, event, kVulkanObjectTypeEvent, false, "VUID-vkGetEventStatus-event-parameter", "VUID-vkGetEventStatus-event-parent");
 
@@ -736,7 +690,6 @@ bool ObjectLifetimes::PreCallValidateSetEvent(
     VkDevice                                    device,
     VkEvent                                     event) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkSetEvent-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, event, kVulkanObjectTypeEvent, false, "VUID-vkSetEvent-event-parameter", "VUID-vkSetEvent-event-parent");
 
@@ -747,7 +700,6 @@ bool ObjectLifetimes::PreCallValidateResetEvent(
     VkDevice                                    device,
     VkEvent                                     event) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkResetEvent-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, event, kVulkanObjectTypeEvent, false, "VUID-vkResetEvent-event-parameter", "VUID-vkResetEvent-event-parent");
 
@@ -760,7 +712,6 @@ bool ObjectLifetimes::PreCallValidateCreateQueryPool(
     const VkAllocationCallbacks*                pAllocator,
     VkQueryPool*                                pQueryPool) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateQueryPool-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -773,7 +724,6 @@ void ObjectLifetimes::PostCallRecordCreateQueryPool(
     VkQueryPool*                                pQueryPool,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pQueryPool, kVulkanObjectTypeQueryPool, pAllocator);
 
 }
@@ -783,7 +733,6 @@ bool ObjectLifetimes::PreCallValidateDestroyQueryPool(
     VkQueryPool                                 queryPool,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyQueryPool-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, queryPool, kVulkanObjectTypeQueryPool, true, "VUID-vkDestroyQueryPool-queryPool-parameter", "VUID-vkDestroyQueryPool-queryPool-parent");
     skip |= ValidateDestroyObject(device, queryPool, kVulkanObjectTypeQueryPool, pAllocator, "VUID-vkDestroyQueryPool-queryPool-00794", "VUID-vkDestroyQueryPool-queryPool-00795");
@@ -795,7 +744,6 @@ void ObjectLifetimes::PreCallRecordDestroyQueryPool(
     VkDevice                                    device,
     VkQueryPool                                 queryPool,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, queryPool, kVulkanObjectTypeQueryPool);
 
 }
@@ -810,7 +758,6 @@ bool ObjectLifetimes::PreCallValidateGetQueryPoolResults(
     VkDeviceSize                                stride,
     VkQueryResultFlags                          flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetQueryPoolResults-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkGetQueryPoolResults-queryPool-parameter", "VUID-vkGetQueryPoolResults-queryPool-parent");
 
@@ -823,7 +770,6 @@ bool ObjectLifetimes::PreCallValidateCreateBuffer(
     const VkAllocationCallbacks*                pAllocator,
     VkBuffer*                                   pBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateBuffer-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -836,7 +782,6 @@ void ObjectLifetimes::PostCallRecordCreateBuffer(
     VkBuffer*                                   pBuffer,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pBuffer, kVulkanObjectTypeBuffer, pAllocator);
 
 }
@@ -846,7 +791,6 @@ bool ObjectLifetimes::PreCallValidateDestroyBuffer(
     VkBuffer                                    buffer,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyBuffer-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, buffer, kVulkanObjectTypeBuffer, true, "VUID-vkDestroyBuffer-buffer-parameter", "VUID-vkDestroyBuffer-buffer-parent");
     skip |= ValidateDestroyObject(device, buffer, kVulkanObjectTypeBuffer, pAllocator, "VUID-vkDestroyBuffer-buffer-00923", "VUID-vkDestroyBuffer-buffer-00924");
@@ -858,7 +802,6 @@ void ObjectLifetimes::PreCallRecordDestroyBuffer(
     VkDevice                                    device,
     VkBuffer                                    buffer,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, buffer, kVulkanObjectTypeBuffer);
 
 }
@@ -869,7 +812,6 @@ bool ObjectLifetimes::PreCallValidateCreateBufferView(
     const VkAllocationCallbacks*                pAllocator,
     VkBufferView*                               pView) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateBufferView-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(device, pCreateInfo->buffer, kVulkanObjectTypeBuffer, false, "VUID-VkBufferViewCreateInfo-buffer-parameter", kVUIDUndefined);
@@ -885,7 +827,6 @@ void ObjectLifetimes::PostCallRecordCreateBufferView(
     VkBufferView*                               pView,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pView, kVulkanObjectTypeBufferView, pAllocator);
 
 }
@@ -895,7 +836,6 @@ bool ObjectLifetimes::PreCallValidateDestroyBufferView(
     VkBufferView                                bufferView,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyBufferView-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, bufferView, kVulkanObjectTypeBufferView, true, "VUID-vkDestroyBufferView-bufferView-parameter", "VUID-vkDestroyBufferView-bufferView-parent");
     skip |= ValidateDestroyObject(device, bufferView, kVulkanObjectTypeBufferView, pAllocator, "VUID-vkDestroyBufferView-bufferView-00937", "VUID-vkDestroyBufferView-bufferView-00938");
@@ -907,7 +847,6 @@ void ObjectLifetimes::PreCallRecordDestroyBufferView(
     VkDevice                                    device,
     VkBufferView                                bufferView,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, bufferView, kVulkanObjectTypeBufferView);
 
 }
@@ -918,7 +857,6 @@ bool ObjectLifetimes::PreCallValidateCreateImage(
     const VkAllocationCallbacks*                pAllocator,
     VkImage*                                    pImage) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateImage-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -931,7 +869,6 @@ void ObjectLifetimes::PostCallRecordCreateImage(
     VkImage*                                    pImage,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pImage, kVulkanObjectTypeImage, pAllocator);
 
 }
@@ -941,7 +878,6 @@ bool ObjectLifetimes::PreCallValidateDestroyImage(
     VkImage                                     image,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyImage-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, true, "VUID-vkDestroyImage-image-parameter", "VUID-vkDestroyImage-image-parent");
     skip |= ValidateDestroyObject(device, image, kVulkanObjectTypeImage, pAllocator, "VUID-vkDestroyImage-image-01001", "VUID-vkDestroyImage-image-01002");
@@ -953,7 +889,6 @@ void ObjectLifetimes::PreCallRecordDestroyImage(
     VkDevice                                    device,
     VkImage                                     image,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, image, kVulkanObjectTypeImage);
 
 }
@@ -964,7 +899,6 @@ bool ObjectLifetimes::PreCallValidateGetImageSubresourceLayout(
     const VkImageSubresource*                   pSubresource,
     VkSubresourceLayout*                        pLayout) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageSubresourceLayout-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, false, "VUID-vkGetImageSubresourceLayout-image-parameter", "VUID-vkGetImageSubresourceLayout-image-parent");
 
@@ -977,7 +911,6 @@ bool ObjectLifetimes::PreCallValidateCreateImageView(
     const VkAllocationCallbacks*                pAllocator,
     VkImageView*                                pView) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateImageView-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(device, pCreateInfo->image, kVulkanObjectTypeImage, false, "VUID-VkImageViewCreateInfo-image-parameter", kVUIDUndefined);
@@ -993,7 +926,6 @@ void ObjectLifetimes::PostCallRecordCreateImageView(
     VkImageView*                                pView,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pView, kVulkanObjectTypeImageView, pAllocator);
 
 }
@@ -1003,7 +935,6 @@ bool ObjectLifetimes::PreCallValidateDestroyImageView(
     VkImageView                                 imageView,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyImageView-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, imageView, kVulkanObjectTypeImageView, true, "VUID-vkDestroyImageView-imageView-parameter", "VUID-vkDestroyImageView-imageView-parent");
     skip |= ValidateDestroyObject(device, imageView, kVulkanObjectTypeImageView, pAllocator, "VUID-vkDestroyImageView-imageView-01027", "VUID-vkDestroyImageView-imageView-01028");
@@ -1015,7 +946,6 @@ void ObjectLifetimes::PreCallRecordDestroyImageView(
     VkDevice                                    device,
     VkImageView                                 imageView,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, imageView, kVulkanObjectTypeImageView);
 
 }
@@ -1026,7 +956,6 @@ bool ObjectLifetimes::PreCallValidateCreateShaderModule(
     const VkAllocationCallbacks*                pAllocator,
     VkShaderModule*                             pShaderModule) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateShaderModule-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1039,7 +968,6 @@ void ObjectLifetimes::PostCallRecordCreateShaderModule(
     VkShaderModule*                             pShaderModule,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pShaderModule, kVulkanObjectTypeShaderModule, pAllocator);
 
 }
@@ -1049,7 +977,6 @@ bool ObjectLifetimes::PreCallValidateDestroyShaderModule(
     VkShaderModule                              shaderModule,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyShaderModule-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, shaderModule, kVulkanObjectTypeShaderModule, true, "VUID-vkDestroyShaderModule-shaderModule-parameter", "VUID-vkDestroyShaderModule-shaderModule-parent");
     skip |= ValidateDestroyObject(device, shaderModule, kVulkanObjectTypeShaderModule, pAllocator, "VUID-vkDestroyShaderModule-shaderModule-01092", "VUID-vkDestroyShaderModule-shaderModule-01093");
@@ -1061,7 +988,6 @@ void ObjectLifetimes::PreCallRecordDestroyShaderModule(
     VkDevice                                    device,
     VkShaderModule                              shaderModule,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, shaderModule, kVulkanObjectTypeShaderModule);
 
 }
@@ -1072,7 +998,6 @@ bool ObjectLifetimes::PreCallValidateCreatePipelineCache(
     const VkAllocationCallbacks*                pAllocator,
     VkPipelineCache*                            pPipelineCache) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreatePipelineCache-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1085,7 +1010,6 @@ void ObjectLifetimes::PostCallRecordCreatePipelineCache(
     VkPipelineCache*                            pPipelineCache,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pPipelineCache, kVulkanObjectTypePipelineCache, pAllocator);
 
 }
@@ -1095,7 +1019,6 @@ bool ObjectLifetimes::PreCallValidateDestroyPipelineCache(
     VkPipelineCache                             pipelineCache,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyPipelineCache-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineCache, kVulkanObjectTypePipelineCache, true, "VUID-vkDestroyPipelineCache-pipelineCache-parameter", "VUID-vkDestroyPipelineCache-pipelineCache-parent");
     skip |= ValidateDestroyObject(device, pipelineCache, kVulkanObjectTypePipelineCache, pAllocator, "VUID-vkDestroyPipelineCache-pipelineCache-00771", "VUID-vkDestroyPipelineCache-pipelineCache-00772");
@@ -1107,7 +1030,6 @@ void ObjectLifetimes::PreCallRecordDestroyPipelineCache(
     VkDevice                                    device,
     VkPipelineCache                             pipelineCache,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, pipelineCache, kVulkanObjectTypePipelineCache);
 
 }
@@ -1118,7 +1040,6 @@ bool ObjectLifetimes::PreCallValidateGetPipelineCacheData(
     size_t*                                     pDataSize,
     void*                                       pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPipelineCacheData-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineCache, kVulkanObjectTypePipelineCache, false, "VUID-vkGetPipelineCacheData-pipelineCache-parameter", "VUID-vkGetPipelineCacheData-pipelineCache-parent");
 
@@ -1131,7 +1052,6 @@ bool ObjectLifetimes::PreCallValidateMergePipelineCaches(
     uint32_t                                    srcCacheCount,
     const VkPipelineCache*                      pSrcCaches) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkMergePipelineCaches-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, dstCache, kVulkanObjectTypePipelineCache, false, "VUID-vkMergePipelineCaches-dstCache-parameter", "VUID-vkMergePipelineCaches-dstCache-parent");
     if (pSrcCaches) {
@@ -1151,7 +1071,6 @@ bool ObjectLifetimes::PreCallValidateCreateGraphicsPipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateGraphicsPipelines-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineCache, kVulkanObjectTypePipelineCache, true, "VUID-vkCreateGraphicsPipelines-pipelineCache-parameter", "VUID-vkCreateGraphicsPipelines-pipelineCache-parent");
     if (pCreateInfos) {
@@ -1178,7 +1097,6 @@ void ObjectLifetimes::PostCallRecordCreateGraphicsPipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines,
     VkResult                                    result) {
-    auto lock = write_shared_lock();
     if (VK_ERROR_VALIDATION_FAILED_EXT == result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1197,7 +1115,6 @@ bool ObjectLifetimes::PreCallValidateCreateComputePipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateComputePipelines-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineCache, kVulkanObjectTypePipelineCache, true, "VUID-vkCreateComputePipelines-pipelineCache-parameter", "VUID-vkCreateComputePipelines-pipelineCache-parent");
     if (pCreateInfos) {
@@ -1219,7 +1136,6 @@ void ObjectLifetimes::PostCallRecordCreateComputePipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines,
     VkResult                                    result) {
-    auto lock = write_shared_lock();
     if (VK_ERROR_VALIDATION_FAILED_EXT == result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1235,7 +1151,6 @@ bool ObjectLifetimes::PreCallValidateDestroyPipeline(
     VkPipeline                                  pipeline,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyPipeline-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipeline, kVulkanObjectTypePipeline, true, "VUID-vkDestroyPipeline-pipeline-parameter", "VUID-vkDestroyPipeline-pipeline-parent");
     skip |= ValidateDestroyObject(device, pipeline, kVulkanObjectTypePipeline, pAllocator, "VUID-vkDestroyPipeline-pipeline-00766", "VUID-vkDestroyPipeline-pipeline-00767");
@@ -1247,7 +1162,6 @@ void ObjectLifetimes::PreCallRecordDestroyPipeline(
     VkDevice                                    device,
     VkPipeline                                  pipeline,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, pipeline, kVulkanObjectTypePipeline);
 
 }
@@ -1258,7 +1172,6 @@ bool ObjectLifetimes::PreCallValidateCreatePipelineLayout(
     const VkAllocationCallbacks*                pAllocator,
     VkPipelineLayout*                           pPipelineLayout) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreatePipelineLayout-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         if (pCreateInfo->pSetLayouts) {
@@ -1278,7 +1191,6 @@ void ObjectLifetimes::PostCallRecordCreatePipelineLayout(
     VkPipelineLayout*                           pPipelineLayout,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pPipelineLayout, kVulkanObjectTypePipelineLayout, pAllocator);
 
 }
@@ -1288,7 +1200,6 @@ bool ObjectLifetimes::PreCallValidateDestroyPipelineLayout(
     VkPipelineLayout                            pipelineLayout,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyPipelineLayout-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineLayout, kVulkanObjectTypePipelineLayout, true, "VUID-vkDestroyPipelineLayout-pipelineLayout-parameter", "VUID-vkDestroyPipelineLayout-pipelineLayout-parent");
     skip |= ValidateDestroyObject(device, pipelineLayout, kVulkanObjectTypePipelineLayout, pAllocator, "VUID-vkDestroyPipelineLayout-pipelineLayout-00299", "VUID-vkDestroyPipelineLayout-pipelineLayout-00300");
@@ -1300,7 +1211,6 @@ void ObjectLifetimes::PreCallRecordDestroyPipelineLayout(
     VkDevice                                    device,
     VkPipelineLayout                            pipelineLayout,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, pipelineLayout, kVulkanObjectTypePipelineLayout);
 
 }
@@ -1311,7 +1221,6 @@ bool ObjectLifetimes::PreCallValidateCreateSampler(
     const VkAllocationCallbacks*                pAllocator,
     VkSampler*                                  pSampler) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSampler-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1324,7 +1233,6 @@ void ObjectLifetimes::PostCallRecordCreateSampler(
     VkSampler*                                  pSampler,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pSampler, kVulkanObjectTypeSampler, pAllocator);
 
 }
@@ -1334,7 +1242,6 @@ bool ObjectLifetimes::PreCallValidateDestroySampler(
     VkSampler                                   sampler,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroySampler-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, sampler, kVulkanObjectTypeSampler, true, "VUID-vkDestroySampler-sampler-parameter", "VUID-vkDestroySampler-sampler-parent");
     skip |= ValidateDestroyObject(device, sampler, kVulkanObjectTypeSampler, pAllocator, "VUID-vkDestroySampler-sampler-01083", "VUID-vkDestroySampler-sampler-01084");
@@ -1346,7 +1253,6 @@ void ObjectLifetimes::PreCallRecordDestroySampler(
     VkDevice                                    device,
     VkSampler                                   sampler,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, sampler, kVulkanObjectTypeSampler);
 
 }
@@ -1356,7 +1262,6 @@ bool ObjectLifetimes::PreCallValidateDestroyDescriptorSetLayout(
     VkDescriptorSetLayout                       descriptorSetLayout,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyDescriptorSetLayout-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, true, "VUID-vkDestroyDescriptorSetLayout-descriptorSetLayout-parameter", "VUID-vkDestroyDescriptorSetLayout-descriptorSetLayout-parent");
     skip |= ValidateDestroyObject(device, descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, pAllocator, "VUID-vkDestroyDescriptorSetLayout-descriptorSetLayout-00284", "VUID-vkDestroyDescriptorSetLayout-descriptorSetLayout-00285");
@@ -1368,7 +1273,6 @@ void ObjectLifetimes::PreCallRecordDestroyDescriptorSetLayout(
     VkDevice                                    device,
     VkDescriptorSetLayout                       descriptorSetLayout,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout);
 
 }
@@ -1379,7 +1283,6 @@ bool ObjectLifetimes::PreCallValidateCreateDescriptorPool(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorPool*                           pDescriptorPool) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorPool-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1392,7 +1295,6 @@ void ObjectLifetimes::PostCallRecordCreateDescriptorPool(
     VkDescriptorPool*                           pDescriptorPool,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pDescriptorPool, kVulkanObjectTypeDescriptorPool, pAllocator);
 
 }
@@ -1402,7 +1304,6 @@ bool ObjectLifetimes::PreCallValidateDestroyFramebuffer(
     VkFramebuffer                               framebuffer,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyFramebuffer-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, framebuffer, kVulkanObjectTypeFramebuffer, true, "VUID-vkDestroyFramebuffer-framebuffer-parameter", "VUID-vkDestroyFramebuffer-framebuffer-parent");
     skip |= ValidateDestroyObject(device, framebuffer, kVulkanObjectTypeFramebuffer, pAllocator, "VUID-vkDestroyFramebuffer-framebuffer-00893", "VUID-vkDestroyFramebuffer-framebuffer-00894");
@@ -1414,7 +1315,6 @@ void ObjectLifetimes::PreCallRecordDestroyFramebuffer(
     VkDevice                                    device,
     VkFramebuffer                               framebuffer,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, framebuffer, kVulkanObjectTypeFramebuffer);
 
 }
@@ -1425,7 +1325,6 @@ bool ObjectLifetimes::PreCallValidateCreateRenderPass(
     const VkAllocationCallbacks*                pAllocator,
     VkRenderPass*                               pRenderPass) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRenderPass-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1438,7 +1337,6 @@ void ObjectLifetimes::PostCallRecordCreateRenderPass(
     VkRenderPass*                               pRenderPass,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pRenderPass, kVulkanObjectTypeRenderPass, pAllocator);
 
 }
@@ -1448,7 +1346,6 @@ bool ObjectLifetimes::PreCallValidateDestroyRenderPass(
     VkRenderPass                                renderPass,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyRenderPass-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, renderPass, kVulkanObjectTypeRenderPass, true, "VUID-vkDestroyRenderPass-renderPass-parameter", "VUID-vkDestroyRenderPass-renderPass-parent");
     skip |= ValidateDestroyObject(device, renderPass, kVulkanObjectTypeRenderPass, pAllocator, "VUID-vkDestroyRenderPass-renderPass-00874", "VUID-vkDestroyRenderPass-renderPass-00875");
@@ -1460,7 +1357,6 @@ void ObjectLifetimes::PreCallRecordDestroyRenderPass(
     VkDevice                                    device,
     VkRenderPass                                renderPass,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, renderPass, kVulkanObjectTypeRenderPass);
 
 }
@@ -1470,7 +1366,6 @@ bool ObjectLifetimes::PreCallValidateGetRenderAreaGranularity(
     VkRenderPass                                renderPass,
     VkExtent2D*                                 pGranularity) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetRenderAreaGranularity-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, renderPass, kVulkanObjectTypeRenderPass, false, "VUID-vkGetRenderAreaGranularity-renderPass-parameter", "VUID-vkGetRenderAreaGranularity-renderPass-parent");
 
@@ -1483,7 +1378,6 @@ bool ObjectLifetimes::PreCallValidateCreateCommandPool(
     const VkAllocationCallbacks*                pAllocator,
     VkCommandPool*                              pCommandPool) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateCommandPool-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -1496,7 +1390,6 @@ void ObjectLifetimes::PostCallRecordCreateCommandPool(
     VkCommandPool*                              pCommandPool,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pCommandPool, kVulkanObjectTypeCommandPool, pAllocator);
 
 }
@@ -1506,7 +1399,6 @@ bool ObjectLifetimes::PreCallValidateResetCommandPool(
     VkCommandPool                               commandPool,
     VkCommandPoolResetFlags                     flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkResetCommandPool-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, commandPool, kVulkanObjectTypeCommandPool, false, "VUID-vkResetCommandPool-commandPool-parameter", "VUID-vkResetCommandPool-commandPool-parent");
 
@@ -1516,7 +1408,6 @@ bool ObjectLifetimes::PreCallValidateResetCommandPool(
 bool ObjectLifetimes::PreCallValidateEndCommandBuffer(
     VkCommandBuffer                             commandBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkEndCommandBuffer-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1526,7 +1417,6 @@ bool ObjectLifetimes::PreCallValidateResetCommandBuffer(
     VkCommandBuffer                             commandBuffer,
     VkCommandBufferResetFlags                   flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkResetCommandBuffer-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1537,7 +1427,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindPipeline(
     VkPipelineBindPoint                         pipelineBindPoint,
     VkPipeline                                  pipeline) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindPipeline-commandBuffer-parameter", "VUID-vkCmdBindPipeline-commonparent");
     skip |= ValidateObject(commandBuffer, pipeline, kVulkanObjectTypePipeline, false, "VUID-vkCmdBindPipeline-pipeline-parameter", "VUID-vkCmdBindPipeline-commonparent");
 
@@ -1550,7 +1439,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetViewport(
     uint32_t                                    viewportCount,
     const VkViewport*                           pViewports) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetViewport-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1562,7 +1450,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetScissor(
     uint32_t                                    scissorCount,
     const VkRect2D*                             pScissors) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetScissor-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1572,7 +1459,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetLineWidth(
     VkCommandBuffer                             commandBuffer,
     float                                       lineWidth) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetLineWidth-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1584,7 +1470,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetDepthBias(
     float                                       depthBiasClamp,
     float                                       depthBiasSlopeFactor) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetDepthBias-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1594,7 +1479,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetBlendConstants(
     VkCommandBuffer                             commandBuffer,
     const float                                 blendConstants[4]) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetBlendConstants-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1605,7 +1489,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetDepthBounds(
     float                                       minDepthBounds,
     float                                       maxDepthBounds) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetDepthBounds-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1616,7 +1499,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetStencilCompareMask(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    compareMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetStencilCompareMask-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1627,7 +1509,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetStencilWriteMask(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    writeMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetStencilWriteMask-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1638,7 +1519,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetStencilReference(
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    reference) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetStencilReference-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1654,7 +1534,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindDescriptorSets(
     uint32_t                                    dynamicOffsetCount,
     const uint32_t*                             pDynamicOffsets) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindDescriptorSets-commandBuffer-parameter", "VUID-vkCmdBindDescriptorSets-commonparent");
     skip |= ValidateObject(commandBuffer, layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdBindDescriptorSets-layout-parameter", "VUID-vkCmdBindDescriptorSets-commonparent");
     if (pDescriptorSets) {
@@ -1672,7 +1551,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindIndexBuffer(
     VkDeviceSize                                offset,
     VkIndexType                                 indexType) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindIndexBuffer-commandBuffer-parameter", "VUID-vkCmdBindIndexBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdBindIndexBuffer-buffer-parameter", "VUID-vkCmdBindIndexBuffer-commonparent");
 
@@ -1686,7 +1564,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindVertexBuffers(
     const VkBuffer*                             pBuffers,
     const VkDeviceSize*                         pOffsets) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindVertexBuffers-commandBuffer-parameter", "VUID-vkCmdBindVertexBuffers-commonparent");
     if (pBuffers) {
         for (uint32_t index0 = 0; index0 < bindingCount; ++index0) {
@@ -1704,7 +1581,6 @@ bool ObjectLifetimes::PreCallValidateCmdDraw(
     uint32_t                                    firstVertex,
     uint32_t                                    firstInstance) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDraw-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1718,7 +1594,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndexed(
     int32_t                                     vertexOffset,
     uint32_t                                    firstInstance) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndexed-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1731,7 +1606,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndirect(
     uint32_t                                    drawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndirect-commandBuffer-parameter", "VUID-vkCmdDrawIndirect-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirect-buffer-parameter", "VUID-vkCmdDrawIndirect-commonparent");
 
@@ -1745,7 +1619,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndexedIndirect(
     uint32_t                                    drawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndexedIndirect-commandBuffer-parameter", "VUID-vkCmdDrawIndexedIndirect-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndexedIndirect-buffer-parameter", "VUID-vkCmdDrawIndexedIndirect-commonparent");
 
@@ -1758,7 +1631,6 @@ bool ObjectLifetimes::PreCallValidateCmdDispatch(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDispatch-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1769,7 +1641,6 @@ bool ObjectLifetimes::PreCallValidateCmdDispatchIndirect(
     VkBuffer                                    buffer,
     VkDeviceSize                                offset) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDispatchIndirect-commandBuffer-parameter", "VUID-vkCmdDispatchIndirect-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDispatchIndirect-buffer-parameter", "VUID-vkCmdDispatchIndirect-commonparent");
 
@@ -1783,7 +1654,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyBuffer(
     uint32_t                                    regionCount,
     const VkBufferCopy*                         pRegions) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyBuffer-commandBuffer-parameter", "VUID-vkCmdCopyBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, srcBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdCopyBuffer-srcBuffer-parameter", "VUID-vkCmdCopyBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdCopyBuffer-dstBuffer-parameter", "VUID-vkCmdCopyBuffer-commonparent");
@@ -1800,7 +1670,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyImage(
     uint32_t                                    regionCount,
     const VkImageCopy*                          pRegions) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyImage-commandBuffer-parameter", "VUID-vkCmdCopyImage-commonparent");
     skip |= ValidateObject(commandBuffer, srcImage, kVulkanObjectTypeImage, false, "VUID-vkCmdCopyImage-srcImage-parameter", "VUID-vkCmdCopyImage-commonparent");
     skip |= ValidateObject(commandBuffer, dstImage, kVulkanObjectTypeImage, false, "VUID-vkCmdCopyImage-dstImage-parameter", "VUID-vkCmdCopyImage-commonparent");
@@ -1818,7 +1687,6 @@ bool ObjectLifetimes::PreCallValidateCmdBlitImage(
     const VkImageBlit*                          pRegions,
     VkFilter                                    filter) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBlitImage-commandBuffer-parameter", "VUID-vkCmdBlitImage-commonparent");
     skip |= ValidateObject(commandBuffer, srcImage, kVulkanObjectTypeImage, false, "VUID-vkCmdBlitImage-srcImage-parameter", "VUID-vkCmdBlitImage-commonparent");
     skip |= ValidateObject(commandBuffer, dstImage, kVulkanObjectTypeImage, false, "VUID-vkCmdBlitImage-dstImage-parameter", "VUID-vkCmdBlitImage-commonparent");
@@ -1834,7 +1702,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyBufferToImage(
     uint32_t                                    regionCount,
     const VkBufferImageCopy*                    pRegions) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyBufferToImage-commandBuffer-parameter", "VUID-vkCmdCopyBufferToImage-commonparent");
     skip |= ValidateObject(commandBuffer, srcBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdCopyBufferToImage-srcBuffer-parameter", "VUID-vkCmdCopyBufferToImage-commonparent");
     skip |= ValidateObject(commandBuffer, dstImage, kVulkanObjectTypeImage, false, "VUID-vkCmdCopyBufferToImage-dstImage-parameter", "VUID-vkCmdCopyBufferToImage-commonparent");
@@ -1850,7 +1717,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyImageToBuffer(
     uint32_t                                    regionCount,
     const VkBufferImageCopy*                    pRegions) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyImageToBuffer-commandBuffer-parameter", "VUID-vkCmdCopyImageToBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, srcImage, kVulkanObjectTypeImage, false, "VUID-vkCmdCopyImageToBuffer-srcImage-parameter", "VUID-vkCmdCopyImageToBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdCopyImageToBuffer-dstBuffer-parameter", "VUID-vkCmdCopyImageToBuffer-commonparent");
@@ -1865,7 +1731,6 @@ bool ObjectLifetimes::PreCallValidateCmdUpdateBuffer(
     VkDeviceSize                                dataSize,
     const void*                                 pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdUpdateBuffer-commandBuffer-parameter", "VUID-vkCmdUpdateBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdUpdateBuffer-dstBuffer-parameter", "VUID-vkCmdUpdateBuffer-commonparent");
 
@@ -1879,7 +1744,6 @@ bool ObjectLifetimes::PreCallValidateCmdFillBuffer(
     VkDeviceSize                                size,
     uint32_t                                    data) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdFillBuffer-commandBuffer-parameter", "VUID-vkCmdFillBuffer-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdFillBuffer-dstBuffer-parameter", "VUID-vkCmdFillBuffer-commonparent");
 
@@ -1894,7 +1758,6 @@ bool ObjectLifetimes::PreCallValidateCmdClearColorImage(
     uint32_t                                    rangeCount,
     const VkImageSubresourceRange*              pRanges) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdClearColorImage-commandBuffer-parameter", "VUID-vkCmdClearColorImage-commonparent");
     skip |= ValidateObject(commandBuffer, image, kVulkanObjectTypeImage, false, "VUID-vkCmdClearColorImage-image-parameter", "VUID-vkCmdClearColorImage-commonparent");
 
@@ -1909,7 +1772,6 @@ bool ObjectLifetimes::PreCallValidateCmdClearDepthStencilImage(
     uint32_t                                    rangeCount,
     const VkImageSubresourceRange*              pRanges) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdClearDepthStencilImage-commandBuffer-parameter", "VUID-vkCmdClearDepthStencilImage-commonparent");
     skip |= ValidateObject(commandBuffer, image, kVulkanObjectTypeImage, false, "VUID-vkCmdClearDepthStencilImage-image-parameter", "VUID-vkCmdClearDepthStencilImage-commonparent");
 
@@ -1923,7 +1785,6 @@ bool ObjectLifetimes::PreCallValidateCmdClearAttachments(
     uint32_t                                    rectCount,
     const VkClearRect*                          pRects) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdClearAttachments-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -1938,7 +1799,6 @@ bool ObjectLifetimes::PreCallValidateCmdResolveImage(
     uint32_t                                    regionCount,
     const VkImageResolve*                       pRegions) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdResolveImage-commandBuffer-parameter", "VUID-vkCmdResolveImage-commonparent");
     skip |= ValidateObject(commandBuffer, srcImage, kVulkanObjectTypeImage, false, "VUID-vkCmdResolveImage-srcImage-parameter", "VUID-vkCmdResolveImage-commonparent");
     skip |= ValidateObject(commandBuffer, dstImage, kVulkanObjectTypeImage, false, "VUID-vkCmdResolveImage-dstImage-parameter", "VUID-vkCmdResolveImage-commonparent");
@@ -1951,7 +1811,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetEvent(
     VkEvent                                     event,
     VkPipelineStageFlags                        stageMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetEvent-commandBuffer-parameter", "VUID-vkCmdSetEvent-commonparent");
     skip |= ValidateObject(commandBuffer, event, kVulkanObjectTypeEvent, false, "VUID-vkCmdSetEvent-event-parameter", "VUID-vkCmdSetEvent-commonparent");
 
@@ -1963,7 +1822,6 @@ bool ObjectLifetimes::PreCallValidateCmdResetEvent(
     VkEvent                                     event,
     VkPipelineStageFlags                        stageMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdResetEvent-commandBuffer-parameter", "VUID-vkCmdResetEvent-commonparent");
     skip |= ValidateObject(commandBuffer, event, kVulkanObjectTypeEvent, false, "VUID-vkCmdResetEvent-event-parameter", "VUID-vkCmdResetEvent-commonparent");
 
@@ -1983,7 +1841,6 @@ bool ObjectLifetimes::PreCallValidateCmdWaitEvents(
     uint32_t                                    imageMemoryBarrierCount,
     const VkImageMemoryBarrier*                 pImageMemoryBarriers) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdWaitEvents-commandBuffer-parameter", "VUID-vkCmdWaitEvents-commonparent");
     if (pEvents) {
         for (uint32_t index0 = 0; index0 < eventCount; ++index0) {
@@ -2016,7 +1873,6 @@ bool ObjectLifetimes::PreCallValidateCmdPipelineBarrier(
     uint32_t                                    imageMemoryBarrierCount,
     const VkImageMemoryBarrier*                 pImageMemoryBarriers) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdPipelineBarrier-commandBuffer-parameter", kVUIDUndefined);
     if (pBufferMemoryBarriers) {
         for (uint32_t index0 = 0; index0 < bufferMemoryBarrierCount; ++index0) {
@@ -2038,7 +1894,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginQuery(
     uint32_t                                    query,
     VkQueryControlFlags                         flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginQuery-commandBuffer-parameter", "VUID-vkCmdBeginQuery-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdBeginQuery-queryPool-parameter", "VUID-vkCmdBeginQuery-commonparent");
 
@@ -2050,7 +1905,6 @@ bool ObjectLifetimes::PreCallValidateCmdEndQuery(
     VkQueryPool                                 queryPool,
     uint32_t                                    query) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndQuery-commandBuffer-parameter", "VUID-vkCmdEndQuery-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdEndQuery-queryPool-parameter", "VUID-vkCmdEndQuery-commonparent");
 
@@ -2063,7 +1917,6 @@ bool ObjectLifetimes::PreCallValidateCmdResetQueryPool(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdResetQueryPool-commandBuffer-parameter", "VUID-vkCmdResetQueryPool-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdResetQueryPool-queryPool-parameter", "VUID-vkCmdResetQueryPool-commonparent");
 
@@ -2076,7 +1929,6 @@ bool ObjectLifetimes::PreCallValidateCmdWriteTimestamp(
     VkQueryPool                                 queryPool,
     uint32_t                                    query) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdWriteTimestamp-commandBuffer-parameter", "VUID-vkCmdWriteTimestamp-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdWriteTimestamp-queryPool-parameter", "VUID-vkCmdWriteTimestamp-commonparent");
 
@@ -2093,7 +1945,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyQueryPoolResults(
     VkDeviceSize                                stride,
     VkQueryResultFlags                          flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyQueryPoolResults-commandBuffer-parameter", "VUID-vkCmdCopyQueryPoolResults-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdCopyQueryPoolResults-queryPool-parameter", "VUID-vkCmdCopyQueryPoolResults-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdCopyQueryPoolResults-dstBuffer-parameter", "VUID-vkCmdCopyQueryPoolResults-commonparent");
@@ -2109,7 +1960,6 @@ bool ObjectLifetimes::PreCallValidateCmdPushConstants(
     uint32_t                                    size,
     const void*                                 pValues) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdPushConstants-commandBuffer-parameter", "VUID-vkCmdPushConstants-commonparent");
     skip |= ValidateObject(commandBuffer, layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdPushConstants-layout-parameter", "VUID-vkCmdPushConstants-commonparent");
 
@@ -2121,7 +1971,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginRenderPass(
     const VkRenderPassBeginInfo*                pRenderPassBegin,
     VkSubpassContents                           contents) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginRenderPass-commandBuffer-parameter", kVUIDUndefined);
     if (pRenderPassBegin) {
         skip |= ValidateObject(commandBuffer, pRenderPassBegin->renderPass, kVulkanObjectTypeRenderPass, false, "VUID-VkRenderPassBeginInfo-renderPass-parameter", "VUID-VkRenderPassBeginInfo-commonparent");
@@ -2135,7 +1984,6 @@ bool ObjectLifetimes::PreCallValidateCmdNextSubpass(
     VkCommandBuffer                             commandBuffer,
     VkSubpassContents                           contents) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdNextSubpass-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -2144,7 +1992,6 @@ bool ObjectLifetimes::PreCallValidateCmdNextSubpass(
 bool ObjectLifetimes::PreCallValidateCmdEndRenderPass(
     VkCommandBuffer                             commandBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndRenderPass-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -2155,7 +2002,6 @@ bool ObjectLifetimes::PreCallValidateCmdExecuteCommands(
     uint32_t                                    commandBufferCount,
     const VkCommandBuffer*                      pCommandBuffers) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdExecuteCommands-commandBuffer-parameter", "VUID-vkCmdExecuteCommands-commonparent");
     if (pCommandBuffers) {
         for (uint32_t index0 = 0; index0 < commandBufferCount; ++index0) {
@@ -2171,7 +2017,6 @@ bool ObjectLifetimes::PreCallValidateBindBufferMemory2(
     uint32_t                                    bindInfoCount,
     const VkBindBufferMemoryInfo*               pBindInfos) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindBufferMemory2-device-parameter", kVUIDUndefined);
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -2188,7 +2033,6 @@ bool ObjectLifetimes::PreCallValidateBindImageMemory2(
     uint32_t                                    bindInfoCount,
     const VkBindImageMemoryInfo*                pBindInfos) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindImageMemory2-device-parameter", kVUIDUndefined);
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -2207,7 +2051,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceGroupPeerMemoryFeatures(
     uint32_t                                    remoteDeviceIndex,
     VkPeerMemoryFeatureFlags*                   pPeerMemoryFeatures) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceGroupPeerMemoryFeatures-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -2217,7 +2060,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetDeviceMask(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    deviceMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetDeviceMask-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -2232,7 +2074,6 @@ bool ObjectLifetimes::PreCallValidateCmdDispatchBase(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDispatchBase-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -2243,7 +2084,6 @@ bool ObjectLifetimes::PreCallValidateEnumeratePhysicalDeviceGroups(
     uint32_t*                                   pPhysicalDeviceGroupCount,
     VkPhysicalDeviceGroupProperties*            pPhysicalDeviceGroupProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkEnumeratePhysicalDeviceGroups-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -2254,7 +2094,6 @@ bool ObjectLifetimes::PreCallValidateGetImageMemoryRequirements2(
     const VkImageMemoryRequirementsInfo2*       pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->image, kVulkanObjectTypeImage, false, "VUID-VkImageMemoryRequirementsInfo2-image-parameter", kVUIDUndefined);
@@ -2268,7 +2107,6 @@ bool ObjectLifetimes::PreCallValidateGetBufferMemoryRequirements2(
     const VkBufferMemoryRequirementsInfo2*      pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetBufferMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->buffer, kVulkanObjectTypeBuffer, false, "VUID-VkBufferMemoryRequirementsInfo2-buffer-parameter", kVUIDUndefined);
@@ -2283,7 +2121,6 @@ bool ObjectLifetimes::PreCallValidateGetImageSparseMemoryRequirements2(
     uint32_t*                                   pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageSparseMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->image, kVulkanObjectTypeImage, false, "VUID-VkImageSparseMemoryRequirementsInfo2-image-parameter", kVUIDUndefined);
@@ -2296,7 +2133,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFeatures2(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceFeatures2*                  pFeatures) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFeatures2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2306,7 +2142,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceProperties2(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceProperties2*                pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2317,7 +2152,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFormatProperties2(
     VkFormat                                    format,
     VkFormatProperties2*                        pFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2328,7 +2162,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceImageFormatProperties2(
     const VkPhysicalDeviceImageFormatInfo2*     pImageFormatInfo,
     VkImageFormatProperties2*                   pImageFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceImageFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2338,7 +2171,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceMemoryProperties2(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceMemoryProperties2*          pMemoryProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceMemoryProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2350,7 +2182,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSparseImageFormatPropertie
     uint32_t*                                   pPropertyCount,
     VkSparseImageFormatProperties2*             pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2361,7 +2192,6 @@ bool ObjectLifetimes::PreCallValidateTrimCommandPool(
     VkCommandPool                               commandPool,
     VkCommandPoolTrimFlags                      flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkTrimCommandPool-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, commandPool, kVulkanObjectTypeCommandPool, false, "VUID-vkTrimCommandPool-commandPool-parameter", "VUID-vkTrimCommandPool-commandPool-parent");
 
@@ -2374,7 +2204,6 @@ bool ObjectLifetimes::PreCallValidateCreateSamplerYcbcrConversion(
     const VkAllocationCallbacks*                pAllocator,
     VkSamplerYcbcrConversion*                   pYcbcrConversion) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSamplerYcbcrConversion-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -2387,7 +2216,6 @@ void ObjectLifetimes::PostCallRecordCreateSamplerYcbcrConversion(
     VkSamplerYcbcrConversion*                   pYcbcrConversion,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pYcbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, pAllocator);
 
 }
@@ -2397,7 +2225,6 @@ bool ObjectLifetimes::PreCallValidateDestroySamplerYcbcrConversion(
     VkSamplerYcbcrConversion                    ycbcrConversion,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroySamplerYcbcrConversion-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, true, "VUID-vkDestroySamplerYcbcrConversion-ycbcrConversion-parameter", "VUID-vkDestroySamplerYcbcrConversion-ycbcrConversion-parent");
     skip |= ValidateDestroyObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -2409,7 +2236,6 @@ void ObjectLifetimes::PreCallRecordDestroySamplerYcbcrConversion(
     VkDevice                                    device,
     VkSamplerYcbcrConversion                    ycbcrConversion,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion);
 
 }
@@ -2420,7 +2246,6 @@ bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplate(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(device, pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, true, "VUID-VkDescriptorUpdateTemplateCreateInfo-descriptorSetLayout-parameter", "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
@@ -2437,7 +2262,6 @@ void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplate(
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator);
 
 }
@@ -2447,7 +2271,6 @@ bool ObjectLifetimes::PreCallValidateDestroyDescriptorUpdateTemplate(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, true, "VUID-vkDestroyDescriptorUpdateTemplate-descriptorUpdateTemplate-parameter", "VUID-vkDestroyDescriptorUpdateTemplate-descriptorUpdateTemplate-parent");
     skip |= ValidateDestroyObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator, "VUID-vkDestroyDescriptorUpdateTemplate-descriptorSetLayout-00356", "VUID-vkDestroyDescriptorUpdateTemplate-descriptorSetLayout-00357");
@@ -2459,7 +2282,6 @@ void ObjectLifetimes::PreCallRecordDestroyDescriptorUpdateTemplate(
     VkDevice                                    device,
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate);
 
 }
@@ -2470,7 +2292,6 @@ bool ObjectLifetimes::PreCallValidateUpdateDescriptorSetWithTemplate(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const void*                                 pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkUpdateDescriptorSetWithTemplate-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorSet, kVulkanObjectTypeDescriptorSet, false, "VUID-vkUpdateDescriptorSetWithTemplate-descriptorSet-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, false, "VUID-vkUpdateDescriptorSetWithTemplate-descriptorUpdateTemplate-parameter", "VUID-vkUpdateDescriptorSetWithTemplate-descriptorUpdateTemplate-parent");
@@ -2483,7 +2304,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalBufferProperties(
     const VkPhysicalDeviceExternalBufferInfo*   pExternalBufferInfo,
     VkExternalBufferProperties*                 pExternalBufferProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalBufferProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2494,7 +2314,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalFenceProperties(
     const VkPhysicalDeviceExternalFenceInfo*    pExternalFenceInfo,
     VkExternalFenceProperties*                  pExternalFenceProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalFenceProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2505,7 +2324,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalSemaphorePropertie
     const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties*              pExternalSemaphoreProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2516,7 +2334,6 @@ bool ObjectLifetimes::PreCallValidateDestroySurfaceKHR(
     VkSurfaceKHR                                surface,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkDestroySurfaceKHR-instance-parameter", kVUIDUndefined);
     skip |= ValidateObject(instance, surface, kVulkanObjectTypeSurfaceKHR, true, "VUID-vkDestroySurfaceKHR-surface-parameter", "VUID-vkDestroySurfaceKHR-surface-parent");
     skip |= ValidateDestroyObject(instance, surface, kVulkanObjectTypeSurfaceKHR, pAllocator, "VUID-vkDestroySurfaceKHR-surface-01267", "VUID-vkDestroySurfaceKHR-surface-01268");
@@ -2528,7 +2345,6 @@ void ObjectLifetimes::PreCallRecordDestroySurfaceKHR(
     VkInstance                                  instance,
     VkSurfaceKHR                                surface,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(instance, surface, kVulkanObjectTypeSurfaceKHR);
 
 }
@@ -2539,7 +2355,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceSupportKHR(
     VkSurfaceKHR                                surface,
     VkBool32*                                   pSupported) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-physicalDevice-parameter", "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-surface-parameter", "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-commonparent");
 
@@ -2551,7 +2366,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkSurfaceKHR                                surface,
     VkSurfaceCapabilitiesKHR*                   pSurfaceCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-physicalDevice-parameter", "VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-surface-parameter", "VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-commonparent");
 
@@ -2564,7 +2378,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(
     uint32_t*                                   pSurfaceFormatCount,
     VkSurfaceFormatKHR*                         pSurfaceFormats) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-physicalDevice-parameter", "VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-surface-parameter", "VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-commonparent");
 
@@ -2577,7 +2390,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfacePresentModesKHR(
     uint32_t*                                   pPresentModeCount,
     VkPresentModeKHR*                           pPresentModes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-physicalDevice-parameter", "VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-surface-parameter", "VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-commonparent");
 
@@ -2590,7 +2402,6 @@ bool ObjectLifetimes::PreCallValidateCreateSwapchainKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSwapchainKHR*                             pSwapchain) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSwapchainKHR-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(device, pCreateInfo->surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-VkSwapchainCreateInfoKHR-surface-parameter", "VUID-VkSwapchainCreateInfoKHR-commonparent");
@@ -2607,7 +2418,6 @@ void ObjectLifetimes::PostCallRecordCreateSwapchainKHR(
     VkSwapchainKHR*                             pSwapchain,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pSwapchain, kVulkanObjectTypeSwapchainKHR, pAllocator);
 
 }
@@ -2620,7 +2430,6 @@ bool ObjectLifetimes::PreCallValidateAcquireNextImageKHR(
     VkFence                                     fence,
     uint32_t*                                   pImageIndex) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkAcquireNextImageKHR-device-parameter", "VUID-vkAcquireNextImageKHR-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkAcquireNextImageKHR-swapchain-parameter", "VUID-vkAcquireNextImageKHR-commonparent");
     skip |= ValidateObject(device, semaphore, kVulkanObjectTypeSemaphore, true, "VUID-vkAcquireNextImageKHR-semaphore-parameter", "VUID-vkAcquireNextImageKHR-semaphore-parent");
@@ -2633,7 +2442,6 @@ bool ObjectLifetimes::PreCallValidateQueuePresentKHR(
     VkQueue                                     queue,
     const VkPresentInfoKHR*                     pPresentInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueuePresentKHR-queue-parameter", kVUIDUndefined);
     if (pPresentInfo) {
         if (pPresentInfo->pWaitSemaphores) {
@@ -2655,7 +2463,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice                                    device,
     VkDeviceGroupPresentCapabilitiesKHR*        pDeviceGroupPresentCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceGroupPresentCapabilitiesKHR-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -2666,7 +2473,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(
     VkSurfaceKHR                                surface,
     VkDeviceGroupPresentModeFlagsKHR*           pModes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceGroupSurfacePresentModesKHR-device-parameter", "VUID-vkGetDeviceGroupSurfacePresentModesKHR-commonparent");
     skip |= ValidateObject(device, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-parameter", "VUID-vkGetDeviceGroupSurfacePresentModesKHR-commonparent");
 
@@ -2679,7 +2485,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDevicePresentRectanglesKHR(
     uint32_t*                                   pRectCount,
     VkRect2D*                                   pRects) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDevicePresentRectanglesKHR-physicalDevice-parameter", "VUID-vkGetPhysicalDevicePresentRectanglesKHR-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDevicePresentRectanglesKHR-surface-parameter", "VUID-vkGetPhysicalDevicePresentRectanglesKHR-commonparent");
 
@@ -2691,7 +2496,6 @@ bool ObjectLifetimes::PreCallValidateAcquireNextImage2KHR(
     const VkAcquireNextImageInfoKHR*            pAcquireInfo,
     uint32_t*                                   pImageIndex) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkAcquireNextImage2KHR-device-parameter", kVUIDUndefined);
     if (pAcquireInfo) {
         skip |= ValidateObject(device, pAcquireInfo->swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-VkAcquireNextImageInfoKHR-swapchain-parameter", "VUID-VkAcquireNextImageInfoKHR-commonparent");
@@ -2707,7 +2511,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceDisplayPlanePropertiesKHR(
     uint32_t*                                   pPropertyCount,
     VkDisplayPlanePropertiesKHR*                pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceDisplayPlanePropertiesKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2719,7 +2522,6 @@ bool ObjectLifetimes::PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(
     uint32_t*                                   pDisplayCount,
     VkDisplayKHR*                               pDisplays) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetDisplayPlaneSupportedDisplaysKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2732,7 +2534,6 @@ void ObjectLifetimes::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(
     VkDisplayKHR*                               pDisplays,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     if (pDisplays) {
         for (uint32_t index = 0; index < *pDisplayCount; index++) {
             CreateObject(physicalDevice, pDisplays[index], kVulkanObjectTypeDisplayKHR, nullptr);
@@ -2748,7 +2549,6 @@ bool ObjectLifetimes::PreCallValidateCreateDisplayModeKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDisplayModeKHR*                           pMode) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkCreateDisplayModeKHR-physicalDevice-parameter", kVUIDUndefined);
     skip |= ValidateObject(physicalDevice, display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkCreateDisplayModeKHR-display-parameter", kVUIDUndefined);
 
@@ -2763,7 +2563,6 @@ void ObjectLifetimes::PostCallRecordCreateDisplayModeKHR(
     VkDisplayModeKHR*                           pMode,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(physicalDevice, *pMode, kVulkanObjectTypeDisplayModeKHR, pAllocator);
 
 }
@@ -2774,7 +2573,6 @@ bool ObjectLifetimes::PreCallValidateGetDisplayPlaneCapabilitiesKHR(
     uint32_t                                    planeIndex,
     VkDisplayPlaneCapabilitiesKHR*              pCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetDisplayPlaneCapabilitiesKHR-physicalDevice-parameter", kVUIDUndefined);
     skip |= ValidateObject(physicalDevice, mode, kVulkanObjectTypeDisplayModeKHR, false, "VUID-vkGetDisplayPlaneCapabilitiesKHR-mode-parameter", kVUIDUndefined);
 
@@ -2787,7 +2585,6 @@ bool ObjectLifetimes::PreCallValidateCreateDisplayPlaneSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateDisplayPlaneSurfaceKHR-instance-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(instance, pCreateInfo->displayMode, kVulkanObjectTypeDisplayModeKHR, false, "VUID-VkDisplaySurfaceCreateInfoKHR-displayMode-parameter", kVUIDUndefined);
@@ -2803,7 +2600,6 @@ void ObjectLifetimes::PostCallRecordCreateDisplayPlaneSurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -2815,7 +2611,6 @@ bool ObjectLifetimes::PreCallValidateCreateSharedSwapchainsKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSwapchainKHR*                             pSwapchains) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSharedSwapchainsKHR-device-parameter", kVUIDUndefined);
     if (pCreateInfos) {
         for (uint32_t index0 = 0; index0 < swapchainCount; ++index0) {
@@ -2835,7 +2630,6 @@ void ObjectLifetimes::PostCallRecordCreateSharedSwapchainsKHR(
     VkSwapchainKHR*                             pSwapchains,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     if (pSwapchains) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
             CreateObject(device, pSwapchains[index], kVulkanObjectTypeSwapchainKHR, pAllocator);
@@ -2852,7 +2646,6 @@ bool ObjectLifetimes::PreCallValidateCreateXlibSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateXlibSurfaceKHR-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -2865,7 +2658,6 @@ void ObjectLifetimes::PostCallRecordCreateXlibSurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -2879,7 +2671,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceXlibPresentationSupportKHR
     Display*                                    dpy,
     VisualID                                    visualID) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2894,7 +2685,6 @@ bool ObjectLifetimes::PreCallValidateCreateXcbSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateXcbSurfaceKHR-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -2907,7 +2697,6 @@ void ObjectLifetimes::PostCallRecordCreateXcbSurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -2921,7 +2710,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(
     xcb_connection_t*                           connection,
     xcb_visualid_t                              visual_id) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2936,7 +2724,6 @@ bool ObjectLifetimes::PreCallValidateCreateWaylandSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateWaylandSurfaceKHR-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -2949,7 +2736,6 @@ void ObjectLifetimes::PostCallRecordCreateWaylandSurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -2962,7 +2748,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceWaylandPresentationSupport
     uint32_t                                    queueFamilyIndex,
     struct wl_display*                          display) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -2977,7 +2762,6 @@ bool ObjectLifetimes::PreCallValidateCreateAndroidSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateAndroidSurfaceKHR-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -2990,7 +2774,6 @@ void ObjectLifetimes::PostCallRecordCreateAndroidSurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -3004,7 +2787,6 @@ bool ObjectLifetimes::PreCallValidateCreateWin32SurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateWin32SurfaceKHR-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -3017,7 +2799,6 @@ void ObjectLifetimes::PostCallRecordCreateWin32SurfaceKHR(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -3029,7 +2810,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceWin32PresentationSupportKH
     VkPhysicalDevice                            physicalDevice,
     uint32_t                                    queueFamilyIndex) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3040,7 +2820,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFeatures2KHR(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceFeatures2*                  pFeatures) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFeatures2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3050,7 +2829,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceProperties2KHR(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceProperties2*                pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3061,7 +2839,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceFormatProperties2KHR(
     VkFormat                                    format,
     VkFormatProperties2*                        pFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3072,7 +2849,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(
     const VkPhysicalDeviceImageFormatInfo2*     pImageFormatInfo,
     VkImageFormatProperties2*                   pImageFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceImageFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3082,7 +2858,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceMemoryProperties2KHR(
     VkPhysicalDevice                            physicalDevice,
     VkPhysicalDeviceMemoryProperties2*          pMemoryProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceMemoryProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3094,7 +2869,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSparseImageFormatPropertie
     uint32_t*                                   pPropertyCount,
     VkSparseImageFormatProperties2*             pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3107,7 +2881,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceGroupPeerMemoryFeaturesKHR(
     uint32_t                                    remoteDeviceIndex,
     VkPeerMemoryFeatureFlags*                   pPeerMemoryFeatures) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceGroupPeerMemoryFeatures-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3117,7 +2890,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetDeviceMaskKHR(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    deviceMask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetDeviceMask-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3132,7 +2904,6 @@ bool ObjectLifetimes::PreCallValidateCmdDispatchBaseKHR(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDispatchBase-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3143,7 +2914,6 @@ bool ObjectLifetimes::PreCallValidateTrimCommandPoolKHR(
     VkCommandPool                               commandPool,
     VkCommandPoolTrimFlags                      flags) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkTrimCommandPool-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, commandPool, kVulkanObjectTypeCommandPool, false, "VUID-vkTrimCommandPool-commandPool-parameter", "VUID-vkTrimCommandPool-commandPool-parent");
 
@@ -3155,7 +2925,6 @@ bool ObjectLifetimes::PreCallValidateEnumeratePhysicalDeviceGroupsKHR(
     uint32_t*                                   pPhysicalDeviceGroupCount,
     VkPhysicalDeviceGroupProperties*            pPhysicalDeviceGroupProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkEnumeratePhysicalDeviceGroups-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -3166,7 +2935,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalBufferPropertiesKH
     const VkPhysicalDeviceExternalBufferInfo*   pExternalBufferInfo,
     VkExternalBufferProperties*                 pExternalBufferProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalBufferProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3179,7 +2947,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryWin32HandleKHR(
     const VkMemoryGetWin32HandleInfoKHR*        pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryWin32HandleKHR-device-parameter", kVUIDUndefined);
     if (pGetWin32HandleInfo) {
         skip |= ValidateObject(device, pGetWin32HandleInfo->memory, kVulkanObjectTypeDeviceMemory, false, "VUID-VkMemoryGetWin32HandleInfoKHR-memory-parameter", kVUIDUndefined);
@@ -3197,7 +2964,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryWin32HandlePropertiesKHR(
     HANDLE                                      handle,
     VkMemoryWin32HandlePropertiesKHR*           pMemoryWin32HandleProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryWin32HandlePropertiesKHR-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3209,7 +2975,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryFdKHR(
     const VkMemoryGetFdInfoKHR*                 pGetFdInfo,
     int*                                        pFd) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryFdKHR-device-parameter", kVUIDUndefined);
     if (pGetFdInfo) {
         skip |= ValidateObject(device, pGetFdInfo->memory, kVulkanObjectTypeDeviceMemory, false, "VUID-VkMemoryGetFdInfoKHR-memory-parameter", kVUIDUndefined);
@@ -3224,7 +2989,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryFdPropertiesKHR(
     int                                         fd,
     VkMemoryFdPropertiesKHR*                    pMemoryFdProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryFdPropertiesKHR-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3235,7 +2999,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalSemaphorePropertie
     const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties*              pExternalSemaphoreProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3247,7 +3010,6 @@ bool ObjectLifetimes::PreCallValidateImportSemaphoreWin32HandleKHR(
     VkDevice                                    device,
     const VkImportSemaphoreWin32HandleInfoKHR*  pImportSemaphoreWin32HandleInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkImportSemaphoreWin32HandleKHR-device-parameter", kVUIDUndefined);
     if (pImportSemaphoreWin32HandleInfo) {
         skip |= ValidateObject(device, pImportSemaphoreWin32HandleInfo->semaphore, kVulkanObjectTypeSemaphore, false, "VUID-VkImportSemaphoreWin32HandleInfoKHR-semaphore-parameter", kVUIDUndefined);
@@ -3264,7 +3026,6 @@ bool ObjectLifetimes::PreCallValidateGetSemaphoreWin32HandleKHR(
     const VkSemaphoreGetWin32HandleInfoKHR*     pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetSemaphoreWin32HandleKHR-device-parameter", kVUIDUndefined);
     if (pGetWin32HandleInfo) {
         skip |= ValidateObject(device, pGetWin32HandleInfo->semaphore, kVulkanObjectTypeSemaphore, false, "VUID-VkSemaphoreGetWin32HandleInfoKHR-semaphore-parameter", kVUIDUndefined);
@@ -3278,7 +3039,6 @@ bool ObjectLifetimes::PreCallValidateImportSemaphoreFdKHR(
     VkDevice                                    device,
     const VkImportSemaphoreFdInfoKHR*           pImportSemaphoreFdInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkImportSemaphoreFdKHR-device-parameter", kVUIDUndefined);
     if (pImportSemaphoreFdInfo) {
         skip |= ValidateObject(device, pImportSemaphoreFdInfo->semaphore, kVulkanObjectTypeSemaphore, false, "VUID-VkImportSemaphoreFdInfoKHR-semaphore-parameter", kVUIDUndefined);
@@ -3292,7 +3052,6 @@ bool ObjectLifetimes::PreCallValidateGetSemaphoreFdKHR(
     const VkSemaphoreGetFdInfoKHR*              pGetFdInfo,
     int*                                        pFd) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetSemaphoreFdKHR-device-parameter", kVUIDUndefined);
     if (pGetFdInfo) {
         skip |= ValidateObject(device, pGetFdInfo->semaphore, kVulkanObjectTypeSemaphore, false, "VUID-VkSemaphoreGetFdInfoKHR-semaphore-parameter", kVUIDUndefined);
@@ -3308,7 +3067,6 @@ bool ObjectLifetimes::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(
     uint32_t                                    set,
     const void*                                 pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-parameter", "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commonparent");
     skip |= ValidateObject(commandBuffer, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, false, "VUID-vkCmdPushDescriptorSetWithTemplateKHR-descriptorUpdateTemplate-parameter", "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commonparent");
     skip |= ValidateObject(commandBuffer, layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdPushDescriptorSetWithTemplateKHR-layout-parameter", "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commonparent");
@@ -3322,7 +3080,6 @@ bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplateKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         skip |= ValidateObject(device, pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, true, "VUID-VkDescriptorUpdateTemplateCreateInfo-descriptorSetLayout-parameter", "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
@@ -3339,7 +3096,6 @@ void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplateKHR(
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator);
 
 }
@@ -3349,7 +3105,6 @@ bool ObjectLifetimes::PreCallValidateDestroyDescriptorUpdateTemplateKHR(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, true, "VUID-vkDestroyDescriptorUpdateTemplate-descriptorUpdateTemplate-parameter", "VUID-vkDestroyDescriptorUpdateTemplate-descriptorUpdateTemplate-parent");
     skip |= ValidateDestroyObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator, "VUID-vkDestroyDescriptorUpdateTemplate-descriptorSetLayout-00356", "VUID-vkDestroyDescriptorUpdateTemplate-descriptorSetLayout-00357");
@@ -3361,7 +3116,6 @@ void ObjectLifetimes::PreCallRecordDestroyDescriptorUpdateTemplateKHR(
     VkDevice                                    device,
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate);
 
 }
@@ -3372,7 +3126,6 @@ bool ObjectLifetimes::PreCallValidateUpdateDescriptorSetWithTemplateKHR(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const void*                                 pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkUpdateDescriptorSetWithTemplate-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorSet, kVulkanObjectTypeDescriptorSet, false, "VUID-vkUpdateDescriptorSetWithTemplate-descriptorSet-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, descriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, false, "VUID-vkUpdateDescriptorSetWithTemplate-descriptorUpdateTemplate-parameter", "VUID-vkUpdateDescriptorSetWithTemplate-descriptorUpdateTemplate-parent");
@@ -3386,7 +3139,6 @@ bool ObjectLifetimes::PreCallValidateCreateRenderPass2KHR(
     const VkAllocationCallbacks*                pAllocator,
     VkRenderPass*                               pRenderPass) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRenderPass2KHR-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3399,7 +3151,6 @@ void ObjectLifetimes::PostCallRecordCreateRenderPass2KHR(
     VkRenderPass*                               pRenderPass,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pRenderPass, kVulkanObjectTypeRenderPass, pAllocator);
 
 }
@@ -3409,7 +3160,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginRenderPass2KHR(
     const VkRenderPassBeginInfo*                pRenderPassBegin,
     const VkSubpassBeginInfoKHR*                pSubpassBeginInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginRenderPass2KHR-commandBuffer-parameter", kVUIDUndefined);
     if (pRenderPassBegin) {
         skip |= ValidateObject(commandBuffer, pRenderPassBegin->renderPass, kVulkanObjectTypeRenderPass, false, "VUID-VkRenderPassBeginInfo-renderPass-parameter", "VUID-VkRenderPassBeginInfo-commonparent");
@@ -3424,7 +3174,6 @@ bool ObjectLifetimes::PreCallValidateCmdNextSubpass2KHR(
     const VkSubpassBeginInfoKHR*                pSubpassBeginInfo,
     const VkSubpassEndInfoKHR*                  pSubpassEndInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdNextSubpass2KHR-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3434,7 +3183,6 @@ bool ObjectLifetimes::PreCallValidateCmdEndRenderPass2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkSubpassEndInfoKHR*                  pSubpassEndInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndRenderPass2KHR-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3444,7 +3192,6 @@ bool ObjectLifetimes::PreCallValidateGetSwapchainStatusKHR(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetSwapchainStatusKHR-device-parameter", "VUID-vkGetSwapchainStatusKHR-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkGetSwapchainStatusKHR-swapchain-parameter", "VUID-vkGetSwapchainStatusKHR-commonparent");
 
@@ -3456,7 +3203,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalFencePropertiesKHR
     const VkPhysicalDeviceExternalFenceInfo*    pExternalFenceInfo,
     VkExternalFenceProperties*                  pExternalFenceProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalFenceProperties-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3468,7 +3214,6 @@ bool ObjectLifetimes::PreCallValidateImportFenceWin32HandleKHR(
     VkDevice                                    device,
     const VkImportFenceWin32HandleInfoKHR*      pImportFenceWin32HandleInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkImportFenceWin32HandleKHR-device-parameter", kVUIDUndefined);
     if (pImportFenceWin32HandleInfo) {
         skip |= ValidateObject(device, pImportFenceWin32HandleInfo->fence, kVulkanObjectTypeFence, false, "VUID-VkImportFenceWin32HandleInfoKHR-fence-parameter", kVUIDUndefined);
@@ -3485,7 +3230,6 @@ bool ObjectLifetimes::PreCallValidateGetFenceWin32HandleKHR(
     const VkFenceGetWin32HandleInfoKHR*         pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetFenceWin32HandleKHR-device-parameter", kVUIDUndefined);
     if (pGetWin32HandleInfo) {
         skip |= ValidateObject(device, pGetWin32HandleInfo->fence, kVulkanObjectTypeFence, false, "VUID-VkFenceGetWin32HandleInfoKHR-fence-parameter", kVUIDUndefined);
@@ -3499,7 +3243,6 @@ bool ObjectLifetimes::PreCallValidateImportFenceFdKHR(
     VkDevice                                    device,
     const VkImportFenceFdInfoKHR*               pImportFenceFdInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkImportFenceFdKHR-device-parameter", kVUIDUndefined);
     if (pImportFenceFdInfo) {
         skip |= ValidateObject(device, pImportFenceFdInfo->fence, kVulkanObjectTypeFence, false, "VUID-VkImportFenceFdInfoKHR-fence-parameter", kVUIDUndefined);
@@ -3513,7 +3256,6 @@ bool ObjectLifetimes::PreCallValidateGetFenceFdKHR(
     const VkFenceGetFdInfoKHR*                  pGetFdInfo,
     int*                                        pFd) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetFenceFdKHR-device-parameter", kVUIDUndefined);
     if (pGetFdInfo) {
         skip |= ValidateObject(device, pGetFdInfo->fence, kVulkanObjectTypeFence, false, "VUID-VkFenceGetFdInfoKHR-fence-parameter", kVUIDUndefined);
@@ -3527,7 +3269,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(
     const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
     VkSurfaceCapabilities2KHR*                  pSurfaceCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-physicalDevice-parameter", kVUIDUndefined);
     if (pSurfaceInfo) {
         skip |= ValidateObject(physicalDevice, pSurfaceInfo->surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-VkPhysicalDeviceSurfaceInfo2KHR-surface-parameter", kVUIDUndefined);
@@ -3542,7 +3283,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(
     uint32_t*                                   pSurfaceFormatCount,
     VkSurfaceFormat2KHR*                        pSurfaceFormats) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-physicalDevice-parameter", kVUIDUndefined);
     if (pSurfaceInfo) {
         skip |= ValidateObject(physicalDevice, pSurfaceInfo->surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-VkPhysicalDeviceSurfaceInfo2KHR-surface-parameter", kVUIDUndefined);
@@ -3556,7 +3296,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceDisplayPlaneProperties2KHR
     uint32_t*                                   pPropertyCount,
     VkDisplayPlaneProperties2KHR*               pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -3567,7 +3306,6 @@ bool ObjectLifetimes::PreCallValidateGetDisplayPlaneCapabilities2KHR(
     const VkDisplayPlaneInfo2KHR*               pDisplayPlaneInfo,
     VkDisplayPlaneCapabilities2KHR*             pCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetDisplayPlaneCapabilities2KHR-physicalDevice-parameter", kVUIDUndefined);
     if (pDisplayPlaneInfo) {
         skip |= ValidateObject(physicalDevice, pDisplayPlaneInfo->mode, kVulkanObjectTypeDisplayModeKHR, false, "VUID-VkDisplayPlaneInfo2KHR-mode-parameter", kVUIDUndefined);
@@ -3581,7 +3319,6 @@ bool ObjectLifetimes::PreCallValidateGetImageMemoryRequirements2KHR(
     const VkImageMemoryRequirementsInfo2*       pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->image, kVulkanObjectTypeImage, false, "VUID-VkImageMemoryRequirementsInfo2-image-parameter", kVUIDUndefined);
@@ -3595,7 +3332,6 @@ bool ObjectLifetimes::PreCallValidateGetBufferMemoryRequirements2KHR(
     const VkBufferMemoryRequirementsInfo2*      pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetBufferMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->buffer, kVulkanObjectTypeBuffer, false, "VUID-VkBufferMemoryRequirementsInfo2-buffer-parameter", kVUIDUndefined);
@@ -3610,7 +3346,6 @@ bool ObjectLifetimes::PreCallValidateGetImageSparseMemoryRequirements2KHR(
     uint32_t*                                   pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageSparseMemoryRequirements2-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->image, kVulkanObjectTypeImage, false, "VUID-VkImageSparseMemoryRequirementsInfo2-image-parameter", kVUIDUndefined);
@@ -3625,7 +3360,6 @@ bool ObjectLifetimes::PreCallValidateCreateSamplerYcbcrConversionKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSamplerYcbcrConversion*                   pYcbcrConversion) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateSamplerYcbcrConversion-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3638,7 +3372,6 @@ void ObjectLifetimes::PostCallRecordCreateSamplerYcbcrConversionKHR(
     VkSamplerYcbcrConversion*                   pYcbcrConversion,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pYcbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, pAllocator);
 
 }
@@ -3648,7 +3381,6 @@ bool ObjectLifetimes::PreCallValidateDestroySamplerYcbcrConversionKHR(
     VkSamplerYcbcrConversion                    ycbcrConversion,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroySamplerYcbcrConversion-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, true, "VUID-vkDestroySamplerYcbcrConversion-ycbcrConversion-parameter", "VUID-vkDestroySamplerYcbcrConversion-ycbcrConversion-parent");
     skip |= ValidateDestroyObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -3660,7 +3392,6 @@ void ObjectLifetimes::PreCallRecordDestroySamplerYcbcrConversionKHR(
     VkDevice                                    device,
     VkSamplerYcbcrConversion                    ycbcrConversion,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, ycbcrConversion, kVulkanObjectTypeSamplerYcbcrConversion);
 
 }
@@ -3670,7 +3401,6 @@ bool ObjectLifetimes::PreCallValidateBindBufferMemory2KHR(
     uint32_t                                    bindInfoCount,
     const VkBindBufferMemoryInfo*               pBindInfos) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindBufferMemory2-device-parameter", kVUIDUndefined);
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -3687,7 +3417,6 @@ bool ObjectLifetimes::PreCallValidateBindImageMemory2KHR(
     uint32_t                                    bindInfoCount,
     const VkBindImageMemoryInfo*                pBindInfos) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindImageMemory2-device-parameter", kVUIDUndefined);
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -3708,7 +3437,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-commandBuffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-buffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, countBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-countBuffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
@@ -3725,7 +3453,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndexedIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-commandBuffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-buffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, countBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-countBuffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
@@ -3739,7 +3466,6 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutablePropertiesKHR(
     uint32_t*                                   pExecutableCount,
     VkPipelineExecutablePropertiesKHR*          pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPipelineExecutablePropertiesKHR-device-parameter", kVUIDUndefined);
     if (pPipelineInfo) {
         skip |= ValidateObject(device, pPipelineInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineInfoKHR-pipeline-parameter", kVUIDUndefined);
@@ -3754,7 +3480,6 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutableStatisticsKHR(
     uint32_t*                                   pStatisticCount,
     VkPipelineExecutableStatisticKHR*           pStatistics) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPipelineExecutableStatisticsKHR-device-parameter", kVUIDUndefined);
     if (pExecutableInfo) {
         skip |= ValidateObject(device, pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter", kVUIDUndefined);
@@ -3769,7 +3494,6 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutableInternalRepresentation
     uint32_t*                                   pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-device-parameter", kVUIDUndefined);
     if (pExecutableInfo) {
         skip |= ValidateObject(device, pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter", kVUIDUndefined);
@@ -3784,7 +3508,6 @@ bool ObjectLifetimes::PreCallValidateCreateDebugReportCallbackEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkDebugReportCallbackEXT*                   pCallback) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateDebugReportCallbackEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -3797,7 +3520,6 @@ void ObjectLifetimes::PostCallRecordCreateDebugReportCallbackEXT(
     VkDebugReportCallbackEXT*                   pCallback,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pCallback, kVulkanObjectTypeDebugReportCallbackEXT, pAllocator);
 
 }
@@ -3807,7 +3529,6 @@ bool ObjectLifetimes::PreCallValidateDestroyDebugReportCallbackEXT(
     VkDebugReportCallbackEXT                    callback,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkDestroyDebugReportCallbackEXT-instance-parameter", kVUIDUndefined);
     skip |= ValidateObject(instance, callback, kVulkanObjectTypeDebugReportCallbackEXT, false, "VUID-vkDestroyDebugReportCallbackEXT-callback-parameter", "VUID-vkDestroyDebugReportCallbackEXT-callback-parent");
     skip |= ValidateDestroyObject(instance, callback, kVulkanObjectTypeDebugReportCallbackEXT, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -3819,7 +3540,6 @@ void ObjectLifetimes::PreCallRecordDestroyDebugReportCallbackEXT(
     VkInstance                                  instance,
     VkDebugReportCallbackEXT                    callback,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(instance, callback, kVulkanObjectTypeDebugReportCallbackEXT);
 
 }
@@ -3834,7 +3554,6 @@ bool ObjectLifetimes::PreCallValidateDebugReportMessageEXT(
     const char*                                 pLayerPrefix,
     const char*                                 pMessage) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkDebugReportMessageEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -3844,7 +3563,6 @@ bool ObjectLifetimes::PreCallValidateDebugMarkerSetObjectTagEXT(
     VkDevice                                    device,
     const VkDebugMarkerObjectTagInfoEXT*        pTagInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDebugMarkerSetObjectTagEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3854,7 +3572,6 @@ bool ObjectLifetimes::PreCallValidateDebugMarkerSetObjectNameEXT(
     VkDevice                                    device,
     const VkDebugMarkerObjectNameInfoEXT*       pNameInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDebugMarkerSetObjectNameEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -3864,7 +3581,6 @@ bool ObjectLifetimes::PreCallValidateCmdDebugMarkerBeginEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDebugMarkerBeginEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3873,7 +3589,6 @@ bool ObjectLifetimes::PreCallValidateCmdDebugMarkerBeginEXT(
 bool ObjectLifetimes::PreCallValidateCmdDebugMarkerEndEXT(
     VkCommandBuffer                             commandBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDebugMarkerEndEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3883,7 +3598,6 @@ bool ObjectLifetimes::PreCallValidateCmdDebugMarkerInsertEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDebugMarkerInsertEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -3897,7 +3611,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindTransformFeedbackBuffersEXT(
     const VkDeviceSize*                         pOffsets,
     const VkDeviceSize*                         pSizes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindTransformFeedbackBuffersEXT-commandBuffer-parameter", "VUID-vkCmdBindTransformFeedbackBuffersEXT-commonparent");
     if (pBuffers) {
         for (uint32_t index0 = 0; index0 < bindingCount; ++index0) {
@@ -3915,7 +3628,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginTransformFeedbackEXT(
     const VkBuffer*                             pCounterBuffers,
     const VkDeviceSize*                         pCounterBufferOffsets) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginTransformFeedbackEXT-commandBuffer-parameter", "VUID-vkCmdBeginTransformFeedbackEXT-commonparent");
     if (pCounterBuffers) {
         for (uint32_t index0 = 0; index0 < counterBufferCount; ++index0) {
@@ -3933,7 +3645,6 @@ bool ObjectLifetimes::PreCallValidateCmdEndTransformFeedbackEXT(
     const VkBuffer*                             pCounterBuffers,
     const VkDeviceSize*                         pCounterBufferOffsets) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndTransformFeedbackEXT-commandBuffer-parameter", "VUID-vkCmdEndTransformFeedbackEXT-commonparent");
     if (pCounterBuffers) {
         for (uint32_t index0 = 0; index0 < counterBufferCount; ++index0) {
@@ -3951,7 +3662,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginQueryIndexedEXT(
     VkQueryControlFlags                         flags,
     uint32_t                                    index) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginQueryIndexedEXT-commandBuffer-parameter", "VUID-vkCmdBeginQueryIndexedEXT-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdBeginQueryIndexedEXT-queryPool-parameter", "VUID-vkCmdBeginQueryIndexedEXT-commonparent");
 
@@ -3964,7 +3674,6 @@ bool ObjectLifetimes::PreCallValidateCmdEndQueryIndexedEXT(
     uint32_t                                    query,
     uint32_t                                    index) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndQueryIndexedEXT-commandBuffer-parameter", "VUID-vkCmdEndQueryIndexedEXT-commonparent");
     skip |= ValidateObject(commandBuffer, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkCmdEndQueryIndexedEXT-queryPool-parameter", "VUID-vkCmdEndQueryIndexedEXT-commonparent");
 
@@ -3980,7 +3689,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndirectByteCountEXT(
     uint32_t                                    counterOffset,
     uint32_t                                    vertexStride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-parameter", "VUID-vkCmdDrawIndirectByteCountEXT-commonparent");
     skip |= ValidateObject(commandBuffer, counterBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirectByteCountEXT-counterBuffer-parameter", "VUID-vkCmdDrawIndirectByteCountEXT-commonparent");
 
@@ -3991,7 +3699,6 @@ bool ObjectLifetimes::PreCallValidateGetImageViewHandleNVX(
     VkDevice                                    device,
     const VkImageViewHandleInfoNVX*             pInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageViewHandleNVX-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4006,7 +3713,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-commandBuffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-buffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, countBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndirectCountKHR-countBuffer-parameter", "VUID-vkCmdDrawIndirectCountKHR-commonparent");
@@ -4023,7 +3729,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawIndexedIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-commandBuffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-buffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
     skip |= ValidateObject(commandBuffer, countBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawIndexedIndirectCountKHR-countBuffer-parameter", "VUID-vkCmdDrawIndexedIndirectCountKHR-commonparent");
@@ -4039,7 +3744,6 @@ bool ObjectLifetimes::PreCallValidateGetShaderInfoAMD(
     size_t*                                     pInfoSize,
     void*                                       pInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetShaderInfoAMD-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipeline, kVulkanObjectTypePipeline, false, "VUID-vkGetShaderInfoAMD-pipeline-parameter", "VUID-vkGetShaderInfoAMD-pipeline-parent");
 
@@ -4054,7 +3758,6 @@ bool ObjectLifetimes::PreCallValidateCreateStreamDescriptorSurfaceGGP(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateStreamDescriptorSurfaceGGP-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4067,7 +3770,6 @@ void ObjectLifetimes::PostCallRecordCreateStreamDescriptorSurfaceGGP(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -4083,7 +3785,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceExternalImageFormatPropert
     VkExternalMemoryHandleTypeFlagsNV           externalHandleType,
     VkExternalImageFormatPropertiesNV*          pExternalImageFormatProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceExternalImageFormatPropertiesNV-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -4097,7 +3798,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryWin32HandleNV(
     VkExternalMemoryHandleTypeFlagsNV           handleType,
     HANDLE*                                     pHandle) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryWin32HandleNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, memory, kVulkanObjectTypeDeviceMemory, false, "VUID-vkGetMemoryWin32HandleNV-memory-parameter", "VUID-vkGetMemoryWin32HandleNV-memory-parent");
 
@@ -4113,7 +3813,6 @@ bool ObjectLifetimes::PreCallValidateCreateViSurfaceNN(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateViSurfaceNN-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4126,7 +3825,6 @@ void ObjectLifetimes::PostCallRecordCreateViSurfaceNN(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -4136,7 +3834,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer,
     const VkConditionalRenderingBeginInfoEXT*   pConditionalRenderingBegin) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginConditionalRenderingEXT-commandBuffer-parameter", kVUIDUndefined);
     if (pConditionalRenderingBegin) {
         skip |= ValidateObject(commandBuffer, pConditionalRenderingBegin->buffer, kVulkanObjectTypeBuffer, false, "VUID-VkConditionalRenderingBeginInfoEXT-buffer-parameter", kVUIDUndefined);
@@ -4148,7 +3845,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginConditionalRenderingEXT(
 bool ObjectLifetimes::PreCallValidateCmdEndConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndConditionalRenderingEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4158,7 +3854,6 @@ bool ObjectLifetimes::PreCallValidateCmdProcessCommandsNVX(
     VkCommandBuffer                             commandBuffer,
     const VkCmdProcessCommandsInfoNVX*          pProcessCommandsInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdProcessCommandsNVX-commandBuffer-parameter", kVUIDUndefined);
     if (pProcessCommandsInfo) {
         skip |= ValidateObject(commandBuffer, pProcessCommandsInfo->objectTable, kVulkanObjectTypeObjectTableNVX, false, "VUID-VkCmdProcessCommandsInfoNVX-objectTable-parameter", "VUID-VkCmdProcessCommandsInfoNVX-commonparent");
@@ -4180,7 +3875,6 @@ bool ObjectLifetimes::PreCallValidateCmdReserveSpaceForCommandsNVX(
     VkCommandBuffer                             commandBuffer,
     const VkCmdReserveSpaceForCommandsInfoNVX*  pReserveSpaceInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdReserveSpaceForCommandsNVX-commandBuffer-parameter", kVUIDUndefined);
     if (pReserveSpaceInfo) {
         skip |= ValidateObject(commandBuffer, pReserveSpaceInfo->objectTable, kVulkanObjectTypeObjectTableNVX, false, "VUID-VkCmdReserveSpaceForCommandsInfoNVX-objectTable-parameter", "VUID-VkCmdReserveSpaceForCommandsInfoNVX-commonparent");
@@ -4196,7 +3890,6 @@ bool ObjectLifetimes::PreCallValidateCreateIndirectCommandsLayoutNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkIndirectCommandsLayoutNVX*                pIndirectCommandsLayout) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateIndirectCommandsLayoutNVX-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4209,7 +3902,6 @@ void ObjectLifetimes::PostCallRecordCreateIndirectCommandsLayoutNVX(
     VkIndirectCommandsLayoutNVX*                pIndirectCommandsLayout,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pIndirectCommandsLayout, kVulkanObjectTypeIndirectCommandsLayoutNVX, pAllocator);
 
 }
@@ -4219,7 +3911,6 @@ bool ObjectLifetimes::PreCallValidateDestroyIndirectCommandsLayoutNVX(
     VkIndirectCommandsLayoutNVX                 indirectCommandsLayout,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyIndirectCommandsLayoutNVX-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, indirectCommandsLayout, kVulkanObjectTypeIndirectCommandsLayoutNVX, false, "VUID-vkDestroyIndirectCommandsLayoutNVX-indirectCommandsLayout-parameter", "VUID-vkDestroyIndirectCommandsLayoutNVX-indirectCommandsLayout-parent");
     skip |= ValidateDestroyObject(device, indirectCommandsLayout, kVulkanObjectTypeIndirectCommandsLayoutNVX, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -4231,7 +3922,6 @@ void ObjectLifetimes::PreCallRecordDestroyIndirectCommandsLayoutNVX(
     VkDevice                                    device,
     VkIndirectCommandsLayoutNVX                 indirectCommandsLayout,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, indirectCommandsLayout, kVulkanObjectTypeIndirectCommandsLayoutNVX);
 
 }
@@ -4242,7 +3932,6 @@ bool ObjectLifetimes::PreCallValidateCreateObjectTableNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkObjectTableNVX*                           pObjectTable) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateObjectTableNVX-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4255,7 +3944,6 @@ void ObjectLifetimes::PostCallRecordCreateObjectTableNVX(
     VkObjectTableNVX*                           pObjectTable,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pObjectTable, kVulkanObjectTypeObjectTableNVX, pAllocator);
 
 }
@@ -4265,7 +3953,6 @@ bool ObjectLifetimes::PreCallValidateDestroyObjectTableNVX(
     VkObjectTableNVX                            objectTable,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyObjectTableNVX-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, objectTable, kVulkanObjectTypeObjectTableNVX, false, "VUID-vkDestroyObjectTableNVX-objectTable-parameter", "VUID-vkDestroyObjectTableNVX-objectTable-parent");
     skip |= ValidateDestroyObject(device, objectTable, kVulkanObjectTypeObjectTableNVX, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -4277,7 +3964,6 @@ void ObjectLifetimes::PreCallRecordDestroyObjectTableNVX(
     VkDevice                                    device,
     VkObjectTableNVX                            objectTable,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, objectTable, kVulkanObjectTypeObjectTableNVX);
 
 }
@@ -4289,7 +3975,6 @@ bool ObjectLifetimes::PreCallValidateRegisterObjectsNVX(
     const VkObjectTableEntryNVX* const*         ppObjectTableEntries,
     const uint32_t*                             pObjectIndices) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkRegisterObjectsNVX-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, objectTable, kVulkanObjectTypeObjectTableNVX, false, "VUID-vkRegisterObjectsNVX-objectTable-parameter", "VUID-vkRegisterObjectsNVX-objectTable-parent");
 
@@ -4303,7 +3988,6 @@ bool ObjectLifetimes::PreCallValidateUnregisterObjectsNVX(
     const VkObjectEntryTypeNVX*                 pObjectEntryTypes,
     const uint32_t*                             pObjectIndices) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkUnregisterObjectsNVX-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, objectTable, kVulkanObjectTypeObjectTableNVX, false, "VUID-vkUnregisterObjectsNVX-objectTable-parameter", "VUID-vkUnregisterObjectsNVX-objectTable-parent");
 
@@ -4315,7 +3999,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceGeneratedCommandsPropertie
     VkDeviceGeneratedCommandsFeaturesNVX*       pFeatures,
     VkDeviceGeneratedCommandsLimitsNVX*         pLimits) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -4327,7 +4010,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetViewportWScalingNV(
     uint32_t                                    viewportCount,
     const VkViewportWScalingNV*                 pViewportWScalings) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetViewportWScalingNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4337,7 +4019,6 @@ bool ObjectLifetimes::PreCallValidateReleaseDisplayEXT(
     VkPhysicalDevice                            physicalDevice,
     VkDisplayKHR                                display) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkReleaseDisplayEXT-physicalDevice-parameter", kVUIDUndefined);
     skip |= ValidateObject(physicalDevice, display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkReleaseDisplayEXT-display-parameter", kVUIDUndefined);
 
@@ -4351,7 +4032,6 @@ bool ObjectLifetimes::PreCallValidateAcquireXlibDisplayEXT(
     Display*                                    dpy,
     VkDisplayKHR                                display) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkAcquireXlibDisplayEXT-physicalDevice-parameter", kVUIDUndefined);
     skip |= ValidateObject(physicalDevice, display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkAcquireXlibDisplayEXT-display-parameter", kVUIDUndefined);
 
@@ -4367,7 +4047,6 @@ bool ObjectLifetimes::PreCallValidateGetRandROutputDisplayEXT(
     RROutput                                    rrOutput,
     VkDisplayKHR*                               pDisplay) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetRandROutputDisplayEXT-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -4380,7 +4059,6 @@ void ObjectLifetimes::PostCallRecordGetRandROutputDisplayEXT(
     VkDisplayKHR*                               pDisplay,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(physicalDevice, *pDisplay, kVulkanObjectTypeDisplayKHR, nullptr);
 
 }
@@ -4391,7 +4069,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2EXT(
     VkSurfaceKHR                                surface,
     VkSurfaceCapabilities2EXT*                  pSurfaceCapabilities) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-physicalDevice-parameter", "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-commonparent");
     skip |= ValidateObject(physicalDevice, surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-surface-parameter", "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-commonparent");
 
@@ -4403,7 +4080,6 @@ bool ObjectLifetimes::PreCallValidateDisplayPowerControlEXT(
     VkDisplayKHR                                display,
     const VkDisplayPowerInfoEXT*                pDisplayPowerInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDisplayPowerControlEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkDisplayPowerControlEXT-display-parameter", kVUIDUndefined);
 
@@ -4416,7 +4092,6 @@ bool ObjectLifetimes::PreCallValidateRegisterDeviceEventEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkRegisterDeviceEventEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4429,7 +4104,6 @@ void ObjectLifetimes::PostCallRecordRegisterDeviceEventEXT(
     VkFence*                                    pFence,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pFence, kVulkanObjectTypeFence, pAllocator);
 
 }
@@ -4441,7 +4115,6 @@ bool ObjectLifetimes::PreCallValidateRegisterDisplayEventEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkRegisterDisplayEventEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkRegisterDisplayEventEXT-display-parameter", kVUIDUndefined);
 
@@ -4456,7 +4129,6 @@ void ObjectLifetimes::PostCallRecordRegisterDisplayEventEXT(
     VkFence*                                    pFence,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pFence, kVulkanObjectTypeFence, pAllocator);
 
 }
@@ -4467,7 +4139,6 @@ bool ObjectLifetimes::PreCallValidateGetSwapchainCounterEXT(
     VkSurfaceCounterFlagBitsEXT                 counter,
     uint64_t*                                   pCounterValue) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetSwapchainCounterEXT-device-parameter", "VUID-vkGetSwapchainCounterEXT-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkGetSwapchainCounterEXT-swapchain-parameter", "VUID-vkGetSwapchainCounterEXT-commonparent");
 
@@ -4479,7 +4150,6 @@ bool ObjectLifetimes::PreCallValidateGetRefreshCycleDurationGOOGLE(
     VkSwapchainKHR                              swapchain,
     VkRefreshCycleDurationGOOGLE*               pDisplayTimingProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetRefreshCycleDurationGOOGLE-device-parameter", "VUID-vkGetRefreshCycleDurationGOOGLE-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkGetRefreshCycleDurationGOOGLE-swapchain-parameter", "VUID-vkGetRefreshCycleDurationGOOGLE-commonparent");
 
@@ -4492,7 +4162,6 @@ bool ObjectLifetimes::PreCallValidateGetPastPresentationTimingGOOGLE(
     uint32_t*                                   pPresentationTimingCount,
     VkPastPresentationTimingGOOGLE*             pPresentationTimings) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPastPresentationTimingGOOGLE-device-parameter", "VUID-vkGetPastPresentationTimingGOOGLE-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkGetPastPresentationTimingGOOGLE-swapchain-parameter", "VUID-vkGetPastPresentationTimingGOOGLE-commonparent");
 
@@ -4505,7 +4174,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetDiscardRectangleEXT(
     uint32_t                                    discardRectangleCount,
     const VkRect2D*                             pDiscardRectangles) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetDiscardRectangleEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4517,7 +4185,6 @@ bool ObjectLifetimes::PreCallValidateSetHdrMetadataEXT(
     const VkSwapchainKHR*                       pSwapchains,
     const VkHdrMetadataEXT*                     pMetadata) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkSetHdrMetadataEXT-device-parameter", "VUID-vkSetHdrMetadataEXT-commonparent");
     if (pSwapchains) {
         for (uint32_t index0 = 0; index0 < swapchainCount; ++index0) {
@@ -4536,7 +4203,6 @@ bool ObjectLifetimes::PreCallValidateCreateIOSSurfaceMVK(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateIOSSurfaceMVK-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4549,7 +4215,6 @@ void ObjectLifetimes::PostCallRecordCreateIOSSurfaceMVK(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -4563,7 +4228,6 @@ bool ObjectLifetimes::PreCallValidateCreateMacOSSurfaceMVK(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateMacOSSurfaceMVK-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4576,7 +4240,6 @@ void ObjectLifetimes::PostCallRecordCreateMacOSSurfaceMVK(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -4586,7 +4249,6 @@ bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectNameEXT(
     VkDevice                                    device,
     const VkDebugUtilsObjectNameInfoEXT*        pNameInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkSetDebugUtilsObjectNameEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4596,7 +4258,6 @@ bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectTagEXT(
     VkDevice                                    device,
     const VkDebugUtilsObjectTagInfoEXT*         pTagInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkSetDebugUtilsObjectTagEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4606,7 +4267,6 @@ bool ObjectLifetimes::PreCallValidateQueueBeginDebugUtilsLabelEXT(
     VkQueue                                     queue,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueBeginDebugUtilsLabelEXT-queue-parameter", kVUIDUndefined);
 
     return skip;
@@ -4615,7 +4275,6 @@ bool ObjectLifetimes::PreCallValidateQueueBeginDebugUtilsLabelEXT(
 bool ObjectLifetimes::PreCallValidateQueueEndDebugUtilsLabelEXT(
     VkQueue                                     queue) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueEndDebugUtilsLabelEXT-queue-parameter", kVUIDUndefined);
 
     return skip;
@@ -4625,7 +4284,6 @@ bool ObjectLifetimes::PreCallValidateQueueInsertDebugUtilsLabelEXT(
     VkQueue                                     queue,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueInsertDebugUtilsLabelEXT-queue-parameter", kVUIDUndefined);
 
     return skip;
@@ -4635,7 +4293,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBeginDebugUtilsLabelEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4644,7 +4301,6 @@ bool ObjectLifetimes::PreCallValidateCmdBeginDebugUtilsLabelEXT(
 bool ObjectLifetimes::PreCallValidateCmdEndDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4654,7 +4310,6 @@ bool ObjectLifetimes::PreCallValidateCmdInsertDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdInsertDebugUtilsLabelEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4666,7 +4321,6 @@ bool ObjectLifetimes::PreCallValidateCreateDebugUtilsMessengerEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkDebugUtilsMessengerEXT*                   pMessenger) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateDebugUtilsMessengerEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4679,7 +4333,6 @@ void ObjectLifetimes::PostCallRecordCreateDebugUtilsMessengerEXT(
     VkDebugUtilsMessengerEXT*                   pMessenger,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pMessenger, kVulkanObjectTypeDebugUtilsMessengerEXT, pAllocator);
 
 }
@@ -4689,7 +4342,6 @@ bool ObjectLifetimes::PreCallValidateDestroyDebugUtilsMessengerEXT(
     VkDebugUtilsMessengerEXT                    messenger,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkDestroyDebugUtilsMessengerEXT-instance-parameter", kVUIDUndefined);
     skip |= ValidateObject(instance, messenger, kVulkanObjectTypeDebugUtilsMessengerEXT, false, "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-parameter", "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-parent");
     skip |= ValidateDestroyObject(instance, messenger, kVulkanObjectTypeDebugUtilsMessengerEXT, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -4701,7 +4353,6 @@ void ObjectLifetimes::PreCallRecordDestroyDebugUtilsMessengerEXT(
     VkInstance                                  instance,
     VkDebugUtilsMessengerEXT                    messenger,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(instance, messenger, kVulkanObjectTypeDebugUtilsMessengerEXT);
 
 }
@@ -4712,7 +4363,6 @@ bool ObjectLifetimes::PreCallValidateSubmitDebugUtilsMessageEXT(
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
     const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkSubmitDebugUtilsMessageEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -4725,7 +4375,6 @@ bool ObjectLifetimes::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(
     const struct AHardwareBuffer*               buffer,
     VkAndroidHardwareBufferPropertiesANDROID*   pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4739,7 +4388,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
     struct AHardwareBuffer**                    pBuffer) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryAndroidHardwareBufferANDROID-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->memory, kVulkanObjectTypeDeviceMemory, false, "VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-memory-parameter", kVUIDUndefined);
@@ -4753,7 +4401,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetSampleLocationsEXT(
     VkCommandBuffer                             commandBuffer,
     const VkSampleLocationsInfoEXT*             pSampleLocationsInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetSampleLocationsEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4764,7 +4411,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceMultisamplePropertiesEXT(
     VkSampleCountFlagBits                       samples,
     VkMultisamplePropertiesEXT*                 pMultisampleProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -4775,7 +4421,6 @@ bool ObjectLifetimes::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(
     VkImage                                     image,
     VkImageDrmFormatModifierPropertiesEXT*      pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetImageDrmFormatModifierPropertiesEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, image, kVulkanObjectTypeImage, false, "VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-parameter", "VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-parent");
 
@@ -4788,7 +4433,6 @@ bool ObjectLifetimes::PreCallValidateCreateValidationCacheEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkValidationCacheEXT*                       pValidationCache) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateValidationCacheEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -4801,7 +4445,6 @@ void ObjectLifetimes::PostCallRecordCreateValidationCacheEXT(
     VkValidationCacheEXT*                       pValidationCache,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pValidationCache, kVulkanObjectTypeValidationCacheEXT, pAllocator);
 
 }
@@ -4811,7 +4454,6 @@ bool ObjectLifetimes::PreCallValidateDestroyValidationCacheEXT(
     VkValidationCacheEXT                        validationCache,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyValidationCacheEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, validationCache, kVulkanObjectTypeValidationCacheEXT, true, "VUID-vkDestroyValidationCacheEXT-validationCache-parameter", "VUID-vkDestroyValidationCacheEXT-validationCache-parent");
     skip |= ValidateDestroyObject(device, validationCache, kVulkanObjectTypeValidationCacheEXT, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -4823,7 +4465,6 @@ void ObjectLifetimes::PreCallRecordDestroyValidationCacheEXT(
     VkDevice                                    device,
     VkValidationCacheEXT                        validationCache,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, validationCache, kVulkanObjectTypeValidationCacheEXT);
 
 }
@@ -4834,7 +4475,6 @@ bool ObjectLifetimes::PreCallValidateMergeValidationCachesEXT(
     uint32_t                                    srcCacheCount,
     const VkValidationCacheEXT*                 pSrcCaches) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkMergeValidationCachesEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, dstCache, kVulkanObjectTypeValidationCacheEXT, false, "VUID-vkMergeValidationCachesEXT-dstCache-parameter", "VUID-vkMergeValidationCachesEXT-dstCache-parent");
     if (pSrcCaches) {
@@ -4852,7 +4492,6 @@ bool ObjectLifetimes::PreCallValidateGetValidationCacheDataEXT(
     size_t*                                     pDataSize,
     void*                                       pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetValidationCacheDataEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, validationCache, kVulkanObjectTypeValidationCacheEXT, false, "VUID-vkGetValidationCacheDataEXT-validationCache-parameter", "VUID-vkGetValidationCacheDataEXT-validationCache-parent");
 
@@ -4864,7 +4503,6 @@ bool ObjectLifetimes::PreCallValidateCmdBindShadingRateImageNV(
     VkImageView                                 imageView,
     VkImageLayout                               imageLayout) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBindShadingRateImageNV-commandBuffer-parameter", "VUID-vkCmdBindShadingRateImageNV-commonparent");
     skip |= ValidateObject(commandBuffer, imageView, kVulkanObjectTypeImageView, true, "VUID-vkCmdBindShadingRateImageNV-imageView-parameter", "VUID-vkCmdBindShadingRateImageNV-commonparent");
 
@@ -4877,7 +4515,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetViewportShadingRatePaletteNV(
     uint32_t                                    viewportCount,
     const VkShadingRatePaletteNV*               pShadingRatePalettes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetViewportShadingRatePaletteNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4889,7 +4526,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetCoarseSampleOrderNV(
     uint32_t                                    customSampleOrderCount,
     const VkCoarseSampleOrderCustomNV*          pCustomSampleOrders) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetCoarseSampleOrderNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -4901,7 +4537,6 @@ bool ObjectLifetimes::PreCallValidateCreateAccelerationStructureNV(
     const VkAllocationCallbacks*                pAllocator,
     VkAccelerationStructureNV*                  pAccelerationStructure) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateAccelerationStructureNV-device-parameter", kVUIDUndefined);
     if (pCreateInfo) {
         if (pCreateInfo->info.pGeometries) {
@@ -4924,7 +4559,6 @@ void ObjectLifetimes::PostCallRecordCreateAccelerationStructureNV(
     VkAccelerationStructureNV*                  pAccelerationStructure,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(device, *pAccelerationStructure, kVulkanObjectTypeAccelerationStructureNV, pAllocator);
 
 }
@@ -4934,7 +4568,6 @@ bool ObjectLifetimes::PreCallValidateDestroyAccelerationStructureNV(
     VkAccelerationStructureNV                   accelerationStructure,
     const VkAllocationCallbacks*                pAllocator) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyAccelerationStructureNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, false, "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-parameter", "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-parent");
     skip |= ValidateDestroyObject(device, accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, pAllocator, kVUIDUndefined, kVUIDUndefined);
@@ -4946,7 +4579,6 @@ void ObjectLifetimes::PreCallRecordDestroyAccelerationStructureNV(
     VkDevice                                    device,
     VkAccelerationStructureNV                   accelerationStructure,
     const VkAllocationCallbacks*                pAllocator) {
-    auto lock = write_shared_lock();
     RecordDestroyObject(device, accelerationStructure, kVulkanObjectTypeAccelerationStructureNV);
 
 }
@@ -4956,7 +4588,6 @@ bool ObjectLifetimes::PreCallValidateGetAccelerationStructureMemoryRequirementsN
     const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo,
     VkMemoryRequirements2KHR*                   pMemoryRequirements) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetAccelerationStructureMemoryRequirementsNV-device-parameter", kVUIDUndefined);
     if (pInfo) {
         skip |= ValidateObject(device, pInfo->accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, false, "VUID-VkAccelerationStructureMemoryRequirementsInfoNV-accelerationStructure-parameter", kVUIDUndefined);
@@ -4970,7 +4601,6 @@ bool ObjectLifetimes::PreCallValidateBindAccelerationStructureMemoryNV(
     uint32_t                                    bindInfoCount,
     const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkBindAccelerationStructureMemoryNV-device-parameter", kVUIDUndefined);
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
@@ -4993,7 +4623,6 @@ bool ObjectLifetimes::PreCallValidateCmdBuildAccelerationStructureNV(
     VkBuffer                                    scratch,
     VkDeviceSize                                scratchOffset) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdBuildAccelerationStructureNV-commandBuffer-parameter", "VUID-vkCmdBuildAccelerationStructureNV-commonparent");
     if (pInfo) {
         if (pInfo->pGeometries) {
@@ -5019,7 +4648,6 @@ bool ObjectLifetimes::PreCallValidateCmdCopyAccelerationStructureNV(
     VkAccelerationStructureNV                   src,
     VkCopyAccelerationStructureModeNV           mode) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdCopyAccelerationStructureNV-commandBuffer-parameter", "VUID-vkCmdCopyAccelerationStructureNV-commonparent");
     skip |= ValidateObject(commandBuffer, dst, kVulkanObjectTypeAccelerationStructureNV, false, "VUID-vkCmdCopyAccelerationStructureNV-dst-parameter", "VUID-vkCmdCopyAccelerationStructureNV-commonparent");
     skip |= ValidateObject(commandBuffer, src, kVulkanObjectTypeAccelerationStructureNV, false, "VUID-vkCmdCopyAccelerationStructureNV-src-parameter", "VUID-vkCmdCopyAccelerationStructureNV-commonparent");
@@ -5044,7 +4672,6 @@ bool ObjectLifetimes::PreCallValidateCmdTraceRaysNV(
     uint32_t                                    height,
     uint32_t                                    depth) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdTraceRaysNV-commandBuffer-parameter", "VUID-vkCmdTraceRaysNV-commonparent");
     skip |= ValidateObject(commandBuffer, raygenShaderBindingTableBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdTraceRaysNV-raygenShaderBindingTableBuffer-parameter", "VUID-vkCmdTraceRaysNV-commonparent");
     skip |= ValidateObject(commandBuffer, missShaderBindingTableBuffer, kVulkanObjectTypeBuffer, true, "VUID-vkCmdTraceRaysNV-missShaderBindingTableBuffer-parameter", "VUID-vkCmdTraceRaysNV-commonparent");
@@ -5062,7 +4689,6 @@ bool ObjectLifetimes::PreCallValidateCreateRayTracingPipelinesNV(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRayTracingPipelinesNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipelineCache, kVulkanObjectTypePipelineCache, true, "VUID-vkCreateRayTracingPipelinesNV-pipelineCache-parameter", "VUID-vkCreateRayTracingPipelinesNV-pipelineCache-parent");
     if (pCreateInfos) {
@@ -5088,7 +4714,6 @@ void ObjectLifetimes::PostCallRecordCreateRayTracingPipelinesNV(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines,
     VkResult                                    result) {
-    auto lock = write_shared_lock();
     if (VK_ERROR_VALIDATION_FAILED_EXT == result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -5107,7 +4732,6 @@ bool ObjectLifetimes::PreCallValidateGetRayTracingShaderGroupHandlesNV(
     size_t                                      dataSize,
     void*                                       pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetRayTracingShaderGroupHandlesNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipeline, kVulkanObjectTypePipeline, false, "VUID-vkGetRayTracingShaderGroupHandlesNV-pipeline-parameter", "VUID-vkGetRayTracingShaderGroupHandlesNV-pipeline-parent");
 
@@ -5120,7 +4744,6 @@ bool ObjectLifetimes::PreCallValidateGetAccelerationStructureHandleNV(
     size_t                                      dataSize,
     void*                                       pData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetAccelerationStructureHandleNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, false, "VUID-vkGetAccelerationStructureHandleNV-accelerationStructure-parameter", "VUID-vkGetAccelerationStructureHandleNV-accelerationStructure-parent");
 
@@ -5135,7 +4758,6 @@ bool ObjectLifetimes::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(
     VkQueryPool                                 queryPool,
     uint32_t                                    firstQuery) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdWriteAccelerationStructuresPropertiesNV-commandBuffer-parameter", "VUID-vkCmdWriteAccelerationStructuresPropertiesNV-commonparent");
     if (pAccelerationStructures) {
         for (uint32_t index0 = 0; index0 < accelerationStructureCount; ++index0) {
@@ -5152,7 +4774,6 @@ bool ObjectLifetimes::PreCallValidateCompileDeferredNV(
     VkPipeline                                  pipeline,
     uint32_t                                    shader) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkCompileDeferredNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, pipeline, kVulkanObjectTypePipeline, false, "VUID-vkCompileDeferredNV-pipeline-parameter", "VUID-vkCompileDeferredNV-pipeline-parent");
 
@@ -5165,7 +4786,6 @@ bool ObjectLifetimes::PreCallValidateGetMemoryHostPointerPropertiesEXT(
     const void*                                 pHostPointer,
     VkMemoryHostPointerPropertiesEXT*           pMemoryHostPointerProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetMemoryHostPointerPropertiesEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5178,7 +4798,6 @@ bool ObjectLifetimes::PreCallValidateCmdWriteBufferMarkerAMD(
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdWriteBufferMarkerAMD-commandBuffer-parameter", "VUID-vkCmdWriteBufferMarkerAMD-commonparent");
     skip |= ValidateObject(commandBuffer, dstBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdWriteBufferMarkerAMD-dstBuffer-parameter", "VUID-vkCmdWriteBufferMarkerAMD-commonparent");
 
@@ -5190,7 +4809,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceCalibrateableTimeDomainsEX
     uint32_t*                                   pTimeDomainCount,
     VkTimeDomainEXT*                            pTimeDomains) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceCalibrateableTimeDomainsEXT-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -5203,7 +4821,6 @@ bool ObjectLifetimes::PreCallValidateGetCalibratedTimestampsEXT(
     uint64_t*                                   pTimestamps,
     uint64_t*                                   pMaxDeviation) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetCalibratedTimestampsEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5214,7 +4831,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawMeshTasksNV(
     uint32_t                                    taskCount,
     uint32_t                                    firstTask) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawMeshTasksNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5227,7 +4843,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawMeshTasksIndirectNV(
     uint32_t                                    drawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-parameter", "VUID-vkCmdDrawMeshTasksIndirectNV-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawMeshTasksIndirectNV-buffer-parameter", "VUID-vkCmdDrawMeshTasksIndirectNV-commonparent");
 
@@ -5243,7 +4858,6 @@ bool ObjectLifetimes::PreCallValidateCmdDrawMeshTasksIndirectCountNV(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-parameter", "VUID-vkCmdDrawMeshTasksIndirectCountNV-commonparent");
     skip |= ValidateObject(commandBuffer, buffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawMeshTasksIndirectCountNV-buffer-parameter", "VUID-vkCmdDrawMeshTasksIndirectCountNV-commonparent");
     skip |= ValidateObject(commandBuffer, countBuffer, kVulkanObjectTypeBuffer, false, "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-parameter", "VUID-vkCmdDrawMeshTasksIndirectCountNV-commonparent");
@@ -5257,7 +4871,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetExclusiveScissorNV(
     uint32_t                                    exclusiveScissorCount,
     const VkRect2D*                             pExclusiveScissors) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetExclusiveScissorNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5267,7 +4880,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetCheckpointNV(
     VkCommandBuffer                             commandBuffer,
     const void*                                 pCheckpointMarker) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetCheckpointNV-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5278,7 +4890,6 @@ bool ObjectLifetimes::PreCallValidateGetQueueCheckpointDataNV(
     uint32_t*                                   pCheckpointDataCount,
     VkCheckpointDataNV*                         pCheckpointData) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(queue, queue, kVulkanObjectTypeQueue, false, "VUID-vkGetQueueCheckpointDataNV-queue-parameter", kVUIDUndefined);
 
     return skip;
@@ -5288,7 +4899,6 @@ bool ObjectLifetimes::PreCallValidateInitializePerformanceApiINTEL(
     VkDevice                                    device,
     const VkInitializePerformanceApiInfoINTEL*  pInitializeInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkInitializePerformanceApiINTEL-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5297,7 +4907,6 @@ bool ObjectLifetimes::PreCallValidateInitializePerformanceApiINTEL(
 bool ObjectLifetimes::PreCallValidateUninitializePerformanceApiINTEL(
     VkDevice                                    device) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkUninitializePerformanceApiINTEL-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5307,7 +4916,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetPerformanceMarkerINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceMarkerInfoINTEL*         pMarkerInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetPerformanceMarkerINTEL-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5317,7 +4925,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetPerformanceStreamMarkerINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceStreamMarkerInfoINTEL*   pMarkerInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetPerformanceStreamMarkerINTEL-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5327,7 +4934,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetPerformanceOverrideINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceOverrideInfoINTEL*       pOverrideInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetPerformanceOverrideINTEL-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5338,7 +4944,6 @@ bool ObjectLifetimes::PreCallValidateGetPerformanceParameterINTEL(
     VkPerformanceParameterTypeINTEL             parameter,
     VkPerformanceValueINTEL*                    pValue) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetPerformanceParameterINTEL-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5349,7 +4954,6 @@ bool ObjectLifetimes::PreCallValidateSetLocalDimmingAMD(
     VkSwapchainKHR                              swapChain,
     VkBool32                                    localDimmingEnable) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkSetLocalDimmingAMD-device-parameter", "VUID-vkSetLocalDimmingAMD-commonparent");
     skip |= ValidateObject(device, swapChain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkSetLocalDimmingAMD-swapChain-parameter", "VUID-vkSetLocalDimmingAMD-commonparent");
 
@@ -5364,7 +4968,6 @@ bool ObjectLifetimes::PreCallValidateCreateImagePipeSurfaceFUCHSIA(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateImagePipeSurfaceFUCHSIA-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -5377,7 +4980,6 @@ void ObjectLifetimes::PostCallRecordCreateImagePipeSurfaceFUCHSIA(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -5391,7 +4993,6 @@ bool ObjectLifetimes::PreCallValidateCreateMetalSurfaceEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateMetalSurfaceEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -5404,7 +5005,6 @@ void ObjectLifetimes::PostCallRecordCreateMetalSurfaceEXT(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -5414,7 +5014,6 @@ bool ObjectLifetimes::PreCallValidateGetBufferDeviceAddressEXT(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfoEXT*         pInfo) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetBufferDeviceAddressEXT-device-parameter", kVUIDUndefined);
 
     return skip;
@@ -5425,7 +5024,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceCooperativeMatrixPropertie
     uint32_t*                                   pPropertyCount,
     VkCooperativeMatrixPropertiesNV*            pProperties) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesNV-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -5436,7 +5034,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSupportedFramebufferMixedS
     uint32_t*                                   pCombinationCount,
     VkFramebufferMixedSamplesCombinationNV*     pCombinations) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-physicalDevice-parameter", kVUIDUndefined);
 
     return skip;
@@ -5450,7 +5047,6 @@ bool ObjectLifetimes::PreCallValidateGetPhysicalDeviceSurfacePresentModes2EXT(
     uint32_t*                                   pPresentModeCount,
     VkPresentModeKHR*                           pPresentModes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, "VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-physicalDevice-parameter", kVUIDUndefined);
     if (pSurfaceInfo) {
         skip |= ValidateObject(physicalDevice, pSurfaceInfo->surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-VkPhysicalDeviceSurfaceInfo2KHR-surface-parameter", kVUIDUndefined);
@@ -5466,7 +5062,6 @@ bool ObjectLifetimes::PreCallValidateAcquireFullScreenExclusiveModeEXT(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkAcquireFullScreenExclusiveModeEXT-device-parameter", "VUID-vkAcquireFullScreenExclusiveModeEXT-commonparent");
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-parameter", "VUID-vkAcquireFullScreenExclusiveModeEXT-commonparent");
 
@@ -5480,7 +5075,6 @@ bool ObjectLifetimes::PreCallValidateReleaseFullScreenExclusiveModeEXT(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, kVUIDUndefined, kVUIDUndefined);
     skip |= ValidateObject(device, swapchain, kVulkanObjectTypeSwapchainKHR, false, kVUIDUndefined, kVUIDUndefined);
 
@@ -5495,7 +5089,6 @@ bool ObjectLifetimes::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(
     const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
     VkDeviceGroupPresentModeFlagsKHR*           pModes) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-device-parameter", kVUIDUndefined);
     if (pSurfaceInfo) {
         skip |= ValidateObject(device, pSurfaceInfo->surface, kVulkanObjectTypeSurfaceKHR, false, "VUID-VkPhysicalDeviceSurfaceInfo2KHR-surface-parameter", kVUIDUndefined);
@@ -5511,7 +5104,6 @@ bool ObjectLifetimes::PreCallValidateCreateHeadlessSurfaceEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(instance, instance, kVulkanObjectTypeInstance, false, "VUID-vkCreateHeadlessSurfaceEXT-instance-parameter", kVUIDUndefined);
 
     return skip;
@@ -5524,7 +5116,6 @@ void ObjectLifetimes::PostCallRecordCreateHeadlessSurfaceEXT(
     VkSurfaceKHR*                               pSurface,
     VkResult                                    result) {
     if (result != VK_SUCCESS) return;
-    auto lock = write_shared_lock();
     CreateObject(instance, *pSurface, kVulkanObjectTypeSurfaceKHR, pAllocator);
 
 }
@@ -5534,7 +5125,6 @@ bool ObjectLifetimes::PreCallValidateCmdSetLineStippleEXT(
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(commandBuffer, commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdSetLineStippleEXT-commandBuffer-parameter", kVUIDUndefined);
 
     return skip;
@@ -5546,7 +5136,6 @@ bool ObjectLifetimes::PreCallValidateResetQueryPoolEXT(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount) {
     bool skip = false;
-    auto lock = read_shared_lock();
     skip |= ValidateObject(device, device, kVulkanObjectTypeDevice, false, "VUID-vkResetQueryPoolEXT-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(device, queryPool, kVulkanObjectTypeQueryPool, false, "VUID-vkResetQueryPoolEXT-queryPool-parameter", "VUID-vkResetQueryPoolEXT-queryPool-parent");
 

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -54,14 +54,8 @@ extern uint64_t object_track_index;
 typedef VkFlags ObjectStatusFlags;
 enum ObjectStatusFlagBits {
     OBJSTATUS_NONE = 0x00000000,                      // No status is set
-    OBJSTATUS_FENCE_IS_SUBMITTED = 0x00000001,        // Fence has been submitted
-    OBJSTATUS_VIEWPORT_BOUND = 0x00000002,            // Viewport state object has been bound
-    OBJSTATUS_RASTER_BOUND = 0x00000004,              // Viewport state object has been bound
-    OBJSTATUS_COLOR_BLEND_BOUND = 0x00000008,         // Viewport state object has been bound
-    OBJSTATUS_DEPTH_STENCIL_BOUND = 0x00000010,       // Viewport state object has been bound
-    OBJSTATUS_GPU_MEM_MAPPED = 0x00000020,            // Memory object is currently mapped
-    OBJSTATUS_COMMAND_BUFFER_SECONDARY = 0x00000040,  // Command Buffer is of type SECONDARY
-    OBJSTATUS_CUSTOM_ALLOCATOR = 0x00000080,          // Allocated with custom allocator
+    OBJSTATUS_COMMAND_BUFFER_SECONDARY = 0x00000001,  // Command Buffer is of type SECONDARY
+    OBJSTATUS_CUSTOM_ALLOCATOR = 0x00000002,          // Allocated with custom allocator
 };
 
 // Object and state information structure
@@ -71,12 +65,6 @@ struct ObjTrackState {
     ObjectStatusFlags status;                                      // Object state
     uint64_t parent_object;                                        // Parent object
     std::unique_ptr<std::unordered_set<uint64_t> > child_objects;  // Child objects (used for VkDescriptorPool only)
-};
-
-// Track Queue information
-struct ObjTrackQueueInfo {
-    uint32_t queue_node_index;
-    VkQueue queue;
 };
 
 typedef std::unordered_map<uint64_t, ObjTrackState *> object_map_type;
@@ -100,10 +88,6 @@ class ObjectLifetimes : public ValidationObject {
     std::vector<object_map_type> object_map;
     // Special-case map for swapchain images
     std::unordered_map<uint64_t, ObjTrackState *> swapchainImageMap;
-    // Map of queue information structures, one per queue
-    std::unordered_map<VkQueue, ObjTrackQueueInfo *> queue_info_map;
-
-    std::vector<VkQueueFamilyProperties> queue_family_properties;
 
     // Constructor for object lifetime tracking
     ObjectLifetimes() : num_objects{}, num_total_objects(0), object_map{} { object_map.resize(kVulkanObjectTypeMax + 1); }
@@ -111,8 +95,6 @@ class ObjectLifetimes : public ValidationObject {
     bool DeviceReportUndestroyedObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
     void DeviceDestroyUndestroyedObjects(VkDevice device, VulkanObjectType object_type);
     void CreateQueue(VkDevice device, VkQueue vkObj);
-    void AddQueueInfo(VkDevice device, uint32_t queue_node_index, VkQueue queue);
-    void ValidateQueueFlags(VkQueue queue, const char *function);
     void AllocateCommandBuffer(VkDevice device, const VkCommandPool command_pool, const VkCommandBuffer command_buffer,
                                VkCommandBufferLevel level);
     void AllocateDescriptorSet(VkDevice device, VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set);

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -963,7 +963,6 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                     self.appendSection('command', '')
                     self.appendSection('command', pre_cv_func_decl)
                     self.appendSection('command', '    bool skip = false;')
-                    self.appendSection('command', '    auto lock = read_shared_lock();')
                     self.appendSection('command', pre_call_validate)
                     self.appendSection('command', '    return skip;')
                     self.appendSection('command', '}')
@@ -973,7 +972,6 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                     pre_cr_func_decl = 'void ObjectLifetimes::PreCallRecord' + func_decl_template + ' {'
                     self.appendSection('command', '')
                     self.appendSection('command', pre_cr_func_decl)
-                    self.appendSection('command', '    auto lock = write_shared_lock();')
                     self.appendSection('command', pre_call_record)
                     self.appendSection('command', '}')
 
@@ -988,7 +986,6 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                         if 'CreateGraphicsPipelines' not in cmdname and 'CreateComputePipelines' not in cmdname and 'CreateRayTracingPipelines' not in cmdname:
                             post_cr_func_decl = post_cr_func_decl.replace('{', '{\n    if (result != VK_SUCCESS) return;')
                     self.appendSection('command', post_cr_func_decl)
-                    self.appendSection('command', '    auto lock = write_shared_lock();')
 
                     self.appendSection('command', post_call_record)
                     self.appendSection('command', '}')


### PR DESCRIPTION
Use vl_concurrent_unordered_map for the object_maps, and remove most use of
the single object_lifetime_mutex. object_lifetime_mutex is still used in a few
cases like to protect access through ObjTrackState::child_objects.

Use shared_ptr for the pointers to ObjTrackState in case of application bugs
like destroying the same object twice, which could otherwise crash when accessing
and freeing that pointer.

I'm seeing around a 15-20% full frame speedup with only the object lifetimes layer enabled in my test app. That's probably a reduction of about half of the time spend in the layers themselves, but it's hard to measure this exactly. Qualitatively, the lock contention is significantly reduced.
