### PR TITLE
Layers: Added external memory as exception to needing vkGet*MemoryRequirements

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -279,7 +279,7 @@ bool BestPractices::ValidateBindBufferMemory(VkBuffer buffer, const char* api_na
     bool skip = false;
     const BUFFER_STATE* buffer_state = GetBufferState(buffer);
 
-    if (!buffer_state->memory_requirements_checked) {
+    if (!buffer_state->memory_requirements_checked && !buffer_state->external_memory_handle) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         kVUID_BestPractices_BufferMemReqNotCalled,
                         "%s: Binding memory to %s but vkGetBufferMemoryRequirements() has not been called on that buffer.",
@@ -329,7 +329,7 @@ bool BestPractices::ValidateBindImageMemory(VkImage image, const char* api_name)
     bool skip = false;
     const IMAGE_STATE* image_state = GetImageState(image);
 
-    if (!image_state->memory_requirements_checked) {
+    if (!image_state->memory_requirements_checked && !image_state->external_memory_handle) {
         skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                         kVUID_BestPractices_ImageMemReqNotCalled,
                         "%s: Binding memory to %s but vkGetImageMemoryRequirements() has not been called on that image.", api_name,

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -91,6 +91,11 @@ IMAGE_STATE::IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo)
     }
     full_range = NormalizeSubresourceRange(*this, init_range);
 
+    auto *externalMemoryInfo = lvl_find_in_chain<VkExternalMemoryImageCreateInfo>(pCreateInfo->pNext);
+    if (externalMemoryInfo) {
+        external_memory_handle = externalMemoryInfo->handleTypes;
+    }
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     auto external_format = lvl_find_in_chain<VkExternalFormatANDROID>(createInfo.pNext);
     if (external_format) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -226,6 +226,8 @@ class BINDABLE : public BASE_NODE {
     VkMemoryRequirements requirements;
     // bool to track if memory requirements were checked
     bool memory_requirements_checked;
+    // Tracks external memory types creating resource
+    VkExternalMemoryHandleTypeFlags external_memory_handle;
     // Sparse binding data, initially just tracking MEM_BINDING per mem object
     //  There's more data for sparse bindings so need better long-term solution
     // TODO : Need to update solution to track all sparse binding data
@@ -234,7 +236,13 @@ class BINDABLE : public BASE_NODE {
     small_unordered_set<VkDeviceMemory, 1> bound_memory_set_;
 
     BINDABLE()
-        : sparse(false), binding{}, requirements{}, memory_requirements_checked(false), sparse_bindings{}, bound_memory_set_{} {};
+        : sparse(false),
+          binding{},
+          requirements{},
+          memory_requirements_checked(false),
+          external_memory_handle(0),
+          sparse_bindings{},
+          bound_memory_set_{} {};
 
     // Update the cached set of memory bindings.
     // Code that changes binding.mem or sparse_bindings must call UpdateBoundMemorySet()
@@ -270,6 +278,11 @@ class BUFFER_STATE : public BINDABLE {
 
         if (createInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
             sparse = true;
+        }
+
+        auto *externalMemoryInfo = lvl_find_in_chain<VkExternalMemoryBufferCreateInfo>(pCreateInfo->pNext);
+        if (externalMemoryInfo) {
+            external_memory_handle = externalMemoryInfo->handleTypes;
         }
     };
 


### PR DESCRIPTION
Currently, when creating a VkBuffer or VkImage with external memory there is need to call `vkGetBufferemoryRequirements`/`vkGetImageMemoryRequirements` as that information is found from the external memory call provided (for example its `
`vkGetAndroidHardwareBufferPropertiesANDROID` on Android)

This PR is to prevent an application that uses external memory and doesn call vkGet*MemoryRequirements from getting a false warning from the Best Practice layer