### PR TITLE
Add validation support for VK_KHR_shader_non_semantic_info

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1746,6 +1746,13 @@ bool CoreChecks::ValidateShaderCapabilities(SHADER_MODULE_STATE const *src, VkSh
                         break;
                 }
             }
+        } else if (insn.opcode() == spv::OpExtension) {
+            std::string extension_name = (char const *)&insn.word(1);
+
+            if (extension_name == "SPV_KHR_non_semantic_info") {
+                skip |= RequireExtension(IsExtEnabled(device_extensions.vk_khr_shader_non_semantic_info),
+                                         VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+            }
         }
     }
 


### PR DESCRIPTION
I needed to update to the latest headers to get the extension in the auto-generated availability flags. I did my best to model what previous updates had done but I may have messed up (previous updates seemed to update the VulkanTools commit pointer but I couldn't figure out why or if it was a coincidence). I can either try and fix it, or else we can defer this PR until the update is done properly and I can rebase my PR to drop that commit.

I also added a couple of tests to make sure the validation worked in both directions (detecting problems and not complaining when it's fine), although they're fairly trivial.