### PR TITLE
Fix-up Instance/Device 'undestroyed object' Reporting in ObjectTracker

### DIFF
--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -35,48 +35,48 @@
 // ObjectTracker undestroyed objects validation function
 bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, const std::string& error_code) {
     bool skip = false;
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeSurfaceKHR, error_code);
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeSwapchainKHR, error_code);
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDisplayKHR, error_code);
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDisplayModeKHR, error_code);
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT, error_code);
-    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeSurfaceKHR, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeSwapchainKHR, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayKHR, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayModeKHR, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT, error_code);
+    skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
     return skip;
 }
 bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const std::string& error_code) {
     bool skip = false;
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeCommandBuffer, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSemaphore, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeFence, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDeviceMemory, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeBuffer, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeImage, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeEvent, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeQueryPool, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeBufferView, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeImageView, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeShaderModule, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypePipelineCache, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypePipelineLayout, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeRenderPass, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypePipeline, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDescriptorSetLayout, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSampler, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDescriptorPool, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDescriptorSet, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeFramebuffer, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeCommandPool, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSamplerYcbcrConversion, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDescriptorUpdateTemplate, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeObjectTableNVX, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeIndirectCommandsLayoutNVX, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeValidationCacheEXT, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeAccelerationStructureNV, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypePerformanceConfigurationINTEL, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeCommandBuffer, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeSemaphore, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeFence, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeDeviceMemory, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeBuffer, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeImage, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeEvent, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeQueryPool, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeBufferView, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeImageView, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeShaderModule, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypePipelineCache, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypePipelineLayout, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeRenderPass, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypePipeline, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeDescriptorSetLayout, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeSampler, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeDescriptorPool, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeDescriptorSet, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeFramebuffer, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeCommandPool, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeSamplerYcbcrConversion, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeDescriptorUpdateTemplate, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeObjectTableNVX, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeIndirectCommandsLayoutNVX, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeValidationCacheEXT, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeAccelerationStructureNV, error_code);
+    skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypePerformanceConfigurationINTEL, error_code);
     return skip;
 }
 
-void ObjectLifetimes::DestroyUndestroyedInstanceObjects(VkInstance instance) {
+void ObjectLifetimes::DestroyLeakedInstanceObjects(VkInstance instance) {
     DestroyUndestroyedObjects(instance, kVulkanObjectTypeSurfaceKHR);
     DestroyUndestroyedObjects(instance, kVulkanObjectTypeSwapchainKHR);
     DestroyUndestroyedObjects(instance, kVulkanObjectTypeDisplayKHR);
@@ -84,7 +84,7 @@ void ObjectLifetimes::DestroyUndestroyedInstanceObjects(VkInstance instance) {
     DestroyUndestroyedObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT);
     DestroyUndestroyedObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT);
 }
-void ObjectLifetimes::DestroyUndestroyedDeviceObjects(VkDevice device) {
+void ObjectLifetimes::DestroyLeakedDeviceObjects(VkDevice device) {
     DestroyUndestroyedObjects(device, kVulkanObjectTypeCommandBuffer);
     DestroyUndestroyedObjects(device, kVulkanObjectTypeSemaphore);
     DestroyUndestroyedObjects(device, kVulkanObjectTypeFence);

--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -33,7 +33,17 @@
 
 
 // ObjectTracker undestroyed objects validation function
-bool ObjectLifetimes::ReportUndestroyedObjects(VkDevice device, const std::string& error_code) {
+bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, const std::string& error_code) {
+    bool skip = false;
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeSurfaceKHR, error_code);
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeSwapchainKHR, error_code);
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDisplayKHR, error_code);
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDisplayModeKHR, error_code);
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT, error_code);
+    skip |= InstanceReportUndestroyedObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
+    return skip;
+}
+bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const std::string& error_code) {
     bool skip = false;
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeCommandBuffer, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSemaphore, error_code);
@@ -58,55 +68,51 @@ bool ObjectLifetimes::ReportUndestroyedObjects(VkDevice device, const std::strin
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeCommandPool, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSamplerYcbcrConversion, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDescriptorUpdateTemplate, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSurfaceKHR, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeSwapchainKHR, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDisplayKHR, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDisplayModeKHR, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDebugReportCallbackEXT, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeObjectTableNVX, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeIndirectCommandsLayoutNVX, error_code);
-    skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeValidationCacheEXT, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypeAccelerationStructureNV, error_code);
     skip |= DeviceReportUndestroyedObjects(device, kVulkanObjectTypePerformanceConfigurationINTEL, error_code);
     return skip;
 }
 
