### PR TITLE
Fix use of VkDisplayKHR objects in thread safety validation

### DIFF
--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -570,6 +570,32 @@ void ThreadSafety::PostCallRecordGetDeviceQueue2(
     device_queues_map[device].insert(*pQueue);
 }
 
+void ThreadSafety::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayPropertiesKHR*                     pProperties,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
+    if (pProperties) {
+        for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+            CreateObject(pProperties[i].display);
+        }
+    }
+}
+
+void ThreadSafety::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayProperties2KHR*                    pProperties,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
+    if (pProperties) {
+        for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+            CreateObject(pProperties[i].displayProperties.display);
+        }
+    }
+}
+
 
 
 void ThreadSafety::PreCallRecordCreateInstance(

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -546,7 +546,19 @@ WRAPPER_PARENT_INSTANCE(uint64_t)
             VkCommandPool pool = iter->second;
             c_VkCommandPoolContents.FinishRead(pool, api_name);
         }
-    } 
+    }
+
+void PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayPropertiesKHR*                     pProperties,
+    VkResult                                    result);
+
+void PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayProperties2KHR*                    pProperties,
+    VkResult                                    result);
 
 void PreCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -575,7 +575,19 @@ WRAPPER_PARENT_INSTANCE(uint64_t)
             VkCommandPool pool = iter->second;
             c_VkCommandPoolContents.FinishRead(pool, api_name);
         }
-    } """
+    }
+
+void PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayPropertiesKHR*                     pProperties,
+    VkResult                                    result);
+
+void PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayProperties2KHR*                    pProperties,
+    VkResult                                    result);"""
 
 
     inline_custom_source_preamble = """
@@ -1122,6 +1134,32 @@ void ThreadSafety::PostCallRecordGetDeviceQueue2(
     CreateObject(*pQueue);
     auto lock = write_lock_guard_t(thread_safety_lock);
     device_queues_map[device].insert(*pQueue);
+}
+
+void ThreadSafety::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayPropertiesKHR*                     pProperties,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
+    if (pProperties) {
+        for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+            CreateObject(pProperties[i].display);
+        }
+    }
+}
+
+void ThreadSafety::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkDisplayProperties2KHR*                    pProperties,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) && (result != VK_INCOMPLETE)) return;
+    if (pProperties) {
+        for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+            CreateObject(pProperties[i].displayProperties.display);
+        }
+    }
 }
 
 """

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -910,6 +910,42 @@ TEST_F(VkPositiveLayerTest, BasicQuery) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
 }
 
+TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayObjects) {
+    TEST_DESCRIPTION("Create and use VkDisplayKHR objects with GetPhysicalDeviceDisplayPropertiesKHR in thread-safety.");
+
+    bool mp_extensions =
+        InstanceExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME) && InstanceExtensionSupported(VK_KHR_DISPLAY_EXTENSION_NAME);
+    if (mp_extensions) {
+        m_instance_extension_names.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+        m_instance_extension_names.push_back(VK_KHR_DISPLAY_EXTENSION_NAME);
+    } else {
+        printf("%s test requires KHR SURFACE and DISPLAY extensions, not available.  Skipping.\n", kSkipPrefix);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetPhysicalDeviceDisplayPropertiesKHR vkGetPhysicalDeviceDisplayPropertiesKHR =
+        (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPropertiesKHR");
+    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
+        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceDisplayPropertiesKHR != nullptr);
+    ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
+
+    m_errorMonitor->ExpectSuccess();
+    uint32_t prop_count = 0;
+    vkGetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, nullptr);
+    if (prop_count != 0) {
+        VkDisplayPropertiesKHR display_props = {};
+        // Create a VkDisplayKHR object
+        vkGetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, &display_props);
+        // Now use this new object in an API call that thread safety will track
+        prop_count = 0;
+        vkGetDisplayModePropertiesKHR(gpu(), display_props.display, &prop_count, nullptr);
+    }
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkPositiveLayerTest, MultiplaneGetImageSubresourceLayout) {
     TEST_DESCRIPTION("Positive test, query layout of a single plane of a multiplane image. (repro Github #2530)");
 


### PR DESCRIPTION
These objects can be created through the `GetPhysicalDeviceDisplayProperties `APIs, so needed to special-case these for this validation object as pointed out by **amshafer** in the original issue.  Added a positive test as well.  

Fixes #1569. 