### PR TITLE
Added support for 00317 and 00318

### DIFF
--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -291,6 +291,7 @@ class DescriptorSetLayout : public BASE_NODE {
 
         VkSampler const *GetImmutableSamplerPtr() const { return layout_->GetImmutableSamplerPtrFromIndex(index_); }
         const IndexRange &GetGlobalIndexRange() const { return layout_->GetGlobalIndexRangeFromIndex(index_); }
+        uint32_t GetIndex() const { return index_; }
         bool AtEnd() const { return index_ == layout_->GetBindingCount(); }
 
         // Return index into dynamic offset array for given binding


### PR DESCRIPTION
VUID-VkWriteDescriptorSet-descriptorCount-00317

> All consecutive bindings updated via a single VkWriteDescriptorSet structure, except those with a descriptorCount of zero, must have identical descriptorType and stageFlags.

VUID-VkWriteDescriptorSet-descriptorCount-00318

> All consecutive bindings updated via a single VkWriteDescriptorSet structure, except those with a descriptorCount of zero, must all either use immutable samplers or must all not use immutable samplers
---

Needed to remove 00321 tests duplicates that were testing what
00317 and 00318 should have been testing instead. There is still
00321 tests left.