### PR TITLE
Use hardware limits where appropriate for glsl-to-spirv generation

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2826,7 +2826,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     VkShaderModule shader_module;
     module_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     module_create_info.pNext = NULL;
-    this->GLSLtoSPV(VK_SHADER_STAGE_VERTEX_BIT, bindStateVertShaderText, shader);
+    this->GLSLtoSPV(&m_device->props.limits, VK_SHADER_STAGE_VERTEX_BIT, bindStateVertShaderText, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(unsigned int) - 1;

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4211,8 +4211,6 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
     }
 }
 
-// ShaderC does validation and croaks if these particular limits are exceeded
-#if !defined(ANDROID)
 TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the geometry stage exceeds the device "
@@ -4300,7 +4298,6 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
         }
     }
 }
-#endif  // !ANDROID
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
     TEST_DESCRIPTION(

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1611,7 +1611,7 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderS
     m_stage_info.pSpecializationInfo = specInfo;
 
     std::vector<unsigned int> spv;
-    framework->GLSLtoSPV(stage, shader_code, spv, debug, spirv_minor_version);
+    framework->GLSLtoSPV(&device->props.limits, stage, shader_code, spv, debug, spirv_minor_version);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -338,14 +338,16 @@ bool VkTestFramework::SetConfigFile(const std::string &name) {
 //
 // Parse either a .conf file provided by the user or the default string above.
 //
-void VkTestFramework::ProcessConfigFile() {
+void VkTestFramework::ProcessConfigFile(VkPhysicalDeviceLimits const *const device_limits) {
     char **configStrings = 0;
     char *config = 0;
+    bool config_file_specified = false;
     if (ConfigFile.size() > 0) {
         configStrings = ReadFileData(ConfigFile.c_str());
-        if (configStrings)
+        if (configStrings) {
             config = *configStrings;
-        else {
+            config_file_specified = true;
+        } else {
             printf("Error opening configuration file; will instead use the default configuration\n");
         }
     }
@@ -404,19 +406,19 @@ void VkTestFramework::ProcessConfigFile() {
         else if (strcmp(token, "MaxProgramTexelOffset") == 0)
             Resources.maxProgramTexelOffset = value;
         else if (strcmp(token, "MaxClipDistances") == 0)
-            Resources.maxClipDistances = value;
+            Resources.maxClipDistances = (config_file_specified ? value : device_limits->maxClipDistances);
         else if (strcmp(token, "MaxComputeWorkGroupCountX") == 0)
-            Resources.maxComputeWorkGroupCountX = value;
+            Resources.maxComputeWorkGroupCountX = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[0]);
         else if (strcmp(token, "MaxComputeWorkGroupCountY") == 0)
-            Resources.maxComputeWorkGroupCountY = value;
+            Resources.maxComputeWorkGroupCountY = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[1]);
         else if (strcmp(token, "MaxComputeWorkGroupCountZ") == 0)
-            Resources.maxComputeWorkGroupCountZ = value;
+            Resources.maxComputeWorkGroupCountZ = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[2]);
         else if (strcmp(token, "MaxComputeWorkGroupSizeX") == 0)
-            Resources.maxComputeWorkGroupSizeX = value;
+            Resources.maxComputeWorkGroupSizeX = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[0]);
         else if (strcmp(token, "MaxComputeWorkGroupSizeY") == 0)
-            Resources.maxComputeWorkGroupSizeY = value;
+            Resources.maxComputeWorkGroupSizeY = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[1]);
         else if (strcmp(token, "MaxComputeWorkGroupSizeZ") == 0)
-            Resources.maxComputeWorkGroupSizeZ = value;
+            Resources.maxComputeWorkGroupSizeZ = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[2]);
         else if (strcmp(token, "MaxComputeUniformComponents") == 0)
             Resources.maxComputeUniformComponents = value;
         else if (strcmp(token, "MaxComputeTextureImageUnits") == 0)
