### PR TITLE
Best Practices: Added checks for attachments and vertex buffers

### DIFF
--- a/layers/best_practices.h
+++ b/layers/best_practices.h
@@ -25,6 +25,9 @@
 
 static const uint32_t kMemoryObjectWarningLimit = 250;
 
+// Maximum number of instanced vertex buffers which should be used
+static const uint32_t kMaxInstancedVertexBuffers = 1;
+
 // Recommended allocation size for vkAllocateMemory
 static const VkDeviceSize kMinDeviceAllocationSize = 256 * 1024;
 
@@ -133,6 +136,8 @@ class BestPractices : public ValidationStateTracker {
                                                   const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains) const;
     bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const;
+    bool PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                          const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer) const;
     bool PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory) const;
     void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,

--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -78,5 +78,15 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SmallDedicatedAllocation 
     "UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation";
 static const char DECORATE_UNUSED *kVUID_BestPractices_NonLazyTransientImage =
     "UNASSIGNED-BestPractices-vkBindImageMemory-non-lazy-transient-image";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateRenderPass_ImageRequiresMemory =
+    "UNASSIGNED-BestPractices-vkCreateRenderPass-image-requires-memory";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateFramebuffer_AttachmentShouldBeTransient =
+    "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-be-transient";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateFramebuffer_AttachmentShouldNotBeTransient =
+    "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreatePipelines_TooManyInstancedVertexBuffers =
+    "UNASSIGNED-BestPractices-vkCreateGraphicsPipelines-too-many-instanced-vertex-buffers";
+static const char DECORATE_UNUSED *kVUID_BestPractices_ClearAttachments_ClearAfterLoad =
+    "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load";
 
 #endif


### PR DESCRIPTION
Added checks for:

 - Store ops for potentially transient images
 - Framebuffer attachments that should/should not be transient
 - Clearing attachments after load
 - Many instanced vertex buffers in a pipeline

This corresponds to checks 8, 10-11, 14 and 32 from [PerfDoc](https://github.com/ARM-software/perfdoc).