### PR TITLE
std::shared_ptr<DEVICE_MEMORY_STATE> and reduce command buffer's binding record

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -314,7 +314,7 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory mem, const VulkanTypedHand
         }
         const DEVICE_MEMORY_STATE *mem_info = ValidationStateTracker::GetDevMemState(mem);
         if (mem_info) {
-            const DEVICE_MEMORY_STATE *prev_binding = ValidationStateTracker::GetDevMemState(mem_binding->binding.mem);
+            const DEVICE_MEMORY_STATE *prev_binding = mem_binding->binding.mem_state.get();
             if (prev_binding) {
                 const char *error_code = "VUID-vkBindImageMemory-image-01044";
                 if (typed_handle.type == kVulkanObjectTypeBuffer) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -279,6 +279,7 @@ class BUFFER_STATE : public BINDABLE {
     VkBuffer buffer;
     VkBufferCreateInfo createInfo;
     VkDeviceAddress deviceAddress;
+    std::vector<VkBufferView> bufferviews;
 
     BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo) : buffer(buff), createInfo(*pCreateInfo) {
         if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
@@ -348,6 +349,7 @@ class IMAGE_STATE : public BINDABLE {
     VkSwapchainKHR create_from_swapchain;
     VkSwapchainKHR bind_swapchain;
     uint32_t bind_swapchain_imageIndex;
+    std::vector<VkImageView> imageviews;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     uint64_t external_format_android;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -755,11 +755,11 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                         *error = error_str.str();
                         return false;
                     } else if (!buffer_node->sparse) {
-                        for (auto mem_binding : buffer_node->GetBoundMemory()) {
-                            if (!GetDevMemState(mem_binding)) {
+                        for (auto mem_state_binding : buffer_node->GetBoundMemoryState()) {
+                            if (!mem_state_binding) {
                                 std::stringstream error_str;
                                 error_str << "Descriptor in binding #" << binding << " index " << index << " uses buffer " << buffer
-                                          << " that references invalid memory " << mem_binding << ".";
+                                          << " that references invalid memory " << mem_state_binding->mem << ".";
                                 *error = error_str.str();
                                 return false;
                             }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -213,6 +213,7 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
     if (result != VK_SUCCESS) return;
     auto buffer_state = GetBufferShared(pCreateInfo->buffer);
     bufferViewMap[*pView] = std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo);
+    buffer_state->bufferviews.emplace_back(*pView);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
@@ -221,6 +222,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
     if (result != VK_SUCCESS) return;
     auto image_state = GetImageShared(pCreateInfo->image);
     imageViewMap[*pView] = std::make_shared<IMAGE_VIEW_STATE>(image_state, *pView, pCreateInfo);
+    image_state->imageviews.emplace_back(*pView);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -6813,7 +6813,6 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroups) {
 TEST_F(VkLayerTest, PipelineStageConditionalRenderingWithWrongQueue) {
     TEST_DESCRIPTION("Run CmdPipelineBarrier with VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT and wrong VkQueueFlagBits");
     ASSERT_NO_FATAL_FAILURE(Init());
-    // m_device->m_queue = m_device->dma_queues()[0]->handle();
     uint32_t only_transfer_queueFamilyIndex = UINT32_MAX;
 
     const auto q_props = vk_testing::PhysicalDevice(gpu()).queue_properties();


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1001

`
“Shallow” binding and tracking of resources at command record time
Currently if a VkImageView (or VkBufferView) is referenced by a command buffer, we also add cross references and in_use updates for all related objects such as VkImage (or VkBuffer) and VkMemory). If instead VkImageView, VkBufferView were updated, the operations that check for references of the related objects (VkImage, VkBuffer, VkMemory) would be able to determine their state (at reset or queue submit validation time) by traversing references to the orginal objects. As this will typically be less frequent than draw command recording, and only apply to validation operations, this should reduce overall bookkeeping overhead.
`
`

1. Use std::shared_ptr<DEVICE_MEMORY_STATE> in memory's binding.

2. Don't record memory of buffer and image, buffer of bufferview, and image of imageview in command buffer's binding. ( BASE_NODE's cb_bindings and CMD_BUFFER_STATE's object_bindings )