### PR TITLE
Fix crash in BP when freeing null handle

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,6 +256,7 @@ void BestPractices::PostCallRecordAllocateMemory(VkDevice device, const VkMemory
 
 bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory,
                                               const VkAllocationCallbacks* pAllocator) const {
+    if (memory == VK_NULL_HANDLE) return false;
     bool skip = false;
 
     const DEVICE_MEMORY_STATE* mem_info = ValidationStateTracker::GetDevMemState(memory);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
- * Copyright (c) 2015-2019 Google, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2020 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,4 +96,97 @@ TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
+}
+
+// This is a positive test. No failures are expected.
+TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
+    VkResult err;
+
+    TEST_DESCRIPTION("Call all applicable destroy and free routines with NULL handles, expecting no validation errors");
+
+
+    InitBestPracticesFramework();
+    InitState();
+
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    m_errorMonitor->ExpectSuccess();
+
+    vk::DestroyBuffer(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyBufferView(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyCommandPool(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyDevice(VK_NULL_HANDLE, NULL);
+    vk::DestroyEvent(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyFramebuffer(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyImage(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyImageView(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyInstance(VK_NULL_HANDLE, NULL);
+    vk::DestroyPipeline(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyPipelineCache(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyPipelineLayout(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyQueryPool(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyRenderPass(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroySampler(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroySemaphore(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyShaderModule(m_device->device(), VK_NULL_HANDLE, NULL);
+
+    VkCommandPool command_pool;
+    VkCommandPoolCreateInfo pool_create_info{};
+    pool_create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
+    pool_create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    vk::CreateCommandPool(m_device->device(), &pool_create_info, nullptr, &command_pool);
+    VkCommandBuffer command_buffers[3] = {};
+    VkCommandBufferAllocateInfo command_buffer_allocate_info{};
+    command_buffer_allocate_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    command_buffer_allocate_info.commandPool = command_pool;
+    command_buffer_allocate_info.commandBufferCount = 1;
+    command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    vk::AllocateCommandBuffers(m_device->device(), &command_buffer_allocate_info, &command_buffers[1]);
+    vk::FreeCommandBuffers(m_device->device(), command_pool, 3, command_buffers);
+    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+
+    VkDescriptorPoolSize ds_type_count = {};
+    ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+    ds_type_count.descriptorCount = 1;
+
+    VkDescriptorPoolCreateInfo ds_pool_ci = {};
+    ds_pool_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    ds_pool_ci.pNext = NULL;
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    VkDescriptorPool ds_pool;
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    ASSERT_VK_SUCCESS(err);
+
+    VkDescriptorSetLayoutBinding dsl_binding = {};
+    dsl_binding.binding = 2;
+    dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+    dsl_binding.descriptorCount = 1;
+    dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    dsl_binding.pImmutableSamplers = NULL;
+
+    const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
+
+    VkDescriptorSet descriptor_sets[3] = {};
+    VkDescriptorSetAllocateInfo alloc_info = {};
+    alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    alloc_info.descriptorSetCount = 1;
+    alloc_info.descriptorPool = ds_pool;
+    alloc_info.pSetLayouts = &ds_layout.handle();
+    err = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_sets[1]);
+    ASSERT_VK_SUCCESS(err);
+    vk::FreeDescriptorSets(m_device->device(), ds_pool, 3, descriptor_sets);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+
+    vk::FreeMemory(m_device->device(), VK_NULL_HANDLE, NULL);
+
+    m_errorMonitor->VerifyNotFound();
 }


### PR DESCRIPTION
The BP validate routine was querying devicememory state even when a null handle was passed in.  Added the same protection as was in the record step, along with a passel of destroy-null-handle tests.

Fixes #1478.