### PR TITLE
Retire Queue submissions when Timeline Semaphore is waited on

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1132,9 +1132,15 @@ struct SEMAPHORE_WAIT {
     uint64_t seq;
 };
 
+struct SEMAPHORE_SIGNAL {
+    VkSemaphore semaphore;
+    uint64_t payload;
+    uint64_t seq;
+};
+
 struct CB_SUBMISSION {
     CB_SUBMISSION(std::vector<VkCommandBuffer> const &cbs, std::vector<SEMAPHORE_WAIT> const &waitSemaphores,
-                  std::vector<VkSemaphore> const &signalSemaphores, std::vector<VkSemaphore> const &externalSemaphores,
+                  std::vector<SEMAPHORE_SIGNAL> const &signalSemaphores, std::vector<VkSemaphore> const &externalSemaphores,
                   VkFence fence, uint32_t perf_submit_pass)
         : cbs(cbs),
           waitSemaphores(waitSemaphores),
@@ -1145,7 +1151,7 @@ struct CB_SUBMISSION {
 
     std::vector<VkCommandBuffer> cbs;
     std::vector<SEMAPHORE_WAIT> waitSemaphores;
-    std::vector<VkSemaphore> signalSemaphores;
+    std::vector<SEMAPHORE_SIGNAL> signalSemaphores;
     std::vector<VkSemaphore> externalSemaphores;
     VkFence fence;
     uint32_t perf_submit_pass;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -776,6 +776,7 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordSetEvent(VkDevice device, VkEvent event);
     void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                      uint64_t timeout, VkResult result);
+    void PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout, VkResult result);
     void PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo, VkResult result);
     void PostCallRecordReleaseProfilingLockKHR(VkDevice device);
 
@@ -1073,6 +1074,7 @@ class ValidationStateTracker : public ValidationObject {
     void RemoveImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info);
     void ResetCommandBufferState(const VkCommandBuffer cb);
     void RetireFence(VkFence fence);
+    void RetireTimelineSemaphore(VkSemaphore semaphore, uint64_t until_payload);
     void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq);
     static bool SetEventStageMask(VkEvent event, VkPipelineStageFlags stageMask, EventToStageMap* localEventToStageMap);
     void ResetCommandBufferPushConstantDataIfIncompatible(CMD_BUFFER_STATE* cb_state, VkPipelineLayout layout);


### PR DESCRIPTION
This addresses #1502 and fixes validation warnings in the CTS tests I modified (linked in that issue).

cc @jasuarez, you were the main contributor to timeline semaphores, I would appreciate a review