### PR TITLE
Fix validation bugs with VK_KHR_separate_depth_stencil_layouts

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9017,8 +9017,9 @@ void CoreChecks::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer) {
 }
 
 void CoreChecks::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR *pSubpassEndInfo) {
-    StateTracker::PostCallRecordCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+    // Record the end at the CoreLevel to ensure StateTracker cleanup doesn't step on anything we need.
     RecordCmdEndRenderPassLayouts(commandBuffer);
+    StateTracker::PostCallRecordCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
 }
 
 bool CoreChecks::ValidateFramebuffer(VkCommandBuffer primaryBuffer, const CMD_BUFFER_STATE *pCB, VkCommandBuffer secondaryBuffer,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -473,7 +473,7 @@ class CoreChecks : public ValidationStateTracker {
 
     void SetGlobalLayout(ImageSubresourcePair imgpair, const VkImageLayout& layout);
 
-    void SetImageViewLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
+    void SetImageViewLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout, VkImageLayout layoutStencil);
     void SetImageViewInitialLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout);
 
     void SetImageInitialLayout(CMD_BUFFER_STATE* cb_node, VkImage image, const VkImageSubresourceRange& range,

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -894,10 +894,12 @@ class StatelessValidation : public ValidationObject {
         const char *vuid;
         const auto *separate_depth_stencil_layouts_features =
             lvl_find_in_chain<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>(physical_device_features2.pNext);
-        const auto *attachment_description_stencil_layout =
-            lvl_find_in_chain<VkAttachmentDescriptionStencilLayoutKHR>(pCreateInfo->pNext);
 
         for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
+            const auto *attachment_description_stencil_layout = (use_rp2) ?
+                lvl_find_in_chain<VkAttachmentDescriptionStencilLayoutKHR>(reinterpret_cast<VkAttachmentDescription2KHR const *>(&pCreateInfo->pAttachments[i])->pNext) :
+                0;
+
             if (pCreateInfo->pAttachments[i].format == VK_FORMAT_UNDEFINED) {
                 std::stringstream ss;
                 ss << (use_rp2 ? "vkCreateRenderPass2KHR" : "vkCreateRenderPass") << ": pCreateInfo->pAttachments[" << i

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -2076,7 +2076,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
             attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
             safe_VkRenderPassCreateInfo2KHR rpci2;
             ConvertVkRenderPassCreateInfoToV2KHR(rpci, &rpci2);
-            rpci2.pNext = &attachment_description_stencil_layout;
+            rpci2.pAttachments[0].pNext = &attachment_description_stencil_layout;
 
             VkImageLayout forbidden_layouts[] = {
                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
@@ -2107,7 +2107,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
             TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
                                      "VUID-VkAttachmentDescriptionStencilLayoutKHR-stencilFinalLayout-03310");
 
-            rpci2.pNext = nullptr;
+            rpci2.pAttachments[0].pNext = nullptr;
         }
     } else {
         if (depth_format) {


### PR DESCRIPTION
There were several bugs:

1) The internal image layout state tracking was not using the extension
to track the layout of the depth aspect and stencil aspect separately.

2) The PostCallRecordCmdEndRenderPass2KHR() routine was wiping out
the command buffer state before validation finished using it. This
was already fixed in the PostCallRecordCmdEndRenderPass() routine
above.

3) Validation for VkAttachmentDescriptionStencilLayoutKHR was
using the wrong pNext to find the extension structure.

Fixes #1381