### PR TITLE
Remove Geometry inp/outp components test from Android runs, fix shaderc error output

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4152,6 +4152,8 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
     }
 }
 
+// ShaderC does validation and croaks if these particular limits are exceeded
+#if !defined(ANDROID)
 TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the geometry stage exceeds the device "
@@ -4239,6 +4241,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
         }
     }
 }
+#endif  // !ANDROID
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
     TEST_DESCRIPTION(

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -114,7 +114,7 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
     shaderc::SpvCompilationResult result =
         compiler.CompileGlslToSpv(pshader, strlen(pshader), MapShadercType(shader_type), "shader", options);
     if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
-        __android_log_print(ANDROID_LOG_ERROR, "VkLayerValidationTests", "GLSLtoSPV compilation failed: %s",
+        __android_log_print(ANDROID_LOG_ERROR, "VulkanLayerValidationTests", "GLSLtoSPV compilation failed: %s",
                             result.GetErrorMessage().c_str());
         return false;
     }


### PR DESCRIPTION
ShaderC does validation that will cause one of the tests to fail on some systems supporting non-zero limits for MaxGeometryInputComp/MaxGeometryOutputComp.  Disallowed this test from running on Android platforms.  

Also fixed an issue with the shaderC error output, which was being excluded from CI output due to an invalid filter key.

Fixes #1313.