### PR TITLE
Split fragment shader input variables count

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1957,7 +1957,9 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
         (pStage->stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT || pStage->stage == VK_SHADER_STAGE_MESH_BIT_NV);
     bool strip_input_array_level =
         (pStage->stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
-         pStage->stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT || pStage->stage == VK_SHADER_STAGE_GEOMETRY_BIT);
+         pStage->stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT ||
+         pStage->stage == VK_SHADER_STAGE_GEOMETRY_BIT ||
+         pStage->stage == VK_SHADER_STAGE_FRAGMENT_BIT);
 
     uint32_t numCompIn = 0, numCompOut = 0;
     for (auto &var : variables) {


### PR DESCRIPTION
Validation layers sum up input variables count for vertex and fragment
shaders performing the input compatibility check. Therefore for
combined all-in-one SPIR-V assemblies the amount of result input
vertices in fragment shader exceeds standard-defined limit
(VkPhysicalDeviceLimits::maxFragmentInputComponents).

Fix treats fragment shaders in a similar way with tessellation and
geometry ones while computing expected amount of inputs, and allows
stripping it.