### PR TITLE
Check vertexStride parameter in CmdDrawIndirectByteCount API

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -8194,6 +8194,7 @@ bool StatelessValidation::PreCallValidateCmdDrawIndirectByteCountEXT(
     if (!device_extensions.vk_khr_get_physical_device_properties_2) skip |= OutputExtensionError("vkCmdDrawIndirectByteCountEXT", VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     if (!device_extensions.vk_ext_transform_feedback) skip |= OutputExtensionError("vkCmdDrawIndirectByteCountEXT", VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     skip |= validate_required_handle("vkCmdDrawIndirectByteCountEXT", "counterBuffer", counterBuffer);
+    if (!skip) skip |= manual_PreCallValidateCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
     return skip;
 }
 

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -103,6 +103,7 @@ class StatelessValidation : public ValidationObject {
         VkPhysicalDeviceShadingRateImagePropertiesNV shading_rate_image_props;
         VkPhysicalDeviceMeshShaderPropertiesNV mesh_shader_props;
         VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_props;
+        VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
 
@@ -1375,6 +1376,11 @@ class StatelessValidation : public ValidationObject {
 
     bool manual_PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                     uint32_t *pImageIndex) const;
+
+    bool manual_PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
+                                                           uint32_t firstInstance, VkBuffer counterBuffer,
+                                                           VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                           uint32_t vertexStride) const;
 
 #include "parameter_validation.h"
 };  // Class StatelessValidation

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -185,6 +185,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetViewportWScalingNV',
             'vkAcquireNextImageKHR',
             'vkAcquireNextImage2KHR',
+            'vkCmdDrawIndirectByteCountEXT',
             ]
 
         # Commands to ignore


### PR DESCRIPTION
Added a check to stateless validation, and a test.

Fixes #1446.