### PR TITLE
More efficient cb_bindings to object_bindings linking 

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -360,11 +360,9 @@ void CoreChecks::SetImageViewInitialLayout(CMD_BUFFER_STATE *cb_node, const IMAG
     if (disabled.image_layout_validation) {
         return;
     }
-    IMAGE_STATE *image_state = GetImageState(view_state.create_info.image);
-    if (image_state) {
-        auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, *image_state);
-        subresource_map->SetSubresourceRangeInitialLayout(*cb_node, view_state.normalized_subresource_range, layout, &view_state);
-    }
+    IMAGE_STATE *image_state = view_state.image_state.get();
+    auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, *image_state);
+    subresource_map->SetSubresourceRangeInitialLayout(*cb_node, view_state.normalized_subresource_range, layout, &view_state);
 }
 
 // Set the initial image layout for a passed non-normalized subresource range
@@ -389,8 +387,7 @@ void CoreChecks::SetImageInitialLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_ST
 
 // Set image layout for all slices of an image view
 void CoreChecks::SetImageViewLayout(CMD_BUFFER_STATE *cb_node, const IMAGE_VIEW_STATE &view_state, VkImageLayout layout) {
-    IMAGE_STATE *image_state = GetImageState(view_state.create_info.image);
-    if (!image_state) return;  // TODO: track/report stale image references
+    IMAGE_STATE *image_state = view_state.image_state.get();
 
     VkImageSubresourceRange sub_range = view_state.normalized_subresource_range;
     // When changing the layout of a 3D image subresource via a 2D or 2D_ARRRAY image view, all depth slices of

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -141,8 +141,12 @@ bool IMAGE_STATE::IsCompatibleAliasing(IMAGE_STATE *other_image_state) {
     return false;
 }
 
-IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const IMAGE_STATE *image_state, VkImageView iv, const VkImageViewCreateInfo *ci)
-    : image_view(iv), create_info(*ci), normalized_subresource_range(ci->subresourceRange), samplerConversion(VK_NULL_HANDLE) {
+IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkImageView iv, const VkImageViewCreateInfo *ci)
+    : image_view(iv),
+      create_info(*ci),
+      normalized_subresource_range(ci->subresourceRange),
+      samplerConversion(VK_NULL_HANDLE),
+      image_state(im) {
     auto *conversionInfo = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(create_info.pNext);
     if (conversionInfo) samplerConversion = conversionInfo->conversion;
     if (image_state) {

--- a/layers/cast_utils.h
+++ b/layers/cast_utils.h
@@ -52,7 +52,7 @@ static inline HandleType CastFromUint64(uint64_t untyped_handle) {
 }
 
 template <typename HandleType>
-static uint64_t CastToUint64(HandleType handle) {
+static inline uint64_t CastToUint64(HandleType handle) {
     static_assert(sizeof(HandleType) <= sizeof(uint64_t), "HandleType must be not larger than the untyped handle size");
     typedef
         typename std::conditional<sizeof(HandleType) == sizeof(uint8_t), uint8_t,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -848,7 +848,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
 
     // Now complete other state checks
     string errorString;
-    auto const &pipeline_layout = pPipe->pipeline_layout;
+    auto const &pipeline_layout = pPipe->pipeline_layout.get();
 
     for (const auto &set_binding_pair : pPipe->active_slots) {
         uint32_t setIndex = set_binding_pair.first;
@@ -858,7 +858,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_DescriptorSetNotBound,
                         "%s uses set #%u but that set is not bound.", report_data->FormatHandle(pPipe->pipeline).c_str(), setIndex);
-        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, pipeline_layout.get(),
+        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, pipeline_layout,
                                                  setIndex, errorString)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
             VkDescriptorSet setHandle = state.per_set[setIndex].bound_descriptor_set->GetSet();

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -858,7 +858,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                         HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_DescriptorSetNotBound,
                         "%s uses set #%u but that set is not bound.", report_data->FormatHandle(pPipe->pipeline).c_str(), setIndex);
-        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, &pipeline_layout,
+        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[setIndex].bound_descriptor_set, pipeline_layout.get(),
                                                  setIndex, errorString)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
             VkDescriptorSet setHandle = state.per_set[setIndex].bound_descriptor_set->GetSet();
@@ -866,7 +866,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                               HandleToUint64(setHandle), kVUID_Core_DrawState_PipelineLayoutsIncompatible,
                               "%s bound as set #%u is not compatible with overlapping %s due to: %s",
                               report_data->FormatHandle(setHandle).c_str(), setIndex,
-                              report_data->FormatHandle(pipeline_layout.layout).c_str(), errorString.c_str());
+                              report_data->FormatHandle(pipeline_layout->layout).c_str(), errorString.c_str());
         } else {  // Valid set is bound and layout compatible, validate that it's updated
             // Pull the set node
             const cvdescriptorset::DescriptorSet *descriptor_set = state.per_set[setIndex].bound_descriptor_set;
@@ -921,7 +921,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     return result;
 }
 
-bool CoreChecks::ValidatePipelineLocked(std::vector<std::unique_ptr<PIPELINE_STATE>> const &pPipelines, int pipelineIndex) const {
+bool CoreChecks::ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STATE>> const &pPipelines, int pipelineIndex) const {
     bool skip = false;
 
     const PIPELINE_STATE *pPipeline = pPipelines[pipelineIndex].get();
@@ -3256,7 +3256,7 @@ VkFormatProperties CoreChecks::GetPDFormatProperties(const VkFormat format) cons
     return format_properties;
 }
 
