### PR TITLE
layers: const-ness changes to enable PreCallValidate to be const

### DIFF
--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -29,7 +29,7 @@ class BestPractices : public ValidationStateTracker {
   public:
     using StateTracker = ValidationStateTracker;
 
-    std::string GetAPIVersionName(uint32_t version);
+    std::string GetAPIVersionName(uint32_t version) const;
 
     bool PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                        VkInstance* pInstance);
@@ -50,12 +50,14 @@ class BestPractices : public ValidationStateTracker {
                                          const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass);
     bool PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory);
+    void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory, VkResult result);
     void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator);
-    bool ValidateBindBufferMemory(VkBuffer buffer, const char* api_name);
+    bool ValidateBindBufferMemory(VkBuffer buffer, const char* api_name) const;
     bool PreCallValidateBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
     bool PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos);
     bool PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos);
-    bool ValidateBindImageMemory(VkImage image, const char* api_name);
+    bool ValidateBindImageMemory(VkImage image, const char* api_name) const;
     bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
     bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos);
     bool PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos);
@@ -67,7 +69,7 @@ class BestPractices : public ValidationStateTracker {
                                                const VkComputePipelineCreateInfo* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines, void* pipe_state);
 
-    bool CheckPipelineStageFlags(std::string api_name, const VkPipelineStageFlags flags);
+    bool CheckPipelineStageFlags(std::string api_name, const VkPipelineStageFlags flags) const;
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
@@ -110,10 +112,11 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                           const VkBindAccelerationStructureMemoryInfoNV* pBindInfos);
     bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence);
+    void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
+                                       VkResult result);
 
   private:
     uint32_t instance_api_version;
-    uint32_t device_api_version;
 
     uint32_t num_mem_objects;
 };

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -271,7 +271,7 @@ bool CoreChecks::FindGlobalLayout(ImageSubresourcePair imgpair, VkImageLayout &l
     return true;
 }
 
-bool CoreChecks::FindLayouts(VkImage image, std::vector<VkImageLayout> &layouts) {
+bool CoreChecks::FindLayouts(VkImage image, std::vector<VkImageLayout> &layouts) const {
     auto sub_data = imageSubresourceMap.find(image);
     if (sub_data == imageSubresourceMap.end()) return false;
     auto image_state = GetImageState(image);
@@ -1251,7 +1251,7 @@ void CoreChecks::TransitionFinalSubpassLayouts(CMD_BUFFER_STATE *pCB, const VkRe
 //
 // AHB-specific validation within non-AHB APIs
 //
-bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) {
+bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) const {
     bool skip = false;
 
     const VkExternalFormatANDROID *ext_fmt_android = lvl_find_in_chain<VkExternalFormatANDROID>(create_info->pNext);
@@ -1328,9 +1328,9 @@ bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data
     return skip;
 }
 
-bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) {
+bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) const {
     bool skip = false;
-    IMAGE_STATE *image_state = GetImageState(create_info->image);
+    const IMAGE_STATE *image_state = GetImageState(create_info->image);
 
     if (image_state->has_ahb_format) {
         if (VK_FORMAT_UNDEFINED != create_info->format) {
@@ -1390,11 +1390,11 @@ bool CoreChecks::ValidateGetImageSubresourceLayoutANDROID(const VkImage image) c
 
 #else
 
-bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) {
+bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) const {
     return false;
 }
 
-bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) { return false; }
+bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) const { return false; }
 
 bool CoreChecks::ValidateGetImageSubresourceLayoutANDROID(const VkImage image) const { return false; }
 
@@ -1613,7 +1613,7 @@ void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateI
 }
 
 bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
-    IMAGE_STATE *image_state = GetImageState(image);
+    const IMAGE_STATE *image_state = GetImageState(image);
     const VulkanTypedHandle obj_struct(image, kVulkanObjectTypeImage);
     bool skip = false;
     if (image_state) {
@@ -3838,7 +3838,7 @@ bool CoreChecks::ValidateBufferUsageFlags(BUFFER_STATE const *buffer_state, VkFl
 }
 
 bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const VkBufferViewCreateInfo *pCreateInfo,
-                                         const VkPhysicalDeviceLimits *device_limits) {
+                                         const VkPhysicalDeviceLimits *device_limits) const {
     bool skip = false;
 
     const VkDeviceSize &range = pCreateInfo->range;
@@ -3883,7 +3883,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
     return skip;
 }
 
