### PR TITLE
cleanup vkCmdWriteTimestamp messages to report correct entrypoint

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6405,38 +6405,38 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
 }
 
 bool CoreChecks::VerifyQueryIsReset(const ValidationStateTracker *state_data, VkCommandBuffer commandBuffer, QueryObject query_obj,
-                                    QueryMap *localQueryToStateMap) {
+                                    const char *func_name, QueryMap *localQueryToStateMap) {
     bool skip = false;
 
     QueryState state = state_data->GetQueryState(localQueryToStateMap, query_obj.pool, query_obj.query);
     if (state != QUERYSTATE_RESET) {
         skip |= log_msg(state_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(commandBuffer), kVUID_Core_DrawState_QueryNotReset,
-                        "vkCmdBeginQuery(): %s and query %" PRIu32
+                        "%s: %s and query %" PRIu32
                         ": query not reset. "
                         "After query pool creation, each query must be reset before it is used. "
                         "Queries must also be reset between uses.",
-                        state_data->report_data->FormatHandle(query_obj.pool).c_str(), query_obj.query);
+                        func_name, state_data->report_data->FormatHandle(query_obj.pool).c_str(), query_obj.query);
     }
 
     return skip;
 }
 
-void CoreChecks::EnqueueVerifyBeginQuery(VkCommandBuffer command_buffer, const QueryObject &query_obj) {
+void CoreChecks::EnqueueVerifyBeginQuery(VkCommandBuffer command_buffer, const QueryObject &query_obj, const char *func_name) {
     CMD_BUFFER_STATE *cb_state = GetCBState(command_buffer);
 
     // Enqueue the submit time validation here, ahead of the submit time state update in the StateTracker's PostCallRecord
-    cb_state->queryUpdates.emplace_back(
-        [command_buffer, query_obj](const ValidationStateTracker *device_data, bool do_validate, QueryMap *localQueryToStateMap) {
-            if (!do_validate) return false;
-            return VerifyQueryIsReset(device_data, command_buffer, query_obj, localQueryToStateMap);
-        });
+    cb_state->queryUpdates.emplace_back([command_buffer, query_obj, func_name](const ValidationStateTracker *device_data,
+                                                                               bool do_validate, QueryMap *localQueryToStateMap) {
+        if (!do_validate) return false;
+        return VerifyQueryIsReset(device_data, command_buffer, query_obj, func_name, localQueryToStateMap);
+    });
 }
 
 void CoreChecks::PreCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags) {
     if (disabled.query_validation) return;
     QueryObject query_obj = {queryPool, slot};
-    EnqueueVerifyBeginQuery(commandBuffer, query_obj);
+    EnqueueVerifyBeginQuery(commandBuffer, query_obj, "vkCmdBeginQuery()");
 }
 
 bool CoreChecks::ValidateCmdEndQuery(const CMD_BUFFER_STATE *cb_state, const QueryObject &query_obj, CMD_TYPE cmd,
@@ -6501,8 +6501,9 @@ static QueryResultType GetQueryResultType(QueryState state, VkQueryResultFlags f
     return QUERYRESULT_UNKNOWN;
 }
 
-bool CoreChecks::ValidateQuery(const ValidationStateTracker *state_data, VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                               uint32_t firstQuery, uint32_t queryCount, VkQueryResultFlags flags, QueryMap *localQueryToStateMap) {
+bool CoreChecks::ValidateCopyQueryPoolResults(const ValidationStateTracker *state_data, VkCommandBuffer commandBuffer,
+                                              VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
+                                              VkQueryResultFlags flags, QueryMap *localQueryToStateMap) {
     bool skip = false;
     for (uint32_t i = 0; i < queryCount; i++) {
         QueryState state = state_data->GetQueryState(localQueryToStateMap, queryPool, firstQuery + i);
@@ -6510,7 +6511,7 @@ bool CoreChecks::ValidateQuery(const ValidationStateTracker *state_data, VkComma
         if (result_type != QUERYRESULT_SOME_DATA) {
             skip |= log_msg(state_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                             HandleToUint64(commandBuffer), kVUID_Core_DrawState_InvalidQuery,
-                            "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
+                            "vkCmdCopyQueryPoolResults(): Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
                             state_data->report_data->FormatHandle(queryPool).c_str(), firstQuery + i,
                             string_QueryResultType(result_type));
         }
@@ -6550,7 +6551,8 @@ void CoreChecks::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuf
         [commandBuffer, queryPool, firstQuery, queryCount, flags](const ValidationStateTracker *device_data, bool do_validate,
                                                                   QueryMap *localQueryToStateMap) {
             if (!do_validate) return false;
-            return ValidateQuery(device_data, commandBuffer, queryPool, firstQuery, queryCount, flags, localQueryToStateMap);
+            return ValidateCopyQueryPoolResults(device_data, commandBuffer, queryPool, firstQuery, queryCount, flags,
+                                                localQueryToStateMap);
         });
 }
 
@@ -6625,11 +6627,12 @@ void CoreChecks::PreCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, V
     // Enqueue the submit time validation check here, before the submit time state update in StateTracker::PostCall...
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     QueryObject query = {queryPool, slot};
-    cb_state->queryUpdates.emplace_back(
-        [commandBuffer, query](const ValidationStateTracker *device_data, bool do_validate, QueryMap *localQueryToStateMap) {
-            if (!do_validate) return false;
-            return VerifyQueryIsReset(device_data, commandBuffer, query, localQueryToStateMap);
-        });
+    const char *func_name = "vkCmdWriteTimestamp()";
+    cb_state->queryUpdates.emplace_back([commandBuffer, query, func_name](const ValidationStateTracker *device_data,
+                                                                          bool do_validate, QueryMap *localQueryToStateMap) {
+        if (!do_validate) return false;
+        return VerifyQueryIsReset(device_data, commandBuffer, query, func_name, localQueryToStateMap);
+    });
 }
 
 bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2KHR *attachments, const VkFramebufferCreateInfo *fbci,
@@ -10234,7 +10237,7 @@ void CoreChecks::PreCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuf
                                                       VkQueryControlFlags flags, uint32_t index) {
     if (disabled.query_validation) return;
     QueryObject query_obj = {queryPool, query, index};
-    EnqueueVerifyBeginQuery(commandBuffer, query_obj);
+    EnqueueVerifyBeginQuery(commandBuffer, query_obj, "vkCmdBeginQueryIndexedEXT()");
 }
 
 bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -157,10 +157,11 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBindImageMemory(const VkBindImageMemoryInfo& bindInfo, const char* api_name) const;
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                  const char* api_name) const;
-    static bool ValidateQuery(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                              uint32_t firstQuery, uint32_t queryCount, VkQueryResultFlags flags, QueryMap* localQueryToStateMap);
+    static bool ValidateCopyQueryPoolResults(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer,
+                                             VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
+                                             VkQueryResultFlags flags, QueryMap* localQueryToStateMap);
     static bool VerifyQueryIsReset(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer, QueryObject query_obj,
-                                   QueryMap* localQueryToStateMap);
+                                   const char* func_name, QueryMap* localQueryToStateMap);
     bool ValidateImportSemaphore(VkSemaphore semaphore, const char* caller_name) const;
     bool ValidateBeginQuery(const CMD_BUFFER_STATE* cb_state, const QueryObject& query_obj, VkFlags flags, CMD_TYPE cmd,
                             const char* cmd_name, const char* vuid_queue_flags, const char* vuid_queue_feedback,
@@ -818,7 +819,7 @@ class CoreChecks : public ValidationStateTracker {
                                          uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                          uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
-    void EnqueueVerifyBeginQuery(VkCommandBuffer, const QueryObject& query_obj);
+    void EnqueueVerifyBeginQuery(VkCommandBuffer, const QueryObject& query_obj, const char* func);
     bool PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags);
     void PreCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags);
     bool PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1958,6 +1958,8 @@ TEST_F(VkLayerTest, QueryPoolPartialTimestamp) {
     query_pool_ci.queryCount = 1;
     vk::CreateQueryPool(m_device->device(), &query_pool_ci, nullptr, &query_pool);
 
+    // Use setup as a positive test...
+    m_errorMonitor->ExpectSuccess();
     m_commandBuffer->begin();
     vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool, 0, 1);
     vk::CmdWriteTimestamp(m_commandBuffer->handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool, 0);
@@ -1970,6 +1972,7 @@ TEST_F(VkLayerTest, QueryPoolPartialTimestamp) {
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
+    m_errorMonitor->VerifyNotFound();
 
     // Attempt to obtain partial results.
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkGetQueryPoolResults-queryType-00818");


### PR DESCRIPTION
Partial fix for #1179  (the part I can reproduce).

Correct and clean up deferred (submit time) validation messages for `vkCmdWriteTimestamp`. Clarify function names and add informative comment.

Ensure that the setup precondition for the timestamp reset test is expecting success. 