### PR TITLE
Clean up some issues related to the drm_format_modifier extension

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1477,7 +1477,10 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     }
 
     VkImageFormatProperties format_limits = {};
-    VkResult res = GetPDImageFormatProperties(pCreateInfo, &format_limits);
+    VkResult res =
+        DispatchGetPhysicalDeviceImageFormatProperties(physical_device, pCreateInfo->format, pCreateInfo->imageType,
+                                                       pCreateInfo->tiling, pCreateInfo->usage, pCreateInfo->flags, &format_limits);
+
     if (res == VK_ERROR_FORMAT_NOT_SUPPORTED) {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         if (!lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo->pNext))

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2410,7 +2410,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         ifp2.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
         ifp2.pNext = &ext_img_fmt_props;
 
-        VkResult fmt_lookup_result = GetPDImageFormatProperties2(&pdifi2, &ifp2);
+        VkResult fmt_lookup_result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &pdifi2, &ifp2);
 
         //  If buffer is not NULL, Android hardware buffers must be supported for import, as reported by
         //  VkExternalImageFormatProperties or VkExternalBufferProperties.

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3256,18 +3256,6 @@ VkFormatProperties CoreChecks::GetPDFormatProperties(const VkFormat format) cons
     return format_properties;
 }
 
-VkResult CoreChecks::GetPDImageFormatProperties(const VkImageCreateInfo *image_ci,
-                                                VkImageFormatProperties *pImageFormatProperties) {
-    return DispatchGetPhysicalDeviceImageFormatProperties(physical_device, image_ci->format, image_ci->imageType, image_ci->tiling,
-                                                          image_ci->usage, image_ci->flags, pImageFormatProperties);
-}
-
-VkResult CoreChecks::GetPDImageFormatProperties2(const VkPhysicalDeviceImageFormatInfo2 *phys_dev_image_fmt_info,
-                                                 VkImageFormatProperties2 *pImageFormatProperties) const {
-    if (!instance_extensions.vk_khr_get_physical_device_properties_2) return VK_ERROR_EXTENSION_NOT_PRESENT;
-    return DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, phys_dev_image_fmt_info, pImageFormatProperties);
-}
-
 bool CoreChecks::ValidatePipelineVertexDivisors(std::vector<std::unique_ptr<PIPELINE_STATE>> const &pipe_state_vec,
                                                 const uint32_t count, const VkGraphicsPipelineCreateInfo *pipe_cis) const {
     bool skip = false;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -237,8 +237,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBindAccelerationStructureMemoryNV(VkDevice device, const VkBindAccelerationStructureMemoryInfoNV& info) const;
     // Prototypes for CoreChecks accessor functions
     VkFormatProperties GetPDFormatProperties(const VkFormat format) const;
-    VkResult GetPDImageFormatProperties(const VkImageCreateInfo*, VkImageFormatProperties*);
-    VkResult GetPDImageFormatProperties2(const VkPhysicalDeviceImageFormatInfo2*, VkImageFormatProperties2*) const;
     const VkPhysicalDeviceMemoryProperties* GetPhysicalDeviceMemoryProperties();
 
     const GlobalQFOTransferBarrierMap<VkImageMemoryBarrier>& GetGlobalQFOReleaseBarrierMap(

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -549,7 +549,7 @@ class CoreChecks : public ValidationStateTracker {
                                          const VkAllocationCallbacks* pAllocator, VkBufferView* pView);
 
     bool ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, const char* func_name,
-                                 const char* vuid = "VUID-VkImageSubresource-aspectMask-parameter") const;
+                                 const char* vuid = kVUID_Core_DrawState_InvalidImageAspect) const;
 
     bool ValidateCreateImageViewSubresourceRange(const IMAGE_STATE* image_state, bool is_imageview_2d_type,
                                                  const VkImageSubresourceRange& subresourceRange);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -3885,7 +3885,7 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     // Not having DEPTH or STENCIL set is an error
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageSubresource-aspectMask-parameter");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier-image-01207");
 
     // Having only one of depth or stencil set for DS image is an error
@@ -3895,7 +3895,7 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     // Having anything other than DEPTH and STENCIL is an error
     conc_test.image_barrier_.subresourceRange.aspectMask =
         VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
-    conc_test("VUID-VkImageSubresource-aspectMask-parameter");
+    conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
 
     // Now test depth-only
     VkFormatProperties format_props;
@@ -5453,7 +5453,7 @@ TEST_F(VkLayerTest, InvalidImageViewAspect) {
     // Cause an error by setting an invalid image aspect
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageSubresource-aspectMask-parameter");
+    CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
     m_errorMonitor->VerifyFound();
 }
 
@@ -5492,7 +5492,8 @@ TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
         subres.arrayLayer = 0;
 
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkGetImageSubresourceLayout-aspectMask-00997");
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkImageSubresource-aspectMask-parameter");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                             "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
         vk::GetImageSubresourceLayout(m_device->device(), img.image(), &subres, &subres_layout);
         m_errorMonitor->VerifyFound();
     }


### PR DESCRIPTION
This had a few issues, including using the wrong version of GetPhysicalDeviceImageFormatProperties call (need to use the '2' version if DRM is active) and not allowing the new VK_IMAGE_ASPECT flags.

Straightened out these checks, fixed some incorrect VUIDs, and removed some dead code as well.

Note that no tests have been added as we don't have any hardware that uses this extension.  Hoping @djdeath and @szihs can verify the changes for their issues.

Fixes #456.
Fixes #796.