-bool CoreChecks::ValidateBufferViewBuffer(const BUFFER_STATE *buffer_state, const VkBufferViewCreateInfo *pCreateInfo) {
+bool CoreChecks::ValidateBufferViewBuffer(const BUFFER_STATE *buffer_state, const VkBufferViewCreateInfo *pCreateInfo) const {
     bool skip = false;
     const VkFormatProperties format_properties = GetPDFormatProperties(pCreateInfo->format);
     if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT) &&
@@ -3970,7 +3970,7 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
 bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
                                                  const VkAllocationCallbacks *pAllocator, VkBufferView *pView) {
     bool skip = false;
-    BUFFER_STATE *buffer_state = GetBufferState(pCreateInfo->buffer);
+    const BUFFER_STATE *buffer_state = GetBufferState(pCreateInfo->buffer);
     // If this isn't a sparse buffer, it needs to have memory backing it at CreateBufferView time
     if (buffer_state) {
         skip |= ValidateMemoryIsBoundToBuffer(buffer_state, "vkCreateBufferView()", "VUID-VkBufferViewCreateInfo-buffer-00935");
@@ -4186,7 +4186,7 @@ bool CoreChecks::ValidateImageSubresourceRange(const uint32_t image_mip_count, c
 }
 
 bool CoreChecks::ValidateCreateImageViewSubresourceRange(const IMAGE_STATE *image_state, bool is_imageview_2d_type,
-                                                         const VkImageSubresourceRange &subresourceRange) {
+                                                         const VkImageSubresourceRange &subresourceRange) const {
     bool is_khr_maintenance1 = device_extensions.vk_khr_maintenance1;
     bool is_image_slicable = image_state->createInfo.imageType == VK_IMAGE_TYPE_3D &&
                              (image_state->createInfo.flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR);
@@ -4256,7 +4256,7 @@ bool CoreChecks::ValidateImageBarrierSubresourceRange(const IMAGE_STATE *image_s
 bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
                                                 const VkAllocationCallbacks *pAllocator, VkImageView *pView) {
     bool skip = false;
-    IMAGE_STATE *image_state = GetImageState(pCreateInfo->image);
+    const IMAGE_STATE *image_state = GetImageState(pCreateInfo->image);
     if (image_state) {
         skip |=
             ValidateImageUsageFlags(image_state,
@@ -4556,7 +4556,7 @@ bool CoreChecks::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkB
     return skip;
 }
 
-bool CoreChecks::ValidateIdleBuffer(VkBuffer buffer) {
+bool CoreChecks::ValidateIdleBuffer(VkBuffer buffer) const {
     bool skip = false;
     auto buffer_state = GetBufferState(buffer);
     if (!buffer_state) {
@@ -4574,7 +4574,7 @@ bool CoreChecks::ValidateIdleBuffer(VkBuffer buffer) {
 }
 
 bool CoreChecks::PreCallValidateDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks *pAllocator) {
-    IMAGE_VIEW_STATE *image_view_state = GetImageViewState(imageView);
+    const IMAGE_VIEW_STATE *image_view_state = GetImageViewState(imageView);
     const VulkanTypedHandle obj_struct(imageView, kVulkanObjectTypeImageView);
 
     bool skip = false;
@@ -4624,8 +4624,8 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     return skip;
 }
 
-bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBufferImageCopy *pRegions, IMAGE_STATE *image_state,
-                                             const char *function) {
+bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBufferImageCopy *pRegions,
+                                             const IMAGE_STATE *image_state, const char *function) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < regionCount; i++) {
@@ -4875,9 +4875,9 @@ static bool ValidateImageBounds(const debug_report_data *report_data, const IMAG
     return skip;
 }
 
-static inline bool ValidateBufferBounds(const debug_report_data *report_data, IMAGE_STATE *image_state, BUFFER_STATE *buff_state,
-                                        uint32_t regionCount, const VkBufferImageCopy *pRegions, const char *func_name,
-                                        const char *msg_code) {
+static inline bool ValidateBufferBounds(const debug_report_data *report_data, const IMAGE_STATE *image_state,
+                                        const BUFFER_STATE *buff_state, uint32_t regionCount, const VkBufferImageCopy *pRegions,
+                                        const char *func_name, const char *msg_code) {
     bool skip = false;
 
     VkDeviceSize buffer_size = buff_state->createInfo.size;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5139,7 +5139,7 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandB
                     // Create an empty proxy in order to use the existing descriptor set update validation
                     // TODO move the validation (like this) that doesn't need descriptor set state to the DSL object so we
                     // don't have to do this.
-                    cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, VK_NULL_HANDLE, dsl, 0, nullptr, this);
+                    cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, this);
                     skip |= ValidatePushDescriptorsUpdate(&proxy_ds, descriptorWriteCount, pDescriptorWrites, func_name);
                 }
             }
@@ -10120,7 +10120,7 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuf
 
     if (dsl && template_state) {
         // Create an empty proxy in order to use the existing descriptor set update validation
-        cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, VK_NULL_HANDLE, dsl, 0, nullptr, this);
+        cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, this);
         // Decode the template into a set of write updates
         cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state, pData,
                                                                 dsl->GetDescriptorSetLayout());

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -48,7 +48,7 @@ class CoreChecks : public ValidationStateTracker {
     bool CheckCommandBufferInFlight(const CMD_BUFFER_STATE* cb_node, const char* action, const char* error_code) const;
     bool VerifyQueueStateToFence(VkFence fence) const;
     void StoreMemRanges(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size);
-    bool ValidateIdleDescriptorSet(VkDescriptorSet set, const char* func_str);
+    bool ValidateIdleDescriptorSet(VkDescriptorSet set, const char* func_str) const;
     void InitializeShadowMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
     bool ValidatePipelineLocked(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pPipelines, int pipelineIndex) const;
     bool ValidatePipelineUnlocked(const PIPELINE_STATE* pPipeline, uint32_t pipelineIndex) const;
@@ -83,9 +83,9 @@ class CoreChecks : public ValidationStateTracker {
                                          const RENDER_PASS_STATE* rp2_state, const char* caller, const char* error_code) const;
     bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE* cb_state, const char* call_source) const;
     bool ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family, const char* err_code,
-                                  const char* cmd_name, const char* queue_family_var_name);
+                                  const char* cmd_name, const char* queue_family_var_name) const;
     bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,
-                                        const VkDeviceQueueCreateInfo* infos);
+                                        const VkDeviceQueueCreateInfo* infos) const;
 
     bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis) const;
@@ -131,10 +131,10 @@ class CoreChecks : public ValidationStateTracker {
                                          const safe_VkSubpassDependency2KHR* dependencies,
                                          const std::vector<uint32_t>& self_dependencies, uint32_t image_mem_barrier_count,
                                          const VkImageMemoryBarrier* image_barriers) const;
-    bool ValidateSecondaryCommandBufferState(const CMD_BUFFER_STATE* pCB, const CMD_BUFFER_STATE* pSubCB);
+    bool ValidateSecondaryCommandBufferState(const CMD_BUFFER_STATE* pCB, const CMD_BUFFER_STATE* pSubCB) const;
     bool ValidateFramebuffer(VkCommandBuffer primaryBuffer, const CMD_BUFFER_STATE* pCB, VkCommandBuffer secondaryBuffer,
-                             const CMD_BUFFER_STATE* pSubCB, const char* caller);
-    bool ValidateDescriptorUpdateTemplate(const char* func_name, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo);
+                             const CMD_BUFFER_STATE* pSubCB, const char* caller) const;
+    bool ValidateDescriptorUpdateTemplate(const char* func_name, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo) const;
     bool ValidateCreateSamplerYcbcrConversion(const char* func_name, const VkSamplerYcbcrConversionCreateInfo* create_info) const;
     bool ValidateImportFence(VkFence fence, const char* caller_name) const;
     bool ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence,
@@ -207,7 +207,7 @@ class CoreChecks : public ValidationStateTracker {
     bool CheckStageMaskQueueCompatibility(VkCommandBuffer command_buffer, VkPipelineStageFlags stage_mask, VkQueueFlags queue_flags,
                                           const char* function, const char* src_or_dest, const char* error_code) const;
     bool ValidateUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
-                                                 VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData);
+                                                 VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) const;
     bool ValidateMemoryIsBoundToBuffer(const BUFFER_STATE*, const char*, const char*) const;
     bool ValidateMemoryIsBoundToImage(const IMAGE_STATE*, const char*, const char*) const;
     bool ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE*, const char*, const char*) const;
