### PR TITLE
layers: Validate specialization constants

### DIFF
--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "4b5159ea8170fa34e29f13448fddebf88e0a722a"
+#define SPIRV_TOOLS_COMMIT_ID "f99beb50a327bc93810b1af8138c84caedd1a3ca"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "4b5159ea8170fa34e29f13448fddebf88e0a722a",
+      "commit" : "f99beb50a327bc93810b1af8138c84caedd1a3ca",
       "prebuild" : [
         "python update_glslang_sources.py"
       ],


### PR DESCRIPTION
Second try. The spirv optimizer has been fixed to address issues in previous attempt and I've added a message consumer which should log when unrecognized extended types fail during specialization.