### PR TITLE
Fix build with gcc5.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -44,7 +44,6 @@
 #include <cmath>
 #include <iostream>
 #include <list>
-#include <math.h>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -21,7 +21,7 @@
 
 #define NOMINMAX
 
-#include <math.h>
+#include <cmath>
 
 #include "chassis.h"
 #include "stateless_validation.h"

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -38,7 +38,7 @@
 #pragma warning(pop)
 #endif
 #include <limits.h>
-#include <math.h>
+#include <cmath>
 
 #if defined(PATH_MAX) && !defined(MAX_PATH)
 #define MAX_PATH PATH_MAX


### PR DESCRIPTION
This fixes the following build error with `gcc-5.3.0` on `Slackware-14.2`.
```
Vulkan-ValidationLayers-sdk-1.1.114.0/layers/parameter_validation_utils.cpp: In lambda function:
Vulkan-ValidationLayers-sdk-1.1.114.0/layers/parameter_validation_utils.cpp:659:13: error: '__builtin_isnan' is not a member of 'std'
         if (std::isnan(v1_f)) return false;
             ^
Vulkan-ValidationLayers-sdk-1.1.114.0/layers/parameter_validation_utils.cpp:659:13: note: suggested alternative:
<built-in>: note:   '__builtin_isnan'
layers/CMakeFiles/VkLayer_stateless_validation.dir/build.make:134: recipe for target 'layers/CMakeFiles/VkLayer_stateless_validation.dir/parameter_validation_utils.cpp.o' failed
make[2]: *** [layers/CMakeFiles/VkLayer_stateless_validation.dir/parameter_validation_utils.cpp.o] Error 1
CMakeFiles/Makefile2:612: recipe for target 'layers/CMakeFiles/VkLayer_stateless_validation.dir/all' failed
make[1]: *** [layers/CMakeFiles/VkLayer_stateless_validation.dir/all] Error 2
```
Please note that this was tested against the `sdk-1.1.114.0` release, but the code has not changed in master so it should still be relevant.