@@ -298,9 +298,9 @@ class CoreChecks : public ValidationStateTracker {
     // Validate contents of a CopyUpdate
     using DescriptorSet = cvdescriptorset::DescriptorSet;
     bool ValidateCopyUpdate(const VkCopyDescriptorSet* update, const DescriptorSet* dst_set, const DescriptorSet* src_set,
-                            const char* func_name, std::string* error_code, std::string* error_msg);
+                            const char* func_name, std::string* error_code, std::string* error_msg) const;
     bool VerifyCopyUpdateContents(const VkCopyDescriptorSet* update, const DescriptorSet* src_set, VkDescriptorType type,
-                                  uint32_t index, const char* func_name, std::string* error_code, std::string* error_msg);
+                                  uint32_t index, const char* func_name, std::string* error_code, std::string* error_msg) const;
     // Validate contents of a WriteUpdate
     bool ValidateWriteUpdate(const DescriptorSet* descriptor_set, const VkWriteDescriptorSet* update, const char* func_name,
                              std::string* error_code, std::string* error_msg) const;
@@ -317,10 +317,11 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBufferUpdate(VkDescriptorBufferInfo const* buffer_info, VkDescriptorType type, const char* func_name,
                               std::string* error_code, std::string* error_msg) const;
     bool ValidateUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const TEMPLATE_STATE* template_state,
-                                                     const void* pData);
-    bool ValidateAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const cvdescriptorset::AllocateDescriptorSetsData*);
+                                                     const void* pData) const;
+    bool ValidateAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*,
+                                        const cvdescriptorset::AllocateDescriptorSetsData*) const;
     bool ValidateUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet* p_wds, uint32_t copy_count,
-                                      const VkCopyDescriptorSet* p_cds, const char* func_name);
+                                      const VkCopyDescriptorSet* p_cds, const char* func_name) const;
 
     // Stuff from shader_validation
     bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE* pPipeline) const;
@@ -359,7 +360,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* src_img,
                                                           const IMAGE_STATE* dst_img, const VkImageCopy* region, const uint32_t i,
                                                           const char* function) const;
-    bool ValidateIdleBuffer(VkBuffer buffer);
+    bool ValidateIdleBuffer(VkBuffer buffer) const;
     bool ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 strict, const VulkanTypedHandle& typed_handle,
                             const char* msgCode, char const* func_name, char const* usage_str) const;
     bool ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
@@ -375,11 +376,11 @@ class CoreChecks : public ValidationStateTracker {
                                                               VkImage image, VkImageView image_view, VkFramebuffer framebuffer,
                                                               VkRenderPass renderpass, uint32_t attachment_index,
                                                               const char* variable_name) const;
-    bool ValidateBufferImageCopyData(uint32_t regionCount, const VkBufferImageCopy* pRegions, IMAGE_STATE* image_state,
-                                     const char* function);
+    bool ValidateBufferImageCopyData(uint32_t regionCount, const VkBufferImageCopy* pRegions, const IMAGE_STATE* image_state,
+                                     const char* function) const;
     bool ValidateBufferViewRange(const BUFFER_STATE* buffer_state, const VkBufferViewCreateInfo* pCreateInfo,
-                                 const VkPhysicalDeviceLimits* device_limits);
-    bool ValidateBufferViewBuffer(const BUFFER_STATE* buffer_state, const VkBufferViewCreateInfo* pCreateInfo);
+                                 const VkPhysicalDeviceLimits* device_limits) const;
+    bool ValidateBufferViewBuffer(const BUFFER_STATE* buffer_state, const VkBufferViewCreateInfo* pCreateInfo) const;
 
     bool PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkImage* pImage);
@@ -449,7 +450,7 @@ class CoreChecks : public ValidationStateTracker {
 
     bool FindGlobalLayout(ImageSubresourcePair imgpair, VkImageLayout& layout);
 
-    bool FindLayouts(VkImage image, std::vector<VkImageLayout>& layouts);
+    bool FindLayouts(VkImage image, std::vector<VkImageLayout>& layouts) const;
 
     bool FindLayout(const ImageSubresPairLayoutMap& imageLayoutMap, ImageSubresourcePair imgpair, VkImageLayout& layout) const;
 
@@ -554,7 +555,7 @@ class CoreChecks : public ValidationStateTracker {
                                  const char* vuid = kVUID_Core_DrawState_InvalidImageAspect) const;
 
     bool ValidateCreateImageViewSubresourceRange(const IMAGE_STATE* image_state, bool is_imageview_2d_type,
-                                                 const VkImageSubresourceRange& subresourceRange);
+                                                 const VkImageSubresourceRange& subresourceRange) const;
 
     bool ValidateCmdClearColorSubresourceRange(const IMAGE_STATE* image_state, const VkImageSubresourceRange& subresourceRange,
                                                const char* param_name) const;
@@ -607,8 +608,8 @@ class CoreChecks : public ValidationStateTracker {
 
     bool PreCallValidateGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                                   VkSubresourceLayout* pLayout);
-    bool ValidateCreateImageANDROID(const debug_report_data* report_data, const VkImageCreateInfo* create_info);
-    bool ValidateCreateImageViewANDROID(const VkImageViewCreateInfo* create_info);
+    bool ValidateCreateImageANDROID(const debug_report_data* report_data, const VkImageCreateInfo* create_info) const;
+    bool ValidateCreateImageViewANDROID(const VkImageViewCreateInfo* create_info) const;
     bool ValidateGetImageSubresourceLayoutANDROID(const VkImage image) const;
     bool ValidateQueueFamilies(uint32_t queue_family_count, const uint32_t* queue_families, const char* cmd_name,
                                const char* array_parameter_name, const char* unique_error_code, const char* valid_error_code,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1248,10 +1248,10 @@ class PIPELINE_STATE : public BASE_NODE {
         stage_state.clear();
     }
 
-    void initGraphicsPipeline(ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
-                              std::shared_ptr<RENDER_PASS_STATE> &&rpstate);
-    void initComputePipeline(ValidationStateTracker *state_data, const VkComputePipelineCreateInfo *pCreateInfo);
-    void initRayTracingPipelineNV(ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo);
+    void initGraphicsPipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
+                              const std::shared_ptr<RENDER_PASS_STATE> &&rpstate);
+    void initComputePipeline(const ValidationStateTracker *state_data, const VkComputePipelineCreateInfo *pCreateInfo);
+    void initRayTracingPipelineNV(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo);
 
     inline VkPipelineBindPoint getPipelineType() const {
         if (graphicsPipelineCI.sType == VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO)

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -356,8 +356,8 @@ enum DescriptorClass { PlainSampler, ImageSampler, Image, TexelBuffer, GeneralBu
 class Descriptor {
   public:
     virtual ~Descriptor(){};
-    virtual void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) = 0;
-    virtual void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) = 0;
+    virtual void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) = 0;
+    virtual void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) = 0;
     // Create binding between resources of this descriptor and given cb_node
     virtual void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) = 0;
     virtual DescriptorClass GetClass() const { return descriptor_class; };
