### PR TITLE
build: export build commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ve
 
 project(Vulkan-ValidationLayers)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 enable_testing()
 
 # User-interface declarations ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Generate compile_commands.json, which can be used by different external
tools for different purposes (e.g., Emacs + LSP).

Change-Id: I7386063bee373a40bf0870c119e40b955dbaa39f