### PR TITLE
Fix Swapchain images layout issue.

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -462,12 +462,16 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
           p_driver_data(0){};
 };
 
+struct SWAPCHAIN_IMAGE {
+    VkImage image;
+    std::unordered_set<VkImage> bound_images;
+};
+
 class SWAPCHAIN_NODE : public BASE_NODE {
   public:
     safe_VkSwapchainCreateInfoKHR createInfo;
     VkSwapchainKHR swapchain;
-    std::vector<VkImage> images;
-    std::unordered_set<VkImage> bound_images;
+    std::vector<SWAPCHAIN_IMAGE> images;
     bool retired = false;
     bool shared_presentable = false;
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1337

In previous version, SWAPCHAIN_NODE has a single bound_images, so when the images of Swapchain are plural, and some regular images bind to a image of Swapchain, and all of bound_images store in the same place, it causes this issues.

Also, when images of SWAPCHAIN store in the same bound_images, it also causes those images of Swapchain thought they were alias images.

So,  in SWAPCHAIN_NODE, each image should have an individual bound_images. 