### PR TITLE
Android: Make tests more reliable

### DIFF
--- a/build-android/test_APK.sh
+++ b/build-android/test_APK.sh
@@ -114,10 +114,6 @@ echo Setting up...
 # Start up
 #
 
-# Wake up the device
-adb $serialFlag shell input keyevent "KEYCODE_MENU"
-adb $serialFlag shell input keyevent "KEYCODE_HOME"
-
 # Grab our Android test mutex
 # Wait for any existing test runs on the devices
 
@@ -143,6 +139,12 @@ function finish {
    rm -r /var/tmp/VkLayerValidationTests.$serial.lock
 }
 trap finish EXIT
+
+# Wake up the device - make sure each keycode has time to be processed
+adb $serialFlag shell input keyevent "KEYCODE_MENU"
+sleep 2
+adb $serialFlag shell input keyevent "KEYCODE_HOME"
+sleep 2
 
 # Clear the log
 adb $serialFlag logcat -c
@@ -175,7 +177,7 @@ fi
 echo
 echo Launching tests...
 
-# Kick off the tests with known expection list
+# Kick off the tests with known exception list
 adb $serialFlag shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.VulkanLayerValidationTests/android.app.NativeActivity --es args --gtest_filter="${filter}"
 
 #
@@ -186,7 +188,7 @@ adb $serialFlag shell am start -a android.intent.action.MAIN -c android-intent.c
 seconds=1200                          # Duration in seconds.
 endTime=$(( $(date +%s) + seconds ))  # Calculate end time.
 
-exitCode=-1;
+exitCode=-1
 
 # Disable exit on error, we expect grep to fail multiple times in this loop
 set +e
@@ -230,9 +232,6 @@ while [ $(date +%s) -lt $endTime ]; do  # Loop until interval has elapsed.
 
 done
 
-# Re-enable exit on error
-set -e
-
 if [ $exitCode -eq -1 ]
 then
     echo "VulkanLayerValidationTests hasn't completed in $seconds seconds. Script exiting."
@@ -244,6 +243,7 @@ fi
 
 # Return to home screen to clear any error pop-ups
 adb $serialFlag shell input keyevent "KEYCODE_HOME"
+sleep 2
 
 # Stop the activity
 adb $serialFlag shell am force-stop com.example.VulkanLayerValidationTests
@@ -284,7 +284,7 @@ then
     echo 
     echo Dumping logcat text, filtered by ''"VulkanLayerValidationTests"'':
     echo =========================================================================================
-    cat $logFile
+    cat $logFile | grep VulkanLayerValidationTests
     echo =========================================================================================
 fi
 


### PR DESCRIPTION
Testing has observed occasional spurious test failures that
may be due to a race condition (if the device takes too long to
wake up, it may miss the HOME keycode or process it in the
wrong state).

These changes include a tentative fix for the above, and also
include changes that allow triage of a timeout failure.
(Currently, on a timeout failure, "adb" gets an error
"failed to stat remote object" when trying to pull the
executioin output, which causes the test script to exit
before logcat text can be collected.)

test_APK.sh:
- add "sleep 2" after every keyevent, to ensure that a keyevent is
  processed before the next keyevent is sent (and to better simulate
  human usage)
- don't wake up the device until after you have the device lock
- don't exit early on error - this exit prevents us from getting the
  logcat text that may be helpful in triaging a timeout failure
- re-establish the filtered logcat output - the full logcat is still
  available as an artifact, but only the filtered output is presented
  in the console, as was done historically
- minor bash syntax and spelling fixes