### PR TITLE
std::shared_ptr<DEVICE_MEMORY_STATE> and reduce command buffer's binding record

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -314,7 +314,7 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory mem, const VulkanTypedHand
         }
         const DEVICE_MEMORY_STATE *mem_info = ValidationStateTracker::GetDevMemState(mem);
         if (mem_info) {
-            const DEVICE_MEMORY_STATE *prev_binding = ValidationStateTracker::GetDevMemState(mem_binding->binding.mem);
+            const DEVICE_MEMORY_STATE *prev_binding = mem_binding->binding.mem_state.get();
             if (prev_binding) {
                 const char *error_code = "VUID-vkBindImageMemory-image-01044";
                 if (typed_handle.type == kVulkanObjectTypeBuffer) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -84,6 +84,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateRenderPassCompatibility(const char* type1_string, const RENDER_PASS_STATE* rp1_state, const char* type2_string,
                                          const RENDER_PASS_STATE* rp2_state, const char* caller, const char* error_code) const;
     bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE* cb_state, const char* call_source) const;
+    bool ReportInvalidCommandBufferRelatedObjs(const CMD_BUFFER_STATE* cb_state, const char* call_source) const;
     bool ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family, const char* err_code,
                                   const char* cmd_name, const char* queue_family_var_name) const;
     bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1527,6 +1527,11 @@ typedef std::map<QueryObject, QueryState> QueryMap;
 typedef std::map<QueryObjectPass, QueryState> QueryPassMap;
 typedef std::unordered_map<VkEvent, VkPipelineStageFlags> EventToStageMap;
 