-void ObjectLifetimes::DestroyUndestroyedObjects(VkDevice device) {
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeCommandBuffer);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeSemaphore);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeFence);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDeviceMemory);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeBuffer);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeImage);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeEvent);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeQueryPool);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeBufferView);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeImageView);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeShaderModule);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypePipelineCache);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypePipelineLayout);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeRenderPass);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypePipeline);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorSetLayout);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeSampler);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorPool);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorSet);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeFramebuffer);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeCommandPool);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeSamplerYcbcrConversion);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorUpdateTemplate);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeSurfaceKHR);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeSwapchainKHR);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDisplayKHR);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDisplayModeKHR);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDebugReportCallbackEXT);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeObjectTableNVX);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeIndirectCommandsLayoutNVX);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeDebugUtilsMessengerEXT);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeValidationCacheEXT);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypeAccelerationStructureNV);
-    DeviceDestroyUndestroyedObjects(device, kVulkanObjectTypePerformanceConfigurationINTEL);
+void ObjectLifetimes::DestroyUndestroyedInstanceObjects(VkInstance instance) {
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeSurfaceKHR);
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeSwapchainKHR);
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeDisplayKHR);
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeDisplayModeKHR);
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT);
+    DestroyUndestroyedObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT);
+}
+void ObjectLifetimes::DestroyUndestroyedDeviceObjects(VkDevice device) {
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeCommandBuffer);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeSemaphore);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeFence);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeDeviceMemory);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeBuffer);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeImage);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeEvent);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeQueryPool);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeBufferView);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeImageView);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeShaderModule);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypePipelineCache);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypePipelineLayout);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeRenderPass);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypePipeline);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorSetLayout);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeSampler);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorPool);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorSet);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeFramebuffer);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeCommandPool);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeSamplerYcbcrConversion);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeDescriptorUpdateTemplate);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeObjectTableNVX);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeIndirectCommandsLayoutNVX);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeValidationCacheEXT);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypeAccelerationStructureNV);
+    DestroyUndestroyedObjects(device, kVulkanObjectTypePerformanceConfigurationINTEL);
 }
 
 

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -110,8 +110,8 @@ class ObjectLifetimes : public ValidationObject {
     bool ReportUndestroyedInstanceObjects(VkInstance instance, const std::string &error_code);
     bool ReportUndestroyedDeviceObjects(VkDevice device, const std::string &error_code);
 
-    bool DeviceReportUndestroyedObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
-    bool InstanceReportUndestroyedObjects(VkInstance instance, VulkanObjectType object_type, const std::string &error_code);
+    bool ReportLeakedDeviceObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
+    bool ReportLeakedInstanceObjects(VkInstance instance, VulkanObjectType object_type, const std::string &error_code);
 
     template <typename ObjType>
     void DestroyUndestroyedObjects(ObjType dispatchable_object, VulkanObjectType object_type) {
@@ -126,8 +126,8 @@ class ObjectLifetimes : public ValidationObject {
                                VkCommandBufferLevel level);
     void AllocateDescriptorSet(VkDevice device, VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set);
     void CreateSwapchainImageObject(VkDevice dispatchable_object, VkImage swapchain_image, VkSwapchainKHR swapchain);
-    void DestroyUndestroyedInstanceObjects(VkInstance instance);
-    void DestroyUndestroyedDeviceObjects(VkDevice device);
+    void DestroyLeakedInstanceObjects(VkInstance instance);
+    void DestroyLeakedDeviceObjects(VkDevice device);
     bool ValidateDeviceObject(const VulkanTypedHandle &device_typed, const char *invalid_handle_code,
                               const char *wrong_device_code);
     void DestroyQueueDataStructures(VkDevice device);

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -107,15 +107,27 @@ class ObjectLifetimes : public ValidationObject {
         }
     }
 
+    bool ReportUndestroyedInstanceObjects(VkInstance instance, const std::string &error_code);
+    bool ReportUndestroyedDeviceObjects(VkDevice device, const std::string &error_code);
+
     bool DeviceReportUndestroyedObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
-    void DeviceDestroyUndestroyedObjects(VkDevice device, VulkanObjectType object_type);
+    bool InstanceReportUndestroyedObjects(VkInstance instance, VulkanObjectType object_type, const std::string &error_code);
+
+    template <typename ObjType>
+    void DestroyUndestroyedObjects(ObjType dispatchable_object, VulkanObjectType object_type) {
+        auto snapshot = object_map[object_type].snapshot();
+        for (const auto &item : snapshot) {
+            auto object_info = item.second;
+            DestroyObjectSilently(object_info->handle, object_type);
+        }
+    }
     void CreateQueue(VkDevice device, VkQueue vkObj);
     void AllocateCommandBuffer(VkDevice device, const VkCommandPool command_pool, const VkCommandBuffer command_buffer,
                                VkCommandBufferLevel level);
     void AllocateDescriptorSet(VkDevice device, VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set);
     void CreateSwapchainImageObject(VkDevice dispatchable_object, VkImage swapchain_image, VkSwapchainKHR swapchain);
-    bool ReportUndestroyedObjects(VkDevice device, const std::string &error_code);
-    void DestroyUndestroyedObjects(VkDevice device);
+    void DestroyUndestroyedInstanceObjects(VkInstance instance);
+    void DestroyUndestroyedDeviceObjects(VkDevice device);
     bool ValidateDeviceObject(const VulkanTypedHandle &device_typed, const char *invalid_handle_code,
                               const char *wrong_device_code);
     void DestroyQueueDataStructures(VkDevice device);

--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -87,6 +87,25 @@ def GetHandleTypes(tree):
             handles[name] = elem.find('type').text
     return handles
 
+# Return a dict containing the parent of every handle
+def GetHandleParents(tree):
+    # Extend OrderedDict with common handle operations
+    class HandleParentDict(OrderedDict):
+        def IsParentDevice(self, handle_type):
+            next_object = self.get(handle_type)
+            while next_object != 'VkDevice' and next_object != 'VkInstance' and next_object != 'VkPhysicalDevice' and next_object is not None:
+                next_object = self.get(next_object)
+            return next_object == 'VkDevice'
+        def GetHandleParent(self, handle_type):
+            return self.get(handle_type)
+
+    handle_parents = HandleParentDict()
+    for elem in tree.findall("types/type/[@category='handle']"):
+        if not elem.get('alias') or not elem.get('parent'):
+            name = elem.get('name')
+            handle_parents[name] = elem.get('parent')
+    return handle_parents
+
 # Return a dict containing the category attribute of every type
 def GetTypeCategories(tree):
     type_categories = OrderedDict()

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -303,11 +303,11 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             output_func += 'bool ObjectLifetimes::ReportUndestroyed%sObjects(Vk%s %s, const std::string& error_code) {\n' % (upper_objtype, upper_objtype, objtype)
             output_func += '    bool skip = false;\n'
             if objtype == 'device':
-                output_func += '    skip |= %sReportUndestroyedObjects(%s, kVulkanObjectTypeCommandBuffer, error_code);\n' % (upper_objtype, objtype)
+                output_func += '    skip |= ReportLeaked%sObjects(%s, kVulkanObjectTypeCommandBuffer, error_code);\n' % (upper_objtype, objtype)
             for handle in self.object_types:
                 if self.handle_types.IsNonDispatchable(handle):
                     if (objtype == 'device' and self.handle_parents.IsParentDevice(handle)) or (objtype == 'instance' and not self.handle_parents.IsParentDevice(handle)):
-                        output_func += '    skip |= %sReportUndestroyedObjects(%s, %s, error_code);\n' % (upper_objtype, objtype, self.GetVulkanObjType(handle))
+                        output_func += '    skip |= ReportLeaked%sObjects(%s, %s, error_code);\n' % (upper_objtype, objtype, self.GetVulkanObjType(handle))
             output_func += '    return skip;\n'
             output_func += '}\n'
         return output_func
@@ -318,7 +318,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         output_func = ''
         for objtype in ['instance', 'device']:
             upper_objtype = objtype.capitalize();
-            output_func += 'void ObjectLifetimes::DestroyUndestroyed%sObjects(Vk%s %s) {\n' % (upper_objtype, upper_objtype, objtype)
+            output_func += 'void ObjectLifetimes::DestroyLeaked%sObjects(Vk%s %s) {\n' % (upper_objtype, upper_objtype, objtype)
             if objtype == 'device':
                 output_func += '    DestroyUndestroyedObjects(%s, kVulkanObjectTypeCommandBuffer);\n' % objtype
             for handle in self.object_types:


### PR DESCRIPTION
No distinction existed between objects having instance or device parent types, necessary for properly reporting the correct VUID. These are now checked and reported separately, at the appropriate time.

Fixes #658.