### PR TITLE
Use shared_ptrs to reduce hash table lookups in descriptor validation

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -360,11 +360,9 @@ void CoreChecks::SetImageViewInitialLayout(CMD_BUFFER_STATE *cb_node, const IMAG
     if (disabled.image_layout_validation) {
         return;
     }
-    IMAGE_STATE *image_state = GetImageState(view_state.create_info.image);
-    if (image_state) {
-        auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, *image_state);
-        subresource_map->SetSubresourceRangeInitialLayout(*cb_node, view_state.normalized_subresource_range, layout, &view_state);
-    }
+    IMAGE_STATE *image_state = view_state.image_state.get();
+    auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, *image_state);
+    subresource_map->SetSubresourceRangeInitialLayout(*cb_node, view_state.normalized_subresource_range, layout, &view_state);
 }
 
 // Set the initial image layout for a passed non-normalized subresource range
@@ -389,8 +387,7 @@ void CoreChecks::SetImageInitialLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_ST
 
 // Set image layout for all slices of an image view
 void CoreChecks::SetImageViewLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_VIEW_STATE &view_state, VkImageLayout layout) {
-    IMAGE_STATE *image_state = GetImageState(view_state.create_info.image);
-    if (!image_state) return;  // TODO: track/report stale image references
+    IMAGE_STATE *image_state = view_state.image_state.get();
 
     VkImageSubresourceRange sub_range = view_state.normalized_subresource_range;
     // When changing the layout of a 3D image subresource via a 2D or 2D_ARRRAY image view, all depth slices of

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -141,8 +141,12 @@ bool IMAGE_STATE::IsCompatibleAliasing(IMAGE_STATE *other_image_state) {
     return false;
 }
 
-IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const IMAGE_STATE *image_state, VkImageView iv, const VkImageViewCreateInfo *ci)
-    : image_view(iv), create_info(*ci), normalized_subresource_range(ci->subresourceRange), samplerConversion(VK_NULL_HANDLE) {
+IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkImageView iv, const VkImageViewCreateInfo *ci)
+    : image_view(iv),
+      create_info(*ci),
+      normalized_subresource_range(ci->subresourceRange),
+      samplerConversion(VK_NULL_HANDLE),
+      image_state(im) {
     auto *conversionInfo = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(create_info.pNext);
     if (conversionInfo) samplerConversion = conversionInfo->conversion;
     if (image_state) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -848,7 +848,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
 
     // Now complete other state checks
     string errorString;
-    auto const &pipeline_layout = pPipe->pipeline_layout;
+    auto const &pipeline_layout = pPipe->pipeline_layout.get();
 
     for (const auto &set_binding_pair : pPipe->active_slots) {
         uint32_t setIndex = set_binding_pair.first;
@@ -858,7 +858,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_DescriptorSetNotBound,
                         "%s uses set #%u but that set is not bound.", report_data->FormatHandle(pPipe->pipeline).c_str(), setIndex);
-        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, pipeline_layout.get(),
+        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, pipeline_layout,
                                                  setIndex, errorString)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
             VkDescriptorSet setHandle = state.per_set[setIndex].bound_descriptor_set->GetSet();

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -382,15 +382,6 @@ bool CoreChecks::ValidateStatus(const CMD_BUFFER_STATE *pNode, CBStatusFlags sta
     return false;
 }
 
