### PR TITLE
Added support for 01004 and 02652

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4781,6 +4781,14 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             }
         }
 
+        // Validate feature set if using CUBE_ARRAY
+        if ((view_type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (enabled_features.core.imageCubeArray == false)) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-viewType-01004",
+                            "vkCreateImageView(): pCreateInfo->viewType can't be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY without "
+                            "enabling the imageCubeArray feature.");
+        }
+
         // Validate correct image aspect bits for desired formats and format consistency
         skip |= ValidateImageAspectMask(image_state->image, image_format, aspect_mask, "vkCreateImageView()");
 
@@ -4889,6 +4897,13 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                             HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02277",
                             "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                             "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
+                            string_VkFormat(view_format), string_VkImageTiling(image_tiling));
+        } else if ((image_usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) &&
+                   !(tiling_features & (VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT))) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                            HandleToUint64(pCreateInfo->image), "VUID-VkImageViewCreateInfo-usage-02652",
+                            "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
+                            "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                             string_VkFormat(view_format), string_VkImageTiling(image_tiling));
         }
 


### PR DESCRIPTION
VUID-VkImageViewCreateInfo-viewType-01004

> If the image cubemap arrays feature is not enabled, viewType must not be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY

VUID-VkImageViewCreateInfo-usage-02652

> If usage contains VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, then the image view’s format features must contain at least one of VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.