### PR TITLE
Move CmdAttachment Perf Warning to BP and Setup BP Tests

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -812,12 +812,13 @@ void BestPractices::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindIn
 }
 
 bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                        const VkClearAttachment* pAttachments, uint32_t rectCount, const VkClearRect* pRects) {
+                                                       const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                       const VkClearRect* pRects) const {
     bool skip = false;
     const CMD_BUFFER_STATE* cb_node = GetCBState(commandBuffer);
     if (!cb_node) return skip;
 
-        // Warn if this is issued prior to Draw Cmd and clearing the entire attachment
+    // Warn if this is issued prior to Draw Cmd and clearing the entire attachment
     if (!cb_node->hasDrawCmd && (cb_node->activeRenderPassBeginInfo.renderArea.extent.width == pRects[0].rect.extent.width) &&
         (cb_node->activeRenderPassBeginInfo.renderArea.extent.height == pRects[0].rect.extent.height)) {
         // There are times where app needs to use ClearAttachments (generally when reusing a buffer inside of a render pass)
@@ -830,5 +831,5 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
                         report_data->FormatHandle(commandBuffer).c_str());
     }
 
-        return skip;
+    return skip;
 }

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -121,7 +121,8 @@ class BestPractices : public ValidationStateTracker {
     void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                        VkResult result);
     bool PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                            const VkClearAttachment* pAttachments, uint32_t rectCount, const VkClearRect* pRects);
+                                            const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                            const VkClearRect* pRects) const;
 
   private:
     uint32_t instance_api_version;

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -120,6 +120,8 @@ class BestPractices : public ValidationStateTracker {
                                         VkFence fence) const;
     void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                        VkResult result);
+    bool PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
+                                            const VkClearAttachment* pAttachments, uint32_t rectCount, const VkClearRect* pRects);
 
   private:
     uint32_t instance_api_version;

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2865,18 +2865,6 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
     skip |= ValidateCmdQueueFlags(cb_node, "vkCmdClearAttachments()", VK_QUEUE_GRAPHICS_BIT,
                                   "VUID-vkCmdClearAttachments-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_node, CMD_CLEARATTACHMENTS, "vkCmdClearAttachments()");
-    // Warn if this is issued prior to Draw Cmd and clearing the entire attachment
-    if (!cb_node->hasDrawCmd && (cb_node->activeRenderPassBeginInfo.renderArea.extent.width == pRects[0].rect.extent.width) &&
-        (cb_node->activeRenderPassBeginInfo.renderArea.extent.height == pRects[0].rect.extent.height)) {
-        // There are times where app needs to use ClearAttachments (generally when reusing a buffer inside of a render pass)
-        // This warning should be made more specific. It'd be best to avoid triggering this test if it's a use that must call
-        // CmdClearAttachments.
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), kVUID_Core_DrawState_ClearCmdBeforeDraw,
-                        "vkCmdClearAttachments() issued on %s prior to any Draw Cmds. It is recommended you "
-                        "use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.",
-                        report_data->FormatHandle(commandBuffer).c_str());
-    }
     skip |= OutsideRenderPass(cb_node, "vkCmdClearAttachments()", "VUID-vkCmdClearAttachments-renderpass");
 
     // Validate that attachment is in reference list of active subpass

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(COMMON_CPP
     vklayertests_pipeline_shader.cpp
     vklayertests_buffer_image_memory_sampler.cpp
     vklayertests_others.cpp
+    vklayertests_best_practices.cpp
     vklayertests_descriptor_renderpass_framebuffer.cpp
     vklayertests_command.cpp
     vklayertests_imageless_framebuffer.cpp

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2019 The Khronos Group Inc.
+ * Copyright (c) 2015-2019 Valve Corporation
+ * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Author: Camden Stocker <camden@lunarg.com>
+ */
+
+#include "cast_utils.h"
+#include "layer_validation_tests.h"
+
+TEST_F(VkLayerTest, CmdClearAttachmentTest) {
+    TEST_DESCRIPTION("Various tests for validating usage of vkCmdClearAttachments");
+
+    VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
+    VkValidationFeaturesEXT features = {};
+    features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    features.enabledValidationFeatureCount = 1;
+    features.pEnabledValidationFeatures = enables;
+    InitFramework(myDbgFunc, m_errorMonitor, &features);
+    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+
+    // Main thing we care about for this test is that the VkImage obj we're
+    // clearing matches Color Attachment of FB
+    //  Also pass down other dummy params to keep driver and paramchecker happy
+    VkClearAttachment color_attachment;
+    color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    color_attachment.clearValue.color.float32[0] = 1.0;
+    color_attachment.clearValue.color.float32[1] = 1.0;
+    color_attachment.clearValue.color.float32[2] = 1.0;
+    color_attachment.clearValue.color.float32[3] = 1.0;
+    color_attachment.colorAttachment = 0;
+    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+
+    // Call for full-sized FB Color attachment prior to issuing a Draw
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw");
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2564,12 +2564,6 @@ TEST_F(VkLayerTest, CmdClearAttachmentTests) {
     color_attachment.colorAttachment = 0;
     VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
 
-    // Call for full-sized FB Color attachment prior to issuing a Draw
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw");
-    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
-    m_errorMonitor->VerifyFound();
-
     clear_rect.rect.extent.width = renderPassBeginInfo().renderArea.extent.width + 4;
     clear_rect.rect.extent.height = clear_rect.rect.extent.height / 2;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdClearAttachments-pRects-00016");


### PR DESCRIPTION
Resolves #1307 tracked in #24 which moves a performance warning to BP.

I also needed to  set up BP test file for all future BP tests. Migrated one test over to BP which is related to the warning in #1307 