+struct VulkanTypedHandleDestoryed {
+    VulkanTypedHandle handle;
+    bool destroyed;
+};
+
 // Cmd Buffer Wrapper Struct - TODO : This desperately needs its own class
 struct CMD_BUFFER_STATE : public BASE_NODE {
     VkCommandBuffer commandBuffer;
@@ -1572,7 +1577,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
     std::vector<VulkanTypedHandle> object_bindings;
-    std::vector<VulkanTypedHandle> broken_bindings;
+    std::vector<VulkanTypedHandleDestoryed> broken_bindings;
 
     QFOTransferBarrierSets<VkBufferMemoryBarrier> qfo_transfer_buffer_barriers;
     QFOTransferBarrierSets<VkImageMemoryBarrier> qfo_transfer_image_barriers;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -755,11 +755,11 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                         *error = error_str.str();
                         return false;
                     } else if (!buffer_node->sparse) {
-                        for (auto mem_binding : buffer_node->GetBoundMemory()) {
-                            if (!GetDevMemState(mem_binding)) {
+                        for (auto mem_state_binding : buffer_node->GetBoundMemoryState()) {
+                            if (!mem_state_binding) {
                                 std::stringstream error_str;
                                 error_str << "Descriptor in binding #" << binding << " index " << index << " uses buffer " << buffer
-                                          << " that references invalid memory " << mem_binding << ".";
+                                          << " that references invalid memory " << mem_state_binding->mem << ".";
                                 *error = error_str.str();
                                 return false;
                             }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -118,10 +118,9 @@ void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage 
     const VulkanTypedHandle obj_struct(image, kVulkanObjectTypeImage);
     InvalidateCommandBuffers(image_state->cb_bindings, obj_struct);
     // Clean up memory mapping, bindings and range references for image
-    for (auto mem_binding : image_state->GetBoundMemory()) {
-        auto mem_info = GetDevMemState(mem_binding);
-        if (mem_info) {
-            RemoveImageMemoryRange(image, mem_info);
+    for (auto mem_state_binding : image_state->GetBoundMemoryState()) {
+        if (mem_state_binding) {
+            RemoveImageMemoryRange(image, mem_state_binding);
         }
     }
     if (image_state->bind_swapchain) {
@@ -253,10 +252,9 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
     const VulkanTypedHandle obj_struct(buffer, kVulkanObjectTypeBuffer);
 
     InvalidateCommandBuffers(buffer_state->cb_bindings, obj_struct);
-    for (auto mem_binding : buffer_state->GetBoundMemory()) {
-        auto mem_info = GetDevMemState(mem_binding);
-        if (mem_info) {
-            RemoveBufferMemoryRange(buffer, mem_info);
+    for (auto mem_state_binding : buffer_state->GetBoundMemoryState()) {
+        if (mem_state_binding) {
+            RemoveBufferMemoryRange(buffer, mem_state_binding);
         }
     }
     ClearMemoryObjectBindings(obj_struct);
@@ -332,9 +330,8 @@ void ValidationStateTracker::AddAliasingImage(IMAGE_STATE *image_state) {
             bound_images = &swapchain_state->images[image_state->bind_swapchain_imageIndex].bound_images;
         }
     } else {
-        auto mem_state = GetDevMemState(image_state->binding.mem);
-        if (mem_state) {
-            bound_images = &mem_state->bound_images;
+        if (image_state->binding.mem_state) {
+            bound_images = &image_state->binding.mem_state->bound_images;
         }
     }
 
@@ -490,12 +487,12 @@ void ValidationStateTracker::AddCommandBufferBindingImage(CMD_BUFFER_STATE *cb_n
         if (AddCommandBufferBinding(image_state->cb_bindings,
                                     VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage, image_state), cb_node)) {
             // Now update CB binding in MemObj mini CB list
-            for (auto mem_binding : image_state->GetBoundMemory()) {
-                DEVICE_MEMORY_STATE *pMemInfo = GetDevMemState(mem_binding);
-                if (pMemInfo) {
+            for (auto mem_state_binding : image_state->GetBoundMemoryState()) {
+                if (mem_state_binding) {
                     // Now update CBInfo's Mem reference list
-                    AddCommandBufferBinding(pMemInfo->cb_bindings,
-                                            VulkanTypedHandle(mem_binding, kVulkanObjectTypeDeviceMemory, pMemInfo), cb_node);
+                    AddCommandBufferBinding(
+                        mem_state_binding->cb_bindings,
+                        VulkanTypedHandle(mem_state_binding->mem, kVulkanObjectTypeDeviceMemory, mem_state_binding), cb_node);
                 }
             }
         }
@@ -528,12 +525,12 @@ void ValidationStateTracker::AddCommandBufferBindingBuffer(CMD_BUFFER_STATE *cb_
     if (AddCommandBufferBinding(buffer_state->cb_bindings,
                                 VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer, buffer_state), cb_node)) {
         // Now update CB binding in MemObj mini CB list
-        for (auto mem_binding : buffer_state->GetBoundMemory()) {
-            DEVICE_MEMORY_STATE *pMemInfo = GetDevMemState(mem_binding);
-            if (pMemInfo) {
+        for (auto mem_state_binding : buffer_state->GetBoundMemoryState()) {
+            if (mem_state_binding) {
                 // Now update CBInfo's Mem reference list
-                AddCommandBufferBinding(pMemInfo->cb_bindings,
-                                        VulkanTypedHandle(mem_binding, kVulkanObjectTypeDeviceMemory, pMemInfo), cb_node);
+                AddCommandBufferBinding(mem_state_binding->cb_bindings,
+                                        VulkanTypedHandle(mem_state_binding->mem, kVulkanObjectTypeDeviceMemory, mem_state_binding),
+                                        cb_node);
             }
         }
     }
@@ -565,12 +562,12 @@ void ValidationStateTracker::AddCommandBufferBindingAccelerationStructure(CMD_BU
             as_state->cb_bindings,
             VulkanTypedHandle(as_state->acceleration_structure, kVulkanObjectTypeAccelerationStructureNV, as_state), cb_node)) {
         // Now update CB binding in MemObj mini CB list
-        for (auto mem_binding : as_state->GetBoundMemory()) {
-            DEVICE_MEMORY_STATE *pMemInfo = GetDevMemState(mem_binding);
-            if (pMemInfo) {
+        for (auto mem_state_binding : as_state->GetBoundMemoryState()) {
+            if (mem_state_binding) {
                 // Now update CBInfo's Mem reference list
-                AddCommandBufferBinding(pMemInfo->cb_bindings,
-                                        VulkanTypedHandle(mem_binding, kVulkanObjectTypeDeviceMemory, pMemInfo), cb_node);
+                AddCommandBufferBinding(mem_state_binding->cb_bindings,
+                                        VulkanTypedHandle(mem_state_binding->mem, kVulkanObjectTypeDeviceMemory, mem_state_binding),
+                                        cb_node);
             }
         }
     }
@@ -607,14 +604,13 @@ void ValidationStateTracker::SetMemBinding(VkDeviceMemory mem, BINDABLE *mem_bin
                                            const VulkanTypedHandle &typed_handle) {
     assert(mem_binding);
     mem_binding->binding.mem = mem;
-    mem_binding->UpdateBoundMemorySet();  // force recreation of cached set
     mem_binding->binding.offset = memory_offset;
     mem_binding->binding.size = mem_binding->requirements.size;
 
     if (mem != VK_NULL_HANDLE) {
-        DEVICE_MEMORY_STATE *mem_info = GetDevMemState(mem);
-        if (mem_info) {
-            mem_info->obj_bindings.insert(typed_handle);
+        mem_binding->binding.mem_state = GetShared<DEVICE_MEMORY_STATE>(mem);
+        if (mem_binding->binding.mem_state) {
+            mem_binding->binding.mem_state->obj_bindings.insert(typed_handle);
             // For image objects, make sure default memory state is correctly set
             // TODO : What's the best/correct way to handle this?
             if (kVulkanObjectTypeImage == typed_handle.type) {
@@ -626,6 +622,7 @@ void ValidationStateTracker::SetMemBinding(VkDeviceMemory mem, BINDABLE *mem_bin
                     }
                 }
             }
+            mem_binding->UpdateBoundMemorySet();  // force recreation of cached set
         }
     }
 }
@@ -646,9 +643,9 @@ bool ValidationStateTracker::SetSparseMemBinding(MEM_BINDING binding, const Vulk
         assert(mem_binding);
         if (mem_binding) {  // Invalid handles are reported by object tracker, but Get returns NULL for them, so avoid SEGV here
             assert(mem_binding->sparse);
-            DEVICE_MEMORY_STATE *mem_info = GetDevMemState(binding.mem);
-            if (mem_info) {
-                mem_info->obj_bindings.insert(typed_handle);
+            binding.mem_state = GetShared<DEVICE_MEMORY_STATE>(binding.mem);
+            if (binding.mem_state) {
+                binding.mem_state->obj_bindings.insert(typed_handle);
                 // Need to set mem binding for this object
                 mem_binding->sparse_bindings.insert(binding);
                 mem_binding->UpdateBoundMemorySet();
@@ -1509,14 +1506,14 @@ void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32
         for (uint32_t j = 0; j < bindInfo.bufferBindCount; j++) {
             for (uint32_t k = 0; k < bindInfo.pBufferBinds[j].bindCount; k++) {
                 auto sparse_binding = bindInfo.pBufferBinds[j].pBinds[k];
-                SetSparseMemBinding({sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
+                SetSparseMemBinding({sparse_binding.memory, nullptr, sparse_binding.memoryOffset, sparse_binding.size},
                                     VulkanTypedHandle(bindInfo.pBufferBinds[j].buffer, kVulkanObjectTypeBuffer));
             }
         }
         for (uint32_t j = 0; j < bindInfo.imageOpaqueBindCount; j++) {
             for (uint32_t k = 0; k < bindInfo.pImageOpaqueBinds[j].bindCount; k++) {
                 auto sparse_binding = bindInfo.pImageOpaqueBinds[j].pBinds[k];
-                SetSparseMemBinding({sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size},
+                SetSparseMemBinding({sparse_binding.memory, nullptr, sparse_binding.memoryOffset, sparse_binding.size},
                                     VulkanTypedHandle(bindInfo.pImageOpaqueBinds[j].image, kVulkanObjectTypeImage));
             }
         }
@@ -1525,7 +1522,7 @@ void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32
                 auto sparse_binding = bindInfo.pImageBinds[j].pBinds[k];
                 // TODO: This size is broken for non-opaque bindings, need to update to comprehend full sparse binding data
                 VkDeviceSize size = sparse_binding.extent.depth * sparse_binding.extent.height * sparse_binding.extent.width * 4;
-                SetSparseMemBinding({sparse_binding.memory, sparse_binding.memoryOffset, size},
+                SetSparseMemBinding({sparse_binding.memory, nullptr, sparse_binding.memoryOffset, size},
                                     VulkanTypedHandle(bindInfo.pImageBinds[j].image, kVulkanObjectTypeImage));
             }
         }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -961,7 +961,7 @@ class ValidationStateTracker : public ValidationObject {
     void FreeCommandBufferStates(COMMAND_POOL_STATE* pool_state, const uint32_t command_buffer_count,
                                  const VkCommandBuffer* command_buffers);
     void FreeDescriptorSet(cvdescriptorset::DescriptorSet* descriptor_set);
-    BASE_NODE* GetStateStructPtrFromObject(const VulkanTypedHandle& object_struct);
+    BASE_NODE* GetStateStructPtrFromObject(const VulkanTypedHandle& object_struct) const;
     void IncrementBoundObjects(CMD_BUFFER_STATE const* cb_node);
     void IncrementResources(CMD_BUFFER_STATE* cb_node);
     void InsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, DEVICE_MEMORY_STATE* mem_info,
@@ -972,6 +972,7 @@ class ValidationStateTracker : public ValidationObject {
                                 VkMemoryRequirements mem_reqs, bool is_linear);
     void InsertMemoryRange(const VulkanTypedHandle& typed_handle, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize memoryOffset,
                            VkMemoryRequirements memRequirements, bool is_linear);
+    void AddRelatedObjInBrokenBindings(std::vector<VulkanTypedHandleDestoryed>& broken_bindings, const VulkanTypedHandle& obj);
     void InvalidateCommandBuffers(small_unordered_map<CMD_BUFFER_STATE*, int, 8>& cb_nodes, const VulkanTypedHandle& obj,
                                   bool unlink = true);
     void InvalidateLinkedCommandBuffers(std::unordered_set<CMD_BUFFER_STATE*>& cb_nodes, const VulkanTypedHandle& obj);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -6813,7 +6813,6 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroups) {
 TEST_F(VkLayerTest, PipelineStageConditionalRenderingWithWrongQueue) {
     TEST_DESCRIPTION("Run CmdPipelineBarrier with VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT and wrong VkQueueFlagBits");
     ASSERT_NO_FATAL_FAILURE(Init());
-    // m_device->m_queue = m_device->dma_queues()[0]->handle();
     uint32_t only_transfer_queueFamilyIndex = UINT32_MAX;
 
     const auto q_props = vk_testing::PhysicalDevice(gpu()).queue_properties();


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1001

1. Use std::shared_ptr<DEVICE_MEMORY_STATE> in memory's binding.

2. Don't record memory of buffer and image, buffer of bufferview, and image of imageview in command buffer's binding. ( BASE_NODE's cb_bindings and CMD_BUFFER_STATE's object_bindings )