### PR TITLE
Best Practices: Add checks for command buffer handling

### DIFF
--- a/layers/best_practices.cpp
+++ b/layers/best_practices.cpp
@@ -432,6 +432,32 @@ bool BestPractices::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
     return skip;
 }
 
+bool BestPractices::PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool) const {
+    bool skip = false;
+
+    if (pCreateInfo->flags & VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT) {
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreateCommandPool_CommandBufferReset,
+            "vkCreateCommandPool(): VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT is set. Consider resetting entire "
+            "pool instead.");
+    }
+
+    return skip;
+}
+
+bool BestPractices::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer,
+                                                      const VkCommandBufferBeginInfo* pBeginInfo) const {
+    bool skip = false;
+
+    if (pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) {
+        skip |= LogPerformanceWarning(device, kVUID_BestPractices_BeginCommandBuffer_SimultaneousUse,
+                                      "vkBeginCommandBuffer(): VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT is set.");
+    }
+
+    return skip;
+}
+
 bool BestPractices::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const {
     bool skip = false;
 

--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -138,6 +138,8 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset) const;
     bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) const;
     bool PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) const;
+    bool PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                          const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool) const;
     bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) const;
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
@@ -150,6 +152,7 @@ class BestPractices : public ValidationStateTracker {
 
     bool CheckPipelineStageFlags(std::string api_name, const VkPipelineStageFlags flags) const;
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) const;
+    bool PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
     bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,

--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -68,5 +68,9 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_DrawState_VtxIndexOutOfBo
     "UNASSIGNED-BestPractices-DrawState-VtxIndexOutOfBounds";
 static const char DECORATE_UNUSED *kVUID_BestPractices_DrawState_ClearCmdBeforeDraw =
     "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateCommandPool_CommandBufferReset =
+    "UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset";
+static const char DECORATE_UNUSED *kVUID_BestPractices_BeginCommandBuffer_SimultaneousUse =
+    "UNASSIGNED-BestPractices-vkBeginCommandBuffer-simultaneous-use";
 
 #endif

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -232,3 +232,41 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
 
     m_errorMonitor->VerifyNotFound();
 }
+
+TEST_F(VkBestPracticesLayerTest, CommandBufferReset) {
+    TEST_DESCRIPTION("Test for validating usage of vkCreateCommandPool with COMMAND_BUFFER_RESET_BIT");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset");
+
+    VkCommandPool command_pool;
+    VkCommandPoolCreateInfo pool_create_info{};
+    pool_create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
+    pool_create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    vk::CreateCommandPool(m_device->device(), &pool_create_info, nullptr, &command_pool);
+
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkBestPracticesLayerTest, SimultaneousUse) {
+    TEST_DESCRIPTION("Test for validating usage of vkBeginCommandBuffer with SIMULTANEOUS_USE");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkBeginCommandBuffer-simultaneous-use");
+
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-ArmBestPractices-vkBeginCommandBuffer-one-time-submit");
+
+    VkCommandBufferBeginInfo cmd_begin_info{};
+    cmd_begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    cmd_begin_info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
+    vk::BeginCommandBuffer(m_commandBuffer->handle(), &cmd_begin_info);
+
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Added checks for:
 - Command pool creation with the RESET_COMMAND_BUFFER bit
 - Simultaneous use of command buffers

This corresponds to checks 1-2 from [PerfDoc](https://github.com/ARM-software/perfdoc).

