### PR TITLE
layers: Label VUID 00337, 00338, 00339

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1502,12 +1502,14 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
         case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
             if (!(usage & VK_IMAGE_USAGE_SAMPLED_BIT)) {
                 error_usage_bit = "VK_IMAGE_USAGE_SAMPLED_BIT";
+                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00337";
             }
             break;
         }
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
             if (!(usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
                 error_usage_bit = "VK_IMAGE_USAGE_STORAGE_BIT";
+                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00339";
             } else if (VK_IMAGE_LAYOUT_GENERAL != image_layout) {
                 std::stringstream error_str;
                 // TODO : Need to create custom enum error codes for these cases
@@ -1538,6 +1540,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
         case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
             if (!(usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
                 error_usage_bit = "VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT";
+                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-00338";
             }
             break;
         }

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -5899,16 +5899,16 @@ TEST_F(VkLayerTest, DSUsageBitsErrors) {
     // These error messages align with VkDescriptorType struct
     std::string error_codes[] = {
         "UNASSIGNED-CoreValidation-DrawState-InvalidImageView",  // placeholder, no error for SAMPLER descriptor
-        "UNASSIGNED-CoreValidation-DrawState-InvalidImageView",  // COMBINED_IMAGE_SAMPLER
-        "UNASSIGNED-CoreValidation-DrawState-InvalidImageView",  // SAMPLED_IMAGE
-        "UNASSIGNED-CoreValidation-DrawState-InvalidImageView",  // STORAGE_IMAGE
+        "VUID-VkWriteDescriptorSet-descriptorType-00337",        // COMBINED_IMAGE_SAMPLER
+        "VUID-VkWriteDescriptorSet-descriptorType-00337",        // SAMPLED_IMAGE
+        "VUID-VkWriteDescriptorSet-descriptorType-00339",        // STORAGE_IMAGE
         "VUID-VkWriteDescriptorSet-descriptorType-00334",        // UNIFORM_TEXEL_BUFFER
         "VUID-VkWriteDescriptorSet-descriptorType-00335",        // STORAGE_TEXEL_BUFFER
         "VUID-VkWriteDescriptorSet-descriptorType-00330",        // UNIFORM_BUFFER
         "VUID-VkWriteDescriptorSet-descriptorType-00331",        // STORAGE_BUFFER
         "VUID-VkWriteDescriptorSet-descriptorType-00330",        // UNIFORM_BUFFER_DYNAMIC
         "VUID-VkWriteDescriptorSet-descriptorType-00331",        // STORAGE_BUFFER_DYNAMIC
-        "UNASSIGNED-CoreValidation-DrawState-InvalidImageView"   // INPUT_ATTACHMENT
+        "VUID-VkWriteDescriptorSet-descriptorType-00338"         // INPUT_ATTACHMENT
     };
     // Start loop at 1 as SAMPLER desc type has no usage bit error
     for (uint32_t i = 1; i < kLocalDescriptorTypeRangeSize; ++i) {


### PR DESCRIPTION
Removes `UNASSIGNED-CoreValidation-DrawState-InvalidImageView` with the actual VUID from spec 