### PR TITLE
Fix Issues in BP after StateTracker moved to its own file

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -247,6 +247,8 @@ bool BestPractices::PreCallValidateAllocateMemory(VkDevice device, const VkMemor
 void BestPractices::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
                                                  VkResult result) {
+    ValidationStateTracker::PostCallRecordAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, result);
+
     if (VK_SUCCESS == result) {
         num_mem_objects++;
     }
@@ -256,7 +258,7 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
                                               const VkAllocationCallbacks* pAllocator) const {
     bool skip = false;
 
-    const DEVICE_MEMORY_STATE* mem_info = GetDevMemState(memory);
+    const DEVICE_MEMORY_STATE* mem_info = ValidationStateTracker::GetDevMemState(memory);
 
     for (auto& obj : mem_info->obj_bindings) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, get_debug_report_enum[obj.type], 0, layer_name.c_str(),

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -124,5 +124,5 @@ class BestPractices : public ValidationStateTracker {
   private:
     uint32_t instance_api_version;
 
-    uint32_t num_mem_objects;
+    uint32_t num_mem_objects = 0;
 };

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "chassis.h"
-#include "core_validation.h"
+#include "state_tracker.h"
 #include <string>
 
 static const uint32_t kMemoryObjectWarningLimit = 250;


### PR DESCRIPTION
Now #include "state_tracker.h" instead of "core_validation.h" since the stateTracker now moved to it's own file.

num_mem_objects in BP was never initialized which caused a performance warning to be thrown saying there were too many memory objects. Now initialize num_mem_objects to 0.