-bool CoreChecks::ValidatePipelineVertexDivisors(std::vector<std::unique_ptr<PIPELINE_STATE>> const &pipe_state_vec,
+bool CoreChecks::ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const &pipe_state_vec,
                                                 const uint32_t count, const VkGraphicsPipelineCreateInfo *pipe_cis) const {
     bool skip = false;
     const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;
@@ -9676,7 +9676,7 @@ void CoreChecks::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchai
             if (swapchain_state->createInfo.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)
                 image_ci.flags |= (VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT_KHR);
 
-            imageMap[pSwapchainImages[i]] = unique_ptr<IMAGE_STATE>(new IMAGE_STATE(pSwapchainImages[i], &image_ci));
+            imageMap[pSwapchainImages[i]] = std::make_shared<IMAGE_STATE>(pSwapchainImages[i], &image_ci);
             auto &image_state = imageMap[pSwapchainImages[i]];
             image_state->valid = false;
             image_state->create_from_swapchain = swapchain;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1925,27 +1925,24 @@ bool CoreChecks::ValidateCommandBufferState(const CMD_BUFFER_STATE *cb_state, co
 }
 
 // Check that the queue family index of 'queue' matches one of the entries in pQueueFamilyIndices
-bool CoreChecks::ValidImageBufferQueue(const CMD_BUFFER_STATE *cb_node, const VulkanTypedHandle &object, VkQueue queue,
+bool CoreChecks::ValidImageBufferQueue(const CMD_BUFFER_STATE *cb_node, const VulkanTypedHandle &object, uint32_t queueFamilyIndex,
                                        uint32_t count, const uint32_t *indices) const {
     bool found = false;
     bool skip = false;
-    auto queue_state = GetQueueState(queue);
-    if (queue_state) {
-        for (uint32_t i = 0; i < count; i++) {
-            if (indices[i] == queue_state->queueFamilyIndex) {
-                found = true;
-                break;
-            }
+    for (uint32_t i = 0; i < count; i++) {
+        if (indices[i] == queueFamilyIndex) {
+            found = true;
+            break;
         }
+    }
 
-        if (!found) {
-            skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, get_debug_report_enum[object.type], object.handle,
-                           kVUID_Core_DrawState_InvalidQueueFamily,
-                           "vkQueueSubmit: %s contains %s which was not created allowing concurrent access to "
-                           "this queue family %d.",
-                           report_data->FormatHandle(cb_node->commandBuffer).c_str(), report_data->FormatHandle(object).c_str(),
-                           queue_state->queueFamilyIndex);
-        }
+    if (!found) {
+        skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, get_debug_report_enum[object.type], object.handle,
+                       kVUID_Core_DrawState_InvalidQueueFamily,
+                       "vkQueueSubmit: %s contains %s which was not created allowing concurrent access to "
+                       "this queue family %d.",
+                       report_data->FormatHandle(cb_node->commandBuffer).c_str(), report_data->FormatHandle(object).c_str(),
+                       queueFamilyIndex);
     }
     return skip;
 }
@@ -1970,15 +1967,17 @@ bool CoreChecks::ValidateQueueFamilyIndices(const CMD_BUFFER_STATE *pCB, VkQueue
         // Ensure that any bound images or buffers created with SHARING_MODE_CONCURRENT have access to the current queue family
         for (const auto &object : pCB->object_bindings) {
             if (object.type == kVulkanObjectTypeImage) {
-                auto image_state = GetImageState(object.Cast<VkImage>());
+                auto image_state = object.node ? (IMAGE_STATE *)object.node : GetImageState(object.Cast<VkImage>());
                 if (image_state && image_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
-                    skip |= ValidImageBufferQueue(pCB, object, queue, image_state->createInfo.queueFamilyIndexCount,
+                    skip |= ValidImageBufferQueue(pCB, object, queue_state->queueFamilyIndex,
+                                                  image_state->createInfo.queueFamilyIndexCount,
                                                   image_state->createInfo.pQueueFamilyIndices);
                 }
             } else if (object.type == kVulkanObjectTypeBuffer) {
-                auto buffer_state = GetBufferState(object.Cast<VkBuffer>());
+                auto buffer_state = object.node ? (BUFFER_STATE *)object.node : GetBufferState(object.Cast<VkBuffer>());
                 if (buffer_state && buffer_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
-                    skip |= ValidImageBufferQueue(pCB, object, queue, buffer_state->createInfo.queueFamilyIndexCount,
+                    skip |= ValidImageBufferQueue(pCB, object, queue_state->queueFamilyIndex,
+                                                  buffer_state->createInfo.queueFamilyIndexCount,
                                                   buffer_state->createInfo.pQueueFamilyIndices);
                 }
             }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -52,8 +52,8 @@ class CoreChecks : public ValidationStateTracker {
     void InitializeShadowMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
     bool ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
     bool ValidatePipelineUnlocked(const PIPELINE_STATE* pPipeline, uint32_t pipelineIndex) const;
-    bool ValidImageBufferQueue(const CMD_BUFFER_STATE* cb_node, const VulkanTypedHandle& object, VkQueue queue, uint32_t count,
-                               const uint32_t* indices) const;
+    bool ValidImageBufferQueue(const CMD_BUFFER_STATE* cb_node, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
+                               uint32_t count, const uint32_t* indices) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence) const;
     bool ValidateSemaphoresForSubmit(VkQueue queue, const VkSubmitInfo* submit,
                                      std::unordered_set<VkSemaphore>* unsignaled_sema_arg,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -50,7 +50,7 @@ class CoreChecks : public ValidationStateTracker {
     void StoreMemRanges(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size);
     bool ValidateIdleDescriptorSet(VkDescriptorSet set, const char* func_str);
     void InitializeShadowMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
-    bool ValidatePipelineLocked(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
+    bool ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
     bool ValidatePipelineUnlocked(const PIPELINE_STATE* pPipeline, uint32_t pipelineIndex) const;
     bool ValidImageBufferQueue(const CMD_BUFFER_STATE* cb_node, const VulkanTypedHandle& object, VkQueue queue, uint32_t count,
                                const uint32_t* indices) const;
@@ -87,7 +87,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,
                                         const VkDeviceQueueCreateInfo* infos);
 
-    bool ValidatePipelineVertexDivisors(std::vector<std::unique_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
+    bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis) const;
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const char* func_name, CMD_BUFFER_STATE* cb_state,
                                                          uint32_t imageMemBarrierCount,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -83,7 +83,7 @@ class BASE_NODE {
     std::unordered_set<CMD_BUFFER_STATE *> cb_bindings;
     // Set to true when the API-level object is destroyed, but this object may
     // hang around until its shared_ptr refcount goes to zero.
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     BASE_NODE() {
         in_use.store(0);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -594,10 +594,10 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, const V
                 auto immut_sampler = p_layout_->GetImmutableSamplerPtrFromIndex(i);
                 for (uint32_t di = 0; di < p_layout_->GetDescriptorCountFromIndex(i); ++di) {
                     if (immut_sampler) {
-                        descriptors_.emplace_back(new SamplerDescriptor(immut_sampler + di));
+                        descriptors_.emplace_back(new SamplerDescriptor(state_data, immut_sampler + di));
                         some_update_ = true;  // Immutable samplers are updated at creation
                     } else
-                        descriptors_.emplace_back(new SamplerDescriptor(nullptr));
+                        descriptors_.emplace_back(new SamplerDescriptor(state_data, nullptr));
                 }
                 break;
             }
@@ -605,10 +605,10 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, const V
                 auto immut = p_layout_->GetImmutableSamplerPtrFromIndex(i);
                 for (uint32_t di = 0; di < p_layout_->GetDescriptorCountFromIndex(i); ++di) {
                     if (immut) {
-                        descriptors_.emplace_back(new ImageSamplerDescriptor(immut + di));
+                        descriptors_.emplace_back(new ImageSamplerDescriptor(state_data, immut + di));
                         some_update_ = true;  // Immutable samplers are updated at creation
                     } else
-                        descriptors_.emplace_back(new ImageSamplerDescriptor(nullptr));
+                        descriptors_.emplace_back(new ImageSamplerDescriptor(state_data, nullptr));
                 }
                 break;
             }
@@ -736,11 +736,11 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                 if (descriptor_class == DescriptorClass::GeneralBuffer) {
                     // Verify that buffers are valid
                     auto buffer = static_cast<const BufferDescriptor *>(descriptor)->GetBuffer();
-                    auto buffer_node = GetBufferState(buffer);
-                    if (!buffer_node) {
+                    auto buffer_node = static_cast<const BufferDescriptor *>(descriptor)->GetBufferState();
+                    if (!buffer_node || buffer_node->destroyed) {
                         std::stringstream error_str;
-                        error_str << "Descriptor in binding #" << binding << " index " << index << " references invalid buffer "
-                                  << buffer << ".";
+                        error_str << "Descriptor in binding #" << binding << " index " << index << " is using buffer "
+                                  << report_data->FormatHandle(buffer).c_str() << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     } else if (!buffer_node->sparse) {
@@ -785,22 +785,24 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                 } else if (descriptor_class == DescriptorClass::ImageSampler || descriptor_class == DescriptorClass::Image) {
                     VkImageView image_view;
                     VkImageLayout image_layout;
+                    const IMAGE_VIEW_STATE *image_view_state;
                     if (descriptor_class == DescriptorClass::ImageSampler) {
                         image_view = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetImageView();
+                        image_view_state = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetImageViewState();
                         image_layout = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetImageLayout();
                     } else {
                         image_view = static_cast<const ImageDescriptor *>(descriptor)->GetImageView();
+                        image_view_state = static_cast<const ImageDescriptor *>(descriptor)->GetImageViewState();
                         image_layout = static_cast<const ImageDescriptor *>(descriptor)->GetImageLayout();
                     }
                     auto reqs = binding_pair.second;
 
-                    auto image_view_state = GetImageViewState(image_view);
-                    if (nullptr == image_view_state) {
+                    if (!image_view_state || image_view_state->destroyed) {
                         // Image view must have been destroyed since initial update. Could potentially flag the descriptor
                         //  as "invalid" (updated = false) at DestroyImageView() time and detect this error at bind time
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " is using imageView "
-                                  << report_data->FormatHandle(image_view).c_str() << " that has been destroyed.";
+                                  << report_data->FormatHandle(image_view).c_str() << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     }
@@ -830,7 +832,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                     }
 
                     if (!disabled.image_layout_validation) {
-                        auto image_node = GetImageState(image_view_ci.image);
+                        auto image_node = image_view_state->image_state.get();
                         assert(image_node);
                         // Verify Image Layout
                         // No "invalid layout" VUID required for this call, since the optimal_layout parameter is UNDEFINED.
@@ -865,33 +867,34 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                     }
                 } else if (descriptor_class == DescriptorClass::TexelBuffer) {
                     auto texel_buffer = static_cast<const TexelDescriptor *>(descriptor);
-                    auto buffer_view = GetBufferViewState(texel_buffer->GetBufferView());
+                    auto buffer_view = texel_buffer->GetBufferView();
+                    auto buffer_view_state = texel_buffer->GetBufferViewState();
 
-                    if (nullptr == buffer_view) {
+                    if (!buffer_view_state || buffer_view_state->destroyed) {
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " is using bufferView "
-                                  << buffer_view << " that has been destroyed.";
+                                  << report_data->FormatHandle(buffer_view).c_str() << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     }
-                    auto buffer = buffer_view->create_info.buffer;
-                    auto buffer_state = GetBufferState(buffer);
-                    if (!buffer_state) {
+                    auto buffer = buffer_view_state->create_info.buffer;
+                    auto buffer_state = buffer_view_state->buffer_state.get();
+                    if (buffer_state->destroyed) {
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " is using buffer "
-                                  << buffer_state << " that has been destroyed.";
+                                  << report_data->FormatHandle(buffer).c_str() << " that has been destroyed.";
                         *error = error_str.str();
                         return false;
                     }
                     auto reqs = binding_pair.second;
-                    auto format_bits = DescriptorRequirementsBitsFromFormat(buffer_view->create_info.format);
+                    auto format_bits = DescriptorRequirementsBitsFromFormat(buffer_view_state->create_info.format);
 
                     if (!(reqs & format_bits)) {
                         // bad component type
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " requires "
                                   << StringDescriptorReqComponentType(reqs) << " component type, but bound descriptor format is "
-                                  << string_VkFormat(buffer_view->create_info.format) << ".";
+                                  << string_VkFormat(buffer_view_state->create_info.format) << ".";
                         *error = error_str.str();
                         return false;
                     }
@@ -899,19 +902,21 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const st
                 if (descriptor_class == DescriptorClass::ImageSampler || descriptor_class == DescriptorClass::PlainSampler) {
                     // Verify Sampler still valid
                     VkSampler sampler;
+                    const SAMPLER_STATE *sampler_state;
                     if (descriptor_class == DescriptorClass::ImageSampler) {
                         sampler = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetSampler();
+                        sampler_state = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetSamplerState();
                     } else {
                         sampler = static_cast<const SamplerDescriptor *>(descriptor)->GetSampler();
+                        sampler_state = static_cast<const SamplerDescriptor *>(descriptor)->GetSamplerState();
                     }
-                    if (!ValidateSampler(sampler)) {
+                    if (!sampler_state || sampler_state->destroyed) {
                         std::stringstream error_str;
-                        error_str << "Descriptor in binding #" << binding << " index " << index << " is using sampler " << sampler
-                                  << " that has been destroyed.";
+                        error_str << "Descriptor in binding #" << binding << " index " << index << " is using sampler "
+                                  << report_data->FormatHandle(sampler).c_str() << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     } else {
-                        const SAMPLER_STATE *sampler_state = GetSamplerState(sampler);
                         if (sampler_state->samplerConversion && !descriptor->IsImmutableSampler()) {
                             std::stringstream error_str;
                             error_str << "sampler (" << sampler << ") in the descriptor set (" << descriptor_set->GetSet()
@@ -958,7 +963,7 @@ void cvdescriptorset::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorS
         auto global_idx = p_layout_->GetGlobalIndexRangeFromBinding(binding_being_updated).start + offset;
         // Loop over the updates for a single binding at a time
         for (uint32_t di = 0; di < update_count; ++di, ++update_index) {
-            descriptors_[global_idx + di]->WriteUpdate(update, update_index);
+            descriptors_[global_idx + di]->WriteUpdate(state_data_, update, update_index);
         }
         // Roll over to next binding in case of consecutive update
         descriptors_remaining -= update_count;
@@ -1184,7 +1189,7 @@ void cvdescriptorset::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet
         auto src = src_set->descriptors_[src_start_idx + di].get();
         auto dst = descriptors_[dst_start_idx + di].get();
         if (src->updated) {
-            dst->CopyUpdate(src);
+            dst->CopyUpdate(state_data_, src);
             some_update_ = true;
             change_count_++;
         } else {
@@ -1330,11 +1335,13 @@ void cvdescriptorset::DescriptorSet::UpdateValidationCache(const CMD_BUFFER_STAT
     }
 }
 
-cvdescriptorset::SamplerDescriptor::SamplerDescriptor(const VkSampler *immut) : sampler_(VK_NULL_HANDLE), immutable_(false) {
+cvdescriptorset::SamplerDescriptor::SamplerDescriptor(ValidationStateTracker *dev_data, const VkSampler *immut)
+    : sampler_(VK_NULL_HANDLE), immutable_(false) {
     updated = false;
     descriptor_class = PlainSampler;
     if (immut) {
         sampler_ = *immut;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
         immutable_ = true;
         updated = true;
     }
@@ -1562,68 +1569,77 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     return true;
 }
 
-void cvdescriptorset::SamplerDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
+void cvdescriptorset::SamplerDescriptor::WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
+                                                     const uint32_t index) {
     if (!immutable_) {
         sampler_ = update->pImageInfo[index].sampler;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
     }
     updated = true;
 }
 
-void cvdescriptorset::SamplerDescriptor::CopyUpdate(const Descriptor *src) {
+void cvdescriptorset::SamplerDescriptor::CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *src) {
     if (!immutable_) {
         auto update_sampler = static_cast<const SamplerDescriptor *>(src)->sampler_;
         sampler_ = update_sampler;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
     }
     updated = true;
 }
 
 void cvdescriptorset::SamplerDescriptor::UpdateDrawState(ValidationStateTracker *dev_data, CMD_BUFFER_STATE *cb_node) {
     if (!immutable_) {
-        auto sampler_state = dev_data->GetSamplerState(sampler_);
+        auto sampler_state = GetSamplerState();
         if (sampler_state) dev_data->AddCommandBufferBindingSampler(cb_node, sampler_state);
     }
 }
 
-cvdescriptorset::ImageSamplerDescriptor::ImageSamplerDescriptor(const VkSampler *immut)
+cvdescriptorset::ImageSamplerDescriptor::ImageSamplerDescriptor(ValidationStateTracker *dev_data, const VkSampler *immut)
     : sampler_(VK_NULL_HANDLE), immutable_(false), image_view_(VK_NULL_HANDLE), image_layout_(VK_IMAGE_LAYOUT_UNDEFINED) {
     updated = false;
     descriptor_class = ImageSampler;
     if (immut) {
         sampler_ = *immut;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
         immutable_ = true;
     }
 }
 
-void cvdescriptorset::ImageSamplerDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
+void cvdescriptorset::ImageSamplerDescriptor::WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
+                                                          const uint32_t index) {
     updated = true;
     const auto &image_info = update->pImageInfo[index];
     if (!immutable_) {
         sampler_ = image_info.sampler;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
     }
     image_view_ = image_info.imageView;
     image_layout_ = image_info.imageLayout;
+    image_view_state_ = dev_data->GetImageViewShared(image_view_);
 }
 
-void cvdescriptorset::ImageSamplerDescriptor::CopyUpdate(const Descriptor *src) {
+void cvdescriptorset::ImageSamplerDescriptor::CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *src) {
     if (!immutable_) {
         auto update_sampler = static_cast<const ImageSamplerDescriptor *>(src)->sampler_;
         sampler_ = update_sampler;
+        sampler_state_ = dev_data->GetSamplerShared(sampler_);
     }
     auto image_view = static_cast<const ImageSamplerDescriptor *>(src)->image_view_;
     auto image_layout = static_cast<const ImageSamplerDescriptor *>(src)->image_layout_;
     updated = true;
     image_view_ = image_view;
     image_layout_ = image_layout;
+    image_view_state_ = dev_data->GetImageViewShared(image_view_);
 }
 
 void cvdescriptorset::ImageSamplerDescriptor::UpdateDrawState(ValidationStateTracker *dev_data, CMD_BUFFER_STATE *cb_node) {
     // First add binding for any non-immutable sampler
     if (!immutable_) {
-        auto sampler_state = dev_data->GetSamplerState(sampler_);
+        auto sampler_state = GetSamplerState();
         if (sampler_state) dev_data->AddCommandBufferBindingSampler(cb_node, sampler_state);
     }
     // Add binding for image
-    auto iv_state = dev_data->GetImageViewState(image_view_);
+    auto iv_state = GetImageViewState();
     if (iv_state) {
         dev_data->AddCommandBufferBindingImageView(cb_node, iv_state);
         dev_data->CallSetImageViewInitialLayoutCallback(cb_node, *iv_state, image_layout_);
@@ -1637,24 +1653,27 @@ cvdescriptorset::ImageDescriptor::ImageDescriptor(const VkDescriptorType type)
     if (VK_DESCRIPTOR_TYPE_STORAGE_IMAGE == type) storage_ = true;
 }
 
-void cvdescriptorset::ImageDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
+void cvdescriptorset::ImageDescriptor::WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
+                                                   const uint32_t index) {
     updated = true;
     const auto &image_info = update->pImageInfo[index];
     image_view_ = image_info.imageView;
     image_layout_ = image_info.imageLayout;
+    image_view_state_ = dev_data->GetImageViewShared(image_view_);
 }
 
-void cvdescriptorset::ImageDescriptor::CopyUpdate(const Descriptor *src) {
+void cvdescriptorset::ImageDescriptor::CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *src) {
     auto image_view = static_cast<const ImageDescriptor *>(src)->image_view_;
     auto image_layout = static_cast<const ImageDescriptor *>(src)->image_layout_;
     updated = true;
     image_view_ = image_view;
     image_layout_ = image_layout;
+    image_view_state_ = dev_data->GetImageViewShared(image_view_);
 }
 
 void cvdescriptorset::ImageDescriptor::UpdateDrawState(ValidationStateTracker *dev_data, CMD_BUFFER_STATE *cb_node) {
     // Add binding for image
-    auto iv_state = dev_data->GetImageViewState(image_view_);
+    auto iv_state = GetImageViewState();
     if (iv_state) {
         dev_data->AddCommandBufferBindingImageView(cb_node, iv_state);
         dev_data->CallSetImageViewInitialLayoutCallback(cb_node, *iv_state, image_layout_);
@@ -1674,24 +1693,27 @@ cvdescriptorset::BufferDescriptor::BufferDescriptor(const VkDescriptorType type)
         storage_ = true;
     }
 }
-void cvdescriptorset::BufferDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
+void cvdescriptorset::BufferDescriptor::WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
+                                                    const uint32_t index) {
     updated = true;
     const auto &buffer_info = update->pBufferInfo[index];
     buffer_ = buffer_info.buffer;
     offset_ = buffer_info.offset;
     range_ = buffer_info.range;
+    buffer_state_ = dev_data->GetBufferShared(buffer_);
 }
 
-void cvdescriptorset::BufferDescriptor::CopyUpdate(const Descriptor *src) {
+void cvdescriptorset::BufferDescriptor::CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *src) {
     auto buff_desc = static_cast<const BufferDescriptor *>(src);
     updated = true;
     buffer_ = buff_desc->buffer_;
     offset_ = buff_desc->offset_;
     range_ = buff_desc->range_;
+    buffer_state_ = dev_data->GetBufferShared(buffer_);
 }
 
 void cvdescriptorset::BufferDescriptor::UpdateDrawState(ValidationStateTracker *dev_data, CMD_BUFFER_STATE *cb_node) {
-    auto buffer_node = dev_data->GetBufferState(buffer_);
+    auto buffer_node = GetBufferState();
     if (buffer_node) dev_data->AddCommandBufferBindingBuffer(cb_node, buffer_node);
 }
 
@@ -1701,18 +1723,21 @@ cvdescriptorset::TexelDescriptor::TexelDescriptor(const VkDescriptorType type) :
     if (VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER == type) storage_ = true;
 }
 
-void cvdescriptorset::TexelDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
+void cvdescriptorset::TexelDescriptor::WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
+                                                   const uint32_t index) {
     updated = true;
     buffer_view_ = update->pTexelBufferView[index];
+    buffer_view_state_ = dev_data->GetBufferViewShared(buffer_view_);
 }
 
-void cvdescriptorset::TexelDescriptor::CopyUpdate(const Descriptor *src) {
+void cvdescriptorset::TexelDescriptor::CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *src) {
     updated = true;
     buffer_view_ = static_cast<const TexelDescriptor *>(src)->buffer_view_;
+    buffer_view_state_ = dev_data->GetBufferViewShared(buffer_view_);
 }
 
 void cvdescriptorset::TexelDescriptor::UpdateDrawState(ValidationStateTracker *dev_data, CMD_BUFFER_STATE *cb_node) {
-    auto bv_state = dev_data->GetBufferViewState(buffer_view_);
+    auto bv_state = GetBufferViewState();
     if (bv_state) {
         dev_data->AddCommandBufferBindingBufferView(cb_node, bv_state);
     }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -594,8 +594,6 @@ class DescriptorSet : public BASE_NODE {
     const std::shared_ptr<DescriptorSetLayout const> GetLayout() const { return p_layout_; };
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return p_layout_->GetDescriptorSetLayout(); }
     VkDescriptorSet GetSet() const { return set_; };
-    // Return unordered_set of all command buffers that this set is bound to
-    std::unordered_set<CMD_BUFFER_STATE *> GetBoundCmdBuffers() const { return cb_bindings; }
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *, const std::map<uint32_t, descriptor_req> &);
@@ -613,11 +611,6 @@ class DescriptorSet : public BASE_NODE {
         cached_validation_[cb_state].dynamic_buffers.clear();
     }
     void ClearCachedValidation(CMD_BUFFER_STATE *cb_state) { cached_validation_.erase(cb_state); }
-    // If given cmd_buffer is in the cb_bindings set, remove it
-    void RemoveBoundCommandBuffer(CMD_BUFFER_STATE *cb_node) {
-        cb_bindings.erase(cb_node);
-        ClearCachedValidation(cb_node);
-    }
     VkSampler const *GetImmutableSamplerPtrFromBinding(const uint32_t index) const {
         return p_layout_->GetImmutableSamplerPtrFromBinding(index);
     };

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2386,9 +2386,10 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
+    std::atomic<bool> destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : desc_update_template(update_template), create_info(*pCreateInfo) {}
+        : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}
 };
 
 class LAYER_PHYS_DEV_PROPERTIES {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2386,7 +2386,7 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
         : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}

--- a/layers/generated/vk_object_types.h
+++ b/layers/generated/vk_object_types.h
@@ -787,10 +787,13 @@ template <> struct VulkanObjectTypeInfo<kVulkanObjectTypeValidationCacheEXT> {
 struct VulkanTypedHandle {
     uint64_t handle;
     VulkanObjectType type;
+    // node is optional, and if non-NULL is used to avoid a hash table lookup
+    class BASE_NODE *node;
     template <typename Handle>
-    VulkanTypedHandle(Handle handle_, VulkanObjectType type_) :
+    VulkanTypedHandle(Handle handle_, VulkanObjectType type_, class BASE_NODE *node_ = nullptr) :
         handle(CastToUint64(handle_)),
-        type(type_) {
+        type(type_),
+        node(node_) {
 #ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
         // For 32 bit it's not always safe to check for traits <-> type
         // as all non-dispatchable handles have the same type-id and thus traits,
@@ -807,6 +810,7 @@ struct VulkanTypedHandle {
     }
     VulkanTypedHandle() :
         handle(VK_NULL_HANDLE),
-        type(kVulkanObjectTypeUnknown) {}
+        type(kVulkanObjectTypeUnknown),
+        node(nullptr) {}
 };
 

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1014,9 +1014,9 @@ struct GPUAV_RESTORABLE_PIPELINE_STATE {
             if (last_bound.push_descriptor_set) {
                 push_descriptor_set_writes = last_bound.push_descriptor_set->GetWrites();
             }
-            if (last_bound.pipeline_state->pipeline_layout.push_constant_ranges == cb_state->push_constant_data_ranges) {
+            if (last_bound.pipeline_state->pipeline_layout->push_constant_ranges == cb_state->push_constant_data_ranges) {
                 push_constants_data = cb_state->push_constant_data;
-                push_constants_ranges = last_bound.pipeline_state->pipeline_layout.push_constant_ranges;
+                push_constants_ranges = last_bound.pipeline_state->pipeline_layout->push_constant_ranges;
             }
         }
     }
@@ -1467,7 +1467,7 @@ struct CreatePipelineTraits<VkRayTracingPipelineCreateInfoNV> {
 template <typename CreateInfo, typename SafeCreateInfo>
 void GpuAssisted::PreCallRecordPipelineCreations(uint32_t count, const CreateInfo *pCreateInfos,
                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                 std::vector<std::unique_ptr<PIPELINE_STATE>> &pipe_state,
+                                                 std::vector<std::shared_ptr<PIPELINE_STATE>> &pipe_state,
                                                  std::vector<SafeCreateInfo> *new_pipeline_create_infos,
                                                  const VkPipelineBindPoint bind_point) {
     using Accessor = CreatePipelineTraits<CreateInfo>;
@@ -1488,7 +1488,7 @@ void GpuAssisted::PreCallRecordPipelineCreations(uint32_t count, const CreateInf
         }
         // If the app requests all available sets, the pipeline layout was not modified at pipeline layout creation and the already
         // instrumented shaders need to be replaced with uninstrumented shaders
-        if (pipe_state[pipeline]->pipeline_layout.set_layouts.size() >= adjusted_max_desc_sets) {
+        if (pipe_state[pipeline]->pipeline_layout->set_layouts.size() >= adjusted_max_desc_sets) {
             replace_shaders = true;
         }
 
@@ -2575,8 +2575,8 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     auto iter = cb_node->lastBound.find(bind_point);  // find() allows read-only access to cb_state
     if (iter != cb_node->lastBound.end()) {
         auto pipeline_state = iter->second.pipeline_state;
-        if (pipeline_state && (pipeline_state->pipeline_layout.set_layouts.size() <= desc_set_bind_index)) {
-            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout.layout, desc_set_bind_index, 1,
+        if (pipeline_state && (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index)) {
+            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout, desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }
         // Record buffer and memory info in CB state tracking

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -185,7 +185,7 @@ class GpuAssisted : public ValidationStateTracker {
                                                   void* crtpl_state_data);
     template <typename CreateInfo, typename SafeCreateInfo>
     void PreCallRecordPipelineCreations(uint32_t count, const CreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
-                                        VkPipeline* pPipelines, std::vector<std::unique_ptr<PIPELINE_STATE>>& pipe_state,
+                                        VkPipeline* pPipelines, std::vector<std::shared_ptr<PIPELINE_STATE>>& pipe_state,
                                         std::vector<SafeCreateInfo>* new_pipeline_create_infos,
                                         const VkPipelineBindPoint bind_point);
     template <typename CreateInfo>

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2814,7 +2814,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
     skip |= ValidateShaderStageGroupNonUniform(module, pStage->stage);
     skip |= ValidateExecutionModes(module, entrypoint);
     skip |= ValidateSpecializationOffsets(report_data, pStage);
-    skip |= ValidatePushConstantUsage(report_data, pipeline->pipeline_layout.push_constant_ranges.get(), module, accessible_ids,
+    skip |= ValidatePushConstantUsage(report_data, pipeline->pipeline_layout->push_constant_ranges.get(), module, accessible_ids,
                                       pStage->stage);
     if (check_point_size && !pipeline->graphicsPipelineCI.pRasterizationState->rasterizerDiscardEnable) {
         skip |= ValidatePointListShaderState(pipeline, module, entrypoint, pStage->stage);
@@ -2824,7 +2824,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
     // Validate descriptor use
     for (auto use : descriptor_uses) {
         // Verify given pipelineLayout has requested setLayout with requested binding
-        const auto &binding = GetDescriptorBinding(&pipeline->pipeline_layout, use.first);
+        const auto &binding = GetDescriptorBinding(pipeline->pipeline_layout.get(), use.first);
         unsigned required_descriptor_count;
         std::set<uint32_t> descriptor_types = TypeToDescriptorTypeSet(module, use.second.type_id, required_descriptor_count);
 

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -113,7 +113,7 @@ struct decoration_set {
     void add(uint32_t decoration, uint32_t value);
 };
 
-struct SHADER_MODULE_STATE {
+struct SHADER_MODULE_STATE : public BASE_NODE {
     // The spirv image itself
     std::vector<uint32_t> words;
     // A mapping of <id> to the first word of its def. this is useful because walking type

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -334,8 +334,15 @@ class ValidationStateTracker : public ValidationObject {
     };
 
     // Accessors for the VALSTATE... maps
+    const std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) const { return GetShared<SAMPLER_STATE>(sampler); }
+    std::shared_ptr<SAMPLER_STATE> GetSamplerShared(VkSampler sampler) { return GetShared<SAMPLER_STATE>(sampler); }
     const SAMPLER_STATE* GetSamplerState(VkSampler sampler) const { return Get<SAMPLER_STATE>(sampler); }
     SAMPLER_STATE* GetSamplerState(VkSampler sampler) { return Get<SAMPLER_STATE>(sampler); }
+
+    const std::shared_ptr<IMAGE_VIEW_STATE> GetImageViewShared(VkImageView image_view) const {
+        return GetShared<IMAGE_VIEW_STATE>(image_view);
+    }
+    std::shared_ptr<IMAGE_VIEW_STATE> GetImageViewShared(VkImageView image_view) { return GetShared<IMAGE_VIEW_STATE>(image_view); }
     const IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) const { return Get<IMAGE_VIEW_STATE>(image_view); }
     IMAGE_VIEW_STATE* GetImageViewState(VkImageView image_view) { return Get<IMAGE_VIEW_STATE>(image_view); }
 
@@ -344,6 +351,12 @@ class ValidationStateTracker : public ValidationObject {
     const IMAGE_STATE* GetImageState(VkImage image) const { return Get<IMAGE_STATE>(image); }
     IMAGE_STATE* GetImageState(VkImage image) { return Get<IMAGE_STATE>(image); }
 
+    const std::shared_ptr<BUFFER_VIEW_STATE> GetBufferViewShared(VkBufferView buffer_view) const {
+        return GetShared<BUFFER_VIEW_STATE>(buffer_view);
+    }
+    std::shared_ptr<BUFFER_VIEW_STATE> GetBufferViewShared(VkBufferView buffer_view) {
+        return GetShared<BUFFER_VIEW_STATE>(buffer_view);
+    }
     const BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) const { return Get<BUFFER_VIEW_STATE>(buffer_view); }
     BUFFER_VIEW_STATE* GetBufferViewState(VkBufferView buffer_view) { return Get<BUFFER_VIEW_STATE>(buffer_view); }
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -901,7 +901,9 @@ class ValidationStateTracker : public ValidationObject {
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
     // State Utilty functions
-    void AddCommandBufferBinding(std::unordered_set<CMD_BUFFER_STATE*>* cb_bindings, const VulkanTypedHandle& obj,
+    bool AddCommandBufferMem(small_unordered_map<CMD_BUFFER_STATE*, int, 8>& cb_bindings, VkDeviceMemory obj,
+                             CMD_BUFFER_STATE* cb_node);
+    bool AddCommandBufferBinding(small_unordered_map<CMD_BUFFER_STATE*, int, 8>& cb_bindings, const VulkanTypedHandle& obj,
                                  CMD_BUFFER_STATE* cb_node);
     void AddCommandBufferBindingAccelerationStructure(CMD_BUFFER_STATE*, ACCELERATION_STRUCTURE_STATE*);
     void AddCommandBufferBindingBuffer(CMD_BUFFER_STATE*, BUFFER_STATE*);
@@ -911,7 +913,6 @@ class ValidationStateTracker : public ValidationObject {
     void AddCommandBufferBindingSampler(CMD_BUFFER_STATE*, SAMPLER_STATE*);
     void AddMemObjInfo(void* object, const VkDeviceMemory mem, const VkMemoryAllocateInfo* pAllocateInfo);
     void AddFramebufferBinding(CMD_BUFFER_STATE* cb_state, FRAMEBUFFER_STATE* fb_state);
-    void ClearCmdBufAndMemReferences(CMD_BUFFER_STATE* cb_node);
     void ClearMemoryObjectBindings(const VulkanTypedHandle& typed_handle);
     void ClearMemoryObjectBinding(const VulkanTypedHandle& typed_handle, VkDeviceMemory mem);
     void DecrementBoundResources(CMD_BUFFER_STATE const* cb_node);
@@ -930,7 +931,9 @@ class ValidationStateTracker : public ValidationObject {
                                 VkMemoryRequirements mem_reqs, bool is_linear);
     void InsertMemoryRange(const VulkanTypedHandle& typed_handle, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize memoryOffset,
                            VkMemoryRequirements memRequirements, bool is_linear);
-    void InvalidateCommandBuffers(std::unordered_set<CMD_BUFFER_STATE*> const& cb_nodes, const VulkanTypedHandle& obj);
+    void InvalidateCommandBuffers(small_unordered_map<CMD_BUFFER_STATE*, int, 8>& cb_nodes, const VulkanTypedHandle& obj,
+                                  bool unlink = true);
+    void InvalidateLinkedCommandBuffers(std::unordered_set<CMD_BUFFER_STATE*>& cb_nodes, const VulkanTypedHandle& obj);
     void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const VkDescriptorSet*,
                                        const cvdescriptorset::AllocateDescriptorSetsData*);
     void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const TEMPLATE_STATE* template_state,

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -858,10 +858,13 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct VulkanTypedHandle {
                 uint64_t handle;
                 VulkanObjectType type;
+                // node is optional, and if non-NULL is used to avoid a hash table lookup
+                class BASE_NODE *node;
                 template <typename Handle>
-                VulkanTypedHandle(Handle handle_, VulkanObjectType type_) :
+                VulkanTypedHandle(Handle handle_, VulkanObjectType type_, class BASE_NODE *node_ = nullptr) :
                     handle(CastToUint64(handle_)),
-                    type(type_) {
+                    type(type_),
+                    node(node_) {
             #ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
                     // For 32 bit it's not always safe to check for traits <-> type
                     // as all non-dispatchable handles have the same type-id and thus traits,
@@ -878,7 +881,8 @@ class HelperFileOutputGenerator(OutputGenerator):
                 }
                 VulkanTypedHandle() :
                     handle(VK_NULL_HANDLE),
-                    type(kVulkanObjectTypeUnknown) {}
+                    type(kVulkanObjectTypeUnknown),
+                    node(nullptr) {}
             }; ''')  +'\n'
 
         return object_types_header

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -263,7 +263,7 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
-    std::atomic<bool> destroyed;
+    bool destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
         : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -263,9 +263,10 @@ enum LayerObjectTypeId {
 struct TEMPLATE_STATE {
     VkDescriptorUpdateTemplateKHR desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
+    std::atomic<bool> destroyed;
 
     TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : desc_update_template(update_template), create_info(*pCreateInfo) {}
+        : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}
 };
 
 class LAYER_PHYS_DEV_PROPERTIES {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4446,7 +4446,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
                               &descriptorSet, 0, NULL);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, " that has been destroyed.");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, " that is invalid or has been destroyed.");
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_commandBuffer->EndRenderPass();


### PR DESCRIPTION
(note: this is stacked on top of #1296, just look at the last commit)

Previously this code did a hash table lookup (and insertion if not present)
followed by a second hash table lookup and insertion. Swap the order of the
checks and check the smaller table (cb_bindings) first, and use a
small_unordered_map for it. This makes there usually be no hash lookup on the
first table. Then replace the second table with a vector, and just push_back
instead of doing a hash table insertion (each object can only be in this table
once). So now, the majority of the time, no hashing and no memory allocation.

Store a BASE_NODE pointer in VulkanTypedHandle, which can be used to skip the
hash table lookup if it's present.

These changes made my test app about 3x faster with image_layout validation disabled.
