### PR TITLE
layers: Fixes when using ValidationStateTracker for Best Practices

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6173,15 +6173,26 @@ void ValidationStateTracker::PostCallRecordResetDescriptorPool(VkDevice device, 
     pPool->availableSets = pPool->maxSets;
 }
 
+bool ValidationStateTracker::PreCallValidateAllocateDescriptorSets(VkDevice device,
+                                                                   const VkDescriptorSetAllocateInfo *pAllocateInfo,
+                                                                   VkDescriptorSet *pDescriptorSets, void *ads_state_data) {
+    // Always update common data
+    cvdescriptorset::AllocateDescriptorSetsData *ads_state =
+        reinterpret_cast<cvdescriptorset::AllocateDescriptorSetsData *>(ads_state_data);
+    UpdateAllocateDescriptorSetsData(pAllocateInfo, ads_state);
+
+    return false;
+}
+
 // Ensure the pool contains enough descriptors and descriptor sets to satisfy
 // an allocation request. Fills common_data with the total number of descriptors of each type required,
 // as well as DescriptorSetLayout ptrs used for later update.
 bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
                                                        VkDescriptorSet *pDescriptorSets, void *ads_state_data) {
-    // Always update common data
+    StateTracker::PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, ads_state_data);
+
     cvdescriptorset::AllocateDescriptorSetsData *ads_state =
         reinterpret_cast<cvdescriptorset::AllocateDescriptorSetsData *>(ads_state_data);
-    UpdateAllocateDescriptorSetsData(pAllocateInfo, ads_state);
     // All state checks for AllocateDescriptorSets is done in single function
     return ValidateAllocateDescriptorSets(pAllocateInfo, ads_state);
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2472,7 +2472,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     }
 
     ValidationObject *device_object = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
-    ValidationObject *validation_data = GetValidationObject(device_object->object_dispatch, LayerObjectTypeCoreValidation);
+    ValidationObject *validation_data = GetValidationObject(device_object->object_dispatch, this->container_type);
     ValidationStateTracker *state_tracker = static_cast<ValidationStateTracker *>(validation_data);
 
     if (nullptr == enabled_features_found) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -509,6 +509,8 @@ class ValidationStateTracker : public ValidationObject {
                                               void* pipe_state);
     void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
                                            VkResult result);
+    bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                               VkDescriptorSet* pDescriptorSets, void* ads_state_data);
     void PreCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
                                                  const VkAllocationCallbacks* pAllocator);
     void PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
@@ -849,6 +851,7 @@ class ValidationStateTracker : public ValidationObject {
     void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     void UpdateDrawState(CMD_BUFFER_STATE* cb_state, const VkPipelineBindPoint bind_point);
+    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*);
 
     DeviceFeatures enabled_features = {};
     // Device specific data
@@ -1188,7 +1191,6 @@ class CoreChecks : public ValidationStateTracker {
                               std::string* error_code, std::string* error_msg);
     bool ValidateUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const TEMPLATE_STATE* template_state,
                                                      const void* pData);
-    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*);
     bool ValidateAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const cvdescriptorset::AllocateDescriptorSetsData*);
     bool ValidateUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet* p_wds, uint32_t copy_count,
                                       const VkCopyDescriptorSet* p_cds, const char* func_name);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2153,8 +2153,8 @@ bool CoreChecks::VerifyCopyUpdateContents(const VkCopyDescriptorSet *update, con
     return true;
 }
 // Update the common AllocateDescriptorSetsData
-void CoreChecks::UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo *p_alloc_info,
-                                                  cvdescriptorset::AllocateDescriptorSetsData *ds_data) {
+void ValidationStateTracker::UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo *p_alloc_info,
+                                                              cvdescriptorset::AllocateDescriptorSetsData *ds_data) {
     for (uint32_t i = 0; i < p_alloc_info->descriptorSetCount; i++) {
         auto layout = GetDescriptorSetLayout(this, p_alloc_info->pSetLayouts[i]);
         if (layout) {

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -812,7 +812,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         intercept->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(ccpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
+    auto usepCreateInfos = (!ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos) ? pCreateInfos : ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos; 
+
+    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, usepCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -753,29 +753,29 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
     bool skip = false;
 
 #ifdef BUILD_CORE_VALIDATION
-        create_graphics_pipeline_api_state cgpl_state{};
+        create_graphics_pipeline_api_state cgpl_state[LayerObjectTypeMaxEnum]{};
 #else
         struct create_graphics_pipeline_api_state {
             const VkGraphicsPipelineCreateInfo* pCreateInfos;
-        } cgpl_state;
+        } cgpl_state[LayerObjectTypeMaxEnum];
 #endif
-    cgpl_state.pCreateInfos = pCreateInfos;
 
     for (auto intercept : layer_data->object_dispatch) {
+        cgpl_state[intercept->container_type].pCreateInfos = pCreateInfos;
         auto lock = intercept->write_lock();
-        skip |= intercept->PreCallValidateCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &cgpl_state);
+        skip |= intercept->PreCallValidateCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(cgpl_state[intercept->container_type]));
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
-        intercept->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &cgpl_state);
+        intercept->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(cgpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, cgpl_state.pCreateInfos, pAllocator, pPipelines);
+    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
-        intercept->PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &cgpl_state);
+        intercept->PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &(cgpl_state[intercept->container_type]));
     }
     return result;
 }

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -939,7 +939,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-#ifdef BUILD_CORE_VALIDATION
+#if defined BUILD_CORE_VALIDATION || defined BUILD_BEST_PRACTICES
     cvdescriptorset::AllocateDescriptorSetsData ads_state(pAllocateInfo->descriptorSetCount);
 #else
     struct ads_state {} ads_state;

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -830,30 +830,32 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
     bool skip = false;
 
 #ifdef BUILD_CORE_VALIDATION
