### PR TITLE
layers: Use persistent objects for ThreadSafety tracking

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -425,7 +425,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     std::vector<ValidationObject*> local_object_dispatch;
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
 #if BUILD_THREAD_SAFETY
-    auto thread_checker = new ThreadSafety;
+    auto thread_checker = new ThreadSafety(nullptr);
     if (!local_disables.thread_safety) {
         local_object_dispatch.emplace_back(thread_checker);
     }
@@ -633,7 +633,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     // Note that this defines the order in which the layer validation objects are called
 #if BUILD_THREAD_SAFETY
-    auto thread_safety = new ThreadSafety;
+    auto thread_safety = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
     thread_safety->container_type = LayerObjectTypeThreading;
     if (!instance_interceptor->disabled.thread_safety) {
         device_interceptor->object_dispatch.emplace_back(thread_safety);

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -839,7 +839,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     std::vector<ValidationObject*> local_object_dispatch;
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
 #if BUILD_THREAD_SAFETY
-    auto thread_checker = new ThreadSafety;
+    auto thread_checker = new ThreadSafety(nullptr);
     if (!local_disables.thread_safety) {
         local_object_dispatch.emplace_back(thread_checker);
     }
@@ -1047,7 +1047,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     // Note that this defines the order in which the layer validation objects are called
 #if BUILD_THREAD_SAFETY
-    auto thread_safety = new ThreadSafety;
+    auto thread_safety = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
     thread_safety->container_type = LayerObjectTypeThreading;
     if (!instance_interceptor->disabled.thread_safety) {
         device_interceptor->object_dispatch.emplace_back(thread_safety);


### PR DESCRIPTION
The previous 'Bucket' change was a big improvement, but it has a significant
remaining problem that two threads *reading* the same object will fight over
a *write* lock for the same bucket. This change creates a tracking object
(ObjectUseData) that persists for the lifetime of the object and is manipulated
using atomic adds to track the read and write counts. The object is looked up
from a concurrent_unordered_map, which only needs a read lock so two threads
each reading won't collide.

Performance for this change is slightly worse than the Bucket implementation in my test app, but I think that's in part because the app uses distinct VkBuffers for everything, and an app that used fewer large buffers would suffer from far more collisions. I also think it would be possible to improve the perf by avoiding the shared_ptr incr/decr and pushing the atomics into the map structure, but that breaks encapsulation a bit. Might be worth doing nonetheless.
