### PR TITLE
tests: Add macOS loader filename

### DIFF
--- a/layers/generated/lvt_function_pointers.cpp
+++ b/layers/generated/lvt_function_pointers.cpp
@@ -249,6 +249,8 @@ void InitDispatchTable() {
 
 #if(WIN32)
     const char filename[] = "vulkan-1.dll";
+#elif(__APPLE__)
+    const char filename[] = "libvulkan.dylib";
 #else
     const char filename[] = "libvulkan.so";
 #endif

--- a/scripts/lvt_file_generator.py
+++ b/scripts/lvt_file_generator.py
@@ -203,6 +203,8 @@ class LvtFileOutputGenerator(OutputGenerator):
         table += '\n'
         table += '#if(WIN32)\n'
         table += '    const char filename[] = "vulkan-1.dll";\n'
+        table += '#elif(__APPLE__)\n'
+        table += '    const char filename[] = "libvulkan.dylib";\n'
         table += '#else\n'
         table += '    const char filename[] = "libvulkan.so";\n'
         table += '#endif\n'


### PR DESCRIPTION
Layer validation tests weren't running on macOS because of platform specific loader filename.