### PR TITLE
Fix duplicate header file entry

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -139,7 +139,6 @@ command_counter_sources = [
 ]
 
 chassis_sources = [
-  "layers/state_tracker.h",
   "layers/core_validation.h",
   "layers/generated/vk_safe_struct.h",
   "layers/generated/thread_safety.h",


### PR DESCRIPTION
layers/state_tracker.h is listed in both core_validation_sources and
chassis_sources and these two lists are then concatenated. This leads
to duplicate entries which then causes errors when loading gn generated
projects into Visual Studio. The error message is:

Cannot load project with duplicated project items:
    ... vulkan-validation-layers/src/layers/state_tracker.h is included
    as 'None' and as 'None' item types.

This was found while investigating crbug.com/1048779.

This fixes issue 1526.