### PR TITLE
layers:Fix struct padding

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -306,7 +306,7 @@ class vl_concurrent_unordered_map {
     struct {
         lock_t lock;
         // Put each lock on its own cache line to avoid false cache line sharing.
-        char padding[64 - sizeof(lock_t)];
+        char padding[(-int(sizeof(lock_t))) & 63];
     } locks[BUCKETS];
 
     uint32_t ConcurrentMapHashObject(const Key &object) const {


### PR DESCRIPTION
Only add lock struct padding if lock is less than 64-bytes.
On Windows x64 std::mutex may be 80 bytes so each lock takes more
than a single 64-byte cache line and no padding needed.