### PR TITLE
Fix shared_mutex supportd version compilation errors

### DIFF
--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -290,7 +290,7 @@ class ThreadSafety : public ValidationObject {
 public:
 
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
     typedef std::shared_mutex thread_safety_lock_t;
     typedef std::shared_lock<thread_safety_lock_t> read_lock_guard_t;
     typedef std::unique_lock<thread_safety_lock_t> write_lock_guard_t;

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -416,7 +416,7 @@ class ThreadSafety : public ValidationObject {
 public:
 
 // shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
     typedef std::shared_mutex thread_safety_lock_t;
     typedef std::shared_lock<thread_safety_lock_t> read_lock_guard_t;
     typedef std::unique_lock<thread_safety_lock_t> write_lock_guard_t;


### PR DESCRIPTION
Conditional compilation defs for include was different than that of implementation, causing compilation failures on some supported versions of Visual Studio.

Fixes #1236.

We also reproduced this on a VS2017 version 15.1 installation.
