### PR TITLE
include cassert in vk_extension_helper.h

### DIFF
--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -38,6 +38,7 @@
 #include <utility>
 #include <set>
 #include <vector>
+#include <cassert>
 
 #include <vulkan/vulkan.h>
 

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -548,6 +548,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             '#include <utility>',
             '#include <set>',
             '#include <vector>',
+            '#include <cassert>',
             '',
             '#include <vulkan/vulkan.h>',
             '',


### PR DESCRIPTION
`vk_extension_helper.h` needs `cassert` to compile and it is annoying to have to include it manually before including the file.