### PR TITLE
layers: Fix broken config file parsing

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -255,10 +255,11 @@ void ConfigFile::ParseFile(const char *filename) {
         if (comments_pos != string::npos) line.erase(comments_pos);
 
         const auto value_pos = line.find_first_of('=');
-
-        const string option = string_trim(line.substr(0, value_pos));
-        const string value = string_trim(line.substr(value_pos));
-        value_map_[option] = value;
+        if (value_pos != string::npos) {
+            const string option = string_trim(line.substr(0, value_pos));
+            const string value = string_trim(line.substr(value_pos + 1));
+            value_map_[option] = value;
+        }
     }
 }
 


### PR DESCRIPTION
vk_layer_settings.txt was not properly parsed because the '=' character was being read as part of the option value. This change makes sure '=' is present in the line being parsed and excludes the character from the option value.