### PR TITLE
Simplify Error Logging in Validation Layers

### DIFF
--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2619,7 +2619,7 @@ class ValidationObject {
         template <typename HANDLE_T>
         bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
 
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
@@ -2639,7 +2639,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
@@ -2659,7 +2659,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogPerformanceWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
@@ -2679,7 +2679,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogInfo(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2615,6 +2615,88 @@ class ValidationObject {
             return nullptr;
         };
 
+        // Debug Logging Templates
+        template <typename HANDLE_T>
+        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogPerformanceWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogInfo(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
         // Handle Wrapping Data
         // Reverse map display handles
         vl_concurrent_unordered_map<VkDisplayKHR, uint64_t, 0> display_id_reverse_mapping;

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,11 +179,11 @@ typedef struct _debug_report_data {
     std::unordered_map<VkCommandBuffer, std::unique_ptr<LoggingLabelState>> debugUtilsCmdBufLabels;
     // This mutex is defined as mutable since the normal usage for a debug report object is as 'const'. The mutable keyword allows
     // the layers to continue this pattern, but also allows them to use/change this specific member for synchronization purposes.
-    mutable std::mutex debug_report_mutex;
+    mutable std::mutex debug_output_mutex;
     const void *instance_pnext_chain{};
 
     void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
-        std::unique_lock<std::mutex> lock(debug_report_mutex);
+        std::unique_lock<std::mutex> lock(debug_output_mutex);
         if (pNameInfo->pObjectName) {
             debugUtilsObjectNameMap[pNameInfo->objectHandle] = pNameInfo->pObjectName;
         } else {
@@ -192,7 +192,7 @@ typedef struct _debug_report_data {
     }
 
     void DebugReportSetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-        std::unique_lock<std::mutex> lock(debug_report_mutex);
+        std::unique_lock<std::mutex> lock(debug_output_mutex);
         if (pNameInfo->pObjectName) {
             debugObjectNameMap[pNameInfo->object] = pNameInfo->pObjectName;
         } else {
@@ -447,7 +447,7 @@ static inline void DebugAnnotFlagsToReportFlags(VkDebugUtilsMessageSeverityFlagB
 
 static inline void layer_debug_utils_destroy_instance(debug_report_data *debug_data) {
     if (debug_data) {
-        std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
+        std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
         RemoveAllMessageCallbacks(debug_data, debug_data->debug_callback_list);
         lock.unlock();
         delete (debug_data);
@@ -456,7 +456,7 @@ static inline void layer_debug_utils_destroy_instance(debug_report_data *debug_d
 
 template <typename T>
 static inline void layer_destroy_callback(debug_report_data *debug_data, T callback, const VkAllocationCallbacks *allocator) {
-    std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
     RemoveDebugUtilsCallback(debug_data, debug_data->debug_callback_list, CastToUint64(callback));
 }
 
@@ -464,7 +464,7 @@ template <typename TCreateInfo, typename TCallback>
 static inline void layer_create_callback(DebugCallbackStatusFlags callback_status, debug_report_data *debug_data,
                                          const TCreateInfo *create_info, const VkAllocationCallbacks *allocator,
                                          TCallback *callback) {
-    std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
 
     debug_data->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
     auto &callback_state = debug_data->debug_callback_list.back();
@@ -588,7 +588,7 @@ static inline int vasprintf(char **strp, char const *fmt, va_list ap) {
 }
 #endif
 
-// This must be called with the debug_report_mutex already held
+// This must be called with the debug_output_mutex already held
 static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg_flags, VkDebugReportObjectTypeEXT object_type,
                                 uint64_t src_object, const std::string &vuid_text, char *err_msg) {
     std::string str_plus_spec_text(err_msg ? err_msg : "Allocation failure");
@@ -635,7 +635,7 @@ static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flag
 static inline bool log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkDebugReportObjectTypeEXT object_type,
                            uint64_t src_object, const std::string &vuid_text, const char *format, ...) {
     if (!debug_data) return false;
-    std::unique_lock<std::mutex> lock(debug_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
     VkFlags local_severity = 0;
     VkFlags local_type = 0;
     DebugReportFlagsToAnnotFlags(msg_flags, true, &local_severity, &local_type);
@@ -803,7 +803,7 @@ static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type 
 
 static inline void BeginQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue,
                                              const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
         auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ true);
         assert(label_state);
@@ -815,7 +815,7 @@ static inline void BeginQueueDebugUtilsLabel(debug_report_data *report_data, VkQ
 }
 
 static inline void EndQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ false);
     if (label_state) {
         // Pop the normal item
@@ -830,7 +830,7 @@ static inline void EndQueueDebugUtilsLabel(debug_report_data *report_data, VkQue
 
 static inline void InsertQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue,
                                               const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ true);
 
     // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
@@ -839,7 +839,7 @@ static inline void InsertQueueDebugUtilsLabel(debug_report_data *report_data, Vk
 
 static inline void BeginCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer,
                                            const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
         auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ true);
         assert(label_state);
@@ -851,7 +851,7 @@ static inline void BeginCmdDebugUtilsLabel(debug_report_data *report_data, VkCom
 }
 
 static inline void EndCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ false);
     if (label_state) {
         // Pop the normal item
@@ -866,7 +866,7 @@ static inline void EndCmdDebugUtilsLabel(debug_report_data *report_data, VkComma
 
 static inline void InsertCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer,
                                             const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ true);
     assert(label_state);
 
@@ -876,7 +876,7 @@ static inline void InsertCmdDebugUtilsLabel(debug_report_data *report_data, VkCo
 
 // Current tracking beyond a single command buffer scope is incorrect, and even when it is we need to be able to clean up
 static inline void ResetCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
-    std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ false);
     if (label_state) {
         label_state->labels.clear();

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -364,6 +364,88 @@ class ValidationObject {
             return nullptr;
         };
 
+        // Debug Logging Templates
+        template <typename HANDLE_T>
+        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogPerformanceWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
+        template <typename HANDLE_T>
+        bool LogInfo(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+
+            return LogMsgLocked(report_data, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VkHandleInfo<HANDLE_T>::kDebugReportObjectType,
+                HandleToUint64(src_object), vuid_text, str);
+        };
+
         // Handle Wrapping Data
         // Reverse map display handles
         vl_concurrent_unordered_map<VkDisplayKHR, uint64_t, 0> display_id_reverse_mapping;

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -368,7 +368,7 @@ class ValidationObject {
         template <typename HANDLE_T>
         bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
 
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
@@ -388,7 +388,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
@@ -408,7 +408,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogPerformanceWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
@@ -428,7 +428,7 @@ class ValidationObject {
 
         template <typename HANDLE_T>
         bool LogInfo(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_report_mutex);
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
                 !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
- * Copyright (c) 2015-2019 Google, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2020 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,8 +226,7 @@ VkRenderFramework::VkRenderFramework()
       m_depthStencil(NULL),
       m_CreateDebugReportCallback(VK_NULL_HANDLE),
       m_DestroyDebugReportCallback(VK_NULL_HANDLE),
-      m_globalMsgCallback(VK_NULL_HANDLE),
-      m_devMsgCallback(VK_NULL_HANDLE) {
+      m_globalMsgCallback(VK_NULL_HANDLE) {
     memset(&m_renderPassBeginInfo, 0, sizeof(m_renderPassBeginInfo));
     m_renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
 
@@ -448,9 +447,6 @@ void VkRenderFramework::InitFramework(PFN_vkDebugReportCallbackEXT dbgFunction, 
                 (PFN_vkDestroyDebugReportCallbackEXT)vk::GetInstanceProcAddr(this->inst, "vkDestroyDebugReportCallbackEXT");
             ASSERT_NE(m_DestroyDebugReportCallback, (PFN_vkDestroyDebugReportCallbackEXT)NULL)
                 << "Did not get function pointer for DestroyDebugReportCallback";
-            m_DebugReportMessage = (PFN_vkDebugReportMessageEXT)vk::GetInstanceProcAddr(this->inst, "vkDebugReportMessageEXT");
-            ASSERT_NE(m_DebugReportMessage, (PFN_vkDebugReportMessageEXT)NULL)
-                << "Did not get function pointer for DebugReportMessage";
         }
     }
 }
@@ -470,8 +466,6 @@ void VkRenderFramework::ShutdownFramework() {
 
     if (m_globalMsgCallback) m_DestroyDebugReportCallback(this->inst, m_globalMsgCallback, NULL);
     m_globalMsgCallback = VK_NULL_HANDLE;
-    if (m_devMsgCallback) m_DestroyDebugReportCallback(this->inst, m_devMsgCallback, NULL);
-    m_devMsgCallback = VK_NULL_HANDLE;
 
     m_renderTargets.clear();
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,9 +246,7 @@ class VkRenderFramework : public VkTestFramework {
     VkDepthStencilObj *m_depthStencil;
     PFN_vkCreateDebugReportCallbackEXT m_CreateDebugReportCallback;
     PFN_vkDestroyDebugReportCallbackEXT m_DestroyDebugReportCallback;
-    PFN_vkDebugReportMessageEXT m_DebugReportMessage;
     VkDebugReportCallbackEXT m_globalMsgCallback;
-    VkDebugReportCallbackEXT m_devMsgCallback;
 
     std::vector<const char *> m_instance_layer_names;
     std::vector<const char *> m_instance_extension_names;


### PR DESCRIPTION
Add local logging functions to the base validation object.  
```
    LogError(VkHandle, VUID, FormatString, ...)
    LogWarning(VkHandle, VUID, FormatString, ...)
    LogPerformanceWarning(VkHandle, VUID, FormatString, ...)
    LogInformation(VkHandle, VUID, FormatString, ...)
```

This eliminates the need to supply `DebugReportData *`, `DebugReportFlagsBitEXT` enum, and `DebugReportObjectType` for each logging call.  

Follow-on PRs will replace log_msg() calls in the Khronos layer with these new functions.  This will in turn reduce dependencies tying the the log_msg() and layer validation tests ErrorMonitor() to the deprecated DebugReport extension.


Here are a couple of examples illustrating the simplifications:

```
@@ -1788,17 +1781,15 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t write_count, const VkWrit
         auto dest_set = p_wds[i].dstSet;
         auto set_node = GetSetNode(dest_set);
         if (!set_node) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT,
-                            HandleToUint64(dest_set), kVUID_Core_DrawState_InvalidDescriptorSet,
-                            "Cannot call %s on %s that has not been allocated.", func_name,
-                            report_data->FormatHandle(dest_set).c_str());
+            skip |=
+                LogError(dest_set, kVUID_Core_DrawState_InvalidDescriptorSet, "Cannot call %s on %s that has not been allocated.",
+                         func_name, report_data->FormatHandle(dest_set).c_str());
         } else {
             std::string error_code;
             std::string error_str;
             if (!ValidateWriteUpdate(set_node, &p_wds[i], func_name, &error_code, &error_str)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT,
-                                HandleToUint64(dest_set), error_code, "%s failed write update validation for %s with error: %s.",
-                                func_name, report_data->FormatHandle(dest_set).c_str(), error_str.c_str());
+                skip |= LogError(dest_set, error_code, "%s failed write update validation for %s with error: %s.", func_name,
+                                 report_data->FormatHandle(dest_set).c_str(), error_str.c_str());
             }
         }
     }
```

```
@@ -791,15 +764,13 @@ class StatelessValidation : public ValidationObject {
                     // Current XML registry logic for validity generation uses the array parameter's optional tag to determine if
                     // elements in the array are allowed be 0
                     if (array_required) {
-                        skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                             kVUID_PVError_RequiredParameter, "%s: value of %s[%d] must not be 0", api_name,
-                                             array_name.get_name().c_str(), i);
+                        skip_call |= LogError(device, kVUID_PVError_RequiredParameter, "%s: value of %s[%d] must not be 0",
+                                              api_name, array_name.get_name().c_str(), i);
                     }
                 } else if ((array[i] & (~all_flags)) != 0) {
-                    skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                         kVUID_PVError_UnrecognizedValue,
-                                         "%s: value of %s[%d] contains flag bits that are not recognized members of %s", api_name,
-                                         array_name.get_name().c_str(), i, flag_bits_name);
+                    skip_call |= LogError(device, kVUID_PVError_UnrecognizedValue,
+                                          "%s: value of %s[%d] contains flag bits that are not recognized members of %s", api_name,
+                                          array_name.get_name().c_str(), i, flag_bits_name);
                 }
             }
         }
```

