### PR TITLE
tests: Minor fixes to SwapchainAcquireTooManyImages

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1257,17 +1257,9 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
 TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     TEST_DESCRIPTION("Acquiring invalid amount of images from the swapchain.");
 
-    if (!AddSurfaceInstanceExtension()) {
-        printf("%s surface extensions not supported, skipping test\n", kSkipPrefix);
-        return;
-    }
-
+    if (!AddSurfaceInstanceExtension()) return;
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
-
-    if (!AddSwapchainDeviceExtension()) {
-        printf("%s swapchain extensions not supported, skipping test\n", kSkipPrefix);
-        return;
-    }
+    if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_TRUE(InitSwapchain());
@@ -1309,11 +1301,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
         return;
     }
 
-    if (!AddSurfaceInstanceExtension()) {
-        printf("%s surface extensions not supported, skipping test\n", kSkipPrefix);
-        return;
-    }
-
+    if (!AddSurfaceInstanceExtension()) return;
     ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
 
     if (extension_dependency_satisfied && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
@@ -1323,10 +1311,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
         return;
     }
 
-    if (!AddSwapchainDeviceExtension()) {
-        printf("%s swapchain extensions not supported, skipping test\n", kSkipPrefix);
-        return;
-    }
+    if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_TRUE(InitSwapchain());

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1269,10 +1269,10 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     ASSERT_VK_SUCCESS(vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &caps));
 
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
-    uint32_t image_i = 0;  // MockICD does not write this so trick it to return sane value
     std::vector<VkFenceObj> fences(acquirable_count);
     for (uint32_t i = 0; i < acquirable_count; ++i) {
         fences[i].init(*m_device, VkFenceObj::create_info());
+        uint32_t image_i = i;  // WORKAROUND: MockICD does not modify the value, so we have to or the validator state gets corrupted
         const auto res = vk::AcquireNextImageKHR(device(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, fences[i].handle(), &image_i);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);
     }
@@ -1280,6 +1280,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     error_fence.init(*m_device, VkFenceObj::create_info());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkAcquireNextImageKHR-swapchain-01802");
+    uint32_t image_i;
     vk::AcquireNextImageKHR(device(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, error_fence.handle(), &image_i);
     m_errorMonitor->VerifyFound();
 
@@ -1321,10 +1322,10 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     ASSERT_VK_SUCCESS(vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &caps));
 
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
-    uint32_t image_i = 0;  // MockICD does not write this so trick it to return sane value
     std::vector<VkFenceObj> fences(acquirable_count);
     for (uint32_t i = 0; i < acquirable_count; ++i) {
         fences[i].init(*m_device, VkFenceObj::create_info());
+        uint32_t image_i = i;  // WORKAROUND: MockICD does not modify the value, so we have to or the validator state gets corrupted
         const auto res = vk::AcquireNextImageKHR(device(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, fences[i].handle(), &image_i);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);
     }
@@ -1338,6 +1339,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     acquire_info.fence = error_fence.handle();
     acquire_info.deviceMask = 0x1;
 
+    uint32_t image_i;
     vk::AcquireNextImage2KHR(device(), &acquire_info, &image_i);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
- remove redundant\duplicate skip message
- fix Mock workaround so it does not depend on swapchain image count to always be 2