### PR TITLE
Use safe_VkImageCreateInfos in core validation

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -65,7 +65,8 @@ static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &creat
 
 IMAGE_STATE::IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo)
     : image(img),
-      createInfo(*pCreateInfo),
+      safe_create_info(pCreateInfo),
+      createInfo(*safe_create_info.ptr()),
       valid(false),
       acquired(false),
       shared_presentable(false),

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -325,7 +325,8 @@ struct SAMPLER_STATE : public BASE_NODE {
 class IMAGE_STATE : public BINDABLE {
   public:
     VkImage image;
-    VkImageCreateInfo createInfo;
+    safe_VkImageCreateInfo safe_create_info;
+    VkImageCreateInfo &createInfo;
     bool valid;               // If this is a swapchain image backing memory track valid here as it doesn't have DEVICE_MEMORY_STATE
     bool acquired;            // If this is a swapchain image, has it been acquired by the app.
     bool shared_presentable;  // True for a front-buffered swapchain image


### PR DESCRIPTION
Fixes crash in
dEQP-VK.image.mutable.2d.r32g32b32a32_sfloat_r32g32b32a32_uint_clear_load_format_list
and others
