### PR TITLE
Remove default initialized push constant ranges

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2318,7 +2318,8 @@ PushConstantRangesId GetCanonicalId(const VkPipelineLayoutCreateInfo *info) {
         sorted.insert(info->pPushConstantRanges + i);
     }
 
-    PushConstantRanges ranges(sorted.size());
+    PushConstantRanges ranges;
+    ranges.reserve(sorted.size());
     for (const auto range : sorted) {
         ranges.emplace_back(*range);
     }


### PR DESCRIPTION
This was creating twice the expected number of push constant ranges.

Change-Id: I539dfa6c957a004e6d5f9e500b0747fc66015b8e