### PR TITLE
Fix call to overwrite_range

### DIFF
--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -1678,6 +1678,7 @@ bool update_range_value(Map &map, const Range &range, MapValue &&value, value_pr
             if ((precedence == value_precedence::prefer_source) && (pos->lower_bound->second != value)) {
                 // We've found a place where we're changing the value, at this point might as well simply over write the range
                 // and be done with it. (save on later merge operations....)
+                pos.seek(range.begin);
                 map.overwrite_range(pos->lower_bound, std::make_pair(range, std::forward<MapValue>(value)));
                 return true;
 


### PR DESCRIPTION
Fixes assert in range vector code from running
api.image_clearing.core.clear_depth_stencil_image.multiple_layers.d24_unorm_s8_uint_separate_layouts_depth