### PR TITLE
Added support for 01973 and 01069

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2340,6 +2340,21 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
             }
         }
 
+        // Check for valid Lod range
+        if (pCreateInfo->minLod > pCreateInfo->maxLod) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkSamplerCreateInfo-maxLod-01973", "vkCreateSampler(): minLod (%f) is greater than maxLod (%f)",
+                            pCreateInfo->minLod, pCreateInfo->maxLod);
+        }
+
+        // Check mipLodBias to device limit
+        if (pCreateInfo->mipLodBias > limits.maxSamplerLodBias) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                            "VUID-VkSamplerCreateInfo-mipLodBias-01069",
+                            "vkCreateSampler(): mipLodBias (%f) is greater than VkPhysicalDeviceLimits::maxSamplerLodBias (%f)",
+                            pCreateInfo->mipLodBias, limits.maxSamplerLodBias);
+        }
+
         const auto *sampler_conversion = lvl_find_in_chain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
         if (sampler_conversion != nullptr) {
             if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -231,6 +231,27 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesEnabled) {
     sampler_info = sampler_info_ref;
 }
 
+TEST_F(VkLayerTest, InvalidSamplerCreateInfo) {
+    TEST_DESCRIPTION("Checks various cases where VkSamplerCreateInfo is invalid");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    // reference to reset values between test cases
+    VkSamplerCreateInfo const sampler_info_ref = SafeSaneSamplerCreateInfo();
+    VkSamplerCreateInfo sampler_info = sampler_info_ref;
+
+    // Mix up Lod values
+    sampler_info.minLod = 4.0f;
+    sampler_info.maxLod = 1.0f;
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-maxLod-01973");
+    sampler_info.minLod = sampler_info_ref.minLod;
+    sampler_info.maxLod = sampler_info_ref.maxLod;
+
+    // Larger mipLodBias than max limit
+    sampler_info.mipLodBias = NearestGreater(m_device->phy().properties().limits.maxSamplerLodBias);
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-mipLodBias-01069");
+    sampler_info.mipLodBias = sampler_info_ref.mipLodBias;
+}
+
 TEST_F(VkLayerTest, UpdateBufferAlignment) {
     TEST_DESCRIPTION("Check alignment parameters for vkCmdUpdateBuffer");
     uint32_t updateData[] = {1, 2, 3, 4, 5, 6, 7, 8};


### PR DESCRIPTION
VUID-VkSamplerCreateInfo-maxLod-01973

> maxLod must be greater than or equal to minLod

VUID-VkSamplerCreateInfo-mipLodBias-01069

> The absolute value of mipLodBias must be less than or equal to VkPhysicalDeviceLimits::maxSamplerLodBias