### PR TITLE
Remove CALLSTATE everywhere except BP

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -562,18 +562,47 @@ bool BestPractices::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, ui
     return skip;
 }
 
+bool BestPractices::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice,
+                                                                            const char* api_name) const {
+    bool skip = false;
+    const auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+
+    if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState == UNCALLED) {
+        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
+                        HandleToUint64(physicalDevice), kVUID_BestPractices_DisplayPlane_PropertiesNotCalled,
+                        "Potential problem with calling %s() without first retrieving properties from "
+                        "vkGetPhysicalDeviceDisplayPlanePropertiesKHR or vkGetPhysicalDeviceDisplayPlaneProperties2KHR.",
+                        api_name);
+    }
+
+    return skip;
+}
+
 bool BestPractices::PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                        uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) const {
     bool skip = false;
 
-    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    skip |= ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(physicalDevice, "vkGetDisplayPlaneSupportedDisplaysKHR");
 
-    if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState != QUERY_DETAILS) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_BestPractices_DisplayPlane_PropertiesNotCalled,
-                        "vkGetDisplayPlaneSupportedDisplaysKHR() called before getting diplay plane properties from "
-                        "vkGetPhysicalDeviceDisplayPlanePropertiesKHR().");
-    }
+    return skip;
+}
+
+bool BestPractices::PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode,
+                                                                  uint32_t planeIndex,
+                                                                  VkDisplayPlaneCapabilitiesKHR* pCapabilities) const {
+    bool skip = false;
+
+    skip |= ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(physicalDevice, "vkGetDisplayPlaneCapabilitiesKHR");
+
+    return skip;
+}
+
+bool BestPractices::PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
+                                                                   const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
+                                                                   VkDisplayPlaneCapabilities2KHR* pCapabilities) const {
+    bool skip = false;
+
+    skip |= ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(physicalDevice, "vkGetDisplayPlaneCapabilities2KHR");
 
     return skip;
 }

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -99,8 +99,14 @@ class BestPractices : public ValidationStateTracker {
                                                uint32_t drawCount, uint32_t stride) const;
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) const;
+    bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, const char* api_name) const;
     bool PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                             uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) const;
+    bool PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode, uint32_t planeIndex,
+                                                       VkDisplayPlaneCapabilitiesKHR* pCapabilities) const;
+    bool PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
+                                                        const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
+                                                        VkDisplayPlaneCapabilities2KHR* pCapabilities) const;
     bool PreCallValidateGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                               VkImage* pSwapchainImages) const;
     bool PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10167,7 +10167,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const CommandVersion 
 
         auto physical_device_state = GetPhysicalDeviceState();
         // TODO: this is technically wrong on many levels, but requires massive cleanup
-        if (physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled) {
+        if (physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called) {
             const uint32_t acquired_images =
                 static_cast<uint32_t>(std::count_if(swapchain_data->images.begin(), swapchain_data->images.end(),
                                                     [=](SWAPCHAIN_IMAGE image) { return GetImageState(image.image)->acquired; }));
@@ -10457,7 +10457,7 @@ bool CoreChecks::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysi
                                                                          const char *api_name) const {
     bool skip = false;
     const auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
-    if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled) {
+    if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called) {
         if (planeIndex >= physical_device_state->display_plane_property_count) {
             skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
                             HandleToUint64(physicalDevice), "VUID-vkGetDisplayPlaneSupportedDisplaysKHR-planeIndex-01249",

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3924,6 +3924,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesK
     if (VK_SUCCESS != result) return;
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
     physical_device_state->surfaceCapabilities = *pSurfaceCapabilities;
 }
 
@@ -3933,6 +3934,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
     if (VK_SUCCESS != result) return;
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
     physical_device_state->surfaceCapabilities = pSurfaceCapabilities->surfaceCapabilities;
 }
 
@@ -3942,6 +3944,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
                                                                                     VkResult result) {
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
     physical_device_state->surfaceCapabilities.minImageCount = pSurfaceCapabilities->minImageCount;
     physical_device_state->surfaceCapabilities.maxImageCount = pSurfaceCapabilities->maxImageCount;
     physical_device_state->surfaceCapabilities.currentExtent = pSurfaceCapabilities->currentExtent;
@@ -4221,12 +4224,14 @@ void ValidationStateTracker::RecordGetPhysicalDeviceDisplayPlanePropertiesState(
     if (*pPropertyCount) {
         if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState < QUERY_COUNT) {
             physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = QUERY_COUNT;
+            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = true;
         }
         physical_device_state->display_plane_property_count = *pPropertyCount;
     }
     if (pProperties) {
         if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState < QUERY_DETAILS) {
             physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = QUERY_DETAILS;
+            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = true;
         }
     }
 }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3924,7 +3924,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesK
     if (VK_SUCCESS != result) return;
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
-    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called = true;
     physical_device_state->surfaceCapabilities = *pSurfaceCapabilities;
 }
 
@@ -3934,7 +3934,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
     if (VK_SUCCESS != result) return;
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
-    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called = true;
     physical_device_state->surfaceCapabilities = pSurfaceCapabilities->surfaceCapabilities;
 }
 
@@ -3944,7 +3944,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
                                                                                     VkResult result) {
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
-    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = true;
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called = true;
     physical_device_state->surfaceCapabilities.minImageCount = pSurfaceCapabilities->minImageCount;
     physical_device_state->surfaceCapabilities.maxImageCount = pSurfaceCapabilities->maxImageCount;
     physical_device_state->surfaceCapabilities.currentExtent = pSurfaceCapabilities->currentExtent;
@@ -4224,14 +4224,14 @@ void ValidationStateTracker::RecordGetPhysicalDeviceDisplayPlanePropertiesState(
     if (*pPropertyCount) {
         if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState < QUERY_COUNT) {
             physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = QUERY_COUNT;
-            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = true;
+            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called = true;
         }
         physical_device_state->display_plane_property_count = *pPropertyCount;
     }
     if (pProperties) {
         if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState < QUERY_DETAILS) {
             physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = QUERY_DETAILS;
-            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = true;
+            physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called = true;
         }
     }
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -104,11 +104,11 @@ struct PHYSICAL_DEVICE_STATE {
     CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = UNCALLED;
-    bool vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = false;
+    bool vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called = false;
     CALL_STATE vkGetPhysicalDeviceSurfacePresentModesKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceFormatsKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = UNCALLED;
-    bool vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = false;
+    bool vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called = false;
     safe_VkPhysicalDeviceFeatures2 features2 = {};
     VkPhysicalDevice phys_device = VK_NULL_HANDLE;
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -104,9 +104,11 @@ struct PHYSICAL_DEVICE_STATE {
     CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = UNCALLED;
+    bool vkGetPhysicalDeviceSurfaceCapabilitiesKHRCalled = false;
     CALL_STATE vkGetPhysicalDeviceSurfacePresentModesKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceFormatsKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = UNCALLED;
+    bool vkGetPhysicalDeviceDisplayPlanePropertiesKHRCalled = false;
     safe_VkPhysicalDeviceFeatures2 features2 = {};
     VkPhysicalDevice phys_device = VK_NULL_HANDLE;
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported


### PR DESCRIPTION
Remove CALLSTATE usages everywhere except in Best Practices and State Tracker. This will enable me to move the CALLSTATE tracking fully into BP layer in a future PR.

Also migrated one warning from Core to BP.