@@ -385,9 +385,9 @@ bool ValidateDescriptorSetLayoutCreateInfo(const debug_report_data *report_data,
 
 class SamplerDescriptor : public Descriptor {
   public:
-    SamplerDescriptor(ValidationStateTracker *dev_data, const VkSampler *);
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override;
+    SamplerDescriptor(const ValidationStateTracker *dev_data, const VkSampler *);
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_; }
@@ -402,9 +402,9 @@ class SamplerDescriptor : public Descriptor {
 
 class ImageSamplerDescriptor : public Descriptor {
   public:
-    ImageSamplerDescriptor(ValidationStateTracker *dev_data, const VkSampler *);
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override;
+    ImageSamplerDescriptor(const ValidationStateTracker *dev_data, const VkSampler *);
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_; }
@@ -427,8 +427,8 @@ class ImageSamplerDescriptor : public Descriptor {
 class ImageDescriptor : public Descriptor {
   public:
     ImageDescriptor(const VkDescriptorType);
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override;
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsStorage() const override { return storage_; }
     VkImageView GetImageView() const { return image_view_; }
@@ -446,8 +446,8 @@ class ImageDescriptor : public Descriptor {
 class TexelDescriptor : public Descriptor {
   public:
     TexelDescriptor(const VkDescriptorType);
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override;
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsStorage() const override { return storage_; }
     VkBufferView GetBufferView() const { return buffer_view_; }
@@ -463,8 +463,8 @@ class TexelDescriptor : public Descriptor {
 class BufferDescriptor : public Descriptor {
   public:
     BufferDescriptor(const VkDescriptorType);
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override;
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsDynamic() const override { return dynamic_; }
     virtual bool IsStorage() const override { return storage_; }
@@ -489,8 +489,10 @@ class InlineUniformDescriptor : public Descriptor {
         updated = false;
         descriptor_class = InlineUniform;
     }
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override { updated = true; }
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override {
+        updated = true;
+    }
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override {}
 };
 
@@ -500,8 +502,10 @@ class AccelerationStructureDescriptor : public Descriptor {
         updated = false;
         descriptor_class = AccelerationStructure;
     }
-    void WriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override { updated = true; }
-    void CopyUpdate(ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
+    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override {
+        updated = true;
+    }
+    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override {}
 };
 
@@ -559,8 +563,8 @@ struct DecodedTemplateUpdate {
 class DescriptorSet : public BASE_NODE {
   public:
     using StateTracker = ValidationStateTracker;
-    DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout const> &,
-                  uint32_t variable_count, StateTracker *state_data, const StateTracker *state_data_const);
+    DescriptorSet(const VkDescriptorSet, DESCRIPTOR_POOL_STATE *, const std::shared_ptr<DescriptorSetLayout const> &,
+                  uint32_t variable_count, const StateTracker *state_data_const);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
     uint32_t GetTotalDescriptorCount() const { return p_layout_->GetTotalDescriptorCount(); };
@@ -582,11 +586,11 @@ class DescriptorSet : public BASE_NODE {
     std::string StringifySetAndLayout() const;
 
     // Perform a push update whose contents were just validated using ValidatePushDescriptorsUpdate
-    void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *p_wds);
+    void PerformPushDescriptorsUpdate(ValidationStateTracker *dev_data, uint32_t write_count, const VkWriteDescriptorSet *p_wds);
     // Perform a WriteUpdate whose contents were just validated using ValidateWriteUpdate
-    void PerformWriteUpdate(const VkWriteDescriptorSet *);
+    void PerformWriteUpdate(ValidationStateTracker *dev_data, const VkWriteDescriptorSet *);
     // Perform a CopyUpdate whose contents were just validated using ValidateCopyUpdate
-    void PerformCopyUpdate(const VkCopyDescriptorSet *, const DescriptorSet *);
+    void PerformCopyUpdate(ValidationStateTracker *dev_data, const VkCopyDescriptorSet *, const DescriptorSet *);
 
     const std::shared_ptr<DescriptorSetLayout const> GetLayout() const { return p_layout_; };
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return p_layout_->GetDescriptorSetLayout(); }
@@ -637,16 +641,13 @@ class DescriptorSet : public BASE_NODE {
 
   private:
     // Private helper to set all bound cmd buffers to INVALID state
-    void InvalidateBoundCmdBuffers();
+    void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);
     bool some_update_;  // has any part of the set ever been updated?
     VkDescriptorSet set_;
     DESCRIPTOR_POOL_STATE *pool_state_;
     const std::shared_ptr<DescriptorSetLayout const> p_layout_;
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
-    // Some transient fake descriptor sets are created in Core validation for push descriptors,
-    // and these only have a const StateTracker available.
-    StateTracker *state_data_;
-    const StateTracker *state_data_const_;
+    const StateTracker *state_data_;
     uint32_t variable_count_;
     uint64_t change_count_;
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -560,7 +560,7 @@ class DescriptorSet : public BASE_NODE {
   public:
     using StateTracker = ValidationStateTracker;
     DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout const> &,
-                  uint32_t variable_count, StateTracker *);
+                  uint32_t variable_count, StateTracker *state_data, const StateTracker *state_data_const);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
     uint32_t GetTotalDescriptorCount() const { return p_layout_->GetTotalDescriptorCount(); };
@@ -643,7 +643,10 @@ class DescriptorSet : public BASE_NODE {
     DESCRIPTOR_POOL_STATE *pool_state_;
     const std::shared_ptr<DescriptorSetLayout const> p_layout_;
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
+    // Some transient fake descriptor sets are created in Core validation for push descriptors,
+    // and these only have a const StateTracker available.
     StateTracker *state_data_;
+    const StateTracker *state_data_const_;
     uint32_t variable_count_;
     uint64_t change_count_;
 

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -72,7 +72,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
                                     VK_QUEUE_GRAPHICS_BIT, "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
                                     "VUID-vkCmdDrawIndexed-renderpass", "VUID-vkCmdDrawIndexed-None-02700",
                                     "VUID-vkCmdDrawIndexed-commandBuffer-02701");
-    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     if (!skip && (cb_state->status & CBSTATUS_INDEX_BUFFER_BOUND)) {
         unsigned int index_size = 0;
         const auto &index_buffer_binding = cb_state->index_buffer_binding;

--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -33,7 +33,7 @@
 
 
 // ObjectTracker undestroyed objects validation function
-bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, const std::string& error_code) {
+bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, const std::string& error_code) const {
     bool skip = false;
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeSurfaceKHR, error_code);
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeSwapchainKHR, error_code);
@@ -43,7 +43,7 @@ bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, cons
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
     return skip;
 }
-bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const std::string& error_code) {
+bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const std::string& error_code) const {
     bool skip = false;
     skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeCommandBuffer, error_code);
     skip |= ReportLeakedDeviceObjects(device, kVulkanObjectTypeSemaphore, error_code);

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -204,7 +204,7 @@ const std::vector<VkFullScreenExclusiveEXT> AllVkFullScreenExclusiveEXTEnums = {
 const std::vector<VkLineRasterizationModeEXT> AllVkLineRasterizationModeEXTEnums = {VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT, VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT, VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT, VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT, };
 
 
-bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) {
+bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) const {
     bool skip = false;
     switch(header->sType) {
 
@@ -1510,7 +1510,7 @@ bool StatelessValidation::ValidatePnextStructContents(const char *api_name, cons
 }
 
 
-bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) {
+bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) const {
     return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                    kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\n",
                    api_name.c_str(), extension_name.c_str());

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -377,7 +377,7 @@ VkResult GpuAssisted::InitializeVma(VkPhysicalDevice physical_device, VkDevice d
 
 // Convenience function for reporting problems with setting up GPU Validation.
 void GpuAssisted::ReportSetupProblem(VkDebugReportObjectTypeEXT object_type, uint64_t object_handle,
-                                     const char *const specific_message) {
+                                     const char *const specific_message) const {
     log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle, "UNASSIGNED-GPU-Assisted Validation Error. ",
             "Detail: (%s)", specific_message);
 }

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -133,7 +133,8 @@ class GpuAssisted : public ValidationStateTracker {
         }
         return buffer_list->second;
     }
-    void ReportSetupProblem(VkDebugReportObjectTypeEXT object_type, uint64_t object_handle, const char* const specific_message);
+    void ReportSetupProblem(VkDebugReportObjectTypeEXT object_type, uint64_t object_handle,
+                            const char* const specific_message) const;
 
   public:
     VkDescriptorSetLayout debug_desc_layout;

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -78,9 +78,9 @@ class ObjectLifetimes : public ValidationObject {
         return std::unique_lock<std::mutex>(validation_object_mutex, std::defer_lock);
     }
 
-    object_lifetime_mutex_t object_lifetime_mutex;
+    mutable object_lifetime_mutex_t object_lifetime_mutex;
     write_object_lifetime_mutex_t write_shared_lock() { return write_object_lifetime_mutex_t(object_lifetime_mutex); }
-    read_object_lifetime_mutex_t read_shared_lock() { return read_object_lifetime_mutex_t(object_lifetime_mutex); }
+    read_object_lifetime_mutex_t read_shared_lock() const { return read_object_lifetime_mutex_t(object_lifetime_mutex); }
 
     std::atomic<uint64_t> num_objects[kVulkanObjectTypeMax + 1];
     std::atomic<uint64_t> num_total_objects;
@@ -107,11 +107,11 @@ class ObjectLifetimes : public ValidationObject {
         }
     }
 
-    bool ReportUndestroyedInstanceObjects(VkInstance instance, const std::string &error_code);
-    bool ReportUndestroyedDeviceObjects(VkDevice device, const std::string &error_code);
+    bool ReportUndestroyedInstanceObjects(VkInstance instance, const std::string &error_code) const;
+    bool ReportUndestroyedDeviceObjects(VkDevice device, const std::string &error_code) const;
 
-    bool ReportLeakedDeviceObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code);
-    bool ReportLeakedInstanceObjects(VkInstance instance, VulkanObjectType object_type, const std::string &error_code);
+    bool ReportLeakedDeviceObjects(VkDevice device, VulkanObjectType object_type, const std::string &error_code) const;
+    bool ReportLeakedInstanceObjects(VkInstance instance, VulkanObjectType object_type, const std::string &error_code) const;
 
     void DestroyUndestroyedObjects(VulkanObjectType object_type);
 
@@ -122,16 +122,16 @@ class ObjectLifetimes : public ValidationObject {
     void DestroyLeakedInstanceObjects();
     void DestroyLeakedDeviceObjects();
     bool ValidateDeviceObject(const VulkanTypedHandle &device_typed, const char *invalid_handle_code,
-                              const char *wrong_device_code);
+                              const char *wrong_device_code) const;
     void DestroyQueueDataStructures();
-    bool ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer command_buffer);
-    bool ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set);
-    bool ValidateSamplerObjects(const VkDescriptorSetLayoutCreateInfo *pCreateInfo);
-    bool ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool isPush);
+    bool ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer command_buffer) const;
+    bool ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set) const;
+    bool ValidateSamplerObjects(const VkDescriptorSetLayoutCreateInfo *pCreateInfo) const;
+    bool ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool isPush) const;
     bool ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, bool null_allowed, const char *invalid_handle_code,
