### PR TITLE
 layers: Implement relaxed UPDATE_AFTER_BIND externsync rules in ThreadSafety

### DIFF
--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -305,6 +305,20 @@ public:
     std::unordered_map<VkCommandPool, std::unordered_set<VkCommandBuffer>> pool_command_buffers_map;
     std::unordered_map<VkDevice, std::unordered_set<VkQueue>> device_queues_map;
 
+    // Track per-descriptorsetlayout and per-descriptorset whether UPDATE_AFTER_BIND is used.
+    // This is used to (sloppily) implement the relaxed externsync rules for UPDATE_AFTER_BIND
+    // descriptors. We model updates of UPDATE_AFTER_BIND descriptors as if they were reads
+    // rather than writes, because they only conflict with the set being freed or reset.
+    //
+    // We don't track the UPDATE_AFTER_BIND state per-binding for a couple reasons:
+    // (1) We only have one counter per object, and if we treated non-UAB as writes
+    //     and UAB as reads then they'd appear to conflict with each other.
+    // (2) Avoid additional tracking of descriptor binding state in the descriptor set
+    //     layout, and tracking of which bindings are accessed by a VkDescriptorUpdateTemplate.
+    vl_concurrent_unordered_map<VkDescriptorSetLayout, bool, 4> dsl_update_after_bind_map;
+    vl_concurrent_unordered_map<VkDescriptorSet, bool, 6> ds_update_after_bind_map;
+    bool DsUpdateAfterBind(VkDescriptorSet) const;
+
     counter<VkCommandBuffer> c_VkCommandBuffer;
     counter<VkDevice> c_VkDevice;
     counter<VkInstance> c_VkInstance;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -661,10 +661,14 @@ struct thread_data_struct {
     VkCommandBuffer commandBuffer;
     VkDevice device;
     VkEvent event;
-    bool bailout;
+    VkDescriptorSet descriptorSet;
+    VkBuffer buffer;
+    uint32_t binding;
+    bool *bailout;
 };
 
 extern "C" void *AddToCommandBuffer(void *arg);
+extern "C" void *UpdateDescriptor(void *arg);
 #endif  // GTEST_IS_THREADSAFE
 
 extern "C" void *ReleaseNullFence(void *arg);

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -6142,8 +6142,9 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
 
     struct thread_data_struct data;
     data.device = m_device->device();
-    data.bailout = false;
-    m_errorMonitor->SetBailout(&data.bailout);
+    bool bailout = false;
+    data.bailout = &bailout;
+    m_errorMonitor->SetBailout(data.bailout);
 
     // Call vk::DestroyFence of VK_NULL_HANDLE repeatedly using multiple threads.
     // There should be no validation error from collision of that non-object.


### PR DESCRIPTION
Make ThreadSafety track which descriptor sets allow UAB and model descriptor
updates to those sets as if they were reads. This is meant to allow concurrent
descriptor updates and concurrent update+bind, which the spec allows for UAB
bindings. This isn't perfect - really this is only supposed to be allowed for
specific bindings that are created with UAB, but we apply it to the whole set
to keep things simple.