### PR TITLE
Precompute vertex attribute alignment requirement

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1214,6 +1214,7 @@ class PIPELINE_STATE : public BASE_NODE {
     // Vtx input info (if any)
     std::vector<VkVertexInputBindingDescription> vertex_binding_descriptions_;
     std::vector<VkVertexInputAttributeDescription> vertex_attribute_descriptions_;
+    std::vector<VkDeviceSize> vertex_attribute_alignments_;
     std::unordered_map<uint32_t, uint32_t> vertex_binding_to_index_map_;
     std::vector<VkPipelineColorBlendAttachmentState> attachments;
     bool blendConstantsEnabled;  // Blend constants enabled for any attachments
@@ -1519,7 +1520,6 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::unordered_set<QueryObject> startedQueries;
     typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> ImageLayoutMap;
     ImageLayoutMap image_layout_map;
-    std::vector<CBVertexBufferBindingInfo> cb_vertex_buffer_binding_info;
     CBVertexBufferBindingInfo current_vertex_buffer_binding_info;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -588,7 +588,7 @@ class DescriptorSet : public BASE_NODE {
     // Perform a CopyUpdate whose contents were just validated using ValidateCopyUpdate
     void PerformCopyUpdate(const VkCopyDescriptorSet *, const DescriptorSet *);
 
-    const std::shared_ptr<DescriptorSetLayout const> GetLayout() const { return p_layout_; };
+    const std::shared_ptr<DescriptorSetLayout const> &GetLayout() const { return p_layout_; };
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return p_layout_->GetDescriptorSetLayout(); }
     VkDescriptorSet GetSet() const { return set_; };
     // Bind given cmd_buffer to this descriptor set and

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -886,7 +886,6 @@ void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
         pCB->activeQueries.clear();
         pCB->startedQueries.clear();
         pCB->image_layout_map.clear();
-        pCB->cb_vertex_buffer_binding_info.clear();
         pCB->current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
         pCB->vertex_buffer_used = false;
         pCB->primaryCommandBuffer = VK_NULL_HANDLE;
@@ -4254,14 +4253,9 @@ void ValidationStateTracker::UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE *cb
     cb_state->hasDispatchCmd = true;
 }
 
-static inline void UpdateResourceTrackingOnDraw(CMD_BUFFER_STATE *pCB) {
-    pCB->cb_vertex_buffer_binding_info.push_back(pCB->current_vertex_buffer_binding_info);
-}
-
 // Generic function to handle state update for all CmdDraw* type functions
 void ValidationStateTracker::UpdateStateCmdDrawType(CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint bind_point) {
     UpdateStateCmdDrawDispatchType(cb_state, bind_point);
-    UpdateResourceTrackingOnDraw(cb_state);
     cb_state->hasDrawCmd = true;
 }
 


### PR DESCRIPTION
Precompute vertex attribute alignment requirement.

Calculate this at pipeline creation time, rather than per-draw.
Avoids frequent hash table lookups of the VK_FORMAT enums.

Remove unused cb_vertex_buffer_binding_info.

Bonus: Make DescriptorSet::GetLayout return const reference