### PR TITLE
Add Subclass for BestPractices Tests

### DIFF
--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -257,6 +257,13 @@ class VkPositiveLayerTest : public VkLayerTest {
   protected:
 };
 
+class VkBestPracticesLayerTest : public VkLayerTest {
+  public:
+    void InitBestPracticesFramework();
+
+  protected:
+};
+
 class VkWsiEnabledLayerTest : public VkLayerTest {
   public:
   protected:

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -16,15 +16,20 @@
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
 
-TEST_F(VkLayerTest, CmdClearAttachmentTest) {
-    TEST_DESCRIPTION("Various tests for validating usage of vkCmdClearAttachments");
-
+void VkBestPracticesLayerTest::InitBestPracticesFramework() {
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
     VkValidationFeaturesEXT features = {};
     features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
     features.enabledValidationFeatureCount = 1;
     features.pEnabledValidationFeatures = enables;
+
     InitFramework(myDbgFunc, m_errorMonitor, &features);
+}
+
+TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
+    TEST_DESCRIPTION("Test for validating usage of vkCmdClearAttachments");
+
+    InitBestPracticesFramework();
     InitState();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 


### PR DESCRIPTION
Includes a BestPractices Tests class and and initBestPracticesFramework to easily enable the BP layer for testing