### PR TITLE
Replace log_msg() in validation layers

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -262,7 +262,7 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
     const DEVICE_MEMORY_STATE* mem_info = ValidationStateTracker::GetDevMemState(memory);
 
     for (auto& obj : mem_info->obj_bindings) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, get_debug_report_enum[obj.type], 0, layer_name.c_str(),
+        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, get_debug_report_enum[obj.type], 0, layer_name.c_str(),
                         "VK Object %s still has a reference to mem obj %s.", report_data->FormatHandle(obj).c_str(),
                         report_data->FormatHandle(mem_info->mem).c_str());
     }

--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -234,9 +234,8 @@ bool BestPractices::PreCallValidateAllocateMemory(VkDevice device, const VkMemor
     bool skip = false;
 
     if (num_mem_objects + 1 > kMemoryObjectWarningLimit) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_BestPractices_AllocateMemory_TooManyObjects,
-                        "Performance Warning: This app has > %" PRIu32 " memory objects.", kMemoryObjectWarningLimit);
+        skip |= LogPerformanceWarning(device, kVUID_BestPractices_AllocateMemory_TooManyObjects,
+                                      "Performance Warning: This app has > %" PRIu32 " memory objects.", kMemoryObjectWarningLimit);
     }
 
     // TODO: Insert get check for GetPhysicalDeviceMemoryProperties once the state is tracked in the StateTracker
@@ -384,11 +383,10 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                                                                      pAllocator, pPipelines, cgpl_state_data);
 
     if ((createInfoCount > 1) && (!pipelineCache)) {
-        skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUID_BestPractices_CreatePipelines_MultiplePipelines,
-                    "Performance Warning: This vkCreateGraphicsPipelines call is creating multiple pipelines but is not using a "
-                    "pipeline cache, which may help with performance");
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreatePipelines_MultiplePipelines,
+            "Performance Warning: This vkCreateGraphicsPipelines call is creating multiple pipelines but is not using a "
+            "pipeline cache, which may help with performance");
     }
 
     return skip;
@@ -402,10 +400,10 @@ bool BestPractices::PreCallValidateCreateComputePipelines(VkDevice device, VkPip
                                                                     pAllocator, pPipelines, ccpl_state_data);
 
     if ((createInfoCount > 1) && (!pipelineCache)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_BestPractices_CreatePipelines_MultiplePipelines,
-                        "Performance Warning: This vkCreateComputePipelines call is creating multiple pipelines but is not using a "
-                        "pipeline cache, which may help with performance");
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreatePipelines_MultiplePipelines,
+            "Performance Warning: This vkCreateComputePipelines call is creating multiple pipelines but is not using a "
+            "pipeline cache, which may help with performance");
     }
 
     return skip;
@@ -510,12 +508,10 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* 
         // Verify vertex binding
         if (pipeline_state->vertex_binding_descriptions_.size() <= 0) {
             if ((!current_vtx_bfr_binding_info.empty()) && (!cb_state->vertex_buffer_used)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, HandleToUint64(cb_state->commandBuffer),
-                                kVUID_BestPractices_DrawState_VtxIndexOutOfBounds,
-                                "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
-                                report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                                report_data->FormatHandle(pipeline_state->pipeline).c_str());
+                skip |= LogPerformanceWarning(cb_state->commandBuffer, kVUID_BestPractices_DrawState_VtxIndexOutOfBounds,
+                                              "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
+                                              report_data->FormatHandle(cb_state->commandBuffer).c_str(),
+                                              report_data->FormatHandle(pipeline_state->pipeline).c_str());
             }
         }
     }
@@ -893,11 +889,10 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
         // There are times where app needs to use ClearAttachments (generally when reusing a buffer inside of a render pass)
         // This warning should be made more specific. It'd be best to avoid triggering this test if it's a use that must call
         // CmdClearAttachments.
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), kVUID_BestPractices_DrawState_ClearCmdBeforeDraw,
-                        "vkCmdClearAttachments() issued on %s prior to any Draw Cmds. It is recommended you "
-                        "use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.",
-                        report_data->FormatHandle(commandBuffer).c_str());
+        skip |= LogPerformanceWarning(commandBuffer, kVUID_BestPractices_DrawState_ClearCmdBeforeDraw,
+                                      "vkCmdClearAttachments() issued on %s prior to any Draw Cmds. It is recommended you "
+                                      "use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.",
+                                      report_data->FormatHandle(commandBuffer).c_str());
     }
 
     return skip;

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -126,6 +126,9 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                            uint32_t* pSurfaceFormatCount,
                                                            VkSurfaceFormatKHR* pSurfaceFormats) const;
+    bool ValidateCommonGetPhysicalDeviceQueueFamilyProperties(const PHYSICAL_DEVICE_STATE* pd_state,
+                                                              uint32_t requested_queue_family_property_count, bool qfp_null,
+                                                              const char* caller_name) const;
     bool PreCallValidateBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                           const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) const;
     bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -255,11 +255,10 @@ bool CoreChecks::FindLayoutVerifyLayout(ImageSubresourcePair imgpair, VkImageLay
         return false;
     }
     if (layout != VK_IMAGE_LAYOUT_MAX_ENUM && layout != imgsubIt->second.layout) {
-        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(imgpair.image),
-                kVUID_Core_DrawState_InvalidLayout,
-                "Cannot query for %s layout when combined aspect mask %d has multiple layout types: %s and %s",
-                report_data->FormatHandle(imgpair.image).c_str(), oldAspectMask, string_VkImageLayout(layout),
-                string_VkImageLayout(imgsubIt->second.layout));
+        LogError(imgpair.image, kVUID_Core_DrawState_InvalidLayout,
+                 "Cannot query for %s layout when combined aspect mask %d has multiple layout types: %s and %s",
+                 report_data->FormatHandle(imgpair.image).c_str(), oldAspectMask, string_VkImageLayout(layout),
+                 string_VkImageLayout(imgsubIt->second.layout));
     }
     layout = imgsubIt->second.layout;
     return true;
@@ -433,11 +432,10 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     const bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);
 
     if (!image_state) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image),
-                        "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                        "Render Pass begin with %s uses %s where pAttachments[%" PRIu32 "] = %s, which refers to an invalid image",
-                        report_data->FormatHandle(renderpass).c_str(), report_data->FormatHandle(framebuffer).c_str(),
-                        attachment_index, report_data->FormatHandle(image_view).c_str());
+        skip |= LogError(image, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                         "Render Pass begin with %s uses %s where pAttachments[%" PRIu32 "] = %s, which refers to an invalid image",
+                         report_data->FormatHandle(renderpass).c_str(), report_data->FormatHandle(framebuffer).c_str(),
+                         attachment_index, report_data->FormatHandle(image_view).c_str());
         return skip;
     }
 
@@ -447,46 +445,46 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03094" : "VUID-vkCmdBeginRenderPass-initialLayout-00895";
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image), vuid,
-                    "Layout/usage mismatch for attachment %u in %s"
-                    " - the %s is %s but the image attached to %s via %s"
-                    " was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT",
-                    attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
-                    report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
+            LogError(image, vuid,
+                     "Layout/usage mismatch for attachment %u in %s"
+                     " - the %s is %s but the image attached to %s via %s"
+                     " was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT",
+                     attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
+                     report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
     }
 
     if (layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
         !(image_usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03097" : "VUID-vkCmdBeginRenderPass-initialLayout-00897";
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image), vuid,
-                    "Layout/usage mismatch for attachment %u in %s"
-                    " - the %s is %s but the image attached to %s via %s"
-                    " was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT",
-                    attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
-                    report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
+            LogError(image, vuid,
+                     "Layout/usage mismatch for attachment %u in %s"
+                     " - the %s is %s but the image attached to %s via %s"
+                     " was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT",
+                     attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
+                     report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
     }
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03098" : "VUID-vkCmdBeginRenderPass-initialLayout-00898";
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image), vuid,
-                    "Layout/usage mismatch for attachment %u in %s"
-                    " - the %s is %s but the image attached to %s via %s"
-                    " was not created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
-                    attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
-                    report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
+            LogError(image, vuid,
+                     "Layout/usage mismatch for attachment %u in %s"
+                     " - the %s is %s but the image attached to %s via %s"
+                     " was not created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
+                     attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
+                     report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
     }
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03099" : "VUID-vkCmdBeginRenderPass-initialLayout-00899";
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image), vuid,
-                    "Layout/usage mismatch for attachment %u in %s"
-                    " - the %s is %s but the image attached to %s via %s"
-                    " was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT",
-                    attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
-                    report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
+            LogError(image, vuid,
+                     "Layout/usage mismatch for attachment %u in %s"
+                     " - the %s is %s but the image attached to %s via %s"
+                     " was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT",
+                     attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
+                     report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
     }
 
     if (device_extensions.vk_khr_maintenance2) {
@@ -496,27 +494,26 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) &&
             !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
             vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03096" : "VUID-vkCmdBeginRenderPass-initialLayout-01758";
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image), vuid,
-                "Layout/usage mismatch for attachment %u in %s"
-                " - the %s is %s but the image attached to %s via %s"
-                " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
-                attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name, string_VkImageLayout(layout),
-                report_data->FormatHandle(framebuffer).c_str(), report_data->FormatHandle(image_view).c_str());
+            skip |= LogError(image, vuid,
+                             "Layout/usage mismatch for attachment %u in %s"
+                             " - the %s is %s but the image attached to %s via %s"
+                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                             attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
+                             string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
+                             report_data->FormatHandle(image_view).c_str());
         }
     } else {
         // The create render pass 2 extension requires maintenance 2 (the previous branch), so no vuid switch needed here.
         if ((layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL ||
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) &&
             !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkCmdBeginRenderPass-initialLayout-00896",
-                            "Layout/usage mismatch for attachment %u in %s"
-                            " - the %s is %s but the image attached to %s via %s"
-                            " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
-                            attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
-                            string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
-                            report_data->FormatHandle(image_view).c_str());
+            skip |= LogError(image, "VUID-vkCmdBeginRenderPass-initialLayout-00896",
+                             "Layout/usage mismatch for attachment %u in %s"
+                             " - the %s is %s but the image attached to %s via %s"
+                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                             attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
+                             string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
+                             report_data->FormatHandle(image_view).c_str());
         }
     }
     return skip;
@@ -534,9 +531,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
     auto framebuffer = framebuffer_state->framebuffer;
 
     if (pRenderPassInfo->attachmentCount != framebufferInfo.attachmentCount) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(pCB->commandBuffer), kVUID_Core_DrawState_InvalidRenderpass,
-                        "You cannot start a render pass using a framebuffer with a different number of attachments.");
+        skip |= LogError(pCB->commandBuffer, kVUID_Core_DrawState_InvalidRenderpass,
+                         "You cannot start a render pass using a framebuffer with a different number of attachments.");
     }
 
     const auto *attachmentInfo = lvl_find_in_chain<VkRenderPassAttachmentBeginInfoKHR>(pRenderPassBegin->pNext);
@@ -551,11 +547,10 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
             auto view_state = GetImageViewState(image_view);
 
             if (!view_state) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,
-                                HandleToUint64(pRenderPassBegin->renderPass), "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                                "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
-                                report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
-                                report_data->FormatHandle(image_view).c_str());
+                skip |= LogError(pRenderPassBegin->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                                 "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
+                                 report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
+                                 report_data->FormatHandle(image_view).c_str());
                 continue;
             }
 
@@ -563,11 +558,10 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
             const IMAGE_STATE *image_state = GetImageState(image);
 
             if (!image_state) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,
-                                HandleToUint64(pRenderPassBegin->renderPass), "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                                "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
-                                report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
-                                report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
+                skip |= LogError(pRenderPassBegin->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                                 "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
+                                 report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
+                                 report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
                 continue;
             }
             auto attachment_initial_layout = pRenderPassInfo->pAttachments[i].initialLayout;
@@ -600,9 +594,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
                     if (subres.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) check_layout = attachment_stencil_initial_layout;
 
                     if (!layout_check.Check(subres, check_layout, pos->current_layout, pos->initial_layout)) {
-                        subres_skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            kVUID_Core_DrawState_InvalidRenderpass,
+                        subres_skip |= LogError(
+                            device, kVUID_Core_DrawState_InvalidRenderpass,
                             "You cannot start a render pass using attachment %u where the render pass initial layout is %s "
                             "and the %s layout of the attachment is %s. The layouts must match, or the render "
                             "pass initial layout for the attachment must be VK_IMAGE_LAYOUT_UNDEFINED",
@@ -801,11 +794,10 @@ bool CoreChecks::ValidateBarrierLayoutToImageUsage(const VkImageMemoryBarrier &i
     }
 
     if (msg_code != kVUIDUndefined) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(img_barrier.image), msg_code,
-                        "%s: Image barrier %s %s Layout=%s is not compatible with %s usage flags 0x%" PRIx32 ".", func_name,
-                        barrier_pname, ((new_not_old) ? "new" : "old"), string_VkImageLayout(layout),
-                        report_data->FormatHandle(img_barrier.image).c_str(), usage_flags);
+        skip |= LogError(img_barrier.image, msg_code,
+                         "%s: Image barrier %s %s Layout=%s is not compatible with %s usage flags 0x%" PRIx32 ".", func_name,
+                         barrier_pname, ((new_not_old) ? "new" : "old"), string_VkImageLayout(layout),
+                         report_data->FormatHandle(img_barrier.image).c_str(), usage_flags);
     }
     return skip;
 }
@@ -847,9 +839,8 @@ bool CoreChecks::ValidateBarriersToImages(const CMD_BUFFER_STATE *cb_state, uint
                     if ((entry.barrier->newLayout != img_barrier.oldLayout) &&
                         (img_barrier.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED)) {
                         const VkImageSubresourceRange &range = img_barrier.subresourceRange;
-                        skip = log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_state->commandBuffer), "VUID-VkImageMemoryBarrier-oldLayout-01197",
+                        skip = LogError(
+                            cb_state->commandBuffer, "VUID-VkImageMemoryBarrier-oldLayout-01197",
                             "%s: %s conflicts with earlier entry pImageMemoryBarrier[%u]. %s"
                             " subresourceRange: aspectMask=%u baseMipLevel=%u levelCount=%u, baseArrayLayer=%u, layerCount=%u; "
                             "conflicting barrier transitions image layout from %s when earlier barrier transitioned to layout %s.",
@@ -875,9 +866,8 @@ bool CoreChecks::ValidateBarriersToImages(const CMD_BUFFER_STATE *cb_state, uint
             // Make sure layout is able to be transitioned, currently only presented shared presentable images are locked
             if (image_state->layout_locked) {
                 // TODO: Add unique id for error when available
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                    HandleToUint64(img_barrier.image), 0,
+                skip |= LogError(
+                    img_barrier.image, 0,
                     "Attempting to transition shared presentable %s"
                     " from layout %s to layout %s, but image has already been presented and cannot have its layout transitioned.",
                     report_data->FormatHandle(img_barrier.image).c_str(), string_VkImageLayout(img_barrier.oldLayout),
@@ -891,22 +881,20 @@ bool CoreChecks::ValidateBarriersToImages(const CMD_BUFFER_STATE *cb_state, uint
                 if (enabled_features.core12.separateDepthStencilLayouts) {
                     if (!(aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    HandleToUint64(img_barrier.image), "VUID-VkImageMemoryBarrier-image-03319",
-                                    "%s: Image barrier %s references %s of format %s that must have either the depth or stencil "
-                                    "aspects set, but its aspectMask is 0x%" PRIx32 ".",
-                                    func_name, barrier_pname.c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                    string_VkFormat(image_create_info.format), aspect_mask);
+                            LogError(img_barrier.image, "VUID-VkImageMemoryBarrier-image-03319",
+                                     "%s: Image barrier %s references %s of format %s that must have either the depth or stencil "
+                                     "aspects set, but its aspectMask is 0x%" PRIx32 ".",
+                                     func_name, barrier_pname.c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                                     string_VkFormat(image_create_info.format), aspect_mask);
                     }
                 } else {
                     auto const ds_mask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
                     if ((aspect_mask & ds_mask) != (ds_mask)) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(img_barrier.image), "VUID-VkImageMemoryBarrier-image-03320",
-                                        "%s: Image barrier %s references %s of format %s that must have the depth and stencil "
-                                        "aspects set, but its aspectMask is 0x%" PRIx32 ".",
-                                        func_name, barrier_pname.c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                        string_VkFormat(image_create_info.format), aspect_mask);
+                        skip |= LogError(img_barrier.image, "VUID-VkImageMemoryBarrier-image-03320",
+                                         "%s: Image barrier %s references %s of format %s that must have the depth and stencil "
+                                         "aspects set, but its aspectMask is 0x%" PRIx32 ".",
+                                         func_name, barrier_pname.c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                                         string_VkFormat(image_create_info.format), aspect_mask);
                     }
                 }
             }
@@ -923,9 +911,8 @@ bool CoreChecks::ValidateBarriersToImages(const CMD_BUFFER_STATE *cb_state, uint
                 for (auto pos = subresource_map->Find(normalized_isr); (pos != subresource_map->End()) && !subres_skip; ++pos) {
                     const auto &value = *pos;
                     if (!layout_check.Check(value.subresource, img_barrier.oldLayout, value.current_layout, value.initial_layout)) {
-                        subres_skip = log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_state->commandBuffer), "VUID-VkImageMemoryBarrier-oldLayout-01197",
+                        subres_skip = LogError(
+                            cb_state->commandBuffer, "VUID-VkImageMemoryBarrier-oldLayout-01197",
                             "For %s you cannot transition the layout of aspect=%d level=%d layer=%d from %s when the "
                             "%s layout is %s.",
                             report_data->FormatHandle(img_barrier.image).c_str(), value.subresource.aspectMask,
@@ -976,13 +963,12 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const char *func_name, con
             }
         }
         if (barrier_record != nullptr) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_state->commandBuffer), BarrierRecord::ErrMsgDuplicateQFOInCB(),
-                            "%s: %s at index %" PRIu32 " %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
-                            " to dstQueueFamilyIndex %" PRIu32 " duplicates existing barrier recorded in this command buffer.",
-                            func_name, barrier_name, b, transfer_type, handle_name,
-                            report_data->FormatHandle(barrier_record->handle).c_str(), barrier_record->srcQueueFamilyIndex,
-                            barrier_record->dstQueueFamilyIndex);
+            skip |= LogWarning(cb_state->commandBuffer, BarrierRecord::ErrMsgDuplicateQFOInCB(),
+                               "%s: %s at index %" PRIu32 " %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
+                               " to dstQueueFamilyIndex %" PRIu32 " duplicates existing barrier recorded in this command buffer.",
+                               func_name, barrier_name, b, transfer_type, handle_name,
+                               report_data->FormatHandle(barrier_record->handle).c_str(), barrier_record->srcQueueFamilyIndex,
+                               barrier_record->dstQueueFamilyIndex);
         }
     }
     return skip;
@@ -1068,13 +1054,12 @@ bool CoreChecks::ValidateAndUpdateQFOScoreboard(const debug_report_data *report_
     auto inserted = scoreboard->insert(std::make_pair(barrier, cb_state));
     if (!inserted.second && inserted.first->second != cb_state) {
         // This is a duplication (but don't report duplicates from the same CB, as we do that at record time
-        skip = log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                       HandleToUint64(cb_state->commandBuffer), BarrierRecord::ErrMsgDuplicateQFOInSubmit(),
-                       "%s: %s %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32 " to dstQueueFamilyIndex %" PRIu32
-                       " duplicates existing barrier submitted in this batch from %s.",
-                       "vkQueueSubmit()", BarrierRecord::BarrierName(), operation, BarrierRecord::HandleName(),
-                       report_data->FormatHandle(barrier.handle).c_str(), barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex,
-                       report_data->FormatHandle(inserted.first->second->commandBuffer).c_str());
+        skip = LogWarning(cb_state->commandBuffer, BarrierRecord::ErrMsgDuplicateQFOInSubmit(),
+                          "%s: %s %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
+                          " to dstQueueFamilyIndex %" PRIu32 " duplicates existing barrier submitted in this batch from %s.",
+                          "vkQueueSubmit()", BarrierRecord::BarrierName(), operation, BarrierRecord::HandleName(),
+                          report_data->FormatHandle(barrier.handle).c_str(), barrier.srcQueueFamilyIndex,
+                          barrier.dstQueueFamilyIndex, report_data->FormatHandle(inserted.first->second->commandBuffer).c_str());
     }
     return skip;
 }
@@ -1097,13 +1082,12 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const CMD_BUFFER_STATE *cb_st
             const QFOTransferBarrierSet<Barrier> &set_for_handle = set_it->second;
             const auto found = set_for_handle.find(release);
             if (found != set_for_handle.cend()) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_state->commandBuffer), BarrierRecord::ErrMsgDuplicateQFOSubmitted(),
-                                "%s: %s releasing queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
-                                " to dstQueueFamilyIndex %" PRIu32
-                                " duplicates existing barrier queued for execution, without intervening acquire operation.",
-                                "vkQueueSubmit()", barrier_name, handle_name, report_data->FormatHandle(found->handle).c_str(),
-                                found->srcQueueFamilyIndex, found->dstQueueFamilyIndex);
+                skip |= LogWarning(cb_state->commandBuffer, BarrierRecord::ErrMsgDuplicateQFOSubmitted(),
+                                   "%s: %s releasing queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
+                                   " to dstQueueFamilyIndex %" PRIu32
+                                   " duplicates existing barrier queued for execution, without intervening acquire operation.",
+                                   "vkQueueSubmit()", barrier_name, handle_name, report_data->FormatHandle(found->handle).c_str(),
+                                   found->srcQueueFamilyIndex, found->dstQueueFamilyIndex);
             }
         }
         skip |= ValidateAndUpdateQFOScoreboard(report_data, cb_state, "releasing", release, &scoreboards->release);
@@ -1117,12 +1101,11 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const CMD_BUFFER_STATE *cb_st
             matching_release_found = set_for_handle.find(acquire) != set_for_handle.cend();
         }
         if (!matching_release_found) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_state->commandBuffer), BarrierRecord::ErrMsgMissingQFOReleaseInSubmit(),
-                            "%s: in submitted command buffer %s acquiring ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
-                            " to dstQueueFamilyIndex %" PRIu32 " has no matching release barrier queued for execution.",
-                            "vkQueueSubmit()", barrier_name, handle_name, report_data->FormatHandle(acquire.handle).c_str(),
-                            acquire.srcQueueFamilyIndex, acquire.dstQueueFamilyIndex);
+            skip |= LogError(cb_state->commandBuffer, BarrierRecord::ErrMsgMissingQFOReleaseInSubmit(),
+                             "%s: in submitted command buffer %s acquiring ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
+                             " to dstQueueFamilyIndex %" PRIu32 " has no matching release barrier queued for execution.",
+                             "vkQueueSubmit()", barrier_name, handle_name, report_data->FormatHandle(acquire.handle).c_str(),
+                             acquire.srcQueueFamilyIndex, acquire.dstQueueFamilyIndex);
         }
         skip |= ValidateAndUpdateQFOScoreboard(report_data, cb_state, "acquiring", acquire, &scoreboards->acquire);
     }
@@ -1237,13 +1220,12 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
         for (auto pos = subresource_map->Find(range); (pos != subresource_map->End()) && !subres_skip; ++pos) {
             if (!layout_check.Check(pos->subresource, explicit_layout, pos->current_layout, pos->initial_layout)) {
                 *error = true;
-                subres_skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                       HandleToUint64(cb_node->commandBuffer), layout_mismatch_msg_code,
-                                       "%s: Cannot use %s (layer=%u mip=%u) with specific layout %s that doesn't match the "
-                                       "%s layout %s.",
-                                       caller, report_data->FormatHandle(image).c_str(), pos->subresource.arrayLayer,
-                                       pos->subresource.mipLevel, string_VkImageLayout(explicit_layout), layout_check.message,
-                                       string_VkImageLayout(layout_check.layout));
+                subres_skip |= LogError(cb_node->commandBuffer, layout_mismatch_msg_code,
+                                        "%s: Cannot use %s (layer=%u mip=%u) with specific layout %s that doesn't match the "
+                                        "%s layout %s.",
+                                        caller, report_data->FormatHandle(image).c_str(), pos->subresource.arrayLayer,
+                                        pos->subresource.mipLevel, string_VkImageLayout(explicit_layout), layout_check.message,
+                                        string_VkImageLayout(layout_check.layout));
             }
         }
         skip |= subres_skip;
@@ -1254,28 +1236,24 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
         if (VK_IMAGE_LAYOUT_GENERAL == explicit_layout) {
             if (image_state->createInfo.tiling != VK_IMAGE_TILING_LINEAR) {
                 // LAYOUT_GENERAL is allowed, but may not be performance optimal, flag as perf warning.
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, HandleToUint64(cb_node->commandBuffer),
-                                kVUID_Core_DrawState_InvalidImageLayout,
-                                "%s: For optimal performance %s layout should be %s instead of GENERAL.", caller,
-                                report_data->FormatHandle(image).c_str(), string_VkImageLayout(optimal_layout));
+                skip |= LogPerformanceWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidImageLayout,
+                                              "%s: For optimal performance %s layout should be %s instead of GENERAL.", caller,
+                                              report_data->FormatHandle(image).c_str(), string_VkImageLayout(optimal_layout));
             }
         } else if (device_extensions.vk_khr_shared_presentable_image) {
             if (image_state->shared_presentable) {
                 if (VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR != explicit_layout) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    layout_invalid_msg_code,
-                                    "Layout for shared presentable image is %s but must be VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR.",
-                                    string_VkImageLayout(optimal_layout));
+                    skip |= LogError(device, layout_invalid_msg_code,
+                                     "Layout for shared presentable image is %s but must be VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR.",
+                                     string_VkImageLayout(optimal_layout));
                 }
             }
         } else {
             *error = true;
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), layout_invalid_msg_code,
-                            "%s: Layout for %s is %s but can only be %s or VK_IMAGE_LAYOUT_GENERAL.", caller,
-                            report_data->FormatHandle(image).c_str(), string_VkImageLayout(explicit_layout),
-                            string_VkImageLayout(optimal_layout));
+            skip |= LogError(cb_node->commandBuffer, layout_invalid_msg_code,
+                             "%s: Layout for %s is %s but can only be %s or VK_IMAGE_LAYOUT_GENERAL.", caller,
+                             report_data->FormatHandle(image).c_str(), string_VkImageLayout(explicit_layout),
+                             string_VkImageLayout(optimal_layout));
         }
     }
     return skip;
@@ -1326,48 +1304,43 @@ bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data
         if (0 != ext_fmt_android->externalFormat) {
             if (VK_FORMAT_UNDEFINED != create_info->format) {
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-pNext-01974",
-                            "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with non-zero "
-                            "externalFormat, but the VkImageCreateInfo's format is not VK_FORMAT_UNDEFINED.");
+                    LogError(device, "VUID-VkImageCreateInfo-pNext-01974",
+                             "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with non-zero "
+                             "externalFormat, but the VkImageCreateInfo's format is not VK_FORMAT_UNDEFINED.");
             }
 
             if (0 != (VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT & create_info->flags)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-pNext-02396",
-                                "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
-                                "non-zero externalFormat, but flags include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-02396",
+                                 "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
+                                 "non-zero externalFormat, but flags include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.");
             }
 
             if (0 != (~VK_IMAGE_USAGE_SAMPLED_BIT & create_info->usage)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-pNext-02397",
-                                "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
-                                "non-zero externalFormat, but usage includes bits other than VK_IMAGE_USAGE_SAMPLED_BIT.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-02397",
+                                 "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
+                                 "non-zero externalFormat, but usage includes bits other than VK_IMAGE_USAGE_SAMPLED_BIT.");
             }
 
             if (VK_IMAGE_TILING_OPTIMAL != create_info->tiling) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-pNext-02398",
-                                "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
-                                "non-zero externalFormat, but layout is not VK_IMAGE_TILING_OPTIMAL.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-02398",
+                                 "vkCreateImage(): VkImageCreateInfo struct has a chained VkExternalFormatANDROID struct with "
+                                 "non-zero externalFormat, but layout is not VK_IMAGE_TILING_OPTIMAL.");
             }
         }
 
         if ((0 != ext_fmt_android->externalFormat) && (0 == ahb_ext_formats_set.count(ext_fmt_android->externalFormat))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkExternalFormatANDROID-externalFormat-01894",
-                            "vkCreateImage(): Chained VkExternalFormatANDROID struct contains a non-zero externalFormat which has "
-                            "not been previously retrieved by vkGetAndroidHardwareBufferPropertiesANDROID().");
+            skip |= LogError(device, "VUID-VkExternalFormatANDROID-externalFormat-01894",
+                             "vkCreateImage(): Chained VkExternalFormatANDROID struct contains a non-zero externalFormat which has "
+                             "not been previously retrieved by vkGetAndroidHardwareBufferPropertiesANDROID().");
         }
     }
 
     if ((nullptr == ext_fmt_android) || (0 == ext_fmt_android->externalFormat)) {
         if (VK_FORMAT_UNDEFINED == create_info->format) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-pNext-01975",
-                            "vkCreateImage(): VkImageCreateInfo struct's format is VK_FORMAT_UNDEFINED, but either does not have a "
-                            "chained VkExternalFormatANDROID struct or the struct exists but has an externalFormat of 0.");
+            skip |=
+                LogError(device, "VUID-VkImageCreateInfo-pNext-01975",
+                         "vkCreateImage(): VkImageCreateInfo struct's format is VK_FORMAT_UNDEFINED, but either does not have a "
+                         "chained VkExternalFormatANDROID struct or the struct exists but has an externalFormat of 0.");
         }
     }
 
@@ -1375,20 +1348,18 @@ bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data
     if (emici && (emici->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID)) {
         if (create_info->imageType != VK_IMAGE_TYPE_2D) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-pNext-02393",
-                        "vkCreateImage(): VkImageCreateInfo struct with imageType %s has chained VkExternalMemoryImageCreateInfo "
-                        "struct with handleType VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID.",
-                        string_VkImageType(create_info->imageType));
+                LogError(device, "VUID-VkImageCreateInfo-pNext-02393",
+                         "vkCreateImage(): VkImageCreateInfo struct with imageType %s has chained VkExternalMemoryImageCreateInfo "
+                         "struct with handleType VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID.",
+                         string_VkImageType(create_info->imageType));
         }
 
         if ((create_info->mipLevels != 1) && (create_info->mipLevels != FullMipChainLevels(create_info->extent))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-pNext-02394",
-                            "vkCreateImage(): VkImageCreateInfo struct with chained VkExternalMemoryImageCreateInfo struct of "
-                            "handleType VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID "
-                            "specifies mipLevels = %" PRId32 " (full chain mipLevels are %" PRId32 ").",
-                            create_info->mipLevels, FullMipChainLevels(create_info->extent));
+            skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-02394",
+                             "vkCreateImage(): VkImageCreateInfo struct with chained VkExternalMemoryImageCreateInfo struct of "
+                             "handleType VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID "
+                             "specifies mipLevels = %" PRId32 " (full chain mipLevels are %" PRId32 ").",
+                             create_info->mipLevels, FullMipChainLevels(create_info->extent));
         }
     }
 
@@ -1401,11 +1372,10 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
 
     if (image_state->has_ahb_format) {
         if (VK_FORMAT_UNDEFINED != create_info->format) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(create_info->image), "VUID-VkImageViewCreateInfo-image-02399",
-                            "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
-                            "format member is %s.",
-                            string_VkFormat(create_info->format));
+            skip |= LogError(create_info->image, "VUID-VkImageViewCreateInfo-image-02399",
+                             "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
+                             "format member is %s.",
+                             string_VkFormat(create_info->format));
         }
 
         // Chain must include a compatible ycbcr conversion
@@ -1420,10 +1390,9 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
             }
         }
         if ((!conv_found) || (external_format != image_state->ahb_format)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(create_info->image), "VUID-VkImageViewCreateInfo-image-02400",
-                            "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
-                            "without a chained VkSamplerYcbcrConversionInfo struct with the same external format.");
+            skip |= LogError(create_info->image, "VUID-VkImageViewCreateInfo-image-02400",
+                             "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
+                             "without a chained VkSamplerYcbcrConversionInfo struct with the same external format.");
         }
 
         // Errors in create_info swizzles
@@ -1431,10 +1400,9 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
             (create_info->components.g != VK_COMPONENT_SWIZZLE_IDENTITY) ||
             (create_info->components.b != VK_COMPONENT_SWIZZLE_IDENTITY) ||
             (create_info->components.a != VK_COMPONENT_SWIZZLE_IDENTITY)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(create_info->image), "VUID-VkImageViewCreateInfo-image-02401",
-                            "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
-                            "includes one or more non-identity component swizzles.");
+            skip |= LogError(create_info->image, "VUID-VkImageViewCreateInfo-image-02401",
+                             "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
+                             "includes one or more non-identity component swizzles.");
         }
     }
 
@@ -1446,11 +1414,10 @@ bool CoreChecks::ValidateGetImageSubresourceLayoutANDROID(const VkImage image) c
 
     const IMAGE_STATE *image_state = GetImageState(image);
     if (image_state->imported_ahb && (0 == image_state->GetBoundMemory().size())) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image),
-                        "VUID-vkGetImageSubresourceLayout-image-01895",
-                        "vkGetImageSubresourceLayout(): Attempt to query layout from an image created with "
-                        "VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID handleType which has not yet been "
-                        "bound to memory.");
+        skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-01895",
+                         "vkGetImageSubresourceLayout(): Attempt to query layout from an image created with "
+                         "VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID handleType which has not yet been "
+                         "bound to memory.");
     }
     return skip;
 }
@@ -1475,26 +1442,23 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         skip |= ValidateCreateImageANDROID(report_data, pCreateInfo);
     } else {  // These checks are omitted or replaced when Android HW Buffer extension is active
         if (pCreateInfo->format == VK_FORMAT_UNDEFINED) {
-            return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                           "VUID-VkImageCreateInfo-format-00943",
-                           "vkCreateImage(): VkFormat for image must not be VK_FORMAT_UNDEFINED.");
+            return LogError(device, "VUID-VkImageCreateInfo-format-00943",
+                            "vkCreateImage(): VkFormat for image must not be VK_FORMAT_UNDEFINED.");
         }
     }
 
     if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
         if (VK_IMAGE_TYPE_2D != pCreateInfo->imageType) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-flags-00949",
-                            "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT "
-                            "flag bit is set");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00949",
+                             "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT "
+                             "flag bit is set");
         }
 
         if ((pCreateInfo->extent.width != pCreateInfo->extent.height) || (pCreateInfo->arrayLayers < 6)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-imageType-00954",
-                            "vkCreateImage(): If VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT flag bit is set, width (%d) must equal "
-                            "height (%d) and arrayLayers (%d) must be >= 6.",
-                            pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->arrayLayers);
+            skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00954",
+                             "vkCreateImage(): If VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT flag bit is set, width (%d) must equal "
+                             "height (%d) and arrayLayers (%d) must be >= 6.",
+                             pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->arrayLayers);
         }
     }
 
@@ -1502,17 +1466,15 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     VkImageUsageFlags attach_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
                                      VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     if ((pCreateInfo->usage & attach_flags) && (pCreateInfo->extent.width > device_limits->maxFramebufferWidth)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-usage-00964",
-                        "vkCreateImage(): Image usage flags include a frame buffer attachment bit and image width exceeds device "
-                        "maxFramebufferWidth.");
+        skip |= LogError(device, "VUID-VkImageCreateInfo-usage-00964",
+                         "vkCreateImage(): Image usage flags include a frame buffer attachment bit and image width exceeds device "
+                         "maxFramebufferWidth.");
     }
 
     if ((pCreateInfo->usage & attach_flags) && (pCreateInfo->extent.height > device_limits->maxFramebufferHeight)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-usage-00965",
-                        "vkCreateImage(): Image usage flags include a frame buffer attachment bit and image height exceeds device "
-                        "maxFramebufferHeight");
+        skip |= LogError(device, "VUID-VkImageCreateInfo-usage-00965",
+                         "vkCreateImage(): Image usage flags include a frame buffer attachment bit and image height exceeds device "
+                         "maxFramebufferHeight");
     }
 
     if (device_extensions.vk_ext_fragment_density_map) {
@@ -1521,13 +1483,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                            std::max((float)phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width, 1.0f));
         if ((pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) && (pCreateInfo->extent.width > ceiling_width)) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-usage-02559",
-                        "vkCreateImage(): Image usage flags include a fragment density map bit and image width (%u) exceeds the "
-                        "ceiling of device "
-                        "maxFramebufferWidth (%u) / minFragmentDensityTexelSize.width (%u). The ceiling value: %u",
-                        pCreateInfo->extent.width, device_limits->maxFramebufferWidth,
-                        phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width, ceiling_width);
+                LogError(device, "VUID-VkImageCreateInfo-usage-02559",
+                         "vkCreateImage(): Image usage flags include a fragment density map bit and image width (%u) exceeds the "
+                         "ceiling of device "
+                         "maxFramebufferWidth (%u) / minFragmentDensityTexelSize.width (%u). The ceiling value: %u",
+                         pCreateInfo->extent.width, device_limits->maxFramebufferWidth,
+                         phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width, ceiling_width);
         }
 
         uint32_t ceiling_height =
@@ -1535,13 +1496,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                            std::max((float)phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.height, 1.0f));
         if ((pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) && (pCreateInfo->extent.height > ceiling_height)) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-usage-02560",
-                        "vkCreateImage(): Image usage flags include a fragment density map bit and image height (%u) exceeds the "
-                        "ceiling of device "
-                        "maxFramebufferHeight (%u) / minFragmentDensityTexelSize.height (%u). The ceiling value: %u",
-                        pCreateInfo->extent.height, device_limits->maxFramebufferHeight,
-                        phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.height, ceiling_height);
+                LogError(device, "VUID-VkImageCreateInfo-usage-02560",
+                         "vkCreateImage(): Image usage flags include a fragment density map bit and image height (%u) exceeds the "
+                         "ceiling of device "
+                         "maxFramebufferHeight (%u) / minFragmentDensityTexelSize.height (%u). The ceiling value: %u",
+                         pCreateInfo->extent.height, device_limits->maxFramebufferHeight,
+                         phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.height, ceiling_height);
         }
     }
 
@@ -1566,16 +1526,15 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         if (!lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo->pNext))
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUIDUndefined,
-                            "vkCreateImage(): Format %s is not supported for this combination of parameters.",
-                            string_VkFormat(pCreateInfo->format));
+            skip |=
+                LogError(device, kVUIDUndefined, "vkCreateImage(): Format %s is not supported for this combination of parameters.",
+                         string_VkFormat(pCreateInfo->format));
     } else {
         if (pCreateInfo->mipLevels > format_limits.maxMipLevels) {
             const char *format_string = string_VkFormat(pCreateInfo->format);
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-mipLevels-02255",
-                            "vkCreateImage(): Image mip levels=%d exceed image format maxMipLevels=%d for format %s.",
-                            pCreateInfo->mipLevels, format_limits.maxMipLevels, format_string);
+            skip |= LogError(device, "VUID-VkImageCreateInfo-mipLevels-02255",
+                             "vkCreateImage(): Image mip levels=%d exceed image format maxMipLevels=%d for format %s.",
+                             pCreateInfo->mipLevels, format_limits.maxMipLevels, format_string);
         }
 
         uint64_t texel_count = (uint64_t)pCreateInfo->extent.width * (uint64_t)pCreateInfo->extent.height *
@@ -1589,68 +1548,62 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         total_size = (total_size + ig_mask) & ~ig_mask;
 
         if (total_size > format_limits.maxResourceSize) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                            kVUID_Core_Image_InvalidFormatLimitsViolation,
-                            "vkCreateImage(): resource size exceeds allowable maximum Image resource size = 0x%" PRIxLEAST64
-                            ", maximum resource size = 0x%" PRIxLEAST64 " ",
-                            total_size, format_limits.maxResourceSize);
+            skip |= LogWarning(device, kVUID_Core_Image_InvalidFormatLimitsViolation,
+                               "vkCreateImage(): resource size exceeds allowable maximum Image resource size = 0x%" PRIxLEAST64
+                               ", maximum resource size = 0x%" PRIxLEAST64 " ",
+                               total_size, format_limits.maxResourceSize);
         }
 
         if (pCreateInfo->arrayLayers > format_limits.maxArrayLayers) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                            "VUID-VkImageCreateInfo-arrayLayers-02256",
-                            "vkCreateImage(): arrayLayers=%d exceeds allowable maximum supported by format of %d.",
-                            pCreateInfo->arrayLayers, format_limits.maxArrayLayers);
+            skip |= LogError(device, "VUID-VkImageCreateInfo-arrayLayers-02256",
+                             "vkCreateImage(): arrayLayers=%d exceeds allowable maximum supported by format of %d.",
+                             pCreateInfo->arrayLayers, format_limits.maxArrayLayers);
         }
 
         if ((pCreateInfo->samples & format_limits.sampleCounts) == 0) {
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-VkImageCreateInfo-samples-02258", "vkCreateImage(): samples %s is not supported by format 0x%.8X.",
-                        string_VkSampleCountFlagBits(pCreateInfo->samples), format_limits.sampleCounts);
+            skip |= LogError(device, "VUID-VkImageCreateInfo-samples-02258",
+                             "vkCreateImage(): samples %s is not supported by format 0x%.8X.",
+                             string_VkSampleCountFlagBits(pCreateInfo->samples), format_limits.sampleCounts);
         }
     }
 
-    // Tests for "Formats requiring sampler Y’CBCR conversion for VK_IMAGE_ASPECT_COLOR_BIT image views"
+    // Tests for "Formats requiring sampler YCBCR conversion for VK_IMAGE_ASPECT_COLOR_BIT image views"
     if (FormatRequiresYcbcrConversion(pCreateInfo->format)) {
         if (!enabled_features.ycbcr_image_array_features.ycbcrImageArrays && pCreateInfo->arrayLayers != 1) {
             const char *error_vuid = (device_extensions.vk_ext_ycbcr_image_arrays) ? "VUID-VkImageCreateInfo-format-02653"
                                                                                    : "VUID-VkImageCreateInfo-format-02564";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0, error_vuid,
-                            "vkCreateImage(): arrayLayers = %d, but when the ycbcrImagesArrays feature is not enabled and using a "
-                            "YCbCr Conversion format, arrayLayers must be 1",
-                            pCreateInfo->arrayLayers);
+            skip |= LogError(device, error_vuid,
+                             "vkCreateImage(): arrayLayers = %d, but when the ycbcrImagesArrays feature is not enabled and using a "
+                             "YCbCr Conversion format, arrayLayers must be 1",
+                             pCreateInfo->arrayLayers);
         }
 
         if (pCreateInfo->mipLevels != 1) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                            "VUID-VkImageCreateInfo-format-02561",
-                            "vkCreateImage(): mipLevels = %d, but when using a YCbCr Conversion format, mipLevels must be 1",
-                            pCreateInfo->arrayLayers);
+            skip |= LogError(device, "VUID-VkImageCreateInfo-format-02561",
+                             "vkCreateImage(): mipLevels = %d, but when using a YCbCr Conversion format, mipLevels must be 1",
+                             pCreateInfo->arrayLayers);
         }
 
         if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                "VUID-VkImageCreateInfo-format-02562",
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-format-02562",
                 "vkCreateImage(): samples = %s, but when using a YCbCr Conversion format, samples must be VK_SAMPLE_COUNT_1_BIT",
                 string_VkSampleCountFlagBits(pCreateInfo->samples));
         }
 
         if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                "VUID-VkImageCreateInfo-format-02563",
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-format-02563",
                 "vkCreateImage(): imageType = %s, but when using a YCbCr Conversion format, imageType must be VK_IMAGE_TYPE_2D ",
                 string_VkImageType(pCreateInfo->imageType));
         }
     }
 
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.core.sparseResidencyAliased)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-flags-01924",
-                        "vkCreateImage(): the sparseResidencyAliased device feature is disabled: Images cannot be created with the "
-                        "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT set.");
+        skip |=
+            LogError(device, "VUID-VkImageCreateInfo-flags-01924",
+                     "vkCreateImage(): the sparseResidencyAliased device feature is disabled: Images cannot be created with the "
+                     "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT set.");
     }
 
     if (device_extensions.vk_khr_maintenance2) {
@@ -1659,17 +1612,17 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                   FormatIsCompressed_ETC2_EAC(pCreateInfo->format))) {
                 // TODO: Add Maintenance2 VUID
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUIDUndefined,
-                            "vkCreateImage(): If pCreateInfo->flags contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT_KHR, "
-                            "format must be block, ETC or ASTC compressed, but is %s",
-                            string_VkFormat(pCreateInfo->format));
+                    LogError(device, kVUIDUndefined,
+                             "vkCreateImage(): If pCreateInfo->flags contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT_KHR, "
+                             "format must be block, ETC or ASTC compressed, but is %s",
+                             string_VkFormat(pCreateInfo->format));
             }
             if (!(pCreateInfo->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
                 // TODO: Add Maintenance2 VUID
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUIDUndefined,
-                            "vkCreateImage(): If pCreateInfo->flags contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT_KHR, "
-                            "flags must also contain VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.");
+                    LogError(device, kVUIDUndefined,
+                             "vkCreateImage(): If pCreateInfo->flags contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT_KHR, "
+                             "flags must also contain VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.");
             }
         }
     }
@@ -1683,10 +1636,9 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     if (!FormatIsMultiplane(pCreateInfo->format) && !(pCreateInfo->flags & VK_IMAGE_CREATE_ALIAS_BIT) &&
         (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT)) {
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-VkImageCreateInfo-format-01577",
-                    "vkCreateImage(): format is %s and flags are %s. The flags should not include VK_IMAGE_CREATE_DISJOINT_BIT.",
-                    string_VkFormat(pCreateInfo->format), string_VkImageCreateFlags(pCreateInfo->flags).c_str());
+            LogError(device, "VUID-VkImageCreateInfo-format-01577",
+                     "vkCreateImage(): format is %s and flags are %s. The flags should not include VK_IMAGE_CREATE_DISJOINT_BIT.",
+                     string_VkFormat(pCreateInfo->format), string_VkImageCreateFlags(pCreateInfo->flags).c_str());
     }
     return skip;
 }
@@ -1736,24 +1688,20 @@ bool CoreChecks::ValidateImageAttributes(const IMAGE_STATE *image_state, const V
 
     if (range.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) {
         char const str[] = "vkCmdClearColorImage aspectMasks for all subresource ranges must be set to VK_IMAGE_ASPECT_COLOR_BIT";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(image_state->image), kVUID_Core_DrawState_InvalidImageAspect, str);
+        skip |= LogError(image_state->image, kVUID_Core_DrawState_InvalidImageAspect, str);
     }
 
     if (FormatIsDepthOrStencil(image_state->createInfo.format)) {
         char const str[] = "vkCmdClearColorImage called with depth/stencil image.";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(image_state->image), "VUID-vkCmdClearColorImage-image-00007", "%s.", str);
+        skip |= LogError(image_state->image, "VUID-vkCmdClearColorImage-image-00007", "%s.", str);
     } else if (FormatIsCompressed(image_state->createInfo.format)) {
         char const str[] = "vkCmdClearColorImage called with compressed image.";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(image_state->image), "VUID-vkCmdClearColorImage-image-00007", "%s.", str);
+        skip |= LogError(image_state->image, "VUID-vkCmdClearColorImage-image-00007", "%s.", str);
     }
 
     if (!(image_state->createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
         char const str[] = "vkCmdClearColorImage called with image created without VK_IMAGE_USAGE_TRANSFER_DST_BIT.";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(image_state->image), "VUID-vkCmdClearColorImage-image-00002", "%s.", str);
+        skip |= LogError(image_state->image, "VUID-vkCmdClearColorImage-image-00002", "%s.", str);
     }
     return skip;
 }
@@ -1782,27 +1730,24 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
     bool skip = false;
     if (strcmp(func_name, "vkCmdClearDepthStencilImage()") == 0) {
         if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-vkCmdClearDepthStencilImage-imageLayout-00012",
-                            "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
-                            string_VkImageLayout(dest_image_layout));
+            skip |= LogError(image_state->image, "VUID-vkCmdClearDepthStencilImage-imageLayout-00012",
+                             "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
+                             string_VkImageLayout(dest_image_layout));
         }
 
     } else {
         assert(strcmp(func_name, "vkCmdClearColorImage()") == 0);
         if (!device_extensions.vk_khr_shared_presentable_image) {
             if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-vkCmdClearColorImage-imageLayout-00005",
-                                "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
-                                string_VkImageLayout(dest_image_layout));
+                skip |= LogError(image_state->image, "VUID-vkCmdClearColorImage-imageLayout-00005",
+                                 "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
+                                 string_VkImageLayout(dest_image_layout));
             }
         } else {
             if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL) &&
                 (dest_image_layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                    HandleToUint64(image_state->image), "VUID-vkCmdClearColorImage-imageLayout-01394",
+                skip |= LogError(
+                    image_state->image, "VUID-vkCmdClearColorImage-imageLayout-01394",
                     "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL, SHARED_PRESENT_KHR, or GENERAL.",
                     func_name, string_VkImageLayout(dest_image_layout));
             }
@@ -1823,11 +1768,10 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
                 } else {
                     assert(strcmp(func_name, "vkCmdClearColorImage()") == 0);
                 }
-                subres_skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                       HandleToUint64(cb_node->commandBuffer), error_code,
-                                       "%s: Cannot clear an image whose layout is %s and doesn't match the %s layout %s.",
-                                       func_name, string_VkImageLayout(dest_image_layout), layout_check.message,
-                                       string_VkImageLayout(layout_check.layout));
+                subres_skip |= LogError(cb_node->commandBuffer, error_code,
+                                        "%s: Cannot clear an image whose layout is %s and doesn't match the %s layout %s.",
+                                        func_name, string_VkImageLayout(dest_image_layout), layout_check.message,
+                                        string_VkImageLayout(layout_check.layout));
             }
         }
         skip |= subres_skip;
@@ -1912,8 +1856,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
                 char const str[] =
                     "vkCmdClearDepthStencilImage aspectMasks for all subresource ranges must be set to VK_IMAGE_ASPECT_DEPTH_BIT "
                     "and/or VK_IMAGE_ASPECT_STENCIL_BIT";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), kVUID_Core_DrawState_InvalidImageAspect, str);
+                skip |= LogError(commandBuffer, kVUID_Core_DrawState_InvalidImageAspect, str);
             }
             if ((pRanges[i].aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0) {
                 any_include_aspect_depth_bit = true;
@@ -1927,17 +1870,15 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
             if (image_stencil_struct != nullptr) {
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                "VUID-vkCmdClearDepthStencilImage-pRanges-02658",
-                                "vkCmdClearDepthStencilImage(): an element of pRanges.aspect includes VK_IMAGE_ASPECT_STENCIL_BIT "
-                                "and image was created with separate stencil usage, VK_IMAGE_USAGE_TRANSFER_DST_BIT must be "
-                                "included in VkImageStencilUsageCreateInfo::stencilUsage used to create image");
+                        LogError(device, "VUID-vkCmdClearDepthStencilImage-pRanges-02658",
+                                 "vkCmdClearDepthStencilImage(): an element of pRanges.aspect includes VK_IMAGE_ASPECT_STENCIL_BIT "
+                                 "and image was created with separate stencil usage, VK_IMAGE_USAGE_TRANSFER_DST_BIT must be "
+                                 "included in VkImageStencilUsageCreateInfo::stencilUsage used to create image");
                 }
             } else {
                 if ((image_state->createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-vkCmdClearDepthStencilImage-pRanges-02659",
+                    skip |= LogError(
+                        device, "VUID-vkCmdClearDepthStencilImage-pRanges-02659",
                         "vkCmdClearDepthStencilImage(): an element of pRanges.aspect includes VK_IMAGE_ASPECT_STENCIL_BIT and "
                         "image was not created with separate stencil usage, VK_IMAGE_USAGE_TRANSFER_DST_BIT must be included "
                         "in VkImageCreateInfo::usage used to create image");
@@ -1945,22 +1886,19 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
             }
         }
         if (any_include_aspect_depth_bit && (image_state->createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                            "VUID-vkCmdClearDepthStencilImage-pRanges-02660",
-                            "vkCmdClearDepthStencilImage(): an element of pRanges.aspect includes VK_IMAGE_ASPECT_DEPTH_BIT, "
-                            "VK_IMAGE_USAGE_TRANSFER_DST_BIT must be included in VkImageCreateInfo::usage used to create image");
+            skip |= LogError(device, "VUID-vkCmdClearDepthStencilImage-pRanges-02660",
+                             "vkCmdClearDepthStencilImage(): an element of pRanges.aspect includes VK_IMAGE_ASPECT_DEPTH_BIT, "
+                             "VK_IMAGE_USAGE_TRANSFER_DST_BIT must be included in VkImageCreateInfo::usage used to create image");
         }
         if (image_state && !FormatIsDepthOrStencil(image_state->createInfo.format)) {
             char const str[] = "vkCmdClearDepthStencilImage called without a depth/stencil image.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkCmdClearDepthStencilImage-image-00014", "%s.", str);
+            skip |= LogError(image, "VUID-vkCmdClearDepthStencilImage-image-00014", "%s.", str);
         }
         if (VK_IMAGE_USAGE_TRANSFER_DST_BIT != (VK_IMAGE_USAGE_TRANSFER_DST_BIT & image_state->createInfo.usage)) {
             char const str[] =
                 "vkCmdClearDepthStencilImage() called with an image that was not created with the VK_IMAGE_USAGE_TRANSFER_DST_BIT "
                 "set.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkCmdClearDepthStencilImage-image-00009", "%s.", str);
+            skip |= LogError(image, "VUID-vkCmdClearDepthStencilImage-image-00009", "%s.", str);
         }
     }
     return skip;
@@ -2159,22 +2097,20 @@ bool CoreChecks::CheckItgOffset(const CMD_BUFFER_STATE *cb_node, const VkOffset3
     if (IsExtentAllZeroes(granularity)) {
         // If the queue family image transfer granularity is (0, 0, 0), then the offset must always be (0, 0, 0)
         if (IsExtentAllZeroes(&offset_extent) == false) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), vuid,
-                            "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) must be (x=0, y=0, z=0) when the command buffer's queue family "
-                            "image transfer granularity is (w=0, h=0, d=0).",
-                            function, i, member, offset->x, offset->y, offset->z);
+            skip |= LogError(cb_node->commandBuffer, vuid,
+                             "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) must be (x=0, y=0, z=0) when the command buffer's queue family "
+                             "image transfer granularity is (w=0, h=0, d=0).",
+                             function, i, member, offset->x, offset->y, offset->z);
         }
     } else {
         // If the queue family image transfer granularity is not (0, 0, 0), then the offset dimensions must always be even
         // integer multiples of the image transfer granularity.
         if (IsExtentAligned(&offset_extent, granularity) == false) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), vuid,
-                            "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) dimensions must be even integer multiples of this command "
-                            "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d).",
-                            function, i, member, offset->x, offset->y, offset->z, granularity->width, granularity->height,
-                            granularity->depth);
+            skip |= LogError(cb_node->commandBuffer, vuid,
+                             "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) dimensions must be even integer multiples of this command "
+                             "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d).",
+                             function, i, member, offset->x, offset->y, offset->z, granularity->width, granularity->height,
+                             granularity->depth);
         }
     }
     return skip;
@@ -2189,12 +2125,11 @@ bool CoreChecks::CheckItgExtent(const CMD_BUFFER_STATE *cb_node, const VkExtent3
         // If the queue family image transfer granularity is (0, 0, 0), then the extent must always match the image
         // subresource extent.
         if (IsExtentEqual(extent, subresource_extent) == false) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), vuid,
-                            "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d) "
-                            "when the command buffer's queue family image transfer granularity is (w=0, h=0, d=0).",
-                            function, i, member, extent->width, extent->height, extent->depth, subresource_extent->width,
-                            subresource_extent->height, subresource_extent->depth);
+            skip |= LogError(cb_node->commandBuffer, vuid,
+                             "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d) "
+                             "when the command buffer's queue family image transfer granularity is (w=0, h=0, d=0).",
+                             function, i, member, extent->width, extent->height, extent->depth, subresource_extent->width,
+                             subresource_extent->height, subresource_extent->depth);
         }
     } else {
         // If the queue family image transfer granularity is not (0, 0, 0), then the extent dimensions must always be even
@@ -2225,14 +2160,14 @@ bool CoreChecks::CheckItgExtent(const CMD_BUFFER_STATE *cb_node, const VkExtent3
                 assert(false);
         }
         if (!(x_ok && y_ok && z_ok)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), vuid,
-                            "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) dimensions must be even integer multiples of this command "
-                            "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d) or offset (x=%d, y=%d, z=%d) + "
-                            "extent (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d).",
-                            function, i, member, extent->width, extent->height, extent->depth, granularity->width,
-                            granularity->height, granularity->depth, offset->x, offset->y, offset->z, extent->width, extent->height,
-                            extent->depth, subresource_extent->width, subresource_extent->height, subresource_extent->depth);
+            skip |=
+                LogError(cb_node->commandBuffer, vuid,
+                         "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) dimensions must be even integer multiples of this command "
+                         "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d) or offset (x=%d, y=%d, z=%d) + "
+                         "extent (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d).",
+                         function, i, member, extent->width, extent->height, extent->depth, granularity->width, granularity->height,
+                         granularity->depth, offset->x, offset->y, offset->z, extent->width, extent->height, extent->depth,
+                         subresource_extent->width, subresource_extent->height, subresource_extent->depth);
         }
     }
     return skip;
@@ -2242,10 +2177,8 @@ bool CoreChecks::ValidateImageMipLevel(const CMD_BUFFER_STATE *cb_node, const IM
                                        const uint32_t i, const char *function, const char *member, const char *vuid) const {
     bool skip = false;
     if (mip_level >= img->createInfo.mipLevels) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->commandBuffer), vuid,
-                        "In %s, pRegions[%u].%s.mipLevel is %u, but provided %s has %u mip levels.", function, i, member, mip_level,
-                        report_data->FormatHandle(img->image).c_str(), img->createInfo.mipLevels);
+        skip |= LogError(cb_node->commandBuffer, vuid, "In %s, pRegions[%u].%s.mipLevel is %u, but provided %s has %u mip levels.",
+                         function, i, member, mip_level, report_data->FormatHandle(img->image).c_str(), img->createInfo.mipLevels);
     }
     return skip;
 }
@@ -2256,12 +2189,11 @@ bool CoreChecks::ValidateImageArrayLayerRange(const CMD_BUFFER_STATE *cb_node, c
     bool skip = false;
     if (base_layer >= img->createInfo.arrayLayers || layer_count > img->createInfo.arrayLayers ||
         (base_layer + layer_count) > img->createInfo.arrayLayers) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->commandBuffer), vuid,
-                        "In %s, pRegions[%u].%s.baseArrayLayer is %u and .layerCount is "
-                        "%u, but provided %s has %u array layers.",
-                        function, i, member, base_layer, layer_count, report_data->FormatHandle(img->image).c_str(),
-                        img->createInfo.arrayLayers);
+        skip |= LogError(cb_node->commandBuffer, vuid,
+                         "In %s, pRegions[%u].%s.baseArrayLayer is %u and .layerCount is "
+                         "%u, but provided %s has %u array layers.",
+                         function, i, member, base_layer, layer_count, report_data->FormatHandle(img->image).c_str(),
+                         img->createInfo.arrayLayers);
     }
     return skip;
 }
@@ -2336,51 +2268,47 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
         //
         if (src_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.srcOffset.y) || (1 != src_copy_extent.height)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(src_state->image), "VUID-VkImageCopy-srcImage-00146",
-                                "vkCmdCopyImage(): pRegion[%d] srcOffset.y is %d and extent.height is %d. For 1D images these must "
-                                "be 0 and 1, respectively.",
-                                i, region.srcOffset.y, src_copy_extent.height);
+                skip |=
+                    LogError(src_state->image, "VUID-VkImageCopy-srcImage-00146",
+                             "vkCmdCopyImage(): pRegion[%d] srcOffset.y is %d and extent.height is %d. For 1D images these must "
+                             "be 0 and 1, respectively.",
+                             i, region.srcOffset.y, src_copy_extent.height);
             }
         }
 
         // VUID-VkImageCopy-srcImage-01785
         if ((src_state->createInfo.imageType == VK_IMAGE_TYPE_1D) && ((0 != region.srcOffset.z) || (1 != src_copy_extent.depth))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(src_state->image), "VUID-VkImageCopy-srcImage-01785",
-                            "vkCmdCopyImage(): pRegion[%d] srcOffset.z is %d and extent.depth is %d. For 1D images "
-                            "these must be 0 and 1, respectively.",
-                            i, region.srcOffset.z, src_copy_extent.depth);
+            skip |= LogError(src_state->image, "VUID-VkImageCopy-srcImage-01785",
+                             "vkCmdCopyImage(): pRegion[%d] srcOffset.z is %d and extent.depth is %d. For 1D images "
+                             "these must be 0 and 1, respectively.",
+                             i, region.srcOffset.z, src_copy_extent.depth);
         }
 
         // VUID-VkImageCopy-srcImage-01787
         if ((src_state->createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.srcOffset.z)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(src_state->image), "VUID-VkImageCopy-srcImage-01787",
-                            "vkCmdCopyImage(): pRegion[%d] srcOffset.z is %d. For 2D images the z-offset must be 0.", i,
-                            region.srcOffset.z);
+            skip |= LogError(src_state->image, "VUID-VkImageCopy-srcImage-01787",
+                             "vkCmdCopyImage(): pRegion[%d] srcOffset.z is %d. For 2D images the z-offset must be 0.", i,
+                             region.srcOffset.z);
         }
 
         if (device_extensions.vk_khr_maintenance1) {
             if (src_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(src_state->image), "VUID-VkImageCopy-srcImage-00141",
-                                "vkCmdCopyImage(): pRegion[%d] srcSubresource.baseArrayLayer is %d and srcSubresource.layerCount "
-                                "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
-                                i, region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
+                        LogError(src_state->image, "VUID-VkImageCopy-srcImage-00141",
+                                 "vkCmdCopyImage(): pRegion[%d] srcSubresource.baseArrayLayer is %d and srcSubresource.layerCount "
+                                 "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
+                                 i, region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
                 }
             }
         } else {  // Pre maint 1
             if (src_state->createInfo.imageType == VK_IMAGE_TYPE_3D || dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    HandleToUint64(src_state->image), "VUID-VkImageCopy-srcImage-00141",
-                                    "vkCmdCopyImage(): pRegion[%d] srcSubresource.baseArrayLayer is %d and "
-                                    "srcSubresource.layerCount is %d. For copies with either source or dest of type "
-                                    "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
-                                    i, region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
+                    skip |= LogError(src_state->image, "VUID-VkImageCopy-srcImage-00141",
+                                     "vkCmdCopyImage(): pRegion[%d] srcSubresource.baseArrayLayer is %d and "
+                                     "srcSubresource.layerCount is %d. For copies with either source or dest of type "
+                                     "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
+                                     i, region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
                 }
             }
         }
@@ -2395,11 +2323,10 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
                 (SafeModulo(region.srcOffset.y, block_size.height) != 0) ||
                 (SafeModulo(region.srcOffset.z, block_size.depth) != 0)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-srcImage-01727" : "VUID-VkImageCopy-srcOffset-00157";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(src_state->image), vuid,
-                                "vkCmdCopyImage(): pRegion[%d] srcOffset (%d, %d) must be multiples of the compressed image's "
-                                "texel width & height (%d, %d).",
-                                i, region.srcOffset.x, region.srcOffset.y, block_size.width, block_size.height);
+                skip |= LogError(src_state->image, vuid,
+                                 "vkCmdCopyImage(): pRegion[%d] srcOffset (%d, %d) must be multiples of the compressed image's "
+                                 "texel width & height (%d, %d).",
+                                 i, region.srcOffset.x, region.srcOffset.y, block_size.width, block_size.height);
             }
 
             const VkExtent3D mip_extent = GetImageSubresourceExtent(src_state, &(region.srcSubresource));
@@ -2407,11 +2334,10 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
                 (src_copy_extent.width + region.srcOffset.x != mip_extent.width)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-srcImage-01728" : "VUID-VkImageCopy-extent-00158";
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(src_state->image), vuid,
-                            "vkCmdCopyImage(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
-                            "width (%d), or when added to srcOffset.x (%d) must equal the image subresource width (%d).",
-                            i, src_copy_extent.width, block_size.width, region.srcOffset.x, mip_extent.width);
+                    LogError(src_state->image, vuid,
+                             "vkCmdCopyImage(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
+                             "width (%d), or when added to srcOffset.x (%d) must equal the image subresource width (%d).",
+                             i, src_copy_extent.width, block_size.width, region.srcOffset.x, mip_extent.width);
             }
 
             // Extent height must be a multiple of block height, or extent+offset height must equal subresource height
@@ -2419,11 +2345,10 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
                 (src_copy_extent.height + region.srcOffset.y != mip_extent.height)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-srcImage-01729" : "VUID-VkImageCopy-extent-00159";
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(src_state->image), vuid,
-                            "vkCmdCopyImage(): pRegion[%d] extent height (%d) must be a multiple of the compressed texture block "
-                            "height (%d), or when added to srcOffset.y (%d) must equal the image subresource height (%d).",
-                            i, src_copy_extent.height, block_size.height, region.srcOffset.y, mip_extent.height);
+                    LogError(src_state->image, vuid,
+                             "vkCmdCopyImage(): pRegion[%d] extent height (%d) must be a multiple of the compressed texture block "
+                             "height (%d), or when added to srcOffset.y (%d) must equal the image subresource height (%d).",
+                             i, src_copy_extent.height, block_size.height, region.srcOffset.y, mip_extent.height);
             }
 
             // Extent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
@@ -2431,11 +2356,10 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.srcOffset.z != mip_extent.depth)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-srcImage-01730" : "VUID-VkImageCopy-extent-00160";
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(src_state->image), vuid,
-                            "vkCmdCopyImage(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
-                            "depth (%d), or when added to srcOffset.z (%d) must equal the image subresource depth (%d).",
-                            i, src_copy_extent.depth, block_size.depth, region.srcOffset.z, mip_extent.depth);
+                    LogError(src_state->image, vuid,
+                             "vkCmdCopyImage(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
+                             "depth (%d), or when added to srcOffset.z (%d) must equal the image subresource depth (%d).",
+                             i, src_copy_extent.depth, block_size.depth, region.srcOffset.z, mip_extent.depth);
             }
         }  // Compressed
 
@@ -2443,38 +2367,35 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
         //
         if (dst_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.dstOffset.y) || (1 != dst_copy_extent.height)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(dst_state->image), "VUID-VkImageCopy-dstImage-00152",
-                                "vkCmdCopyImage(): pRegion[%d] dstOffset.y is %d and dst_copy_extent.height is %d. For 1D images "
-                                "these must be 0 and 1, respectively.",
-                                i, region.dstOffset.y, dst_copy_extent.height);
+                skip |= LogError(dst_state->image, "VUID-VkImageCopy-dstImage-00152",
+                                 "vkCmdCopyImage(): pRegion[%d] dstOffset.y is %d and dst_copy_extent.height is %d. For 1D images "
+                                 "these must be 0 and 1, respectively.",
+                                 i, region.dstOffset.y, dst_copy_extent.height);
             }
         }
 
         // VUID-VkImageCopy-dstImage-01786
         if ((dst_state->createInfo.imageType == VK_IMAGE_TYPE_1D) && ((0 != region.dstOffset.z) || (1 != dst_copy_extent.depth))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(dst_state->image), "VUID-VkImageCopy-dstImage-01786",
-                            "vkCmdCopyImage(): pRegion[%d] dstOffset.z is %d and extent.depth is %d. For 1D images these must be 0 "
-                            "and 1, respectively.",
-                            i, region.dstOffset.z, dst_copy_extent.depth);
+            skip |=
+                LogError(dst_state->image, "VUID-VkImageCopy-dstImage-01786",
+                         "vkCmdCopyImage(): pRegion[%d] dstOffset.z is %d and extent.depth is %d. For 1D images these must be 0 "
+                         "and 1, respectively.",
+                         i, region.dstOffset.z, dst_copy_extent.depth);
         }
 
         // VUID-VkImageCopy-dstImage-01788
         if ((dst_state->createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.dstOffset.z)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(dst_state->image), "VUID-VkImageCopy-dstImage-01788",
-                            "vkCmdCopyImage(): pRegion[%d] dstOffset.z is %d. For 2D images the z-offset must be 0.", i,
-                            region.dstOffset.z);
+            skip |= LogError(dst_state->image, "VUID-VkImageCopy-dstImage-01788",
+                             "vkCmdCopyImage(): pRegion[%d] dstOffset.z is %d. For 2D images the z-offset must be 0.", i,
+                             region.dstOffset.z);
         }
 
         if (dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
             if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(dst_state->image), "VUID-VkImageCopy-srcImage-00141",
-                                "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and dstSubresource.layerCount "
-                                "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
-                                i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
+                skip |= LogError(dst_state->image, "VUID-VkImageCopy-srcImage-00141",
+                                 "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and dstSubresource.layerCount "
+                                 "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
+                                 i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
             }
         }
         // VU01199 changed with mnt1
@@ -2482,22 +2403,20 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
             if (dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(dst_state->image), "VUID-VkImageCopy-srcImage-00141",
-                                "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and dstSubresource.layerCount "
-                                "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
-                                i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
+                        LogError(dst_state->image, "VUID-VkImageCopy-srcImage-00141",
+                                 "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and dstSubresource.layerCount "
+                                 "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
+                                 i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
                 }
             }
         } else {  // Pre maint 1
             if (src_state->createInfo.imageType == VK_IMAGE_TYPE_3D || dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    HandleToUint64(dst_state->image), "VUID-VkImageCopy-srcImage-00141",
-                                    "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and "
-                                    "dstSubresource.layerCount is %d. For copies with either source or dest of type "
-                                    "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
-                                    i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
+                    skip |= LogError(dst_state->image, "VUID-VkImageCopy-srcImage-00141",
+                                     "vkCmdCopyImage(): pRegion[%d] dstSubresource.baseArrayLayer is %d and "
+                                     "dstSubresource.layerCount is %d. For copies with either source or dest of type "
+                                     "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
+                                     i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
                 }
             }
         }
@@ -2512,47 +2431,43 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const VkImage
                 (SafeModulo(region.dstOffset.y, block_size.height) != 0) ||
                 (SafeModulo(region.dstOffset.z, block_size.depth) != 0)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-dstImage-01731" : "VUID-VkImageCopy-dstOffset-00162";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(dst_state->image), vuid,
-                                "vkCmdCopyImage(): pRegion[%d] dstOffset (%d, %d) must be multiples of the compressed image's "
-                                "texel width & height (%d, %d).",
-                                i, region.dstOffset.x, region.dstOffset.y, block_size.width, block_size.height);
+                skip |= LogError(dst_state->image, vuid,
+                                 "vkCmdCopyImage(): pRegion[%d] dstOffset (%d, %d) must be multiples of the compressed image's "
+                                 "texel width & height (%d, %d).",
+                                 i, region.dstOffset.x, region.dstOffset.y, block_size.width, block_size.height);
             }
 
             const VkExtent3D mip_extent = GetImageSubresourceExtent(dst_state, &(region.dstSubresource));
             if ((SafeModulo(dst_copy_extent.width, block_size.width) != 0) &&
                 (dst_copy_extent.width + region.dstOffset.x != mip_extent.width)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-dstImage-01732" : "VUID-VkImageCopy-extent-00163";
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(dst_state->image), vuid,
-                            "vkCmdCopyImage(): pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
-                            "block width (%d), or when added to dstOffset.x (%d) must equal the image subresource width (%d).",
-                            i, dst_copy_extent.width, block_size.width, region.dstOffset.x, mip_extent.width);
+                skip |= LogError(
+                    dst_state->image, vuid,
+                    "vkCmdCopyImage(): pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
+                    "block width (%d), or when added to dstOffset.x (%d) must equal the image subresource width (%d).",
+                    i, dst_copy_extent.width, block_size.width, region.dstOffset.x, mip_extent.width);
             }
 
             // Extent height must be a multiple of block height, or dst_copy_extent+offset height must equal subresource height
             if ((SafeModulo(dst_copy_extent.height, block_size.height) != 0) &&
                 (dst_copy_extent.height + region.dstOffset.y != mip_extent.height)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-dstImage-01733" : "VUID-VkImageCopy-extent-00164";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(dst_state->image), vuid,
-                                "vkCmdCopyImage(): pRegion[%d] dst_copy_extent height (%d) must be a multiple of the compressed "
-                                "texture block height (%d), or when added to dstOffset.y (%d) must equal the image subresource "
-                                "height (%d).",
-                                i, dst_copy_extent.height, block_size.height, region.dstOffset.y, mip_extent.height);
+                skip |= LogError(dst_state->image, vuid,
+                                 "vkCmdCopyImage(): pRegion[%d] dst_copy_extent height (%d) must be a multiple of the compressed "
+                                 "texture block height (%d), or when added to dstOffset.y (%d) must equal the image subresource "
+                                 "height (%d).",
+                                 i, dst_copy_extent.height, block_size.height, region.dstOffset.y, mip_extent.height);
             }
 
             // Extent depth must be a multiple of block depth, or dst_copy_extent+offset depth must equal subresource depth
             uint32_t copy_depth = (slice_override ? depth_slices : dst_copy_extent.depth);
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.dstOffset.z != mip_extent.depth)) {
                 const char *vuid = ext_ycbcr ? "VUID-VkImageCopy-dstImage-01734" : "VUID-VkImageCopy-extent-00165";
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(dst_state->image), vuid,
-                            "vkCmdCopyImage(): pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
-                            "block depth (%d), or when added to dstOffset.z (%d) must equal the image subresource depth (%d).",
-                            i, dst_copy_extent.depth, block_size.depth, region.dstOffset.z, mip_extent.depth);
+                skip |= LogError(
+                    dst_state->image, vuid,
+                    "vkCmdCopyImage(): pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
+                    "block depth (%d), or when added to dstOffset.z (%d) must equal the image subresource depth (%d).",
+                    i, dst_copy_extent.depth, block_size.depth, region.dstOffset.z, mip_extent.depth);
             }
         }  // Compressed
     }
@@ -2571,8 +2486,7 @@ bool CoreChecks::CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, c
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Copy between non-multiplane images with differing aspectMasks ( 0x" << std::hex
                << region.srcSubresource.aspectMask << " and 0x" << region.dstSubresource.aspectMask << " )";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-srcImage-01551", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-srcImage-01551", "%s.", ss.str().c_str());
         }
     } else {
         // Source image multiplane checks
@@ -2581,23 +2495,20 @@ bool CoreChecks::CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, c
         if ((2 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT_KHR) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT_KHR)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Source image aspect mask (0x" << std::hex << aspect << ") is invalid for 2-plane format";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-srcImage-01552", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-srcImage-01552", "%s.", ss.str().c_str());
         }
         if ((3 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT_KHR) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT_KHR) &&
             (aspect != VK_IMAGE_ASPECT_PLANE_2_BIT_KHR)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Source image aspect mask (0x" << std::hex << aspect << ") is invalid for 3-plane format";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-srcImage-01553", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-srcImage-01553", "%s.", ss.str().c_str());
         }
         // Single-plane to multi-plane
         if ((!FormatIsMultiplane(src_image_state->createInfo.format)) && (FormatIsMultiplane(dst_image_state->createInfo.format)) &&
             (VK_IMAGE_ASPECT_COLOR_BIT != aspect)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Source image aspect mask (0x" << std::hex << aspect << ") is not VK_IMAGE_ASPECT_COLOR_BIT";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstImage-01557", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstImage-01557", "%s.", ss.str().c_str());
         }
 
         // Dest image multiplane checks
@@ -2606,23 +2517,20 @@ bool CoreChecks::CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, c
         if ((2 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT_KHR) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT_KHR)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Dest image aspect mask (0x" << std::hex << aspect << ") is invalid for 2-plane format";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstImage-01554", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstImage-01554", "%s.", ss.str().c_str());
         }
         if ((3 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT_KHR) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT_KHR) &&
             (aspect != VK_IMAGE_ASPECT_PLANE_2_BIT_KHR)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Dest image aspect mask (0x" << std::hex << aspect << ") is invalid for 3-plane format";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstImage-01555", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstImage-01555", "%s.", ss.str().c_str());
         }
         // Multi-plane to single-plane
         if ((FormatIsMultiplane(src_image_state->createInfo.format)) && (!FormatIsMultiplane(dst_image_state->createInfo.format)) &&
             (VK_IMAGE_ASPECT_COLOR_BIT != aspect)) {
             std::stringstream ss;
             ss << "vkCmdCopyImage(): Dest image aspect mask (0x" << std::hex << aspect << ") is not VK_IMAGE_ASPECT_COLOR_BIT";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-srcImage-01556", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-srcImage-01556", "%s.", ss.str().c_str());
         }
     }
 
@@ -2692,8 +2600,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                     std::stringstream ss;
                     ss << "vkCmdCopyImage(): number of depth slices in source and destination subresources for pRegions[" << i
                        << "] do not match";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(command_buffer), "VUID-VkImageCopy-extent-00140", "%s.", ss.str().c_str());
+                    skip |= LogError(command_buffer, "VUID-VkImageCopy-extent-00140", "%s.", ss.str().c_str());
                 }
             }
         } else {
@@ -2702,8 +2609,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                 std::stringstream ss;
                 ss << "vkCmdCopyImage(): number of layers in source and destination subresources for pRegions[" << i
                    << "] do not match";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(command_buffer), "VUID-VkImageCopy-extent-00140", "%s.", ss.str().c_str());
+                skip |= LogError(command_buffer, "VUID-VkImageCopy-extent-00140", "%s.", ss.str().c_str());
             }
         }
 
@@ -2716,8 +2622,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
             // not multi-plane, the aspectMask member of srcSubresource and dstSubresource must match
             if (region.srcSubresource.aspectMask != region.dstSubresource.aspectMask) {
                 char const str[] = "vkCmdCopyImage(): Src and dest aspectMasks for each region must match";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(command_buffer), "VUID-VkImageCopy-aspectMask-00137", "%s.", str);
+                skip |= LogError(command_buffer, "VUID-VkImageCopy-aspectMask-00137", "%s.", str);
             }
         }
 
@@ -2726,8 +2631,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
             std::stringstream ss;
             ss << "vkCmdCopyImage(): pRegion[" << i
                << "] srcSubresource.aspectMask cannot specify aspects not present in source image";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-aspectMask-00142", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-aspectMask-00142", "%s.", ss.str().c_str());
         }
 
         // For each region, the aspectMask member of dstSubresource must be present in the destination image
@@ -2735,8 +2639,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
             std::stringstream ss;
             ss << "vkCmdCopyImage(): pRegion[" << i
                << "] dstSubresource.aspectMask cannot specify aspects not present in dest image";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-aspectMask-00143", "%s.", ss.str().c_str());
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-aspectMask-00143", "%s.", ss.str().c_str());
         }
 
         // Check region extents for 1D-1D, 2D-2D, and 3D-3D copies
@@ -2749,8 +2652,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                    << " ], offset [ " << region.srcOffset.x << ", " << region.srcOffset.y << ", " << region.srcOffset.z
                    << " ], extent [ " << src_copy_extent.width << ", " << src_copy_extent.height << ", " << src_copy_extent.depth
                    << " ] exceeds the source image dimensions";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(command_buffer), "VUID-vkCmdCopyImage-pRegions-00122", "%s.", ss.str().c_str());
+                skip |= LogError(command_buffer, "VUID-vkCmdCopyImage-pRegions-00122", "%s.", ss.str().c_str());
             }
 
             // The destination region specified by a given element of regions must be a region that is contained within dst_image
@@ -2761,8 +2663,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                    << " ], offset [ " << region.dstOffset.x << ", " << region.dstOffset.y << ", " << region.dstOffset.z
                    << " ], extent [ " << dst_copy_extent.width << ", " << dst_copy_extent.height << ", " << dst_copy_extent.depth
                    << " ] exceeds the destination image dimensions";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(command_buffer), "VUID-vkCmdCopyImage-pRegions-00123", "%s.", ss.str().c_str());
+                skip |= LogError(command_buffer, "VUID-vkCmdCopyImage-pRegions-00123", "%s.", ss.str().c_str());
             }
         }
 
@@ -2772,28 +2673,25 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
         uint32_t extent_check = ExceedsBounds(&(region.srcOffset), &src_copy_extent, &subresource_extent);
         if (extent_check & x_bit) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(command_buffer), "VUID-VkImageCopy-srcOffset-00144",
-                        "vkCmdCopyImage(): Source image pRegion %1d x-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                        "width [%1d].",
-                        i, region.srcOffset.x, src_copy_extent.width, subresource_extent.width);
+                LogError(command_buffer, "VUID-VkImageCopy-srcOffset-00144",
+                         "vkCmdCopyImage(): Source image pRegion %1d x-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                         "width [%1d].",
+                         i, region.srcOffset.x, src_copy_extent.width, subresource_extent.width);
         }
 
         if (extent_check & y_bit) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(command_buffer), "VUID-VkImageCopy-srcOffset-00145",
-                        "vkCmdCopyImage(): Source image pRegion %1d y-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                        "height [%1d].",
-                        i, region.srcOffset.y, src_copy_extent.height, subresource_extent.height);
+                LogError(command_buffer, "VUID-VkImageCopy-srcOffset-00145",
+                         "vkCmdCopyImage(): Source image pRegion %1d y-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                         "height [%1d].",
+                         i, region.srcOffset.y, src_copy_extent.height, subresource_extent.height);
         }
         if (extent_check & z_bit) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(command_buffer), "VUID-VkImageCopy-srcOffset-00147",
-                        "vkCmdCopyImage(): Source image pRegion %1d z-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                        "depth [%1d].",
-                        i, region.srcOffset.z, src_copy_extent.depth, subresource_extent.depth);
+                LogError(command_buffer, "VUID-VkImageCopy-srcOffset-00147",
+                         "vkCmdCopyImage(): Source image pRegion %1d z-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                         "depth [%1d].",
+                         i, region.srcOffset.z, src_copy_extent.depth, subresource_extent.depth);
         }
 
         // Adjust dest extent if necessary
@@ -2802,25 +2700,22 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
 
         extent_check = ExceedsBounds(&(region.dstOffset), &dst_copy_extent, &subresource_extent);
         if (extent_check & x_bit) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstOffset-00150",
-                            "vkCmdCopyImage(): Dest image pRegion %1d x-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                            "width [%1d].",
-                            i, region.dstOffset.x, dst_copy_extent.width, subresource_extent.width);
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstOffset-00150",
+                             "vkCmdCopyImage(): Dest image pRegion %1d x-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                             "width [%1d].",
+                             i, region.dstOffset.x, dst_copy_extent.width, subresource_extent.width);
         }
         if (extent_check & y_bit) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstOffset-00151",
-                            "vkCmdCopyImage(): Dest image pRegion %1d y-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                            "height [%1d].",
-                            i, region.dstOffset.y, dst_copy_extent.height, subresource_extent.height);
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstOffset-00151",
+                             "vkCmdCopyImage(): Dest image pRegion %1d y-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                             "height [%1d].",
+                             i, region.dstOffset.y, dst_copy_extent.height, subresource_extent.height);
         }
         if (extent_check & z_bit) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-VkImageCopy-dstOffset-00153",
-                            "vkCmdCopyImage(): Dest image pRegion %1d z-dimension offset [%1d] + extent [%1d] exceeds subResource "
-                            "depth [%1d].",
-                            i, region.dstOffset.z, dst_copy_extent.depth, subresource_extent.depth);
+            skip |= LogError(command_buffer, "VUID-VkImageCopy-dstOffset-00153",
+                             "vkCmdCopyImage(): Dest image pRegion %1d z-dimension offset [%1d] + extent [%1d] exceeds subResource "
+                             "depth [%1d].",
+                             i, region.dstOffset.z, dst_copy_extent.depth, subresource_extent.depth);
         }
 
         // The union of all source regions, and the union of all destination regions, specified by the elements of regions,
@@ -2831,8 +2726,7 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                                      FormatIsMultiplane(src_image_state->createInfo.format))) {
                     std::stringstream ss;
                     ss << "vkCmdCopyImage(): pRegions[" << i << "] src overlaps with pRegions[" << j << "].";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(command_buffer), "VUID-vkCmdCopyImage-pRegions-00124", "%s.", ss.str().c_str());
+                    skip |= LogError(command_buffer, "VUID-vkCmdCopyImage-pRegions-00124", "%s.", ss.str().c_str());
                 }
             }
         }
@@ -2844,22 +2738,19 @@ bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
     if (FormatIsDepthOrStencil(src_image_state->createInfo.format) || FormatIsDepthOrStencil(dst_image_state->createInfo.format)) {
         if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
             char const str[] = "vkCmdCopyImage called with unmatched source and dest image depth/stencil formats.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), kVUID_Core_DrawState_MismatchedImageFormat, str);
+            skip |= LogError(command_buffer, kVUID_Core_DrawState_MismatchedImageFormat, str);
         }
     } else {
         if (!FormatSizesAreEqual(src_image_state->createInfo.format, dst_image_state->createInfo.format, regionCount, pRegions)) {
             char const str[] = "vkCmdCopyImage called with unmatched source and dest image format sizes.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-vkCmdCopyImage-srcImage-00135", "%s.", str);
+            skip |= LogError(command_buffer, "VUID-vkCmdCopyImage-srcImage-00135", "%s.", str);
         }
     }
 
     // Source and dest image sample counts must match
     if (src_image_state->createInfo.samples != dst_image_state->createInfo.samples) {
         char const str[] = "vkCmdCopyImage() called on image pair with non-identical sample counts.";
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(command_buffer), "VUID-vkCmdCopyImage-srcImage-00136", "%s", str);
+        skip |= LogError(command_buffer, "VUID-vkCmdCopyImage-srcImage-00136", "%s", str);
     }
 
     skip |= ValidateMemoryIsBoundToImage(src_image_state, "vkCmdCopyImage()", "VUID-vkCmdCopyImage-srcImage-00127");
@@ -2936,11 +2827,10 @@ bool CoreChecks::ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, u
 
     for (uint32_t j = 0; j < rect_count; j++) {
         if (!ContainsRect(render_area, clear_rects[j].rect)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(command_buffer), "VUID-vkCmdClearAttachments-pRects-00016",
-                            "vkCmdClearAttachments(): The area defined by pRects[%d] is not contained in the area of "
-                            "the current render pass instance.",
-                            j);
+            skip |= LogError(command_buffer, "VUID-vkCmdClearAttachments-pRects-00016",
+                             "vkCmdClearAttachments(): The area defined by pRects[%d] is not contained in the area of "
+                             "the current render pass instance.",
+                             j);
         }
 
         if (image_view_state) {
@@ -2949,11 +2839,10 @@ bool CoreChecks::ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, u
             const auto attachment_layer_count = image_view_state->create_info.subresourceRange.layerCount;
             if ((clear_rects[j].baseArrayLayer >= attachment_layer_count) ||
                 (clear_rects[j].baseArrayLayer + clear_rects[j].layerCount > attachment_layer_count)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(command_buffer), "VUID-vkCmdClearAttachments-pRects-00017",
-                                "vkCmdClearAttachments(): The layers defined in pRects[%d] are not contained in the layers "
-                                "of pAttachment[%d].",
-                                j, attachment_index);
+                skip |= LogError(command_buffer, "VUID-vkCmdClearAttachments-pRects-00017",
+                                 "vkCmdClearAttachments(): The layers defined in pRects[%d] are not contained in the layers "
+                                 "of pAttachment[%d].",
+                                 j, attachment_index);
             }
         }
     }
@@ -2985,35 +2874,31 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
             uint32_t fb_attachment = VK_ATTACHMENT_UNUSED;
 
             if (0 == clear_desc->aspectMask) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-VkClearAttachment-aspectMask-requiredbitmask", " ");
+                skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-requiredbitmask", " ");
             } else if (clear_desc->aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-VkClearAttachment-aspectMask-00020", " ");
+                skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-00020", " ");
             } else if (clear_desc->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
                 uint32_t color_attachment = VK_ATTACHMENT_UNUSED;
                 if (clear_desc->colorAttachment < subpass_desc->colorAttachmentCount) {
                     color_attachment = subpass_desc->pColorAttachments[clear_desc->colorAttachment].attachment;
                     if ((color_attachment != VK_ATTACHMENT_UNUSED) && (color_attachment >= renderpass_attachment_count)) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                        HandleToUint64(commandBuffer), "VUID-vkCmdClearAttachments-aspectMask-02501",
-                                        "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u is not VK_ATTACHMENT_UNUSED "
-                                        "and not a valid attachment for %s attachmentCount=%u. Subpass %u pColorAttachment[%u]=%u.",
-                                        attachment_index, clear_desc->colorAttachment,
-                                        report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
-                                        cb_node->activeSubpass, clear_desc->colorAttachment, color_attachment,
-                                        renderpass_attachment_count);
+                        skip |= LogError(
+                            commandBuffer, "VUID-vkCmdClearAttachments-aspectMask-02501",
+                            "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u is not VK_ATTACHMENT_UNUSED "
+                            "and not a valid attachment for %s attachmentCount=%u. Subpass %u pColorAttachment[%u]=%u.",
+                            attachment_index, clear_desc->colorAttachment,
+                            report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(), cb_node->activeSubpass,
+                            clear_desc->colorAttachment, color_attachment, renderpass_attachment_count);
 
                         color_attachment = VK_ATTACHMENT_UNUSED;  // Defensive, prevent lookup past end of renderpass attachment
                     }
                 } else {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(commandBuffer), "VUID-vkCmdClearAttachments-aspectMask-02501",
-                                    "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u out of range for %s"
-                                    " subpass %u. colorAttachmentCount=%u",
-                                    attachment_index, clear_desc->colorAttachment,
-                                    report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
-                                    cb_node->activeSubpass, subpass_desc->colorAttachmentCount);
+                    skip |= LogError(commandBuffer, "VUID-vkCmdClearAttachments-aspectMask-02501",
+                                     "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u out of range for %s"
+                                     " subpass %u. colorAttachmentCount=%u",
+                                     attachment_index, clear_desc->colorAttachment,
+                                     report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
+                                     cb_node->activeSubpass, subpass_desc->colorAttachmentCount);
                 }
                 fb_attachment = color_attachment;
 
@@ -3021,23 +2906,18 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                     (clear_desc->aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT)) {
                     char const str[] =
                         "vkCmdClearAttachments() aspectMask [%d] must set only VK_IMAGE_ASPECT_COLOR_BIT of a color attachment.";
-                    skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-VkClearAttachment-aspectMask-00019", str, attachment_index);
+                    skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-00019", str, attachment_index);
                 }
             } else {  // Must be depth and/or stencil
                 if (((clear_desc->aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != VK_IMAGE_ASPECT_DEPTH_BIT) &&
                     ((clear_desc->aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) != VK_IMAGE_ASPECT_STENCIL_BIT)) {
                     char const str[] = "vkCmdClearAttachments() aspectMask [%d] is not a valid combination of bits.";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(commandBuffer), "VUID-VkClearAttachment-aspectMask-parameter", str,
-                                    attachment_index);
+                    skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-parameter", str, attachment_index);
                 }
                 if (!subpass_desc->pDepthStencilAttachment ||
                     (subpass_desc->pDepthStencilAttachment->attachment == VK_ATTACHMENT_UNUSED)) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), kVUID_Core_DrawState_MissingAttachmentReference,
+                    skip |= LogPerformanceWarning(
+                        commandBuffer, kVUID_Core_DrawState_MissingAttachmentReference,
                         "vkCmdClearAttachments() depth/stencil clear with no depth/stencil attachment in subpass; ignored");
                 } else {
                     fb_attachment = subpass_desc->pDepthStencilAttachment->attachment;
@@ -3147,9 +3027,8 @@ bool CoreChecks::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, V
 
             // layer counts must match
             if (pRegions[i].srcSubresource.layerCount != pRegions[i].dstSubresource.layerCount) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageResolve-layerCount-00267",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageResolve-layerCount-00267",
                     "vkCmdResolveImage(): layerCount in source and destination subresource of pRegions[%d] does not match.", i);
             }
             // For each region, src and dest image aspect must be color only
@@ -3157,30 +3036,25 @@ bool CoreChecks::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, V
                 (pRegions[i].dstSubresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)) {
                 char const str[] =
                     "vkCmdResolveImage(): src and dest aspectMasks for each region must specify only VK_IMAGE_ASPECT_COLOR_BIT";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageResolve-aspectMask-00266", "%s.", str);
+                skip |= LogError(cb_node->commandBuffer, "VUID-VkImageResolve-aspectMask-00266", "%s.", str);
             }
         }
 
         if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
             char const str[] = "vkCmdResolveImage called with unmatched source and dest formats.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_MismatchedImageFormat, str);
+            skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_MismatchedImageFormat, str);
         }
         if (src_image_state->createInfo.imageType != dst_image_state->createInfo.imageType) {
             char const str[] = "vkCmdResolveImage called with unmatched source and dest image types.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_MismatchedImageType, str);
+            skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_MismatchedImageType, str);
         }
         if (src_image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT) {
             char const str[] = "vkCmdResolveImage called with source sample count less than 2.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdResolveImage-srcImage-00257", "%s.", str);
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdResolveImage-srcImage-00257", "%s.", str);
         }
         if (dst_image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
             char const str[] = "vkCmdResolveImage called with dest sample count greater than 1.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdResolveImage-dstImage-00259", "%s.", str);
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdResolveImage-dstImage-00259", "%s.", str);
         }
     } else {
         assert(0);
@@ -3239,16 +3113,14 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
         }
 
         if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_3D != src_type)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-filter-00237",
-                            "vkCmdBlitImage(): source image type must be VK_IMAGE_TYPE_3D when cubic filtering is specified.");
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-filter-00237",
+                             "vkCmdBlitImage(): source image type must be VK_IMAGE_TYPE_3D when cubic filtering is specified.");
         }
 
         if ((VK_SAMPLE_COUNT_1_BIT != src_image_state->createInfo.samples) ||
             (VK_SAMPLE_COUNT_1_BIT != dst_image_state->createInfo.samples)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-srcImage-00228",
-                            "vkCmdBlitImage(): source or dest image has sample count other than VK_SAMPLE_COUNT_1_BIT.");
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-srcImage-00228",
+                             "vkCmdBlitImage(): source or dest image has sample count other than VK_SAMPLE_COUNT_1_BIT.");
         }
 
         // Validate consistency for unsigned formats
@@ -3257,8 +3129,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             ss << "vkCmdBlitImage(): If one of srcImage and dstImage images has unsigned integer format, "
                << "the other one must also have unsigned integer format.  "
                << "Source format is " << string_VkFormat(src_format) << " Destination format is " << string_VkFormat(dst_format);
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-srcImage-00230", "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-srcImage-00230", "%s.", ss.str().c_str());
         }
 
         // Validate consistency for signed formats
@@ -3267,8 +3138,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             ss << "vkCmdBlitImage(): If one of srcImage and dstImage images has signed integer format, "
                << "the other one must also have signed integer format.  "
                << "Source format is " << string_VkFormat(src_format) << " Destination format is " << string_VkFormat(dst_format);
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-srcImage-00229", "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-srcImage-00229", "%s.", ss.str().c_str());
         }
 
         // Validate filter for Depth/Stencil formats
@@ -3276,8 +3146,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             std::stringstream ss;
             ss << "vkCmdBlitImage(): If the format of srcImage is a depth, stencil, or depth stencil "
                << "then filter must be VK_FILTER_NEAREST.";
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-srcImage-00232", "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-srcImage-00232", "%s.", ss.str().c_str());
         }
 
         // Validate aspect bits and formats for depth/stencil images
@@ -3288,9 +3157,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
                    << "stencil, the other one must have exactly the same format.  "
                    << "Source format is " << string_VkFormat(src_format) << " Destination format is "
                    << string_VkFormat(dst_format);
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-srcImage-00231", "%s.", ss.str().c_str());
+                skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-srcImage-00231", "%s.", ss.str().c_str());
             }
         }  // Depth or Stencil
 
@@ -3329,45 +3196,37 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
                 (rgn.srcOffsets[0].z == rgn.srcOffsets[1].z)) {
                 std::stringstream ss;
                 ss << "vkCmdBlitImage(): pRegions[" << i << "].srcOffsets specify a zero-volume area.";
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
+                skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
             }
             if ((rgn.dstOffsets[0].x == rgn.dstOffsets[1].x) || (rgn.dstOffsets[0].y == rgn.dstOffsets[1].y) ||
                 (rgn.dstOffsets[0].z == rgn.dstOffsets[1].z)) {
                 std::stringstream ss;
                 ss << "vkCmdBlitImage(): pRegions[" << i << "].dstOffsets specify a zero-volume area.";
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(cb_node->commandBuffer), kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
+                skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
             }
 
             // Check that src/dst layercounts match
             if (rgn.srcSubresource.layerCount != rgn.dstSubresource.layerCount) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-layerCount-00239",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-layerCount-00239",
                     "vkCmdBlitImage(): layerCount in source and destination subresource of pRegions[%d] does not match.", i);
             }
 
             if (rgn.srcSubresource.aspectMask != rgn.dstSubresource.aspectMask) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-aspectMask-00238",
-                                "vkCmdBlitImage(): aspectMask members for pRegion[%d] do not match.", i);
+                skip |= LogError(cb_node->commandBuffer, "VUID-VkImageBlit-aspectMask-00238",
+                                 "vkCmdBlitImage(): aspectMask members for pRegion[%d] do not match.", i);
             }
 
             if (!VerifyAspectsPresent(rgn.srcSubresource.aspectMask, src_format)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-aspectMask-00241",
-                                "vkCmdBlitImage(): region [%d] source aspectMask (0x%x) specifies aspects not present in source "
-                                "image format %s.",
-                                i, rgn.srcSubresource.aspectMask, string_VkFormat(src_format));
+                skip |= LogError(cb_node->commandBuffer, "VUID-VkImageBlit-aspectMask-00241",
+                                 "vkCmdBlitImage(): region [%d] source aspectMask (0x%x) specifies aspects not present in source "
+                                 "image format %s.",
+                                 i, rgn.srcSubresource.aspectMask, string_VkFormat(src_format));
             }
 
             if (!VerifyAspectsPresent(rgn.dstSubresource.aspectMask, dst_format)) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-aspectMask-00242",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-aspectMask-00242",
                     "vkCmdBlitImage(): region [%d] dest aspectMask (0x%x) specifies aspects not present in dest image format %s.",
                     i, rgn.dstSubresource.aspectMask, string_VkFormat(dst_format));
             }
@@ -3377,21 +3236,20 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             if (VK_IMAGE_TYPE_1D == src_type) {
                 if ((0 != rgn.srcOffsets[0].y) || (1 != rgn.srcOffsets[1].y)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcImage-00245",
-                                "vkCmdBlitImage(): region [%d], source image of type VK_IMAGE_TYPE_1D with srcOffset[].y values "
-                                "of (%1d, %1d). These must be (0, 1).",
-                                i, rgn.srcOffsets[0].y, rgn.srcOffsets[1].y);
+                        LogError(cb_node->commandBuffer, "VUID-VkImageBlit-srcImage-00245",
+                                 "vkCmdBlitImage(): region [%d], source image of type VK_IMAGE_TYPE_1D with srcOffset[].y values "
+                                 "of (%1d, %1d). These must be (0, 1).",
+                                 i, rgn.srcOffsets[0].y, rgn.srcOffsets[1].y);
                 }
             }
 
             if ((VK_IMAGE_TYPE_1D == src_type) || (VK_IMAGE_TYPE_2D == src_type)) {
                 if ((0 != rgn.srcOffsets[0].z) || (1 != rgn.srcOffsets[1].z)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcImage-00247",
-                                    "vkCmdBlitImage(): region [%d], source image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
-                                    "srcOffset[].z values of (%1d, %1d). These must be (0, 1).",
-                                    i, rgn.srcOffsets[0].z, rgn.srcOffsets[1].z);
+                    skip |=
+                        LogError(cb_node->commandBuffer, "VUID-VkImageBlit-srcImage-00247",
+                                 "vkCmdBlitImage(): region [%d], source image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
+                                 "srcOffset[].z values of (%1d, %1d). These must be (0, 1).",
+                                 i, rgn.srcOffsets[0].z, rgn.srcOffsets[1].z);
                 }
             }
 
@@ -3399,34 +3257,30 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             if ((rgn.srcOffsets[0].x < 0) || (rgn.srcOffsets[0].x > static_cast<int32_t>(src_extent.width)) ||
                 (rgn.srcOffsets[1].x < 0) || (rgn.srcOffsets[1].x > static_cast<int32_t>(src_extent.width))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcOffset-00243",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-srcOffset-00243",
                     "vkCmdBlitImage(): region [%d] srcOffset[].x values (%1d, %1d) exceed srcSubresource width extent (%1d).", i,
                     rgn.srcOffsets[0].x, rgn.srcOffsets[1].x, src_extent.width);
             }
             if ((rgn.srcOffsets[0].y < 0) || (rgn.srcOffsets[0].y > static_cast<int32_t>(src_extent.height)) ||
                 (rgn.srcOffsets[1].y < 0) || (rgn.srcOffsets[1].y > static_cast<int32_t>(src_extent.height))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcOffset-00244",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-srcOffset-00244",
                     "vkCmdBlitImage(): region [%d] srcOffset[].y values (%1d, %1d) exceed srcSubresource height extent (%1d).", i,
                     rgn.srcOffsets[0].y, rgn.srcOffsets[1].y, src_extent.height);
             }
             if ((rgn.srcOffsets[0].z < 0) || (rgn.srcOffsets[0].z > static_cast<int32_t>(src_extent.depth)) ||
                 (rgn.srcOffsets[1].z < 0) || (rgn.srcOffsets[1].z > static_cast<int32_t>(src_extent.depth))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcOffset-00246",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-srcOffset-00246",
                     "vkCmdBlitImage(): region [%d] srcOffset[].z values (%1d, %1d) exceed srcSubresource depth extent (%1d).", i,
                     rgn.srcOffsets[0].z, rgn.srcOffsets[1].z, src_extent.depth);
             }
             if (oob) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-pRegions-00215",
-                                "vkCmdBlitImage(): region [%d] source image blit region exceeds image dimensions.", i);
+                skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-pRegions-00215",
+                                 "vkCmdBlitImage(): region [%d] source image blit region exceeds image dimensions.", i);
             }
 
             // Validate dest image offsets
@@ -3434,21 +3288,19 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             if (VK_IMAGE_TYPE_1D == dst_type) {
                 if ((0 != rgn.dstOffsets[0].y) || (1 != rgn.dstOffsets[1].y)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-dstImage-00250",
-                                "vkCmdBlitImage(): region [%d], dest image of type VK_IMAGE_TYPE_1D with dstOffset[].y values of "
-                                "(%1d, %1d). These must be (0, 1).",
-                                i, rgn.dstOffsets[0].y, rgn.dstOffsets[1].y);
+                        LogError(cb_node->commandBuffer, "VUID-VkImageBlit-dstImage-00250",
+                                 "vkCmdBlitImage(): region [%d], dest image of type VK_IMAGE_TYPE_1D with dstOffset[].y values of "
+                                 "(%1d, %1d). These must be (0, 1).",
+                                 i, rgn.dstOffsets[0].y, rgn.dstOffsets[1].y);
                 }
             }
 
             if ((VK_IMAGE_TYPE_1D == dst_type) || (VK_IMAGE_TYPE_2D == dst_type)) {
                 if ((0 != rgn.dstOffsets[0].z) || (1 != rgn.dstOffsets[1].z)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-dstImage-00252",
-                                    "vkCmdBlitImage(): region [%d], dest image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
-                                    "dstOffset[].z values of (%1d, %1d). These must be (0, 1).",
-                                    i, rgn.dstOffsets[0].z, rgn.dstOffsets[1].z);
+                    skip |= LogError(cb_node->commandBuffer, "VUID-VkImageBlit-dstImage-00252",
+                                     "vkCmdBlitImage(): region [%d], dest image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
+                                     "dstOffset[].z values of (%1d, %1d). These must be (0, 1).",
+                                     i, rgn.dstOffsets[0].z, rgn.dstOffsets[1].z);
                 }
             }
 
@@ -3456,45 +3308,40 @@ bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
             if ((rgn.dstOffsets[0].x < 0) || (rgn.dstOffsets[0].x > static_cast<int32_t>(dst_extent.width)) ||
                 (rgn.dstOffsets[1].x < 0) || (rgn.dstOffsets[1].x > static_cast<int32_t>(dst_extent.width))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-dstOffset-00248",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-dstOffset-00248",
                     "vkCmdBlitImage(): region [%d] dstOffset[].x values (%1d, %1d) exceed dstSubresource width extent (%1d).", i,
                     rgn.dstOffsets[0].x, rgn.dstOffsets[1].x, dst_extent.width);
             }
             if ((rgn.dstOffsets[0].y < 0) || (rgn.dstOffsets[0].y > static_cast<int32_t>(dst_extent.height)) ||
                 (rgn.dstOffsets[1].y < 0) || (rgn.dstOffsets[1].y > static_cast<int32_t>(dst_extent.height))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-dstOffset-00249",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-dstOffset-00249",
                     "vkCmdBlitImage(): region [%d] dstOffset[].y values (%1d, %1d) exceed dstSubresource height extent (%1d).", i,
                     rgn.dstOffsets[0].y, rgn.dstOffsets[1].y, dst_extent.height);
             }
             if ((rgn.dstOffsets[0].z < 0) || (rgn.dstOffsets[0].z > static_cast<int32_t>(dst_extent.depth)) ||
                 (rgn.dstOffsets[1].z < 0) || (rgn.dstOffsets[1].z > static_cast<int32_t>(dst_extent.depth))) {
                 oob = true;
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-dstOffset-00251",
+                skip |= LogError(
+                    cb_node->commandBuffer, "VUID-VkImageBlit-dstOffset-00251",
                     "vkCmdBlitImage(): region [%d] dstOffset[].z values (%1d, %1d) exceed dstSubresource depth extent (%1d).", i,
                     rgn.dstOffsets[0].z, rgn.dstOffsets[1].z, dst_extent.depth);
             }
             if (oob) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-vkCmdBlitImage-pRegions-00216",
-                                "vkCmdBlitImage(): region [%d] destination image blit region exceeds image dimensions.", i);
+                skip |= LogError(cb_node->commandBuffer, "VUID-vkCmdBlitImage-pRegions-00216",
+                                 "vkCmdBlitImage(): region [%d] destination image blit region exceeds image dimensions.", i);
             }
 
             if ((VK_IMAGE_TYPE_3D == src_type) || (VK_IMAGE_TYPE_3D == dst_type)) {
                 if ((0 != rgn.srcSubresource.baseArrayLayer) || (1 != rgn.srcSubresource.layerCount) ||
                     (0 != rgn.dstSubresource.baseArrayLayer) || (1 != rgn.dstSubresource.layerCount)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(cb_node->commandBuffer), "VUID-VkImageBlit-srcImage-00240",
-                                "vkCmdBlitImage(): region [%d] blit to/from a 3D image type with a non-zero baseArrayLayer, or a "
-                                "layerCount other than 1.",
-                                i);
+                        LogError(cb_node->commandBuffer, "VUID-VkImageBlit-srcImage-00240",
+                                 "vkCmdBlitImage(): region [%d] blit to/from a 3D image type with a non-zero baseArrayLayer, or a "
+                                 "layerCount other than 1.",
+                                 i);
                 }
             }
         }  // per-region checks
@@ -3550,9 +3397,8 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE *pCB, const I
                     bool matches = ImageLayoutMatches(initial_layout_state->aspect_mask, image_layout, initial_layout);
                     if (!matches) {
                         std::string formatted_label = FormatDebugLabel(" ", pCB->debug_label);
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(pCB->commandBuffer), kVUID_Core_DrawState_InvalidImageLayout,
+                        skip |= LogError(
+                            pCB->commandBuffer, kVUID_Core_DrawState_InvalidImageLayout,
                             "Submitted command buffer expects %s (subresource: aspectMask 0x%X array layer %u, mip level %u) "
                             "to be in layout %s--instead, current layout is %s.%s",
                             report_data->FormatHandle(image).c_str(), isr_pair.subresource.aspectMask,
@@ -3610,33 +3456,29 @@ bool CoreChecks::ValidateLayoutVsAttachmentDescription(const debug_report_data *
         if (use_rp2 && ((first_layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) ||
                         (first_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) ||
                         (first_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL))) {
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkRenderPassCreateInfo2-pAttachments-02522",
-                        "Cannot clear attachment %d with invalid first layout %s.", attachment, string_VkImageLayout(first_layout));
+            skip |= LogError(device, "VUID-VkRenderPassCreateInfo2-pAttachments-02522",
+                             "Cannot clear attachment %d with invalid first layout %s.", attachment,
+                             string_VkImageLayout(first_layout));
         } else if (!use_rp2 && ((first_layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) ||
                                 (first_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL))) {
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkRenderPassCreateInfo-pAttachments-00836",
-                        "Cannot clear attachment %d with invalid first layout %s.", attachment, string_VkImageLayout(first_layout));
+            skip |= LogError(device, "VUID-VkRenderPassCreateInfo-pAttachments-00836",
+                             "Cannot clear attachment %d with invalid first layout %s.", attachment,
+                             string_VkImageLayout(first_layout));
         }
     }
     if (attachment_description.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
         if (first_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL) {
             vuid = use_rp2 ? kVUID_Core_DrawState_InvalidRenderpass : "VUID-VkRenderPassCreateInfo-pAttachments-01566";
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                        "Cannot clear attachment %d with invalid first layout %s.", attachment, string_VkImageLayout(first_layout));
+            skip |= LogError(device, vuid, "Cannot clear attachment %d with invalid first layout %s.", attachment,
+                             string_VkImageLayout(first_layout));
         }
     }
 
     if (attachment_description.stencilLoadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
         if (first_layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL) {
             vuid = use_rp2 ? kVUID_Core_DrawState_InvalidRenderpass : "VUID-VkRenderPassCreateInfo-pAttachments-01567";
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                        "Cannot clear attachment %d with invalid first layout %s.", attachment, string_VkImageLayout(first_layout));
+            skip |= LogError(device, vuid, "Cannot clear attachment %d with invalid first layout %s.", attachment,
+                             string_VkImageLayout(first_layout));
         }
     }
     return skip;
@@ -3653,20 +3495,19 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
         if (pCreateInfo->pAttachments[i].initialLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
             if ((FormatIsColor(format) || FormatHasDepth(format)) &&
                 pCreateInfo->pAttachments[i].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                kVUID_Core_DrawState_InvalidRenderpass,
-                                "Render pass has an attachment with loadOp == VK_ATTACHMENT_LOAD_OP_LOAD and initialLayout == "
-                                "VK_IMAGE_LAYOUT_UNDEFINED.  This is probably not what you intended.  Consider using "
-                                "VK_ATTACHMENT_LOAD_OP_DONT_CARE instead if the image truely is undefined at the start of the "
-                                "render pass.");
+                skip |= LogWarning(device, kVUID_Core_DrawState_InvalidRenderpass,
+                                   "Render pass has an attachment with loadOp == VK_ATTACHMENT_LOAD_OP_LOAD and initialLayout == "
+                                   "VK_IMAGE_LAYOUT_UNDEFINED.  This is probably not what you intended.  Consider using "
+                                   "VK_ATTACHMENT_LOAD_OP_DONT_CARE instead if the image truely is undefined at the start of the "
+                                   "render pass.");
             }
             if (FormatHasStencil(format) && pCreateInfo->pAttachments[i].stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                kVUID_Core_DrawState_InvalidRenderpass,
-                                "Render pass has an attachment with stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD and initialLayout "
-                                "== VK_IMAGE_LAYOUT_UNDEFINED.  This is probably not what you intended.  Consider using "
-                                "VK_ATTACHMENT_LOAD_OP_DONT_CARE instead if the image truely is undefined at the start of the "
-                                "render pass.");
+                skip |=
+                    LogWarning(device, kVUID_Core_DrawState_InvalidRenderpass,
+                               "Render pass has an attachment with stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD and initialLayout "
+                               "== VK_IMAGE_LAYOUT_UNDEFINED.  This is probably not what you intended.  Consider using "
+                               "VK_ATTACHMENT_LOAD_OP_DONT_CARE instead if the image truely is undefined at the start of the "
+                               "render pass.");
             }
         }
     }
@@ -3688,18 +3529,17 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 
                 case VK_IMAGE_LAYOUT_GENERAL:
                     // May not be optimal. TODO: reconsider this warning based on other constraints.
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUID_Core_DrawState_InvalidImageLayout,
-                                    "Layout for input attachment is GENERAL but should be READ_ONLY_OPTIMAL.");
+                    skip |= LogPerformanceWarning(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                                  "Layout for input attachment is GENERAL but should be READ_ONLY_OPTIMAL.");
                     break;
 
                 case VK_IMAGE_LAYOUT_UNDEFINED:
                 case VK_IMAGE_LAYOUT_PREINITIALIZED:
                     vuid = use_rp2 ? "VUID-VkAttachmentReference2-layout-03077" : "VUID-VkAttachmentReference-layout-00857";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                                    "Layout for input attachment reference %u in subpass %u is %s but must be "
-                                    "DEPTH_STENCIL_READ_ONLY, SHADER_READ_ONLY_OPTIMAL, or GENERAL.",
-                                    j, i, string_VkImageLayout(subpass.pInputAttachments[j].layout));
+                    skip |= LogError(device, vuid,
+                                     "Layout for input attachment reference %u in subpass %u is %s but must be "
+                                     "DEPTH_STENCIL_READ_ONLY, SHADER_READ_ONLY_OPTIMAL, or GENERAL.",
+                                     j, i, string_VkImageLayout(subpass.pInputAttachments[j].layout));
                     break;
 
                 case VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR:
@@ -3707,17 +3547,15 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                 case VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR:
                 case VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR:
                     if (!enabled_features.core12.separateDepthStencilLayouts) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
                             "Layout for input attachment reference %u in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
                             j, i, string_VkImageLayout(subpass.pInputAttachments[j].layout));
                     } else if (subpass.pInputAttachments[j].aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-attachment-03314",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-attachment-03314",
                             "Layout for input attachment reference %u in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -3747,40 +3585,36 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                                     attachment_reference_stencil_layout->stencilLayout ==
                                         VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL ||
                                     attachment_reference_stencil_layout->stencilLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
-                                    skip |=
-                                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
-                                                "In the attachment reference %u in subpass %u with pNext chain instance "
-                                                "VkAttachmentReferenceStencilLayoutKHR"
-                                                "the stencilLayout member but must not be "
-                                                "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
-                                                "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
-                                                "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
-                                                j, i);
+                                    skip |= LogError(device, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
+                                                     "In the attachment reference %u in subpass %u with pNext chain instance "
+                                                     "VkAttachmentReferenceStencilLayoutKHR"
+                                                     "the stencilLayout member but must not be "
+                                                     "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
+                                                     "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
+                                                     "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
+                                                     j, i);
                                 }
                             } else {
-                                skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03315",
-                                            "When the layout for input attachment reference %u in subpass %u is "
-                                            "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
-                                            "VkAttachmentReferenceStencilLayout instance.",
-                                            j, i);
+                                skip |= LogError(
+                                    device, "VUID-VkAttachmentReference2-attachment-03315",
+                                    "When the layout for input attachment reference %u in subpass %u is "
+                                    "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
+                                    "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
+                                    "VkAttachmentReferenceStencilLayout instance.",
+                                    j, i);
                             }
                         }
                     } else if (subpass.pInputAttachments[j].aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) {
                         if (subpass.pInputAttachments[j].layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pInputAttachments[j].layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkAttachmentReference2-attachment-03315",
+                            skip |= LogError(
+                                device, "VUID-VkAttachmentReference2-attachment-03315",
                                 "When the aspectMask for input attachment reference %u in subpass %u is VK_IMAGE_ASPECT_DEPTH_BIT "
                                 "then the layout must not be VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or "
                                 "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -3789,13 +3623,12 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                     } else if (subpass.pInputAttachments[j].aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                         if (subpass.pInputAttachments[j].layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pInputAttachments[j].layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03317",
-                                            "When the aspectMask for input attachment reference %u in subpass %u is "
-                                            "VK_IMAGE_ASPECT_STENCIL_BIT "
-                                            "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
-                                            j, i);
+                            skip |= LogError(device, "VUID-VkAttachmentReference2-attachment-03317",
+                                             "When the aspectMask for input attachment reference %u in subpass %u is "
+                                             "VK_IMAGE_ASPECT_STENCIL_BIT "
+                                             "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
+                                             "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
+                                             j, i);
                         }
                     }
                     break;
@@ -3811,10 +3644,9 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 
                 default:
                     // No other layouts are acceptable
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    kVUID_Core_DrawState_InvalidImageLayout,
-                                    "Layout for input attachment is %s but can only be READ_ONLY_OPTIMAL or GENERAL.",
-                                    string_VkImageLayout(subpass.pInputAttachments[j].layout));
+                    skip |= LogError(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                     "Layout for input attachment is %s but can only be READ_ONLY_OPTIMAL or GENERAL.",
+                                     string_VkImageLayout(subpass.pInputAttachments[j].layout));
             }
 
             if (attach_first_use[attach_index]) {
@@ -3830,9 +3662,9 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                 if (!used_as_depth && !used_as_color &&
                     pCreateInfo->pAttachments[attach_index].loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                     vuid = use_rp2 ? "VUID-VkSubpassDescription2-loadOp-03064" : "VUID-VkSubpassDescription-loadOp-00846";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                                    "%s: attachment %u is first used as an input attachment in subpass %u with loadOp=CLEAR.",
-                                    function_name, attach_index, attach_index);
+                    skip |= LogError(device, vuid,
+                                     "%s: attachment %u is first used as an input attachment in subpass %u with loadOp=CLEAR.",
+                                     function_name, attach_index, attach_index);
                 }
             }
             attach_first_use[attach_index] = false;
@@ -3854,18 +3686,17 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 
                 case VK_IMAGE_LAYOUT_GENERAL:
                     // May not be optimal; TODO: reconsider this warning based on other constraints?
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUID_Core_DrawState_InvalidImageLayout,
-                                    "Layout for color attachment is GENERAL but should be COLOR_ATTACHMENT_OPTIMAL.");
+                    skip |= LogPerformanceWarning(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                                  "Layout for color attachment is GENERAL but should be COLOR_ATTACHMENT_OPTIMAL.");
                     break;
 
                 case VK_IMAGE_LAYOUT_UNDEFINED:
                 case VK_IMAGE_LAYOUT_PREINITIALIZED:
                     vuid = use_rp2 ? "VUID-VkAttachmentReference2-layout-03077" : "VUID-VkAttachmentReference-layout-00857";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                                    "Layout for color attachment reference %u in subpass %u is %s but should be "
-                                    "COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
-                                    j, i, string_VkImageLayout(subpass.pColorAttachments[j].layout));
+                    skip |= LogError(device, vuid,
+                                     "Layout for color attachment reference %u in subpass %u is %s but should be "
+                                     "COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
+                                     j, i, string_VkImageLayout(subpass.pColorAttachments[j].layout));
                     break;
 
                 case VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR:
@@ -3873,17 +3704,15 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                 case VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR:
                 case VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR:
                     if (!enabled_features.core12.separateDepthStencilLayouts) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
                             "Layout for color attachment reference %u in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
                             j, i, string_VkImageLayout(subpass.pColorAttachments[j].layout));
                     } else if (subpass.pColorAttachments[j].aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-attachment-03314",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-attachment-03314",
                             "Layout for color attachment reference %u in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -3913,40 +3742,36 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                                     attachment_reference_stencil_layout->stencilLayout ==
                                         VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL ||
                                     attachment_reference_stencil_layout->stencilLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
-                                    skip |=
-                                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
-                                                "In the attachment reference %u in subpass %u with pNext chain instance "
-                                                "VkAttachmentReferenceStencilLayoutKHR"
-                                                "the stencilLayout member but must not be "
-                                                "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
-                                                "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
-                                                "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
-                                                j, i);
+                                    skip |= LogError(device, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
+                                                     "In the attachment reference %u in subpass %u with pNext chain instance "
+                                                     "VkAttachmentReferenceStencilLayoutKHR"
+                                                     "the stencilLayout member but must not be "
+                                                     "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
+                                                     "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
+                                                     "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
+                                                     j, i);
                                 }
                             } else {
-                                skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03315",
-                                            "When the layout for color attachment reference %u in subpass %u is "
-                                            "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
-                                            "VkAttachmentReferenceStencilLayout instance.",
-                                            j, i);
+                                skip |= LogError(
+                                    device, "VUID-VkAttachmentReference2-attachment-03315",
+                                    "When the layout for color attachment reference %u in subpass %u is "
+                                    "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
+                                    "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
+                                    "VkAttachmentReferenceStencilLayout instance.",
+                                    j, i);
                             }
                         }
                     } else if (subpass.pColorAttachments[j].aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) {
                         if (subpass.pColorAttachments[j].layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pColorAttachments[j].layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkAttachmentReference2-attachment-03315",
+                            skip |= LogError(
+                                device, "VUID-VkAttachmentReference2-attachment-03315",
                                 "When the aspectMask for color attachment reference %u in subpass %u is VK_IMAGE_ASPECT_DEPTH_BIT "
                                 "then the layout must not be VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or "
                                 "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -3955,32 +3780,30 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                     } else if (subpass.pColorAttachments[j].aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                         if (subpass.pColorAttachments[j].layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pColorAttachments[j].layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03317",
-                                            "When the aspectMask for color attachment reference %u in subpass %u is "
-                                            "VK_IMAGE_ASPECT_STENCIL_BIT "
-                                            "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
-                                            j, i);
+                            skip |= LogError(device, "VUID-VkAttachmentReference2-attachment-03317",
+                                             "When the aspectMask for color attachment reference %u in subpass %u is "
+                                             "VK_IMAGE_ASPECT_STENCIL_BIT "
+                                             "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
+                                             "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
+                                             j, i);
                         }
                     }
                     break;
 
                 default:
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    kVUID_Core_DrawState_InvalidImageLayout,
-                                    "Layout for color attachment is %s but can only be COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
-                                    string_VkImageLayout(subpass.pColorAttachments[j].layout));
+                    skip |= LogError(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                     "Layout for color attachment is %s but can only be COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
+                                     string_VkImageLayout(subpass.pColorAttachments[j].layout));
             }
 
             if (subpass.pResolveAttachments && (subpass.pResolveAttachments[j].attachment != VK_ATTACHMENT_UNUSED) &&
                 (subpass.pResolveAttachments[j].layout == VK_IMAGE_LAYOUT_UNDEFINED ||
                  subpass.pResolveAttachments[j].layout == VK_IMAGE_LAYOUT_PREINITIALIZED)) {
                 vuid = use_rp2 ? "VUID-VkAttachmentReference2-layout-03077" : "VUID-VkAttachmentReference-layout-00857";
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                                "Layout for resolve attachment reference %u in subpass %u is %s but should be "
-                                "COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
-                                j, i, string_VkImageLayout(subpass.pResolveAttachments[j].layout));
+                skip |= LogError(device, vuid,
+                                 "Layout for resolve attachment reference %u in subpass %u is %s but should be "
+                                 "COLOR_ATTACHMENT_OPTIMAL or GENERAL.",
+                                 j, i, string_VkImageLayout(subpass.pResolveAttachments[j].layout));
             }
 
             if (attach_first_use[attach_index]) {
@@ -4000,18 +3823,17 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                 case VK_IMAGE_LAYOUT_GENERAL:
                     // May not be optimal; TODO: reconsider this warning based on other constraints? GENERAL can be better than
                     // doing a bunch of transitions.
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUID_Core_DrawState_InvalidImageLayout,
-                                    "GENERAL layout for depth attachment may not give optimal performance.");
+                    skip |= LogPerformanceWarning(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                                  "GENERAL layout for depth attachment may not give optimal performance.");
                     break;
 
                 case VK_IMAGE_LAYOUT_UNDEFINED:
                 case VK_IMAGE_LAYOUT_PREINITIALIZED:
                     vuid = use_rp2 ? "VUID-VkAttachmentReference2-layout-03077" : "VUID-VkAttachmentReference-layout-00857";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                                    "Layout for depth attachment reference in subpass %u is %s but must be a valid depth/stencil "
-                                    "layout or GENERAL.",
-                                    i, string_VkImageLayout(subpass.pDepthStencilAttachment->layout));
+                    skip |= LogError(device, vuid,
+                                     "Layout for depth attachment reference in subpass %u is %s but must be a valid depth/stencil "
+                                     "layout or GENERAL.",
+                                     i, string_VkImageLayout(subpass.pDepthStencilAttachment->layout));
                     break;
 
                 case VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR:
@@ -4019,17 +3841,15 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                 case VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR:
                 case VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR:
                     if (!enabled_features.core12.separateDepthStencilLayouts) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
                             "Layout for depth attachment reference in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
                             i, string_VkImageLayout(subpass.pDepthStencilAttachment->layout));
                     } else if (subpass.pDepthStencilAttachment->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAttachmentReference2-attachment-03314",
+                        skip |= LogError(
+                            device, "VUID-VkAttachmentReference2-attachment-03314",
                             "Layout for depth attachment reference in subpass %u is %s but must not be "
                             "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
                             "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -4059,40 +3879,36 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                                     attachment_reference_stencil_layout->stencilLayout ==
                                         VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL ||
                                     attachment_reference_stencil_layout->stencilLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
-                                    skip |=
-                                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
-                                                "In the attachment reference in subpass %u with pNext chain instance "
-                                                "VkAttachmentReferenceStencilLayoutKHR"
-                                                "the stencilLayout member but must not be "
-                                                "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
-                                                "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
-                                                "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
-                                                "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
-                                                i);
+                                    skip |= LogError(device, "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318",
+                                                     "In the attachment reference in subpass %u with pNext chain instance "
+                                                     "VkAttachmentReferenceStencilLayoutKHR"
+                                                     "the stencilLayout member but must not be "
+                                                     "VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, "
+                                                     "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
+                                                     "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, or "
+                                                     "VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.",
+                                                     i);
                                 }
                             } else {
-                                skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03315",
-                                            "When the layout for depth attachment reference in subpass %u is "
-                                            "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
-                                            "VkAttachmentReferenceStencilLayout instance.",
-                                            i);
+                                skip |= LogError(
+                                    device, "VUID-VkAttachmentReference2-attachment-03315",
+                                    "When the layout for depth attachment reference in subpass %u is "
+                                    "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR or "
+                                    "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR then the pNext chain must include a valid "
+                                    "VkAttachmentReferenceStencilLayout instance.",
+                                    i);
                             }
                         }
                     } else if (subpass.pDepthStencilAttachment->aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) {
                         if (subpass.pDepthStencilAttachment->layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pDepthStencilAttachment->layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkAttachmentReference2-attachment-03315",
+                            skip |= LogError(
+                                device, "VUID-VkAttachmentReference2-attachment-03315",
                                 "When the aspectMask for depth attachment reference in subpass %u is VK_IMAGE_ASPECT_DEPTH_BIT "
                                 "then the layout must not be VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR, or "
                                 "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR.",
@@ -4101,13 +3917,12 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
                     } else if (subpass.pDepthStencilAttachment->aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                         if (subpass.pDepthStencilAttachment->layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR ||
                             subpass.pDepthStencilAttachment->layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkAttachmentReference2-attachment-03317",
-                                            "When the aspectMask for depth attachment reference in subpass %u is "
-                                            "VK_IMAGE_ASPECT_STENCIL_BIT "
-                                            "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
-                                            "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
-                                            i);
+                            skip |= LogError(device, "VUID-VkAttachmentReference2-attachment-03317",
+                                             "When the aspectMask for depth attachment reference in subpass %u is "
+                                             "VK_IMAGE_ASPECT_STENCIL_BIT "
+                                             "then the layout must not be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, or "
+                                             "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
+                                             i);
                         }
                     }
                     break;
@@ -4123,11 +3938,10 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 
                 default:
                     // No other layouts are acceptable
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    kVUID_Core_DrawState_InvalidImageLayout,
-                                    "Layout for depth attachment is %s but can only be DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
-                                    "DEPTH_STENCIL_READ_ONLY_OPTIMAL or GENERAL.",
-                                    string_VkImageLayout(subpass.pDepthStencilAttachment->layout));
+                    skip |= LogError(device, kVUID_Core_DrawState_InvalidImageLayout,
+                                     "Layout for depth attachment is %s but can only be DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "
+                                     "DEPTH_STENCIL_READ_ONLY_OPTIMAL or GENERAL.",
+                                     string_VkImageLayout(subpass.pDepthStencilAttachment->layout));
             }
 
             auto attach_index = subpass.pDepthStencilAttachment->attachment;
@@ -4143,8 +3957,10 @@ bool CoreChecks::ValidateLayouts(RenderPassCreateVersion rp_version, VkDevice de
 
 // Helper function to validate correct usage bits set for buffers or images. Verify that (actual & desired) flags != 0 or, if strict
 // is true, verify that (actual & desired) flags == desired
-bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 strict, const VulkanTypedHandle &typed_handle,
-                                    const char *msgCode, char const *func_name, char const *usage_str) const {
+template <typename T1>
+bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 strict, const T1 object,
+                                    const VulkanTypedHandle &typed_handle, const char *msgCode, char const *func_name,
+                                    char const *usage_str) const {
     bool correct_usage = false;
     bool skip = false;
     const char *type_str = object_string[typed_handle.type];
@@ -4153,18 +3969,17 @@ bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 st
     } else {
         correct_usage = ((actual & desired) != 0);
     }
+
     if (!correct_usage) {
         if (msgCode == kVUIDUndefined) {
             // TODO: Fix callers with kVUIDUndefined to use correct validation checks.
-            skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, get_debug_report_enum[typed_handle.type],
-                           typed_handle.handle, kVUID_Core_MemTrack_InvalidUsageFlag,
-                           "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
-                           report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
+            skip = LogError(object, kVUID_Core_MemTrack_InvalidUsageFlag,
+                            "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
+                            report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
         } else {
-            skip =
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, get_debug_report_enum[typed_handle.type], typed_handle.handle,
-                        msgCode, "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
-                        report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
+            skip = LogError(object, msgCode,
+                            "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
+                            report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
         }
     }
     return skip;
@@ -4174,7 +3989,7 @@ bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 st
 // where an error will be flagged if usage is not correct
 bool CoreChecks::ValidateImageUsageFlags(IMAGE_STATE const *image_state, VkFlags desired, bool strict, const char *msgCode,
                                          char const *func_name, char const *usage_string) const {
-    return ValidateUsageFlags(image_state->createInfo.usage, desired, strict,
+    return ValidateUsageFlags(image_state->createInfo.usage, desired, strict, image_state->image,
                               VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage), msgCode, func_name, usage_string);
 }
 
@@ -4184,19 +3999,17 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(IMAGE_STATE const *image_state,
     bool skip = false;
     if (image_state->createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
         if ((format_properties.linearTilingFeatures & desired) != desired) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), linear_vuid,
-                            "In %s, invalid linearTilingFeatures (0x%08X) for format %u used by %s.", func_name,
-                            format_properties.linearTilingFeatures, image_state->createInfo.format,
-                            report_data->FormatHandle(image_state->image).c_str());
+            skip |=
+                LogError(image_state->image, linear_vuid, "In %s, invalid linearTilingFeatures (0x%08X) for format %u used by %s.",
+                         func_name, format_properties.linearTilingFeatures, image_state->createInfo.format,
+                         report_data->FormatHandle(image_state->image).c_str());
         }
     } else if (image_state->createInfo.tiling == VK_IMAGE_TILING_OPTIMAL) {
         if ((format_properties.optimalTilingFeatures & desired) != desired) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), optimal_vuid,
-                            "In %s, invalid optimalTilingFeatures (0x%08X) for format %u used by %s.", func_name,
-                            format_properties.optimalTilingFeatures, image_state->createInfo.format,
-                            report_data->FormatHandle(image_state->image).c_str());
+            skip |= LogError(image_state->image, optimal_vuid,
+                             "In %s, invalid optimalTilingFeatures (0x%08X) for format %u used by %s.", func_name,
+                             format_properties.optimalTilingFeatures, image_state->createInfo.format,
+                             report_data->FormatHandle(image_state->image).c_str());
         }
     }
     return skip;
@@ -4207,24 +4020,21 @@ bool CoreChecks::ValidateImageSubresourceLayers(const CMD_BUFFER_STATE *cb_node,
     bool skip = false;
     // layerCount must not be zero
     if (subresource_layers->layerCount == 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->commandBuffer), "VUID-VkImageSubresourceLayers-layerCount-01700",
-                        "In %s, pRegions[%u].%s.layerCount must not be zero.", func_name, i, member);
+        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-layerCount-01700",
+                         "In %s, pRegions[%u].%s.layerCount must not be zero.", func_name, i, member);
     }
     // aspectMask must not contain VK_IMAGE_ASPECT_METADATA_BIT
     if (subresource_layers->aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->commandBuffer), "VUID-VkImageSubresourceLayers-aspectMask-00168",
-                        "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_METADATA_BIT set.", func_name, i, member);
+        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-aspectMask-00168",
+                         "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_METADATA_BIT set.", func_name, i, member);
     }
     // if aspectMask contains COLOR, it must not contain either DEPTH or STENCIL
     if ((subresource_layers->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) &&
         (subresource_layers->aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->commandBuffer), "VUID-VkImageSubresourceLayers-aspectMask-00167",
-                        "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_COLOR_BIT and either VK_IMAGE_ASPECT_DEPTH_BIT or "
-                        "VK_IMAGE_ASPECT_STENCIL_BIT set.",
-                        func_name, i, member);
+        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-aspectMask-00167",
+                         "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_COLOR_BIT and either VK_IMAGE_ASPECT_DEPTH_BIT or "
+                         "VK_IMAGE_ASPECT_STENCIL_BIT set.",
+                         func_name, i, member);
     }
     return skip;
 }
@@ -4233,7 +4043,7 @@ bool CoreChecks::ValidateImageSubresourceLayers(const CMD_BUFFER_STATE *cb_node,
 // where an error will be flagged if usage is not correct
 bool CoreChecks::ValidateBufferUsageFlags(BUFFER_STATE const *buffer_state, VkFlags desired, bool strict, const char *msgCode,
                                           char const *func_name, char const *usage_string) const {
-    return ValidateUsageFlags(buffer_state->createInfo.usage, desired, strict,
+    return ValidateUsageFlags(buffer_state->createInfo.usage, desired, strict, buffer_state->buffer,
                               VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer), msgCode, func_name, usage_string);
 }
 
@@ -4245,39 +4055,35 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
     if (range != VK_WHOLE_SIZE) {
         // Range must be greater than 0
         if (range <= 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-range-00928",
-                            "If VkBufferViewCreateInfo range (%" PRIuLEAST64
-                            ") does not equal VK_WHOLE_SIZE, range must be greater than 0.",
-                            range);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00928",
+                             "If VkBufferViewCreateInfo range (%" PRIuLEAST64
+                             ") does not equal VK_WHOLE_SIZE, range must be greater than 0.",
+                             range);
         }
         // Range must be a multiple of the element size of format
         const uint32_t format_size = FormatElementSize(pCreateInfo->format);
         if (SafeModulo(range, format_size) != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-range-00929",
-                            "If VkBufferViewCreateInfo range (%" PRIuLEAST64
-                            ") does not equal VK_WHOLE_SIZE, range must be a multiple of the element size of the format "
-                            "(%" PRIu32 ").",
-                            range, format_size);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00929",
+                             "If VkBufferViewCreateInfo range (%" PRIuLEAST64
+                             ") does not equal VK_WHOLE_SIZE, range must be a multiple of the element size of the format "
+                             "(%" PRIu32 ").",
+                             range, format_size);
         }
         // Range divided by the element size of format must be less than or equal to VkPhysicalDeviceLimits::maxTexelBufferElements
         if (SafeDivision(range, format_size) > device_limits->maxTexelBufferElements) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-range-00930",
-                            "If VkBufferViewCreateInfo range (%" PRIuLEAST64
-                            ") does not equal VK_WHOLE_SIZE, range divided by the element size of the format (%" PRIu32
-                            ") must be less than or equal to VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
-                            range, format_size, device_limits->maxTexelBufferElements);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00930",
+                             "If VkBufferViewCreateInfo range (%" PRIuLEAST64
+                             ") does not equal VK_WHOLE_SIZE, range divided by the element size of the format (%" PRIu32
+                             ") must be less than or equal to VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
+                             range, format_size, device_limits->maxTexelBufferElements);
         }
         // The sum of range and offset must be less than or equal to the size of buffer
         if (range + pCreateInfo->offset > buffer_state->createInfo.size) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-offset-00931",
-                            "If VkBufferViewCreateInfo range (%" PRIuLEAST64
-                            ") does not equal VK_WHOLE_SIZE, the sum of offset (%" PRIuLEAST64
-                            ") and range must be less than or equal to the size of the buffer (%" PRIuLEAST64 ").",
-                            range, pCreateInfo->offset, buffer_state->createInfo.size);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-offset-00931",
+                             "If VkBufferViewCreateInfo range (%" PRIuLEAST64
+                             ") does not equal VK_WHOLE_SIZE, the sum of offset (%" PRIuLEAST64
+                             ") and range must be less than or equal to the size of the buffer (%" PRIuLEAST64 ").",
+                             range, pCreateInfo->offset, buffer_state->createInfo.size);
         }
     }
     return skip;
@@ -4288,17 +4094,15 @@ bool CoreChecks::ValidateBufferViewBuffer(const BUFFER_STATE *buffer_state, cons
     const VkFormatProperties format_properties = GetPDFormatProperties(pCreateInfo->format);
     if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-buffer-00933",
-                        "If buffer was created with `usage` containing VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, format must "
-                        "be supported for uniform texel buffers");
+        skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-00933",
+                         "If buffer was created with `usage` containing VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, format must "
+                         "be supported for uniform texel buffers");
     }
     if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-buffer-00934",
-                        "If buffer was created with `usage` containing VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, format must "
-                        "be supported for storage texel buffers");
+        skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-00934",
+                         "If buffer was created with `usage` containing VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, format must "
+                         "be supported for storage texel buffers");
     }
     return skip;
 }
@@ -4310,34 +4114,30 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     // TODO: Add check for "VUID-vkCreateBuffer-flags-00911"        (sparse address space accounting)
 
     if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!enabled_features.core.sparseBinding)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkBufferCreateInfo-flags-00915",
-                        "vkCreateBuffer(): the sparseBinding device feature is disabled: Buffers cannot be created with the "
-                        "VK_BUFFER_CREATE_SPARSE_BINDING_BIT set.");
+        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00915",
+                         "vkCreateBuffer(): the sparseBinding device feature is disabled: Buffers cannot be created with the "
+                         "VK_BUFFER_CREATE_SPARSE_BINDING_BIT set.");
     }
 
     if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!enabled_features.core.sparseResidencyBuffer)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkBufferCreateInfo-flags-00916",
-                        "vkCreateBuffer(): the sparseResidencyBuffer device feature is disabled: Buffers cannot be created with "
-                        "the VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT set.");
+        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00916",
+                         "vkCreateBuffer(): the sparseResidencyBuffer device feature is disabled: Buffers cannot be created with "
+                         "the VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT set.");
     }
 
     if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.core.sparseResidencyAliased)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkBufferCreateInfo-flags-00917",
-                        "vkCreateBuffer(): the sparseResidencyAliased device feature is disabled: Buffers cannot be created with "
-                        "the VK_BUFFER_CREATE_SPARSE_ALIASED_BIT set.");
+        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00917",
+                         "vkCreateBuffer(): the sparseResidencyAliased device feature is disabled: Buffers cannot be created with "
+                         "the VK_BUFFER_CREATE_SPARSE_ALIASED_BIT set.");
     }
 
     auto chained_devaddr_struct = lvl_find_in_chain<VkBufferDeviceAddressCreateInfoEXT>(pCreateInfo->pNext);
     if (chained_devaddr_struct) {
         if (!(pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT) &&
             chained_devaddr_struct->deviceAddress != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkBufferCreateInfo-deviceAddress-02604",
-                            "vkCreateBuffer(): Non-zero VkBufferDeviceAddressCreateInfoEXT::deviceAddress "
-                            "requires VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT.");
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-deviceAddress-02604",
+                             "vkCreateBuffer(): Non-zero VkBufferDeviceAddressCreateInfoEXT::deviceAddress "
+                             "requires VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT.");
         }
     }
 
@@ -4345,18 +4145,16 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     if (chained_opaqueaddr_struct) {
         if (!(pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR) &&
             chained_opaqueaddr_struct->opaqueCaptureAddress != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkBufferCreateInfo-opaqueCaptureAddress-03337",
-                            "vkCreateBuffer(): Non-zero VkBufferOpaqueCaptureAddressCreateInfoKHR::opaqueCaptureAddress"
-                            "requires VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR.");
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-opaqueCaptureAddress-03337",
+                             "vkCreateBuffer(): Non-zero VkBufferOpaqueCaptureAddressCreateInfoKHR::opaqueCaptureAddress"
+                             "requires VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR.");
         }
     }
 
     if ((pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR) &&
         !enabled_features.core12.bufferDeviceAddressCaptureReplay) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-            "VUID-VkBufferCreateInfo-flags-03338",
+        skip |= LogError(
+            device, "VUID-VkBufferCreateInfo-flags-03338",
             "vkCreateBuffer(): the bufferDeviceAddressCaptureReplay device feature is disabled: Buffers cannot be created with "
             "the VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT set.");
     }
@@ -4386,22 +4184,20 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
 
         // Buffer view offset must be less than the size of buffer
         if (pCreateInfo->offset >= buffer_state->createInfo.size) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-offset-00925",
-                            "VkBufferViewCreateInfo offset (%" PRIuLEAST64
-                            ") must be less than the size of the buffer (%" PRIuLEAST64 ").",
-                            pCreateInfo->offset, buffer_state->createInfo.size);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-offset-00925",
+                             "VkBufferViewCreateInfo offset (%" PRIuLEAST64
+                             ") must be less than the size of the buffer (%" PRIuLEAST64 ").",
+                             pCreateInfo->offset, buffer_state->createInfo.size);
         }
 
         const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;
         // Buffer view offset must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment
         if ((pCreateInfo->offset % device_limits->minTexelBufferOffsetAlignment) != 0 &&
             !enabled_features.texel_buffer_alignment_features.texelBufferAlignment) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-offset-02749",
-                            "VkBufferViewCreateInfo offset (%" PRIuLEAST64
-                            ") must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment (%" PRIuLEAST64 ").",
-                            pCreateInfo->offset, device_limits->minTexelBufferOffsetAlignment);
+            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-offset-02749",
+                             "VkBufferViewCreateInfo offset (%" PRIuLEAST64
+                             ") must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment (%" PRIuLEAST64 ").",
+                             pCreateInfo->offset, device_limits->minTexelBufferOffsetAlignment);
         }
 
         if (enabled_features.texel_buffer_alignment_features.texelBufferAlignment) {
@@ -4416,9 +4212,8 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                     alignmentRequirement = std::min(alignmentRequirement, elementSize);
                 }
                 if (SafeModulo(pCreateInfo->offset, alignmentRequirement) != 0) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-buffer-02750",
+                    skip |= LogError(
+                        buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-02750",
                         "If buffer was created with usage containing VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, "
                         "VkBufferViewCreateInfo offset (%" PRIuLEAST64
                         ") must be a multiple of the lesser of "
@@ -4439,9 +4234,8 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                     alignmentRequirement = std::min(alignmentRequirement, elementSize);
                 }
                 if (SafeModulo(pCreateInfo->offset, alignmentRequirement) != 0) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(buffer_state->buffer), "VUID-VkBufferViewCreateInfo-buffer-02751",
+                    skip |= LogError(
+                        buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-02751",
                         "If buffer was created with usage containing VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, "
                         "VkBufferViewCreateInfo offset (%" PRIuLEAST64
                         ") must be a multiple of the lesser of "
@@ -4468,46 +4262,39 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
 bool CoreChecks::ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, const char *func_name,
                                          const char *vuid) const {
     bool skip = false;
-    VkDebugReportObjectTypeEXT objectType = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
-    if (image != VK_NULL_HANDLE) {
-        objectType = VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT;
-    }
 
     if (FormatIsColor(format)) {
         if ((aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != VK_IMAGE_ASPECT_COLOR_BIT) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Color image formats must have the VK_IMAGE_ASPECT_COLOR_BIT set.", func_name);
+            skip |= LogError(image, vuid, "%s: Color image formats must have the VK_IMAGE_ASPECT_COLOR_BIT set.", func_name);
         } else if ((aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != aspect_mask) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Color image formats must have ONLY the VK_IMAGE_ASPECT_COLOR_BIT set.", func_name);
+            skip |= LogError(image, vuid, "%s: Color image formats must have ONLY the VK_IMAGE_ASPECT_COLOR_BIT set.", func_name);
         }
     } else if (FormatIsDepthAndStencil(format)) {
         if ((aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Depth/stencil image formats must have at least one of VK_IMAGE_ASPECT_DEPTH_BIT and "
-                            "VK_IMAGE_ASPECT_STENCIL_BIT set.",
-                            func_name);
+            skip |= LogError(image, vuid,
+                             "%s: Depth/stencil image formats must have at least one of VK_IMAGE_ASPECT_DEPTH_BIT and "
+                             "VK_IMAGE_ASPECT_STENCIL_BIT set.",
+                             func_name);
         } else if ((aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) != aspect_mask) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Combination depth/stencil image formats can have only the VK_IMAGE_ASPECT_DEPTH_BIT and "
-                            "VK_IMAGE_ASPECT_STENCIL_BIT set.",
-                            func_name);
+            skip |= LogError(image, vuid,
+                             "%s: Combination depth/stencil image formats can have only the VK_IMAGE_ASPECT_DEPTH_BIT and "
+                             "VK_IMAGE_ASPECT_STENCIL_BIT set.",
+                             func_name);
         }
     } else if (FormatIsDepthOnly(format)) {
         if ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != VK_IMAGE_ASPECT_DEPTH_BIT) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Depth-only image formats must have the VK_IMAGE_ASPECT_DEPTH_BIT set.", func_name);
+            skip |= LogError(image, vuid, "%s: Depth-only image formats must have the VK_IMAGE_ASPECT_DEPTH_BIT set.", func_name);
         } else if ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != aspect_mask) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Depth-only image formats can have only the VK_IMAGE_ASPECT_DEPTH_BIT set.", func_name);
+            skip |=
+                LogError(image, vuid, "%s: Depth-only image formats can have only the VK_IMAGE_ASPECT_DEPTH_BIT set.", func_name);
         }
     } else if (FormatIsStencilOnly(format)) {
         if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) != VK_IMAGE_ASPECT_STENCIL_BIT) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Stencil-only image formats must have the VK_IMAGE_ASPECT_STENCIL_BIT set.", func_name);
+            skip |=
+                LogError(image, vuid, "%s: Stencil-only image formats must have the VK_IMAGE_ASPECT_STENCIL_BIT set.", func_name);
         } else if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) != aspect_mask) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Stencil-only image formats can have only the VK_IMAGE_ASPECT_STENCIL_BIT set.", func_name);
+            skip |= LogError(image, vuid, "%s: Stencil-only image formats can have only the VK_IMAGE_ASPECT_STENCIL_BIT set.",
+                             func_name);
         }
     } else if (FormatIsMultiplane(format)) {
         VkImageAspectFlags valid_flags = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
@@ -4515,10 +4302,11 @@ bool CoreChecks::ValidateImageAspectMask(VkImage image, VkFormat format, VkImage
             valid_flags = valid_flags | VK_IMAGE_ASPECT_PLANE_2_BIT;
         }
         if ((aspect_mask & valid_flags) != aspect_mask) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, HandleToUint64(image), vuid,
-                            "%s: Multi-plane image formats may have only VK_IMAGE_ASPECT_COLOR_BIT or VK_IMAGE_ASPECT_PLANE_n_BITs "
-                            "set, where n = [0, 1, 2].",
-                            func_name);
+            skip |=
+                LogError(image, vuid,
+                         "%s: Multi-plane image formats may have only VK_IMAGE_ASPECT_COLOR_BIT or VK_IMAGE_ASPECT_PLANE_n_BITs "
+                         "set, where n = [0, 1, 2].",
+                         func_name);
         }
     }
     return skip;
@@ -4526,61 +4314,55 @@ bool CoreChecks::ValidateImageAspectMask(VkImage image, VkFormat format, VkImage
 
 bool CoreChecks::ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
                                                const VkImageSubresourceRange &subresourceRange, const char *cmd_name,
-                                               const char *param_name, const char *image_layer_count_var_name,
-                                               const uint64_t image_handle, SubresourceRangeErrorCodes errorCodes) const {
+                                               const char *param_name, const char *image_layer_count_var_name, const VkImage image,
+                                               SubresourceRangeErrorCodes errorCodes) const {
     bool skip = false;
 
     // Validate mip levels
     if (subresourceRange.baseMipLevel >= image_mip_count) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                        errorCodes.base_mip_err,
-                        "%s: %s.baseMipLevel (= %" PRIu32
-                        ") is greater or equal to the mip level count of the image (i.e. greater or equal to %" PRIu32 ").",
-                        cmd_name, param_name, subresourceRange.baseMipLevel, image_mip_count);
+        skip |= LogError(image, errorCodes.base_mip_err,
+                         "%s: %s.baseMipLevel (= %" PRIu32
+                         ") is greater or equal to the mip level count of the image (i.e. greater or equal to %" PRIu32 ").",
+                         cmd_name, param_name, subresourceRange.baseMipLevel, image_mip_count);
     }
 
     if (subresourceRange.levelCount != VK_REMAINING_MIP_LEVELS) {
         if (subresourceRange.levelCount == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                            errorCodes.mip_count_err, "%s: %s.levelCount is 0.", cmd_name, param_name);
+            skip |= LogError(image, errorCodes.mip_count_err, "%s: %s.levelCount is 0.", cmd_name, param_name);
         } else {
             const uint64_t necessary_mip_count = uint64_t{subresourceRange.baseMipLevel} + uint64_t{subresourceRange.levelCount};
 
             if (necessary_mip_count > image_mip_count) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                                errorCodes.mip_count_err,
-                                "%s: %s.baseMipLevel + .levelCount (= %" PRIu32 " + %" PRIu32 " = %" PRIu64
-                                ") is greater than the mip level count of the image (i.e. greater than %" PRIu32 ").",
-                                cmd_name, param_name, subresourceRange.baseMipLevel, subresourceRange.levelCount,
-                                necessary_mip_count, image_mip_count);
+                skip |= LogError(image, errorCodes.mip_count_err,
+                                 "%s: %s.baseMipLevel + .levelCount (= %" PRIu32 " + %" PRIu32 " = %" PRIu64
+                                 ") is greater than the mip level count of the image (i.e. greater than %" PRIu32 ").",
+                                 cmd_name, param_name, subresourceRange.baseMipLevel, subresourceRange.levelCount,
+                                 necessary_mip_count, image_mip_count);
             }
         }
     }
 
     // Validate array layers
     if (subresourceRange.baseArrayLayer >= image_layer_count) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                        errorCodes.base_layer_err,
-                        "%s: %s.baseArrayLayer (= %" PRIu32
-                        ") is greater or equal to the %s of the image when it was created (i.e. greater or equal to %" PRIu32 ").",
-                        cmd_name, param_name, subresourceRange.baseArrayLayer, image_layer_count_var_name, image_layer_count);
+        skip |= LogError(image, errorCodes.base_layer_err,
+                         "%s: %s.baseArrayLayer (= %" PRIu32
+                         ") is greater or equal to the %s of the image when it was created (i.e. greater or equal to %" PRIu32 ").",
+                         cmd_name, param_name, subresourceRange.baseArrayLayer, image_layer_count_var_name, image_layer_count);
     }
 
     if (subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS) {
         if (subresourceRange.layerCount == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                            errorCodes.layer_count_err, "%s: %s.layerCount is 0.", cmd_name, param_name);
+            skip |= LogError(image, errorCodes.layer_count_err, "%s: %s.layerCount is 0.", cmd_name, param_name);
         } else {
             const uint64_t necessary_layer_count =
                 uint64_t{subresourceRange.baseArrayLayer} + uint64_t{subresourceRange.layerCount};
 
             if (necessary_layer_count > image_layer_count) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, image_handle,
-                                errorCodes.layer_count_err,
-                                "%s: %s.baseArrayLayer + .layerCount (= %" PRIu32 " + %" PRIu32 " = %" PRIu64
-                                ") is greater than the %s of the image when it was created (i.e. greater than %" PRIu32 ").",
-                                cmd_name, param_name, subresourceRange.baseArrayLayer, subresourceRange.layerCount,
-                                necessary_layer_count, image_layer_count_var_name, image_layer_count);
+                skip |= LogError(image, errorCodes.layer_count_err,
+                                 "%s: %s.baseArrayLayer + .layerCount (= %" PRIu32 " + %" PRIu32 " = %" PRIu64
+                                 ") is greater than the %s of the image when it was created (i.e. greater than %" PRIu32 ").",
+                                 cmd_name, param_name, subresourceRange.baseArrayLayer, subresourceRange.layerCount,
+                                 necessary_layer_count, image_layer_count_var_name, image_layer_count);
             }
         }
     }
@@ -4611,7 +4393,7 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const IMAGE_STATE *imag
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_layer_count, subresourceRange,
                                          "vkCreateImageView", "pCreateInfo->subresourceRange", image_layer_count_var_name,
-                                         HandleToUint64(image_state->image), subresourceRangeErrorCodes);
+                                         image_state->image, subresourceRangeErrorCodes);
 }
 
 bool CoreChecks::ValidateCmdClearColorSubresourceRange(const IMAGE_STATE *image_state,
@@ -4624,7 +4406,7 @@ bool CoreChecks::ValidateCmdClearColorSubresourceRange(const IMAGE_STATE *image_
     subresourceRangeErrorCodes.layer_count_err = "VUID-vkCmdClearColorImage-pRanges-01693";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         "vkCmdClearColorImage", param_name, "arrayLayers", HandleToUint64(image_state->image),
+                                         "vkCmdClearColorImage", param_name, "arrayLayers", image_state->image,
                                          subresourceRangeErrorCodes);
 }
 
@@ -4638,8 +4420,8 @@ bool CoreChecks::ValidateCmdClearDepthSubresourceRange(const IMAGE_STATE *image_
     subresourceRangeErrorCodes.layer_count_err = "VUID-vkCmdClearDepthStencilImage-pRanges-01695";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         "vkCmdClearDepthStencilImage", param_name, "arrayLayers",
-                                         HandleToUint64(image_state->image), subresourceRangeErrorCodes);
+                                         "vkCmdClearDepthStencilImage", param_name, "arrayLayers", image_state->image,
+                                         subresourceRangeErrorCodes);
 }
 
 bool CoreChecks::ValidateImageBarrierSubresourceRange(const IMAGE_STATE *image_state,
@@ -4652,8 +4434,7 @@ bool CoreChecks::ValidateImageBarrierSubresourceRange(const IMAGE_STATE *image_s
     subresourceRangeErrorCodes.layer_count_err = "VUID-VkImageMemoryBarrier-subresourceRange-01725";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         cmd_name, param_name, "arrayLayers", HandleToUint64(image_state->image),
-                                         subresourceRangeErrorCodes);
+                                         cmd_name, param_name, "arrayLayers", image_state->image, subresourceRangeErrorCodes);
 }
 
 bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
@@ -4691,19 +4472,17 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             if (api_version >= VK_API_VERSION_1_1 || device_extensions.vk_khr_maintenance2) {
                 if (!device_extensions.vk_ext_separate_stencil_usage) {
                     if ((image_usage | chained_ivuci_struct->usage) != image_usage) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-pNext-02661",
-                                        "vkCreateImageView(): pNext chain includes VkImageViewUsageCreateInfo, usage must not "
-                                        "include any bits that were not set in VkImageCreateInfo::usage used to create image");
+                        skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-pNext-02661",
+                                         "vkCreateImageView(): pNext chain includes VkImageViewUsageCreateInfo, usage must not "
+                                         "include any bits that were not set in VkImageCreateInfo::usage used to create image");
                     }
                 } else {
                     const auto image_stencil_struct =
                         lvl_find_in_chain<VkImageStencilUsageCreateInfoEXT>(image_state->createInfo.pNext);
                     if (image_stencil_struct == nullptr) {
                         if ((image_usage | chained_ivuci_struct->usage) != image_usage) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-pNext-02662",
+                            skip |= LogError(
+                                pCreateInfo->image, "VUID-VkImageViewCreateInfo-pNext-02662",
                                 "vkCreateImageView(): pNext chain includes VkImageViewUsageCreateInfo and image was not created "
                                 "with a VkImageStencilUsageCreateInfo in pNext of vkImageCreateInfo, usage must not include "
                                 "any bits that were not set in VkImageCreateInfo::usage used to create image");
@@ -4712,9 +4491,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) == VK_IMAGE_ASPECT_STENCIL_BIT &&
                             (image_stencil_struct->stencilUsage | chained_ivuci_struct->usage) !=
                                 image_stencil_struct->stencilUsage) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-pNext-02663",
+                            skip |= LogError(
+                                pCreateInfo->image, "VUID-VkImageViewCreateInfo-pNext-02663",
                                 "vkCreateImageView(): pNext chain includes VkImageViewUsageCreateInfo, image was created with a "
                                 "VkImageStencilUsageCreateInfo in pNext of vkImageCreateInfo, and subResourceRange.aspectMask "
                                 "includes VK_IMAGE_ASPECT_STENCIL_BIT, VkImageViewUsageCreateInfo::usage must not include any "
@@ -4722,9 +4500,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         }
                         if ((aspect_mask & ~VK_IMAGE_ASPECT_STENCIL_BIT) != 0 &&
                             (image_usage | chained_ivuci_struct->usage) != image_usage) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-pNext-02664",
+                            skip |= LogError(
+                                pCreateInfo->image, "VUID-VkImageViewCreateInfo-pNext-02664",
                                 "vkCreateImageView(): pNext chain includes VkImageViewUsageCreateInfo, image was created with a "
                                 "VkImageStencilUsageCreateInfo in pNext of vkImageCreateInfo, and subResourceRange.aspectMask "
                                 "includes bits other than VK_IMAGE_ASPECT_STENCIL_BIT, VkImageViewUsageCreateInfo::usage must not "
@@ -4747,9 +4524,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                     ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)
                        << " is not compatible with plane " << GetPlaneIndex(aspect_mask) << " of underlying image format "
                        << string_VkFormat(image_format) << ", must be " << string_VkFormat(compat_format) << ".";
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01586", "%s",
-                                    ss.str().c_str());
+                    skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01586", "%s", ss.str().c_str());
                 }
             } else {
                 if ((!device_extensions.vk_khr_maintenance2 ||
@@ -4762,9 +4537,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                            << report_data->FormatHandle(pCreateInfo->image).c_str() << "  format " << string_VkFormat(image_format)
                            << ".  Images created with the VK_IMAGE_CREATE_MUTABLE_FORMAT BIT "
                            << "can support ImageViews with differing formats but they must be in the same compatibility class.";
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01018", "%s",
-                                        ss.str().c_str());
+                        skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01018", "%s", ss.str().c_str());
                     }
                 }
             }
@@ -4775,9 +4548,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                 ss << "vkCreateImageView() format " << string_VkFormat(view_format) << " differs from "
                    << report_data->FormatHandle(pCreateInfo->image).c_str() << " format " << string_VkFormat(image_format)
                    << ".  Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT BIT was set on image creation.";
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01019", "%s", ss.str().c_str());
+                skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01019", "%s", ss.str().c_str());
             }
         }
 
@@ -4787,25 +4558,22 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         switch (image_type) {
             case VK_IMAGE_TYPE_1D:
                 if (view_type != VK_IMAGE_VIEW_TYPE_1D && view_type != VK_IMAGE_VIEW_TYPE_1D_ARRAY) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-subResourceRange-01021",
-                                    "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                    string_VkImageViewType(view_type), string_VkImageType(image_type));
+                    skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-subResourceRange-01021",
+                                     "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                     string_VkImageViewType(view_type), string_VkImageType(image_type));
                 }
                 break;
             case VK_IMAGE_TYPE_2D:
                 if (view_type != VK_IMAGE_VIEW_TYPE_2D && view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
                     if ((view_type == VK_IMAGE_VIEW_TYPE_CUBE || view_type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) &&
                         !(image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01003",
-                                        "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                        string_VkImageViewType(view_type), string_VkImageType(image_type));
+                        skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01003",
+                                         "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                         string_VkImageViewType(view_type), string_VkImageType(image_type));
                     } else if (view_type != VK_IMAGE_VIEW_TYPE_CUBE && view_type != VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-subResourceRange-01021",
-                                        "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                        string_VkImageViewType(view_type), string_VkImageType(image_type));
+                        skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-subResourceRange-01021",
+                                         "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                         string_VkImageViewType(view_type), string_VkImageType(image_type));
                     }
                 }
                 break;
@@ -4815,33 +4583,29 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         if ((view_type == VK_IMAGE_VIEW_TYPE_2D || view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY)) {
                             if (!(image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR)) {
                                 skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-01005",
-                                            "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                            string_VkImageViewType(view_type), string_VkImageType(image_type));
+                                    LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01005",
+                                             "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                             string_VkImageViewType(view_type), string_VkImageType(image_type));
                             } else if ((image_flags & (VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT |
                                                        VK_IMAGE_CREATE_SPARSE_ALIASED_BIT))) {
-                                skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-subResourceRange-01021",
-                                            "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s "
-                                            "when the VK_IMAGE_CREATE_SPARSE_BINDING_BIT, VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or "
-                                            "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT flags are enabled.",
-                                            string_VkImageViewType(view_type), string_VkImageType(image_type));
+                                skip |= LogError(
+                                    pCreateInfo->image, "VUID-VkImageViewCreateInfo-subResourceRange-01021",
+                                    "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s "
+                                    "when the VK_IMAGE_CREATE_SPARSE_BINDING_BIT, VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or "
+                                    "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT flags are enabled.",
+                                    string_VkImageViewType(view_type), string_VkImageType(image_type));
                             }
                         } else {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-subResourceRange-01021",
-                                            "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                            string_VkImageViewType(view_type), string_VkImageType(image_type));
+                            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-subResourceRange-01021",
+                                             "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                             string_VkImageViewType(view_type), string_VkImageType(image_type));
                         }
                     }
                 } else {
                     if (view_type != VK_IMAGE_VIEW_TYPE_3D) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                        HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-subResourceRange-01021",
-                                        "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
-                                        string_VkImageViewType(view_type), string_VkImageType(image_type));
+                        skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-subResourceRange-01021",
+                                         "vkCreateImageView(): pCreateInfo->viewType %s is not compatible with image type %s.",
+                                         string_VkImageViewType(view_type), string_VkImageType(image_type));
                     }
                 }
                 break;
@@ -4859,61 +4623,53 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                                                                                        : format_properties.optimalTilingFeatures;
 
         if (tiling_features == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-None-02273",
-                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s has no supported format features on this "
-                            "physical device.",
-                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-None-02273",
+                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s has no supported format features on this "
+                             "physical device.",
+                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         } else if ((image_usage & VK_IMAGE_USAGE_SAMPLED_BIT) && !(tiling_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02274",
-                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
-                            "VK_IMAGE_USAGE_SAMPLED_BIT.",
-                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-usage-02274",
+                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
+                             "VK_IMAGE_USAGE_SAMPLED_BIT.",
+                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         } else if ((image_usage & VK_IMAGE_USAGE_STORAGE_BIT) && !(tiling_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02275",
-                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
-                            "VK_IMAGE_USAGE_STORAGE_BIT.",
-                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-usage-02275",
+                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
+                             "VK_IMAGE_USAGE_STORAGE_BIT.",
+                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         } else if ((image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
                    !(tiling_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02276",
-                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
-                            "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.",
-                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-usage-02276",
+                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
+                             "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.",
+                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         } else if ((image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
                    !(tiling_features & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02277",
-                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
-                            "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
-                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-usage-02277",
+                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
+                             "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
+                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         }
 
         if (image_usage & VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV) {
             if (view_type != VK_IMAGE_VIEW_TYPE_2D && view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-02086",
-                                "vkCreateImageView() If image was created with usage containing "
-                                "VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, viewType must be "
-                                "VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY.");
+                skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-02086",
+                                 "vkCreateImageView() If image was created with usage containing "
+                                 "VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, viewType must be "
+                                 "VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY.");
             }
             if (view_format != VK_FORMAT_R8_UINT) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-image-02087",
-                                "vkCreateImageView() If image was created with usage containing "
-                                "VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, format must be VK_FORMAT_R8_UINT.");
+                skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-02087",
+                                 "vkCreateImageView() If image was created with usage containing "
+                                 "VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, format must be VK_FORMAT_R8_UINT.");
             }
         }
     }
     return skip;
 }
 
-static inline bool ValidateCmdCopyBufferBounds(const debug_report_data *report_data, const BUFFER_STATE *src_buffer_state,
-                                               const BUFFER_STATE *dst_buffer_state, uint32_t regionCount,
-                                               const VkBufferCopy *pRegions) {
+bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_state, const BUFFER_STATE *dst_buffer_state,
+                                             uint32_t regionCount, const VkBufferCopy *pRegions) const {
     bool skip = false;
 
     VkDeviceSize src_buffer_size = src_buffer_state->createInfo.size;
@@ -4931,49 +4687,44 @@ static inline bool ValidateCmdCopyBufferBounds(const debug_report_data *report_d
 
         // The srcOffset member of each element of pRegions must be less than the size of srcBuffer
         if (pRegions[i].srcOffset >= src_buffer_size) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(src_buffer_state->buffer), "VUID-vkCmdCopyBuffer-srcOffset-00113",
-                            "vkCmdCopyBuffer(): pRegions[%d].srcOffset (%" PRIuLEAST64
-                            ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
-                            i, pRegions[i].srcOffset, i, pRegions[i].size);
+            skip |= LogError(src_buffer_state->buffer, "VUID-vkCmdCopyBuffer-srcOffset-00113",
+                             "vkCmdCopyBuffer(): pRegions[%d].srcOffset (%" PRIuLEAST64
+                             ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
+                             i, pRegions[i].srcOffset, i, pRegions[i].size);
         }
 
         // The dstOffset member of each element of pRegions must be less than the size of dstBuffer
         if (pRegions[i].dstOffset >= dst_buffer_size) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(dst_buffer_state->buffer), "VUID-vkCmdCopyBuffer-dstOffset-00114",
-                            "vkCmdCopyBuffer(): pRegions[%d].dstOffset (%" PRIuLEAST64
-                            ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
-                            i, pRegions[i].dstOffset, i, pRegions[i].size);
+            skip |= LogError(dst_buffer_state->buffer, "VUID-vkCmdCopyBuffer-dstOffset-00114",
+                             "vkCmdCopyBuffer(): pRegions[%d].dstOffset (%" PRIuLEAST64
+                             ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
+                             i, pRegions[i].dstOffset, i, pRegions[i].size);
         }
 
         // The size member of each element of pRegions must be less than or equal to the size of srcBuffer minus srcOffset
         if (pRegions[i].size > (src_buffer_size - pRegions[i].srcOffset)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(src_buffer_state->buffer), "VUID-vkCmdCopyBuffer-size-00115",
-                            "vkCmdCopyBuffer(): pRegions[%d].size (%" PRIuLEAST64
-                            ") is greater than the source buffer size (%" PRIuLEAST64
-                            ") minus pRegions[%d].srcOffset (%" PRIuLEAST64 ").",
-                            i, pRegions[i].size, src_buffer_size, i, pRegions[i].srcOffset);
+            skip |= LogError(src_buffer_state->buffer, "VUID-vkCmdCopyBuffer-size-00115",
+                             "vkCmdCopyBuffer(): pRegions[%d].size (%" PRIuLEAST64
+                             ") is greater than the source buffer size (%" PRIuLEAST64
+                             ") minus pRegions[%d].srcOffset (%" PRIuLEAST64 ").",
+                             i, pRegions[i].size, src_buffer_size, i, pRegions[i].srcOffset);
         }
 
         // The size member of each element of pRegions must be less than or equal to the size of dstBuffer minus dstOffset
         if (pRegions[i].size > (dst_buffer_size - pRegions[i].dstOffset)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(dst_buffer_state->buffer), "VUID-vkCmdCopyBuffer-size-00116",
-                            "vkCmdCopyBuffer(): pRegions[%d].size (%" PRIuLEAST64
-                            ") is greater than the destination buffer size (%" PRIuLEAST64
-                            ") minus pRegions[%d].dstOffset (%" PRIuLEAST64 ").",
-                            i, pRegions[i].size, dst_buffer_size, i, pRegions[i].dstOffset);
+            skip |= LogError(dst_buffer_state->buffer, "VUID-vkCmdCopyBuffer-size-00116",
+                             "vkCmdCopyBuffer(): pRegions[%d].size (%" PRIuLEAST64
+                             ") is greater than the destination buffer size (%" PRIuLEAST64
+                             ") minus pRegions[%d].dstOffset (%" PRIuLEAST64 ").",
+                             i, pRegions[i].size, dst_buffer_size, i, pRegions[i].dstOffset);
         }
     }
 
     // The union of the source regions, and the union of the destination regions, must not overlap in memory
     if (src_buffer_state->buffer == dst_buffer_state->buffer) {
         if (((src_min > dst_min) && (src_min < dst_max)) || ((src_max > dst_min) && (src_max < dst_max))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(src_buffer_state->buffer), "VUID-vkCmdCopyBuffer-pRegions-00117",
-                            "vkCmdCopyBuffer(): Detected overlap between source and dest regions in memory.");
+            skip |= LogError(src_buffer_state->buffer, "VUID-vkCmdCopyBuffer-pRegions-00117",
+                             "vkCmdCopyBuffer(): Detected overlap between source and dest regions in memory.");
         }
     }
 
@@ -5001,7 +4752,7 @@ bool CoreChecks::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkB
                               "VUID-vkCmdCopyBuffer-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_node, CMD_COPYBUFFER, "vkCmdCopyBuffer()");
     skip |= InsideRenderPass(cb_node, "vkCmdCopyBuffer()", "VUID-vkCmdCopyBuffer-renderpass");
-    skip |= ValidateCmdCopyBufferBounds(report_data, src_buffer_state, dst_buffer_state, regionCount, pRegions);
+    skip |= ValidateCmdCopyBufferBounds(src_buffer_state, dst_buffer_state, regionCount, pRegions);
     return skip;
 }
 
@@ -5009,14 +4760,12 @@ bool CoreChecks::ValidateIdleBuffer(VkBuffer buffer) const {
     bool skip = false;
     auto buffer_state = GetBufferState(buffer);
     if (!buffer_state) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, HandleToUint64(buffer),
-                        kVUID_Core_DrawState_DoubleDestroy, "Cannot free %s that has not been allocated.",
-                        report_data->FormatHandle(buffer).c_str());
+        skip |= LogError(buffer, kVUID_Core_DrawState_DoubleDestroy, "Cannot free %s that has not been allocated.",
+                         report_data->FormatHandle(buffer).c_str());
     } else {
         if (buffer_state->in_use.load()) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(buffer), "VUID-vkDestroyBuffer-buffer-00922",
-                            "Cannot free %s that is in use by a command buffer.", report_data->FormatHandle(buffer).c_str());
+            skip |= LogError(buffer, "VUID-vkDestroyBuffer-buffer-00922", "Cannot free %s that is in use by a command buffer.",
+                             report_data->FormatHandle(buffer).c_str());
         }
     }
     return skip;
@@ -5073,19 +4822,17 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     skip |= InsideRenderPass(cb_node, "vkCmdFillBuffer()", "VUID-vkCmdFillBuffer-renderpass");
 
     if (dstOffset >= buffer_state->createInfo.size) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(dstBuffer), "VUID-vkCmdFillBuffer-dstOffset-00024",
-                        "vkCmdFillBuffer(): dstOffset (0x%" PRIxLEAST64
-                        ") is not less than destination buffer (%s) size (0x%" PRIxLEAST64 ").",
-                        dstOffset, report_data->FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size);
+        skip |= LogError(dstBuffer, "VUID-vkCmdFillBuffer-dstOffset-00024",
+                         "vkCmdFillBuffer(): dstOffset (0x%" PRIxLEAST64
+                         ") is not less than destination buffer (%s) size (0x%" PRIxLEAST64 ").",
+                         dstOffset, report_data->FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size);
     }
 
     if ((size != VK_WHOLE_SIZE) && (size > (buffer_state->createInfo.size - dstOffset))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                        HandleToUint64(dstBuffer), "VUID-vkCmdFillBuffer-size-00027",
-                        "vkCmdFillBuffer(): size (0x%" PRIxLEAST64 ") is greater than dstBuffer (%s) size (0x%" PRIxLEAST64
-                        ") minus dstOffset (0x%" PRIxLEAST64 ").",
-                        size, report_data->FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
+        skip |= LogError(dstBuffer, "VUID-vkCmdFillBuffer-size-00027",
+                         "vkCmdFillBuffer(): size (0x%" PRIxLEAST64 ") is greater than dstBuffer (%s) size (0x%" PRIxLEAST64
+                         ") minus dstOffset (0x%" PRIxLEAST64 ").",
+                         size, report_data->FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
     }
 
     return skip;
@@ -5098,31 +4845,29 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
     for (uint32_t i = 0; i < regionCount; i++) {
         if (image_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((pRegions[i].imageOffset.y != 0) || (pRegions[i].imageExtent.height != 1)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-srcImage-00199",
-                                "%s(): pRegion[%d] imageOffset.y is %d and imageExtent.height is %d. For 1D images these must be 0 "
-                                "and 1, respectively.",
-                                function, i, pRegions[i].imageOffset.y, pRegions[i].imageExtent.height);
+                skip |=
+                    LogError(image_state->image, "VUID-VkBufferImageCopy-srcImage-00199",
+                             "%s(): pRegion[%d] imageOffset.y is %d and imageExtent.height is %d. For 1D images these must be 0 "
+                             "and 1, respectively.",
+                             function, i, pRegions[i].imageOffset.y, pRegions[i].imageExtent.height);
             }
         }
 
         if ((image_state->createInfo.imageType == VK_IMAGE_TYPE_1D) || (image_state->createInfo.imageType == VK_IMAGE_TYPE_2D)) {
             if ((pRegions[i].imageOffset.z != 0) || (pRegions[i].imageExtent.depth != 1)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-srcImage-00201",
-                                "%s(): pRegion[%d] imageOffset.z is %d and imageExtent.depth is %d. For 1D and 2D images these "
-                                "must be 0 and 1, respectively.",
-                                function, i, pRegions[i].imageOffset.z, pRegions[i].imageExtent.depth);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-srcImage-00201",
+                                 "%s(): pRegion[%d] imageOffset.z is %d and imageExtent.depth is %d. For 1D and 2D images these "
+                                 "must be 0 and 1, respectively.",
+                                 function, i, pRegions[i].imageOffset.z, pRegions[i].imageExtent.depth);
             }
         }
 
         if (image_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
             if ((0 != pRegions[i].imageSubresource.baseArrayLayer) || (1 != pRegions[i].imageSubresource.layerCount)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-baseArrayLayer-00213",
-                                "%s(): pRegion[%d] imageSubresource.baseArrayLayer is %d and imageSubresource.layerCount is %d. "
-                                "For 3D images these must be 0 and 1, respectively.",
-                                function, i, pRegions[i].imageSubresource.baseArrayLayer, pRegions[i].imageSubresource.layerCount);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-baseArrayLayer-00213",
+                                 "%s(): pRegion[%d] imageSubresource.baseArrayLayer is %d and imageSubresource.layerCount is %d. "
+                                 "For 3D images these must be 0 and 1, respectively.",
+                                 function, i, pRegions[i].imageSubresource.baseArrayLayer, pRegions[i].imageSubresource.layerCount);
             }
         }
 
@@ -5131,35 +4876,31 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
         uint32_t element_size = FormatElementSize(image_state->createInfo.format, pRegions[i].imageSubresource.aspectMask);
 
         if (!FormatIsDepthAndStencil(image_state->createInfo.format) && SafeModulo(pRegions[i].bufferOffset, element_size) != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferOffset-00193",
-                            "%s(): pRegion[%d] bufferOffset 0x%" PRIxLEAST64
-                            " must be a multiple of this format's texel size (%" PRIu32 ").",
-                            function, i, pRegions[i].bufferOffset, element_size);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-bufferOffset-00193",
+                             "%s(): pRegion[%d] bufferOffset 0x%" PRIxLEAST64
+                             " must be a multiple of this format's texel size (%" PRIu32 ").",
+                             function, i, pRegions[i].bufferOffset, element_size);
         }
 
         //  BufferOffset must be a multiple of 4
         if (SafeModulo(pRegions[i].bufferOffset, 4) != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferOffset-00194",
-                            "%s(): pRegion[%d] bufferOffset 0x%" PRIxLEAST64 " must be a multiple of 4.", function, i,
-                            pRegions[i].bufferOffset);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-bufferOffset-00194",
+                             "%s(): pRegion[%d] bufferOffset 0x%" PRIxLEAST64 " must be a multiple of 4.", function, i,
+                             pRegions[i].bufferOffset);
         }
 
         //  BufferRowLength must be 0, or greater than or equal to the width member of imageExtent
         if ((pRegions[i].bufferRowLength != 0) && (pRegions[i].bufferRowLength < pRegions[i].imageExtent.width)) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                        HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferRowLength-00195",
-                        "%s(): pRegion[%d] bufferRowLength (%d) must be zero or greater-than-or-equal-to imageExtent.width (%d).",
-                        function, i, pRegions[i].bufferRowLength, pRegions[i].imageExtent.width);
+                LogError(image_state->image, "VUID-VkBufferImageCopy-bufferRowLength-00195",
+                         "%s(): pRegion[%d] bufferRowLength (%d) must be zero or greater-than-or-equal-to imageExtent.width (%d).",
+                         function, i, pRegions[i].bufferRowLength, pRegions[i].imageExtent.width);
         }
 
         //  BufferImageHeight must be 0, or greater than or equal to the height member of imageExtent
         if ((pRegions[i].bufferImageHeight != 0) && (pRegions[i].bufferImageHeight < pRegions[i].imageExtent.height)) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferImageHeight-00196",
+            skip |= LogError(
+                image_state->image, "VUID-VkBufferImageCopy-bufferImageHeight-00196",
                 "%s(): pRegion[%d] bufferImageHeight (%d) must be zero or greater-than-or-equal-to imageExtent.height (%d).",
                 function, i, pRegions[i].bufferImageHeight, pRegions[i].imageExtent.height);
         }
@@ -5169,50 +4910,45 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
         // imageOffset.x and (imageExtent.width + imageOffset.x) must both be >= 0 and <= image subresource width
         if ((pRegions[i].imageOffset.x < 0) || (pRegions[i].imageOffset.x > static_cast<int32_t>(adusted_image_extent.width)) ||
             ((pRegions[i].imageOffset.x + pRegions[i].imageExtent.width) > static_cast<int32_t>(adusted_image_extent.width))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageOffset-00197",
-                            "%s(): Both pRegion[%d] imageoffset.x (%d) and (imageExtent.width + imageOffset.x) (%d) must be >= "
-                            "zero or <= image subresource width (%d).",
-                            function, i, pRegions[i].imageOffset.x, (pRegions[i].imageOffset.x + pRegions[i].imageExtent.width),
-                            adusted_image_extent.width);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageOffset-00197",
+                             "%s(): Both pRegion[%d] imageoffset.x (%d) and (imageExtent.width + imageOffset.x) (%d) must be >= "
+                             "zero or <= image subresource width (%d).",
+                             function, i, pRegions[i].imageOffset.x, (pRegions[i].imageOffset.x + pRegions[i].imageExtent.width),
+                             adusted_image_extent.width);
         }
 
         // imageOffset.y and (imageExtent.height + imageOffset.y) must both be >= 0 and <= image subresource height
         if ((pRegions[i].imageOffset.y < 0) || (pRegions[i].imageOffset.y > static_cast<int32_t>(adusted_image_extent.height)) ||
             ((pRegions[i].imageOffset.y + pRegions[i].imageExtent.height) > static_cast<int32_t>(adusted_image_extent.height))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageOffset-00198",
-                            "%s(): Both pRegion[%d] imageoffset.y (%d) and (imageExtent.height + imageOffset.y) (%d) must be >= "
-                            "zero or <= image subresource height (%d).",
-                            function, i, pRegions[i].imageOffset.y, (pRegions[i].imageOffset.y + pRegions[i].imageExtent.height),
-                            adusted_image_extent.height);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageOffset-00198",
+                             "%s(): Both pRegion[%d] imageoffset.y (%d) and (imageExtent.height + imageOffset.y) (%d) must be >= "
+                             "zero or <= image subresource height (%d).",
+                             function, i, pRegions[i].imageOffset.y, (pRegions[i].imageOffset.y + pRegions[i].imageExtent.height),
+                             adusted_image_extent.height);
         }
 
         // imageOffset.z and (imageExtent.depth + imageOffset.z) must both be >= 0 and <= image subresource depth
         if ((pRegions[i].imageOffset.z < 0) || (pRegions[i].imageOffset.z > static_cast<int32_t>(adusted_image_extent.depth)) ||
             ((pRegions[i].imageOffset.z + pRegions[i].imageExtent.depth) > static_cast<int32_t>(adusted_image_extent.depth))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageOffset-00200",
-                            "%s(): Both pRegion[%d] imageoffset.z (%d) and (imageExtent.depth + imageOffset.z) (%d) must be >= "
-                            "zero or <= image subresource depth (%d).",
-                            function, i, pRegions[i].imageOffset.z, (pRegions[i].imageOffset.z + pRegions[i].imageExtent.depth),
-                            adusted_image_extent.depth);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageOffset-00200",
+                             "%s(): Both pRegion[%d] imageoffset.z (%d) and (imageExtent.depth + imageOffset.z) (%d) must be >= "
+                             "zero or <= image subresource depth (%d).",
+                             function, i, pRegions[i].imageOffset.z, (pRegions[i].imageOffset.z + pRegions[i].imageExtent.depth),
+                             adusted_image_extent.depth);
         }
 
         // subresource aspectMask must have exactly 1 bit set
         const int num_bits = sizeof(VkFlags) * CHAR_BIT;
         std::bitset<num_bits> aspect_mask_bits(pRegions[i].imageSubresource.aspectMask);
         if (aspect_mask_bits.count() != 1) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-aspectMask-00212",
-                            "%s: aspectMasks for imageSubresource in each region must have only a single bit set.", function);
+            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-aspectMask-00212",
+                             "%s: aspectMasks for imageSubresource in each region must have only a single bit set.", function);
         }
 
         // image subresource aspect bit must match format
         if (!VerifyAspectsPresent(pRegions[i].imageSubresource.aspectMask, image_state->createInfo.format)) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-aspectMask-00211",
+            skip |= LogError(
+                image_state->image, "VUID-VkBufferImageCopy-aspectMask-00211",
                 "%s(): pRegion[%d] subresource aspectMask 0x%x specifies aspects that are not present in image format 0x%x.",
                 function, i, pRegions[i].imageSubresource.aspectMask, image_state->createInfo.format);
         }
@@ -5223,18 +4959,16 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
 
             //  BufferRowLength must be a multiple of block width
             if (SafeModulo(pRegions[i].bufferRowLength, block_size.width) != 0) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                    HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferRowLength-00203",
+                skip |= LogError(
+                    image_state->image, "VUID-VkBufferImageCopy-bufferRowLength-00203",
                     "%s(): pRegion[%d] bufferRowLength (%d) must be a multiple of the compressed image's texel width (%d)..",
                     function, i, pRegions[i].bufferRowLength, block_size.width);
             }
 
             //  BufferRowHeight must be a multiple of block height
             if (SafeModulo(pRegions[i].bufferImageHeight, block_size.height) != 0) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                    HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferImageHeight-00204",
+                skip |= LogError(
+                    image_state->image, "VUID-VkBufferImageCopy-bufferImageHeight-00204",
                     "%s(): pRegion[%d] bufferImageHeight (%d) must be a multiple of the compressed image's texel height (%d)..",
                     function, i, pRegions[i].bufferImageHeight, block_size.height);
             }
@@ -5243,56 +4977,51 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
             if ((SafeModulo(pRegions[i].imageOffset.x, block_size.width) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.y, block_size.height) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.z, block_size.depth) != 0)) {
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageOffset-00205",
-                            "%s(): pRegion[%d] imageOffset(x,y) (%d, %d) must be multiples of the compressed image's texel "
-                            "width & height (%d, %d)..",
-                            function, i, pRegions[i].imageOffset.x, pRegions[i].imageOffset.y, block_size.width, block_size.height);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageOffset-00205",
+                                 "%s(): pRegion[%d] imageOffset(x,y) (%d, %d) must be multiples of the compressed image's texel "
+                                 "width & height (%d, %d)..",
+                                 function, i, pRegions[i].imageOffset.x, pRegions[i].imageOffset.y, block_size.width,
+                                 block_size.height);
             }
 
             // bufferOffset must be a multiple of block size (linear bytes)
             uint32_t block_size_in_bytes = FormatElementSize(image_state->createInfo.format);
             if (SafeModulo(pRegions[i].bufferOffset, block_size_in_bytes) != 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-bufferOffset-00206",
-                                "%s(): pRegion[%d] bufferOffset (0x%" PRIxLEAST64
-                                ") must be a multiple of the compressed image's texel block size (%" PRIu32 ")..",
-                                function, i, pRegions[i].bufferOffset, block_size_in_bytes);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-bufferOffset-00206",
+                                 "%s(): pRegion[%d] bufferOffset (0x%" PRIxLEAST64
+                                 ") must be a multiple of the compressed image's texel block size (%" PRIu32 ")..",
+                                 function, i, pRegions[i].bufferOffset, block_size_in_bytes);
             }
 
             // imageExtent width must be a multiple of block width, or extent+offset width must equal subresource width
             VkExtent3D mip_extent = GetImageSubresourceExtent(image_state, &(pRegions[i].imageSubresource));
             if ((SafeModulo(pRegions[i].imageExtent.width, block_size.width) != 0) &&
                 (pRegions[i].imageExtent.width + pRegions[i].imageOffset.x != mip_extent.width)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageExtent-00207",
-                                "%s(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block width "
-                                "(%d), or when added to offset.x (%d) must equal the image subresource width (%d)..",
-                                function, i, pRegions[i].imageExtent.width, block_size.width, pRegions[i].imageOffset.x,
-                                mip_extent.width);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageExtent-00207",
+                                 "%s(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block width "
+                                 "(%d), or when added to offset.x (%d) must equal the image subresource width (%d)..",
+                                 function, i, pRegions[i].imageExtent.width, block_size.width, pRegions[i].imageOffset.x,
+                                 mip_extent.width);
             }
 
             // imageExtent height must be a multiple of block height, or extent+offset height must equal subresource height
             if ((SafeModulo(pRegions[i].imageExtent.height, block_size.height) != 0) &&
                 (pRegions[i].imageExtent.height + pRegions[i].imageOffset.y != mip_extent.height)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageExtent-00208",
-                                "%s(): pRegion[%d] extent height (%d) must be a multiple of the compressed texture block height "
-                                "(%d), or when added to offset.y (%d) must equal the image subresource height (%d)..",
-                                function, i, pRegions[i].imageExtent.height, block_size.height, pRegions[i].imageOffset.y,
-                                mip_extent.height);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageExtent-00208",
+                                 "%s(): pRegion[%d] extent height (%d) must be a multiple of the compressed texture block height "
+                                 "(%d), or when added to offset.y (%d) must equal the image subresource height (%d)..",
+                                 function, i, pRegions[i].imageExtent.height, block_size.height, pRegions[i].imageOffset.y,
+                                 mip_extent.height);
             }
 
             // imageExtent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
             if ((SafeModulo(pRegions[i].imageExtent.depth, block_size.depth) != 0) &&
                 (pRegions[i].imageExtent.depth + pRegions[i].imageOffset.z != mip_extent.depth)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-imageExtent-00209",
-                                "%s(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block depth "
-                                "(%d), or when added to offset.z (%d) must equal the image subresource depth (%d)..",
-                                function, i, pRegions[i].imageExtent.depth, block_size.depth, pRegions[i].imageOffset.z,
-                                mip_extent.depth);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-imageExtent-00209",
+                                 "%s(): pRegion[%d] extent width (%d) must be a multiple of the compressed texture block depth "
+                                 "(%d), or when added to offset.z (%d) must equal the image subresource depth (%d)..",
+                                 function, i, pRegions[i].imageExtent.depth, block_size.depth, pRegions[i].imageOffset.z,
+                                 mip_extent.depth);
             }
         }
 
@@ -5301,21 +5030,19 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
             // VK_IMAGE_ASPECT_PLANE_2_BIT valid only for image formats with three planes
             if ((FormatPlaneCount(image_state->createInfo.format) < 3) &&
                 (pRegions[i].imageSubresource.aspectMask == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-aspectMask-01560",
-                                "%s(): pRegion[%d] subresource aspectMask cannot be VK_IMAGE_ASPECT_PLANE_2_BIT unless image "
-                                "format has three planes.",
-                                function, i);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-aspectMask-01560",
+                                 "%s(): pRegion[%d] subresource aspectMask cannot be VK_IMAGE_ASPECT_PLANE_2_BIT unless image "
+                                 "format has three planes.",
+                                 function, i);
             }
 
             // image subresource aspectMask must be VK_IMAGE_ASPECT_PLANE_*_BIT
             if (0 == (pRegions[i].imageSubresource.aspectMask &
                       (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT))) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image_state->image), "VUID-VkBufferImageCopy-aspectMask-01560",
-                                "%s(): pRegion[%d] subresource aspectMask for multi-plane image formats must have a "
-                                "VK_IMAGE_ASPECT_PLANE_*_BIT when copying to or from.",
-                                function, i);
+                skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-aspectMask-01560",
+                                 "%s(): pRegion[%d] subresource aspectMask for multi-plane image formats must have a "
+                                 "VK_IMAGE_ASPECT_PLANE_*_BIT when copying to or from.",
+                                 function, i);
             }
         }
     }
@@ -5323,8 +5050,8 @@ bool CoreChecks::ValidateBufferImageCopyData(uint32_t regionCount, const VkBuffe
     return skip;
 }
 
-static bool ValidateImageBounds(const debug_report_data *report_data, const IMAGE_STATE *image_state, const uint32_t regionCount,
-                                const VkBufferImageCopy *pRegions, const char *func_name, const char *msg_code) {
+bool CoreChecks::ValidateImageBounds(const IMAGE_STATE *image_state, const uint32_t regionCount, const VkBufferImageCopy *pRegions,
+                                     const char *func_name, const char *msg_code) const {
     bool skip = false;
     const VkImageCreateInfo *image_info = &(image_state->createInfo);
 
@@ -5334,10 +5061,9 @@ static bool ValidateImageBounds(const debug_report_data *report_data, const IMAG
 
         if (IsExtentSizeZero(&extent))  // Warn on zero area subresource
         {
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, (uint64_t)0,
-                        kVUID_Core_Image_ZeroAreaSubregion, "%s: pRegion[%d] imageExtent of {%1d, %1d, %1d} has zero area",
-                        func_name, i, extent.width, extent.height, extent.depth);
+            skip |= LogWarning(image_state->image, kVUID_Core_Image_ZeroAreaSubregion,
+                               "%s: pRegion[%d] imageExtent of {%1d, %1d, %1d} has zero area", func_name, i, extent.width,
+                               extent.height, extent.depth);
         }
 
         VkExtent3D image_extent = GetImageSubresourceExtent(image_state, &(pRegions[i].imageSubresource));
@@ -5357,17 +5083,15 @@ static bool ValidateImageBounds(const debug_report_data *report_data, const IMAG
         }
 
         if (0 != ExceedsBounds(&offset, &extent, &image_extent)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, (uint64_t)0,
-                            msg_code, "%s: pRegion[%d] exceeds image bounds..", func_name, i);
+            skip |= LogError(image_state->image, msg_code, "%s: pRegion[%d] exceeds image bounds..", func_name, i);
         }
     }
 
     return skip;
 }
 
-static inline bool ValidateBufferBounds(const debug_report_data *report_data, const IMAGE_STATE *image_state,
-                                        const BUFFER_STATE *buff_state, uint32_t regionCount, const VkBufferImageCopy *pRegions,
-                                        const char *func_name, const char *msg_code) {
+bool CoreChecks::ValidateBufferBounds(const IMAGE_STATE *image_state, const BUFFER_STATE *buff_state, uint32_t regionCount,
+                                      const VkBufferImageCopy *pRegions, const char *func_name, const char *msg_code) const {
     bool skip = false;
 
     VkDeviceSize buffer_size = buff_state->createInfo.size;
@@ -5403,9 +5127,8 @@ static inline bool ValidateBufferBounds(const debug_report_data *report_data, co
             max_buffer_offset += pRegions[i].bufferOffset;                                       // add initial offset (bytes)
 
             if (buffer_size < max_buffer_offset) {
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, (uint64_t)0,
-                            msg_code, "%s: pRegion[%d] exceeds buffer size of %" PRIu64 " bytes..", func_name, i, buffer_size);
+                skip |= LogError(device, msg_code, "%s: pRegion[%d] exceeds buffer size of %" PRIu64 " bytes..", func_name, i,
+                                 buffer_size);
             }
         }
     }
@@ -5431,14 +5154,14 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuff
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
 
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->createInfo.commandPool), "VUID-vkCmdCopyImageToBuffer-commandBuffer-cmdpool",
-                        "Cannot call vkCmdCopyImageToBuffer() on a command buffer allocated from a pool without graphics, compute, "
-                        "or transfer capabilities..");
+        skip |=
+            LogError(cb_node->createInfo.commandPool, "VUID-vkCmdCopyImageToBuffer-commandBuffer-cmdpool",
+                     "Cannot call vkCmdCopyImageToBuffer() on a command buffer allocated from a pool without graphics, compute, "
+                     "or transfer capabilities..");
     }
-    skip |= ValidateImageBounds(report_data, src_image_state, regionCount, pRegions, "vkCmdCopyImageToBuffer()",
+    skip |= ValidateImageBounds(src_image_state, regionCount, pRegions, "vkCmdCopyImageToBuffer()",
                                 "VUID-vkCmdCopyImageToBuffer-pRegions-00182");
-    skip |= ValidateBufferBounds(report_data, src_image_state, dst_buffer_state, regionCount, pRegions, "vkCmdCopyImageToBuffer()",
+    skip |= ValidateBufferBounds(src_image_state, dst_buffer_state, regionCount, pRegions, "vkCmdCopyImageToBuffer()",
                                  "VUID-vkCmdCopyImageToBuffer-pRegions-00183");
 
     skip |= ValidateImageSampleCount(src_image_state, VK_SAMPLE_COUNT_1_BIT, "vkCmdCopyImageToBuffer(): srcImage",
@@ -5510,14 +5233,14 @@ bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuff
     const auto pPool = cb_node->command_pool.get();
     VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[pPool->queueFamilyIndex].queueFlags;
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(cb_node->createInfo.commandPool), "VUID-vkCmdCopyBufferToImage-commandBuffer-cmdpool",
-                        "Cannot call vkCmdCopyBufferToImage() on a command buffer allocated from a pool without graphics, compute, "
-                        "or transfer capabilities..");
+        skip |=
+            LogError(cb_node->createInfo.commandPool, "VUID-vkCmdCopyBufferToImage-commandBuffer-cmdpool",
+                     "Cannot call vkCmdCopyBufferToImage() on a command buffer allocated from a pool without graphics, compute, "
+                     "or transfer capabilities..");
     }
-    skip |= ValidateImageBounds(report_data, dst_image_state, regionCount, pRegions, "vkCmdCopyBufferToImage()",
+    skip |= ValidateImageBounds(dst_image_state, regionCount, pRegions, "vkCmdCopyBufferToImage()",
                                 "VUID-vkCmdCopyBufferToImage-pRegions-00172");
-    skip |= ValidateBufferBounds(report_data, dst_image_state, src_buffer_state, regionCount, pRegions, "vkCmdCopyBufferToImage()",
+    skip |= ValidateBufferBounds(dst_image_state, src_buffer_state, regionCount, pRegions, "vkCmdCopyBufferToImage()",
                                  "VUID-vkCmdCopyBufferToImage-pRegions-00171");
     skip |= ValidateImageSampleCount(dst_image_state, VK_SAMPLE_COUNT_1_BIT, "vkCmdCopyBufferToImage(): dstImage",
                                      "VUID-vkCmdCopyBufferToImage-dstImage-00179");
@@ -5580,9 +5303,8 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     const int num_bits = sizeof(sub_aspect) * CHAR_BIT;
     std::bitset<num_bits> aspect_mask_bits(sub_aspect);
     if (aspect_mask_bits.count() != 1) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image),
-                        "VUID-vkGetImageSubresourceLayout-aspectMask-00997",
-                        "vkGetImageSubresourceLayout(): VkImageSubresource.aspectMask must have exactly 1 bit set.");
+        skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-aspectMask-00997",
+                         "vkGetImageSubresourceLayout(): VkImageSubresource.aspectMask must have exactly 1 bit set.");
     }
 
     const IMAGE_STATE *image_entry = GetImageState(image);
@@ -5594,33 +5316,29 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     if (device_extensions.vk_ext_image_drm_format_modifier) {
         if ((image_entry->createInfo.tiling != VK_IMAGE_TILING_LINEAR) &&
             (image_entry->createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkGetImageSubresourceLayout-image-02270",
-                            "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR or "
-                            "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.");
+            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-02270",
+                             "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR or "
+                             "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.");
         }
     } else {
         if (image_entry->createInfo.tiling != VK_IMAGE_TILING_LINEAR) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkGetImageSubresourceLayout-image-00996",
-                            "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR.");
+            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-00996",
+                             "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR.");
         }
     }
 
     // mipLevel must be less than the mipLevels specified in VkImageCreateInfo when the image was created
     if (pSubresource->mipLevel >= image_entry->createInfo.mipLevels) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image),
-                        "VUID-vkGetImageSubresourceLayout-mipLevel-01716",
-                        "vkGetImageSubresourceLayout(): pSubresource.mipLevel (%d) must be less than %d.", pSubresource->mipLevel,
-                        image_entry->createInfo.mipLevels);
+        skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-mipLevel-01716",
+                         "vkGetImageSubresourceLayout(): pSubresource.mipLevel (%d) must be less than %d.", pSubresource->mipLevel,
+                         image_entry->createInfo.mipLevels);
     }
 
     // arrayLayer must be less than the arrayLayers specified in VkImageCreateInfo when the image was created
     if (pSubresource->arrayLayer >= image_entry->createInfo.arrayLayers) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, HandleToUint64(image),
-                        "VUID-vkGetImageSubresourceLayout-arrayLayer-01717",
-                        "vkGetImageSubresourceLayout(): pSubresource.arrayLayer (%d) must be less than %d.",
-                        pSubresource->arrayLayer, image_entry->createInfo.arrayLayers);
+        skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-arrayLayer-01717",
+                         "vkGetImageSubresourceLayout(): pSubresource.arrayLayer (%d) must be less than %d.",
+                         pSubresource->arrayLayer, image_entry->createInfo.arrayLayers);
     }
 
     // subresource's aspect must be compatible with image's format.
@@ -5634,18 +5352,16 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
                 vuid = "VUID-vkGetImageSubresourceLayout-format-01582";  // 3-plane version
             }
             if (sub_aspect != (sub_aspect & allowed_flags)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image), vuid,
-                                "vkGetImageSubresourceLayout(): For multi-planar images, VkImageSubresource.aspectMask (0x%" PRIx32
-                                ") must be a single-plane specifier flag.",
-                                sub_aspect);
+                skip |= LogError(image, vuid,
+                                 "vkGetImageSubresourceLayout(): For multi-planar images, VkImageSubresource.aspectMask (0x%" PRIx32
+                                 ") must be a single-plane specifier flag.",
+                                 sub_aspect);
             }
         } else if (FormatIsColor(img_format)) {
             if (sub_aspect != VK_IMAGE_ASPECT_COLOR_BIT) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                HandleToUint64(image), kVUID_Core_DrawState_InvalidImageAspect,
-                                "vkGetImageSubresourceLayout(): For color formats, VkImageSubresource.aspectMask must be "
-                                "VK_IMAGE_ASPECT_COLOR.");
+                skip |= LogError(image, kVUID_Core_DrawState_InvalidImageAspect,
+                                 "vkGetImageSubresourceLayout(): For color formats, VkImageSubresource.aspectMask must be "
+                                 "VK_IMAGE_ASPECT_COLOR.");
             }
         } else if (FormatIsDepthOrStencil(img_format)) {
             if ((sub_aspect != VK_IMAGE_ASPECT_DEPTH_BIT) && (sub_aspect != VK_IMAGE_ASPECT_STENCIL_BIT)) {
@@ -5655,10 +5371,9 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
         if ((sub_aspect != VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT) && (sub_aspect != VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT) &&
             (sub_aspect != VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT) && (sub_aspect != VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
             // TODO: This VU also needs to ensure that the DRM index is in range and valid.
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                            HandleToUint64(image), "VUID-vkGetImageSubresourceLayout-tiling-02271",
-                            "vkGetImageSubresourceLayout(): VkImageSubresource.aspectMask must be "
-                            "VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT.");
+            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-tiling-02271",
+                             "vkGetImageSubresourceLayout(): VkImageSubresource.aspectMask must be "
+                             "VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT.");
         }
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3883,7 +3883,7 @@ bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const
                                                           const VkAllocationCallbacks *pAllocator,
                                                           VkDescriptorSetLayout *pSetLayout) const {
     return cvdescriptorset::ValidateDescriptorSetLayoutCreateInfo(
-        report_data, pCreateInfo, IsExtEnabled(device_extensions.vk_khr_push_descriptor), phys_dev_ext_props.max_push_descriptors,
+        this, pCreateInfo, IsExtEnabled(device_extensions.vk_khr_push_descriptor), phys_dev_ext_props.max_push_descriptors,
         IsExtEnabled(device_extensions.vk_ext_descriptor_indexing), &enabled_features.core12,
         &enabled_features.inline_uniform_block, &phys_dev_ext_props.inline_uniform_block_props, &device_extensions);
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11206,6 +11206,19 @@ bool CoreChecks::ValidateCmdDrawStrideWithBuffer(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
+bool CoreChecks::PreCallValidateReleaseProfilingLockKHR(VkDevice device) const {
+    bool skip = false;
+
+    if (!performance_lock_acquired) {
+        skip |= log_msg(
+            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device),
+            "VUID-vkReleaseProfilingLockKHR-device-03235",
+            "The profiling lock of device must have been held via a previous successful call to vkAcquireProfilingLockKHR.");
+    }
+
+    return skip;
+}
+
 void PIPELINE_STATE::initGraphicsPipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                                           std::shared_ptr<const RENDER_PASS_STATE> &&rpstate) {
     reset();

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -396,11 +396,13 @@ class CoreChecks : public ValidationStateTracker {
                                                           const IMAGE_STATE* dst_img, const VkImageCopy* region, const uint32_t i,
                                                           const char* function) const;
     bool ValidateIdleBuffer(VkBuffer buffer) const;
-    bool ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 strict, const VulkanTypedHandle& typed_handle,
-                            const char* msgCode, char const* func_name, char const* usage_str) const;
+    template <typename T1>
+    bool ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 strict, const T1 object,
+                            const VulkanTypedHandle& typed_handle, const char* msgCode, char const* func_name,
+                            char const* usage_str) const;
     bool ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
                                        const VkImageSubresourceRange& subresourceRange, const char* cmd_name,
-                                       const char* param_name, const char* image_layer_count_var_name, const uint64_t image_handle,
+                                       const char* param_name, const char* image_layer_count_var_name, const VkImage image,
                                        SubresourceRangeErrorCodes errorCodes) const;
     void SetImageLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state,
                         const VkImageSubresourceRange& image_subresource_range, VkImageLayout layout,
@@ -606,6 +608,13 @@ class CoreChecks : public ValidationStateTracker {
 
     bool PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkImageView* pView) const;
+
+    bool ValidateCmdCopyBufferBounds(const BUFFER_STATE* src_buffer_state, const BUFFER_STATE* dst_buffer_state,
+                                     uint32_t regionCount, const VkBufferCopy* pRegions) const;
+    bool ValidateImageBounds(const IMAGE_STATE* image_state, const uint32_t regionCount, const VkBufferImageCopy* pRegions,
+                             const char* func_name, const char* msg_code) const;
+    bool ValidateBufferBounds(const IMAGE_STATE* image_state, const BUFFER_STATE* buff_state, uint32_t regionCount,
+                              const VkBufferImageCopy* pRegions, const char* func_name, const char* msg_code) const;
 
     bool ValidateCopyBufferImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img,
                                                                 const VkBufferImageCopy* region, const uint32_t i,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -360,6 +360,23 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateExecutionModes(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint) const;
+    bool ValidateViConsistency(VkPipelineVertexInputStateCreateInfo const* vi) const;
+    bool ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo const* vi, SHADER_MODULE_STATE const* vs,
+                                   spirv_inst_iter entrypoint) const;
+    bool ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const* fs, spirv_inst_iter entrypoint,
+                                            PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
+    bool ValidatePushConstantUsage(std::vector<VkPushConstantRange> const* push_constant_ranges, SHADER_MODULE_STATE const* src,
+                                   std::unordered_set<uint32_t> accessible_ids, VkShaderStageFlagBits stage) const;
+    bool ValidatePushConstantBlockAgainstPipeline(std::vector<VkPushConstantRange> const* push_constant_ranges,
+                                                  SHADER_MODULE_STATE const* src, spirv_inst_iter type,
+                                                  VkShaderStageFlagBits stage) const;
+    bool ValidateSpecializationOffsets(VkPipelineShaderStageCreateInfo const* info) const;
+    bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure) const;
+    bool RequireFeature(VkBool32 feature, char const* feature_name) const;
+    bool RequireExtension(bool extension, char const* extension_name) const;
+    bool ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const* producer, spirv_inst_iter producer_entrypoint,
+                                        shader_stage_attributes const* producer_stage, SHADER_MODULE_STATE const* consumer,
+                                        spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
 
     // Buffer Validation Functions
     template <class OBJECT, class LAYOUT>

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1063,6 +1063,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCmdDrawStrideWithBuffer(VkCommandBuffer commandBuffer, const std::string& vuid, const uint32_t stride,
                                          const char* struct_name, const uint32_t struct_size, const uint32_t drawCount,
                                          const VkDeviceSize offset, const BUFFER_STATE* buffer_state) const;
+    bool PreCallValidateReleaseProfilingLockKHR(VkDevice device) const;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -376,7 +376,7 @@ class Descriptor {
 //   else return false and update error_msg with description of incompatibility
 bool VerifySetLayoutCompatibility(const debug_report_data *report_data, DescriptorSetLayout const *lh_ds_layout,
                                   DescriptorSetLayout const *rh_ds_layout, std::string *error_msg);
-bool ValidateDescriptorSetLayoutCreateInfo(const debug_report_data *report_data, const VkDescriptorSetLayoutCreateInfo *create_info,
+bool ValidateDescriptorSetLayoutCreateInfo(const ValidationObject *val_obj, const VkDescriptorSetLayoutCreateInfo *create_info,
                                            const bool push_descriptor_ext, const uint32_t max_push_descriptors,
                                            const bool descriptor_indexing_ext,
                                            const VkPhysicalDeviceVulkan12Features *core12_features,

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -82,13 +82,12 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
         }
         VkDeviceSize end_offset = (index_size * ((VkDeviceSize)firstIndex + indexCount)) + index_buffer_binding.offset;
         if (end_offset > index_buffer_binding.size) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,
-                            HandleToUint64(index_buffer_binding.buffer), "VUID-vkCmdDrawIndexed-indexSize-00463",
-                            "vkCmdDrawIndexed() index size (%d) * (firstIndex (%d) + indexCount (%d)) "
-                            "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
-                            " bytes, "
-                            "which is greater than the index buffer size (%" PRIuLEAST64 ").",
-                            index_size, firstIndex, indexCount, index_buffer_binding.offset, end_offset, index_buffer_binding.size);
+            skip |=
+                LogError(index_buffer_binding.buffer, "VUID-vkCmdDrawIndexed-indexSize-00463",
+                         "vkCmdDrawIndexed() index size (%d) * (firstIndex (%d) + indexCount (%d)) "
+                         "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
+                         " bytes, which is greater than the index buffer size (%" PRIuLEAST64 ").",
+                         index_size, firstIndex, indexCount, index_buffer_binding.offset, end_offset, index_buffer_binding.size);
         }
     }
     return skip;
@@ -166,16 +165,14 @@ bool CoreChecks::ValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkB
                                               uint32_t stride, const char *apiName) const {
     bool skip = false;
     if (offset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawIndirectCount-offset-02710",
-                        "%s() parameter, VkDeviceSize offset (0x%" PRIxLEAST64 "), is not a multiple of 4.", apiName, offset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndirectCount-offset-02710",
+                         "%s() parameter, VkDeviceSize offset (0x%" PRIxLEAST64 "), is not a multiple of 4.", apiName, offset);
     }
 
     if (countBufferOffset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawIndirectCount-countBufferOffset-02716",
-                        "%s() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.", apiName,
-                        countBufferOffset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndirectCount-countBufferOffset-02716",
+                         "%s() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.", apiName,
+                         countBufferOffset);
     }
     skip |= ValidateCmdDrawStrideWithStruct(commandBuffer, "VUID-vkCmdDrawIndirectCount-stride-03110", stride, apiName,
                                             sizeof(VkDrawIndirectCommand));
@@ -220,18 +217,16 @@ bool CoreChecks::ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuff
                                                      uint32_t stride) const {
     bool skip = false;
     if (offset & 3) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-            HandleToUint64(commandBuffer), "VUID-vkCmdDrawIndexedIndirectCount-offset-02710",
+        skip |= LogError(
+            commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-offset-02710",
             "vkCmdDrawIndexedIndirectCount() parameter, VkDeviceSize offset (0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
     }
 
     if (countBufferOffset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawIndexedIndirectCount-countBufferOffset-02716",
-                        "vkCmdDrawIndexedIndirectCount() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64
-                        "), is not a multiple of 4.",
-                        countBufferOffset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-countBufferOffset-02716",
+                         "vkCmdDrawIndexedIndirectCount() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64
+                         "), is not a multiple of 4.",
+                         countBufferOffset);
     }
 
     skip |= ValidateCmdDrawStrideWithStruct(commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-stride-03142", stride,

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -89,8 +89,7 @@ static void InstanceExtensionWhitelist(ValidationObject *layer_data, const VkIns
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized instance extensions
         if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kInstanceExtensionNames)) {
-            log_msg(layer_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUIDUndefined,
+            layer_data->LogWarning(layer_data->instance, kVUIDUndefined,
                     "Instance Extension %s is not supported by this layer.  Using this extension may adversely affect validation "
                     "results and/or produce undefined behavior.",
                     pCreateInfo->ppEnabledExtensionNames[i]);
@@ -103,8 +102,7 @@ static void DeviceExtensionWhitelist(ValidationObject *layer_data, const VkDevic
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized device extensions
         if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceExtensionNames)) {
-            log_msg(layer_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUIDUndefined,
+            layer_data->LogWarning(layer_data->device, kVUIDUndefined,
                     "Device Extension %s is not supported by this layer.  Using this extension may adversely affect validation "
                     "results and/or produce undefined behavior.",
                     pCreateInfo->ppEnabledExtensionNames[i]);

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -1793,9 +1793,9 @@ bool StatelessValidation::ValidatePnextStructContents(const char *api_name, cons
 
 
 bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) const {
-    return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                   kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\n",
-                   api_name.c_str(), extension_name.c_str());
+    return LogError(instance,
+                    kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\n",
+                    api_name.c_str(), extension_name.c_str());
 }
 
 

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -146,7 +146,7 @@ public:
         if (iter != object_table.end()) {
             return std::move(iter->second);
         } else {
-            log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object), kVUID_Threading_Info,
+            object_data->LogError(object, kVUID_Threading_Info,
                     "Couldn't find %s Object 0x%" PRIxLEAST64
                     ". This should not happen and may indicate a bug in the application.",
                     object_string[objectType], (uint64_t)(object));
@@ -175,8 +175,7 @@ public:
                 assert(prevCount.GetWriteCount() != 0);
                 // There are no readers.  Two writers just collided.
                 if (use_data->thread != tid) {
-                    skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                        kVUID_Threading_MultipleThreads,
+                    skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                         "THREADING ERROR : object of type %s is simultaneously used in "
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);
@@ -196,8 +195,7 @@ public:
             } else {
                 // There are readers.  This writer collided with them.
                 if (use_data->thread != tid) {
-                    skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                        kVUID_Threading_MultipleThreads,
+                    skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                         "THREADING ERROR : object of type %s is simultaneously used in "
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);
@@ -248,8 +246,7 @@ public:
             use_data->thread = tid;
         } else if (prevCount.GetWriteCount() > 0 && use_data->thread != tid) {
             // There is a writer of the object.
-            skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                kVUID_Threading_MultipleThreads,
+            skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                 "THREADING ERROR : object of type %s is simultaneously used in "
                 "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                 typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -42,11 +42,11 @@ bool StatelessValidation::validate_string(const char *apiName, const ParameterNa
     if (result == VK_STRING_ERROR_NONE) {
         return skip;
     } else if (result & VK_STRING_ERROR_LENGTH) {
-        skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                       "%s: string %s exceeds max length %d", apiName, stringName.get_name().c_str(), MaxParamCheckerStringLength);
+        skip = LogError(device, vuid, "%s: string %s exceeds max length %d", apiName, stringName.get_name().c_str(),
+                        MaxParamCheckerStringLength);
     } else if (result & VK_STRING_ERROR_BAD_DATA) {
-        skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, vuid,
-                       "%s: string %s contains invalid characters or is badly formed", apiName, stringName.get_name().c_str());
+        skip = LogError(device, vuid, "%s: string %s contains invalid characters or is badly formed", apiName,
+                        stringName.get_name().c_str());
     }
     return skip;
 }
@@ -56,17 +56,15 @@ bool StatelessValidation::validate_api_version(uint32_t api_version, uint32_t ef
     uint32_t api_version_nopatch = VK_MAKE_VERSION(VK_VERSION_MAJOR(api_version), VK_VERSION_MINOR(api_version), 0);
     if (api_version_nopatch != effective_api_version) {
         if (api_version_nopatch < VK_API_VERSION_1_0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,
-                            HandleToUint64(instance), kVUIDUndefined,
-                            "Invalid CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
-                            "Using VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
-                            api_version, VK_VERSION_MAJOR(effective_api_version), VK_VERSION_MINOR(effective_api_version));
+            skip |= LogError(instance, kVUIDUndefined,
+                             "Invalid CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
+                             "Using VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
+                             api_version, VK_VERSION_MAJOR(effective_api_version), VK_VERSION_MINOR(effective_api_version));
         } else {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,
-                            HandleToUint64(instance), kVUIDUndefined,
-                            "Unrecognized CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
-                            "Assuming VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
-                            api_version, VK_VERSION_MAJOR(effective_api_version), VK_VERSION_MINOR(effective_api_version));
+            skip |= LogWarning(instance, kVUIDUndefined,
+                               "Unrecognized CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
+                               "Assuming VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
+                               api_version, VK_VERSION_MAJOR(effective_api_version), VK_VERSION_MINOR(effective_api_version));
         }
     }
     return skip;
@@ -124,13 +122,13 @@ void StatelessValidation::PostCallRecordQueuePresentKHR(VkQueue queue, const VkP
     for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
         auto swapchains_result = pPresentInfo->pResults ? pPresentInfo->pResults[i] : result;
         if (swapchains_result == VK_SUBOPTIMAL_KHR) {
-            log_msg(report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
-                    HandleToUint64(pPresentInfo->pSwapchains[i]), kVUID_PVPerfWarn_SuboptimalSwapchain,
-                    "vkQueuePresentKHR: %s :VK_SUBOPTIMAL_KHR was returned. VK_SUBOPTIMAL_KHR - Presentation will still succeed, "
-                    "subject to the window resize behavior, but the swapchain is no longer configured optimally for the surface it "
-                    "targets. Applications should query updated surface information and recreate their swapchain at the next "
-                    "convenient opportunity.",
-                    report_data->FormatHandle(pPresentInfo->pSwapchains[i]).c_str());
+            LogPerformanceWarning(
+                pPresentInfo->pSwapchains[i], kVUID_PVPerfWarn_SuboptimalSwapchain,
+                "vkQueuePresentKHR: %s :VK_SUBOPTIMAL_KHR was returned. VK_SUBOPTIMAL_KHR - Presentation will still succeed, "
+                "subject to the window resize behavior, but the swapchain is no longer configured optimally for the surface it "
+                "targets. Applications should query updated surface information and recreate their swapchain at the next "
+                "convenient opportunity.",
+                report_data->FormatHandle(pPresentInfo->pSwapchains[i]).c_str());
         }
     }
 }
@@ -223,10 +221,9 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
         bool negative_viewport =
             IsExtEnabled(extension_state_by_name(device_extensions, VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME));
         if (maint1 && negative_viewport) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-00374",
-                            "VkDeviceCreateInfo->ppEnabledExtensionNames must not simultaneously include VK_KHR_maintenance1 and "
-                            "VK_AMD_negative_viewport_height.");
+            skip |= LogError(device, "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-00374",
+                             "VkDeviceCreateInfo->ppEnabledExtensionNames must not simultaneously include VK_KHR_maintenance1 and "
+                             "VK_AMD_negative_viewport_height.");
         }
     }
 
@@ -234,10 +231,9 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
         bool khr_bda = IsExtEnabled(extension_state_by_name(device_extensions, VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME));
         bool ext_bda = IsExtEnabled(extension_state_by_name(device_extensions, VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME));
         if (khr_bda && ext_bda) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-03328",
-                            "VkDeviceCreateInfo->ppEnabledExtensionNames must not contain both VK_KHR_buffer_device_address and "
-                            "VK_EXT_buffer_device_address.");
+            skip |= LogError(device, "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-03328",
+                             "VkDeviceCreateInfo->ppEnabledExtensionNames must not contain both VK_KHR_buffer_device_address and "
+                             "VK_EXT_buffer_device_address.");
         }
     }
 
@@ -246,20 +242,18 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
         const auto *features2 = lvl_find_in_chain<VkPhysicalDeviceFeatures2KHR>(pCreateInfo->pNext);
         if (features2) {
             // Cannot include VkPhysicalDeviceFeatures2KHR and have non-null pEnabledFeatures
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            kVUID_PVError_InvalidUsage,
-                            "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceFeatures2KHR struct when "
-                            "pCreateInfo->pEnabledFeatures is non-NULL.");
+            skip |= LogError(device, kVUID_PVError_InvalidUsage,
+                             "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceFeatures2KHR struct when "
+                             "pCreateInfo->pEnabledFeatures is non-NULL.");
         }
     }
 
     auto features2 = lvl_find_in_chain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
     if (features2) {
         if (!instance_extensions.vk_khr_get_physical_device_properties_2) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            kVUID_PVError_ExtensionNotEnabled,
-                            "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceFeatures2 struct, "
-                            "VK_KHR_get_physical_device_properties2 must be enabled when it creates an instance.");
+            skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                             "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceFeatures2 struct, "
+                             "VK_KHR_get_physical_device_properties2 must be enabled when it creates an instance.");
         }
     }
 
@@ -275,10 +269,9 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
             }
         }
         if (!extension_found) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            kVUID_PVError_ExtensionNotEnabled,
-                            "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT "
-                            "struct, VK_EXT_vertex_attribute_divisor must be enabled when it creates a device.");
+            skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                             "VkDeviceCreateInfo->pNext includes a VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT "
+                             "struct, VK_EXT_vertex_attribute_divisor must be enabled when it creates a device.");
         }
     }
 
@@ -292,9 +285,8 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES ||
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES ||
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-VkDeviceCreateInfo-pNext-02829",
+                skip |= LogError(
+                    instance, "VUID-VkDeviceCreateInfo-pNext-02829",
                     "If the pNext chain includes a VkPhysicalDeviceVulkan11Features structure, then it must not include a "
                     "VkPhysicalDevice16BitStorageFeatures, VkPhysicalDeviceMultiviewFeatures, "
                     "VkPhysicalDeviceVariablePointersFeatures, VkPhysicalDeviceProtectedMemoryFeatures, "
@@ -322,9 +314,8 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES ||
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES ||
                 current->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-VkDeviceCreateInfo-pNext-02830",
+                skip |= LogError(
+                    instance, "VUID-VkDeviceCreateInfo-pNext-02830",
                     "If the pNext chain includes a VkPhysicalDeviceVulkan12Features structure, then it must not include a "
                     "VkPhysicalDevice8BitStorageFeatures, VkPhysicalDeviceShaderAtomicInt64Features, "
                     "VkPhysicalDeviceShaderFloat16Int8Features, VkPhysicalDeviceDescriptorIndexingFeatures, "
@@ -346,18 +337,17 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const uint32_t requested_queue_family = pCreateInfo->pQueueCreateInfos[i].queueFamilyIndex;
             if (requested_queue_family == VK_QUEUE_FAMILY_IGNORED) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                                HandleToUint64(physicalDevice), "VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381",
-                                "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32
-                                "].queueFamilyIndex is VK_QUEUE_FAMILY_IGNORED, but it is required to provide a valid queue family "
-                                "index value.",
-                                i);
+                skip |=
+                    LogError(physicalDevice, "VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381",
+                             "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32
+                             "].queueFamilyIndex is VK_QUEUE_FAMILY_IGNORED, but it is required to provide a valid queue family "
+                             "index value.",
+                             i);
             } else if (set.count(requested_queue_family)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                                HandleToUint64(physicalDevice), "VUID-VkDeviceCreateInfo-queueFamilyIndex-00372",
-                                "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32 "].queueFamilyIndex (=%" PRIu32
-                                ") is not unique within pCreateInfo->pQueueCreateInfos array.",
-                                i, requested_queue_family);
+                skip |= LogError(physicalDevice, "VUID-VkDeviceCreateInfo-queueFamilyIndex-00372",
+                                 "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32 "].queueFamilyIndex (=%" PRIu32
+                                 ") is not unique within pCreateInfo->pQueueCreateInfos array.",
+                                 i, requested_queue_family);
             } else {
                 set.insert(requested_queue_family);
             }
@@ -366,11 +356,10 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
                 for (uint32_t j = 0; j < pCreateInfo->pQueueCreateInfos[i].queueCount; ++j) {
                     const float queue_priority = pCreateInfo->pQueueCreateInfos[i].pQueuePriorities[j];
                     if (!(queue_priority >= 0.f) || !(queue_priority <= 1.f)) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                                        HandleToUint64(physicalDevice), "VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383",
-                                        "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32 "].pQueuePriorities[%" PRIu32
-                                        "] (=%f) is not between 0 and 1 (inclusive).",
-                                        i, j, queue_priority);
+                        skip |= LogError(physicalDevice, "VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383",
+                                         "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32 "].pQueuePriorities[%" PRIu32
+                                         "] (=%f) is not between 0 and 1 (inclusive).",
+                                         i, j, queue_priority);
                     }
                 }
             }
@@ -382,10 +371,9 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
 
 bool StatelessValidation::require_device_extension(bool flag, char const *function_name, char const *extension_name) const {
     if (!flag) {
-        return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                       kVUID_PVError_ExtensionNotEnabled,
-                       "%s() called even though the %s extension was not enabled for this VkDevice.", function_name,
-                       extension_name);
+        return LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                        "%s() called even though the %s extension was not enabled for this VkDevice.", function_name,
+                        extension_name);
     }
 
     return false;
@@ -395,29 +383,26 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
                                                              const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer) const {
     bool skip = false;
 
-    const LogMiscParams log_misc{VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, VK_NULL_HANDLE, "vkCreateBuffer"};
-
     if (pCreateInfo != nullptr) {
-        skip |= ValidateGreaterThanZero(pCreateInfo->size, "pCreateInfo->size", "VUID-VkBufferCreateInfo-size-00912", log_misc);
+        skip |=
+            ValidateGreaterThanZero(pCreateInfo->size, "pCreateInfo->size", "VUID-VkBufferCreateInfo-size-00912", "vkCreateBuffer");
 
         // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
         if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
             if (pCreateInfo->queueFamilyIndexCount <= 1) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkBufferCreateInfo-sharingMode-00914",
-                                "vkCreateBuffer: if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
+                skip |= LogError(device, "VUID-VkBufferCreateInfo-sharingMode-00914",
+                                 "vkCreateBuffer: if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
             }
 
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
             // queueFamilyIndexCount uint32_t values
             if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkBufferCreateInfo-sharingMode-00913",
-                                "vkCreateBuffer: if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
-                                "pCreateInfo->queueFamilyIndexCount uint32_t values.");
+                skip |= LogError(device, "VUID-VkBufferCreateInfo-sharingMode-00913",
+                                 "vkCreateBuffer: if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
+                                 "pCreateInfo->queueFamilyIndexCount uint32_t values.");
             }
         }
 
@@ -425,10 +410,9 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
         // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
         if (((pCreateInfo->flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
             ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkBufferCreateInfo-flags-00918",
-                            "vkCreateBuffer: if pCreateInfo->flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or "
-                            "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain VK_BUFFER_CREATE_SPARSE_BINDING_BIT.");
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00918",
+                             "vkCreateBuffer: if pCreateInfo->flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or "
+                             "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain VK_BUFFER_CREATE_SPARSE_BINDING_BIT.");
         }
     }
 
@@ -439,48 +423,43 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                                             const VkAllocationCallbacks *pAllocator, VkImage *pImage) const {
     bool skip = false;
 
-    const LogMiscParams log_misc{VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, VK_NULL_HANDLE, "vkCreateImage"};
-
     if (pCreateInfo != nullptr) {
         // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
         if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
             if (pCreateInfo->queueFamilyIndexCount <= 1) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-sharingMode-00942",
-                                "vkCreateImage(): if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-sharingMode-00942",
+                                 "vkCreateImage(): if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
             }
 
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
             // queueFamilyIndexCount uint32_t values
             if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-sharingMode-00941",
-                                "vkCreateImage(): if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
-                                "pCreateInfo->queueFamilyIndexCount uint32_t values.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-sharingMode-00941",
+                                 "vkCreateImage(): if pCreateInfo->sharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
+                                 "pCreateInfo->queueFamilyIndexCount uint32_t values.");
             }
         }
 
         skip |= ValidateGreaterThanZero(pCreateInfo->extent.width, "pCreateInfo->extent.width",
-                                        "VUID-VkImageCreateInfo-extent-00944", log_misc);
+                                        "VUID-VkImageCreateInfo-extent-00944", "vkCreateImage");
         skip |= ValidateGreaterThanZero(pCreateInfo->extent.height, "pCreateInfo->extent.height",
-                                        "VUID-VkImageCreateInfo-extent-00945", log_misc);
+                                        "VUID-VkImageCreateInfo-extent-00945", "vkCreateImage");
         skip |= ValidateGreaterThanZero(pCreateInfo->extent.depth, "pCreateInfo->extent.depth",
-                                        "VUID-VkImageCreateInfo-extent-00946", log_misc);
+                                        "VUID-VkImageCreateInfo-extent-00946", "vkCreateImage");
 
         skip |= ValidateGreaterThanZero(pCreateInfo->mipLevels, "pCreateInfo->mipLevels", "VUID-VkImageCreateInfo-mipLevels-00947",
-                                        log_misc);
+                                        "vkCreateImage");
         skip |= ValidateGreaterThanZero(pCreateInfo->arrayLayers, "pCreateInfo->arrayLayers",
-                                        "VUID-VkImageCreateInfo-arrayLayers-00948", log_misc);
+                                        "VUID-VkImageCreateInfo-arrayLayers-00948", "vkCreateImage");
 
         // InitialLayout must be PREINITIALIZED or UNDEFINED
         if ((pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) &&
             (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                "VUID-VkImageCreateInfo-initialLayout-00993",
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-initialLayout-00993",
                 "vkCreateImage(): initialLayout is %s, must be VK_IMAGE_LAYOUT_UNDEFINED or VK_IMAGE_LAYOUT_PREINITIALIZED.",
                 string_VkImageLayout(pCreateInfo->initialLayout));
         }
@@ -488,54 +467,48 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         // If imageType is VK_IMAGE_TYPE_1D, both extent.height and extent.depth must be 1
         if ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) &&
             ((pCreateInfo->extent.height != 1) || (pCreateInfo->extent.depth != 1))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-imageType-00956",
-                            "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_1D, both pCreateInfo->extent.height and "
-                            "pCreateInfo->extent.depth must be 1.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00956",
+                             "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_1D, both pCreateInfo->extent.height and "
+                             "pCreateInfo->extent.depth must be 1.");
         }
 
         if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D) {
             if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
                 if (pCreateInfo->extent.width != pCreateInfo->extent.height) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkImageCreateInfo-imageType-00954",
-                                    "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, but "
-                                    "pCreateInfo->extent.width (=%" PRIu32 ") and pCreateInfo->extent.height (=%" PRIu32
-                                    ") are not equal.",
-                                    pCreateInfo->extent.width, pCreateInfo->extent.height);
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00954",
+                                     "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, but "
+                                     "pCreateInfo->extent.width (=%" PRIu32 ") and pCreateInfo->extent.height (=%" PRIu32
+                                     ") are not equal.",
+                                     pCreateInfo->extent.width, pCreateInfo->extent.height);
                 }
 
                 if (pCreateInfo->arrayLayers < 6) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkImageCreateInfo-imageType-00954",
-                                    "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, but "
-                                    "pCreateInfo->arrayLayers (=%" PRIu32 ") is not greater than or equal to 6.",
-                                    pCreateInfo->arrayLayers);
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00954",
+                                     "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, but "
+                                     "pCreateInfo->arrayLayers (=%" PRIu32 ") is not greater than or equal to 6.",
+                                     pCreateInfo->arrayLayers);
                 }
             }
 
             if (pCreateInfo->extent.depth != 1) {
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-imageType-00957",
-                            "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_2D, pCreateInfo->extent.depth must be 1.");
+                skip |= LogError(
+                    device, "VUID-VkImageCreateInfo-imageType-00957",
+                    "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_2D, pCreateInfo->extent.depth must be 1.");
             }
         }
 
         // 3D image may have only 1 layer
         if ((pCreateInfo->imageType == VK_IMAGE_TYPE_3D) && (pCreateInfo->arrayLayers != 1)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-imageType-00961",
-                            "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_3D, pCreateInfo->arrayLayers must be 1.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00961",
+                             "vkCreateImage(): if pCreateInfo->imageType is VK_IMAGE_TYPE_3D, pCreateInfo->arrayLayers must be 1.");
         }
 
         // If multi-sample, validate type, usage, tiling and mip levels.
         if ((pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) &&
             ((pCreateInfo->imageType != VK_IMAGE_TYPE_2D) || (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
              (pCreateInfo->mipLevels != 1) || (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-samples-02257",
-                            "vkCreateImage(): Multi-sample image with incompatible type, usage, tiling, or mips.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-samples-02257",
+                             "vkCreateImage(): Multi-sample image with incompatible type, usage, tiling, or mips.");
         }
 
         if (0 != (pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
@@ -543,16 +516,14 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                              VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
             // At least one of the legal attachment bits must be set
             if (0 == (pCreateInfo->usage & legal_flags)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-usage-00966",
-                                "vkCreateImage(): Transient attachment image without a compatible attachment flag set.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-usage-00966",
+                                 "vkCreateImage(): Transient attachment image without a compatible attachment flag set.");
             }
             // No flags other than the legal attachment bits may be set
             legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
             if (0 != (pCreateInfo->usage & ~legal_flags)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-usage-00963",
-                                "vkCreateImage(): Transient attachment image with incompatible usage flags set.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-usage-00963",
+                                 "vkCreateImage(): Transient attachment image with incompatible usage flags set.");
             }
         }
 
@@ -563,149 +534,130 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                                                                              : (uint32_t)(floor(log2(maxDim)) + 1);
         if (maxDim > 0 && pCreateInfo->mipLevels > maxMipLevels) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkImageCreateInfo-mipLevels-00958",
-                        "vkCreateImage(): pCreateInfo->mipLevels must be less than or equal to "
-                        "floor(log2(max(pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->extent.depth)))+1.");
+                LogError(device, "VUID-VkImageCreateInfo-mipLevels-00958",
+                         "vkCreateImage(): pCreateInfo->mipLevels must be less than or equal to "
+                         "floor(log2(max(pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->extent.depth)))+1.");
         }
 
         if ((pCreateInfo->flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkImageCreateInfo-flags-00950",
-                            "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT but "
-                            "pCreateInfo->imageType is not VK_IMAGE_TYPE_3D.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00950",
+                             "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT but "
+                             "pCreateInfo->imageType is not VK_IMAGE_TYPE_3D.");
         }
 
         if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkImageCreateInfo-flags-00969",
-                            "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
-                            "VkPhysicalDeviceFeatures::sparseBinding feature is disabled.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00969",
+                             "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
+                             "VkPhysicalDeviceFeatures::sparseBinding feature is disabled.");
         }
 
         // If flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain
         // VK_IMAGE_CREATE_SPARSE_BINDING_BIT
         if (((pCreateInfo->flags & (VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
             ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkImageCreateInfo-flags-00987",
-                            "vkCreateImage: if pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or "
-                            "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain VK_IMAGE_CREATE_SPARSE_BINDING_BIT.");
+            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00987",
+                             "vkCreateImage: if pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or "
+                             "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain VK_IMAGE_CREATE_SPARSE_BINDING_BIT.");
         }
 
         // Check for combinations of attributes that are incompatible with having VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT set
         if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0) {
             // Linear tiling is unsupported
             if (VK_IMAGE_TILING_LINEAR == pCreateInfo->tiling) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                kVUID_PVError_InvalidUsage,
-                                "vkCreateImage: if pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT then image "
-                                "tiling of VK_IMAGE_TILING_LINEAR is not supported");
+                skip |= LogError(device, kVUID_PVError_InvalidUsage,
+                                 "vkCreateImage: if pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT then image "
+                                 "tiling of VK_IMAGE_TILING_LINEAR is not supported");
             }
 
             // Sparse 1D image isn't valid
             if (VK_IMAGE_TYPE_1D == pCreateInfo->imageType) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-imageType-00970",
-                                "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 1D image.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00970",
+                                 "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 1D image.");
             }
 
             // Sparse 2D image when device doesn't support it
             if ((VK_FALSE == physical_device_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-imageType-00971",
-                                "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 2D image if corresponding "
-                                "feature is not enabled on the device.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00971",
+                                 "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 2D image if corresponding "
+                                 "feature is not enabled on the device.");
             }
 
             // Sparse 3D image when device doesn't support it
             if ((VK_FALSE == physical_device_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-imageType-00972",
-                                "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 3D image if corresponding "
-                                "feature is not enabled on the device.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00972",
+                                 "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 3D image if corresponding "
+                                 "feature is not enabled on the device.");
             }
 
             // Multi-sample 2D image when device doesn't support it
             if (VK_IMAGE_TYPE_2D == pCreateInfo->imageType) {
                 if ((VK_FALSE == physical_device_features.sparseResidency2Samples) &&
                     (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkImageCreateInfo-imageType-00973",
-                                    "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 2-sample image if "
-                                    "corresponding feature is not enabled on the device.");
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00973",
+                                     "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 2-sample image if "
+                                     "corresponding feature is not enabled on the device.");
                 } else if ((VK_FALSE == physical_device_features.sparseResidency4Samples) &&
                            (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkImageCreateInfo-imageType-00974",
-                                    "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 4-sample image if "
-                                    "corresponding feature is not enabled on the device.");
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00974",
+                                     "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 4-sample image if "
+                                     "corresponding feature is not enabled on the device.");
                 } else if ((VK_FALSE == physical_device_features.sparseResidency8Samples) &&
                            (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkImageCreateInfo-imageType-00975",
-                                    "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 8-sample image if "
-                                    "corresponding feature is not enabled on the device.");
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00975",
+                                     "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 8-sample image if "
+                                     "corresponding feature is not enabled on the device.");
                 } else if ((VK_FALSE == physical_device_features.sparseResidency16Samples) &&
                            (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkImageCreateInfo-imageType-00976",
-                                    "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 16-sample image if "
-                                    "corresponding feature is not enabled on the device.");
+                    skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00976",
+                                     "vkCreateImage: cannot specify VK_IMAGE_CREATE_SPARSE_BINDING_BIT for 16-sample image if "
+                                     "corresponding feature is not enabled on the device.");
                 }
             }
         }
 
         if (pCreateInfo->usage & VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV) {
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-imageType-02082",
-                                "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
-                                "imageType must be VK_IMAGE_TYPE_2D.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-02082",
+                                 "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
+                                 "imageType must be VK_IMAGE_TYPE_2D.");
             }
             if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-samples-02083",
-                                "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
-                                "samples must be VK_SAMPLE_COUNT_1_BIT.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-samples-02083",
+                                 "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
+                                 "samples must be VK_SAMPLE_COUNT_1_BIT.");
             }
             if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-tiling-02084",
-                                "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
-                                "tiling must be VK_IMAGE_TILING_OPTIMAL.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-tiling-02084",
+                                 "vkCreateImage: if usage includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, "
+                                 "tiling must be VK_IMAGE_TILING_OPTIMAL.");
             }
         }
 
         if (pCreateInfo->flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) {
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D && pCreateInfo->imageType != VK_IMAGE_TYPE_3D) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-flags-02050",
-                                "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
-                                "imageType must be VK_IMAGE_TYPE_2D or VK_IMAGE_TYPE_3D.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-flags-02050",
+                                 "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
+                                 "imageType must be VK_IMAGE_TYPE_2D or VK_IMAGE_TYPE_3D.");
             }
 
             if ((pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) || FormatIsDepthOrStencil(pCreateInfo->format)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-flags-02051",
-                                "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
-                                "it must not also contain VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT and format must "
-                                "not be a depth/stencil format.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-flags-02051",
+                                 "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
+                                 "it must not also contain VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT and format must "
+                                 "not be a depth/stencil format.");
             }
 
             if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D && (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-flags-02052",
-                                "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
-                                "imageType is VK_IMAGE_TYPE_2D, extent.width and extent.height must be "
-                                "greater than 1.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-flags-02052",
+                                 "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
+                                 "imageType is VK_IMAGE_TYPE_2D, extent.width and extent.height must be "
+                                 "greater than 1.");
             } else if (pCreateInfo->imageType == VK_IMAGE_TYPE_3D &&
                        (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1 || pCreateInfo->extent.depth == 1)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkImageCreateInfo-flags-02053",
-                                "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
-                                "imageType is VK_IMAGE_TYPE_3D, extent.width, extent.height, and extent.depth "
-                                "must be greater than 1.");
+                skip |= LogError(device, "VUID-VkImageCreateInfo-flags-02053",
+                                 "vkCreateImage: If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
+                                 "imageType is VK_IMAGE_TYPE_3D, extent.width, extent.height, and extent.depth "
+                                 "must be greater than 1.");
             }
         }
 
@@ -716,11 +668,10 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 // No flags other than the legal attachment bits may be set
                 legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
                 if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                    "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539",
-                                    "vkCreateImage(): in pNext chain, VkImageStencilUsageCreateInfo::stencilUsage includes "
-                                    "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, it must not include bits other than "
-                                    "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT");
+                    skip |= LogError(device, "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539",
+                                     "vkCreateImage(): in pNext chain, VkImageStencilUsageCreateInfo::stencilUsage includes "
+                                     "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, it must not include bits other than "
+                                     "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT");
                 }
             }
 
@@ -728,20 +679,18 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
                     if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                    "VUID-VkImageCreateInfo-Format-02536",
-                                    "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                                    "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width exceeds device "
-                                    "maxFramebufferWidth");
+                            LogError(device, "VUID-VkImageCreateInfo-Format-02536",
+                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width exceeds device "
+                                     "maxFramebufferWidth");
                     }
 
                     if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                    "VUID-VkImageCreateInfo-format-02537",
-                                    "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                                    "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height exceeds device "
-                                    "maxFramebufferHeight");
+                            LogError(device, "VUID-VkImageCreateInfo-format-02537",
+                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height exceeds device "
+                                     "maxFramebufferHeight");
                     }
                 }
 
@@ -749,26 +698,23 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
                     (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
                     skip |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                "VUID-VkImageCreateInfo-format-02538",
-                                "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                                "stencilUsage including VK_IMAGE_USAGE_STORAGE_BIT and the multisampled storage images feature is "
-                                "not enabled, image samples must be VK_SAMPLE_COUNT_1_BIT");
+                        LogError(device, "VUID-VkImageCreateInfo-format-02538",
+                                 "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                                 "stencilUsage including VK_IMAGE_USAGE_STORAGE_BIT and the multisampled storage images feature is "
+                                 "not enabled, image samples must be VK_SAMPLE_COUNT_1_BIT");
                 }
 
                 if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) &&
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0)) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-VkImageCreateInfo-format-02795",
+                    skip |= LogError(
+                        device, "VUID-VkImageCreateInfo-format-02795",
                         "vkCreateImage(): Depth-stencil image in which usage includes VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT "
                         "contains VkImageStencilUsageCreateInfo structure, VkImageStencilUsageCreateInfo::stencilUsage must  "
                         "also include VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT");
                 } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) &&
                            ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0)) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-VkImageCreateInfo-format-02796",
+                    skip |= LogError(
+                        device, "VUID-VkImageCreateInfo-format-02796",
                         "vkCreateImage(): Depth-stencil image in which usage does not include "
                         "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT "
                         "contains VkImageStencilUsageCreateInfo structure, VkImageStencilUsageCreateInfo::stencilUsage must  "
@@ -777,17 +723,15 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
                 if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) &&
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0)) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-VkImageCreateInfo-format-02797",
+                    skip |= LogError(
+                        device, "VUID-VkImageCreateInfo-format-02797",
                         "vkCreateImage(): Depth-stencil image in which usage includes VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT "
                         "contains VkImageStencilUsageCreateInfo structure, VkImageStencilUsageCreateInfo::stencilUsage must  "
                         "also include VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT");
                 } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0) &&
                            ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0)) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                        "VUID-VkImageCreateInfo-format-02798",
+                    skip |= LogError(
+                        device, "VUID-VkImageCreateInfo-format-02798",
                         "vkCreateImage(): Depth-stencil image in which usage does not include "
                         "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT "
                         "contains VkImageStencilUsageCreateInfo structure, VkImageStencilUsageCreateInfo::stencilUsage must  "
@@ -801,8 +745,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 }
 
 bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewport, const char *fn_name,
-                                                         const ParameterName &parameter_name,
-                                                         VkDebugReportObjectTypeEXT object_type, uint64_t object = 0) const {
+                                                         const ParameterName &parameter_name, VkCommandBuffer object) const {
     bool skip = false;
 
     // Note: for numerical correctness
@@ -840,18 +783,18 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
 
     if (!(viewport.width > 0.0f)) {
         width_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-width-01770",
-                        "%s: %s.width (=%f) is not greater than 0.0.", fn_name, parameter_name.get_name().c_str(), viewport.width);
+        skip |= LogError(object, "VUID-VkViewport-width-01770", "%s: %s.width (=%f) is not greater than 0.0.", fn_name,
+                         parameter_name.get_name().c_str(), viewport.width);
     } else if (!(f_lte_u32_exact(viewport.width, max_w) || f_lte_u32_direct(viewport.width, max_w))) {
         width_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-width-01771",
-                        "%s: %s.width (=%f) exceeds VkPhysicalDeviceLimits::maxViewportDimensions[0] (=%" PRIu32 ").", fn_name,
-                        parameter_name.get_name().c_str(), viewport.width, max_w);
+        skip |= LogError(object, "VUID-VkViewport-width-01771",
+                         "%s: %s.width (=%f) exceeds VkPhysicalDeviceLimits::maxViewportDimensions[0] (=%" PRIu32 ").", fn_name,
+                         parameter_name.get_name().c_str(), viewport.width, max_w);
     } else if (!f_lte_u32_exact(viewport.width, max_w) && f_lte_u32_direct(viewport.width, max_w)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, object_type, object, kVUID_PVError_NONE,
-                        "%s: %s.width (=%f) technically exceeds VkPhysicalDeviceLimits::maxViewportDimensions[0] (=%" PRIu32
-                        "), but it is within the static_cast<float>(maxViewportDimensions[0]) limit.",
-                        fn_name, parameter_name.get_name().c_str(), viewport.width, max_w);
+        skip |= LogWarning(object, kVUID_PVError_NONE,
+                           "%s: %s.width (=%f) technically exceeds VkPhysicalDeviceLimits::maxViewportDimensions[0] (=%" PRIu32
+                           "), but it is within the static_cast<float>(maxViewportDimensions[0]) limit.",
+                           fn_name, parameter_name.get_name().c_str(), viewport.width, max_w);
     }
 
     // height
@@ -862,20 +805,20 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
 
     if (!negative_height_enabled && !(viewport.height > 0.0f)) {
         height_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-height-01772",
-                        "%s: %s.height (=%f) is not greater 0.0.", fn_name, parameter_name.get_name().c_str(), viewport.height);
+        skip |= LogError(object, "VUID-VkViewport-height-01772", "%s: %s.height (=%f) is not greater 0.0.", fn_name,
+                         parameter_name.get_name().c_str(), viewport.height);
     } else if (!(f_lte_u32_exact(fabsf(viewport.height), max_h) || f_lte_u32_direct(fabsf(viewport.height), max_h))) {
         height_healthy = false;
 
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-height-01773",
-                        "%s: Absolute value of %s.height (=%f) exceeds VkPhysicalDeviceLimits::maxViewportDimensions[1] (=%" PRIu32
-                        ").",
-                        fn_name, parameter_name.get_name().c_str(), viewport.height, max_h);
+        skip |= LogError(object, "VUID-VkViewport-height-01773",
+                         "%s: Absolute value of %s.height (=%f) exceeds VkPhysicalDeviceLimits::maxViewportDimensions[1] (=%" PRIu32
+                         ").",
+                         fn_name, parameter_name.get_name().c_str(), viewport.height, max_h);
     } else if (!f_lte_u32_exact(fabsf(viewport.height), max_h) && f_lte_u32_direct(fabsf(viewport.height), max_h)) {
         height_healthy = false;
 
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, object_type, object, kVUID_PVError_NONE,
+        skip |= LogWarning(
+            object, kVUID_PVError_NONE,
             "%s: Absolute value of %s.height (=%f) technically exceeds VkPhysicalDeviceLimits::maxViewportDimensions[1] (=%" PRIu32
             "), but it is within the static_cast<float>(maxViewportDimensions[1]) limit.",
             fn_name, parameter_name.get_name().c_str(), viewport.height, max_h);
@@ -885,20 +828,20 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
     bool x_healthy = true;
     if (!(viewport.x >= device_limits.viewportBoundsRange[0])) {
         x_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-x-01774",
-                        "%s: %s.x (=%f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).", fn_name,
-                        parameter_name.get_name().c_str(), viewport.x, device_limits.viewportBoundsRange[0]);
+        skip |= LogError(object, "VUID-VkViewport-x-01774",
+                         "%s: %s.x (=%f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).", fn_name,
+                         parameter_name.get_name().c_str(), viewport.x, device_limits.viewportBoundsRange[0]);
     }
 
     // x + width
     if (x_healthy && width_healthy) {
         const float right_bound = viewport.x + viewport.width;
         if (!(right_bound <= device_limits.viewportBoundsRange[1])) {
-            skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-x-01232",
-                        "%s: %s.x + %s.width (=%f + %f = %f) is greater than VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).",
-                        fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.x, viewport.width,
-                        right_bound, device_limits.viewportBoundsRange[1]);
+            skip |= LogError(
+                object, "VUID-VkViewport-x-01232",
+                "%s: %s.x + %s.width (=%f + %f = %f) is greater than VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).",
+                fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.x, viewport.width,
+                right_bound, device_limits.viewportBoundsRange[1]);
         }
     }
 
@@ -906,14 +849,14 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
     bool y_healthy = true;
     if (!(viewport.y >= device_limits.viewportBoundsRange[0])) {
         y_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-y-01775",
-                        "%s: %s.y (=%f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).", fn_name,
-                        parameter_name.get_name().c_str(), viewport.y, device_limits.viewportBoundsRange[0]);
+        skip |= LogError(object, "VUID-VkViewport-y-01775",
+                         "%s: %s.y (=%f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).", fn_name,
+                         parameter_name.get_name().c_str(), viewport.y, device_limits.viewportBoundsRange[0]);
     } else if (negative_height_enabled && !(viewport.y <= device_limits.viewportBoundsRange[1])) {
         y_healthy = false;
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-y-01776",
-                        "%s: %s.y (=%f) exceeds VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).", fn_name,
-                        parameter_name.get_name().c_str(), viewport.y, device_limits.viewportBoundsRange[1]);
+        skip |= LogError(object, "VUID-VkViewport-y-01776",
+                         "%s: %s.y (=%f) exceeds VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).", fn_name,
+                         parameter_name.get_name().c_str(), viewport.y, device_limits.viewportBoundsRange[1]);
     }
 
     // y + height
@@ -921,36 +864,36 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
         const float boundary = viewport.y + viewport.height;
 
         if (!(boundary <= device_limits.viewportBoundsRange[1])) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-y-01233",
-                            "%s: %s.y + %s.height (=%f + %f = %f) exceeds VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).",
-                            fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.y,
-                            viewport.height, boundary, device_limits.viewportBoundsRange[1]);
+            skip |= LogError(object, "VUID-VkViewport-y-01233",
+                             "%s: %s.y + %s.height (=%f + %f = %f) exceeds VkPhysicalDeviceLimits::viewportBoundsRange[1] (=%f).",
+                             fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.y,
+                             viewport.height, boundary, device_limits.viewportBoundsRange[1]);
         } else if (negative_height_enabled && !(boundary >= device_limits.viewportBoundsRange[0])) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-y-01777",
-                        "%s: %s.y + %s.height (=%f + %f = %f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).",
-                        fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.y, viewport.height,
-                        boundary, device_limits.viewportBoundsRange[0]);
+                LogError(object, "VUID-VkViewport-y-01777",
+                         "%s: %s.y + %s.height (=%f + %f = %f) is less than VkPhysicalDeviceLimits::viewportBoundsRange[0] (=%f).",
+                         fn_name, parameter_name.get_name().c_str(), parameter_name.get_name().c_str(), viewport.y, viewport.height,
+                         boundary, device_limits.viewportBoundsRange[0]);
         }
     }
 
     if (!device_extensions.vk_ext_depth_range_unrestricted) {
         // minDepth
         if (!(viewport.minDepth >= 0.0) || !(viewport.minDepth <= 1.0)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-minDepth-01234",
+            skip |= LogError(object, "VUID-VkViewport-minDepth-01234",
 
-                            "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.minDepth (=%f) is not within the "
-                            "[0.0, 1.0] range.",
-                            fn_name, parameter_name.get_name().c_str(), viewport.minDepth);
+                             "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.minDepth (=%f) is not within the "
+                             "[0.0, 1.0] range.",
+                             fn_name, parameter_name.get_name().c_str(), viewport.minDepth);
         }
 
         // maxDepth
         if (!(viewport.maxDepth >= 0.0) || !(viewport.maxDepth <= 1.0)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object, "VUID-VkViewport-maxDepth-01235",
+            skip |= LogError(object, "VUID-VkViewport-maxDepth-01235",
 
-                            "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.maxDepth (=%f) is not within the "
-                            "[0.0, 1.0] range.",
-                            fn_name, parameter_name.get_name().c_str(), viewport.maxDepth);
+                             "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.maxDepth (=%f) is not within the "
+                             "[0.0, 1.0] range.",
+                             fn_name, parameter_name.get_name().c_str(), viewport.maxDepth);
         }
     }
 
@@ -986,39 +929,35 @@ bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSample
     }
 
     if (sampleOrderInfo == nullptr) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkCoarseSampleOrderCustomNV-shadingRate-02073",
-                        "VkCoarseSampleOrderCustomNV shadingRate must be a shading rate "
-                        "that generates fragments with more than one pixel.");
+        skip |= LogError(device, "VUID-VkCoarseSampleOrderCustomNV-shadingRate-02073",
+                         "VkCoarseSampleOrderCustomNV shadingRate must be a shading rate "
+                         "that generates fragments with more than one pixel.");
         return skip;
     }
 
     if (order->sampleCount == 0 || (order->sampleCount & (order->sampleCount - 1)) ||
         !(order->sampleCount & device_limits.framebufferNoAttachmentsSampleCounts)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkCoarseSampleOrderCustomNV-sampleCount-02074",
-                        "VkCoarseSampleOrderCustomNV sampleCount (=%" PRIu32
-                        ") must "
-                        "correspond to a sample count enumerated in VkSampleCountFlags whose corresponding bit "
-                        "is set in framebufferNoAttachmentsSampleCounts.",
-                        order->sampleCount);
+        skip |= LogError(device, "VUID-VkCoarseSampleOrderCustomNV-sampleCount-02074",
+                         "VkCoarseSampleOrderCustomNV sampleCount (=%" PRIu32
+                         ") must "
+                         "correspond to a sample count enumerated in VkSampleCountFlags whose corresponding bit "
+                         "is set in framebufferNoAttachmentsSampleCounts.",
+                         order->sampleCount);
     }
 
     if (order->sampleLocationCount != order->sampleCount * sampleOrderInfo->width * sampleOrderInfo->height) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02075",
-                        "VkCoarseSampleOrderCustomNV sampleLocationCount (=%" PRIu32
-                        ") must "
-                        "be equal to the product of sampleCount (=%" PRIu32
-                        "), the fragment width for shadingRate "
-                        "(=%" PRIu32 "), and the fragment height for shadingRate (=%" PRIu32 ").",
-                        order->sampleLocationCount, order->sampleCount, sampleOrderInfo->width, sampleOrderInfo->height);
+        skip |= LogError(device, "VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02075",
+                         "VkCoarseSampleOrderCustomNV sampleLocationCount (=%" PRIu32
+                         ") must "
+                         "be equal to the product of sampleCount (=%" PRIu32
+                         "), the fragment width for shadingRate "
+                         "(=%" PRIu32 "), and the fragment height for shadingRate (=%" PRIu32 ").",
+                         order->sampleLocationCount, order->sampleCount, sampleOrderInfo->width, sampleOrderInfo->height);
     }
 
     if (order->sampleLocationCount > phys_dev_ext_props.shading_rate_image_props.shadingRateMaxCoarseSamples) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-            "VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02076",
+        skip |= LogError(
+            device, "VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02076",
             "VkCoarseSampleOrderCustomNV sampleLocationCount (=%" PRIu32
             ") must "
             "be less than or equal to VkPhysicalDeviceShadingRateImagePropertiesNV shadingRateMaxCoarseSamples (=%" PRIu32 ").",
@@ -1034,19 +973,16 @@ bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSample
     for (uint32_t i = 0; i < order->sampleLocationCount; ++i) {
         const VkCoarseSampleLocationNV *sampleLoc = &order->pSampleLocations[i];
         if (sampleLoc->pixelX >= sampleOrderInfo->width) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkCoarseSampleLocationNV-pixelX-02078",
-                            "pixelX must be less than the width (in pixels) of the fragment.");
+            skip |= LogError(device, "VUID-VkCoarseSampleLocationNV-pixelX-02078",
+                             "pixelX must be less than the width (in pixels) of the fragment.");
         }
         if (sampleLoc->pixelY >= sampleOrderInfo->height) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkCoarseSampleLocationNV-pixelY-02079",
-                            "pixelY must be less than the height (in pixels) of the fragment.");
+            skip |= LogError(device, "VUID-VkCoarseSampleLocationNV-pixelY-02079",
+                             "pixelY must be less than the height (in pixels) of the fragment.");
         }
         if (sampleLoc->sample >= order->sampleCount) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkCoarseSampleLocationNV-sample-02080",
-                            "sample must be less than the number of coverage samples in each pixel belonging to the fragment.");
+            skip |= LogError(device, "VUID-VkCoarseSampleLocationNV-sample-02080",
+                             "sample must be less than the number of coverage samples in each pixel belonging to the fragment.");
         }
         uint32_t idx = sampleLoc->sample + order->sampleCount * (sampleLoc->pixelX + sampleOrderInfo->width * sampleLoc->pixelY);
         sampleLocationsMask |= 1ULL << idx;
@@ -1054,9 +990,8 @@ bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSample
 
     uint64_t expectedMask = (order->sampleLocationCount == 64) ? ~0ULL : ((1ULL << order->sampleLocationCount) - 1);
     if (sampleLocationsMask != expectedMask) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-            "VUID-VkCoarseSampleOrderCustomNV-pSampleLocations-02077",
+        skip |= LogError(
+            device, "VUID-VkCoarseSampleOrderCustomNV-pSampleLocations-02077",
             "The array pSampleLocations must contain exactly one entry for "
             "every combination of valid values for pixelX, pixelY, and sample in the structure VkCoarseSampleOrderCustomNV.");
     }
@@ -1102,13 +1037,11 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             auto feedback_struct = lvl_find_in_chain<VkPipelineCreationFeedbackCreateInfoEXT>(pCreateInfos[i].pNext);
             if ((feedback_struct != nullptr) &&
                 (feedback_struct->pipelineStageCreationFeedbackCount != pCreateInfos[i].stageCount)) {
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02668",
-                            "vkCreateGraphicsPipelines(): in pCreateInfo[%" PRIu32
-                            "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount"
-                            "(=%" PRIu32 ") must equal VkGraphicsPipelineCreateInfo::stageCount(=%" PRIu32 ").",
-                            i, feedback_struct->pipelineStageCreationFeedbackCount, pCreateInfos[i].stageCount);
+                skip |= LogError(device, "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02668",
+                                 "vkCreateGraphicsPipelines(): in pCreateInfo[%" PRIu32
+                                 "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount"
+                                 "(=%" PRIu32 ") must equal VkGraphicsPipelineCreateInfo::stageCount(=%" PRIu32 ").",
+                                 i, feedback_struct->pipelineStageCreationFeedbackCount, pCreateInfos[i].stageCount);
             }
 
             // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
@@ -1170,11 +1103,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 auto const &vertex_input_state = pCreateInfos[i].pVertexInputState;
 
                 if (pCreateInfos[i].pVertexInputState->flags != 0) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkPipelineVertexInputStateCreateInfo-flags-zerobitmask",
-                                    "vkCreateGraphicsPipelines: pararameter "
-                                    "pCreateInfos[%d].pVertexInputState->flags (%u) is reserved and must be zero.",
-                                    i, vertex_input_state->flags);
+                    skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-flags-zerobitmask",
+                                     "vkCreateGraphicsPipelines: pararameter "
+                                     "pCreateInfos[%d].pVertexInputState->flags (%u) is reserved and must be zero.",
+                                     i, vertex_input_state->flags);
                 }
 
                 const VkStructureType allowed_structs_VkPipelineVertexInputStateCreateInfo[] = {
@@ -1228,21 +1160,20 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 }
 
                 if (vertex_input_state->vertexBindingDescriptionCount > device_limits.maxVertexInputBindings) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkPipelineVertexInputStateCreateInfo-vertexBindingDescriptionCount-00613",
-                                    "vkCreateGraphicsPipelines: pararameter "
-                                    "pCreateInfo[%d].pVertexInputState->vertexBindingDescriptionCount (%u) is "
-                                    "greater than VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
-                                    i, vertex_input_state->vertexBindingDescriptionCount, device_limits.maxVertexInputBindings);
+                    skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-vertexBindingDescriptionCount-00613",
+                                     "vkCreateGraphicsPipelines: pararameter "
+                                     "pCreateInfo[%d].pVertexInputState->vertexBindingDescriptionCount (%u) is "
+                                     "greater than VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                     i, vertex_input_state->vertexBindingDescriptionCount, device_limits.maxVertexInputBindings);
                 }
 
                 if (vertex_input_state->vertexAttributeDescriptionCount > device_limits.maxVertexInputAttributes) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkPipelineVertexInputStateCreateInfo-vertexAttributeDescriptionCount-00614",
-                                    "vkCreateGraphicsPipelines: pararameter "
-                                    "pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptionCount (%u) is "
-                                    "greater than VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
-                                    i, vertex_input_state->vertexAttributeDescriptionCount, device_limits.maxVertexInputAttributes);
+                    skip |=
+                        LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-vertexAttributeDescriptionCount-00614",
+                                 "vkCreateGraphicsPipelines: pararameter "
+                                 "pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptionCount (%u) is "
+                                 "greater than VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
+                                 i, vertex_input_state->vertexAttributeDescriptionCount, device_limits.maxVertexInputAttributes);
                 }
 
                 std::unordered_set<uint32_t> vertex_bindings(vertex_input_state->vertexBindingDescriptionCount);
@@ -1250,31 +1181,29 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     auto const &vertex_bind_desc = vertex_input_state->pVertexBindingDescriptions[d];
                     auto const &binding_it = vertex_bindings.find(vertex_bind_desc.binding);
                     if (binding_it != vertex_bindings.cend()) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfo[%d].pVertexInputState->pVertexBindingDescription[%d].binding "
-                                        "(%" PRIu32 ") is not distinct.",
-                                        i, d, vertex_bind_desc.binding);
+                        skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfo[%d].pVertexInputState->pVertexBindingDescription[%d].binding "
+                                         "(%" PRIu32 ") is not distinct.",
+                                         i, d, vertex_bind_desc.binding);
                     }
                     vertex_bindings.insert(vertex_bind_desc.binding);
 
                     if (vertex_bind_desc.binding >= device_limits.maxVertexInputBindings) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkVertexInputBindingDescription-binding-00618",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].binding (%u) is "
-                                        "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
-                                        i, d, vertex_bind_desc.binding, device_limits.maxVertexInputBindings);
+                        skip |= LogError(device, "VUID-VkVertexInputBindingDescription-binding-00618",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].binding (%u) is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                         i, d, vertex_bind_desc.binding, device_limits.maxVertexInputBindings);
                     }
 
                     if (vertex_bind_desc.stride > device_limits.maxVertexInputBindingStride) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkVertexInputBindingDescription-stride-00619",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].stride (%u) is greater "
-                                        "than VkPhysicalDeviceLimits::maxVertexInputBindingStride (%u).",
-                                        i, d, vertex_bind_desc.stride, device_limits.maxVertexInputBindingStride);
+                        skip |=
+                            LogError(device, "VUID-VkVertexInputBindingDescription-stride-00619",
+                                     "vkCreateGraphicsPipelines: parameter "
+                                     "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].stride (%u) is greater "
+                                     "than VkPhysicalDeviceLimits::maxVertexInputBindingStride (%u).",
+                                     i, d, vertex_bind_desc.stride, device_limits.maxVertexInputBindingStride);
                     }
                 }
 
@@ -1283,9 +1212,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     auto const &vertex_attrib_desc = vertex_input_state->pVertexAttributeDescriptions[d];
                     auto const &location_it = attribute_locations.find(vertex_attrib_desc.location);
                     if (location_it != attribute_locations.cend()) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617",
+                        skip |= LogError(
+                            device, "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617",
                             "vkCreateGraphicsPipelines: parameter "
                             "pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptions[%d].location (%u) is not distinct.",
                             i, d, vertex_attrib_desc.location);
@@ -1294,9 +1222,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     auto const &binding_it = vertex_bindings.find(vertex_attrib_desc.binding);
                     if (binding_it == vertex_bindings.cend()) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                        skip |= LogError(
+                            device, "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
                             "vkCreateGraphicsPipelines: parameter "
                             " pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptions[%d].binding (%u) does not exist "
                             "in any pCreateInfo[%d].pVertexInputState->pVertexBindingDescription.",
@@ -1304,30 +1231,27 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     }
 
                     if (vertex_attrib_desc.location >= device_limits.maxVertexInputAttributes) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkVertexInputAttributeDescription-location-00620",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].location (%u) is "
-                                        "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
-                                        i, d, vertex_attrib_desc.location, device_limits.maxVertexInputAttributes);
+                        skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-location-00620",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].location (%u) is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
+                                         i, d, vertex_attrib_desc.location, device_limits.maxVertexInputAttributes);
                     }
 
                     if (vertex_attrib_desc.binding >= device_limits.maxVertexInputBindings) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkVertexInputAttributeDescription-binding-00621",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].binding (%u) is "
-                                        "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
-                                        i, d, vertex_attrib_desc.binding, device_limits.maxVertexInputBindings);
+                        skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-binding-00621",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].binding (%u) is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                         i, d, vertex_attrib_desc.binding, device_limits.maxVertexInputBindings);
                     }
 
                     if (vertex_attrib_desc.offset > device_limits.maxVertexInputAttributeOffset) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkVertexInputAttributeDescription-offset-00622",
-                                        "vkCreateGraphicsPipelines: parameter "
-                                        "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].offset (%u) is "
-                                        "greater than VkPhysicalDeviceLimits::maxVertexInputAttributeOffset (%u).",
-                                        i, d, vertex_attrib_desc.offset, device_limits.maxVertexInputAttributeOffset);
+                        skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-offset-00622",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].offset (%u) is "
+                                         "greater than VkPhysicalDeviceLimits::maxVertexInputAttributeOffset (%u).",
+                                         i, d, vertex_attrib_desc.offset, device_limits.maxVertexInputAttributeOffset);
                     }
                 }
             }
@@ -1347,12 +1271,11 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 // pTessellationState is ignored without both tessellation control and tessellation evaluation shaders stages
                 if (has_control && has_eval) {
                     if (pCreateInfos[i].pTessellationState == nullptr) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkGraphicsPipelineCreateInfo-pStages-00731",
-                                        "vkCreateGraphicsPipelines: if pCreateInfos[%d].pStages includes a tessellation control "
-                                        "shader stage and a tessellation evaluation shader stage, "
-                                        "pCreateInfos[%d].pTessellationState must not be NULL.",
-                                        i, i);
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-00731",
+                                         "vkCreateGraphicsPipelines: if pCreateInfos[%d].pStages includes a tessellation control "
+                                         "shader stage and a tessellation evaluation shader stage, "
+                                         "pCreateInfos[%d].pTessellationState must not be NULL.",
+                                         i, i);
                     } else {
                         const VkStructureType allowed_type =
                             VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO;
@@ -1370,13 +1293,12 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                         if (pCreateInfos[i].pTessellationState->patchControlPoints == 0 ||
                             pCreateInfos[i].pTessellationState->patchControlPoints > device_limits.maxTessellationPatchSize) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214",
-                                            "vkCreateGraphicsPipelines: invalid parameter "
-                                            "pCreateInfos[%d].pTessellationState->patchControlPoints value %u. patchControlPoints "
-                                            "should be >0 and <=%u.",
-                                            i, pCreateInfos[i].pTessellationState->patchControlPoints,
-                                            device_limits.maxTessellationPatchSize);
+                            skip |= LogError(device, "VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214",
+                                             "vkCreateGraphicsPipelines: invalid parameter "
+                                             "pCreateInfos[%d].pTessellationState->patchControlPoints value %u. patchControlPoints "
+                                             "should be >0 and <=%u.",
+                                             i, pCreateInfos[i].pTessellationState->patchControlPoints,
+                                             device_limits.maxTessellationPatchSize);
                         }
                     }
                 }
@@ -1386,21 +1308,19 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             if ((pCreateInfos[i].pRasterizationState != nullptr) &&
                 (pCreateInfos[i].pRasterizationState->rasterizerDiscardEnable == VK_FALSE)) {
                 if (pCreateInfos[i].pViewportState == nullptr) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00750",
-                                    "vkCreateGraphicsPipelines: Rasterization is enabled (pCreateInfos[%" PRIu32
-                                    "].pRasterizationState->rasterizerDiscardEnable is VK_FALSE), but pCreateInfos[%" PRIu32
-                                    "].pViewportState (=NULL) is not a valid pointer.",
-                                    i, i);
+                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00750",
+                                     "vkCreateGraphicsPipelines: Rasterization is enabled (pCreateInfos[%" PRIu32
+                                     "].pRasterizationState->rasterizerDiscardEnable is VK_FALSE), but pCreateInfos[%" PRIu32
+                                     "].pViewportState (=NULL) is not a valid pointer.",
+                                     i, i);
                 } else {
                     const auto &viewport_state = *pCreateInfos[i].pViewportState;
 
                     if (viewport_state.sType != VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-sType-sType",
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "].pViewportState->sType is not VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO.",
-                                        i);
+                        skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-sType-sType",
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pViewportState->sType is not VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO.",
+                                         i);
                     }
 
                     const VkStructureType allowed_structs_VkPipelineViewportStateCreateInfo[] = {
@@ -1438,122 +1358,106 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (!physical_device_features.multiViewport) {
                         if (viewport_state.viewportCount != 1) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216",
-                                            "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
-                                            "disabled, but pCreateInfos[%" PRIu32 "].pViewportState->viewportCount (=%" PRIu32
-                                            ") is not 1.",
-                                            i, viewport_state.viewportCount);
+                            skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216",
+                                             "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
+                                             "disabled, but pCreateInfos[%" PRIu32 "].pViewportState->viewportCount (=%" PRIu32
+                                             ") is not 1.",
+                                             i, viewport_state.viewportCount);
                         }
 
                         if (viewport_state.scissorCount != 1) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01217",
-                                            "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
-                                            "disabled, but pCreateInfos[%" PRIu32 "].pViewportState->scissorCount (=%" PRIu32
-                                            ") is not 1.",
-                                            i, viewport_state.scissorCount);
+                            skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01217",
+                                             "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
+                                             "disabled, but pCreateInfos[%" PRIu32 "].pViewportState->scissorCount (=%" PRIu32
+                                             ") is not 1.",
+                                             i, viewport_state.scissorCount);
                         }
 
                         if (exclusive_scissor_struct && (exclusive_scissor_struct->exclusiveScissorCount != 0 &&
                                                          exclusive_scissor_struct->exclusiveScissorCount != 1)) {
-                            skip |=
-                                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE,
-                                        "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02027",
-                                        "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
-                                        "disabled, but pCreateInfos[%" PRIu32
-                                        "] VkPipelineViewportExclusiveScissorStateCreateInfoNV::exclusiveScissorCount (=%" PRIu32
-                                        ") is not 1.",
-                                        i, exclusive_scissor_struct->exclusiveScissorCount);
+                            skip |= LogError(
+                                device, "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02027",
+                                "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
+                                "disabled, but pCreateInfos[%" PRIu32
+                                "] VkPipelineViewportExclusiveScissorStateCreateInfoNV::exclusiveScissorCount (=%" PRIu32
+                                ") is not 1.",
+                                i, exclusive_scissor_struct->exclusiveScissorCount);
                         }
 
                         if (shading_rate_image_struct &&
                             (shading_rate_image_struct->viewportCount != 0 && shading_rate_image_struct->viewportCount != 1)) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE,
-                                            "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02054",
-                                            "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
-                                            "disabled, but pCreateInfos[%" PRIu32
-                                            "] VkPipelineViewportShadingRateImageStateCreateInfoNV::viewportCount (=%" PRIu32
-                                            ") is neither 0 nor 1.",
-                                            i, shading_rate_image_struct->viewportCount);
+                            skip |= LogError(device, "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02054",
+                                             "vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is "
+                                             "disabled, but pCreateInfos[%" PRIu32
+                                             "] VkPipelineViewportShadingRateImageStateCreateInfoNV::viewportCount (=%" PRIu32
+                                             ") is neither 0 nor 1.",
+                                             i, shading_rate_image_struct->viewportCount);
                         }
 
                     } else {  // multiViewport enabled
                         if (viewport_state.viewportCount == 0) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-arraylength",
+                            skip |= LogError(
+                                device, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-arraylength",
                                 "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "].pViewportState->viewportCount is 0.", i);
                         } else if (viewport_state.viewportCount > device_limits.maxViewports) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01218",
-                                            "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                            "].pViewportState->viewportCount (=%" PRIu32
-                                            ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                                            i, viewport_state.viewportCount, device_limits.maxViewports);
+                            skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01218",
+                                             "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                             "].pViewportState->viewportCount (=%" PRIu32
+                                             ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                                             i, viewport_state.viewportCount, device_limits.maxViewports);
                         }
 
                         if (viewport_state.scissorCount == 0) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-arraylength",
+                            skip |= LogError(
+                                device, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-arraylength",
                                 "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "].pViewportState->scissorCount is 0.", i);
                         } else if (viewport_state.scissorCount > device_limits.maxViewports) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01219",
-                                            "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                            "].pViewportState->scissorCount (=%" PRIu32
-                                            ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                                            i, viewport_state.scissorCount, device_limits.maxViewports);
+                            skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01219",
+                                             "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                             "].pViewportState->scissorCount (=%" PRIu32
+                                             ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                                             i, viewport_state.scissorCount, device_limits.maxViewports);
                         }
                     }
 
                     if (exclusive_scissor_struct && exclusive_scissor_struct->exclusiveScissorCount > device_limits.maxViewports) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE,
-                                        "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02028",
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "] exclusiveScissorCount (=%" PRIu32
-                                        ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                                        i, exclusive_scissor_struct->exclusiveScissorCount, device_limits.maxViewports);
+                        skip |=
+                            LogError(device, "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02028",
+                                     "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "] exclusiveScissorCount (=%" PRIu32
+                                     ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                                     i, exclusive_scissor_struct->exclusiveScissorCount, device_limits.maxViewports);
                     }
 
                     if (shading_rate_image_struct && shading_rate_image_struct->viewportCount > device_limits.maxViewports) {
-                        skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02055",
-                                    "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                    "] VkPipelineViewportShadingRateImageStateCreateInfoNV viewportCount (=%" PRIu32
-                                    ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                                    i, shading_rate_image_struct->viewportCount, device_limits.maxViewports);
+                        skip |= LogError(device, "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02055",
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "] VkPipelineViewportShadingRateImageStateCreateInfoNV viewportCount (=%" PRIu32
+                                         ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                                         i, shading_rate_image_struct->viewportCount, device_limits.maxViewports);
                     }
 
                     if (viewport_state.scissorCount != viewport_state.viewportCount) {
-                        skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01220",
-                                    "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "].pViewportState->scissorCount (=%" PRIu32
-                                    ") is not identical to pCreateInfos[%" PRIu32 "].pViewportState->viewportCount (=%" PRIu32 ").",
-                                    i, viewport_state.scissorCount, i, viewport_state.viewportCount);
+                        skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01220",
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pViewportState->scissorCount (=%" PRIu32 ") is not identical to pCreateInfos[%" PRIu32
+                                         "].pViewportState->viewportCount (=%" PRIu32 ").",
+                                         i, viewport_state.scissorCount, i, viewport_state.viewportCount);
                     }
 
                     if (exclusive_scissor_struct && exclusive_scissor_struct->exclusiveScissorCount != 0 &&
                         exclusive_scissor_struct->exclusiveScissorCount != viewport_state.viewportCount) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE,
-                                        "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02029",
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "] exclusiveScissorCount (=%" PRIu32
-                                        ") must be zero or identical to pCreateInfos[%" PRIu32
-                                        "].pViewportState->viewportCount (=%" PRIu32 ").",
-                                        i, exclusive_scissor_struct->exclusiveScissorCount, i, viewport_state.viewportCount);
+                        skip |=
+                            LogError(device, "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02029",
+                                     "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "] exclusiveScissorCount (=%" PRIu32
+                                     ") must be zero or identical to pCreateInfos[%" PRIu32
+                                     "].pViewportState->viewportCount (=%" PRIu32 ").",
+                                     i, exclusive_scissor_struct->exclusiveScissorCount, i, viewport_state.viewportCount);
                     }
 
                     if (shading_rate_image_struct && shading_rate_image_struct->shadingRateImageEnable &&
                         shading_rate_image_struct->viewportCount != viewport_state.viewportCount) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-shadingRateImageEnable-02056",
+                        skip |= LogError(
+                            device, "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-shadingRateImageEnable-02056",
                             "vkCreateGraphicsPipelines: If shadingRateImageEnable is enabled, pCreateInfos[%" PRIu32
                             "] "
                             "VkPipelineViewportShadingRateImageStateCreateInfoNV viewportCount (=%" PRIu32
@@ -1562,9 +1466,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     }
 
                     if (!has_dynamic_viewport && viewport_state.viewportCount > 0 && viewport_state.pViewports == nullptr) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00747",
+                        skip |= LogError(
+                            device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00747",
                             "vkCreateGraphicsPipelines: The viewport state is static (pCreateInfos[%" PRIu32
                             "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_VIEWPORT), but pCreateInfos[%" PRIu32
                             "].pViewportState->pViewports (=NULL) is an invalid pointer.",
@@ -1572,9 +1475,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     }
 
                     if (!has_dynamic_scissor && viewport_state.scissorCount > 0 && viewport_state.pScissors == nullptr) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748",
+                        skip |= LogError(
+                            device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748",
                             "vkCreateGraphicsPipelines: The scissor state is static (pCreateInfos[%" PRIu32
                             "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_SCISSOR), but pCreateInfos[%" PRIu32
                             "].pViewportState->pScissors (=NULL) is an invalid pointer.",
@@ -1585,20 +1487,18 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         exclusive_scissor_struct->exclusiveScissorCount > 0 &&
                         exclusive_scissor_struct->pExclusiveScissors == nullptr) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-pDynamicStates-02030",
-                                    "vkCreateGraphicsPipelines: The exclusive scissor state is static (pCreateInfos[%" PRIu32
-                                    "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV), but "
-                                    "pCreateInfos[%" PRIu32 "] pExclusiveScissors (=NULL) is an invalid pointer.",
-                                    i, i);
+                            LogError(device, "VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-pDynamicStates-02030",
+                                     "vkCreateGraphicsPipelines: The exclusive scissor state is static (pCreateInfos[%" PRIu32
+                                     "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV), but "
+                                     "pCreateInfos[%" PRIu32 "] pExclusiveScissors (=NULL) is an invalid pointer.",
+                                     i, i);
                     }
 
                     if (!has_dynamic_shading_rate_palette_nv && shading_rate_image_struct &&
                         shading_rate_image_struct->viewportCount > 0 &&
                         shading_rate_image_struct->pShadingRatePalettes == nullptr) {
-                        skip |= log_msg(
-                            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-pDynamicStates-02057",
+                        skip |= LogError(
+                            device, "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-pDynamicStates-02057",
                             "vkCreateGraphicsPipelines: The shading rate palette state is static (pCreateInfos[%" PRIu32
                             "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV), "
                             "but pCreateInfos[%" PRIu32 "] pShadingRatePalettes (=NULL) is an invalid pointer.",
@@ -1607,12 +1507,11 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (vp_swizzle_struct) {
                         if (vp_swizzle_struct->viewportCount != viewport_state.viewportCount) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportSwizzleStateCreateInfoNV-viewportCount-01215",
-                                            "vkCreateGraphicsPipelines: The viewport swizzle state vieport count of %" PRIu32
-                                            " does "
-                                            "not match the viewport count of %" PRIu32 " in VkPipelineViewportStateCreateInfo.",
-                                            vp_swizzle_struct->viewportCount, viewport_state.viewportCount);
+                            skip |= LogError(device, "VUID-VkPipelineViewportSwizzleStateCreateInfoNV-viewportCount-01215",
+                                             "vkCreateGraphicsPipelines: The viewport swizzle state vieport count of %" PRIu32
+                                             " does "
+                                             "not match the viewport count of %" PRIu32 " in VkPipelineViewportStateCreateInfo.",
+                                             vp_swizzle_struct->viewportCount, viewport_state.viewportCount);
                         }
                     }
 
@@ -1624,57 +1523,51 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= manual_PreCallValidateViewport(viewport, fn_name,
                                                                    ParameterName("pCreateInfos[%i].pViewportState->pViewports[%i]",
                                                                                  ParameterName::IndexVector{i, viewport_i}),
-                                                                   VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT);
+                                                                   VkCommandBuffer(0));
                         }
                     }
 
                     if (has_dynamic_viewport_w_scaling_nv && !device_extensions.vk_nv_clip_space_w_scaling) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE, kVUID_PVError_ExtensionNotEnabled,
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, but "
-                                        "VK_NV_clip_space_w_scaling extension is not enabled.",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, but "
+                                         "VK_NV_clip_space_w_scaling extension is not enabled.",
+                                         i);
                     }
 
                     if (has_dynamic_discard_rectangle_ext && !device_extensions.vk_ext_discard_rectangles) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE, kVUID_PVError_ExtensionNotEnabled,
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT, but "
-                                        "VK_EXT_discard_rectangles extension is not enabled.",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT, but "
+                                         "VK_EXT_discard_rectangles extension is not enabled.",
+                                         i);
                     }
 
                     if (has_dynamic_sample_locations_ext && !device_extensions.vk_ext_sample_locations) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE, kVUID_PVError_ExtensionNotEnabled,
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, but "
-                                        "VK_EXT_sample_locations extension is not enabled.",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, but "
+                                         "VK_EXT_sample_locations extension is not enabled.",
+                                         i);
                     }
 
                     if (has_dynamic_exclusive_scissor_nv && !device_extensions.vk_nv_scissor_exclusive) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE, kVUID_PVError_ExtensionNotEnabled,
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, but "
-                                        "VK_NV_scissor_exclusive extension is not enabled.",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_ExtensionNotEnabled,
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, but "
+                                         "VK_NV_scissor_exclusive extension is not enabled.",
+                                         i);
                     }
 
                     if (coarse_sample_order_struct &&
                         coarse_sample_order_struct->sampleOrderType != VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV &&
                         coarse_sample_order_struct->customSampleOrderCount != 0) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                        VK_NULL_HANDLE,
-                                        "VUID-VkPipelineViewportCoarseSampleOrderStateCreateInfoNV-sampleOrderType-02072",
-                                        "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                        "] "
-                                        "VkPipelineViewportCoarseSampleOrderStateCreateInfoNV sampleOrderType is not "
-                                        "VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV and customSampleOrderCount is not 0.",
-                                        i);
+                        skip |= LogError(device, "VUID-VkPipelineViewportCoarseSampleOrderStateCreateInfoNV-sampleOrderType-02072",
+                                         "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                         "] "
+                                         "VkPipelineViewportCoarseSampleOrderStateCreateInfoNV sampleOrderType is not "
+                                         "VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV and customSampleOrderCount is not 0.",
+                                         i);
                     }
 
                     if (coarse_sample_order_struct) {
@@ -1685,19 +1578,17 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (vp_w_scaling_struct && (vp_w_scaling_struct->viewportWScalingEnable == VK_TRUE)) {
                         if (vp_w_scaling_struct->viewportCount != viewport_state.viewportCount) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                            VK_NULL_HANDLE, "VUID-VkPipelineViewportStateCreateInfo-viewportWScalingEnable-01726",
-                                            "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
-                                            "] "
-                                            "VkPipelineViewportWScalingStateCreateInfoNV.viewportCount (=%" PRIu32
-                                            ") "
-                                            "is not equal to VkPipelineViewportStateCreateInfo.viewportCount (=%" PRIu32 ").",
-                                            i, vp_w_scaling_struct->viewportCount, viewport_state.viewportCount);
+                            skip |= LogError(device, "VUID-VkPipelineViewportStateCreateInfo-viewportWScalingEnable-01726",
+                                             "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                                             "] "
+                                             "VkPipelineViewportWScalingStateCreateInfoNV.viewportCount (=%" PRIu32
+                                             ") "
+                                             "is not equal to VkPipelineViewportStateCreateInfo.viewportCount (=%" PRIu32 ").",
+                                             i, vp_w_scaling_struct->viewportCount, viewport_state.viewportCount);
                         }
                         if (!has_dynamic_viewport_w_scaling_nv && !vp_w_scaling_struct->pViewportWScalings) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
-                                VK_NULL_HANDLE, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715",
+                            skip |= LogError(
+                                device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715",
                                 "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
                                 "] "
                                 "VkPipelineViewportWScalingStateCreateInfoNV.pViewportWScalings (=NULL) is not a valid array.",
@@ -1707,11 +1598,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 }
 
                 if (pCreateInfos[i].pMultisampleState == nullptr) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00751",
-                                    "vkCreateGraphicsPipelines: if pCreateInfos[%d].pRasterizationState->rasterizerDiscardEnable "
-                                    "is VK_FALSE, pCreateInfos[%d].pMultisampleState must not be NULL.",
-                                    i, i);
+                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00751",
+                                     "vkCreateGraphicsPipelines: if pCreateInfos[%d].pRasterizationState->rasterizerDiscardEnable "
+                                     "is VK_FALSE, pCreateInfos[%d].pMultisampleState must not be NULL.",
+                                     i, i);
                 } else {
                     const VkStructureType valid_next_stypes[] = {LvlTypeMap<VkPipelineCoverageModulationStateCreateInfoNV>::kSType,
                                                                  LvlTypeMap<VkPipelineCoverageToColorStateCreateInfoNV>::kSType,
@@ -1759,25 +1649,24 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         pCreateInfos[i].pMultisampleState->alphaToOneEnable);
 
                     if (pCreateInfos[i].pMultisampleState->sType != VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        kVUID_PVError_InvalidStructSType,
-                                        "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pMultisampleState->sType must be "
-                                        "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_InvalidStructSType,
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pMultisampleState->sType must be "
+                                         "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
+                                         i);
                     }
                     if (pCreateInfos[i].pMultisampleState->sampleShadingEnable == VK_TRUE) {
                         if (!physical_device_features.sampleRateShading) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784",
-                                            "vkCreateGraphicsPipelines(): parameter "
-                                            "pCreateInfos[%d].pMultisampleState->sampleShadingEnable.",
-                                            i);
+                            skip |= LogError(device, "VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784",
+                                             "vkCreateGraphicsPipelines(): parameter "
+                                             "pCreateInfos[%d].pMultisampleState->sampleShadingEnable.",
+                                             i);
                         }
                         // TODO Add documentation issue about when minSampleShading must be in range and when it is ignored
                         // For now a "least noise" test *only* when sampleShadingEnable is VK_TRUE.
                         if (!in_inclusive_range(pCreateInfos[i].pMultisampleState->minSampleShading, 0.F, 1.0F)) {
-                            skip |= log_msg(
-                                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            skip |= LogError(
+                                device,
+
                                 "VUID-VkPipelineMultisampleStateCreateInfo-minSampleShading-00786",
                                 "vkCreateGraphicsPipelines(): parameter pCreateInfos[%d].pMultisampleState->minSampleShading.", i);
                         }
@@ -1791,101 +1680,97 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                              line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT)) {
                             if (pCreateInfos[i].pMultisampleState->alphaToCoverageEnable) {
                                 skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
-                                            "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                            "pCreateInfos[%d].pMultisampleState->alphaToCoverageEnable == VK_TRUE.",
-                                            i);
+                                    LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
+                                             "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
+                                             "pCreateInfos[%d].pMultisampleState->alphaToCoverageEnable == VK_TRUE.",
+                                             i);
                             }
                             if (pCreateInfos[i].pMultisampleState->alphaToOneEnable) {
                                 skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
-                                            "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                            "pCreateInfos[%d].pMultisampleState->alphaToOneEnable == VK_TRUE.",
-                                            i);
+                                    LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
+                                             "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
+                                             "pCreateInfos[%d].pMultisampleState->alphaToOneEnable == VK_TRUE.",
+                                             i);
                             }
                             if (pCreateInfos[i].pMultisampleState->sampleShadingEnable) {
                                 skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
-                                            "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                            "pCreateInfos[%d].pMultisampleState->sampleShadingEnable == VK_TRUE.",
-                                            i);
+                                    LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
+                                             "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
+                                             "pCreateInfos[%d].pMultisampleState->sampleShadingEnable == VK_TRUE.",
+                                             i);
                             }
                         }
                         if (line_state->stippledLineEnable && !has_dynamic_line_stipple) {
                             if (line_state->lineStippleFactor < 1 || line_state->lineStippleFactor > 256) {
                                 skip |=
-                                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                            "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineStippleFactor = %d must be in the "
-                                            "range [1,256].",
-                                            i, line_state->lineStippleFactor);
+                                    LogError(device, "VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineStippleFactor = %d must be in the "
+                                             "range [1,256].",
+                                             i, line_state->lineStippleFactor);
                             }
                         }
                         const auto *line_features =
                             lvl_find_in_chain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(device_createinfo_pnext);
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT &&
                             (!line_features || !line_features->rectangularLines)) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02768",
-                                            "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                            "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT requires the rectangularLines feature.",
-                                            i);
+                            skip |=
+                                LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02768",
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT requires the rectangularLines feature.",
+                                         i);
                         }
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT &&
                             (!line_features || !line_features->bresenhamLines)) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769",
-                                            "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                            "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT requires the bresenhamLines feature.",
-                                            i);
+                            skip |=
+                                LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769",
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT requires the bresenhamLines feature.",
+                                         i);
                         }
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT &&
                             (!line_features || !line_features->smoothLines)) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02770",
-                                            "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                            "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT requires the smoothLines feature.",
-                                            i);
+                            skip |=
+                                LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02770",
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT requires the smoothLines feature.",
+                                         i);
                         }
                         if (line_state->stippledLineEnable) {
                             if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT &&
                                 (!line_features || !line_features->stippledRectangularLines)) {
-                                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02771",
-                                                "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                                "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT with stipple requires the "
-                                                "stippledRectangularLines feature.",
-                                                i);
+                                skip |=
+                                    LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02771",
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT with stipple requires the "
+                                             "stippledRectangularLines feature.",
+                                             i);
                             }
                             if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT &&
                                 (!line_features || !line_features->stippledBresenhamLines)) {
-                                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02772",
-                                                "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                                "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT with stipple requires the "
-                                                "stippledBresenhamLines feature.",
-                                                i);
+                                skip |=
+                                    LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02772",
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT with stipple requires the "
+                                             "stippledBresenhamLines feature.",
+                                             i);
                             }
                             if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT &&
                                 (!line_features || !line_features->stippledSmoothLines)) {
-                                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02773",
-                                                "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                                "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT with stipple requires the "
-                                                "stippledSmoothLines feature.",
-                                                i);
+                                skip |=
+                                    LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02773",
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT with stipple requires the "
+                                             "stippledSmoothLines feature.",
+                                             i);
                             }
                             if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT &&
                                 (!line_features || !line_features->stippledSmoothLines || !device_limits.strictLines)) {
-                                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
-                                                0, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774",
-                                                "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
-                                                "VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT with stipple requires the "
-                                                "stippledRectangularLines and strictLines features.",
-                                                i);
+                                skip |=
+                                    LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774",
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT with stipple requires the "
+                                             "stippledRectangularLines and strictLines features.",
+                                             i);
                             }
                         }
                     }
@@ -1993,11 +1878,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         "VUID-VkPipelineDepthStencilStateCreateInfo-depthCompareOp-parameter");
 
                     if (pCreateInfos[i].pDepthStencilState->sType != VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        kVUID_PVError_InvalidStructSType,
-                                        "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pDepthStencilState->sType must be "
-                                        "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_InvalidStructSType,
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pDepthStencilState->sType must be "
+                                         "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
+                                         i);
                     }
                 }
 
@@ -2104,11 +1988,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     }
 
                     if (pCreateInfos[i].pColorBlendState->sType != VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        kVUID_PVError_InvalidStructSType,
-                                        "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pColorBlendState->sType must be "
-                                        "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
-                                        i);
+                        skip |= LogError(device, kVUID_PVError_InvalidStructSType,
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pColorBlendState->sType must be "
+                                         "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
+                                         i);
                     }
 
                     // If logicOpEnable is VK_TRUE, logicOp must be a valid VkLogicOp value
@@ -2125,29 +2008,27 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
                 if (pCreateInfos[i].basePipelineIndex != -1) {
                     if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkGraphicsPipelineCreateInfo-flags-00724",
-                                        "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineHandle, must be "
-                                        "VK_NULL_HANDLE if pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag "
-                                        "and pCreateInfos->basePipelineIndex is not -1.");
+                        skip |=
+                            LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00724",
+                                     "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineHandle, must be "
+                                     "VK_NULL_HANDLE if pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag "
+                                     "and pCreateInfos->basePipelineIndex is not -1.");
                     }
                 }
 
                 if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
                     if (pCreateInfos[i].basePipelineIndex != -1) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkGraphicsPipelineCreateInfo-flags-00725",
-                                        "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineIndex, must be -1 if "
-                                        "pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag and "
-                                        "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.");
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00725",
+                                         "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineIndex, must be -1 if "
+                                         "pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag and "
+                                         "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.");
                     }
                 } else {
                     if (static_cast<const uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
-                                        "vkCreateGraphicsPipelines parameter pCreateInfos->basePipelineIndex (%d) must be a valid"
-                                        "index into the pCreateInfos array, of size %d.",
-                                        pCreateInfos[i].basePipelineIndex, createInfoCount);
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
+                                         "vkCreateGraphicsPipelines parameter pCreateInfos->basePipelineIndex (%d) must be a valid"
+                                         "index into the pCreateInfos array, of size %d.",
+                                         pCreateInfos[i].basePipelineIndex, createInfoCount);
                     }
                 }
             }
@@ -2156,41 +2037,37 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 if (!device_extensions.vk_nv_fill_rectangle) {
                     if (pCreateInfos[i].pRasterizationState->polygonMode == VK_POLYGON_MODE_FILL_RECTANGLE_NV) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01414",
-                                    "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                    "pCreateInfos->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_FILL_RECTANGLE_NV "
-                                    "if the extension VK_NV_fill_rectangle is not enabled.");
+                            LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01414",
+                                     "vkCreateGraphicsPipelines parameter, VkPolygonMode "
+                                     "pCreateInfos->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_FILL_RECTANGLE_NV "
+                                     "if the extension VK_NV_fill_rectangle is not enabled.");
                     } else if ((pCreateInfos[i].pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL) &&
                                (physical_device_features.fillModeNonSolid == false)) {
-                        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                        kVUID_PVError_DeviceFeature,
-                                        "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                        "pCreateInfos->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
-                                        "VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
+                        skip |= LogError(device, kVUID_PVError_DeviceFeature,
+                                         "vkCreateGraphicsPipelines parameter, VkPolygonMode "
+                                         "pCreateInfos->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
+                                         "VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
                     }
                 } else {
                     if ((pCreateInfos[i].pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL) &&
                         (pCreateInfos[i].pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL_RECTANGLE_NV) &&
                         (physical_device_features.fillModeNonSolid == false)) {
                         skip |=
-                            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507",
-                                    "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                    "pCreateInfos->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
-                                    "VK_POLYGON_MODE_FILL_RECTANGLE_NV if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
+                            LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507",
+                                     "vkCreateGraphicsPipelines parameter, VkPolygonMode "
+                                     "pCreateInfos->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
+                                     "VK_POLYGON_MODE_FILL_RECTANGLE_NV if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
                     }
                 }
 
                 if (!has_dynamic_line_width && !physical_device_features.wideLines &&
                     (pCreateInfos[i].pRasterizationState->lineWidth != 1.0f)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, 0,
-                                    "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749",
-                                    "The line width state is static (pCreateInfos[%" PRIu32
-                                    "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_LINE_WIDTH) and "
-                                    "VkPhysicalDeviceFeatures::wideLines is disabled, but pCreateInfos[%" PRIu32
-                                    "].pRasterizationState->lineWidth (=%f) is not 1.0.",
-                                    i, i, pCreateInfos[i].pRasterizationState->lineWidth);
+                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749",
+                                     "The line width state is static (pCreateInfos[%" PRIu32
+                                     "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_LINE_WIDTH) and "
+                                     "VkPhysicalDeviceFeatures::wideLines is disabled, but pCreateInfos[%" PRIu32
+                                     "].pRasterizationState->lineWidth (=%f) is not 1.0.",
+                                     i, i, pCreateInfos[i].pRasterizationState->lineWidth);
                 }
             }
 
@@ -2217,19 +2094,18 @@ bool StatelessValidation::manual_PreCallValidateCreateComputePipelines(VkDevice 
                                 "VUID-VkPipelineShaderStageCreateInfo-pName-parameter", pCreateInfos[i].stage.pName);
         auto feedback_struct = lvl_find_in_chain<VkPipelineCreationFeedbackCreateInfoEXT>(pCreateInfos[i].pNext);
         if ((feedback_struct != nullptr) && (feedback_struct->pipelineStageCreationFeedbackCount != 1)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02669",
-                            "vkCreateComputePipelines(): in pCreateInfo[%" PRIu32
-                            "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount must equal 1, found %" PRIu32 ".",
-                            i, feedback_struct->pipelineStageCreationFeedbackCount);
+            skip |=
+                LogError(device, "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02669",
+                         "vkCreateComputePipelines(): in pCreateInfo[%" PRIu32
+                         "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount must equal 1, found %" PRIu32 ".",
+                         i, feedback_struct->pipelineStageCreationFeedbackCount);
         }
 
         // Make sure compute stage is selected
         if (pCreateInfos[i].stage.stage != VK_SHADER_STAGE_COMPUTE_BIT) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, 0,
-                            "VUID-VkComputePipelineCreateInfo-stage-00701",
-                            "vkCreateComputePipelines(): the pCreateInfo[%u].stage.stage (%s) is not VK_SHADER_STAGE_COMPUTE_BIT",
-                            i, string_VkShaderStageFlagBits(pCreateInfos[i].stage.stage));
+            skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-stage-00701",
+                             "vkCreateComputePipelines(): the pCreateInfo[%u].stage.stage (%s) is not VK_SHADER_STAGE_COMPUTE_BIT",
+                             i, string_VkShaderStageFlagBits(pCreateInfos[i].stage.stage));
         }
     }
     return skip;
@@ -2245,67 +2121,59 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
 
         if (pCreateInfo->anisotropyEnable == VK_TRUE) {
             if (!in_inclusive_range(pCreateInfo->maxAnisotropy, 1.0F, limits.maxSamplerAnisotropy)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-anisotropyEnable-01071",
-                                "vkCreateSampler(): value of %s must be in range [1.0, %f] %s, but %f found.",
-                                "pCreateInfo->maxAnisotropy", limits.maxSamplerAnisotropy,
-                                "VkPhysicalDeviceLimits::maxSamplerAnistropy", pCreateInfo->maxAnisotropy);
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071",
+                                 "vkCreateSampler(): value of %s must be in range [1.0, %f] %s, but %f found.",
+                                 "pCreateInfo->maxAnisotropy", limits.maxSamplerAnisotropy,
+                                 "VkPhysicalDeviceLimits::maxSamplerAnistropy", pCreateInfo->maxAnisotropy);
             }
 
             // Anistropy cannot be enabled in sampler unless enabled as a feature
             if (features.samplerAnisotropy == VK_FALSE) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-anisotropyEnable-01070",
-                                "vkCreateSampler(): Anisotropic sampling feature is not enabled, %s must be VK_FALSE.",
-                                "pCreateInfo->anisotropyEnable");
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-anisotropyEnable-01070",
+                                 "vkCreateSampler(): Anisotropic sampling feature is not enabled, %s must be VK_FALSE.",
+                                 "pCreateInfo->anisotropyEnable");
             }
         }
 
         if (pCreateInfo->unnormalizedCoordinates == VK_TRUE) {
             if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072",
-                                "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
-                                "pCreateInfo->minFilter (%s) and pCreateInfo->magFilter (%s) must be equal.",
-                                string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072",
+                                 "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
+                                 "pCreateInfo->minFilter (%s) and pCreateInfo->magFilter (%s) must be equal.",
+                                 string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
             }
             if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073",
-                                "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
-                                "pCreateInfo->mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                                string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073",
+                                 "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
+                                 "pCreateInfo->mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                                 string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
             }
             if (pCreateInfo->minLod != 0.0f || pCreateInfo->maxLod != 0.0f) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074",
-                                "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
-                                "pCreateInfo->minLod (%f) and pCreateInfo->maxLod (%f) must both be zero.",
-                                pCreateInfo->minLod, pCreateInfo->maxLod);
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074",
+                                 "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
+                                 "pCreateInfo->minLod (%f) and pCreateInfo->maxLod (%f) must both be zero.",
+                                 pCreateInfo->minLod, pCreateInfo->maxLod);
             }
             if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
                  pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
                 (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
                  pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075",
-                                "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
-                                "pCreateInfo->addressModeU (%s) and pCreateInfo->addressModeV (%s) must both be "
-                                "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
-                                string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                                string_VkSamplerAddressMode(pCreateInfo->addressModeV));
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075",
+                                 "vkCreateSampler(): when pCreateInfo->unnormalizedCoordinates is VK_TRUE, "
+                                 "pCreateInfo->addressModeU (%s) and pCreateInfo->addressModeV (%s) must both be "
+                                 "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
+                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV));
             }
             if (pCreateInfo->anisotropyEnable == VK_TRUE) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076",
-                                "vkCreateSampler(): pCreateInfo->anisotropyEnable and pCreateInfo->unnormalizedCoordinates must "
-                                "not both be VK_TRUE.");
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076",
+                                 "vkCreateSampler(): pCreateInfo->anisotropyEnable and pCreateInfo->unnormalizedCoordinates must "
+                                 "not both be VK_TRUE.");
             }
             if (pCreateInfo->compareEnable == VK_TRUE) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077",
-                                "vkCreateSampler(): pCreateInfo->compareEnable and pCreateInfo->unnormalizedCoordinates must "
-                                "not both be VK_TRUE.");
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077",
+                                 "vkCreateSampler(): pCreateInfo->compareEnable and pCreateInfo->unnormalizedCoordinates must "
+                                 "not both be VK_TRUE.");
             }
         }
 
@@ -2331,20 +2199,18 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
              (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE) ||
              (pCreateInfo->addressModeW == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE))) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkSamplerCreateInfo-addressModeU-01079",
-                        "vkCreateSampler(): A VkSamplerAddressMode value is set to VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE "
-                        "but the VK_KHR_sampler_mirror_clamp_to_edge extension has not been enabled.");
+                LogError(device, "VUID-VkSamplerCreateInfo-addressModeU-01079",
+                         "vkCreateSampler(): A VkSamplerAddressMode value is set to VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE "
+                         "but the VK_KHR_sampler_mirror_clamp_to_edge extension has not been enabled.");
         }
 
         // Checks for the IMG cubic filtering extension
         if (device_extensions.vk_img_filter_cubic) {
             if ((pCreateInfo->anisotropyEnable == VK_TRUE) &&
                 ((pCreateInfo->minFilter == VK_FILTER_CUBIC_IMG) || (pCreateInfo->magFilter == VK_FILTER_CUBIC_IMG))) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSamplerCreateInfo-magFilter-01081",
-                                "vkCreateSampler(): Anisotropic sampling must not be VK_TRUE when either minFilter or magFilter "
-                                "are VK_FILTER_CUBIC_IMG.");
+                skip |= LogError(device, "VUID-VkSamplerCreateInfo-magFilter-01081",
+                                 "vkCreateSampler(): Anisotropic sampling must not be VK_TRUE when either minFilter or magFilter "
+                                 "are VK_FILTER_CUBIC_IMG.");
             }
         }
 
@@ -2354,8 +2220,9 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                 (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
                 (pCreateInfo->addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
                 (pCreateInfo->anisotropyEnable != VK_FALSE) || (pCreateInfo->unnormalizedCoordinates != VK_FALSE)) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                skip |= LogError(
+                    device,
+
                     "VUID-VkSamplerCreateInfo-addressModeU-01646",
                     "vkCreateSampler():  SamplerYCbCrConversion is enabled: "
                     "addressModeU (%s), addressModeV (%s), addressModeW (%s) must be CLAMP_TO_EDGE, and anisotropyEnable (%s) "
@@ -2389,11 +2256,10 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
                     for (uint32_t descriptor_index = 0; descriptor_index < pCreateInfo->pBindings[i].descriptorCount;
                          ++descriptor_index) {
                         if (pCreateInfo->pBindings[i].pImmutableSamplers[descriptor_index] == VK_NULL_HANDLE) {
-                            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                            kVUID_PVError_RequiredParameter,
-                                            "vkCreateDescriptorSetLayout: required parameter "
-                                            "pCreateInfo->pBindings[%d].pImmutableSamplers[%d] specified as VK_NULL_HANDLE",
-                                            i, descriptor_index);
+                            skip |= LogError(device, kVUID_PVError_RequiredParameter,
+                                             "vkCreateDescriptorSetLayout: required parameter "
+                                             "pCreateInfo->pBindings[%d].pImmutableSamplers[%d] specified as VK_NULL_HANDLE",
+                                             i, descriptor_index);
                         }
                     }
                 }
@@ -2401,12 +2267,11 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
                 // If descriptorCount is not 0, stageFlags must be a valid combination of VkShaderStageFlagBits values
                 if ((pCreateInfo->pBindings[i].stageFlags != 0) &&
                     ((pCreateInfo->pBindings[i].stageFlags & (~AllVkShaderStageFlagBits)) != 0)) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkDescriptorSetLayoutBinding-descriptorCount-00283",
-                                    "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%d].descriptorCount is not 0, "
-                                    "pCreateInfo->pBindings[%d].stageFlags must be a valid combination of VkShaderStageFlagBits "
-                                    "values.",
-                                    i, i);
+                    skip |= LogError(device, "VUID-VkDescriptorSetLayoutBinding-descriptorCount-00283",
+                                     "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%d].descriptorCount is not 0, "
+                                     "pCreateInfo->pBindings[%d].stageFlags must be a valid combination of VkShaderStageFlagBits "
+                                     "values.",
+                                     i, i);
                 }
             }
         }
@@ -2434,9 +2299,8 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
             // descriptorCount must be greater than 0
             if (pDescriptorWrites[i].descriptorCount == 0) {
                 skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
-                            "%s(): parameter pDescriptorWrites[%d].descriptorCount must be greater than 0.", vkCallingFunction, i);
+                    LogError(device, "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
+                             "%s(): parameter pDescriptorWrites[%d].descriptorCount must be greater than 0.", vkCallingFunction, i);
             }
 
             // If called from vkCmdPushDescriptorSetKHR, the dstSet member is ignored.
@@ -2456,13 +2320,12 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                 // VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                 // pImageInfo must be a pointer to an array of descriptorCount valid VkDescriptorImageInfo structures
                 if (pDescriptorWrites[i].pImageInfo == nullptr) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkWriteDescriptorSet-descriptorType-00322",
-                                    "%s(): if pDescriptorWrites[%d].descriptorType is "
-                                    "VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
-                                    "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
-                                    "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%d].pImageInfo must not be NULL.",
-                                    vkCallingFunction, i, i);
+                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00322",
+                                     "%s(): if pDescriptorWrites[%d].descriptorType is "
+                                     "VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
+                                     "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
+                                     "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%d].pImageInfo must not be NULL.",
+                                     vkCallingFunction, i, i);
                 } else if (pDescriptorWrites[i].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER) {
                     // If descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
                     // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageView and imageLayout
@@ -2488,13 +2351,12 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                 // VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, pBufferInfo must be a
                 // pointer to an array of descriptorCount valid VkDescriptorBufferInfo structures
                 if (pDescriptorWrites[i].pBufferInfo == nullptr) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkWriteDescriptorSet-descriptorType-00324",
-                                    "%s(): if pDescriptorWrites[%d].descriptorType is "
-                                    "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, "
-                                    "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, "
-                                    "pDescriptorWrites[%d].pBufferInfo must not be NULL.",
-                                    vkCallingFunction, i, i);
+                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00324",
+                                     "%s(): if pDescriptorWrites[%d].descriptorType is "
+                                     "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, "
+                                     "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, "
+                                     "pDescriptorWrites[%d].pBufferInfo must not be NULL.",
+                                     vkCallingFunction, i, i);
                 } else {
                     for (uint32_t descriptorIndex = 0; descriptorIndex < pDescriptorWrites[i].descriptorCount; ++descriptorIndex) {
                         skip |= validate_required_handle(vkCallingFunction,
@@ -2508,12 +2370,11 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                 // If descriptorType is VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER or VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
                 // pTexelBufferView must be a pointer to an array of descriptorCount valid VkBufferView handles
                 if (pDescriptorWrites[i].pTexelBufferView == nullptr) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    "VUID-VkWriteDescriptorSet-descriptorType-00323",
-                                    "%s(): if pDescriptorWrites[%d].descriptorType is "
-                                    "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER or VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, "
-                                    "pDescriptorWrites[%d].pTexelBufferView must not be NULL.",
-                                    vkCallingFunction, i, i);
+                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00323",
+                                     "%s(): if pDescriptorWrites[%d].descriptorType is "
+                                     "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER or VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, "
+                                     "pDescriptorWrites[%d].pTexelBufferView must not be NULL.",
+                                     vkCallingFunction, i, i);
                 } else {
                     for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount;
                          ++descriptor_index) {
@@ -2532,11 +2393,10 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     if (pDescriptorWrites[i].pBufferInfo != NULL) {
                         if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, uniformAlignment) != 0) {
                             skip |=
-                                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                                        0, "VUID-VkWriteDescriptorSet-descriptorType-00327",
-                                        "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
-                                        ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
-                                        vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniformAlignment);
+                                LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00327",
+                                         "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                         ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                         vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniformAlignment);
                         }
                     }
                 }
@@ -2547,11 +2407,10 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     if (pDescriptorWrites[i].pBufferInfo != NULL) {
                         if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, storageAlignment) != 0) {
                             skip |=
-                                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
-                                        0, "VUID-VkWriteDescriptorSet-descriptorType-00328",
-                                        "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
-                                        ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
-                                        vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storageAlignment);
+                                LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00328",
+                                         "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                         ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                         vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storageAlignment);
                         }
                     }
                 }
@@ -2622,9 +2481,8 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
 
         // Explicit VUs
         if (!physical_device_features.inheritedQueries && pInfo->occlusionQueryEnable == VK_TRUE) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                HandleToUint64(commandBuffer), "VUID-VkCommandBufferInheritanceInfo-occlusionQueryEnable-00056",
+            skip |= LogError(
+                commandBuffer, "VUID-VkCommandBufferInheritanceInfo-occlusionQueryEnable-00056",
                 "%s: Inherited queries feature is disabled, but pBeginInfo->pInheritanceInfo->occlusionQueryEnable is VK_TRUE.",
                 cmd_name);
         }
@@ -2652,10 +2510,8 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
             const auto *cr_features = lvl_find_in_chain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(device_createinfo_pnext);
             const auto inherited_conditional_rendering = cr_features && cr_features->inheritedConditionalRendering;
             if (!inherited_conditional_rendering && conditional_rendering->conditionalRenderingEnable == VK_TRUE) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(commandBuffer),
-                    "VUID-VkCommandBufferInheritanceConditionalRenderingInfoEXT-conditionalRenderingEnable-01977",
+                skip |= LogError(
+                    commandBuffer, "VUID-VkCommandBufferInheritanceConditionalRenderingInfoEXT-conditionalRenderingEnable-01977",
                     "vkBeginCommandBuffer: Inherited conditional rendering is disabled, but "
                     "pBeginInfo->pInheritanceInfo->pNext<VkCommandBufferInheritanceConditionalRenderingInfoEXT> is VK_TRUE.");
             }
@@ -2671,25 +2527,22 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewport(VkCommandBuffer c
 
     if (!physical_device_features.multiViewport) {
         if (firstViewport != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetViewport-firstViewport-01224",
-                            "vkCmdSetViewport: The multiViewport feature is disabled, but firstViewport (=%" PRIu32 ") is not 0.",
-                            firstViewport);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetViewport-firstViewport-01224",
+                             "vkCmdSetViewport: The multiViewport feature is disabled, but firstViewport (=%" PRIu32 ") is not 0.",
+                             firstViewport);
         }
         if (viewportCount > 1) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetViewport-viewportCount-01225",
-                            "vkCmdSetViewport: The multiViewport feature is disabled, but viewportCount (=%" PRIu32 ") is not 1.",
-                            viewportCount);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetViewport-viewportCount-01225",
+                             "vkCmdSetViewport: The multiViewport feature is disabled, but viewportCount (=%" PRIu32 ") is not 1.",
+                             viewportCount);
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
         if (sum > device_limits.maxViewports) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetViewport-firstViewport-01223",
-                            "vkCmdSetViewport: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
-                            ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                            firstViewport, viewportCount, sum, device_limits.maxViewports);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetViewport-firstViewport-01223",
+                             "vkCmdSetViewport: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
+                             ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                             firstViewport, viewportCount, sum, device_limits.maxViewports);
         }
     }
 
@@ -2697,9 +2550,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewport(VkCommandBuffer c
         for (uint32_t viewport_i = 0; viewport_i < viewportCount; ++viewport_i) {
             const auto &viewport = pViewports[viewport_i];  // will crash on invalid ptr
             const char *fn_name = "vkCmdSetViewport";
-            skip |= manual_PreCallValidateViewport(viewport, fn_name,
-                                                   ParameterName("pViewports[%i]", ParameterName::IndexVector{viewport_i}),
-                                                   VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, HandleToUint64(commandBuffer));
+            skip |= manual_PreCallValidateViewport(
+                viewport, fn_name, ParameterName("pViewports[%i]", ParameterName::IndexVector{viewport_i}), commandBuffer);
         }
     }
 
@@ -2712,25 +2564,22 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
 
     if (!physical_device_features.multiViewport) {
         if (firstScissor != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-firstScissor-00593",
-                            "vkCmdSetScissor: The multiViewport feature is disabled, but firstScissor (=%" PRIu32 ") is not 0.",
-                            firstScissor);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-firstScissor-00593",
+                             "vkCmdSetScissor: The multiViewport feature is disabled, but firstScissor (=%" PRIu32 ") is not 0.",
+                             firstScissor);
         }
         if (scissorCount > 1) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-scissorCount-00594",
-                            "vkCmdSetScissor: The multiViewport feature is disabled, but scissorCount (=%" PRIu32 ") is not 1.",
-                            scissorCount);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-scissorCount-00594",
+                             "vkCmdSetScissor: The multiViewport feature is disabled, but scissorCount (=%" PRIu32 ") is not 1.",
+                             scissorCount);
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstScissor) + static_cast<uint64_t>(scissorCount);
         if (sum > device_limits.maxViewports) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-firstScissor-00592",
-                            "vkCmdSetScissor: firstScissor + scissorCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
-                            ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                            firstScissor, scissorCount, sum, device_limits.maxViewports);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-firstScissor-00592",
+                             "vkCmdSetScissor: firstScissor + scissorCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
+                             ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                             firstScissor, scissorCount, sum, device_limits.maxViewports);
         }
     }
 
@@ -2739,35 +2588,31 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
             const auto &scissor = pScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-x-00595",
-                                "vkCmdSetScissor: pScissors[%" PRIu32 "].offset.x (=%" PRIi32 ") is negative.", scissor_i,
-                                scissor.offset.x);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-x-00595",
+                                 "vkCmdSetScissor: pScissors[%" PRIu32 "].offset.x (=%" PRIi32 ") is negative.", scissor_i,
+                                 scissor.offset.x);
             }
 
             if (scissor.offset.y < 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-x-00595",
-                                "vkCmdSetScissor: pScissors[%" PRIu32 "].offset.y (=%" PRIi32 ") is negative.", scissor_i,
-                                scissor.offset.y);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-x-00595",
+                                 "vkCmdSetScissor: pScissors[%" PRIu32 "].offset.y (=%" PRIi32 ") is negative.", scissor_i,
+                                 scissor.offset.y);
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
             if (x_sum > INT32_MAX) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-offset-00596",
-                                "vkCmdSetScissor: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
-                                ") of pScissors[%" PRIu32 "] will overflow int32_t.",
-                                scissor.offset.x, scissor.extent.width, x_sum, scissor_i);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-offset-00596",
+                                 "vkCmdSetScissor: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
+                                 ") of pScissors[%" PRIu32 "] will overflow int32_t.",
+                                 scissor.offset.x, scissor.extent.width, x_sum, scissor_i);
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
             if (y_sum > INT32_MAX) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetScissor-offset-00597",
-                                "vkCmdSetScissor: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
-                                ") of pScissors[%" PRIu32 "] will overflow int32_t.",
-                                scissor.offset.y, scissor.extent.height, y_sum, scissor_i);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-offset-00597",
+                                 "vkCmdSetScissor: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
+                                 ") of pScissors[%" PRIu32 "] will overflow int32_t.",
+                                 scissor.offset.y, scissor.extent.height, y_sum, scissor_i);
             }
         }
     }
@@ -2779,9 +2624,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer 
     bool skip = false;
 
     if (!physical_device_features.wideLines && (lineWidth != 1.0f)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetLineWidth-lineWidth-00788",
-                        "VkPhysicalDeviceFeatures::wideLines is disabled, but lineWidth (=%f) is not 1.0.", lineWidth);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetLineWidth-lineWidth-00788",
+                         "VkPhysicalDeviceFeatures::wideLines is disabled, but lineWidth (=%f) is not 1.0.", lineWidth);
     }
 
     return skip;
@@ -2793,15 +2637,13 @@ bool StatelessValidation::manual_PreCallValidateCmdDraw(VkCommandBuffer commandB
     if (vertexCount == 0) {
         // TODO: Verify against Valid Usage section. I don't see a non-zero vertexCount listed, may need to add that and make
         // this an error or leave as is.
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t vertexCount, is 0");
+        skip |= LogWarning(device, kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t vertexCount, is 0");
     }
 
     if (instanceCount == 0) {
         // TODO: Verify against Valid Usage section. I don't see a non-zero instanceCount listed, may need to add that and make
         // this an error or leave as is.
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t instanceCount, is 0");
+        skip |= LogWarning(device, kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t instanceCount, is 0");
     }
     return skip;
 }
@@ -2811,9 +2653,8 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndirect(VkCommandBuffer 
     bool skip = false;
 
     if (!physical_device_features.multiDrawIndirect && ((count > 1))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        kVUID_PVError_DeviceFeature,
-                        "CmdDrawIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", count);
+        skip |= LogError(device, kVUID_PVError_DeviceFeature,
+                         "CmdDrawIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", count);
     }
     return skip;
 }
@@ -2822,9 +2663,9 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndexedIndirect(VkCommand
                                                                        VkDeviceSize offset, uint32_t count, uint32_t stride) const {
     bool skip = false;
     if (!physical_device_features.multiDrawIndirect && ((count > 1))) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, kVUID_PVError_DeviceFeature,
-            "CmdDrawIndexedIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", count);
+        skip |=
+            LogError(device, kVUID_PVError_DeviceFeature,
+                     "CmdDrawIndexedIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", count);
     }
     return skip;
 }
@@ -2835,9 +2676,8 @@ bool StatelessValidation::manual_PreCallValidateCmdClearAttachments(VkCommandBuf
     bool skip = false;
     for (uint32_t rect = 0; rect < rectCount; rect++) {
         if (pRects[rect].layerCount == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdClearAttachments-layerCount-01934",
-                            "CmdClearAttachments(): pRects[%d].layerCount is zero.", rect);
+            skip |= LogError(commandBuffer, "VUID-vkCmdClearAttachments-layerCount-01934",
+                             "CmdClearAttachments(): pRects[%d].layerCount is zero.", rect);
         }
     }
     return skip;
@@ -2857,12 +2697,11 @@ bool StatelessValidation::ValidateGetPhysicalDeviceImageFormatProperties2(VkPhys
                 // No flags other than the legal attachment bits may be set
                 legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
                 if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, 0,
-                                    "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539",
-                                    "%s(): in pNext chain, VkImageStencilUsageCreateInfo::stencilUsage "
-                                    "includes VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, it must not include bits other than "
-                                    "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT",
-                                    apiName);
+                    skip |= LogError(physicalDevice, "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539",
+                                     "%s(): in pNext chain, VkImageStencilUsageCreateInfo::stencilUsage "
+                                     "includes VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, it must not include bits other than "
+                                     "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT",
+                                     apiName);
                 }
             }
         }
@@ -2899,15 +2738,13 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyImage(VkCommandBuffer com
 
     if (pRegions != nullptr) {
         if ((pRegions->srcSubresource.aspectMask & legal_aspect_flags) == 0) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                "VUID-VkImageSubresourceLayers-aspectMask-parameter",
+            skip |= LogError(
+                device, "VUID-VkImageSubresourceLayers-aspectMask-parameter",
                 "vkCmdCopyImage() parameter, VkImageAspect pRegions->srcSubresource.aspectMask, is an unrecognized enumerator.");
         }
         if ((pRegions->dstSubresource.aspectMask & legal_aspect_flags) == 0) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                "VUID-VkImageSubresourceLayers-aspectMask-parameter",
+            skip |= LogError(
+                device, "VUID-VkImageSubresourceLayers-aspectMask-parameter",
                 "vkCmdCopyImage() parameter, VkImageAspect pRegions->dstSubresource.aspectMask, is an unrecognized enumerator.");
         }
     }
@@ -2928,15 +2765,13 @@ bool StatelessValidation::manual_PreCallValidateCmdBlitImage(VkCommandBuffer com
 
     if (pRegions != nullptr) {
         if ((pRegions->srcSubresource.aspectMask & legal_aspect_flags) == 0) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                kVUID_PVError_UnrecognizedValue,
+            skip |= LogError(
+                device, kVUID_PVError_UnrecognizedValue,
                 "vkCmdBlitImage() parameter, VkImageAspect pRegions->srcSubresource.aspectMask, is an unrecognized enumerator");
         }
         if ((pRegions->dstSubresource.aspectMask & legal_aspect_flags) == 0) {
-            skip |= log_msg(
-                report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                kVUID_PVError_UnrecognizedValue,
+            skip |= LogError(
+                device, kVUID_PVError_UnrecognizedValue,
                 "vkCmdBlitImage() parameter, VkImageAspect pRegions->dstSubresource.aspectMask, is an unrecognized enumerator");
         }
     }
@@ -2950,8 +2785,8 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyBuffer(VkCommandBuffer co
     if (pRegions != nullptr) {
         for (uint32_t i = 0; i < regionCount; i++) {
             if (pRegions[i].size == 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkBufferCopy-size-01988", "vkCmdCopyBuffer() pRegions[%u].size must be greater than zero", i);
+                skip |= LogError(device, "VUID-VkBufferCopy-size-01988",
+                                 "vkCmdCopyBuffer() pRegions[%u].size must be greater than zero", i);
             }
         }
     }
@@ -2972,10 +2807,9 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyBufferToImage(VkCommandBu
 
     if (pRegions != nullptr) {
         if ((pRegions->imageSubresource.aspectMask & legal_aspect_flags) == 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            kVUID_PVError_UnrecognizedValue,
-                            "vkCmdCopyBufferToImage() parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an "
-                            "unrecognized enumerator");
+            skip |= LogError(device, kVUID_PVError_UnrecognizedValue,
+                             "vkCmdCopyBufferToImage() parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an "
+                             "unrecognized enumerator");
         }
     }
     return skip;
@@ -2995,10 +2829,9 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyImageToBuffer(VkCommandBu
 
     if (pRegions != nullptr) {
         if ((pRegions->imageSubresource.aspectMask & legal_aspect_flags) == 0) {
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUID_PVError_UnrecognizedValue,
-                    "vkCmdCopyImageToBuffer parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an unrecognized "
-                    "enumerator");
+            LogError(device, kVUID_PVError_UnrecognizedValue,
+                     "vkCmdCopyImageToBuffer parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an unrecognized "
+                     "enumerator");
         }
     }
     return skip;
@@ -3010,23 +2843,20 @@ bool StatelessValidation::manual_PreCallValidateCmdUpdateBuffer(VkCommandBuffer 
     bool skip = false;
 
     if (dstOffset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-vkCmdUpdateBuffer-dstOffset-00036",
-                        "vkCmdUpdateBuffer() parameter, VkDeviceSize dstOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.",
-                        dstOffset);
+        skip |= LogError(device, "VUID-vkCmdUpdateBuffer-dstOffset-00036",
+                         "vkCmdUpdateBuffer() parameter, VkDeviceSize dstOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.",
+                         dstOffset);
     }
 
     if ((dataSize <= 0) || (dataSize > 65536)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-vkCmdUpdateBuffer-dataSize-00037",
-                        "vkCmdUpdateBuffer() parameter, VkDeviceSize dataSize (0x%" PRIxLEAST64
-                        "), must be greater than zero and less than or equal to 65536.",
-                        dataSize);
+        skip |= LogError(device, "VUID-vkCmdUpdateBuffer-dataSize-00037",
+                         "vkCmdUpdateBuffer() parameter, VkDeviceSize dataSize (0x%" PRIxLEAST64
+                         "), must be greater than zero and less than or equal to 65536.",
+                         dataSize);
     } else if (dataSize & 3) {
-        skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-vkCmdUpdateBuffer-dataSize-00038",
-                    "vkCmdUpdateBuffer() parameter, VkDeviceSize dataSize (0x%" PRIxLEAST64 "), is not a multiple of 4.", dataSize);
+        skip |= LogError(device, "VUID-vkCmdUpdateBuffer-dataSize-00038",
+                         "vkCmdUpdateBuffer() parameter, VkDeviceSize dataSize (0x%" PRIxLEAST64 "), is not a multiple of 4.",
+                         dataSize);
     }
     return skip;
 }
@@ -3036,22 +2866,19 @@ bool StatelessValidation::manual_PreCallValidateCmdFillBuffer(VkCommandBuffer co
     bool skip = false;
 
     if (dstOffset & 3) {
-        skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-vkCmdFillBuffer-dstOffset-00025",
-                    "vkCmdFillBuffer() parameter, VkDeviceSize dstOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.", dstOffset);
+        skip |= LogError(device, "VUID-vkCmdFillBuffer-dstOffset-00025",
+                         "vkCmdFillBuffer() parameter, VkDeviceSize dstOffset (0x%" PRIxLEAST64 "), is not a multiple of 4.",
+                         dstOffset);
     }
 
     if (size != VK_WHOLE_SIZE) {
         if (size <= 0) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-vkCmdFillBuffer-size-00026",
-                        "vkCmdFillBuffer() parameter, VkDeviceSize size (0x%" PRIxLEAST64 "), must be greater than zero.", size);
+                LogError(device, "VUID-vkCmdFillBuffer-size-00026",
+                         "vkCmdFillBuffer() parameter, VkDeviceSize size (0x%" PRIxLEAST64 "), must be greater than zero.", size);
         } else if (size & 3) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-vkCmdFillBuffer-size-00028",
-                            "vkCmdFillBuffer() parameter, VkDeviceSize size (0x%" PRIxLEAST64 "), is not a multiple of 4.", size);
+            skip |= LogError(device, "VUID-vkCmdFillBuffer-size-00028",
+                             "vkCmdFillBuffer() parameter, VkDeviceSize size (0x%" PRIxLEAST64 "), is not a multiple of 4.", size);
         }
     }
     return skip;
@@ -3062,32 +2889,28 @@ bool StatelessValidation::manual_PreCallValidateCreateSwapchainKHR(VkDevice devi
                                                                    VkSwapchainKHR *pSwapchain) const {
     bool skip = false;
 
-    const LogMiscParams log_misc{VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, VK_NULL_HANDLE, "vkCreateSwapchainKHR"};
-
     if (pCreateInfo != nullptr) {
         // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
         if (pCreateInfo->imageSharingMode == VK_SHARING_MODE_CONCURRENT) {
             // If imageSharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
             if (pCreateInfo->queueFamilyIndexCount <= 1) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSwapchainCreateInfoKHR-imageSharingMode-01278",
-                                "vkCreateSwapchainKHR(): if pCreateInfo->imageSharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
+                skip |= LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageSharingMode-01278",
+                                 "vkCreateSwapchainKHR(): if pCreateInfo->imageSharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->queueFamilyIndexCount must be greater than 1.");
             }
 
             // If imageSharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
             // queueFamilyIndexCount uint32_t values
             if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkSwapchainCreateInfoKHR-imageSharingMode-01277",
-                                "vkCreateSwapchainKHR(): if pCreateInfo->imageSharingMode is VK_SHARING_MODE_CONCURRENT, "
-                                "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
-                                "pCreateInfo->queueFamilyIndexCount uint32_t values.");
+                skip |= LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageSharingMode-01277",
+                                 "vkCreateSwapchainKHR(): if pCreateInfo->imageSharingMode is VK_SHARING_MODE_CONCURRENT, "
+                                 "pCreateInfo->pQueueFamilyIndices must be a pointer to an array of "
+                                 "pCreateInfo->queueFamilyIndexCount uint32_t values.");
             }
         }
 
         skip |= ValidateGreaterThanZero(pCreateInfo->imageArrayLayers, "pCreateInfo->imageArrayLayers",
-                                        "VUID-VkSwapchainCreateInfoKHR-imageArrayLayers-01275", log_misc);
+                                        "VUID-VkSwapchainCreateInfoKHR-imageArrayLayers-01275", "vkCreateSwapchainKHR");
     }
 
     return skip;
@@ -3103,11 +2926,10 @@ bool StatelessValidation::manual_PreCallValidateQueuePresentKHR(VkQueue queue, c
             skip |= require_device_extension(IsExtEnabled(device_extensions.vk_khr_incremental_present), "vkQueuePresentKHR",
                                              VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME);
             if (present_regions->swapchainCount != pPresentInfo->swapchainCount) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                kVUID_PVError_InvalidUsage,
-                                "QueuePresentKHR(): pPresentInfo->swapchainCount has a value of %i but VkPresentRegionsKHR "
-                                "extension swapchainCount is %i. These values must be equal.",
-                                pPresentInfo->swapchainCount, present_regions->swapchainCount);
+                skip |= LogError(device, kVUID_PVError_InvalidUsage,
+                                 "QueuePresentKHR(): pPresentInfo->swapchainCount has a value of %i but VkPresentRegionsKHR "
+                                 "extension swapchainCount is %i. These values must be equal.",
+                                 pPresentInfo->swapchainCount, present_regions->swapchainCount);
             }
             skip |= validate_struct_pnext("QueuePresentKHR", "pCreateInfo->pNext->pNext", NULL, present_regions->pNext, 0, NULL,
                                           GeneratedVulkanHeaderVersion, "VUID-VkPresentInfoKHR-pNext-pNext");
@@ -3133,9 +2955,8 @@ bool StatelessValidation::manual_PreCallValidateCreateWin32SurfaceKHR(VkInstance
     bool skip = false;
 
     if (pCreateInfo->hwnd == nullptr) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308",
-                        "vkCreateWin32SurfaceKHR(): hwnd must be a valid Win32 HWND but hwnd is NULL.");
+        skip |= LogError(device, "VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308",
+                         "vkCreateWin32SurfaceKHR(): hwnd must be a valid Win32 HWND but hwnd is NULL.");
     }
 
     return skip;
@@ -3149,27 +2970,24 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice de
 
     if (pCreateInfo) {
         if (pCreateInfo->maxSets <= 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                            VK_NULL_HANDLE, "VUID-VkDescriptorPoolCreateInfo-maxSets-00301",
-                            "vkCreateDescriptorPool(): pCreateInfo->maxSets is not greater than 0.");
+            skip |= LogError(device, "VUID-VkDescriptorPoolCreateInfo-maxSets-00301",
+                             "vkCreateDescriptorPool(): pCreateInfo->maxSets is not greater than 0.");
         }
 
         if (pCreateInfo->pPoolSizes) {
             for (uint32_t i = 0; i < pCreateInfo->poolSizeCount; ++i) {
                 if (pCreateInfo->pPoolSizes[i].descriptorCount <= 0) {
-                    skip |= log_msg(
-                        report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, VK_NULL_HANDLE,
-                        "VUID-VkDescriptorPoolSize-descriptorCount-00302",
+                    skip |= LogError(
+                        device, "VUID-VkDescriptorPoolSize-descriptorCount-00302",
                         "vkCreateDescriptorPool(): pCreateInfo->pPoolSizes[%" PRIu32 "].descriptorCount is not greater than 0.", i);
                 }
                 if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT &&
                     (pCreateInfo->pPoolSizes[i].descriptorCount % 4) != 0) {
-                    skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                                    VK_NULL_HANDLE, "VUID-VkDescriptorPoolSize-type-02218",
-                                    "vkCreateDescriptorPool(): pCreateInfo->pPoolSizes[%" PRIu32
-                                    "].type is VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT "
-                                    " and pCreateInfo->pPoolSizes[%" PRIu32 "].descriptorCount is not a multiple of 4.",
-                                    i, i);
+                    skip |= LogError(device, "VUID-VkDescriptorPoolSize-type-02218",
+                                     "vkCreateDescriptorPool(): pCreateInfo->pPoolSizes[%" PRIu32
+                                     "].type is VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT "
+                                     " and pCreateInfo->pPoolSizes[%" PRIu32 "].descriptorCount is not a multiple of 4.",
+                                     i, i);
                 }
             }
         }
@@ -3184,26 +3002,23 @@ bool StatelessValidation::manual_PreCallValidateCmdDispatch(VkCommandBuffer comm
 
     if (groupCountX > device_limits.maxComputeWorkGroupCount[0]) {
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(commandBuffer), "VUID-vkCmdDispatch-groupCountX-00386",
-                    "vkCmdDispatch(): groupCountX (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
-                    groupCountX, device_limits.maxComputeWorkGroupCount[0]);
+            LogError(commandBuffer, "VUID-vkCmdDispatch-groupCountX-00386",
+                     "vkCmdDispatch(): groupCountX (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
+                     groupCountX, device_limits.maxComputeWorkGroupCount[0]);
     }
 
     if (groupCountY > device_limits.maxComputeWorkGroupCount[1]) {
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(commandBuffer), "VUID-vkCmdDispatch-groupCountY-00387",
-                    "vkCmdDispatch(): groupCountY (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
-                    groupCountY, device_limits.maxComputeWorkGroupCount[1]);
+            LogError(commandBuffer, "VUID-vkCmdDispatch-groupCountY-00387",
+                     "vkCmdDispatch(): groupCountY (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
+                     groupCountY, device_limits.maxComputeWorkGroupCount[1]);
     }
 
     if (groupCountZ > device_limits.maxComputeWorkGroupCount[2]) {
         skip |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                    HandleToUint64(commandBuffer), "VUID-vkCmdDispatch-groupCountZ-00388",
-                    "vkCmdDispatch(): groupCountZ (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
-                    groupCountZ, device_limits.maxComputeWorkGroupCount[2]);
+            LogError(commandBuffer, "VUID-vkCmdDispatch-groupCountZ-00388",
+                     "vkCmdDispatch(): groupCountZ (%" PRIu32 ") exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
+                     groupCountZ, device_limits.maxComputeWorkGroupCount[2]);
     }
 
     return skip;
@@ -3214,9 +3029,8 @@ bool StatelessValidation::manual_PreCallValidateCmdDispatchIndirect(VkCommandBuf
     bool skip = false;
 
     if ((offset % 4) != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchIndirect-offset-02710",
-                        "vkCmdDispatchIndirect(): offset (%" PRIu64 ") must be a multiple of 4.", offset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchIndirect-offset-02710",
+                         "vkCmdDispatchIndirect(): offset (%" PRIu64 ") must be a multiple of 4.", offset);
     }
     return skip;
 }
@@ -3229,47 +3043,41 @@ bool StatelessValidation::manual_PreCallValidateCmdDispatchBaseKHR(VkCommandBuff
     // Paired if {} else if {} tests used to avoid any possible uint underflow
     uint32_t limit = device_limits.maxComputeWorkGroupCount[0];
     if (baseGroupX >= limit) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-baseGroupX-00421",
-                        "vkCmdDispatch(): baseGroupX (%" PRIu32
-                        ") equals or exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
-                        baseGroupX, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-baseGroupX-00421",
+                         "vkCmdDispatch(): baseGroupX (%" PRIu32
+                         ") equals or exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
+                         baseGroupX, limit);
     } else if (groupCountX > (limit - baseGroupX)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-groupCountX-00424",
-                        "vkCmdDispatchBaseKHR(): baseGroupX (%" PRIu32 ") + groupCountX (%" PRIu32
-                        ") exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
-                        baseGroupX, groupCountX, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-groupCountX-00424",
+                         "vkCmdDispatchBaseKHR(): baseGroupX (%" PRIu32 ") + groupCountX (%" PRIu32
+                         ") exceeds device limit maxComputeWorkGroupCount[0] (%" PRIu32 ").",
+                         baseGroupX, groupCountX, limit);
     }
 
     limit = device_limits.maxComputeWorkGroupCount[1];
     if (baseGroupY >= limit) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-baseGroupX-00422",
-                        "vkCmdDispatch(): baseGroupY (%" PRIu32
-                        ") equals or exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
-                        baseGroupY, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-baseGroupX-00422",
+                         "vkCmdDispatch(): baseGroupY (%" PRIu32
+                         ") equals or exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
+                         baseGroupY, limit);
     } else if (groupCountY > (limit - baseGroupY)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-groupCountY-00425",
-                        "vkCmdDispatchBaseKHR(): baseGroupY (%" PRIu32 ") + groupCountY (%" PRIu32
-                        ") exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
-                        baseGroupY, groupCountY, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-groupCountY-00425",
+                         "vkCmdDispatchBaseKHR(): baseGroupY (%" PRIu32 ") + groupCountY (%" PRIu32
+                         ") exceeds device limit maxComputeWorkGroupCount[1] (%" PRIu32 ").",
+                         baseGroupY, groupCountY, limit);
     }
 
     limit = device_limits.maxComputeWorkGroupCount[2];
     if (baseGroupZ >= limit) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-baseGroupZ-00423",
-                        "vkCmdDispatch(): baseGroupZ (%" PRIu32
-                        ") equals or exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
-                        baseGroupZ, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-baseGroupZ-00423",
+                         "vkCmdDispatch(): baseGroupZ (%" PRIu32
+                         ") equals or exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
+                         baseGroupZ, limit);
     } else if (groupCountZ > (limit - baseGroupZ)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDispatchBase-groupCountZ-00426",
-                        "vkCmdDispatchBaseKHR(): baseGroupZ (%" PRIu32 ") + groupCountZ (%" PRIu32
-                        ") exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
-                        baseGroupZ, groupCountZ, limit);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDispatchBase-groupCountZ-00426",
+                         "vkCmdDispatchBaseKHR(): baseGroupZ (%" PRIu32 ") + groupCountZ (%" PRIu32
+                         ") exceeds device limit maxComputeWorkGroupCount[2] (%" PRIu32 ").",
+                         baseGroupZ, groupCountZ, limit);
     }
 
     return skip;
@@ -3292,37 +3100,33 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
     if (!physical_device_features.multiViewport) {
         if (firstExclusiveScissor != 0) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02035",
-                        "vkCmdSetExclusiveScissorNV: The multiViewport feature is disabled, but firstExclusiveScissor (=%" PRIu32
-                        ") is not 0.",
-                        firstExclusiveScissor);
+                LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02035",
+                         "vkCmdSetExclusiveScissorNV: The multiViewport feature is disabled, but firstExclusiveScissor (=%" PRIu32
+                         ") is not 0.",
+                         firstExclusiveScissor);
         }
         if (exclusiveScissorCount > 1) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-exclusiveScissorCount-02036",
-                        "vkCmdSetExclusiveScissorNV: The multiViewport feature is disabled, but exclusiveScissorCount (=%" PRIu32
-                        ") is not 1.",
-                        exclusiveScissorCount);
+                LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-exclusiveScissorCount-02036",
+                         "vkCmdSetExclusiveScissorNV: The multiViewport feature is disabled, but exclusiveScissorCount (=%" PRIu32
+                         ") is not 1.",
+                         exclusiveScissorCount);
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstExclusiveScissor) + static_cast<uint64_t>(exclusiveScissorCount);
         if (sum > device_limits.maxViewports) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02034",
-                            "vkCmdSetExclusiveScissorNV: firstExclusiveScissor + exclusiveScissorCount (=%" PRIu32 " + %" PRIu32
-                            " = %" PRIu64 ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                            firstExclusiveScissor, exclusiveScissorCount, sum, device_limits.maxViewports);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02034",
+                             "vkCmdSetExclusiveScissorNV: firstExclusiveScissor + exclusiveScissorCount (=%" PRIu32 " + %" PRIu32
+                             " = %" PRIu64 ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                             firstExclusiveScissor, exclusiveScissorCount, sum, device_limits.maxViewports);
         }
     }
 
     if (firstExclusiveScissor >= device_limits.maxViewports) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02033",
-                        "vkCmdSetExclusiveScissorNV: firstExclusiveScissor (=%" PRIu32 ") must be less than maxViewports (=%" PRIu32
-                        ").",
-                        firstExclusiveScissor, device_limits.maxViewports);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02033",
+                         "vkCmdSetExclusiveScissorNV: firstExclusiveScissor (=%" PRIu32
+                         ") must be less than maxViewports (=%" PRIu32 ").",
+                         firstExclusiveScissor, device_limits.maxViewports);
     }
 
     if (pExclusiveScissors) {
@@ -3330,35 +3134,31 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
             const auto &scissor = pExclusiveScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-x-02037",
-                                "vkCmdSetExclusiveScissorNV: pScissors[%" PRIu32 "].offset.x (=%" PRIi32 ") is negative.",
-                                scissor_i, scissor.offset.x);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-x-02037",
+                                 "vkCmdSetExclusiveScissorNV: pScissors[%" PRIu32 "].offset.x (=%" PRIi32 ") is negative.",
+                                 scissor_i, scissor.offset.x);
             }
 
             if (scissor.offset.y < 0) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-x-02037",
-                                "vkCmdSetExclusiveScissorNV: pScissors[%" PRIu32 "].offset.y (=%" PRIi32 ") is negative.",
-                                scissor_i, scissor.offset.y);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-x-02037",
+                                 "vkCmdSetExclusiveScissorNV: pScissors[%" PRIu32 "].offset.y (=%" PRIi32 ") is negative.",
+                                 scissor_i, scissor.offset.y);
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
             if (x_sum > INT32_MAX) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-offset-02038",
-                                "vkCmdSetExclusiveScissorNV: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
-                                ") of pScissors[%" PRIu32 "] will overflow int32_t.",
-                                scissor.offset.x, scissor.extent.width, x_sum, scissor_i);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-offset-02038",
+                                 "vkCmdSetExclusiveScissorNV: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
+                                 ") of pScissors[%" PRIu32 "] will overflow int32_t.",
+                                 scissor.offset.x, scissor.extent.width, x_sum, scissor_i);
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
             if (y_sum > INT32_MAX) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                                HandleToUint64(commandBuffer), "VUID-vkCmdSetExclusiveScissorNV-offset-02039",
-                                "vkCmdSetExclusiveScissorNV: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
-                                ") of pScissors[%" PRIu32 "] will overflow int32_t.",
-                                scissor.offset.y, scissor.extent.height, y_sum, scissor_i);
+                skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-offset-02039",
+                                 "vkCmdSetExclusiveScissorNV: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
+                                 ") of pScissors[%" PRIu32 "] will overflow int32_t.",
+                                 scissor.offset.y, scissor.extent.height, y_sum, scissor_i);
             }
         }
     }
@@ -3371,18 +3171,16 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewportWScalingNV(VkComma
                                                                          const VkViewportWScalingNV *pViewportWScalings) const {
     bool skip = false;
     if (firstViewport >= device_limits.maxViewports) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportWScalingNV-firstViewport-01323",
-                        "vkCmdSetViewportWScalingNV: firstViewport (=%" PRIu32 ") must be less than maxViewports (=%" PRIu32 ").",
-                        firstViewport, device_limits.maxViewports);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetViewportWScalingNV-firstViewport-01323",
+                         "vkCmdSetViewportWScalingNV: firstViewport (=%" PRIu32 ") must be less than maxViewports (=%" PRIu32 ").",
+                         firstViewport, device_limits.maxViewports);
     } else {
         const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
         if ((sum < 1) || (sum > device_limits.maxViewports)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                            HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportWScalingNV-firstViewport-01324",
-                            "vkCmdSetViewportWScalingNV: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
-                            ") must be between 1 and VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 "), inculsive.",
-                            firstViewport, viewportCount, sum, device_limits.maxViewports);
+            skip |= LogError(commandBuffer, "VUID-vkCmdSetViewportWScalingNV-firstViewport-01324",
+                             "vkCmdSetViewportWScalingNV: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
+                             ") must be between 1 and VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 "), inculsive.",
+                             firstViewport, viewportCount, sum, device_limits.maxViewports);
         }
     }
 
@@ -3397,37 +3195,33 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewportShadingRatePalette
     if (!physical_device_features.multiViewport) {
         if (firstViewport != 0) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02068",
-                        "vkCmdSetViewportShadingRatePaletteNV: The multiViewport feature is disabled, but firstViewport (=%" PRIu32
-                        ") is not 0.",
-                        firstViewport);
+                LogError(commandBuffer, "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02068",
+                         "vkCmdSetViewportShadingRatePaletteNV: The multiViewport feature is disabled, but firstViewport (=%" PRIu32
+                         ") is not 0.",
+                         firstViewport);
         }
         if (viewportCount > 1) {
             skip |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportShadingRatePaletteNV-viewportCount-02069",
-                        "vkCmdSetViewportShadingRatePaletteNV: The multiViewport feature is disabled, but viewportCount (=%" PRIu32
-                        ") is not 1.",
-                        viewportCount);
+                LogError(commandBuffer, "VUID-vkCmdSetViewportShadingRatePaletteNV-viewportCount-02069",
+                         "vkCmdSetViewportShadingRatePaletteNV: The multiViewport feature is disabled, but viewportCount (=%" PRIu32
+                         ") is not 1.",
+                         viewportCount);
         }
     }
 
     if (firstViewport >= device_limits.maxViewports) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02066",
-                        "vkCmdSetViewportShadingRatePaletteNV: firstViewport (=%" PRIu32
-                        ") must be less than maxViewports (=%" PRIu32 ").",
-                        firstViewport, device_limits.maxViewports);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02066",
+                         "vkCmdSetViewportShadingRatePaletteNV: firstViewport (=%" PRIu32
+                         ") must be less than maxViewports (=%" PRIu32 ").",
+                         firstViewport, device_limits.maxViewports);
     }
 
     const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
     if (sum > device_limits.maxViewports) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02067",
-                        "vkCmdSetViewportShadingRatePaletteNV: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32 " = %" PRIu64
-                        ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
-                        firstViewport, viewportCount, sum, device_limits.maxViewports);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02067",
+                         "vkCmdSetViewportShadingRatePaletteNV: firstViewport + viewportCount (=%" PRIu32 " + %" PRIu32
+                         " = %" PRIu64 ") is greater than VkPhysicalDeviceLimits::maxViewports (=%" PRIu32 ").",
+                         firstViewport, viewportCount, sum, device_limits.maxViewports);
     }
 
     return skip;
@@ -3439,10 +3233,9 @@ bool StatelessValidation::manual_PreCallValidateCmdSetCoarseSampleOrderNV(
     bool skip = false;
 
     if (sampleOrderType != VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV && customSampleOrderCount != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetCoarseSampleOrderNV-sampleOrderType-02081",
-                        "vkCmdSetCoarseSampleOrderNV: If sampleOrderType is not VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV, "
-                        "customSampleOrderCount must be 0.");
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetCoarseSampleOrderNV-sampleOrderType-02081",
+                         "vkCmdSetCoarseSampleOrderNV: If sampleOrderType is not VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV, "
+                         "customSampleOrderCount must be 0.");
     }
 
     for (uint32_t order_i = 0; order_i < customSampleOrderCount; ++order_i) {
@@ -3457,9 +3250,8 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawMeshTasksNV(VkCommandBuff
     bool skip = false;
 
     if (taskCount > phys_dev_ext_props.mesh_shader_props.maxDrawMeshTasksCount) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-            HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksNV-taskCount-02119",
+        skip |= LogError(
+            commandBuffer, "VUID-vkCmdDrawMeshTasksNV-taskCount-02119",
             "vkCmdDrawMeshTasksNV() parameter, uint32_t taskCount (0x%" PRIxLEAST32
             "), must be less than or equal to VkPhysicalDeviceMeshShaderPropertiesNV::maxDrawMeshTasksCount (0x%" PRIxLEAST32 ").",
             taskCount, phys_dev_ext_props.mesh_shader_props.maxDrawMeshTasksCount);
@@ -3474,23 +3266,20 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawMeshTasksIndirectNV(VkCom
     bool skip = false;
     static const int condition_multiples = 0b0011;
     if (offset & condition_multiples) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-            HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksIndirectNV-offset-02710",
+        skip |= LogError(
+            commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectNV-offset-02710",
             "vkCmdDrawMeshTasksIndirectNV() parameter, VkDeviceSize offset (0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
     }
     if (drawCount > 1 && ((stride & condition_multiples) || stride < sizeof(VkDrawMeshTasksIndirectCommandNV))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02146",
-                        "vkCmdDrawMeshTasksIndirectNV() parameter, uint32_t stride (0x%" PRIxLEAST32
-                        "), is not a multiple of 4 or smaller than sizeof (VkDrawMeshTasksIndirectCommandNV).",
-                        stride);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02146",
+                         "vkCmdDrawMeshTasksIndirectNV() parameter, uint32_t stride (0x%" PRIxLEAST32
+                         "), is not a multiple of 4 or smaller than sizeof (VkDrawMeshTasksIndirectCommandNV).",
+                         stride);
     }
     if (!physical_device_features.multiDrawIndirect && ((drawCount > 1))) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02718",
-                        "vkCmdDrawMeshTasksIndirectNV(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d",
-                        drawCount);
+        skip |= LogError(
+            commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02718",
+            "vkCmdDrawMeshTasksIndirectNV(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", drawCount);
     }
 
     return skip;
@@ -3503,19 +3292,17 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawMeshTasksIndirectCountNV(
     bool skip = false;
 
     if (offset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksIndirectCountNV-offset-02710",
-                        "vkCmdDrawMeshTasksIndirectCountNV() parameter, VkDeviceSize offset (0x%" PRIxLEAST64
-                        "), is not a multiple of 4.",
-                        offset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectCountNV-offset-02710",
+                         "vkCmdDrawMeshTasksIndirectCountNV() parameter, VkDeviceSize offset (0x%" PRIxLEAST64
+                         "), is not a multiple of 4.",
+                         offset);
     }
 
     if (countBufferOffset & 3) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBufferOffset-02716",
-                        "vkCmdDrawMeshTasksIndirectCountNV() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64
-                        "), is not a multiple of 4.",
-                        countBufferOffset);
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBufferOffset-02716",
+                         "vkCmdDrawMeshTasksIndirectCountNV() parameter, VkDeviceSize countBufferOffset (0x%" PRIxLEAST64
+                         "), is not a multiple of 4.",
+                         countBufferOffset);
     }
 
     return skip;
@@ -3532,11 +3319,10 @@ bool StatelessValidation::manual_PreCallValidateCreateQueryPool(VkDevice device,
         // VkQueryPipelineStatisticFlagBits values
         if ((pCreateInfo->queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS) && (pCreateInfo->pipelineStatistics != 0) &&
             ((pCreateInfo->pipelineStatistics & (~AllVkQueryPipelineStatisticFlagBits)) != 0)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkQueryPoolCreateInfo-queryType-00792",
-                            "vkCreateQueryPool(): if pCreateInfo->queryType is VK_QUERY_TYPE_PIPELINE_STATISTICS, "
-                            "pCreateInfo->pipelineStatistics must be a valid combination of VkQueryPipelineStatisticFlagBits "
-                            "values.");
+            skip |= LogError(device, "VUID-VkQueryPoolCreateInfo-queryType-00792",
+                             "vkCreateQueryPool(): if pCreateInfo->queryType is VK_QUERY_TYPE_PIPELINE_STATISTICS, "
+                             "pCreateInfo->pipelineStatistics must be a valid combination of VkQueryPipelineStatisticFlagBits "
+                             "values.");
         }
     }
     return skip;
@@ -3579,9 +3365,8 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
     if (pAllocateInfo) {
         auto chained_prio_struct = lvl_find_in_chain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext);
         if (chained_prio_struct && (chained_prio_struct->priority < 0.0f || chained_prio_struct->priority > 1.0f)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkMemoryPriorityAllocateInfoEXT-priority-02602",
-                            "priority (=%f) must be between `0` and `1`, inclusive.", chained_prio_struct->priority);
+            skip |= LogError(device, "VUID-VkMemoryPriorityAllocateInfoEXT-priority-02602",
+                             "priority (=%f) must be between `0` and `1`, inclusive.", chained_prio_struct->priority);
         }
 
         VkMemoryAllocateFlags flags = 0;
@@ -3593,10 +3378,9 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
         auto opaque_alloc_info = lvl_find_in_chain<VkMemoryOpaqueCaptureAddressAllocateInfoKHR>(pAllocateInfo->pNext);
         if (opaque_alloc_info && opaque_alloc_info->opaqueCaptureAddress != 0) {
             if (!(flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329",
-                                "If opaqueCaptureAddress is non-zero, VkMemoryAllocateFlagsInfo::flags must include "
-                                "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR.");
+                skip |= LogError(device, "VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329",
+                                 "If opaqueCaptureAddress is non-zero, VkMemoryAllocateFlagsInfo::flags must include "
+                                 "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR.");
             }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -3609,9 +3393,8 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
 #endif
 
             if (import_memory_host_pointer) {
-                skip |= log_msg(
-                    report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    "VUID-VkMemoryAllocateInfo-pNext-03332",
+                skip |= LogError(
+                    device, "VUID-VkMemoryAllocateInfo-pNext-03332",
                     "If the pNext chain includes a VkImportMemoryHostPointerInfoEXT structure, opaqueCaptureAddress must be zero.");
             }
             if (
@@ -3623,9 +3406,8 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
                 (import_memory_ahb && import_memory_ahb->buffer) ||
 #endif
                 (import_memory_host_pointer && import_memory_host_pointer->handleType)) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03333",
-                                "If the parameters define an import operation, opaqueCaptureAddress must be zero.");
+                skip |= LogError(device, "VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03333",
+                                 "If the parameters define an import operation, opaqueCaptureAddress must be zero.");
             }
         }
 
@@ -3645,15 +3427,13 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
                 }
             }
             if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR) && !capture_replay) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkMemoryAllocateInfo-flags-03330",
-                                "If VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR is set, "
-                                "bufferDeviceAddressCaptureReplay must be enabled.");
+                skip |= LogError(device, "VUID-VkMemoryAllocateInfo-flags-03330",
+                                 "If VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR is set, "
+                                 "bufferDeviceAddressCaptureReplay must be enabled.");
             }
             if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR) && !buffer_device_address) {
-                skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                "VUID-VkMemoryAllocateInfo-flags-03331",
-                                "If VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR is set, bufferDeviceAddress must be enabled.");
+                skip |= LogError(device, "VUID-VkMemoryAllocateInfo-flags-03331",
+                                 "If VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR is set, bufferDeviceAddress must be enabled.");
             }
         }
     }
@@ -3661,15 +3441,13 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
 }
 
 bool StatelessValidation::ValidateGeometryTrianglesNV(const VkGeometryTrianglesNV &triangles,
-                                                      VkDebugReportObjectTypeEXT object_type, uint64_t object_handle,
-                                                      const char *func_name) const {
+                                                      VkAccelerationStructureNV object_handle, const char *func_name) const {
     bool skip = false;
 
     if (triangles.vertexFormat != VK_FORMAT_R32G32B32_SFLOAT && triangles.vertexFormat != VK_FORMAT_R16G16B16_SFLOAT &&
         triangles.vertexFormat != VK_FORMAT_R16G16B16_SNORM && triangles.vertexFormat != VK_FORMAT_R32G32_SFLOAT &&
         triangles.vertexFormat != VK_FORMAT_R16G16_SFLOAT && triangles.vertexFormat != VK_FORMAT_R16G16_SNORM) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkGeometryTrianglesNV-vertexFormat-02430", "%s", func_name);
+        skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-vertexFormat-02430", "%s", func_name);
     } else {
         uint32_t vertex_component_size = 0;
         if (triangles.vertexFormat == VK_FORMAT_R32G32B32_SFLOAT || triangles.vertexFormat == VK_FORMAT_R32G32_SFLOAT) {
@@ -3679,15 +3457,13 @@ bool StatelessValidation::ValidateGeometryTrianglesNV(const VkGeometryTrianglesN
             vertex_component_size = 2;
         }
         if (vertex_component_size > 0 && SafeModulo(triangles.vertexOffset, vertex_component_size) != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                            "VUID-VkGeometryTrianglesNV-vertexOffset-02429", "%s", func_name);
+            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-vertexOffset-02429", "%s", func_name);
         }
     }
 
     if (triangles.indexType != VK_INDEX_TYPE_UINT32 && triangles.indexType != VK_INDEX_TYPE_UINT16 &&
         triangles.indexType != VK_INDEX_TYPE_NONE_NV) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkGeometryTrianglesNV-indexType-02433", "%s", func_name);
+        skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexType-02433", "%s", func_name);
     } else {
         uint32_t index_element_size = 0;
         if (triangles.indexType == VK_INDEX_TYPE_UINT32) {
@@ -3696,97 +3472,86 @@ bool StatelessValidation::ValidateGeometryTrianglesNV(const VkGeometryTrianglesN
             index_element_size = 2;
         }
         if (index_element_size > 0 && SafeModulo(triangles.indexOffset, index_element_size) != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                            "VUID-VkGeometryTrianglesNV-indexOffset-02432", "%s", func_name);
+            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexOffset-02432", "%s", func_name);
         }
     }
     if (triangles.indexType == VK_INDEX_TYPE_NONE_NV) {
         if (triangles.indexCount != 0) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                            "VUID-VkGeometryTrianglesNV-indexCount-02436", "%s", func_name);
+            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexCount-02436", "%s", func_name);
         }
         if (triangles.indexData != VK_NULL_HANDLE) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                            "VUID-VkGeometryTrianglesNV-indexData-02434", "%s", func_name);
+            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexData-02434", "%s", func_name);
         }
     }
 
     if (SafeModulo(triangles.transformOffset, 16) != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkGeometryTrianglesNV-transformOffset-02438", "%s", func_name);
+        skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-transformOffset-02438", "%s", func_name);
     }
 
     return skip;
 }
 
-bool StatelessValidation::ValidateGeometryAABBNV(const VkGeometryAABBNV &aabbs, VkDebugReportObjectTypeEXT object_type,
-                                                 uint64_t object_handle, const char *func_name) const {
+bool StatelessValidation::ValidateGeometryAABBNV(const VkGeometryAABBNV &aabbs, VkAccelerationStructureNV object_handle,
+                                                 const char *func_name) const {
     bool skip = false;
 
     if (SafeModulo(aabbs.offset, 8) != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkGeometryAABBNV-offset-02440", "%s", func_name);
+        skip |= LogError(object_handle, "VUID-VkGeometryAABBNV-offset-02440", "%s", func_name);
     }
     if (SafeModulo(aabbs.stride, 8) != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkGeometryAABBNV-stride-02441", "%s", func_name);
+        skip |= LogError(object_handle, "VUID-VkGeometryAABBNV-stride-02441", "%s", func_name);
     }
 
     return skip;
 }
 
-bool StatelessValidation::ValidateGeometryNV(const VkGeometryNV &geometry, VkDebugReportObjectTypeEXT object_type,
-                                             uint64_t object_handle, const char *func_name) const {
+bool StatelessValidation::ValidateGeometryNV(const VkGeometryNV &geometry, VkAccelerationStructureNV object_handle,
+                                             const char *func_name) const {
     bool skip = false;
     if (geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_NV) {
-        skip = ValidateGeometryTrianglesNV(geometry.geometry.triangles, object_type, object_handle, func_name);
+        skip = ValidateGeometryTrianglesNV(geometry.geometry.triangles, object_handle, func_name);
     } else if (geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_NV) {
-        skip = ValidateGeometryAABBNV(geometry.geometry.aabbs, object_type, object_handle, func_name);
+        skip = ValidateGeometryAABBNV(geometry.geometry.aabbs, object_handle, func_name);
     }
     return skip;
 }
 
 bool StatelessValidation::ValidateAccelerationStructureInfoNV(const VkAccelerationStructureInfoNV &info,
-                                                              VkDebugReportObjectTypeEXT object_type, uint64_t object_handle,
+                                                              VkAccelerationStructureNV object_handle,
                                                               const char *func_name) const {
     bool skip = false;
     if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV && info.geometryCount != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkAccelerationStructureInfoNV-type-02425",
-                        "VkAccelerationStructureInfoNV: If type is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV then "
-                        "geometryCount must be 0.");
+        skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-type-02425",
+                         "VkAccelerationStructureInfoNV: If type is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV then "
+                         "geometryCount must be 0.");
     }
     if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV && info.instanceCount != 0) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkAccelerationStructureInfoNV-type-02426",
-                        "VkAccelerationStructureInfoNV: If type is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV then "
-                        "instanceCount must be 0.");
+        skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-type-02426",
+                         "VkAccelerationStructureInfoNV: If type is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV then "
+                         "instanceCount must be 0.");
     }
     if (info.flags & VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_NV &&
         info.flags & VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_NV) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkAccelerationStructureInfoNV-flags-02592",
-                        "VkAccelerationStructureInfoNV: If flags has the VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_NV"
-                        "bit set, then it must not have the VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_NV bit set.");
+        skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-flags-02592",
+                         "VkAccelerationStructureInfoNV: If flags has the VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_NV"
+                         "bit set, then it must not have the VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT_NV bit set.");
     }
     if (info.geometryCount > phys_dev_ext_props.ray_tracing_props.maxGeometryCount) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkAccelerationStructureInfoNV-geometryCount-02422",
-                        "VkAccelerationStructureInfoNV: geometryCount must be less than or equal to "
-                        "VkPhysicalDeviceRayTracingPropertiesNV::maxGeometryCount.");
+        skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-geometryCount-02422",
+                         "VkAccelerationStructureInfoNV: geometryCount must be less than or equal to "
+                         "VkPhysicalDeviceRayTracingPropertiesNV::maxGeometryCount.");
     }
     if (info.instanceCount > phys_dev_ext_props.ray_tracing_props.maxInstanceCount) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                        "VUID-VkAccelerationStructureInfoNV-instanceCount-02423",
-                        "VkAccelerationStructureInfoNV: instanceCount must be less than or equal to "
-                        "VkPhysicalDeviceRayTracingPropertiesNV::maxInstanceCount.");
+        skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-instanceCount-02423",
+                         "VkAccelerationStructureInfoNV: instanceCount must be less than or equal to "
+                         "VkPhysicalDeviceRayTracingPropertiesNV::maxInstanceCount.");
     }
     if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV && info.geometryCount > 0) {
         uint64_t total_triangle_count = 0;
         for (uint32_t i = 0; i < info.geometryCount; i++) {
             const VkGeometryNV &geometry = info.pGeometries[i];
 
-            skip |= ValidateGeometryNV(geometry, object_type, object_handle, func_name);
+            skip |= ValidateGeometryNV(geometry, object_handle, func_name);
 
             if (geometry.geometryType != VK_GEOMETRY_TYPE_TRIANGLES_NV) {
                 continue;
@@ -3794,10 +3559,9 @@ bool StatelessValidation::ValidateAccelerationStructureInfoNV(const VkAccelerati
             total_triangle_count += geometry.geometry.triangles.indexCount / 3;
         }
         if (total_triangle_count > phys_dev_ext_props.ray_tracing_props.maxTriangleCount) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, object_type, object_handle,
-                            "VUID-VkAccelerationStructureInfoNV-maxTriangleCount-02424",
-                            "VkAccelerationStructureInfoNV: The total number of triangles in all geometries must be less than "
-                            "or equal to VkPhysicalDeviceRayTracingPropertiesNV::maxTriangleCount.");
+            skip |= LogError(object_handle, "VUID-VkAccelerationStructureInfoNV-maxTriangleCount-02424",
+                             "VkAccelerationStructureInfoNV: The total number of triangles in all geometries must be less than "
+                             "or equal to VkPhysicalDeviceRayTracingPropertiesNV::maxTriangleCount.");
         }
     }
     if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV && info.geometryCount > 1) {
@@ -3806,12 +3570,10 @@ bool StatelessValidation::ValidateAccelerationStructureInfoNV(const VkAccelerati
             const VkGeometryNV &geometry = info.pGeometries[i];
             if (geometry.geometryType != first_geometry_type) {
                 // TODO: update fake VUID below with the real one once it is generated.
-                skip |=
-                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT,
-                            0, "UNASSIGNED-VkAccelerationStructureInfoNV-pGeometries-XXXX",
-                            "VkAccelerationStructureInfoNV: info.pGeometries[%d].geometryType does not match "
-                            "info.pGeometries[0].geometryType.",
-                            i);
+                skip |= LogError(device, "UNASSIGNED-VkAccelerationStructureInfoNV-pGeometries-XXXX",
+                                 "VkAccelerationStructureInfoNV: info.pGeometries[%d].geometryType does not match "
+                                 "info.pGeometries[0].geometryType.",
+                                 i);
             }
         }
     }
@@ -3826,14 +3588,13 @@ bool StatelessValidation::manual_PreCallValidateCreateAccelerationStructureNV(
     if (pCreateInfo) {
         if ((pCreateInfo->compactedSize != 0) &&
             ((pCreateInfo->info.geometryCount != 0) || (pCreateInfo->info.instanceCount != 0))) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                            "VUID-VkAccelerationStructureCreateInfoNV-compactedSize-02421",
-                            "vkCreateAccelerationStructureNV(): pCreateInfo->compactedSize nonzero (%" PRIu64
-                            ") with info.geometryCount (%" PRIu32 ") or info.instanceCount (%" PRIu32 ") nonzero.",
-                            pCreateInfo->compactedSize, pCreateInfo->info.geometryCount, pCreateInfo->info.instanceCount);
+            skip |= LogError(device, "VUID-VkAccelerationStructureCreateInfoNV-compactedSize-02421",
+                             "vkCreateAccelerationStructureNV(): pCreateInfo->compactedSize nonzero (%" PRIu64
+                             ") with info.geometryCount (%" PRIu32 ") or info.instanceCount (%" PRIu32 ") nonzero.",
+                             pCreateInfo->compactedSize, pCreateInfo->info.geometryCount, pCreateInfo->info.instanceCount);
         }
 
-        skip |= ValidateAccelerationStructureInfoNV(pCreateInfo->info, VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT, 0,
+        skip |= ValidateAccelerationStructureInfoNV(pCreateInfo->info, VkAccelerationStructureNV(0),
                                                     "vkCreateAccelerationStructureNV()");
     }
 
@@ -3849,8 +3610,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructureNV(
     bool skip = false;
 
     if (pInfo != nullptr) {
-        skip |= ValidateAccelerationStructureInfoNV(*pInfo, VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT,
-                                                    HandleToUint64(dst), "vkCmdBuildAccelerationStructureNV()");
+        skip |= ValidateAccelerationStructureInfoNV(*pInfo, dst, "vkCmdBuildAccelerationStructureNV()");
     }
 
     return skip;
@@ -3861,9 +3621,8 @@ bool StatelessValidation::manual_PreCallValidateGetAccelerationStructureHandleNV
                                                                                  size_t dataSize, void *pData) const {
     bool skip = false;
     if (dataSize < 8) {
-        skip = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT,
-                       HandleToUint64(accelerationStructure), "VUID-vkGetAccelerationStructureHandleNV-dataSize-02240",
-                       "vkGetAccelerationStructureHandleNV(): dataSize must be greater than or equal to 8.");
+        skip = LogError(accelerationStructure, "VUID-vkGetAccelerationStructureHandleNV-dataSize-02240",
+                        "vkGetAccelerationStructureHandleNV(): dataSize must be greater than or equal to 8.");
     }
     return skip;
 }
@@ -3878,12 +3637,11 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesNV(VkDe
     for (uint32_t i = 0; i < createInfoCount; i++) {
         auto feedback_struct = lvl_find_in_chain<VkPipelineCreationFeedbackCreateInfoEXT>(pCreateInfos[i].pNext);
         if ((feedback_struct != nullptr) && (feedback_struct->pipelineStageCreationFeedbackCount != pCreateInfos[i].stageCount)) {
-            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_NULL_HANDLE,
-                            "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02670",
-                            "vkCreateRayTracingPipelinesNV(): in pCreateInfo[%" PRIu32
-                            "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount"
-                            "(=%" PRIu32 ") must equal VkRayTracingPipelineCreateInfoNV::stageCount(=%" PRIu32 ").",
-                            i, feedback_struct->pipelineStageCreationFeedbackCount, pCreateInfos[i].stageCount);
+            skip |= LogError(device, "VUID-VkPipelineCreationFeedbackCreateInfoEXT-pipelineStageCreationFeedbackCount-02670",
+                             "vkCreateRayTracingPipelinesNV(): in pCreateInfo[%" PRIu32
+                             "], VkPipelineCreationFeedbackEXT::pipelineStageCreationFeedbackCount"
+                             "(=%" PRIu32 ") must equal VkRayTracingPipelineCreateInfoNV::stageCount(=%" PRIu32 ").",
+                             i, feedback_struct->pipelineStageCreationFeedbackCount, pCreateInfos[i].stageCount);
         }
     }
 
@@ -3944,9 +3702,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetLineStippleEXT(VkCommandBu
     bool skip = false;
 
     if (lineStippleFactor < 1 || lineStippleFactor > 256) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdSetLineStippleEXT-lineStippleFactor-02776",
-                        "vkCmdSetLineStippleEXT::lineStippleFactor=%d is not in [1,256].", lineStippleFactor);
+        skip |= LogError(commandBuffer, "VUID-vkCmdSetLineStippleEXT-lineStippleFactor-02776",
+                         "vkCmdSetLineStippleEXT::lineStippleFactor=%d is not in [1,256].", lineStippleFactor);
     }
 
     return skip;
@@ -3957,16 +3714,14 @@ bool StatelessValidation::manual_PreCallValidateCmdBindIndexBuffer(VkCommandBuff
     bool skip = false;
 
     if (indexType == VK_INDEX_TYPE_NONE_NV) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdBindIndexBuffer-indexType-02507",
-                        "vkCmdBindIndexBuffer() indexType must not be VK_INDEX_TYPE_NONE_NV.");
+        skip |= LogError(commandBuffer, "VUID-vkCmdBindIndexBuffer-indexType-02507",
+                         "vkCmdBindIndexBuffer() indexType must not be VK_INDEX_TYPE_NONE_NV.");
     }
 
     const auto *index_type_uint8_features = lvl_find_in_chain<VkPhysicalDeviceIndexTypeUint8FeaturesEXT>(device_createinfo_pnext);
     if (indexType == VK_INDEX_TYPE_UINT8_EXT && !index_type_uint8_features->indexTypeUint8) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        HandleToUint64(commandBuffer), "VUID-vkCmdBindIndexBuffer-indexType-02765",
-                        "vkCmdBindIndexBuffer() indexType is VK_INDEX_TYPE_UINT8_EXT but indexTypeUint8 feature is not enabled.");
+        skip |= LogError(commandBuffer, "VUID-vkCmdBindIndexBuffer-indexType-02765",
+                         "vkCmdBindIndexBuffer() indexType is VK_INDEX_TYPE_UINT8_EXT but indexTypeUint8 feature is not enabled.");
     }
 
     return skip;
@@ -3976,9 +3731,8 @@ bool StatelessValidation::manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDev
                                                                            const VkDebugUtilsObjectNameInfoEXT *pNameInfo) const {
     bool skip = false;
     if (pNameInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device),
-                        "VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02589",
-                        "vkSetDebugUtilsObjectNameEXT() pNameInfo->objectType cannot be VK_OBJECT_TYPE_UNKNOWN.");
+        skip |= LogError(device, "VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02589",
+                         "vkSetDebugUtilsObjectNameEXT() pNameInfo->objectType cannot be VK_OBJECT_TYPE_UNKNOWN.");
     }
     return skip;
 }
@@ -3987,9 +3741,8 @@ bool StatelessValidation::manual_PreCallValidateSetDebugUtilsObjectTagEXT(VkDevi
                                                                           const VkDebugUtilsObjectTagInfoEXT *pTagInfo) const {
     bool skip = false;
     if (pTagInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device),
-                        "VUID-VkDebugUtilsObjectTagInfoEXT-objectType-01908",
-                        "vkSetDebugUtilsObjectTagEXT() pTagInfo->objectType cannot be VK_OBJECT_TYPE_UNKNOWN.");
+        skip |= LogError(device, "VUID-VkDebugUtilsObjectTagInfoEXT-objectType-01908",
+                         "vkSetDebugUtilsObjectTagEXT() pTagInfo->objectType cannot be VK_OBJECT_TYPE_UNKNOWN.");
     }
     return skip;
 }
@@ -4000,9 +3753,8 @@ bool StatelessValidation::manual_PreCallValidateAcquireNextImageKHR(VkDevice dev
     bool skip = false;
 
     if (semaphore == VK_NULL_HANDLE && fence == VK_NULL_HANDLE) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
-                        HandleToUint64(swapchain), "VUID-vkAcquireNextImageKHR-semaphore-01780",
-                        "vkAcquireNextImageKHR: semaphore and fence are both VK_NULL_HANDLE.");
+        skip |= LogError(swapchain, "VUID-vkAcquireNextImageKHR-semaphore-01780",
+                         "vkAcquireNextImageKHR: semaphore and fence are both VK_NULL_HANDLE.");
     }
 
     return skip;
@@ -4013,9 +3765,8 @@ bool StatelessValidation::manual_PreCallValidateAcquireNextImage2KHR(VkDevice de
     bool skip = false;
 
     if (pAcquireInfo->semaphore == VK_NULL_HANDLE && pAcquireInfo->fence == VK_NULL_HANDLE) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,
-                        HandleToUint64(pAcquireInfo->swapchain), "VUID-VkAcquireNextImageInfoKHR-semaphore-01782",
-                        "vkAcquireNextImage2KHR: pAcquireInfo->semaphore and pAcquireInfo->fence are both VK_NULL_HANDLE.");
+        skip |= LogError(pAcquireInfo->swapchain, "VUID-VkAcquireNextImageInfoKHR-semaphore-01782",
+                         "vkAcquireNextImage2KHR: pAcquireInfo->semaphore and pAcquireInfo->fence are both VK_NULL_HANDLE.");
     }
 
     return skip;
@@ -4028,9 +3779,8 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndirectByteCountEXT(VkCo
     bool skip = false;
 
     if ((vertexStride <= 0) || (vertexStride > phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride)) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, HandleToUint64(counterBuffer),
-            "VUID-vkCmdDrawIndirectByteCountEXT-vertexStride-02289",
+        skip |= LogError(
+            counterBuffer, "VUID-vkCmdDrawIndirectByteCountEXT-vertexStride-02289",
             "vkCmdDrawIndirectByteCountEXT: vertexStride (%d) must be between 0 and maxTransformFeedbackBufferDataStride (%d).",
             vertexStride, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride);
     }
@@ -4048,9 +3798,8 @@ bool StatelessValidation::ValidateCreateSamplerYcbcrConversion(VkDevice device,
     // Check samplerYcbcrConversion feature is set
     const auto *ycbcr_features = lvl_find_in_chain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(device_createinfo_pnext);
     if ((ycbcr_features == nullptr) || (ycbcr_features->samplerYcbcrConversion == VK_FALSE)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                        "VUID-vkCreateSamplerYcbcrConversion-None-01648", "samplerYcbcrConversion must be enabled to call %s.",
-                        apiName);
+        skip |= LogError(device, "VUID-vkCreateSamplerYcbcrConversion-None-01648",
+                         "samplerYcbcrConversion must be enabled to call %s.", apiName);
     }
     return skip;
 }
@@ -4077,12 +3826,11 @@ bool StatelessValidation::manual_PreCallValidateImportSemaphoreFdKHR(
         VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
 
     if (0 == (pImportSemaphoreFdInfo->handleType & supported_handle_types)) {
-        skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, 0,
-                        "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143",
-                        "vkImportSemaphoreFdKHR() to semaphore %s handleType %s is not one of the supported handleTypes (%s).",
-                        report_data->FormatHandle(pImportSemaphoreFdInfo->semaphore).c_str(),
-                        string_VkExternalSemaphoreHandleTypeFlagBits(pImportSemaphoreFdInfo->handleType),
-                        string_VkExternalSemaphoreHandleTypeFlags(supported_handle_types).c_str());
+        skip |= LogError(device, "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143",
+                         "vkImportSemaphoreFdKHR() to semaphore %s handleType %s is not one of the supported handleTypes (%s).",
+                         report_data->FormatHandle(pImportSemaphoreFdInfo->semaphore).c_str(),
+                         string_VkExternalSemaphoreHandleTypeFlagBits(pImportSemaphoreFdInfo->handleType),
+                         string_VkExternalSemaphoreHandleTypeFlags(supported_handle_types).c_str());
     }
     return skip;
 }

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
  * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2019 Google Inc.
+ * Copyright (C) 2015-2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -78,6 +78,13 @@ struct spirv_inst_iter {
     spirv_inst_iter const &operator*() const { return *this; }
 };
 
+struct shader_stage_attributes {
+    char const *const name;
+    bool arrayed_input;
+    bool arrayed_output;
+    VkShaderStageFlags stage;
+};
+
 struct decoration_set {
     enum {
         location_bit = 1 << 0,
@@ -318,8 +325,7 @@ std::unordered_set<uint32_t> MarkAccessibleIds(SHADER_MODULE_STATE const *src, s
 void ProcessExecutionModes(SHADER_MODULE_STATE const *src, const spirv_inst_iter &entrypoint, PIPELINE_STATE *pipeline);
 
 std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescriptorSlot(
-    debug_report_data const *report_data, SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids,
-    bool *has_writable_descriptor);
+    SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids, bool *has_writable_descriptor);
 
 uint32_t DescriptorTypeToReqs(SHADER_MODULE_STATE const *module, uint32_t type_id);
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4396,19 +4396,6 @@ void ValidationStateTracker::PostCallRecordAcquireProfilingLockKHR(VkDevice devi
     if (result == VK_SUCCESS) performance_lock_acquired = true;
 }
 
-bool ValidationStateTracker::PreCallValidateReleaseProfilingLockKHR(VkDevice device) const {
-    bool skip = false;
-
-    if (!performance_lock_acquired) {
-        skip |= log_msg(
-            report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, HandleToUint64(device),
-            "VUID-vkReleaseProfilingLockKHR-device-03235",
-            "The profiling lock of device must have been held via a previous successful call to vkAcquireProfilingLockKHR.");
-    }
-
-    return skip;
-}
-
 void ValidationStateTracker::PostCallRecordReleaseProfilingLockKHR(VkDevice device) {
     performance_lock_acquired = false;
     for (auto &cmd_buffer : commandBufferMap) {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4834,7 +4834,7 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
     ProcessExecutionModes(module, entrypoint, pipeline);
 
     stage_state->descriptor_uses =
-        CollectInterfaceByDescriptorSlot(report_data, module, stage_state->accessible_ids, &stage_state->has_writable_descriptor);
+        CollectInterfaceByDescriptorSlot(module, stage_state->accessible_ids, &stage_state->has_writable_descriptor);
     // Capture descriptor uses for the pipeline
     for (auto use : stage_state->descriptor_uses) {
         // While validating shaders capture which slots are used by the pipeline

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -780,7 +780,6 @@ class ValidationStateTracker : public ValidationObject {
     void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                      uint64_t timeout, VkResult result);
     void PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo, VkResult result);
-    bool PreCallValidateReleaseProfilingLockKHR(VkDevice device) const;
     void PostCallRecordReleaseProfilingLockKHR(VkDevice device);
 
     // Allocate/Free

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -595,8 +595,7 @@ static void InstanceExtensionWhitelist(ValidationObject *layer_data, const VkIns
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized instance extensions
         if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kInstanceExtensionNames)) {
-            log_msg(layer_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUIDUndefined,
+            layer_data->LogWarning(layer_data->instance, kVUIDUndefined,
                     "Instance Extension %s is not supported by this layer.  Using this extension may adversely affect validation "
                     "results and/or produce undefined behavior.",
                     pCreateInfo->ppEnabledExtensionNames[i]);
@@ -609,8 +608,7 @@ static void DeviceExtensionWhitelist(ValidationObject *layer_data, const VkDevic
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized device extensions
         if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceExtensionNames)) {
-            log_msg(layer_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                    kVUIDUndefined,
+            layer_data->LogWarning(layer_data->device, kVUIDUndefined,
                     "Device Extension %s is not supported by this layer.  Using this extension may adversely affect validation "
                     "results and/or produce undefined behavior.",
                     pCreateInfo->ppEnabledExtensionNames[i]);

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -392,9 +392,9 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             self.newline()
 
             ext_template  = 'bool StatelessValidation::OutputExtensionError(const std::string &api_name, const std::string &extension_name) const {\n'
-            ext_template += '    return log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,\n'
-            ext_template += '                   kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\\n",\n'
-            ext_template += '                   api_name.c_str(), extension_name.c_str());\n'
+            ext_template += '    return LogError(instance,\n'
+            ext_template += '                    kVUID_PVError_ExtensionNotEnabled, "Attemped to call %s() but its required extension %s has not been enabled\\n",\n'
+            ext_template += '                    api_name.c_str(), extension_name.c_str());\n'
             ext_template += '}\n'
             write(ext_template, file=self.outFile)
             self.newline()

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -272,7 +272,7 @@ public:
         if (iter != object_table.end()) {
             return std::move(iter->second);
         } else {
-            log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object), kVUID_Threading_Info,
+            object_data->LogError(object, kVUID_Threading_Info,
                     "Couldn't find %s Object 0x%" PRIxLEAST64
                     ". This should not happen and may indicate a bug in the application.",
                     object_string[objectType], (uint64_t)(object));
@@ -301,8 +301,7 @@ public:
                 assert(prevCount.GetWriteCount() != 0);
                 // There are no readers.  Two writers just collided.
                 if (use_data->thread != tid) {
-                    skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                        kVUID_Threading_MultipleThreads,
+                    skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                         "THREADING ERROR : object of type %s is simultaneously used in "
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);
@@ -322,8 +321,7 @@ public:
             } else {
                 // There are readers.  This writer collided with them.
                 if (use_data->thread != tid) {
-                    skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                        kVUID_Threading_MultipleThreads,
+                    skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                         "THREADING ERROR : object of type %s is simultaneously used in "
                         "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                         typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);
@@ -374,8 +372,7 @@ public:
             use_data->thread = tid;
         } else if (prevCount.GetWriteCount() > 0 && use_data->thread != tid) {
             // There is a writer of the object.
-            skip |= log_msg(object_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, objectType, (uint64_t)(object),
-                kVUID_Threading_MultipleThreads,
+            skip |= object_data->LogError(object, kVUID_Threading_MultipleThreads,
                 "THREADING ERROR : object of type %s is simultaneously used in "
                 "thread 0x%" PRIx64 " and thread 0x%" PRIx64,
                 typeName, (uint64_t)use_data->thread.load(std::memory_order_relaxed), (uint64_t)tid);


### PR DESCRIPTION
A big part of the move to moving away from dependencies on the VK_EXT_debug_report extension, which has been deprecated.  Eliminates about 1200 loc/160k bytes from the source tree.  Also fixed errors/inconsistencies discovered across the layers.

OLD:
```
 skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT,
                                HandleToUint64(dest_set), error_code, "%s failed write update validation for %s with error: %s.",
                                func_name, report_data->FormatHandle(dest_set).c_str(), error_str.c_str());
```
NEW:
```
                skip |= LogError(dest_set, error_code, "%s failed write update validation for %s with error: %s.", func_name,
                                 report_data->FormatHandle(dest_set).c_str(), error_str.c_str());
```