### PR TITLE
threading: Remove use of debug report defs

### DIFF
--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -125,7 +125,7 @@ template <typename T>
 class counter {
 public:
     const char *typeName;
-    VkDebugReportObjectTypeEXT objectType;
+    VulkanObjectType object_type;
     ValidationObject *object_data;
 
     vl_concurrent_unordered_map<T, std::shared_ptr<ObjectUseData>, 6> object_table;
@@ -149,7 +149,7 @@ public:
             object_data->LogError(object, kVUID_Threading_Info,
                     "Couldn't find %s Object 0x%" PRIxLEAST64
                     ". This should not happen and may indicate a bug in the application.",
-                    object_string[objectType], (uint64_t)(object));
+                    object_string[object_type], (uint64_t)(object));
             return nullptr;
         }
     }
@@ -270,9 +270,9 @@ public:
         }
         use_data->RemoveReader();
     }
-    counter(const char *name = "", VkDebugReportObjectTypeEXT type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, ValidationObject *val_obj = nullptr) {
+    counter(const char *name = "", VulkanObjectType type = kVulkanObjectTypeUnknown, ValidationObject *val_obj = nullptr) {
             typeName = name;
-        objectType = type;
+        object_type = type;
         object_data = val_obj;
     }
 
@@ -368,50 +368,50 @@ public:
 
     ThreadSafety(ThreadSafety *parent)
         : parent_instance(parent),
-          c_VkCommandBuffer("VkCommandBuffer", VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, this),
-          c_VkDevice("VkDevice", VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, this),
-          c_VkInstance("VkInstance", VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, this),
-          c_VkQueue("VkQueue", VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, this),
-          c_VkCommandPoolContents("VkCommandPool", VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT, this),
+          c_VkCommandBuffer("VkCommandBuffer", kVulkanObjectTypeCommandBuffer, this),
+          c_VkDevice("VkDevice", kVulkanObjectTypeDevice, this),
+          c_VkInstance("VkInstance", kVulkanObjectTypeInstance, this),
+          c_VkQueue("VkQueue", kVulkanObjectTypeQueue, this),
+          c_VkCommandPoolContents("VkCommandPool", kVulkanObjectTypeCommandPool, this),
 
 #ifdef DISTINCT_NONDISPATCHABLE_HANDLES
-          c_VkAccelerationStructureNV("VkAccelerationStructureNV", VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT, this),
-          c_VkBuffer("VkBuffer", VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, this),
-          c_VkBufferView("VkBufferView", VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT, this),
-          c_VkCommandPool("VkCommandPool", VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT, this),
-          c_VkDebugReportCallbackEXT("VkDebugReportCallbackEXT", VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT, this),
-          c_VkDebugUtilsMessengerEXT("VkDebugUtilsMessengerEXT", VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, this),
-          c_VkDescriptorPool("VkDescriptorPool", VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, this),
-          c_VkDescriptorSet("VkDescriptorSet", VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, this),
-          c_VkDescriptorSetLayout("VkDescriptorSetLayout", VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, this),
-          c_VkDescriptorUpdateTemplate("VkDescriptorUpdateTemplate", VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT, this),
-          c_VkDeviceMemory("VkDeviceMemory", VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT, this),
-          c_VkDisplayKHR("VkDisplayKHR", VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT, this),
-          c_VkDisplayModeKHR("VkDisplayModeKHR", VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT, this),
-          c_VkEvent("VkEvent", VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT, this),
-          c_VkFence("VkFence", VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, this),
-          c_VkFramebuffer("VkFramebuffer", VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, this),
-          c_VkImage("VkImage", VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, this),
-          c_VkImageView("VkImageView", VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, this),
-          c_VkIndirectCommandsLayoutNVX("VkIndirectCommandsLayoutNVX", VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT, this),
-          c_VkObjectTableNVX("VkObjectTableNVX", VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT, this),
-          c_VkPerformanceConfigurationINTEL("VkPerformanceConfigurationINTEL", VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, this),
-          c_VkPipeline("VkPipeline", VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, this),
-          c_VkPipelineCache("VkPipelineCache", VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT, this),
-          c_VkPipelineLayout("VkPipelineLayout", VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, this),
-          c_VkQueryPool("VkQueryPool", VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT, this),
-          c_VkRenderPass("VkRenderPass", VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, this),
-          c_VkSampler("VkSampler", VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, this),
-          c_VkSamplerYcbcrConversion("VkSamplerYcbcrConversion", VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT, this),
-          c_VkSemaphore("VkSemaphore", VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, this),
-          c_VkShaderModule("VkShaderModule", VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, this),
-          c_VkSurfaceKHR("VkSurfaceKHR", VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT, this),
-          c_VkSwapchainKHR("VkSwapchainKHR", VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, this),
-          c_VkValidationCacheEXT("VkValidationCacheEXT", VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT, this)
+          c_VkAccelerationStructureNV("VkAccelerationStructureNV", kVulkanObjectTypeAccelerationStructureNV, this),
+          c_VkBuffer("VkBuffer", kVulkanObjectTypeBuffer, this),
+          c_VkBufferView("VkBufferView", kVulkanObjectTypeBufferView, this),
+          c_VkCommandPool("VkCommandPool", kVulkanObjectTypeCommandPool, this),
+          c_VkDebugReportCallbackEXT("VkDebugReportCallbackEXT", kVulkanObjectTypeDebugReportCallbackEXT, this),
+          c_VkDebugUtilsMessengerEXT("VkDebugUtilsMessengerEXT", kVulkanObjectTypeDebugUtilsMessengerEXT, this),
+          c_VkDescriptorPool("VkDescriptorPool", kVulkanObjectTypeDescriptorPool, this),
+          c_VkDescriptorSet("VkDescriptorSet", kVulkanObjectTypeDescriptorSet, this),
+          c_VkDescriptorSetLayout("VkDescriptorSetLayout", kVulkanObjectTypeDescriptorSetLayout, this),
+          c_VkDescriptorUpdateTemplate("VkDescriptorUpdateTemplate", kVulkanObjectTypeDescriptorUpdateTemplate, this),
+          c_VkDeviceMemory("VkDeviceMemory", kVulkanObjectTypeDeviceMemory, this),
+          c_VkDisplayKHR("VkDisplayKHR", kVulkanObjectTypeDisplayKHR, this),
+          c_VkDisplayModeKHR("VkDisplayModeKHR", kVulkanObjectTypeDisplayModeKHR, this),
+          c_VkEvent("VkEvent", kVulkanObjectTypeEvent, this),
+          c_VkFence("VkFence", kVulkanObjectTypeFence, this),
+          c_VkFramebuffer("VkFramebuffer", kVulkanObjectTypeFramebuffer, this),
+          c_VkImage("VkImage", kVulkanObjectTypeImage, this),
+          c_VkImageView("VkImageView", kVulkanObjectTypeImageView, this),
+          c_VkIndirectCommandsLayoutNVX("VkIndirectCommandsLayoutNVX", kVulkanObjectTypeIndirectCommandsLayoutNVX, this),
+          c_VkObjectTableNVX("VkObjectTableNVX", kVulkanObjectTypeObjectTableNVX, this),
+          c_VkPerformanceConfigurationINTEL("VkPerformanceConfigurationINTEL", kVulkanObjectTypePerformanceConfigurationINTEL, this),
+          c_VkPipeline("VkPipeline", kVulkanObjectTypePipeline, this),
+          c_VkPipelineCache("VkPipelineCache", kVulkanObjectTypePipelineCache, this),
+          c_VkPipelineLayout("VkPipelineLayout", kVulkanObjectTypePipelineLayout, this),
+          c_VkQueryPool("VkQueryPool", kVulkanObjectTypeQueryPool, this),
+          c_VkRenderPass("VkRenderPass", kVulkanObjectTypeRenderPass, this),
+          c_VkSampler("VkSampler", kVulkanObjectTypeSampler, this),
+          c_VkSamplerYcbcrConversion("VkSamplerYcbcrConversion", kVulkanObjectTypeSamplerYcbcrConversion, this),
+          c_VkSemaphore("VkSemaphore", kVulkanObjectTypeSemaphore, this),
+          c_VkShaderModule("VkShaderModule", kVulkanObjectTypeShaderModule, this),
+          c_VkSurfaceKHR("VkSurfaceKHR", kVulkanObjectTypeSurfaceKHR, this),
+          c_VkSwapchainKHR("VkSwapchainKHR", kVulkanObjectTypeSwapchainKHR, this),
+          c_VkValidationCacheEXT("VkValidationCacheEXT", kVulkanObjectTypeValidationCacheEXT, this)
 
 
 #else   // DISTINCT_NONDISPATCHABLE_HANDLES
-          c_uint64_t("NON_DISPATCHABLE_HANDLE", VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, this)
+          c_uint64_t("NON_DISPATCHABLE_HANDLE", kVulkanObjectTypeUnknown, this)
 #endif  // DISTINCT_NONDISPATCHABLE_HANDLES
               {};
 


### PR DESCRIPTION
Thread checker used obsolete debug-report enums for object identifiers -- updated to use VulkanObjectTypes instead.  This gives additional information for Vulkan objects defined after the debug report extension was released.