@@ -430,13 +432,13 @@ void VkTestFramework::ProcessConfigFile() {
         else if (strcmp(token, "MaxVaryingComponents") == 0)
             Resources.maxVaryingComponents = value;
         else if (strcmp(token, "MaxVertexOutputComponents") == 0)
-            Resources.maxVertexOutputComponents = value;
+            Resources.maxVertexOutputComponents = (config_file_specified ? value : device_limits->maxVertexOutputComponents);
         else if (strcmp(token, "MaxGeometryInputComponents") == 0)
-            Resources.maxGeometryInputComponents = value;
+            Resources.maxGeometryInputComponents = (config_file_specified ? value : device_limits->maxGeometryInputComponents);
         else if (strcmp(token, "MaxGeometryOutputComponents") == 0)
-            Resources.maxGeometryOutputComponents = value;
+            Resources.maxGeometryOutputComponents = (config_file_specified ? value : device_limits->maxGeometryOutputComponents);
         else if (strcmp(token, "MaxFragmentInputComponents") == 0)
-            Resources.maxFragmentInputComponents = value;
+            Resources.maxFragmentInputComponents = (config_file_specified ? value : device_limits->maxFragmentInputComponents);
         else if (strcmp(token, "MaxImageUnits") == 0)
             Resources.maxImageUnits = value;
         else if (strcmp(token, "MaxCombinedImageUnitsAndFragmentOutputs") == 0)
@@ -460,9 +462,10 @@ void VkTestFramework::ProcessConfigFile() {
         else if (strcmp(token, "MaxGeometryTextureImageUnits") == 0)
             Resources.maxGeometryTextureImageUnits = value;
         else if (strcmp(token, "MaxGeometryOutputVertices") == 0)
-            Resources.maxGeometryOutputVertices = value;
+            Resources.maxGeometryOutputVertices = (config_file_specified ? value : device_limits->maxGeometryOutputVertices);
         else if (strcmp(token, "MaxGeometryTotalOutputComponents") == 0)
-            Resources.maxGeometryTotalOutputComponents = value;
+            Resources.maxGeometryTotalOutputComponents =
+                (config_file_specified ? value : device_limits->maxGeometryTotalOutputComponents);
         else if (strcmp(token, "MaxGeometryUniformComponents") == 0)
             Resources.maxGeometryUniformComponents = value;
         else if (strcmp(token, "MaxGeometryVaryingComponents") == 0)
@@ -492,7 +495,7 @@ void VkTestFramework::ProcessConfigFile() {
         else if (strcmp(token, "MaxTessGenLevel") == 0)
             Resources.maxTessGenLevel = value;
         else if (strcmp(token, "MaxViewports") == 0)
-            Resources.maxViewports = value;
+            Resources.maxViewports = (config_file_specified ? value : device_limits->maxViewports);
         else if (strcmp(token, "MaxVertexAtomicCounters") == 0)
             Resources.maxVertexAtomicCounters = value;
         else if (strcmp(token, "MaxTessControlAtomicCounters") == 0)
@@ -526,7 +529,7 @@ void VkTestFramework::ProcessConfigFile() {
         else if (strcmp(token, "MaxTransformFeedbackInterleavedComponents") == 0)
             Resources.maxTransformFeedbackInterleavedComponents = value;
         else if (strcmp(token, "MaxCullDistances") == 0)
-            Resources.maxCullDistances = value;
+            Resources.maxCullDistances = (config_file_specified ? value : device_limits->maxCullDistances);
         else if (strcmp(token, "MaxCombinedClipAndCullDistances") == 0)
             Resources.maxCombinedClipAndCullDistances = value;
         else if (strcmp(token, "MaxSamples") == 0)
@@ -740,8 +743,8 @@ EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_typ
 // Compile a given string containing GLSL into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv,
-                                bool debug, uint32_t spirv_minor_version) {
+bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
+                                const char *pshader, std::vector<unsigned int> &spirv, bool debug, uint32_t spirv_minor_version) {
     glslang::TProgram program;
     const char *shaderStrings[1];
 
@@ -749,7 +752,7 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
     // shader source? Optional name maybe?
     //    SetConfigFile(fileName);
 
-    ProcessConfigFile();
+    ProcessConfigFile(device_limits);
 
     EShMessages messages = EShMsgDefault;
     SetMessageOptions(messages);

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -58,8 +58,8 @@ class VkTestFramework : public ::testing::Test {
     static void InitArgs(int *argc, char *argv[]);
     static void Finish();
 
-    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv, bool debug = false,
-                   uint32_t spirv_minor_version = 0);
+    bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
+                   std::vector<unsigned int> &spv, bool debug = false, uint32_t spirv_minor_version = 0);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_canonicalize_spv;
     static bool m_strip_spv;
@@ -78,7 +78,7 @@ class VkTestFramework : public ::testing::Test {
     int m_num_shader_strings;
     TBuiltInResource Resources;
     void SetMessageOptions(EShMessages &messages);
-    void ProcessConfigFile();
+    void ProcessConfigFile(VkPhysicalDeviceLimits const *const device_limits);
     EShLanguage FindLanguage(const std::string &name);
     EShLanguage FindLanguage(const VkShaderStageFlagBits shader_type);
     std::string ConfigFile;

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -82,8 +82,8 @@ shaderc_shader_kind MapShadercType(VkShaderStageFlagBits vkShader) {
 
 // Compile a given string containing GLSL into SPIR-V
 // Return value of false means an error was encountered
-bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spirv,
-                                bool debug, uint32_t spirv_minor_version) {
+bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
+                                const char *pshader, std::vector<unsigned int> &spirv, bool debug, uint32_t spirv_minor_version) {
     // On Android, use shaderc instead.
     shaderc::Compiler compiler;
     shaderc::CompileOptions options;
@@ -110,6 +110,23 @@ bool VkTestFramework::GLSLtoSPV(const VkShaderStageFlagBits shader_type, const c
             options.SetTargetSpirv(shaderc_spirv_version_1_4);
             break;
     }
+
+    // Override glslang built-in GL settings with actual hardware values
+    options.SetLimit(shaderc_limit_max_clip_distances, device_limits->maxClipDistances);
+    options.SetLimit(shaderc_limit_max_compute_work_group_count_x, device_limits->maxComputeWorkGroupCount[0]);
+    options.SetLimit(shaderc_limit_max_compute_work_group_count_y, device_limits->maxComputeWorkGroupCount[1]);
+    options.SetLimit(shaderc_limit_max_compute_work_group_count_z, device_limits->maxComputeWorkGroupCount[2]);
+    options.SetLimit(shaderc_limit_max_compute_work_group_size_x, device_limits->maxComputeWorkGroupSize[0]);
+    options.SetLimit(shaderc_limit_max_compute_work_group_size_y, device_limits->maxComputeWorkGroupSize[1]);
+    options.SetLimit(shaderc_limit_max_compute_work_group_size_z, device_limits->maxComputeWorkGroupSize[2]);
+    options.SetLimit(shaderc_limit_max_cull_distances, device_limits->maxCullDistances);
+    options.SetLimit(shaderc_limit_max_fragment_input_components, device_limits->maxFragmentInputComponents);
+    options.SetLimit(shaderc_limit_max_geometry_input_components, device_limits->maxGeometryInputComponents);
+    options.SetLimit(shaderc_limit_max_geometry_output_components, device_limits->maxGeometryOutputComponents);
+    options.SetLimit(shaderc_limit_max_geometry_output_vertices, device_limits->maxGeometryOutputVertices);
+    options.SetLimit(shaderc_limit_max_geometry_total_output_components, device_limits->maxGeometryTotalOutputComponents);
+    options.SetLimit(shaderc_limit_max_vertex_output_components, device_limits->maxVertexOutputComponents);
+    options.SetLimit(shaderc_limit_max_viewports, device_limits->maxViewports);
 
     shaderc::SpvCompilationResult result =
         compiler.CompileGlslToSpv(pshader, strlen(pshader), MapShadercType(shader_type), "shader", options);

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -37,8 +37,8 @@ class VkTestFramework : public ::testing::Test {
     static void Finish();
 
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
-    bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *pshader, std::vector<unsigned int> &spv, bool debug = false,
-                   uint32_t spirv_minor_version = 0);
+    bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
+                   std::vector<unsigned int> &spv, bool debug = false, uint32_t spirv_minor_version = 0);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_devsim_layer;
     static ANativeWindow *window;


### PR DESCRIPTION
The test framework commonly converts glsl to spirv when creating  `VkShaderObj `objects. Glslang validates GL limits (see the list below) using internal, default limits.  The desktop interface to glslang passes in another set of default values.  However, neither the default glslang values nor the version created by the test framework use the actual hardware values for common items.  This PR passes in the current `PhysicalDeviceLimits `values so that glslang's validation will not generate inappropriate limits violation errors.

Also restored the `ExceedMaxGeometryInputOutputComponents `test for Android, since it will no longer generate invalid limits violations.

**Vulkan PDev limits which overlap with glslang's default OpenGL limits**:

- maxClipDistances;
- maxComputeWorkGroupCountX;
- maxComputeWorkGroupCountY;
- maxComputeWorkGroupCountZ;
- maxComputeWorkGroupSizeX;
- maxComputeWorkGroupSizeY;
- maxComputeWorkGroupSizeZ;
- maxCullDistances;
- maxGeometryInputComponents;
- maxGeometryOutputComponents;
- maxGeometryOutputVertices;
- maxGeometryTotalOutputComponents;
- maxVertexOutputComponents;
- maxViewports;

