### PR TITLE
repo: Update code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@
 # Use defaults from the Google style with the following exceptions:
 BasedOnStyle: Google
 IndentWidth: 4
+AccessModifierOffset: -2
 ColumnLimit: 132
 SortIncludes: false
 ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ to work on an issue that is assigned, simply coordinate with the current assigne
 #### **Coding Conventions and Formatting**
 * Use the **[Google style guide](https://google.github.io/styleguide/cppguide.html)** for source code with the following exceptions:
     * The column limit is 132 (as opposed to the default value 80). The clang-format tool will handle this. See below.
-    * The indent is 4 spaces instead of the default 2 spaces. Again, the clang-format tool will handle this.
+    * The indent is 4 spaces instead of the default 2 spaces. Access modifier (e.g. `public:`) is indented 2 spaces instead of the
+      default 1 space. Again, the clang-format tool will handle this.
+    * The C++ file extension is `*.cpp` instead of the default `*.cc`.
     * If you can justify a reason for violating a rule in the guidelines, then you are free to do so. Be prepared to defend your
 decision during code review. This should be used responsibly. An example of a bad reason is "I don't like that rule." An example of
 a good reason is "This violates the style guide, but it improves type safety."

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -26,7 +26,7 @@
 static const uint32_t kMemoryObjectWarningLimit = 250;
 
 class BestPractices : public ValidationStateTracker {
-   public:
+  public:
     using StateTracker = ValidationStateTracker;
 
     std::string GetAPIVersionName(uint32_t version);
@@ -88,7 +88,7 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                             uint32_t* pDisplayCount, VkDisplayKHR* pDisplays);
 
-   private:
+  private:
     uint32_t instance_api_version;
     uint32_t device_api_version;
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8451,7 +8451,7 @@ static const std::string buffer_error_codes[] = {
 };
 
 class ValidatorState {
-   public:
+  public:
     ValidatorState(const CoreChecks *device_data, const char *func_name, const CMD_BUFFER_STATE *cb_state,
                    const VulkanTypedHandle &barrier_handle, const VkSharingMode sharing_mode)
         : report_data_(device_data->report_data),
@@ -8542,7 +8542,7 @@ class ValidatorState {
     const char *GetTypeString() const { return object_string[barrier_handle_.type]; }
     VkSharingMode GetSharingMode() const { return sharing_mode_; }
 
-   protected:
+  protected:
     const debug_report_data *const report_data_;
     const char *const func_name_;
     const uint64_t cb_handle64_;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -51,7 +51,7 @@ enum SyncScope {
 enum FENCE_STATUS { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
 
 class FENCE_STATE {
-   public:
+  public:
     VkFence fence;
     VkFenceCreateInfo createInfo;
     std::pair<VkQueue, uint64_t> signaler;
@@ -63,20 +63,20 @@ class FENCE_STATE {
 };
 
 class SEMAPHORE_STATE : public BASE_NODE {
-   public:
+  public:
     std::pair<VkQueue, uint64_t> signaler;
     bool signaled;
     SyncScope scope;
 };
 
 class EVENT_STATE : public BASE_NODE {
-   public:
+  public:
     int write_in_use;
     VkPipelineStageFlags stageMask;
 };
 
 class QUEUE_STATE {
-   public:
+  public:
     VkQueue queue;
     uint32_t queueFamilyIndex;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
@@ -87,7 +87,7 @@ class QUEUE_STATE {
 };
 
 class QUERY_POOL_STATE : public BASE_NODE {
-   public:
+  public:
     VkQueryPoolCreateInfo createInfo;
 };
 
@@ -204,7 +204,7 @@ struct GpuValidationState;
     VALSTATETRACK_MAP_AND_TRAITS_IMPL(handle_type, state_type, map_member, true)
 
 class ValidationStateTracker : public ValidationObject {
-   public:
+  public:
     //  TODO -- move to private
     //  TODO -- make consistent with traits approach below.
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
@@ -256,7 +256,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE, accelerationStructureMap)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
 
-   public:
+  public:
     template <typename State>
     typename AccessorTraits<State>::ReturnType Get(typename AccessorTraits<State>::Handle handle) {
         using Traits = AccessorTraits<State>;
@@ -929,7 +929,7 @@ class ValidationStateTracker : public ValidationObject {
 };
 
 class CoreChecks : public ValidationStateTracker {
-   public:
+  public:
     using StateTracker = ValidationStateTracker;
     std::unordered_set<uint64_t> ahb_ext_formats_set;
     GlobalQFOTransferBarrierMap<VkImageMemoryBarrier> qfo_release_image_barrier_map;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -73,7 +73,7 @@ enum CALL_STATE {
 };
 
 class BASE_NODE {
-   public:
+  public:
     // Track when object is being used by an in-flight command buffer
     std::atomic_int in_use;
     // Track command buffers that this object is bound to
@@ -209,7 +209,7 @@ struct hash<MEM_BINDING> {
 
 // Superclass for bindable object state (currently images and buffers)
 class BINDABLE : public BASE_NODE {
-   public:
+  public:
     bool sparse;  // Is this object being bound with sparse memory or not?
     // Non-sparse binding data
     MEM_BINDING binding;
@@ -246,7 +246,7 @@ class BINDABLE : public BASE_NODE {
 };
 
 class BUFFER_STATE : public BINDABLE {
-   public:
+  public:
     VkBuffer buffer;
     VkBufferCreateInfo createInfo;
     BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo) : buffer(buff), createInfo(*pCreateInfo) {
@@ -274,7 +274,7 @@ class BUFFER_STATE : public BINDABLE {
 };
 
 class BUFFER_VIEW_STATE : public BASE_NODE {
-   public:
+  public:
     VkBufferView buffer_view;
     VkBufferViewCreateInfo create_info;
     BUFFER_VIEW_STATE(VkBufferView bv, const VkBufferViewCreateInfo *ci) : buffer_view(bv), create_info(*ci){};
@@ -293,7 +293,7 @@ struct SAMPLER_STATE : public BASE_NODE {
 };
 
 class IMAGE_STATE : public BINDABLE {
-   public:
+  public:
     VkImage image;
     VkImageCreateInfo createInfo;
     bool valid;               // If this is a swapchain image backing memory track valid here as it doesn't have DEVICE_MEMORY_STATE
@@ -328,7 +328,7 @@ class IMAGE_STATE : public BINDABLE {
 };
 
 class IMAGE_VIEW_STATE : public BASE_NODE {
-   public:
+  public:
     VkImageView image_view;
     VkImageViewCreateInfo create_info;
     VkImageSubresourceRange normalized_subresource_range;
@@ -340,7 +340,7 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
 };
 
 class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
-   public:
+  public:
     VkAccelerationStructureNV acceleration_structure;
     safe_VkAccelerationStructureCreateInfoNV create_info;
     bool memory_requirements_checked = false;
@@ -405,7 +405,7 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
 };
 
 class SWAPCHAIN_NODE {
-   public:
+  public:
     safe_VkSwapchainCreateInfoKHR createInfo;
     VkSwapchainKHR swapchain;
     std::vector<VkImage> images;
@@ -507,7 +507,7 @@ std::string FormatDebugLabel(const char *prefix, const LoggingLabel &label);
 const static VkImageLayout kInvalidLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
 // Interface class.
 class ImageSubresourceLayoutMap {
-   public:
+  public:
     typedef std::function<bool(const VkImageSubresource &, VkImageLayout, VkImageLayout)> Callback;
     struct InitialLayoutState {
         VkImageView image_view;          // For relaxed matching rule evaluation, else VK_NULL_HANDLE
@@ -528,7 +528,7 @@ class ImageSubresourceLayoutMap {
     };
 
     class ConstIteratorInterface {
-       public:
+      public:
         // Make the value accessor non virtual
         const SubresourceLayout &operator*() const { return value_; }
 
@@ -536,12 +536,12 @@ class ImageSubresourceLayoutMap {
         virtual bool AtEnd() const = 0;
         virtual ~ConstIteratorInterface(){};
 
-       protected:
+      protected:
         SubresourceLayout value_;
     };
 
     class ConstIterator {
-       public:
+      public:
         ConstIterator &operator++() {
             ++(*it_);
             return *this;
@@ -550,7 +550,7 @@ class ImageSubresourceLayoutMap {
         ConstIterator(ConstIteratorInterface *it) : it_(it){};
         bool AtEnd() const { return it_->AtEnd(); }
 
-       protected:
+      protected:
         std::unique_ptr<ConstIteratorInterface> it_;
     };
 
@@ -574,7 +574,7 @@ class ImageSubresourceLayoutMap {
 
 template <typename AspectTraits_, size_t kSparseThreshold = 64U>
 class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
-   public:
+  public:
     typedef ImageSubresourceLayoutMap Base;
     typedef AspectTraits_ AspectTraits;
     typedef Base::SubresourceLayout SubresourceLayout;
@@ -589,7 +589,7 @@ class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
 
     template <typename Container>
     class ConstIteratorImpl : public Base::ConstIteratorInterface {
-       public:
+      public:
         ConstIteratorImpl &operator++() override {
             ++it_;
             UpdateValue();
@@ -604,7 +604,7 @@ class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
         ~ConstIteratorImpl() override {}
         virtual bool AtEnd() const override { return the_end_; }
 
-       protected:
+      protected:
         void UpdateValue() {
             if (it_ != container_->cend()) {
                 value_.subresource = map_->Decode((*it_).first);
@@ -785,7 +785,7 @@ class ImageSubresourceLayoutMapImpl : public ImageSubresourceLayoutMap {
     }
     ~ImageSubresourceLayoutMapImpl() override {}
 
-   protected:
+  protected:
     // This looks a bit ponderous but kAspectCount is a compile time constant
     VkImageSubresource Decode(size_t index) const {
         VkImageSubresource subres;
@@ -1131,7 +1131,7 @@ struct interface_var {
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;
 
 class PIPELINE_STATE : public BASE_NODE {
-   public:
+  public:
     struct StageState {
         std::unordered_set<uint32_t> accessible_ids;
         std::vector<std::pair<descriptor_slot_t, interface_var>> descriptor_uses;
@@ -1530,7 +1530,7 @@ struct MT_FB_ATTACHMENT_INFO {
 };
 
 class FRAMEBUFFER_STATE : public BASE_NODE {
-   public:
+  public:
     VkFramebuffer framebuffer;
     safe_VkFramebufferCreateInfo createInfo;
     std::shared_ptr<RENDER_PASS_STATE> rp_state;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -86,7 +86,7 @@ struct IndexRange {
  *  global indices for the lowest binding#.
  */
 class DescriptorSetLayoutDef {
-   public:
+  public:
     // Constructors and destructor
     DescriptorSetLayoutDef(const VkDescriptorSetLayoutCreateInfo *p_create_info);
     size_t hash() const;
@@ -153,7 +153,7 @@ class DescriptorSetLayoutDef {
     };
     const BindingTypeStats &GetBindingTypeStats() const { return binding_type_stats_; }
 
-   private:
+  private:
     // Only the first three data members are used for hash and equality checks, the other members are derived from them, and are
     // used to speed up the various lookups/queries/validations
     VkDescriptorSetLayoutCreateFlags flags_;
@@ -185,7 +185,7 @@ using DescriptorSetLayoutDict = hash_util::Dictionary<DescriptorSetLayoutDef, ha
 using DescriptorSetLayoutId = DescriptorSetLayoutDict::Id;
 
 class DescriptorSetLayout {
-   public:
+  public:
     // Constructors and destructor
     DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info, const VkDescriptorSetLayout layout);
     bool HasBinding(const uint32_t binding) const { return layout_id_->HasBinding(binding); }
@@ -264,7 +264,7 @@ class DescriptorSetLayout {
 
     // Binding Iterator
     class ConstBindingIterator {
-       public:
+      public:
         ConstBindingIterator() = delete;
         ConstBindingIterator(const ConstBindingIterator &other) = default;
         ConstBindingIterator &operator=(const ConstBindingIterator &rhs) = default;
@@ -330,13 +330,13 @@ class DescriptorSetLayout {
             return next;
         }
 
-       private:
+      private:
         const DescriptorSetLayout *layout_;
         uint32_t index_;
     };
     ConstBindingIterator end() const { return ConstBindingIterator(this, GetBindingCount()); }
 
-   private:
+  private:
     VkDescriptorSetLayout layout_;
     bool layout_destroyed_;
     DescriptorSetLayoutId layout_id_;
@@ -353,7 +353,7 @@ class DescriptorSetLayout {
 enum DescriptorClass { PlainSampler, ImageSampler, Image, TexelBuffer, GeneralBuffer, InlineUniform, AccelerationStructure };
 
 class Descriptor {
-   public:
+  public:
     virtual ~Descriptor(){};
     virtual void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) = 0;
     virtual void CopyUpdate(const Descriptor *) = 0;
@@ -383,7 +383,7 @@ bool ValidateDescriptorSetLayoutCreateInfo(const debug_report_data *report_data,
                                            const DeviceExtensions *device_extensions);
 
 class SamplerDescriptor : public Descriptor {
-   public:
+  public:
     SamplerDescriptor(const VkSampler *);
     void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const Descriptor *) override;
@@ -391,13 +391,13 @@ class SamplerDescriptor : public Descriptor {
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_; }
 
-   private:
+  private:
     VkSampler sampler_;
     bool immutable_;
 };
 
 class ImageSamplerDescriptor : public Descriptor {
-   public:
+  public:
     ImageSamplerDescriptor(const VkSampler *);
     void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const Descriptor *) override;
@@ -407,7 +407,7 @@ class ImageSamplerDescriptor : public Descriptor {
     VkImageView GetImageView() const { return image_view_; }
     VkImageLayout GetImageLayout() const { return image_layout_; }
 
-   private:
+  private:
     VkSampler sampler_;
     bool immutable_;
     VkImageView image_view_;
@@ -415,7 +415,7 @@ class ImageSamplerDescriptor : public Descriptor {
 };
 
 class ImageDescriptor : public Descriptor {
-   public:
+  public:
     ImageDescriptor(const VkDescriptorType);
     void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const Descriptor *) override;
@@ -424,14 +424,14 @@ class ImageDescriptor : public Descriptor {
     VkImageView GetImageView() const { return image_view_; }
     VkImageLayout GetImageLayout() const { return image_layout_; }
 
-   private:
+  private:
     bool storage_;
     VkImageView image_view_;
     VkImageLayout image_layout_;
 };
 
 class TexelDescriptor : public Descriptor {
-   public:
+  public:
     TexelDescriptor(const VkDescriptorType);
     void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const Descriptor *) override;
@@ -439,13 +439,13 @@ class TexelDescriptor : public Descriptor {
     virtual bool IsStorage() const override { return storage_; }
     VkBufferView GetBufferView() const { return buffer_view_; }
 
-   private:
+  private:
     VkBufferView buffer_view_;
     bool storage_;
 };
 
 class BufferDescriptor : public Descriptor {
-   public:
+  public:
     BufferDescriptor(const VkDescriptorType);
     void WriteUpdate(const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const Descriptor *) override;
@@ -456,7 +456,7 @@ class BufferDescriptor : public Descriptor {
     VkDeviceSize GetOffset() const { return offset_; }
     VkDeviceSize GetRange() const { return range_; }
 
-   private:
+  private:
     bool storage_;
     bool dynamic_;
     VkBuffer buffer_;
@@ -465,7 +465,7 @@ class BufferDescriptor : public Descriptor {
 };
 
 class InlineUniformDescriptor : public Descriptor {
-   public:
+  public:
     InlineUniformDescriptor(const VkDescriptorType) {
         updated = false;
         descriptor_class = InlineUniform;
@@ -476,7 +476,7 @@ class InlineUniformDescriptor : public Descriptor {
 };
 
 class AccelerationStructureDescriptor : public Descriptor {
-   public:
+  public:
     AccelerationStructureDescriptor(const VkDescriptorType) {
         updated = false;
         descriptor_class = AccelerationStructure;
@@ -538,7 +538,7 @@ struct DecodedTemplateUpdate {
  *   be correct at the time of update.
  */
 class DescriptorSet : public BASE_NODE {
-   public:
+  public:
     using StateTracker = ValidationStateTracker;
     DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout const> &,
                   uint32_t variable_count, StateTracker *);
@@ -621,7 +621,7 @@ class DescriptorSet : public BASE_NODE {
     const Descriptor *GetDescriptorFromGlobalIndex(const uint32_t index) const { return descriptors_[index].get(); }
     uint64_t GetChangeCount() const { return change_count_; }
 
-   private:
+  private:
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers();
     bool some_update_;  // has any part of the set ever been updated?
@@ -652,7 +652,7 @@ class DescriptorSet : public BASE_NODE {
 };
 // For the "bindless" style resource usage with many descriptors, need to optimize binding and validation
 class PrefilterBindRequestMap {
-   public:
+  public:
     static const uint32_t kManyDescriptors_ = 64;  // TODO base this number on measured data
     std::unique_ptr<BindingReqMap> filtered_map_;
     const BindingReqMap &orig_map_;

--- a/layers/generated/.clang-format
+++ b/layers/generated/.clang-format
@@ -1,5 +1,4 @@
 ---
 # Disable clang-format for generated code
 DisableFormat: true
-SortIncludes: false
 ...

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -51,14 +51,14 @@ struct GpuQueueBarrierCommandInfo {
 // Class to encapsulate Descriptor Set allocation.  This manager creates and destroys Descriptor Pools
 // as needed to satisfy requests for descriptor sets.
 class GpuDescriptorSetManager {
-   public:
+  public:
     GpuDescriptorSetManager(CoreChecks *dev_data);
     ~GpuDescriptorSetManager();
 
     VkResult GetDescriptorSets(uint32_t count, VkDescriptorPool *pool, std::vector<VkDescriptorSet> *desc_sets);
     void PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDescriptorSet desc_set);
 
-   private:
+  private:
     static const uint32_t kItemsPerChunk = 512;
     struct PoolTracker {
         uint32_t size;

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
- * Copyright (C) 2015-2016 Google Inc.
+/* Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (C) 2015-2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ size_t HashWithUnderlying(Value value, typename std::enable_if<std::is_enum<Valu
 }
 
 class HashCombiner {
-   public:
+  public:
     using Key = size_t;
 
     template <typename Value>
@@ -96,7 +96,7 @@ class HashCombiner {
     Key Value() const { return combined_; }
     void Reset(Key combined = 0) { combined_ = combined; }
 
-   private:
+  private:
     Key combined_;
 };
 
@@ -128,7 +128,7 @@ struct IsOrderedContainer {
 // function object
 template <typename T, typename Hasher = std::hash<T>, typename KeyEqual = std::equal_to<T>>
 class Dictionary {
-   public:
+  public:
     using Def = T;
     using Id = std::shared_ptr<const Def>;
 
@@ -146,7 +146,7 @@ class Dictionary {
         return *dict.insert(from_input).first;
     }
 
-   private:
+  private:
     struct HashKeyValue {
         size_t operator()(const Id &value) const { return Hasher()(*value); }
     };

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -70,7 +70,7 @@ struct ObjTrackState {
 typedef vl_concurrent_unordered_map<uint64_t, std::shared_ptr<ObjTrackState>, 6> object_map_type;
 
 class ObjectLifetimes : public ValidationObject {
-   public:
+  public:
     // Override chassis read/write locks for this validation object
     // This override takes a deferred lock. i.e. it is not acquired.
     // This class does its own locking with a shared mutex.

--- a/layers/parameter_name.h
+++ b/layers/parameter_name.h
@@ -45,7 +45,7 @@
  * the IndexVector, but that's fine given how it is used in parameter validation.
  */
 class ParameterName {
-   public:
+  public:
     /// Container for index values to be used with parameter name string formatting.
     typedef std::initializer_list<size_t> IndexVector;
 
@@ -53,7 +53,7 @@ class ParameterName {
     /// one format specifier for each index value specified.
     const char *const IndexFormatSpecifier = "%i";
 
-   public:
+  public:
     /**
      * Construct a ParameterName object from a string literal, without formatting.
      *
@@ -80,7 +80,7 @@ class ParameterName {
     /// Retrive the formatted name string.
     std::string get_name() const { return (num_indices_ == 0) ? std::string(source_) : Format(); }
 
-   private:
+  private:
     /// Replace the %i format specifiers in the source string with the values from the index vector.
     std::string Format() const {
         std::string::size_type current = 0;
@@ -121,7 +121,7 @@ class ParameterName {
         return (count == num_indices_);
     }
 
-   private:
+  private:
     const char *source_;  ///< Format string.
     const size_t *args_;  ///< Array index values for formatting.
     size_t num_indices_;  ///< Number of array index values.

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -218,7 +218,7 @@ class ValidationCache {
     std::unordered_set<uint32_t> good_shader_hashes;
     ValidationCache() {}
 
-   public:
+  public:
     static VkValidationCacheEXT Create(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
         auto cache = new ValidationCache();
         cache->Load(pCreateInfo);
@@ -284,7 +284,7 @@ class ValidationCache {
 
     void Insert(uint32_t hash) { good_shader_hashes.insert(hash); }
 
-   private:
+  private:
     void Sha1ToVkUuid(const char *sha1_str, uint8_t *uuid) {
         // Convert sha1_str from a hex string to binary. We only need VK_UUID_SIZE bytes of
         // output, so pad with zeroes if the input string is shorter than that, and truncate

--- a/layers/sparse_containers.h
+++ b/layers/sparse_containers.h
@@ -88,7 +88,7 @@ namespace sparse_container {
 
 template <typename IndexType_, typename T, bool kSetReplaces, T kDefaultValue = T(), size_t kSparseThreshold = 16>
 class SparseVector {
-   public:
+  public:
     typedef IndexType_ IndexType;
     typedef T value_type;
     typedef value_type ValueType;
@@ -227,7 +227,7 @@ class SparseVector {
 
     friend class ConstIterator;
     class ConstIterator {
-       public:
+      public:
         using SparseType = typename SparseVector::SparseType;
         using SparseIterator = typename SparseType::const_iterator;
         using IndexType = typename SparseVector::IndexType;
@@ -288,7 +288,7 @@ class SparseVector {
 
         ConstIterator() : vec_(nullptr), the_end_(true) {}
 
-       protected:
+      protected:
         const SparseVector *vec_;
         bool the_end_;
         SparseIterator it_sparse_;

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -88,7 +88,7 @@ struct LogMiscParams {
 };
 
 class StatelessValidation : public ValidationObject {
-   public:
+  public:
     VkPhysicalDeviceLimits device_limits = {};
     safe_VkPhysicalDeviceFeatures2 physical_device_features2;
     const VkPhysicalDeviceFeatures &physical_device_features = physical_device_features2.features;

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -41,7 +41,7 @@
 #define MAX_CHARS_PER_LINE 4096
 
 class ConfigFile {
-   public:
+  public:
     ConfigFile();
     ~ConfigFile();
 
@@ -49,7 +49,7 @@ class ConfigFile {
     void setOption(const std::string &_option, const std::string &_val);
     std::string vk_layer_disables_env_var{};
 
-   private:
+  private:
     bool m_fileIsParsed;
     std::map<std::string, std::string> m_valueMap;
 

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -33,7 +33,7 @@ class small_unordered_map {
 
     std::unordered_map<Key, T> inner_map;
 
-   public:
+  public:
     small_unordered_map() {
         for (int i = 0; i < N; ++i) {
             small_data_allocated[i] = false;
@@ -48,7 +48,7 @@ class small_unordered_map {
         int index;
         inner_iterator it;
 
-       public:
+      public:
         iterator() {}
 
         iterator operator++() {

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -88,8 +88,8 @@ VK_LAYER_EXPORT bool white_list(const char *item, const std::set<std::string> &l
 // If a vk_layer_settings.txt file is present and an application defines a debug callback, both callbacks
 // will be active.  If no vk_layer_settings.txt file is present, creating an application-defined debug
 // callback will cause the default callbacks to be unregisterd and removed.
-VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data,
-                                                   const VkAllocationCallbacks *pAllocator, const char *layer_identifier) {
+VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data, const VkAllocationCallbacks *pAllocator,
+                                                   const char *layer_identifier) {
     VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
 
     std::string report_flags_key = layer_identifier;
@@ -151,8 +151,8 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
 
 // NOTE: This function has been deprecated, and the above function (layer_debug_messenger_actions) should be
 //       used in its place.
-VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data,
-                                                const VkAllocationCallbacks *pAllocator, const char *layer_identifier) {
+VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, const VkAllocationCallbacks *pAllocator,
+                                                const char *layer_identifier) {
     VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
 
     std::string report_flags_key = layer_identifier;

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -133,11 +133,11 @@ typedef enum VkStringErrorFlagBits {
 } VkStringErrorFlagBits;
 typedef VkFlags VkStringErrorFlags;
 
-VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data,
-                                                const VkAllocationCallbacks *pAllocator, const char *layer_identifier);
+VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, const VkAllocationCallbacks *pAllocator,
+                                                const char *layer_identifier);
 
-VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data,
-                                                   const VkAllocationCallbacks *pAllocator, const char *layer_identifier);
+VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_data, const VkAllocationCallbacks *pAllocator,
+                                                   const char *layer_identifier);
 
 VK_LAYER_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 VK_LAYER_EXPORT bool white_list(const char *item, const std::set<std::string> &whitelist);
@@ -189,7 +189,7 @@ static inline int u_ffs(int val) {
 // predicate. This can be used as a substitute for iterators in exceptional cases.
 template <typename Key, typename T, int BUCKETSLOG2 = 2, typename Hash = std::hash<Key>>
 class vl_concurrent_unordered_map {
-   public:
+  public:
     void insert_or_assign(const Key &key, const T &value) {
         uint32_t h = ConcurrentMapHashObject(key);
         write_lock_guard_t lock(locks[h].lock);
@@ -218,7 +218,7 @@ class vl_concurrent_unordered_map {
 
     // type returned by find() and end().
     class FindResult {
-       public:
+      public:
         FindResult(bool a, T b) : result(a, std::move(b)) {}
 
         // == and != only support comparing against end()
@@ -234,7 +234,7 @@ class vl_concurrent_unordered_map {
         std::pair<bool, T> *operator->() { return &result; }
         const std::pair<bool, T> *operator->() const { return &result; }
 
-       private:
+      private:
         // (found, reference to element)
         std::pair<bool, T> result;
     };
@@ -286,7 +286,7 @@ class vl_concurrent_unordered_map {
         return ret;
     }
 
-   private:
+  private:
     static const int BUCKETS = (1 << BUCKETSLOG2);
 // shared_mutex support added in MSVC 2015 update 2
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -224,7 +224,7 @@ T NearestSmaller(const T from) {
 }
 
 class VkLayerTest : public VkRenderFramework {
-   public:
+  public:
     void VKTriangleTest(BsoFailSelect failCase);
 
     void GenericDrawPreparation(VkCommandBufferObj *commandBuffer, VkPipelineObj &pipelineobj, VkDescriptorSetObj &descriptorSet,
@@ -236,7 +236,7 @@ class VkLayerTest : public VkRenderFramework {
     bool AddSwapchainDeviceExtension();
     VkCommandBufferObj *CommandBuffer();
 
-   protected:
+  protected:
     uint32_t m_instance_api_version = 0;
     uint32_t m_target_api_version = 0;
     bool m_enableWSI;
@@ -251,18 +251,18 @@ class VkLayerTest : public VkRenderFramework {
 };
 
 class VkPositiveLayerTest : public VkLayerTest {
-   public:
-   protected:
+  public:
+  protected:
 };
 
 class VkWsiEnabledLayerTest : public VkLayerTest {
-   public:
-   protected:
+  public:
+  protected:
     VkWsiEnabledLayerTest() { m_enableWSI = true; }
 };
 
 class VkBufferTest {
-   public:
+  public:
     enum eTestEnFlags {
         eDoubleDelete,
         eInvalidDeviceOffset,
@@ -283,7 +283,7 @@ class VkBufferTest {
     const VkBuffer &GetBuffer();
     void TestDoubleDestroy();
 
-   protected:
+  protected:
     bool AllocateCurrent;
     bool BoundCurrent;
     bool CreateCurrent;
@@ -296,7 +296,7 @@ class VkBufferTest {
 
 struct CreatePipelineHelper;
 class VkVerticesObj {
-   public:
+  public:
     VkVerticesObj(VkDeviceObj *aVulkanDevice, unsigned aAttributeCount, unsigned aBindingCount, unsigned aByteStride,
                   VkDeviceSize aVertexCount, const float *aVerticies);
     ~VkVerticesObj();
@@ -304,7 +304,7 @@ class VkVerticesObj {
     bool AddVertexInputToPipeHelpr(CreatePipelineHelper *pipelineHelper);
     void BindVertexBuffers(VkCommandBuffer aCommandBuffer, unsigned aOffsetCount = 0, VkDeviceSize *aOffsetList = nullptr);
 
-   protected:
+  protected:
     static uint32_t BindIdGenerator;
 
     bool BoundCurrent;
@@ -351,7 +351,7 @@ bool IsValidVkStruct(const T &s) {
 // Designed with minimal error checking to ensure easy error state creation
 // See OneshotTest for typical usage
 struct CreatePipelineHelper {
-   public:
+  public:
     std::vector<VkDescriptorSetLayoutBinding> dsl_bindings_;
     std::unique_ptr<OneOffDescriptorSet> descriptor_set_;
     std::vector<VkPipelineShaderStageCreateInfo> shader_stages_;
@@ -431,7 +431,7 @@ struct CreatePipelineHelper {
 };
 
 struct CreateComputePipelineHelper {
-   public:
+  public:
     std::vector<VkDescriptorSetLayoutBinding> dsl_bindings_;
     std::unique_ptr<OneOffDescriptorSet> descriptor_set_;
     VkPipelineLayoutCreateInfo pipeline_layout_ci_ = {};
@@ -491,7 +491,7 @@ struct CreateComputePipelineHelper {
 // Designed with minimal error checking to ensure easy error state creation
 // See OneshotTest for typical usage
 struct CreateNVRayTracingPipelineHelper {
-   public:
+  public:
     std::vector<VkDescriptorSetLayoutBinding> dsl_bindings_;
     std::unique_ptr<OneOffDescriptorSet> descriptor_set_;
     std::vector<VkPipelineShaderStageCreateInfo> shader_stages_;
@@ -575,7 +575,7 @@ class ExtensionChain {
     typedef std::vector<const char *> List;
     List *list_;
 
-   public:
+  public:
     template <typename F>
     ExtensionChain(F &add_if, List *list) : add_if_(add_if), list_(list) {}
 
@@ -601,7 +601,7 @@ VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstan
 VkPhysicalDeviceSubgroupProperties GetSubgroupProperties(VkInstance instance, VkPhysicalDevice gpu);
 
 class BarrierQueueFamilyTestHelper {
-   public:
+  public:
     struct QueueFamilyObjs {
         uint32_t index;
         // We would use std::unique_ptr, but this triggers a compiler error on older compilers

--- a/tests/test_environment.h
+++ b/tests/test_environment.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 
 namespace vk_testing {
 class Environment : public ::testing::Environment {
-   public:
+  public:
     Environment();
 
     bool parse_args(int argc, char **argv);
@@ -44,7 +44,7 @@ class Environment : public ::testing::Environment {
     VkInstance get_instance() { return inst; }
     VkPhysicalDevice gpus[16];
 
-   private:
+  private:
     VkApplicationInfo app_;
     uint32_t default_dev_;
     VkInstance inst;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -57,7 +57,7 @@ std::vector<Dst *> MakeTestbindingHandles(const std::vector<Src *> &v) {
 
 typedef vk_testing::Queue VkQueueObj;
 class VkDeviceObj : public vk_testing::Device {
-   public:
+  public:
     VkDeviceObj(uint32_t id, VkPhysicalDevice obj);
     VkDeviceObj(uint32_t id, VkPhysicalDevice obj, std::vector<const char *> &extension_names,
                 VkPhysicalDeviceFeatures *features = nullptr, void *create_device_pnext = nullptr);
@@ -92,7 +92,7 @@ class VkDeviceObj : public vk_testing::Device {
 // were encountered. Call VerifyNotFound to determine if any unexpected
 // failure was encountered.
 class ErrorMonitor {
-   public:
+  public:
     ErrorMonitor();
 
     ~ErrorMonitor();
@@ -134,7 +134,7 @@ class ErrorMonitor {
     void VerifyFound();
     void VerifyNotFound();
 
-   private:
+  private:
     // TODO: This is stopgap to block new unexpected errors from being introduced. The long-term goal is to remove the use of this
     // function and its definition.
     bool IgnoreMessage(std::string const &msg) const;
@@ -154,7 +154,7 @@ class VkCommandBufferObj;
 class VkDepthStencilObj;
 
 class VkRenderFramework : public VkTestFramework {
-   public:
+  public:
     VkInstance instance() { return inst; }
     VkDevice device() { return m_device->device(); }
     VkDeviceObj *DeviceObj() const { return m_device; }
@@ -197,7 +197,7 @@ class VkRenderFramework : public VkTestFramework {
     bool DeviceIsMockICD();
     bool DeviceSimulation();
 
-   protected:
+  protected:
     VkRenderFramework();
     virtual ~VkRenderFramework() = 0;
 
@@ -258,12 +258,12 @@ typedef vk_testing::Buffer VkBufferObj;
 typedef vk_testing::AccelerationStructure VkAccelerationStructureObj;
 
 class VkCommandPoolObj : public vk_testing::CommandPool {
-   public:
+  public:
     VkCommandPoolObj(VkDeviceObj *device, uint32_t queue_family_index, VkCommandPoolCreateFlags flags = 0);
 };
 
 class VkCommandBufferObj : public vk_testing::CommandBuffer {
-   public:
+  public:
     VkCommandBufferObj(VkDeviceObj *device, VkCommandPoolObj *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
                        VkQueueObj *queue = nullptr);
     void PipelineBarrier(VkPipelineStageFlags src_stages, VkPipelineStageFlags dest_stages, VkDependencyFlags dependencyFlags,
@@ -298,13 +298,13 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
     void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer);
     void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer, VkBuffer instanceData);
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
     VkQueueObj *m_queue;
 };
 
 class VkConstantBufferObj : public VkBufferObj {
-   public:
+  public:
     VkConstantBufferObj(VkDeviceObj *device,
                         VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     VkConstantBufferObj(VkDeviceObj *device, VkDeviceSize size, const void *data,
@@ -312,27 +312,27 @@ class VkConstantBufferObj : public VkBufferObj {
 
     VkDescriptorBufferInfo m_descriptorBufferInfo;
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
 };
 
 class VkRenderpassObj {
-   public:
+  public:
     VkRenderpassObj(VkDeviceObj *device);
     ~VkRenderpassObj();
     VkRenderPass handle() { return m_renderpass; }
 
-   protected:
+  protected:
     VkRenderPass m_renderpass;
     VkDevice device;
 };
 
 class VkImageObj : public vk_testing::Image {
-   public:
+  public:
     VkImageObj(VkDeviceObj *dev);
     bool IsCompatible(VkImageUsageFlags usages, VkFormatFeatureFlags features);
 
-   public:
+  public:
     void Init(uint32_t const width, uint32_t const height, uint32_t const mipLevels, VkFormat const format, VkFlags const usage,
               VkImageTiling const tiling = VK_IMAGE_TILING_LINEAR, VkMemoryPropertyFlags const reqs = 0,
               const std::vector<uint32_t> *queue_families = nullptr, bool memory = true);
@@ -392,7 +392,7 @@ class VkImageObj : public vk_testing::Image {
     uint32_t height() const { return extent().height; }
     VkDeviceObj *device() const { return m_device; }
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
 
     vk_testing::ImageView m_targetView;
@@ -400,18 +400,18 @@ class VkImageObj : public vk_testing::Image {
 };
 
 class VkTextureObj : public VkImageObj {
-   public:
+  public:
     VkTextureObj(VkDeviceObj *device, uint32_t *colors = NULL);
 
     const VkDescriptorImageInfo &DescriptorImageInfo() const { return m_descriptorImageInfo; }
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
     vk_testing::ImageView m_textureView;
 };
 
 class VkDepthStencilObj : public VkImageObj {
-   public:
+  public:
     VkDepthStencilObj(VkDeviceObj *device);
     void Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format,
               VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
@@ -420,7 +420,7 @@ class VkDepthStencilObj : public VkImageObj {
 
     VkFormat Format() const;
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
     bool m_initialized;
     vk_testing::ImageView m_imageView;
@@ -429,15 +429,15 @@ class VkDepthStencilObj : public VkImageObj {
 };
 
 class VkSamplerObj : public vk_testing::Sampler {
-   public:
+  public:
     VkSamplerObj(VkDeviceObj *device);
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
 };
 
 class VkDescriptorSetLayoutObj : public vk_testing::DescriptorSetLayout {
-   public:
+  public:
     VkDescriptorSetLayoutObj() = default;
     VkDescriptorSetLayoutObj(const VkDeviceObj *device,
                              const std::vector<VkDescriptorSetLayoutBinding> &descriptor_set_bindings = {},
@@ -452,7 +452,7 @@ class VkDescriptorSetLayoutObj : public vk_testing::DescriptorSetLayout {
 };
 
 class VkDescriptorSetObj : public vk_testing::DescriptorPool {
-   public:
+  public:
     VkDescriptorSetObj(VkDeviceObj *device);
     ~VkDescriptorSetObj();
 
@@ -464,7 +464,7 @@ class VkDescriptorSetObj : public vk_testing::DescriptorPool {
     VkDescriptorSet GetDescriptorSetHandle() const;
     VkPipelineLayout GetPipelineLayout() const;
 
-   protected:
+  protected:
     VkDeviceObj *m_device;
     std::vector<VkDescriptorSetLayoutBinding> m_layout_bindings;
     std::map<VkDescriptorType, int> m_type_counts;
@@ -479,20 +479,20 @@ class VkDescriptorSetObj : public vk_testing::DescriptorPool {
 };
 
 class VkShaderObj : public vk_testing::ShaderModule {
-   public:
+  public:
     VkShaderObj(VkDeviceObj *device, const char *shaderText, VkShaderStageFlagBits stage, VkRenderFramework *framework,
                 char const *name = "main", bool debug = false, VkSpecializationInfo *specInfo = nullptr);
     VkShaderObj(VkDeviceObj *device, const std::string spv_source, VkShaderStageFlagBits stage, VkRenderFramework *framework,
                 char const *name = "main", VkSpecializationInfo *specInfo = nullptr);
     VkPipelineShaderStageCreateInfo const &GetStageCreateInfo() const;
 
-   protected:
+  protected:
     VkPipelineShaderStageCreateInfo m_stage_info;
     VkDeviceObj *m_device;
 };
 
 class VkPipelineLayoutObj : public vk_testing::PipelineLayout {
-   public:
+  public:
     VkPipelineLayoutObj() = default;
     VkPipelineLayoutObj(VkDeviceObj *device, const std::vector<const VkDescriptorSetLayoutObj *> &descriptor_layouts = {},
                         const std::vector<VkPushConstantRange> &push_constant_ranges = {});
@@ -508,7 +508,7 @@ class VkPipelineLayoutObj : public vk_testing::PipelineLayout {
 };
 
 class VkPipelineObj : public vk_testing::Pipeline {
-   public:
+  public:
     VkPipelineObj(VkDeviceObj *device);
     void AddShader(VkShaderObj *shaderObj);
     void AddShader(VkPipelineShaderStageCreateInfo const &createInfo);
@@ -537,7 +537,7 @@ class VkPipelineObj : public vk_testing::Pipeline {
 
     VkResult CreateVKPipeline(VkPipelineLayout layout, VkRenderPass render_pass, VkGraphicsPipelineCreateInfo *gp_ci = nullptr);
 
-   protected:
+  protected:
     VkPipelineVertexInputStateCreateInfo m_vi_state;
     VkPipelineInputAssemblyStateCreateInfo m_ia_state;
     VkPipelineRasterizationStateCreateInfo m_rs_state;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -84,11 +84,11 @@ namespace internal {
 
 template <typename T>
 class Handle {
-   public:
+  public:
     const T &handle() const { return handle_; }
     bool initialized() const { return (handle_ != T{}); }
 
-   protected:
+  protected:
     typedef T handle_type;
 
     explicit Handle() : handle_{} {}
@@ -111,13 +111,13 @@ class Handle {
         handle_ = handle;
     }
 
-   private:
+  private:
     T handle_;
 };
 
 template <typename T>
 class NonDispHandle : public Handle<T> {
-   protected:
+  protected:
     explicit NonDispHandle() : Handle<T>(), dev_handle_(VK_NULL_HANDLE) {}
     explicit NonDispHandle(VkDevice dev, T handle) : Handle<T>(handle), dev_handle_(dev) {}
 
@@ -140,14 +140,14 @@ class NonDispHandle : public Handle<T> {
         dev_handle_ = dev;
     }
 
-   private:
+  private:
     VkDevice dev_handle_;
 };
 
 }  // namespace internal
 
 class PhysicalDevice : public internal::Handle<VkPhysicalDevice> {
-   public:
+  public:
     explicit PhysicalDevice(VkPhysicalDevice phy) : Handle(phy) {
         memory_properties_ = memory_properties();
         device_properties_ = properties();
@@ -168,7 +168,7 @@ class PhysicalDevice : public internal::Handle<VkPhysicalDevice> {
     // vkEnumerateLayers()
     std::vector<VkLayerProperties> layers() const;
 
-   private:
+  private:
     void add_extension_dependencies(uint32_t dependency_count, VkExtensionProperties *depencency_props,
                                     std::vector<VkExtensionProperties> &ext_list);
 
@@ -178,18 +178,18 @@ class PhysicalDevice : public internal::Handle<VkPhysicalDevice> {
 };
 
 class QueueCreateInfoArray {
-   private:
+  private:
     std::vector<VkDeviceQueueCreateInfo> queue_info_;
     std::vector<std::vector<float>> queue_priorities_;
 
-   public:
+  public:
     QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties> &queue_props);
     size_t size() const { return queue_info_.size(); }
     const VkDeviceQueueCreateInfo *data() const { return queue_info_.data(); }
 };
 
 class Device : public internal::Handle<VkDevice> {
-   public:
+  public:
     explicit Device(VkPhysicalDevice phy) : phy_(phy) {}
     ~Device();
 
@@ -262,7 +262,7 @@ class Device : public internal::Handle<VkDevice> {
                                                    const DescriptorSet &dst_set, uint32_t dst_binding, uint32_t dst_array_element,
                                                    uint32_t count);
 
-   private:
+  private:
     enum QueueIndex {
         GRAPHICS,
         COMPUTE,
@@ -283,7 +283,7 @@ class Device : public internal::Handle<VkDevice> {
 };
 
 class Queue : public internal::Handle<VkQueue> {
-   public:
+  public:
     explicit Queue(VkQueue queue, int index) : Handle(queue) { family_index_ = index; }
 
     // vkQueueSubmit()
@@ -296,12 +296,12 @@ class Queue : public internal::Handle<VkQueue> {
 
     int get_family_index() { return family_index_; }
 
-   private:
+  private:
     int family_index_;
 };
 
 class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
-   public:
+  public:
     ~DeviceMemory();
 
     // vkAllocateMemory()
@@ -322,7 +322,7 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
 };
 
 class Fence : public internal::NonDispHandle<VkFence> {
-   public:
+  public:
     ~Fence();
 
     // vkCreateFence()
@@ -337,7 +337,7 @@ class Fence : public internal::NonDispHandle<VkFence> {
 };
 
 class Semaphore : public internal::NonDispHandle<VkSemaphore> {
-   public:
+  public:
     ~Semaphore();
 
     // vkCreateSemaphore()
@@ -347,7 +347,7 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
 };
 
 class Event : public internal::NonDispHandle<VkEvent> {
-   public:
+  public:
     ~Event();
 
     // vkCreateEvent()
@@ -364,7 +364,7 @@ class Event : public internal::NonDispHandle<VkEvent> {
 };
 
 class QueryPool : public internal::NonDispHandle<VkQueryPool> {
-   public:
+  public:
     ~QueryPool();
 
     // vkCreateQueryPool()
@@ -377,7 +377,7 @@ class QueryPool : public internal::NonDispHandle<VkQueryPool> {
 };
 
 class Buffer : public internal::NonDispHandle<VkBuffer> {
-   public:
+  public:
     explicit Buffer() : NonDispHandle() {}
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info) { init(dev, info); }
     explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
@@ -439,14 +439,14 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
         return barrier;
     }
 
-   private:
+  private:
     VkBufferCreateInfo create_info_;
 
     DeviceMemory internal_mem_;
 };
 
 class BufferView : public internal::NonDispHandle<VkBufferView> {
-   public:
+  public:
     ~BufferView();
 
     // vkCreateBufferView()
@@ -468,7 +468,7 @@ inline VkBufferViewCreateInfo BufferView::createInfo(VkBuffer buffer, VkFormat f
 }
 
 class Image : public internal::NonDispHandle<VkImage> {
-   public:
+  public:
     explicit Image() : NonDispHandle(), format_features_(0) {}
     explicit Image(const Device &dev, const VkImageCreateInfo &info) : format_features_(0) { init(dev, info); }
 
@@ -538,7 +538,7 @@ class Image : public internal::NonDispHandle<VkImage> {
     static VkExtent3D extent(int32_t width, int32_t height, int32_t depth);
     static VkExtent3D extent(const VkExtent3D &extent, uint32_t mip_level);
 
-   private:
+  private:
     void init_info(const Device &dev, const VkImageCreateInfo &info);
 
     VkImageCreateInfo create_info_;
@@ -548,7 +548,7 @@ class Image : public internal::NonDispHandle<VkImage> {
 };
 
 class ImageView : public internal::NonDispHandle<VkImageView> {
-   public:
+  public:
     ~ImageView();
 
     // vkCreateImageView()
@@ -556,7 +556,7 @@ class ImageView : public internal::NonDispHandle<VkImageView> {
 };
 
 class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStructureNV> {
-   public:
+  public:
     explicit AccelerationStructure(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true) {
         init(dev, info, init_memory);
     }
@@ -577,14 +577,14 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
 
     void create_scratch_buffer(const Device &dev, Buffer *buffer);
 
-   private:
+  private:
     VkAccelerationStructureInfoNV info_;
     DeviceMemory memory_;
     uint64_t opaque_handle_;
 };
 
 class ShaderModule : public internal::NonDispHandle<VkShaderModule> {
-   public:
+  public:
     ~ShaderModule();
 
     // vkCreateShaderModule()
@@ -595,7 +595,7 @@ class ShaderModule : public internal::NonDispHandle<VkShaderModule> {
 };
 
 class Pipeline : public internal::NonDispHandle<VkPipeline> {
-   public:
+  public:
     ~Pipeline();
 
     // vkCreateGraphicsPipeline()
@@ -617,7 +617,7 @@ class Pipeline : public internal::NonDispHandle<VkPipeline> {
 };
 
 class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
-   public:
+  public:
     PipelineLayout() NOEXCEPT : NonDispHandle(){};
     ~PipelineLayout();
 
@@ -635,7 +635,7 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
 };
 
 class Sampler : public internal::NonDispHandle<VkSampler> {
-   public:
+  public:
     ~Sampler();
 
     // vkCreateSampler()
@@ -643,7 +643,7 @@ class Sampler : public internal::NonDispHandle<VkSampler> {
 };
 
 class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout> {
-   public:
+  public:
     DescriptorSetLayout() NOEXCEPT : NonDispHandle(){};
     ~DescriptorSetLayout();
 
@@ -661,7 +661,7 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
 };
 
 class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
-   public:
+  public:
     ~DescriptorPool();
 
     // Descriptor sets allocated from this pool will need access to the original
@@ -687,7 +687,7 @@ class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
     static VkDescriptorPoolCreateInfo create_info(VkDescriptorPoolCreateFlags flags, uint32_t max_sets,
                                                   const PoolSizes &pool_sizes);
 
-   private:
+  private:
     VkDescriptorPool pool_;
 
     // Track whether this pool's usage is VK_DESCRIPTOR_POOL_USAGE_DYNAMIC
@@ -708,7 +708,7 @@ inline VkDescriptorPoolCreateInfo DescriptorPool::create_info(VkDescriptorPoolCr
 }
 
 class DescriptorSet : public internal::NonDispHandle<VkDescriptorSet> {
-   public:
+  public:
     ~DescriptorSet();
 
     explicit DescriptorSet() : NonDispHandle() {}
@@ -716,12 +716,12 @@ class DescriptorSet : public internal::NonDispHandle<VkDescriptorSet> {
         containing_pool_ = pool;
     }
 
-   private:
+  private:
     DescriptorPool *containing_pool_;
 };
 
 class CommandPool : public internal::NonDispHandle<VkCommandPool> {
-   public:
+  public:
     ~CommandPool();
 
     explicit CommandPool() : NonDispHandle() {}
@@ -741,7 +741,7 @@ inline VkCommandPoolCreateInfo CommandPool::create_info(uint32_t queue_family_in
 }
 
 class CommandBuffer : public internal::Handle<VkCommandBuffer> {
-   public:
+  public:
     ~CommandBuffer();
 
     explicit CommandBuffer() : Handle() {}
@@ -762,7 +762,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
 
     static VkCommandBufferAllocateInfo create_info(VkCommandPool const &pool);
 
-   private:
+  private:
     VkDevice dev_handle_;
     VkCommandPool cmd_pool_;
 };

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -58,7 +58,7 @@ using namespace std;
 class VkImageObj;
 
 class VkTestFramework : public ::testing::Test {
-   public:
+  public:
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
     static bool optionMatch(const char *option, char *optionLine);
     static void InitArgs(int *argc, char *argv[]);
@@ -76,11 +76,11 @@ class VkTestFramework : public ::testing::Test {
     char **ReadFileData(const char *fileName);
     void FreeFileData(char **data);
 
-   protected:
+  protected:
     VkTestFramework();
     virtual ~VkTestFramework() = 0;
 
-   private:
+  private:
     int m_compile_options;
     int m_num_shader_strings;
     TBuiltInResource Resources;
@@ -96,7 +96,7 @@ class VkTestFramework : public ::testing::Test {
 };
 
 class TestEnvironment : public ::testing::Environment {
-   public:
+  public:
     void SetUp();
 
     void TearDown();

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -35,7 +35,7 @@
 #define ICD_SPV_MAGIC 0x07230203
 
 class VkTestFramework : public ::testing::Test {
-   public:
+  public:
     VkTestFramework();
     ~VkTestFramework();
 
@@ -52,7 +52,7 @@ class VkTestFramework : public ::testing::Test {
 };
 
 class TestEnvironment : public ::testing::Environment {
-   public:
+  public:
     void SetUp();
 
     void TearDown();


### PR DESCRIPTION
- make access modifiers indented by 2 spaces
  (originally 1 space, so preserves being a half indent; accidentally 3 spaces in this repo)
- document we use `*.cpp` instead of Google's `*.cc`