### PR TITLE
Invalid error message during calling vkCmdPipelineBarrier

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6692,10 +6692,12 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer
     assert(cb_state);
 
     bool skip = false;
-    auto barrier_op_type = ComputeBarrierOperationsType(cb_state, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                                        imageMemoryBarrierCount, pImageMemoryBarriers);
-    skip |= ValidateStageMasksAgainstQueueCapabilities(cb_state, srcStageMask, dstStageMask, barrier_op_type,
-                                                       "vkCmdPipelineBarrier", "VUID-vkCmdPipelineBarrier-srcStageMask-01183");
+    if (bufferMemoryBarrierCount || imageMemoryBarrierCount) {
+        auto barrier_op_type = ComputeBarrierOperationsType(cb_state, bufferMemoryBarrierCount, pBufferMemoryBarriers,
+                                                            imageMemoryBarrierCount, pImageMemoryBarriers);
+        skip |= ValidateStageMasksAgainstQueueCapabilities(cb_state, srcStageMask, dstStageMask, barrier_op_type,
+                                                           "vkCmdPipelineBarrier", "VUID-vkCmdPipelineBarrier-srcStageMask-01183");
+    }
     skip |= ValidateCmdQueueFlags(cb_state, "vkCmdPipelineBarrier()",
                                   VK_QUEUE_TRANSFER_BIT | VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
                                   "VUID-vkCmdPipelineBarrier-commandBuffer-cmdpool");


### PR DESCRIPTION
Accroding specification https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdPipelineBarrier.html
We can call vkCmdPipelineBarrier with zero value for bufferMemoryBarrierCount  and imageMemoryBarrierCount.

In this case we shouldn't validate Stage's Masks for Queue's  Capabilities, because in this case we will try to validate ComputeBarrierOperations for BarrierOperationsType::kGeneral with invalid srcStageMask and dstStageMask for non-existent VkImage's list or VkBuffer's list.

See please: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/4fde9b75099271ded2de6d1a5903cb57a0e93931/layers/core_validation.cpp#L6570,
https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/4fde9b75099271ded2de6d1a5903cb57a0e93931/layers/core_validation.cpp#L6592
and https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/4fde9b75099271ded2de6d1a5903cb57a0e93931/layers/core_validation.cpp#L6540