### PR TITLE
Make threading respect CreatePipelines partial results

### DIFF
--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -1428,11 +1428,10 @@ void ThreadSafety::PostCallRecordCreateGraphicsPipelines(
     VkResult                                    result) {
     FinishReadObjectParentInstance(device);
     FinishReadObject(pipelineCache);
-    if (result == VK_SUCCESS) {
-        if (pPipelines) {
-            for (uint32_t index = 0; index < createInfoCount; index++) {
-                CreateObject(pPipelines[index]);
-            }
+    if (pPipelines) {
+        for (uint32_t index = 0; index < createInfoCount; index++) {
+            if (!pPipelines[index]) continue;
+            CreateObject(pPipelines[index]);
         }
     }
 }
@@ -1458,11 +1457,10 @@ void ThreadSafety::PostCallRecordCreateComputePipelines(
     VkResult                                    result) {
     FinishReadObjectParentInstance(device);
     FinishReadObject(pipelineCache);
-    if (result == VK_SUCCESS) {
-        if (pPipelines) {
-            for (uint32_t index = 0; index < createInfoCount; index++) {
-                CreateObject(pPipelines[index]);
-            }
+    if (pPipelines) {
+        for (uint32_t index = 0; index < createInfoCount; index++) {
+            if (!pPipelines[index]) continue;
+            CreateObject(pPipelines[index]);
         }
     }
 }
@@ -5585,11 +5583,10 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesNV(
     VkResult                                    result) {
     FinishReadObjectParentInstance(device);
     FinishReadObject(pipelineCache);
-    if (result == VK_SUCCESS) {
-        if (pPipelines) {
-            for (uint32_t index = 0; index < createInfoCount; index++) {
-                CreateObject(pPipelines[index]);
-            }
+    if (pPipelines) {
+        for (uint32_t index = 0; index < createInfoCount; index++) {
+            if (!pPipelines[index]) continue;
+            CreateObject(pPipelines[index]);
         }
     }
 }

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -415,9 +415,45 @@ public:
 #endif  // DISTINCT_NONDISPATCHABLE_HANDLES
               {};
 
-#define WRAPPER(type)                                                    void StartWriteObject(type object) {                                     c_##type.StartWrite(object);                                     }                                                                    void FinishWriteObject(type object) {                                    c_##type.FinishWrite(object);                                    }                                                                    void StartReadObject(type object) {                                      c_##type.StartRead(object);                                      }                                                                    void FinishReadObject(type object) {                                     c_##type.FinishRead(object);                                     }                                                                    void CreateObject(type object) {                                         c_##type.CreateObject(object);                                   }                                                                    void DestroyObject(type object) {                                        c_##type.DestroyObject(object);                                  }
+#define WRAPPER(type)                                                \
+    void StartWriteObject(type object) {                             \
+        c_##type.StartWrite(object);                                 \
+    }                                                                \
+    void FinishWriteObject(type object) {                            \
+        c_##type.FinishWrite(object);                                \
+    }                                                                \
+    void StartReadObject(type object) {                              \
+        c_##type.StartRead(object);                                  \
+    }                                                                \
+    void FinishReadObject(type object) {                             \
+        c_##type.FinishRead(object);                                 \
+    }                                                                \
+    void CreateObject(type object) {                                 \
+        c_##type.CreateObject(object);                               \
+    }                                                                \
+    void DestroyObject(type object) {                                \
+        c_##type.DestroyObject(object);                              \
+    }
 
-#define WRAPPER_PARENT_INSTANCE(type)                                    void StartWriteObjectParentInstance(type object) {                                     (parent_instance ? parent_instance : this)->c_##type.StartWrite(object);                                     }                                                                    void FinishWriteObjectParentInstance(type object) {                                    (parent_instance ? parent_instance : this)->c_##type.FinishWrite(object);                                    }                                                                    void StartReadObjectParentInstance(type object) {                                      (parent_instance ? parent_instance : this)->c_##type.StartRead(object);                                      }                                                                    void FinishReadObjectParentInstance(type object) {                                     (parent_instance ? parent_instance : this)->c_##type.FinishRead(object);                                     }                                                                    void CreateObjectParentInstance(type object) {                                         (parent_instance ? parent_instance : this)->c_##type.CreateObject(object);                                   }                                                                    void DestroyObjectParentInstance(type object) {                                        (parent_instance ? parent_instance : this)->c_##type.DestroyObject(object);                                  }
+#define WRAPPER_PARENT_INSTANCE(type)                                                   \
+    void StartWriteObjectParentInstance(type object) {                                  \
+        (parent_instance ? parent_instance : this)->c_##type.StartWrite(object);        \
+    }                                                                                   \
+    void FinishWriteObjectParentInstance(type object) {                                 \
+        (parent_instance ? parent_instance : this)->c_##type.FinishWrite(object);       \
+    }                                                                                   \
+    void StartReadObjectParentInstance(type object) {                                   \
+        (parent_instance ? parent_instance : this)->c_##type.StartRead(object);         \
+    }                                                                                   \
+    void FinishReadObjectParentInstance(type object) {                                  \
+        (parent_instance ? parent_instance : this)->c_##type.FinishRead(object);        \
+    }                                                                                   \
+    void CreateObjectParentInstance(type object) {                                      \
+        (parent_instance ? parent_instance : this)->c_##type.CreateObject(object);      \
+    }                                                                                   \
+    void DestroyObjectParentInstance(type object) {                                     \
+        (parent_instance ? parent_instance : this)->c_##type.DestroyObject(object);     \
+    }
 
 WRAPPER_PARENT_INSTANCE(VkDevice)
 WRAPPER_PARENT_INSTANCE(VkInstance)

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -476,44 +476,44 @@ COUNTER_CLASS_INSTANCES_TEMPLATE
 #endif  // DISTINCT_NONDISPATCHABLE_HANDLES
               {};
 
-#define WRAPPER(type)                                                \
-    void StartWriteObject(type object) {                             \
-        c_##type.StartWrite(object);                                 \
-    }                                                                \
-    void FinishWriteObject(type object) {                            \
-        c_##type.FinishWrite(object);                                \
-    }                                                                \
-    void StartReadObject(type object) {                              \
-        c_##type.StartRead(object);                                  \
-    }                                                                \
-    void FinishReadObject(type object) {                             \
-        c_##type.FinishRead(object);                                 \
-    }                                                                \
-    void CreateObject(type object) {                                 \
-        c_##type.CreateObject(object);                               \
-    }                                                                \
-    void DestroyObject(type object) {                                \
-        c_##type.DestroyObject(object);                              \
+#define WRAPPER(type)                                                \\
+    void StartWriteObject(type object) {                             \\
+        c_##type.StartWrite(object);                                 \\
+    }                                                                \\
+    void FinishWriteObject(type object) {                            \\
+        c_##type.FinishWrite(object);                                \\
+    }                                                                \\
+    void StartReadObject(type object) {                              \\
+        c_##type.StartRead(object);                                  \\
+    }                                                                \\
+    void FinishReadObject(type object) {                             \\
+        c_##type.FinishRead(object);                                 \\
+    }                                                                \\
+    void CreateObject(type object) {                                 \\
+        c_##type.CreateObject(object);                               \\
+    }                                                                \\
+    void DestroyObject(type object) {                                \\
+        c_##type.DestroyObject(object);                              \\
     }
 
-#define WRAPPER_PARENT_INSTANCE(type)                                \
-    void StartWriteObjectParentInstance(type object) {                             \
-        (parent_instance ? parent_instance : this)->c_##type.StartWrite(object);                                 \
-    }                                                                \
-    void FinishWriteObjectParentInstance(type object) {                            \
-        (parent_instance ? parent_instance : this)->c_##type.FinishWrite(object);                                \
-    }                                                                \
-    void StartReadObjectParentInstance(type object) {                              \
-        (parent_instance ? parent_instance : this)->c_##type.StartRead(object);                                  \
-    }                                                                \
-    void FinishReadObjectParentInstance(type object) {                             \
-        (parent_instance ? parent_instance : this)->c_##type.FinishRead(object);                                 \
-    }                                                                \
-    void CreateObjectParentInstance(type object) {                                 \
-        (parent_instance ? parent_instance : this)->c_##type.CreateObject(object);                               \
-    }                                                                \
-    void DestroyObjectParentInstance(type object) {                                \
-        (parent_instance ? parent_instance : this)->c_##type.DestroyObject(object);                              \
+#define WRAPPER_PARENT_INSTANCE(type)                                                   \\
+    void StartWriteObjectParentInstance(type object) {                                  \\
+        (parent_instance ? parent_instance : this)->c_##type.StartWrite(object);        \\
+    }                                                                                   \\
+    void FinishWriteObjectParentInstance(type object) {                                 \\
+        (parent_instance ? parent_instance : this)->c_##type.FinishWrite(object);       \\
+    }                                                                                   \\
+    void StartReadObjectParentInstance(type object) {                                   \\
+        (parent_instance ? parent_instance : this)->c_##type.StartRead(object);         \\
+    }                                                                                   \\
+    void FinishReadObjectParentInstance(type object) {                                  \\
+        (parent_instance ? parent_instance : this)->c_##type.FinishRead(object);        \\
+    }                                                                                   \\
+    void CreateObjectParentInstance(type object) {                                      \\
+        (parent_instance ? parent_instance : this)->c_##type.CreateObject(object);      \\
+    }                                                                                   \\
+    void DestroyObjectParentInstance(type object) {                                     \\
+        (parent_instance ? parent_instance : this)->c_##type.DestroyObject(object);     \\
     }
 
 WRAPPER_PARENT_INSTANCE(VkDevice)


### PR DESCRIPTION
The CreatePipelines APIs **CAN** return valid results even with non-success return codes, but this caused crashes in the threading layer.  

Reproduce with CTS test case 
     `dEQP-VK.api.object_management.alloc_callback_fail_multiple.graphics_pipeline`

Fixes #1254.

