### PR TITLE
gpu: Stop validation if features missing

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2448,7 +2448,8 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     if (enabled.gpu_validation) {
         // The only CoreCheck specific init is for gpu_validation
-        core_checks->GpuPostCallRecordCreateDevice(&enabled, pCreateInfo);
+        auto *device_state = static_cast<StateTracker *>(validation_data);
+        core_checks->GpuPostCallRecordCreateDevice(&enabled, pCreateInfo, &device_state->enabled_features.core);
         core_checks->SetCommandBufferResetCallback(
             [core_checks](VkCommandBuffer command_buffer) -> void { core_checks->GpuResetCommandBuffer(command_buffer); });
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1219,7 +1219,8 @@ class CoreChecks : public ValidationStateTracker {
     // Gpu Validation Functions
     void GpuPreCallRecordCreateDevice(VkPhysicalDevice gpu, safe_VkDeviceCreateInfo* modified_create_info,
                                       VkPhysicalDeviceFeatures* supported_features);
-    void GpuPostCallRecordCreateDevice(const CHECK_ENABLED* enables, const VkDeviceCreateInfo* pCreateInfo);
+    void GpuPostCallRecordCreateDevice(const CHECK_ENABLED* enables, const VkDeviceCreateInfo* pCreateInfo,
+                                       VkPhysicalDeviceFeatures* enabled_features);
     void GpuPreCallRecordDestroyDevice();
     void GpuResetCommandBuffer(const VkCommandBuffer commandBuffer);
     bool GpuPreCallCreateShaderModule(const VkShaderModuleCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,


### PR DESCRIPTION
The shader instrumentation uses fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics so don't instrument shaders if those features are missing