### PR TITLE
Fix too restrictive IF chain in ValidateImageBarrierAttachment

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5412,20 +5412,24 @@ bool CoreChecks::ValidateImageBarrierAttachment(const char *funcName, CMD_BUFFER
         if (sub_desc.pDepthStencilAttachment && sub_desc.pDepthStencilAttachment->attachment == attach_index) {
             sub_image_layout = sub_desc.pDepthStencilAttachment->layout;
             sub_image_found = true;
-        } else if (device_extensions.vk_khr_depth_stencil_resolve) {
+        }
+        if (!sub_image_found && device_extensions.vk_khr_depth_stencil_resolve) {
             const auto *resolve = lvl_find_in_chain<VkSubpassDescriptionDepthStencilResolveKHR>(sub_desc.pNext);
             if (resolve && resolve->pDepthStencilResolveAttachment &&
                 resolve->pDepthStencilResolveAttachment->attachment == attach_index) {
                 sub_image_layout = resolve->pDepthStencilResolveAttachment->layout;
                 sub_image_found = true;
             }
-        } else {
+        }
+        if (!sub_image_found) {
             for (uint32_t j = 0; j < sub_desc.colorAttachmentCount; ++j) {
                 if (sub_desc.pColorAttachments && sub_desc.pColorAttachments[j].attachment == attach_index) {
                     sub_image_layout = sub_desc.pColorAttachments[j].layout;
                     sub_image_found = true;
                     break;
-                } else if (sub_desc.pResolveAttachments && sub_desc.pResolveAttachments[j].attachment == attach_index) {
+                }
+                if (!sub_image_found && sub_desc.pResolveAttachments &&
+                    sub_desc.pResolveAttachments[j].attachment == attach_index) {
                     sub_image_layout = sub_desc.pResolveAttachments[j].layout;
                     sub_image_found = true;
                     break;


### PR DESCRIPTION
The validation layer thinks that the renderpass in which the cmd barrier is called doesn't have any references to image attachment it is locking on, however, this is incorrect as the attachment is inside of the pColorAttachment.

The function is searching for a reference in some places, but an if/else statement is written so that if an extension is found, all the other fields are not checked, even if the attachment is not in the first examined field, and the validation layers returns a false negative.

Change-Id: I4116ff3a647044ea0434af332568946c53e17c24