### PR TITLE
Tobin angle build fixes

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -571,7 +571,7 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory mem, const VulkanTypedHand
     bool skip = false;
     // It's an error to bind an object to NULL memory
     if (mem != VK_NULL_HANDLE) {
-        const BINDABLE *mem_binding = GetObjectMemBinding(typed_handle);
+        const BINDABLE *mem_binding = ValidationStateTracker::GetObjectMemBinding(typed_handle);
         assert(mem_binding);
         if (mem_binding->sparse) {
             const char *error_code = "VUID-vkBindImageMemory-image-01045";
@@ -589,9 +589,9 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory mem, const VulkanTypedHand
                             apiName, report_data->FormatHandle(mem).c_str(), report_data->FormatHandle(typed_handle).c_str(),
                             handle_type);
         }
-        const DEVICE_MEMORY_STATE *mem_info = GetDevMemState(mem);
+        const DEVICE_MEMORY_STATE *mem_info = ValidationStateTracker::GetDevMemState(mem);
         if (mem_info) {
-            const DEVICE_MEMORY_STATE *prev_binding = GetDevMemState(mem_binding->binding.mem);
+            const DEVICE_MEMORY_STATE *prev_binding = ValidationStateTracker::GetDevMemState(mem_binding->binding.mem);
             if (prev_binding) {
                 const char *error_code = "VUID-vkBindImageMemory-image-01044";
                 if (typed_handle.type == kVulkanObjectTypeBuffer) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -814,8 +814,8 @@ class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
         return subres;
     }
 
-    uint32_t LevelLimit(uint32_t level) const { return std::min(image_state_.full_range.levelCount, level); }
-    uint32_t LayerLimit(uint32_t layer) const { return std::min(image_state_.full_range.layerCount, layer); }
+    uint32_t LevelLimit(uint32_t level) const { return (std::min)(image_state_.full_range.levelCount, level); }
+    uint32_t LayerLimit(uint32_t layer) const { return (std::min)(image_state_.full_range.layerCount, layer); }
 
     bool InRange(const VkImageSubresource &subres) const {
         bool in_range = (subres.mipLevel < image_state_.full_range.levelCount) &&

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -31,7 +31,7 @@
 #include "vk_safe_struct.cpp"
 
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
     #include <shared_mutex>
     typedef std::shared_mutex dispatch_lock_t;
     typedef std::shared_lock<dispatch_lock_t> read_dispatch_lock_guard_t;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -195,7 +195,8 @@ VkResult CoreChecks::GpuInitializeVma() {
     VmaAllocatorCreateInfo allocatorInfo = {};
     allocatorInfo.device = device;
     ValidationObject *device_object = GetLayerDataPtr(get_dispatch_key(allocatorInfo.device), layer_data_map);
-    ValidationObject *validation_data = GetValidationObject(device_object->object_dispatch, LayerObjectTypeCoreValidation);
+    ValidationObject *validation_data =
+        ValidationObject::GetValidationObject(device_object->object_dispatch, LayerObjectTypeCoreValidation);
     CoreChecks *core_checks = static_cast<CoreChecks *>(validation_data);
     allocatorInfo.physicalDevice = core_checks->physical_device;
 
@@ -598,7 +599,7 @@ void CoreChecks::GpuPostCallRecordPipelineCreations(const uint32_t count, const 
         return;
     }
     for (uint32_t pipeline = 0; pipeline < count; ++pipeline) {
-        auto pipeline_state = GetPipelineState(pPipelines[pipeline]);
+        auto pipeline_state = ValidationStateTracker::GetPipelineState(pPipelines[pipeline]);
         if (nullptr == pipeline_state) continue;
 
         uint32_t stageCount = 0;

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -21,7 +21,7 @@
  */
 
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
 #include <shared_mutex>
 typedef std::shared_mutex object_lifetime_mutex_t;
 typedef std::shared_lock<object_lifetime_mutex_t> read_object_lifetime_mutex_t;

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -161,7 +161,7 @@ static inline int u_ffs(int val) {
 #endif
 
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
 #include <shared_mutex>
 #endif
 
@@ -257,7 +257,7 @@ class vl_concurrent_unordered_map {
    private:
     static const int BUCKETS = (1 << BUCKETSLOG2);
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
 #include <shared_mutex>
     typedef std::shared_mutex lock_t;
     typedef std::shared_lock<lock_t> read_lock_guard_t;

--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -3137,7 +3137,7 @@ the containers.
 
 #ifndef VMA_USE_STL_SHARED_MUTEX
     // Minimum Visual Studio 2015 Update 2
-    #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+    #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
         #define VMA_USE_STL_SHARED_MUTEX 1
     #endif
 #endif

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1122,7 +1122,7 @@ VkResult DispatchSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsO
             write('#include "vk_safe_struct.cpp"', file=self.outFile)
             self.newline()
             write('// shared_mutex support added in MSVC 2015 update 2', file=self.outFile)
-            write('#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918', file=self.outFile)
+            write('#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2', file=self.outFile)
             write('    #include <shared_mutex>', file=self.outFile)
             write('    typedef std::shared_mutex dispatch_lock_t;', file=self.outFile)
             write('    typedef std::shared_lock<dispatch_lock_t> read_dispatch_lock_guard_t;', file=self.outFile)


### PR DESCRIPTION
ANGLE uses an older Windows SDK than what you get by default with newer VS versions. This leads to some picky build errors. Putting these out there for consideration. The first 2 CLs seem pretty harmless. Probably a better way to do the last one (std::min vs Win min), so open for suggestions. Tried explicitly including <algorithm> and still getting ambiguous function error and this fixes it, at least.
