### PR TITLE
Move NOMINMAX definition from sources to CMake file

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -140,7 +140,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/gene
 
 if(WIN32)
     # Applies to all configurations
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
     add_compile_options("/bigobj")
     # Allow Windows to use multiprocessor compilation

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -20,9 +20,6 @@
  * Shannon McPherson <shannon@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
-
 #include <cmath>
 #include <set>
 #include <sstream>

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -35,9 +35,6 @@
  * Author: Shannon McPherson <shannon@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
-
 #include <algorithm>
 #include <array>
 #include <assert.h>

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -19,9 +19,6 @@
  *         John Zulauf <jzulauf@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
-
 #include "chassis.h"
 #include "core_validation_error_enums.h"
 #include "core_validation.h"

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -35,9 +35,6 @@
  * Author: Shannon McPherson <shannon@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
-
 #include "chassis.h"
 #include "core_validation.h"
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -24,7 +24,6 @@
 #pragma once
 
 
-#define NOMINMAX
 #include <atomic>
 #include <mutex>
 #include <cinttypes>

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2019 The Khronos Group Inc.
- * Copyright (c) 2018-2019 Valve Corporation
- * Copyright (c) 2018-2019 LunarG, Inc.
+/* Copyright (c) 2018-2020 The Khronos Group Inc.
+ * Copyright (c) 2018-2020 Valve Corporation
+ * Copyright (c) 2018-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
  * Author: Tony Barbour <tony@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
 // This define indicates to build the VMA routines themselves
 #define VMA_IMPLEMENTATION
 // This define indicates that we will supply Vulkan function pointers at initialization

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
- * Copyright (C) 2015-2019 Google Inc.
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (C) 2015-2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #ifndef HASH_UTIL_H_
 #define HASH_UTIL_H_
 
-#define NOMINMAX
 #include <cstdint>
 #include <functional>
 #include <limits>

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -19,8 +19,6 @@
  * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
-#define NOMINMAX
-
 #include <cmath>
 
 #include "chassis.h"

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -19,8 +19,6 @@
  * Author: Dave Houlton <daveh@lunarg.com>
  */
 
-#define NOMINMAX
-
 #include "shader_validation.h"
 
 #include <cassert>

--- a/layers/sparse_containers.h
+++ b/layers/sparse_containers.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019 The Khronos Group Inc.
- * Copyright (c) 2019 Valve Corporation
- * Copyright (c) 2019 LunarG, Inc.
- * Copyright (C) 2019 Google Inc.
+/* Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ * Copyright (C) 2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
  */
 #ifndef SPARSE_CONTAINERS_H_
 #define SPARSE_CONTAINERS_H_
-#define NOMINMAX
 #include <cassert>
 #include <memory>
 #include <unordered_map>

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -20,9 +20,6 @@
  * Shannon McPherson <shannon@lunarg.com>
  */
 
-// Allow use of STL min and max functions in Windows
-#define NOMINMAX
-
 #include <cmath>
 #include <set>
 #include <sstream>

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -1,8 +1,8 @@
 /**************************************************************************
  *
- * Copyright 2014-2019 Valve Software
- * Copyright 2015-2019 Google Inc.
- * Copyright 2019 LunarG, Inc.
+ * Copyright 2014-2020 Valve Software
+ * Copyright 2015-2020 Google Inc.
+ * Copyright 2019-2020 LunarG, Inc.
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,8 @@
 #include <sys/stat.h>
 
 #include <vulkan/vk_layer.h>
+// sdk_platform header redefines NOMINMAX
+#undef NOMINMAX
 #include <vulkan/vk_sdk_platform.h>
 #include "vk_layer_utils.h"
 

--- a/layers/vk_loader_platform.h
+++ b/layers/vk_loader_platform.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2015-2018 The Khronos Group Inc.
- * Copyright (c) 2015-2018 Valve Corporation
- * Copyright (c) 2015-2018 LunarG, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@
 #endif  // _WIN32
 
 #include "vulkan/vk_platform.h"
+// sdk_platform header redefines NOMINMAX
+#undef NOMINMAX
 #include "vulkan/vk_sdk_platform.h"
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -198,7 +198,6 @@ class LayerChassisOutputGenerator(OutputGenerator):
     postcallrecord_loop = "for (auto intercept : layer_data->object_dispatch) {"
 
     inline_custom_header_preamble = """
-#define NOMINMAX
 #include <atomic>
 #include <mutex>
 #include <cinttypes>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2019 Valve Corporation
-# Copyright (c) 2014-2019 LunarG, Inc.
+# Copyright (c) 2014-2020 Valve Corporation
+# Copyright (c) 2014-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
+    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
     # Allow Windows to use multiprocessor compilation

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
- * Copyright (c) 2015-2019 Google, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2020 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #ifdef ANDROID
 #include "vulkan_wrapper.h"
 #else
-#define NOMINMAX
 #include <vulkan/vulkan.h>
 #endif
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,12 @@
 #include <string.h>
 
 #ifdef _WIN32
-#define NOMINMAX
 // WinSock2.h must be included *BEFORE* windows.h
 #include <winsock2.h>
 #endif
 
+// sdk_platform header redefines NOMINMAX
+#undef NOMINMAX
 #include <vulkan/vk_sdk_platform.h>
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
Not having NOMINMAX defined in every file was causing build issues in Chromium.  As @jzulauf-lunarg suggested, this change moves that definition into the CMake file, making local definitions unnecessary.  Passes internal CI cleanly.

Fixes #1501.