### PR TITLE
Fix incorrect test in vkCreateDevice() best practices

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -88,7 +88,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
     }
 
     auto pd_state = GetPhysicalDeviceState(physicalDevice);
-    if ((pd_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState == UNCALLED) && (pCreateInfo->pEnabledFeatures != NULL)) {
+    if ((pd_state->vkGetPhysicalDeviceFeaturesState == UNCALLED) && (pCreateInfo->pEnabledFeatures != NULL)) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         kVUID_BestPractices_CreateDevice_PDFeaturesNotCalled,
                         "vkCreateDevice() called before getting physical device features from vkGetPhysicalDeviceFeatures().");

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3773,6 +3773,29 @@ void ValidationStateTracker::PostCallRecordCreateXlibSurfaceKHR(VkInstance insta
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
+void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice,
+  VkPhysicalDeviceFeatures *pFeatures) {
+  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+  physical_device_state->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+  physical_device_state->features2.pNext = nullptr;
+  physical_device_state->features2.features = *pFeatures;
+}
+
+void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
+  VkPhysicalDeviceFeatures2* pFeatures) {
+  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+  physical_device_state->features2.initialize(pFeatures);
+}
+
+void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
+  VkPhysicalDeviceFeatures2* pFeatures) {
+  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+  physical_device_state->features2.initialize(pFeatures);
+}
+
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice,
                                                                                    VkSurfaceKHR surface,
                                                                                    VkSurfaceCapabilitiesKHR *pSurfaceCapabilities,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3774,26 +3774,26 @@ void ValidationStateTracker::PostCallRecordCreateXlibSurfaceKHR(VkInstance insta
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice,
-  VkPhysicalDeviceFeatures *pFeatures) {
-  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
-  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
-  physical_device_state->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-  physical_device_state->features2.pNext = nullptr;
-  physical_device_state->features2.features = *pFeatures;
+                                                                     VkPhysicalDeviceFeatures *pFeatures) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+    physical_device_state->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    physical_device_state->features2.pNext = nullptr;
+    physical_device_state->features2.features = *pFeatures;
 }
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
-  VkPhysicalDeviceFeatures2* pFeatures) {
-  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
-  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
-  physical_device_state->features2.initialize(pFeatures);
+                                                                      VkPhysicalDeviceFeatures2 *pFeatures) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+    physical_device_state->features2.initialize(pFeatures);
 }
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
-  VkPhysicalDeviceFeatures2* pFeatures) {
-  auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
-  physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
-  physical_device_state->features2.initialize(pFeatures);
+                                                                         VkPhysicalDeviceFeatures2 *pFeatures) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+    physical_device_state->features2.initialize(pFeatures);
 }
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -448,7 +448,7 @@ class ValidationStateTracker : public ValidationObject {
                                                                   VkDisplayPlanePropertiesKHR* pProperties, VkResult result);
     void PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
                                                                    VkDisplayPlaneProperties2KHR* pProperties, VkResult result);
-    void PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures *pFeatures);
+    void PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures);
     void PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
     void PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
     void PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -448,6 +448,9 @@ class ValidationStateTracker : public ValidationObject {
                                                                   VkDisplayPlanePropertiesKHR* pProperties, VkResult result);
     void PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
                                                                    VkDisplayPlaneProperties2KHR* pProperties, VkResult result);
+    void PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures *pFeatures);
+    void PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
+    void PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures);
     void PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,
                                                               VkQueueFamilyProperties* pQueueFamilyProperties);
     void PostCallRecordGetPhysicalDeviceQueueFamilyProperties2(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,


### PR DESCRIPTION
- Add state tracking for `vkGetPhysicalDeviceFeatures*()` variants
- Test correct state in `vkCreateDevice()` best-practices check

Fixes #1272