### PR TITLE
Fix ErrorMonitor default flag mask

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -3858,10 +3858,10 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxVertexOutputComponents) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         if (overflow) {
-            CreatePipelineHelper::OneshotTest(*this, set_info, VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                                              "Vertex shader exceeds VkPhysicalDeviceLimits::maxVertexOutputComponents");
+            CreatePipelineHelper::OneshotTest(*this, set_info, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                              "Vertex shader exceeds VkPhysicalDeviceLimits::maxVertexOutputComponents", false);
         } else {
-            CreatePipelineHelper::OneshotTest(*this, set_info, VK_DEBUG_REPORT_WARNING_BIT_EXT, "", true);
+            CreatePipelineHelper::OneshotTest(*this, set_info, VK_DEBUG_REPORT_ERROR_BIT_EXT, "", true);
         }
     }
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -41,7 +41,7 @@ ErrorMonitor::ErrorMonitor() {
 ErrorMonitor::~ErrorMonitor() { test_platform_thread_delete_mutex(&mutex_); }
 
 void ErrorMonitor::Reset() {
-    message_flags_ = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    message_flags_ = 0;
     bailout_ = NULL;
     message_found_ = VK_FALSE;
     failure_message_strings_.clear();


### PR DESCRIPTION
Was defaulted to Error, for some reason, allowing false negatives.