-    create_ray_tracing_pipeline_api_state crtpl_state{};
+    create_ray_tracing_pipeline_api_state crtpl_state[LayerObjectTypeMaxEnum]{};
 #else
     struct create_ray_tracing_pipeline_api_state {
         const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
-    } crtpl_state;
+    } crtpl_state[LayerObjectTypeMaxEnum];
 #endif
-    crtpl_state.pCreateInfos = pCreateInfos;
 
     for (auto intercept : layer_data->object_dispatch) {
+        crtpl_state[intercept->container_type].pCreateInfos = pCreateInfos;
         auto lock = intercept->write_lock();
         skip |= intercept->PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos,
-                                                                      pAllocator, pPipelines, &crtpl_state);
+                                                                      pAllocator, pPipelines, &(crtpl_state[intercept->container_type]));
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                            pPipelines, &crtpl_state);
+                                                            pPipelines, &(crtpl_state[intercept->container_type]));
     }
+
     VkResult result = DispatchCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                             pPipelines, result, &crtpl_state);
+                                                             pPipelines, result, &(crtpl_state[intercept->container_type]));
     }
     return result;
 }

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -771,7 +771,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         intercept->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(cgpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
+    auto usepCreateInfos = (!cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos) ? pCreateInfos : cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos; 
+
+    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, usepCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2377,6 +2377,7 @@ enum LayerObjectTypeId {
     LayerObjectTypeObjectTracker,               // Instance or device object tracker layer object
     LayerObjectTypeCoreValidation,              // Instance or device core validation layer object
     LayerObjectTypeBestPractices,               // Instance or device best practices layer object
+    LayerObjectTypeMaxEnum,                     // Max enum count
 };
 
 struct TEMPLATE_STATE {

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1233,7 +1233,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         intercept->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(ccpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
+    auto usepCreateInfos = (!ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos) ? pCreateInfos : ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos; 
+
+    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, usepCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1192,7 +1192,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         intercept->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(cgpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
+    auto usepCreateInfos = (!cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos) ? pCreateInfos : cgpl_state[LayerObjectTypeCoreValidation].pCreateInfos; 
+
+    VkResult result = DispatchCreateGraphicsPipelines(device, pipelineCache, createInfoCount, usepCreateInfos, pAllocator, pPipelines);
 
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1360,7 +1360,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-#ifdef BUILD_CORE_VALIDATION
+#if defined BUILD_CORE_VALIDATION || defined BUILD_BEST_PRACTICES
     cvdescriptorset::AllocateDescriptorSetsData ads_state(pAllocateInfo->descriptorSetCount);
 #else
     struct ads_state {} ads_state;

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1213,27 +1213,29 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
     bool skip = false;
 
 #ifdef BUILD_CORE_VALIDATION
-    create_compute_pipeline_api_state ccpl_state{};
+    create_compute_pipeline_api_state ccpl_state[LayerObjectTypeMaxEnum]{};
 #else
     struct create_compute_pipeline_api_state {
         const VkComputePipelineCreateInfo* pCreateInfos;
-    } ccpl_state;
+    } ccpl_state[LayerObjectTypeMaxEnum];
 #endif
-    ccpl_state.pCreateInfos = pCreateInfos;
 
     for (auto intercept : layer_data->object_dispatch) {
+        ccpl_state[intercept->container_type].pCreateInfos = pCreateInfos;
         auto lock = intercept->write_lock();
-        skip |= intercept->PreCallValidateCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &ccpl_state);
+        skip |= intercept->PreCallValidateCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(ccpl_state[intercept->container_type]));
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
-        intercept->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &ccpl_state);
+        intercept->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, &(ccpl_state[intercept->container_type]));
     }
-    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, ccpl_state.pCreateInfos, pAllocator, pPipelines);
+
+    VkResult result = DispatchCreateComputePipelines(device, pipelineCache, createInfoCount, ccpl_state[LayerObjectTypeCoreValidation].pCreateInfos, pAllocator, pPipelines);
+
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
-        intercept->PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &ccpl_state);
+        intercept->PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, &(ccpl_state[intercept->container_type]));
     }
     return result;
 }

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1251,30 +1251,32 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
     bool skip = false;
 
 #ifdef BUILD_CORE_VALIDATION
-    create_ray_tracing_pipeline_api_state crtpl_state{};
+    create_ray_tracing_pipeline_api_state crtpl_state[LayerObjectTypeMaxEnum]{};
 #else
     struct create_ray_tracing_pipeline_api_state {
         const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
-    } crtpl_state;
+    } crtpl_state[LayerObjectTypeMaxEnum];
 #endif
-    crtpl_state.pCreateInfos = pCreateInfos;
 
     for (auto intercept : layer_data->object_dispatch) {
+        crtpl_state[intercept->container_type].pCreateInfos = pCreateInfos;
         auto lock = intercept->write_lock();
         skip |= intercept->PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos,
-                                                                      pAllocator, pPipelines, &crtpl_state);
+                                                                      pAllocator, pPipelines, &(crtpl_state[intercept->container_type]));
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                            pPipelines, &crtpl_state);
+                                                            pPipelines, &(crtpl_state[intercept->container_type]));
     }
+
     VkResult result = DispatchCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
         intercept->PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                             pPipelines, result, &crtpl_state);
+                                                             pPipelines, result, &(crtpl_state[intercept->container_type]));
     }
     return result;
 }


### PR DESCRIPTION
There were issues when using the Validation State Tracker for multiple Validation objects (Core and Best Practices). This resolves some, but not necessarily all of those issues. There will be a future PR for the rest of the problems.