### PR TITLE
Fixed overly aggressive object lifetimes DescriptorUpdateTemplate validation

### DIFF
--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -2248,32 +2248,6 @@ void ObjectLifetimes::PreCallRecordDestroySamplerYcbcrConversion(
 
 }
 
-bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplate(
-    VkDevice                                    device,
-    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) const {
-    bool skip = false;
-    skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
-    if (pCreateInfo) {
-        skip |= ValidateObject(pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, true, kVUIDUndefined, "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
-        skip |= ValidateObject(pCreateInfo->pipelineLayout, kVulkanObjectTypePipelineLayout, true, kVUIDUndefined, "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
-    }
-
-    return skip;
-}
-
-void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplate(
-    VkDevice                                    device,
-    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate,
-    VkResult                                    result) {
-    if (result != VK_SUCCESS) return;
-    CreateObject(*pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator);
-
-}
-
 bool ObjectLifetimes::PreCallValidateDestroyDescriptorUpdateTemplate(
     VkDevice                                    device,
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
@@ -3080,32 +3054,6 @@ bool ObjectLifetimes::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(
     skip |= ValidateObject(layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdPushDescriptorSetWithTemplateKHR-layout-parameter", "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commonparent");
 
     return skip;
-}
-
-bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplateKHR(
-    VkDevice                                    device,
-    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) const {
-    bool skip = false;
-    skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorUpdateTemplate-device-parameter", kVUIDUndefined);
-    if (pCreateInfo) {
-        skip |= ValidateObject(pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, true, kVUIDUndefined, "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
-        skip |= ValidateObject(pCreateInfo->pipelineLayout, kVulkanObjectTypePipelineLayout, true, kVUIDUndefined, "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
-    }
-
-    return skip;
-}
-
-void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplateKHR(
-    VkDevice                                    device,
-    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate,
-    VkResult                                    result) {
-    if (result != VK_SUCCESS) return;
-    CreateObject(*pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator);
-
 }
 
 bool ObjectLifetimes::PreCallValidateDestroyDescriptorUpdateTemplateKHR(

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -940,3 +940,49 @@ bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device,
 
     return skip;
 }
+
+bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device,
+                                                                    const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
+                                                                    const VkAllocationCallbacks *pAllocator,
+                                                                    VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) const {
+    bool skip = false;
+    skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateDescriptorUpdateTemplate-device-parameter",
+                           kVUIDUndefined);
+    if (pCreateInfo) {
+        if (pCreateInfo->templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET) {
+            skip |= ValidateObject(pCreateInfo->descriptorSetLayout, kVulkanObjectTypeDescriptorSetLayout, false,
+                                   "VUID-VkDescriptorUpdateTemplateCreateInfo-templateType-00350",
+                                   "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
+        }
+        if (pCreateInfo->templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR) {
+            skip |= ValidateObject(pCreateInfo->pipelineLayout, kVulkanObjectTypePipelineLayout, false,
+                                   "VUID-VkDescriptorUpdateTemplateCreateInfo-templateType-00352",
+                                   "VUID-VkDescriptorUpdateTemplateCreateInfo-commonparent");
+        }
+    }
+
+    return skip;
+}
+
+bool ObjectLifetimes::PreCallValidateCreateDescriptorUpdateTemplateKHR(
+    VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
+    VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) const {
+    return PreCallValidateCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+}
+
+void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
+                                                                   const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
+                                                                   const VkAllocationCallbacks *pAllocator,
+                                                                   VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
+                                                                   VkResult result) {
+    if (result != VK_SUCCESS) return;
+    CreateObject(*pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator);
+}
+
+void ObjectLifetimes::PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device,
+                                                                      const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
+                                                                      const VkAllocationCallbacks *pAllocator,
+                                                                      VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
+                                                                      VkResult result) {
+    return PostCallRecordCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, result);
+}

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -167,6 +167,9 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             'vkCreateFramebuffer',
             'vkSetDebugUtilsObjectNameEXT',
             'vkSetDebugUtilsObjectTagEXT',
+            'vkCreateDescriptorUpdateTemplate',
+            'vkCreateDescriptorUpdateTemplateKHR',
+
             ]
         # These VUIDS are not implicit, but are best handled in this layer. Codegen for vkDestroy calls will generate a key
         # which is translated here into a good VU.  Saves ~40 checks.


### PR DESCRIPTION
A couple of parameters must only be checked if specific templateType flags are set.  Added a couple of new VUs and new test cases.


Fixes #1431.