-std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorSetLayout(const ValidationStateTracker *state_data,
-                                                                                         VkDescriptorSetLayout dsLayout) {
-    auto it = state_data->descriptorSetLayoutMap.find(dsLayout);
-    if (it == state_data->descriptorSetLayoutMap.end()) {
-        return nullptr;
-    }
-    return it->second;
-}
-
 // Return true if for a given PSO, the given state enum is dynamic, else return false
 static bool IsDynamic(const PIPELINE_STATE *pPipeline, const VkDynamicState state) {
     if (pPipeline && pPipeline->graphicsPipelineCI.pDynamicState) {
@@ -3725,7 +3716,7 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     unsigned int push_descriptor_set_count = 0;
     {
         for (i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-            set_layouts[i] = GetDescriptorSetLayout(this, pCreateInfo->pSetLayouts[i]);
+            set_layouts[i] = GetDescriptorSetLayoutShared(pCreateInfo->pSetLayouts[i]);
             if (set_layouts[i]->IsPushDescriptor()) ++push_descriptor_set_count;
         }
     }
@@ -9984,7 +9975,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDev
 bool CoreChecks::ValidateDescriptorUpdateTemplate(const char *func_name,
                                                   const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo) {
     bool skip = false;
-    const auto layout = GetDescriptorSetLayout(this, pCreateInfo->descriptorSetLayout);
+    const auto layout = GetDescriptorSetLayoutShared(pCreateInfo->descriptorSetLayout);
     if (VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET == pCreateInfo->templateType && !layout) {
         const VulkanTypedHandle ds_typed(pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout);
         skip |=

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -50,7 +50,7 @@ class CoreChecks : public ValidationStateTracker {
     void StoreMemRanges(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size);
     bool ValidateIdleDescriptorSet(VkDescriptorSet set, const char* func_str);
     void InitializeShadowMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
-    bool ValidatePipelineLocked(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
+    bool ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
     bool ValidatePipelineUnlocked(const PIPELINE_STATE* pPipeline, uint32_t pipelineIndex) const;
     bool ValidImageBufferQueue(const CMD_BUFFER_STATE* cb_node, const VulkanTypedHandle& object, VkQueue queue, uint32_t count,
                                const uint32_t* indices) const;
@@ -87,7 +87,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,
                                         const VkDeviceQueueCreateInfo* infos);
 
-    bool ValidatePipelineVertexDivisors(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
+    bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis) const;
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const char* func_name, CMD_BUFFER_STATE* cb_state,
                                                          uint32_t imageMemBarrierCount,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -83,7 +83,7 @@ class BASE_NODE {
     std::unordered_set<CMD_BUFFER_STATE *> cb_bindings;
     // Set to true when the API-level object is destroyed, but this object may
     // hang around until its shared_ptr refcount goes to zero.
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     BASE_NODE() {
         in_use.store(0);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1643,9 +1643,6 @@ enum BarrierOperationsType {
     kGeneral,     // Either no ownership operations or a mix of ownership operation types and/or non-ownership operations
 };
 
-std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorSetLayout(const ValidationStateTracker *,
-                                                                                         VkDescriptorSetLayout);
-
 ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(CMD_BUFFER_STATE *cb_state, const IMAGE_STATE &image_state);
 const ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(const CMD_BUFFER_STATE *cb_state, VkImage image);
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -188,7 +188,7 @@ static inline bool operator==(const DescriptorSetLayoutDef &lhs, const Descripto
 using DescriptorSetLayoutDict = hash_util::Dictionary<DescriptorSetLayoutDef, hash_util::HasHashMember<DescriptorSetLayoutDef>>;
 using DescriptorSetLayoutId = DescriptorSetLayoutDict::Id;
 
-class DescriptorSetLayout {
+class DescriptorSetLayout : public BASE_NODE {
   public:
     // Constructors and destructor
     DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info, const VkDescriptorSetLayout layout);
@@ -199,8 +199,6 @@ class DescriptorSetLayout {
     bool IsCompatible(DescriptorSetLayout const *rh_ds_layout) const;
     // Straightforward Get functions
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return layout_; };
-    bool IsDestroyed() const { return layout_destroyed_; }
-    void MarkDestroyed() { layout_destroyed_ = true; }
     const DescriptorSetLayoutDef *GetLayoutDef() const { return layout_id_.get(); }
     DescriptorSetLayoutId GetLayoutId() const { return layout_id_; }
     uint32_t GetTotalDescriptorCount() const { return layout_id_->GetTotalDescriptorCount(); };
@@ -342,7 +340,6 @@ class DescriptorSetLayout {
 
   private:
     VkDescriptorSetLayout layout_;
-    bool layout_destroyed_;
     DescriptorSetLayoutId layout_id_;
 };
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2386,9 +2386,10 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
+    std::atomic<bool> destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : desc_update_template(update_template), create_info(*pCreateInfo) {}
+        : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}
 };
 
 class LAYER_PHYS_DEV_PROPERTIES {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2386,7 +2386,7 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
         : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1014,9 +1014,9 @@ struct GPUAV_RESTORABLE_PIPELINE_STATE {
             if (last_bound.push_descriptor_set) {
                 push_descriptor_set_writes = last_bound.push_descriptor_set->GetWrites();
             }
-            if (last_bound.pipeline_state->pipeline_layout.push_constant_ranges == cb_state->push_constant_data_ranges) {
+            if (last_bound.pipeline_state->pipeline_layout->push_constant_ranges == cb_state->push_constant_data_ranges) {
                 push_constants_data = cb_state->push_constant_data;
-                push_constants_ranges = last_bound.pipeline_state->pipeline_layout.push_constant_ranges;
+                push_constants_ranges = last_bound.pipeline_state->pipeline_layout->push_constant_ranges;
             }
         }
     }
@@ -1467,7 +1467,7 @@ struct CreatePipelineTraits<VkRayTracingPipelineCreateInfoNV> {
 template <typename CreateInfo, typename SafeCreateInfo>
 void GpuAssisted::PreCallRecordPipelineCreations(uint32_t count, const CreateInfo *pCreateInfos,
                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                 std::vector<std::unique_ptr<PIPELINE_STATE>> &pipe_state,
+                                                 std::vector<std::shared_ptr<PIPELINE_STATE>> &pipe_state,
                                                  std::vector<SafeCreateInfo> *new_pipeline_create_infos,
                                                  const VkPipelineBindPoint bind_point) {
     using Accessor = CreatePipelineTraits<CreateInfo>;
@@ -1488,7 +1488,7 @@ void GpuAssisted::PreCallRecordPipelineCreations(uint32_t count, const CreateInf
         }
         // If the app requests all available sets, the pipeline layout was not modified at pipeline layout creation and the already
         // instrumented shaders need to be replaced with uninstrumented shaders
-        if (pipe_state[pipeline]->pipeline_layout.set_layouts.size() >= adjusted_max_desc_sets) {
+        if (pipe_state[pipeline]->pipeline_layout->set_layouts.size() >= adjusted_max_desc_sets) {
             replace_shaders = true;
         }
 
@@ -2575,8 +2575,8 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     auto iter = cb_node->lastBound.find(bind_point);  // find() allows read-only access to cb_state
     if (iter != cb_node->lastBound.end()) {
         auto pipeline_state = iter->second.pipeline_state;
-        if (pipeline_state && (pipeline_state->pipeline_layout.set_layouts.size() <= desc_set_bind_index)) {
-            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout.layout, desc_set_bind_index, 1,
+        if (pipeline_state && (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index)) {
+            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout, desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }
         // Record buffer and memory info in CB state tracking

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -185,7 +185,7 @@ class GpuAssisted : public ValidationStateTracker {
                                                   void* crtpl_state_data);
     template <typename CreateInfo, typename SafeCreateInfo>
     void PreCallRecordPipelineCreations(uint32_t count, const CreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-                                        VkPipeline* pPipelines, std::vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state,
+                                        VkPipeline* pPipelines, std::vector<std::shared_ptr<PIPELINE_STATE>>& pipe_state,
                                         std::vector<SafeCreateInfo>* new_pipeline_create_infos,
                                         const VkPipelineBindPoint bind_point);
     template <typename CreateInfo>

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2804,7 +2804,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
     skip |= ValidateShaderStageGroupNonUniform(module, pStage->stage);
     skip |= ValidateExecutionModes(module, entrypoint);
     skip |= ValidateSpecializationOffsets(report_data, pStage);
-    skip |= ValidatePushConstantUsage(report_data, pipeline->pipeline_layout.push_constant_ranges.get(), module, accessible_ids,
+    skip |= ValidatePushConstantUsage(report_data, pipeline->pipeline_layout->push_constant_ranges.get(), module, accessible_ids,
                                       pStage->stage);
     if (check_point_size && !pipeline->graphicsPipelineCI.pRasterizationState->rasterizerDiscardEnable) {
         skip |= ValidatePointListShaderState(pipeline, module, entrypoint, pStage->stage);
@@ -2814,7 +2814,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
     // Validate descriptor use
     for (auto use : descriptor_uses) {
         // Verify given pipelineLayout has requested setLayout with requested binding
-        const auto &binding = GetDescriptorBinding(&pipeline->pipeline_layout, use.first);
+        const auto &binding = GetDescriptorBinding(pipeline->pipeline_layout.get(), use.first);
         unsigned required_descriptor_count;
         std::set<uint32_t> descriptor_types = TypeToDescriptorTypeSet(module, use.second.type_id, required_descriptor_count);
 

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -113,7 +113,7 @@ struct decoration_set {
     void add(uint32_t decoration, uint32_t value);
 };
 
-struct SHADER_MODULE_STATE {
+struct SHADER_MODULE_STATE : public BASE_NODE {
     // The spirv image itself
     std::vector<uint32_t> words;
     // A mapping of <id> to the first word of its def. this is useful because walking type

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -89,7 +89,7 @@ void ValidationStateTracker::RecordDestroySamplerYcbcrConversionANDROID(VkSample
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkImage *pImage, VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<IMAGE_STATE> is_node(new IMAGE_STATE(*pImage, pCreateInfo));
+    auto is_node = std::make_shared<IMAGE_STATE>(*pImage, pCreateInfo);
     if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
         RecordCreateImageANDROID(pCreateInfo, is_node.get());
     }
@@ -132,6 +132,7 @@ void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage 
     }
     RemoveAliasingImage(image_state);
     ClearMemoryObjectBindings(obj_struct);
+    image_state->destroyed = true;
     // Remove image from imageMap
     imageMap.erase(image);
 }
@@ -199,7 +200,7 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
                                                         VkResult result) {
     if (result != VK_SUCCESS) return;
     // TODO : This doesn't create deep copy of pQueueFamilyIndices so need to fix that if/when we want that data to be valid
-    std::unique_ptr<BUFFER_STATE> buffer_state(new BUFFER_STATE(*pBuffer, pCreateInfo));
+    auto buffer_state = std::make_shared<BUFFER_STATE>(*pBuffer, pCreateInfo);
 
     // Get a set of requirements in the case the app does not
     DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
@@ -211,15 +212,16 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
                                                             const VkAllocationCallbacks *pAllocator, VkBufferView *pView,
                                                             VkResult result) {
     if (result != VK_SUCCESS) return;
-    bufferViewMap[*pView] = std::unique_ptr<BUFFER_VIEW_STATE>(new BUFFER_VIEW_STATE(*pView, pCreateInfo));
+    auto buffer_state = GetBufferShared(pCreateInfo->buffer);
+    bufferViewMap[*pView] = std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
                                                            const VkAllocationCallbacks *pAllocator, VkImageView *pView,
                                                            VkResult result) {
     if (result != VK_SUCCESS) return;
-    auto image_state = GetImageState(pCreateInfo->image);
-    imageViewMap[*pView] = std::unique_ptr<IMAGE_VIEW_STATE>(new IMAGE_VIEW_STATE(image_state, *pView, pCreateInfo));
+    auto image_state = GetImageShared(pCreateInfo->image);
+    imageViewMap[*pView] = std::make_shared<IMAGE_VIEW_STATE>(image_state, *pView, pCreateInfo);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
@@ -241,6 +243,7 @@ void ValidationStateTracker::PreCallRecordDestroyImageView(VkDevice device, VkIm
 
     // Any bound cmd buffers are now invalid
     InvalidateCommandBuffers(image_view_state->cb_bindings, obj_struct);
+    image_view_state->destroyed = true;
     imageViewMap.erase(imageView);
 }
 
@@ -257,6 +260,7 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
         }
     }
     ClearMemoryObjectBindings(obj_struct);
+    buffer_state->destroyed = true;
     bufferMap.erase(buffer_state->buffer);
 }
 
@@ -268,6 +272,7 @@ void ValidationStateTracker::PreCallRecordDestroyBufferView(VkDevice device, VkB
 
     // Any bound cmd buffers are now invalid
     InvalidateCommandBuffers(buffer_view_state->cb_bindings, obj_struct);
+    buffer_view_state->destroyed = true;
     bufferViewMap.erase(bufferView);
 }
 
@@ -449,8 +454,8 @@ BINDABLE *ValidationStateTracker::GetObjectMemBinding(const VulkanTypedHandle &t
 void ValidationStateTracker::AddMemObjInfo(void *object, const VkDeviceMemory mem, const VkMemoryAllocateInfo *pAllocateInfo) {
     assert(object != NULL);
 
-    auto *mem_info = new DEVICE_MEMORY_STATE(object, mem, pAllocateInfo);
-    memObjMap[mem] = unique_ptr<DEVICE_MEMORY_STATE>(mem_info);
+    memObjMap[mem] = std::make_shared<DEVICE_MEMORY_STATE>(object, mem, pAllocateInfo);
+    auto mem_info = memObjMap[mem].get();
 
     auto dedicated = lvl_find_in_chain<VkMemoryDedicatedAllocateInfoKHR>(pAllocateInfo->pNext);
     if (dedicated) {
@@ -774,6 +779,7 @@ void ValidationStateTracker::UpdateDrawState(CMD_BUFFER_STATE *cb_state, const V
 
 // Remove set from setMap and delete the set
 void ValidationStateTracker::FreeDescriptorSet(cvdescriptorset::DescriptorSet *descriptor_set) {
+    descriptor_set->destroyed = true;
     setMap.erase(descriptor_set->GetSet());
 }
 
@@ -1469,6 +1475,7 @@ void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMe
     // Any bound cmd buffers are now invalid
     InvalidateCommandBuffers(mem_info->cb_bindings, obj_struct);
     RemoveAliasingImages(mem_info->bound_images);
+    mem_info->destroyed = true;
     memObjMap.erase(mem);
 }
 
@@ -1573,7 +1580,7 @@ void ValidationStateTracker::PostCallRecordCreateSemaphore(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
                                                            VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<SEMAPHORE_STATE> semaphore_state(new SEMAPHORE_STATE{});
+    auto semaphore_state = std::make_shared<SEMAPHORE_STATE>();
     semaphore_state->signaler.first = VK_NULL_HANDLE;
     semaphore_state->signaler.second = 0;
     semaphore_state->signaled = false;
@@ -1672,12 +1679,16 @@ void ValidationStateTracker::PostCallRecordDeviceWaitIdle(VkDevice device, VkRes
 
 void ValidationStateTracker::PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator) {
     if (!fence) return;
+    auto fence_state = GetFenceState(fence);
+    fence_state->destroyed = true;
     fenceMap.erase(fence);
 }
 
 void ValidationStateTracker::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore,
                                                            const VkAllocationCallbacks *pAllocator) {
     if (!semaphore) return;
+    auto semaphore_state = GetSemaphoreState(semaphore);
+    semaphore_state->destroyed = true;
     semaphoreMap.erase(semaphore);
 }
 
@@ -1695,6 +1706,7 @@ void ValidationStateTracker::PreCallRecordDestroyQueryPool(VkDevice device, VkQu
     QUERY_POOL_STATE *qp_state = GetQueryPoolState(queryPool);
     const VulkanTypedHandle obj_struct(queryPool, kVulkanObjectTypeQueryPool);
     InvalidateCommandBuffers(qp_state->cb_bindings, obj_struct);
+    qp_state->destroyed = true;
     queryPoolMap.erase(queryPool);
 }
 
@@ -1888,6 +1900,8 @@ void ValidationStateTracker::PostCallRecordGetImageSparseMemoryRequirements2KHR(
 void ValidationStateTracker::PreCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                                               const VkAllocationCallbacks *pAllocator) {
     if (!shaderModule) return;
+    auto shader_module_state = GetShaderModuleState(shaderModule);
+    shader_module_state->destroyed = true;
     shaderModuleMap.erase(shaderModule);
 }
 
@@ -1898,12 +1912,15 @@ void ValidationStateTracker::PreCallRecordDestroyPipeline(VkDevice device, VkPip
     const VulkanTypedHandle obj_struct(pipeline, kVulkanObjectTypePipeline);
     // Any bound cmd buffers are now invalid
     InvalidateCommandBuffers(pipeline_state->cb_bindings, obj_struct);
+    pipeline_state->destroyed = true;
     pipelineMap.erase(pipeline);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
                                                                 const VkAllocationCallbacks *pAllocator) {
     if (!pipelineLayout) return;
+    auto pipeline_layout_state = GetPipelineLayout(pipelineLayout);
+    pipeline_layout_state->destroyed = true;
     pipelineLayoutMap.erase(pipelineLayout);
 }
 
@@ -1916,6 +1933,7 @@ void ValidationStateTracker::PreCallRecordDestroySampler(VkDevice device, VkSamp
     if (sampler_state) {
         InvalidateCommandBuffers(sampler_state->cb_bindings, obj_struct);
     }
+    sampler_state->destroyed = true;
     samplerMap.erase(sampler);
 }
 
@@ -1941,6 +1959,7 @@ void ValidationStateTracker::PreCallRecordDestroyDescriptorPool(VkDevice device,
         for (auto ds : desc_pool_state->sets) {
             FreeDescriptorSet(ds);
         }
+        desc_pool_state->destroyed = true;
         descriptorPoolMap.erase(descriptorPool);
     }
 }
@@ -1960,6 +1979,7 @@ void ValidationStateTracker::FreeCommandBufferStates(COMMAND_POOL_STATE *pool_st
             // Remove the cb debug labels
             EraseCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
             // Remove CBState from CB map
+            cb_state->destroyed = true;
             commandBufferMap.erase(cb_state->commandBuffer);
         }
     }
@@ -1975,7 +1995,7 @@ void ValidationStateTracker::PostCallRecordCreateCommandPool(VkDevice device, co
                                                              const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
                                                              VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<COMMAND_POOL_STATE> cmd_pool_state(new COMMAND_POOL_STATE{});
+    auto cmd_pool_state = std::make_shared<COMMAND_POOL_STATE>();
     cmd_pool_state->createFlags = pCreateInfo->flags;
     cmd_pool_state->queueFamilyIndex = pCreateInfo->queueFamilyIndex;
     commandPoolMap[*pCommandPool] = std::move(cmd_pool_state);
@@ -1985,7 +2005,7 @@ void ValidationStateTracker::PostCallRecordCreateQueryPool(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool,
                                                            VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<QUERY_POOL_STATE> query_pool_state(new QUERY_POOL_STATE{});
+    auto query_pool_state = std::make_shared<QUERY_POOL_STATE>();
     query_pool_state->createInfo = *pCreateInfo;
     queryPoolMap[*pQueryPool] = std::move(query_pool_state);
 
@@ -2006,6 +2026,7 @@ void ValidationStateTracker::PreCallRecordDestroyCommandPool(VkDevice device, Vk
         // Create a vector, as FreeCommandBufferStates deletes from cp_state->commandBuffers during iteration.
         std::vector<VkCommandBuffer> cb_vec{cp_state->commandBuffers.begin(), cp_state->commandBuffers.end()};
         FreeCommandBufferStates(cp_state, static_cast<uint32_t>(cb_vec.size()), cb_vec.data());
+        cp_state->destroyed = true;
         commandPoolMap.erase(commandPool);
     }
 }
@@ -2058,6 +2079,7 @@ void ValidationStateTracker::PreCallRecordDestroyFramebuffer(VkDevice device, Vk
     FRAMEBUFFER_STATE *framebuffer_state = GetFramebufferState(framebuffer);
     const VulkanTypedHandle obj_struct(framebuffer, kVulkanObjectTypeFramebuffer);
     InvalidateCommandBuffers(framebuffer_state->cb_bindings, obj_struct);
+    framebuffer_state->destroyed = true;
     frameBufferMap.erase(framebuffer);
 }
 
@@ -2067,13 +2089,14 @@ void ValidationStateTracker::PreCallRecordDestroyRenderPass(VkDevice device, VkR
     RENDER_PASS_STATE *rp_state = GetRenderPassState(renderPass);
     const VulkanTypedHandle obj_struct(renderPass, kVulkanObjectTypeRenderPass);
     InvalidateCommandBuffers(rp_state->cb_bindings, obj_struct);
+    rp_state->destroyed = true;
     renderPassMap.erase(renderPass);
 }
 
 void ValidationStateTracker::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkFence *pFence, VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<FENCE_STATE> fence_state(new FENCE_STATE{});
+    auto fence_state = std::make_shared<FENCE_STATE>();
     fence_state->fence = *pFence;
     fence_state->createInfo = *pCreateInfo;
     fence_state->state = (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED;
@@ -2089,10 +2112,10 @@ bool ValidationStateTracker::PreCallValidateCreateGraphicsPipelines(VkDevice dev
     cgpl_state->pCreateInfos = pCreateInfos;  // GPU validation can alter this, so we have to set a default value for the Chassis
     cgpl_state->pipe_state.reserve(count);
     for (uint32_t i = 0; i < count; i++) {
-        cgpl_state->pipe_state.push_back(std::unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
+        cgpl_state->pipe_state.push_back(std::make_shared<PIPELINE_STATE>());
         (cgpl_state->pipe_state)[i]->initGraphicsPipeline(this, &pCreateInfos[i],
                                                           GetRenderPassStateSharedPtr(pCreateInfos[i].renderPass));
-        (cgpl_state->pipe_state)[i]->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
+        (cgpl_state->pipe_state)[i]->pipeline_layout = GetPipelineLayoutShared(pCreateInfos[i].layout);
     }
     return false;
 }
@@ -2121,9 +2144,9 @@ bool ValidationStateTracker::PreCallValidateCreateComputePipelines(VkDevice devi
     ccpl_state->pipe_state.reserve(count);
     for (uint32_t i = 0; i < count; i++) {
         // Create and initialize internal tracking data structure
-        ccpl_state->pipe_state.push_back(unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
+        ccpl_state->pipe_state.push_back(std::make_shared<PIPELINE_STATE>());
         ccpl_state->pipe_state.back()->initComputePipeline(this, &pCreateInfos[i]);
-        ccpl_state->pipe_state.back()->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
+        ccpl_state->pipe_state.back()->pipeline_layout = GetPipelineLayoutShared(pCreateInfos[i].layout);
     }
     return false;
 }
@@ -2153,9 +2176,9 @@ bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesNV(VkDevice
     crtpl_state->pipe_state.reserve(count);
     for (uint32_t i = 0; i < count; i++) {
         // Create and initialize internal tracking data structure
-        crtpl_state->pipe_state.push_back(unique_ptr<PIPELINE_STATE>(new PIPELINE_STATE));
+        crtpl_state->pipe_state.push_back(std::make_shared<PIPELINE_STATE>());
         crtpl_state->pipe_state.back()->initRayTracingPipelineNV(this, &pCreateInfos[i]);
-        crtpl_state->pipe_state.back()->pipeline_layout = *GetPipelineLayout(pCreateInfos[i].layout);
+        crtpl_state->pipe_state.back()->pipeline_layout = GetPipelineLayoutShared(pCreateInfos[i].layout);
     }
     return false;
 }
@@ -2177,7 +2200,7 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(
 void ValidationStateTracker::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                                          const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
                                                          VkResult result) {
-    samplerMap[*pSampler] = unique_ptr<SAMPLER_STATE>(new SAMPLER_STATE(pSampler, pCreateInfo));
+    samplerMap[*pSampler] = std::make_shared<SAMPLER_STATE>(pSampler, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateDescriptorSetLayout(VkDevice device,
@@ -2240,7 +2263,7 @@ void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device,
                                                                 VkPipelineLayout *pPipelineLayout, VkResult result) {
     if (VK_SUCCESS != result) return;
 
-    std::unique_ptr<PIPELINE_LAYOUT_STATE> pipeline_layout_state(new PIPELINE_LAYOUT_STATE{});
+    auto pipeline_layout_state = std::make_shared<PIPELINE_LAYOUT_STATE>();
     pipeline_layout_state->layout = *pPipelineLayout;
     pipeline_layout_state->set_layouts.resize(pCreateInfo->setLayoutCount);
     PipelineLayoutSetLayoutsDef set_layouts(pCreateInfo->setLayoutCount);
@@ -2266,8 +2289,7 @@ void ValidationStateTracker::PostCallRecordCreateDescriptorPool(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkDescriptorPool *pDescriptorPool, VkResult result) {
     if (VK_SUCCESS != result) return;
-    descriptorPoolMap[*pDescriptorPool] =
-        std::unique_ptr<DESCRIPTOR_POOL_STATE>(new DESCRIPTOR_POOL_STATE(*pDescriptorPool, pCreateInfo));
+    descriptorPoolMap[*pDescriptorPool] = std::make_shared<DESCRIPTOR_POOL_STATE>(*pDescriptorPool, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
@@ -2347,7 +2369,7 @@ void ValidationStateTracker::PostCallRecordAllocateCommandBuffers(VkDevice devic
         for (uint32_t i = 0; i < pCreateInfo->commandBufferCount; i++) {
             // Add command buffer to its commandPool map
             pPool->commandBuffers.insert(pCommandBuffer[i]);
-            std::unique_ptr<CMD_BUFFER_STATE> pCB(new CMD_BUFFER_STATE{});
+            auto pCB = std::make_shared<CMD_BUFFER_STATE>();
             pCB->createInfo = *pCreateInfo;
             pCB->device = device;
             // Add command buffer to map
@@ -2527,7 +2549,7 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
         cb_state->static_status = MakeStaticStateMask(pipe_state->graphicsPipelineCI.ptr()->pDynamicState);
         cb_state->status |= cb_state->static_status;
     }
-    ResetCommandBufferPushConstantDataIfIncompatible(cb_state, pipe_state->pipeline_layout.layout);
+    ResetCommandBufferPushConstantDataIfIncompatible(cb_state, pipe_state->pipeline_layout->layout);
     cb_state->lastBound[pipelineBindPoint].pipeline_state = pipe_state;
     SetPipelineState(pipe_state);
     AddCommandBufferBinding(&pipe_state->cb_bindings, VulkanTypedHandle(pipeline, kVulkanObjectTypePipeline), cb_state);
@@ -2574,7 +2596,7 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevic
                                                                          VkAccelerationStructureNV *pAccelerationStructure,
                                                                          VkResult result) {
     if (VK_SUCCESS != result) return;
-    std::unique_ptr<ACCELERATION_STRUCTURE_STATE> as_state(new ACCELERATION_STRUCTURE_STATE(*pAccelerationStructure, pCreateInfo));
+    auto as_state = std::make_shared<ACCELERATION_STRUCTURE_STATE>(*pAccelerationStructure, pCreateInfo);
 
     // Query the requirements in case the application doesn't (to avoid bind/validation time query)
     VkAccelerationStructureMemoryRequirementsInfoNV as_memory_requirements_info = {};
@@ -2696,6 +2718,7 @@ void ValidationStateTracker::PreCallRecordDestroyAccelerationStructureNV(VkDevic
             }
         }
         ClearMemoryObjectBindings(obj_struct);
+        as_state->destroyed = true;
         accelerationStructureMap.erase(accelerationStructure);
     }
 }
@@ -3130,8 +3153,8 @@ void ValidationStateTracker::PostCallRecordCreateFramebuffer(VkDevice device, co
                                                              VkResult result) {
     if (VK_SUCCESS != result) return;
     // Shadow create info and store in map
-    std::unique_ptr<FRAMEBUFFER_STATE> fb_state(
-        new FRAMEBUFFER_STATE(*pFramebuffer, pCreateInfo, GetRenderPassStateSharedPtr(pCreateInfo->renderPass)));
+    auto fb_state =
+        std::make_shared<FRAMEBUFFER_STATE>(*pFramebuffer, pCreateInfo, GetRenderPassStateSharedPtr(pCreateInfo->renderPass));
 
     if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR) == 0) {
         for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
@@ -3521,7 +3544,7 @@ void ValidationStateTracker::RecordCreateSwapchainState(VkResult result, const V
                                                         VkSwapchainKHR *pSwapchain, SURFACE_STATE *surface_state,
                                                         SWAPCHAIN_NODE *old_swapchain_state) {
     if (VK_SUCCESS == result) {
-        auto swapchain_state = unique_ptr<SWAPCHAIN_NODE>(new SWAPCHAIN_NODE(pCreateInfo, *pSwapchain));
+        auto swapchain_state = std::make_shared<SWAPCHAIN_NODE>(pCreateInfo, *pSwapchain);
         if (VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR == pCreateInfo->presentMode ||
             VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR == pCreateInfo->presentMode) {
             swapchain_state->shared_presentable = true;
@@ -3561,6 +3584,7 @@ void ValidationStateTracker::PreCallRecordDestroySwapchainKHR(VkDevice device, V
             if (surface_state->swapchain == swapchain_data) surface_state->swapchain = nullptr;
         }
         RemoveAliasingImages(swapchain_data->bound_images);
+        swapchain_data->destroyed = true;
         swapchainMap.erase(swapchain);
     }
 }
@@ -3717,11 +3741,14 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceQueueFamilyPropertie
 }
 void ValidationStateTracker::PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                             const VkAllocationCallbacks *pAllocator) {
+    if (!surface) return;
+    auto surface_state = GetSurfaceState(surface);
+    surface_state->destroyed = true;
     surface_map.erase(surface);
 }
 
 void ValidationStateTracker::RecordVulkanSurface(VkSurfaceKHR *pSurface) {
-    surface_map[*pSurface] = std::unique_ptr<SURFACE_STATE>(new SURFACE_STATE{*pSurface});
+    surface_map[*pSurface] = std::make_shared<SURFACE_STATE>(*pSurface);
 }
 
 void ValidationStateTracker::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance,
@@ -3989,6 +4016,8 @@ void ValidationStateTracker::PreCallRecordDestroyDescriptorUpdateTemplate(VkDevi
                                                                           VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                                           const VkAllocationCallbacks *pAllocator) {
     if (!descriptorUpdateTemplate) return;
+    auto template_state = GetDescriptorTemplateState(descriptorUpdateTemplate);
+    template_state->destroyed = true;
     desc_template_map.erase(descriptorUpdateTemplate);
 }
 
@@ -3996,13 +4025,15 @@ void ValidationStateTracker::PreCallRecordDestroyDescriptorUpdateTemplateKHR(VkD
                                                                              VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate,
                                                                              const VkAllocationCallbacks *pAllocator) {
     if (!descriptorUpdateTemplate) return;
+    auto template_state = GetDescriptorTemplateState(descriptorUpdateTemplate);
+    template_state->destroyed = true;
     desc_template_map.erase(descriptorUpdateTemplate);
 }
 
 void ValidationStateTracker::RecordCreateDescriptorUpdateTemplateState(const VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo,
                                                                        VkDescriptorUpdateTemplateKHR *pDescriptorUpdateTemplate) {
     safe_VkDescriptorUpdateTemplateCreateInfo local_create_info(pCreateInfo);
-    std::unique_ptr<TEMPLATE_STATE> template_state(new TEMPLATE_STATE(*pDescriptorUpdateTemplate, &local_create_info));
+    auto template_state = std::make_shared<TEMPLATE_STATE>(*pDescriptorUpdateTemplate, &local_create_info);
     desc_template_map[*pDescriptorUpdateTemplate] = std::move(template_state);
 }
 
@@ -4219,8 +4250,8 @@ void ValidationStateTracker::PerformAllocateDescriptorSets(const VkDescriptorSet
     for (uint32_t i = 0; i < p_alloc_info->descriptorSetCount; i++) {
         uint32_t variable_count = variable_count_valid ? variable_count_info->pDescriptorCounts[i] : 0;
 
-        std::unique_ptr<cvdescriptorset::DescriptorSet> new_ds(new cvdescriptorset::DescriptorSet(
-            descriptor_sets[i], p_alloc_info->descriptorPool, ds_data->layout_nodes[i], variable_count, this));
+        auto new_ds = std::make_shared<cvdescriptorset::DescriptorSet>(descriptor_sets[i], p_alloc_info->descriptorPool,
+                                                                       ds_data->layout_nodes[i], variable_count, this);
         pool_state->sets.insert(new_ds.get());
         new_ds->in_use.store(0);
         setMap[descriptor_sets[i]] = std::move(new_ds);
@@ -4351,9 +4382,9 @@ void ValidationStateTracker::PostCallRecordCreateShaderModule(VkDevice device, c
 
     spv_target_env spirv_environment = ((api_version >= VK_API_VERSION_1_1) ? SPV_ENV_VULKAN_1_1 : SPV_ENV_VULKAN_1_0);
     bool is_spirv = (pCreateInfo->pCode[0] == spv::MagicNumber);
-    std::unique_ptr<SHADER_MODULE_STATE> new_shader_module(
-        is_spirv ? new SHADER_MODULE_STATE(pCreateInfo, *pShaderModule, spirv_environment, csm_state->unique_shader_id)
-                 : new SHADER_MODULE_STATE());
+    auto new_shader_module = is_spirv ? std::make_shared<SHADER_MODULE_STATE>(pCreateInfo, *pShaderModule, spirv_environment,
+                                                                              csm_state->unique_shader_id)
+                                      : std::make_shared<SHADER_MODULE_STATE>();
     shaderModuleMap[*pShaderModule] = std::move(new_shader_module);
 }
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -332,8 +332,15 @@ class ValidationStateTracker : public ValidationObject {
     };
 
     // Accessors for the VALSTATE... maps
+    const std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) const { return GetShared<SAMPLER_STATE>(sampler); }
+    std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) { return GetShared<SAMPLER_STATE>(sampler); }
     const SAMPLER_STATE* GetSamplerState(VkSampler sampler) const { return Get<SAMPLER_STATE>(sampler); }
     SAMPLER_STATE* GetSamplerState(VkSampler sampler) { return Get<SAMPLER_STATE>(sampler); }
+
+    const std::shared_ptr<IMAGE_VIEW_STATE> GetImageViewShared(VkImageView image_view) const {
+        return GetShared<IMAGE_VIEW_STATE>(image_view);
+    }
+    std::shared_ptr<IMAGE_VIEW_STATE> GetImageViewShared(VkImageView image_view) { return GetShared<IMAGE_VIEW_STATE>(image_view); }
     const IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) const { return Get<IMAGE_VIEW_STATE>(image_view); }
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) { return Get<IMAGE_VIEW_STATE>(image_view); }
 
@@ -342,6 +349,12 @@ class ValidationStateTracker : public ValidationObject {
     const IMAGE_STATE* GetImageState(VkImage image) const { return Get<IMAGE_STATE>(image); }
     IMAGE_STATE* GetImageState(VkImage image) { return Get<IMAGE_STATE>(image); }
 
+    const std::shared_ptr<BUFFER_VIEW_STATE> GetBufferViewShared(VkBufferView buffer_view) const {
+        return GetShared<BUFFER_VIEW_STATE>(buffer_view);
+    }
+    std::shared_ptr<BUFFER_VIEW_STATE> GetBufferViewShared(VkBufferView buffer_view) {
+        return GetShared<BUFFER_VIEW_STATE>(buffer_view);
+    }
     const BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) const { return Get<BUFFER_VIEW_STATE>(buffer_view); }
     BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) { return Get<BUFFER_VIEW_STATE>(buffer_view); }
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -48,7 +48,7 @@ enum SyncScope {
 
 enum FENCE_STATUS { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
 
-class FENCE_STATE {
+class FENCE_STATE : public BASE_NODE {
   public:
     VkFence fence;
     VkFenceCreateInfo createInfo;
@@ -110,21 +110,21 @@ struct PHYSICAL_DEVICE_STATE {
 // This structure is used to save data across the CreateGraphicsPipelines down-chain API call
 struct create_graphics_pipeline_api_state {
     std::vector<safe_VkGraphicsPipelineCreateInfo> gpu_create_infos;
-    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
+    std::vector<std::shared_ptr<PIPELINE_STATE>> pipe_state;
     const VkGraphicsPipelineCreateInfo* pCreateInfos;
 };
 
 // This structure is used to save data across the CreateComputePipelines down-chain API call
 struct create_compute_pipeline_api_state {
     std::vector<safe_VkComputePipelineCreateInfo> gpu_create_infos;
-    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
+    std::vector<std::shared_ptr<PIPELINE_STATE>> pipe_state;
     const VkComputePipelineCreateInfo* pCreateInfos;
 };
 
 // This structure is used to save data across the CreateRayTracingPipelinesNV down-chain API call.
 struct create_ray_tracing_pipeline_api_state {
     std::vector<safe_VkRayTracingPipelineCreateInfoNV> gpu_create_infos;
-    std::vector<std::unique_ptr<PIPELINE_STATE>> pipe_state;
+    std::vector<std::shared_ptr<PIPELINE_STATE>> pipe_state;
     const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
 };
 
@@ -168,7 +168,7 @@ struct hash<GpuQueue> {
 };
 }  // namespace std
 
-struct SURFACE_STATE {
+struct SURFACE_STATE : public BASE_NODE {
     VkSurfaceKHR surface = VK_NULL_HANDLE;
     SWAPCHAIN_NODE* swapchain = nullptr;
     std::unordered_map<GpuQueue, bool> gpu_queue_support;
@@ -243,7 +243,8 @@ class ValidationStateTracker : public ValidationObject {
         using StateType = StateType_;
         using HandleType = typename AccessorStateHandle<StateType>::HandleType;
         using ReturnType = StateType*;
-        using MappedType = std::unique_ptr<StateType>;
+        using SharedType = std::shared_ptr<StateType>;
+        using MappedType = std::shared_ptr<StateType>;
         using MapType = unordered_map<HandleType, MappedType>;
     };
 
@@ -275,7 +276,7 @@ class ValidationStateTracker : public ValidationObject {
 
   public:
     template <typename State>
-    typename AccessorTraits<State>::ReturnType Get(typename AccessorTraits<State>::Handle handle) {
+    typename AccessorTraits<State>::ReturnType Get(typename AccessorTraits<State>::HandleType handle) {
         using Traits = AccessorTraits<State>;
         auto map_member = Traits::Map();
         const typename Traits::MapType& map =
@@ -302,17 +303,53 @@ class ValidationStateTracker : public ValidationObject {
         return found_it->second.get();
     };
 
+    template <typename State>
+    typename AccessorTraits<State>::SharedType GetShared(typename AccessorTraits<State>::HandleType handle) {
+        using Traits = AccessorTraits<State>;
+        auto map_member = Traits::Map();
+        const typename Traits::MapType& map =
+            (Traits::kInstanceScope && (this->*map_member).size() == 0) ? instance_state->*map_member : this->*map_member;
+
+        const auto found_it = map.find(handle);
+        if (found_it == map.end()) {
+            return nullptr;
+        }
+        return found_it->second;
+    };
+
+    template <typename State>
+    const typename AccessorTraits<State>::SharedType GetShared(typename AccessorTraits<State>::HandleType handle) const {
+        using Traits = AccessorTraits<State>;
+        auto map_member = Traits::Map();
+        const typename Traits::MapType& map =
+            (Traits::kInstanceScope && (this->*map_member).size() == 0) ? instance_state->*map_member : this->*map_member;
+
+        const auto found_it = map.find(handle);
+        if (found_it == map.cend()) {
+            return nullptr;
+        }
+        return found_it->second;
+    };
+
     // Accessors for the VALSTATE... maps
     const SAMPLER_STATE* GetSamplerState(VkSampler sampler) const { return Get<SAMPLER_STATE>(sampler); }
     SAMPLER_STATE* GetSamplerState(VkSampler sampler) { return Get<SAMPLER_STATE>(sampler); }
     const IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) const { return Get<IMAGE_VIEW_STATE>(image_view); }
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) { return Get<IMAGE_VIEW_STATE>(image_view); }
+
+    const std::shared_ptr<IMAGE_STATE> GetImageShared(VkImage image) const { return GetShared<IMAGE_STATE>(image); }
+    std::shared_ptr<IMAGE_STATE> GetImageShared(VkImage image) { return GetShared<IMAGE_STATE>(image); }
     const IMAGE_STATE* GetImageState(VkImage image) const { return Get<IMAGE_STATE>(image); }
     IMAGE_STATE* GetImageState(VkImage image) { return Get<IMAGE_STATE>(image); }
+
     const BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) const { return Get<BUFFER_VIEW_STATE>(buffer_view); }
     BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) { return Get<BUFFER_VIEW_STATE>(buffer_view); }
+
+    const std::shared_ptr<BUFFER_STATE> GetBufferShared(VkBuffer buffer) const { return GetShared<BUFFER_STATE>(buffer); }
+    std::shared_ptr<BUFFER_STATE> GetBufferShared(VkBuffer buffer) { return GetShared<BUFFER_STATE>(buffer); }
     const BUFFER_STATE* GetBufferState(VkBuffer buffer) const { return Get<BUFFER_STATE>(buffer); }
     BUFFER_STATE* GetBufferState(VkBuffer buffer) { return Get<BUFFER_STATE>(buffer); }
+
     const PIPELINE_STATE* GetPipelineState(VkPipeline pipeline) const { return Get<PIPELINE_STATE>(pipeline); }
     PIPELINE_STATE* GetPipelineState(VkPipeline pipeline) { return Get<PIPELINE_STATE>(pipeline); }
     const DEVICE_MEMORY_STATE* GetDevMemState(VkDeviceMemory mem) const { return Get<DEVICE_MEMORY_STATE>(mem); }
@@ -339,10 +376,18 @@ class ValidationStateTracker : public ValidationObject {
     CMD_BUFFER_STATE* GetCBState(const VkCommandBuffer cb) { return Get<CMD_BUFFER_STATE>(cb); }
     const COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool) const { return Get<COMMAND_POOL_STATE>(pool); }
     COMMAND_POOL_STATE* GetCommandPoolState(VkCommandPool pool) { return Get<COMMAND_POOL_STATE>(pool); }
+
+    const std::shared_ptr<PIPELINE_LAYOUT_STATE> GetPipelineLayoutShared(VkPipelineLayout pipeLayout) const {
+        return GetShared<PIPELINE_LAYOUT_STATE>(pipeLayout);
+    }
+    std::shared_ptr<PIPELINE_LAYOUT_STATE> GetPipelineLayoutShared(VkPipelineLayout pipeLayout) {
+        return GetShared<PIPELINE_LAYOUT_STATE>(pipeLayout);
+    }
     const PIPELINE_LAYOUT_STATE* GetPipelineLayout(VkPipelineLayout pipeLayout) const {
         return Get<PIPELINE_LAYOUT_STATE>(pipeLayout);
     }
     PIPELINE_LAYOUT_STATE* GetPipelineLayout(VkPipelineLayout pipeLayout) { return Get<PIPELINE_LAYOUT_STATE>(pipeLayout); }
+
     const FENCE_STATE* GetFenceState(VkFence fence) const { return Get<FENCE_STATE>(fence); }
     FENCE_STATE* GetFenceState(VkFence fence) { return Get<FENCE_STATE>(fence); }
     const QUERY_POOL_STATE* GetQueryPoolState(VkQueryPool query_pool) const { return Get<QUERY_POOL_STATE>(query_pool); }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -223,9 +223,6 @@ class ValidationStateTracker : public ValidationObject {
     unordered_map<VkQueue, QUEUE_STATE> queueMap;
     unordered_map<VkEvent, EVENT_STATE> eventMap;
 
-    unordered_map<VkRenderPass, std::shared_ptr<RENDER_PASS_STATE>> renderPassMap;
-    unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> descriptorSetLayoutMap;
-
     std::unordered_set<VkQueue> queues;  // All queues under given device
     QueryMap queryToStateMap;
     unordered_map<VkSamplerYcbcrConversion, uint64_t> ycbcr_conversion_ahb_fmt_map;
@@ -248,6 +245,8 @@ class ValidationStateTracker : public ValidationObject {
         using MapType = unordered_map<HandleType, MappedType>;
     };
 
+    VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, RENDER_PASS_STATE, renderPassMap)
+    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout, descriptorSetLayoutMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, SAMPLER_STATE, samplerMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkImageView, IMAGE_VIEW_STATE, imageViewMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkImage, IMAGE_STATE, imageMap)
@@ -332,6 +331,22 @@ class ValidationStateTracker : public ValidationObject {
     };
 
     // Accessors for the VALSTATE... maps
+    const std::shared_ptr<cvdescriptorset::DescriptorSetLayout> GetDescriptorSetLayoutShared(VkDescriptorSetLayout dsLayout) const {
+        return GetShared<cvdescriptorset::DescriptorSetLayout>(dsLayout);
+    }
+    std::shared_ptr<cvdescriptorset::DescriptorSetLayout> GetDescriptorSetLayoutShared(VkDescriptorSetLayout dsLayout) {
+        return GetShared<cvdescriptorset::DescriptorSetLayout>(dsLayout);
+    }
+
+    const std::shared_ptr<RENDER_PASS_STATE> GetRenderPassShared(VkRenderPass renderpass) const {
+        return GetShared<RENDER_PASS_STATE>(renderpass);
+    }
+    std::shared_ptr<RENDER_PASS_STATE> GetRenderPassShared(VkRenderPass renderpass) {
+        return GetShared<RENDER_PASS_STATE>(renderpass);
+    }
+    const RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass) const { return Get<RENDER_PASS_STATE>(renderpass); }
+    RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass) { return Get<RENDER_PASS_STATE>(renderpass); }
+
     const std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) const { return GetShared<SAMPLER_STATE>(sampler); }
     std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) { return GetShared<SAMPLER_STATE>(sampler); }
     const SAMPLER_STATE* GetSamplerState(VkSampler sampler) const { return Get<SAMPLER_STATE>(sampler); }
@@ -419,9 +434,6 @@ class ValidationStateTracker : public ValidationObject {
     // Class Declarations for helper functions
     IMAGE_VIEW_STATE* GetAttachmentImageViewState(FRAMEBUFFER_STATE* framebuffer, uint32_t index);
     const IMAGE_VIEW_STATE* GetAttachmentImageViewState(const FRAMEBUFFER_STATE* framebuffer, uint32_t index) const;
-    const RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass) const;
-    RENDER_PASS_STATE* GetRenderPassState(VkRenderPass renderpass);
-    std::shared_ptr<RENDER_PASS_STATE> GetRenderPassStateSharedPtr(VkRenderPass renderpass);
     const EVENT_STATE* GetEventState(VkEvent event) const;
     EVENT_STATE* GetEventState(VkEvent event);
     const QUEUE_STATE* GetQueueState(VkQueue queue) const;

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -263,7 +263,7 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
         : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -263,9 +263,10 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
+    std::atomic<bool> destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : desc_update_template(update_template), create_info(*pCreateInfo) {}
+        : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}
 };
 
 class LAYER_PHYS_DEV_PROPERTIES {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4446,7 +4446,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
                               &descriptorSet, 0, NULL);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, " that has been destroyed.");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, " that is invalid or has been destroyed.");
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_commandBuffer->EndRenderPass();


### PR DESCRIPTION
Allocate the *_STATE objects as shared_ptrs, so other objects can keep references to them even if the API-level object gets destroyed. Take advantage of this in descriptor set validation to only do the hash table lookup at Update time, not at Draw time when the descriptor set is validated. This can be a significant speedup for large descriptor sets that are used much more frequently than they're updated.

These changes made my test app 10% faster with just image_layout validation disabled, and 
25% faster with image layout and command_buffer_state validation disabled.

Related to #1001.