### PR TITLE
Don't report GPU-AV errors from inline uniform blocks

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -87,6 +87,8 @@ array elements, those elements are not required to have been written.
 The instrumentation code needs to know which elements of a descriptor array have been written, so that it can tell if one is used
 that has not been written.
 
+Note that currently, VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT validation is not working and all accesses are reported as valid.
+
 
 ## GPU-Assisted Validation Options
 


### PR DESCRIPTION
The shader instrumentation is not designed to know if part of a block is accessed or not, so when applied to an inline uniform block, it can return false positives, as it would running the included test.
Warn when appropriate and never generate an error for VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT descriptors