-                                 const char *wrong_device_code);
+                                 const char *wrong_device_code) const;
 
-    ObjectLifetimes *GetObjectLifetimeData(std::vector<ValidationObject *> &object_dispatch) {
+    ObjectLifetimes *GetObjectLifetimeData(std::vector<ValidationObject *> &object_dispatch) const {
         for (auto layer_object : object_dispatch) {
             if (layer_object->container_type == LayerObjectTypeObjectTracker) {
                 return (reinterpret_cast<ObjectLifetimes *>(layer_object));
@@ -141,7 +141,7 @@ class ObjectLifetimes : public ValidationObject {
     };
 
     bool CheckObjectValidity(uint64_t object_handle, VulkanObjectType object_type, bool null_allowed,
-                             const char *invalid_handle_code, const char *wrong_device_code) {
+                             const char *invalid_handle_code, const char *wrong_device_code) const {
         VkDebugReportObjectTypeEXT debug_object_type = get_debug_report_enum[object_type];
 
         // Look for object in object map
@@ -184,7 +184,7 @@ class ObjectLifetimes : public ValidationObject {
 
     template <typename T1>
     bool ValidateObject(T1 object, VulkanObjectType object_type, bool null_allowed, const char *invalid_handle_code,
-                        const char *wrong_device_code) {
+                        const char *wrong_device_code) const {
         if (null_allowed && (object == VK_NULL_HANDLE)) {
             return false;
         }
@@ -254,7 +254,7 @@ class ObjectLifetimes : public ValidationObject {
 
     template <typename T1>
     bool ValidateDestroyObject(T1 object, VulkanObjectType object_type, const VkAllocationCallbacks *pAllocator,
-                               const char *expected_custom_allocator_code, const char *expected_default_allocator_code) {
+                               const char *expected_custom_allocator_code, const char *expected_default_allocator_code) const {
         auto object_handle = HandleToUint64(object);
         bool custom_allocator = pAllocator != nullptr;
         VkDebugReportObjectTypeEXT debug_object_type = get_debug_report_enum[object_type];

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -36,7 +36,7 @@ inline bool in_inclusive_range(const T &value, const T &min, const T &max) {
 }
 
 bool StatelessValidation::validate_string(const char *apiName, const ParameterName &stringName, const std::string &vuid,
-                                          const char *validateString) {
+                                          const char *validateString) const {
     bool skip = false;
 
     VkStringErrorFlags result = vk_string_validate(MaxParamCheckerStringLength, validateString);
@@ -53,7 +53,7 @@ bool StatelessValidation::validate_string(const char *apiName, const ParameterNa
     return skip;
 }
 
-bool StatelessValidation::validate_api_version(uint32_t api_version, uint32_t effective_api_version) {
+bool StatelessValidation::validate_api_version(uint32_t api_version, uint32_t effective_api_version) const {
     bool skip = false;
     uint32_t api_version_nopatch = VK_MAKE_VERSION(VK_VERSION_MAJOR(api_version), VK_VERSION_MINOR(api_version), 0);
     if (api_version_nopatch != effective_api_version) {
@@ -74,7 +74,7 @@ bool StatelessValidation::validate_api_version(uint32_t api_version, uint32_t ef
     return skip;
 }
 
-bool StatelessValidation::validate_instance_extensions(const VkInstanceCreateInfo *pCreateInfo) {
+bool StatelessValidation::validate_instance_extensions(const VkInstanceCreateInfo *pCreateInfo) const {
     bool skip = false;
     // Create and use a local instance extension object, as an actual instance has not been created yet
     uint32_t specified_version = (pCreateInfo->pApplicationInfo ? pCreateInfo->pApplicationInfo->apiVersion : VK_API_VERSION_1_0);
@@ -303,7 +303,7 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
     return skip;
 }
 
-bool StatelessValidation::require_device_extension(bool flag, char const *function_name, char const *extension_name) {
+bool StatelessValidation::require_device_extension(bool flag, char const *function_name, char const *extension_name) const {
     if (!flag) {
         return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                        kVUID_PVError_ExtensionNotEnabled,
@@ -809,7 +809,7 @@ static SampleOrderInfo sampleOrderInfos[] = {
     {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV, 4, 4},
 };
 
-bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV *order) {
+bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV *order) const {
     bool skip = false;
 
     SampleOrderInfo *sampleOrderInfo;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -988,7 +988,7 @@ class ValidationStateTracker : public ValidationObject {
                                                    VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate);
     void RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
     void RecordPipelineShaderStage(const VkPipelineShaderStageCreateInfo* pStage, PIPELINE_STATE* pipeline,
-                                   PIPELINE_STATE::StageState* stage_state);
+                                   PIPELINE_STATE::StageState* stage_state) const;
     void RecordRenderPassDAG(RenderPassCreateVersion rp_version, const VkRenderPassCreateInfo2KHR* pCreateInfo,
                              RENDER_PASS_STATE* render_pass);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
@@ -1017,7 +1017,7 @@ class ValidationStateTracker : public ValidationObject {
     void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point);
     void UpdateDrawState(CMD_BUFFER_STATE* cb_state, const VkPipelineBindPoint bind_point);
-    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*);
+    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*) const;
 
     DeviceFeatures enabled_features = {};
     // Device specific data

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -113,7 +113,7 @@ class StatelessValidation : public ValidationObject {
     // Though this validation object is predominantly statless, the Framebuffer checks are greatly simplified by creating and
     // updating a map of the renderpass usage states, and these accesses need thread protection. Use a mutex separate from the
     // parent object's to maintain that functionality.
-    std::mutex renderpass_map_mutex;
+    mutable std::mutex renderpass_map_mutex;
     std::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
 
     // Constructor for stateles validation tracking
@@ -131,7 +131,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool ValidateGreaterThan(const T value, const T lower_bound, const ParameterName &parameter_name, const std::string &vuid,
-                             const LogMiscParams &misc) {
+                             const LogMiscParams &misc) const {
         bool skip_call = false;
 
         if (value <= lower_bound) {
@@ -147,7 +147,7 @@ class StatelessValidation : public ValidationObject {
 
     template <typename T>
     bool ValidateGreaterThanZero(const T value, const ParameterName &parameter_name, const std::string &vuid,
-                                 const LogMiscParams &misc) {
+                                 const LogMiscParams &misc) const {
         return ValidateGreaterThan(value, T{0}, parameter_name, vuid, misc);
     }
     /**
@@ -161,7 +161,7 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     bool validate_required_pointer(const char *apiName, const ParameterName &parameterName, const void *value,
-                                   const std::string &vuid) {
+                                   const std::string &vuid) const {
         bool skip_call = false;
 
         if (value == NULL) {
@@ -191,7 +191,7 @@ class StatelessValidation : public ValidationObject {
     template <typename T1, typename T2>
     bool validate_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, T1 count,
                         const T2 *array, bool countRequired, bool arrayRequired, const char *count_required_vuid,
-                        const char *array_required_vuid) {
+                        const char *array_required_vuid) const {
         bool skip_call = false;
 
         // Count parameters not tagged as optional cannot be 0
@@ -233,7 +233,7 @@ class StatelessValidation : public ValidationObject {
     template <typename T1, typename T2>
     bool validate_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, const T1 *count,
                         const T2 *array, bool countPtrRequired, bool countValueRequired, bool arrayRequired,
-                        const char *count_required_vuid, const char *array_required_vuid) {
+                        const char *count_required_vuid, const char *array_required_vuid) const {
         bool skip_call = false;
 
         if (count == NULL) {
@@ -267,7 +267,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool validate_struct_type(const char *apiName, const ParameterName &parameterName, const char *sTypeName, const T *value,
-                              VkStructureType sType, bool required, const char *struct_vuid, const char *stype_vuid) {
+                              VkStructureType sType, bool required, const char *struct_vuid, const char *stype_vuid) const {
         bool skip_call = false;
 
         if (value == NULL) {
@@ -306,7 +306,7 @@ class StatelessValidation : public ValidationObject {
     bool validate_struct_type_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName,
                                     const char *sTypeName, uint32_t count, const T *array, VkStructureType sType,
                                     bool countRequired, bool arrayRequired, const char *stype_vuid, const char *param_vuid,
-                                    const char *count_required_vuid) {
+                                    const char *count_required_vuid) const {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -350,7 +350,7 @@ class StatelessValidation : public ValidationObject {
     bool validate_struct_type_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName,
                                     const char *sTypeName, uint32_t *count, const T *array, VkStructureType sType,
                                     bool countPtrRequired, bool countValueRequired, bool arrayRequired, const char *stype_vuid,
-                                    const char *param_vuid, const char *count_required_vuid) {
+                                    const char *param_vuid, const char *count_required_vuid) const {
         bool skip_call = false;
 
         if (count == NULL) {
@@ -378,7 +378,7 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     template <typename T>
-    bool validate_required_handle(const char *api_name, const ParameterName &parameter_name, T value) {
+    bool validate_required_handle(const char *api_name, const ParameterName &parameter_name, T value) const {
         bool skip_call = false;
 
         if (value == VK_NULL_HANDLE) {
@@ -413,7 +413,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool validate_handle_array(const char *api_name, const ParameterName &count_name, const ParameterName &array_name,
-                               uint32_t count, const T *array, bool count_required, bool array_required) {
+                               uint32_t count, const T *array, bool count_required, bool array_required) const {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -453,7 +453,7 @@ class StatelessValidation : public ValidationObject {
      */
     bool validate_string_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName, uint32_t count,
                                const char *const *array, bool countRequired, bool arrayRequired, const char *count_required_vuid,
-                               const char *array_required_vuid) {
+                               const char *array_required_vuid) const {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -474,7 +474,8 @@ class StatelessValidation : public ValidationObject {
     }
 
     // Forward declaration for pNext validation
-    bool ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure *header);
+    bool ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name,
+                                     const VkBaseOutStructure *header) const;
 
     /**
      * Validate a structure's pNext member.
@@ -494,7 +495,7 @@ class StatelessValidation : public ValidationObject {
      */
     bool validate_struct_pnext(const char *api_name, const ParameterName &parameter_name, const char *allowed_struct_names,
                                const void *next, size_t allowed_type_count, const VkStructureType *allowed_types,
-                               uint32_t header_version, const char *vuid) {
+                               uint32_t header_version, const char *vuid) const {
         bool skip_call = false;
 
         // TODO: The valid pNext structure types are not recursive. Each structure has its own list of valid sTypes for pNext.
@@ -592,7 +593,7 @@ class StatelessValidation : public ValidationObject {
      * @param value Boolean value to validate.
      * @return Boolean value indicating that the call should be skipped.
      */
-    bool validate_bool32(const char *apiName, const ParameterName &parameterName, VkBool32 value) {
+    bool validate_bool32(const char *apiName, const ParameterName &parameterName, VkBool32 value) const {
         bool skip_call = false;
 
         if ((value != VK_TRUE) && (value != VK_FALSE)) {
@@ -623,7 +624,7 @@ class StatelessValidation : public ValidationObject {
      */
     template <typename T>
     bool validate_ranged_enum(const char *apiName, const ParameterName &parameterName, const char *enumName,
-                              const std::vector<T> &valid_values, T value, const char *vuid) {
+                              const std::vector<T> &valid_values, T value, const char *vuid) const {
         bool skip = false;
 
         if (std::find(valid_values.begin(), valid_values.end(), value) == valid_values.end()) {
@@ -661,7 +662,7 @@ class StatelessValidation : public ValidationObject {
     template <typename T>
     bool validate_ranged_enum_array(const char *apiName, const ParameterName &countName, const ParameterName &arrayName,
                                     const char *enumName, const std::vector<T> &valid_values, uint32_t count, const T *array,
-                                    bool countRequired, bool arrayRequired) {
+                                    bool countRequired, bool arrayRequired) const {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -693,7 +694,7 @@ class StatelessValidation : public ValidationObject {
      * @param value Value to validate.
      * @return Boolean value indicating that the call should be skipped.
      */
-    bool validate_reserved_flags(const char *api_name, const ParameterName &parameter_name, VkFlags value, const char *vuid) {
+    bool validate_reserved_flags(const char *api_name, const ParameterName &parameter_name, VkFlags value, const char *vuid) const {
         bool skip_call = false;
 
         if (value != 0) {
@@ -723,7 +724,7 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     bool validate_flags(const char *api_name, const ParameterName &parameter_name, const char *flag_bits_name, VkFlags all_flags,
-                        VkFlags value, const FlagType flag_type, const char *vuid, const char *flags_zero_vuid = nullptr) {
+                        VkFlags value, const FlagType flag_type, const char *vuid, const char *flags_zero_vuid = nullptr) const {
         bool skip_call = false;
 
         if ((value & ~all_flags) != 0) {
@@ -774,7 +775,7 @@ class StatelessValidation : public ValidationObject {
      */
     bool validate_flags_array(const char *api_name, const ParameterName &count_name, const ParameterName &array_name,
                               const char *flag_bits_name, VkFlags all_flags, uint32_t count, const VkFlags *array,
-                              bool count_required, bool array_required) {
+                              bool count_required, bool array_required) const {
         bool skip_call = false;
 
         if ((count == 0) || (array == NULL)) {
@@ -805,7 +806,7 @@ class StatelessValidation : public ValidationObject {
 
     template <typename ExtensionState>
     bool validate_extension_reqs(const ExtensionState &extensions, const char *vuid, const char *extension_type,
-                                 const char *extension_name) {
+                                 const char *extension_name) const {
         bool skip = false;
         if (!extension_name) {
             return skip;  // Robust to invalid char *
@@ -839,7 +840,7 @@ class StatelessValidation : public ValidationObject {
     template <typename RenderPassCreateInfoGeneric>
     bool ValidateSubpassGraphicsFlags(const debug_report_data *report_data, const RenderPassCreateInfoGeneric *pCreateInfo,
                                       uint32_t dependency_index, uint32_t subpass, VkPipelineStageFlags stages, const char *vuid,
-                                      const char *target) {
+                                      const char *target) const {
         const VkPipelineStageFlags kCommonStages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
         const VkPipelineStageFlags kFramebufferStages =
             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
@@ -885,7 +886,7 @@ class StatelessValidation : public ValidationObject {
     template <typename RenderPassCreateInfoGeneric>
     bool CreateRenderPassGeneric(VkDevice device, const RenderPassCreateInfoGeneric *pCreateInfo,
                                  const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                 RenderPassCreateVersion rp_version) {
+                                 RenderPassCreateVersion rp_version) const {
         bool skip = false;
         uint32_t max_color_attachments = device_limits.maxColorAttachments;
         bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);
@@ -961,15 +962,16 @@ class StatelessValidation : public ValidationObject {
         }
     }
 
-    bool require_device_extension(bool flag, char const *function_name, char const *extension_name);
+    bool require_device_extension(bool flag, char const *function_name, char const *extension_name) const;
 
-    bool validate_instance_extensions(const VkInstanceCreateInfo *pCreateInfo);
+    bool validate_instance_extensions(const VkInstanceCreateInfo *pCreateInfo) const;
 
-    bool validate_api_version(uint32_t api_version, uint32_t effective_api_version);
+    bool validate_api_version(uint32_t api_version, uint32_t effective_api_version) const;
 
-    bool validate_string(const char *apiName, const ParameterName &stringName, const std::string &vuid, const char *validateString);
+    bool validate_string(const char *apiName, const ParameterName &stringName, const std::string &vuid,
+                         const char *validateString) const;
 
-    bool ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV *order);
+    bool ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV *order) const;
 
     bool ValidateQueueFamilies(uint32_t queue_family_count, const uint32_t *queue_families, const char *cmd_name,
                                const char *array_parameter_name, const std::string &unique_error_code,
@@ -987,7 +989,7 @@ class StatelessValidation : public ValidationObject {
     bool ValidateAccelerationStructureInfoNV(const VkAccelerationStructureInfoNV &info, VkDebugReportObjectTypeEXT object_type,
                                              uint64_t object_handle, const char *func_nam) const;
 
-    bool OutputExtensionError(const std::string &api_name, const std::string &extension_name);
+    bool OutputExtensionError(const std::string &api_name, const std::string &extension_name) const;
 
     void PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
                                         const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass, VkResult result);

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -210,7 +210,7 @@ class vl_concurrent_unordered_map {
         return maps[h].erase(key);
     }
 
-    bool contains(const Key &key) {
+    bool contains(const Key &key) const {
         uint32_t h = ConcurrentMapHashObject(key);
         read_lock_guard_t lock(locks[h].lock);
         return maps[h].count(key) != 0;
@@ -241,9 +241,9 @@ class vl_concurrent_unordered_map {
 
     // find()/end() return a FindResult containing a copy of the value. For end(),
     // return a default value.
-    FindResult end() { return FindResult(false, T()); }
+    FindResult end() const { return FindResult(false, T()); }
 
-    FindResult find(const Key &key) {
+    FindResult find(const Key &key) const {
         uint32_t h = ConcurrentMapHashObject(key);
         read_lock_guard_t lock(locks[h].lock);
 
@@ -273,7 +273,7 @@ class vl_concurrent_unordered_map {
         }
     }
 
-    std::vector<std::pair<const Key, T>> snapshot(std::function<bool(T)> f = nullptr) {
+    std::vector<std::pair<const Key, T>> snapshot(std::function<bool(T)> f = nullptr) const {
         std::vector<std::pair<const Key, T>> ret;
         for (int h = 0; h < BUCKETS; ++h) {
             read_lock_guard_t lock(locks[h].lock);
@@ -302,7 +302,7 @@ class vl_concurrent_unordered_map {
 
     std::unordered_map<Key, T, Hash> maps[BUCKETS];
     struct {
-        lock_t lock;
+        mutable lock_t lock;
         // Put each lock on its own cache line to avoid false cache line sharing.
         char padding[(-int(sizeof(lock_t))) & 63];
     } locks[BUCKETS];

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -305,7 +305,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         output_func = ''
         for objtype in ['instance', 'device']:
             upper_objtype = objtype.capitalize();
-            output_func += 'bool ObjectLifetimes::ReportUndestroyed%sObjects(Vk%s %s, const std::string& error_code) {\n' % (upper_objtype, upper_objtype, objtype)
+            output_func += 'bool ObjectLifetimes::ReportUndestroyed%sObjects(Vk%s %s, const std::string& error_code) const {\n' % (upper_objtype, upper_objtype, objtype)
             output_func += '    bool skip = false;\n'
             if objtype == 'device':
                 output_func += '    skip |= ReportLeaked%sObjects(%s, kVulkanObjectTypeCommandBuffer, error_code);\n' % (upper_objtype, objtype)

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -344,7 +344,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             write(self.enumValueLists, file=self.outFile)
             self.newline()
 
-            pnext_handler  = 'bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) {\n'
+            pnext_handler  = 'bool StatelessValidation::ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure* header) const {\n'
             pnext_handler += '    bool skip = false;\n'
             pnext_handler += '    switch(header->sType) {\n'
 
@@ -381,7 +381,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             write(pnext_handler, file=self.outFile)
             self.newline()
 
-            ext_template  = 'bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) {\n'
+            ext_template  = 'bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) const {\n'
             ext_template += '    return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,\n'
             ext_template += '                   kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\\n",\n'
             ext_template += '                   api_name.c_str(), extension_name.c_str());\n'


### PR DESCRIPTION
This commit contains changes that enable all the PreCallValidate
methods to be converted to const. That switch will actually happen
in a later commit.

Best practices layer: Move some state setting from PreCallValidate to
PostCallRecord.

Add a const StateTracker to DescriptorSet. This is needed to handle some
temp/proxy descriptor sets created as part of push descriptor validation.

Make the vl_concurrent_unordered_map locks mutable, and some of the read-only
methods const. Similar for object_lifetime_mutex (to make read_shared_lock
const) and Stateless validation's renderpass_map_mutex.

Move image_state->layout_locked = true from PreCallValidateQueuePresentKHR
to PostCallRecordQueuePresentKHR.

Make a bunch of internal/helper methods and local STATE pointers const.

Remove redundant DestroyLeaked*Objects calls from
PreCallValidateDestroyInstance.