### PR TITLE
scripts: Add aliased types to handle_types

### DIFF
--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -85,6 +85,25 @@ def GetHandleTypes(tree):
         if not elem.get('alias'):
             name = elem.get('name')
             handles[name] = elem.find('type').text
+
+    for elem in tree.findall("types/type/[@category='handle']"):
+        if elem.get('alias'):
+            name = elem.get('name')
+            # Get the dispatchable/non-dispatchable type from the alias
+            handles[name] = handles[elem.get('alias')]
+
+    return handles
+
+# Return a dict indicating whether a handle is an aliased type
+def GetHandleAliased(tree):
+    handles = OrderedDict()
+    for elem in tree.findall("types/type/[@category='handle']"):
+        name = elem.get('name')
+        if elem.get('alias'):
+            handles[name] = True
+        else:
+            handles[name] = False
+
     return handles
 
 # Return a dict containing the parent of every handle

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -313,7 +313,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             if objtype == 'device':
                 output_func += '    skip |= ReportLeaked%sObjects(%s, kVulkanObjectTypeCommandBuffer, error_code);\n' % (upper_objtype, objtype)
             for handle in self.object_types:
-                if self.handle_types.IsNonDispatchable(handle):
+                if self.handle_types.IsNonDispatchable(handle) and not self.is_aliased_type[handle]:
                     if (objtype == 'device' and self.handle_parents.IsParentDevice(handle)) or (objtype == 'instance' and not self.handle_parents.IsParentDevice(handle)):
                         output_func += '    skip |= ReportLeaked%sObjects(%s, %s, error_code);\n' % (upper_objtype, objtype, self.GetVulkanObjType(handle))
             output_func += '    return skip;\n'
@@ -330,7 +330,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             if objtype == 'device':
                 output_func += '    DestroyUndestroyedObjects(kVulkanObjectTypeCommandBuffer);\n'
             for handle in self.object_types:
-                if self.handle_types.IsNonDispatchable(handle):
+                if self.handle_types.IsNonDispatchable(handle) and not self.is_aliased_type[handle]:
                     if (objtype == 'device' and self.handle_parents.IsParentDevice(handle)) or (objtype == 'instance' and not self.handle_parents.IsParentDevice(handle)):
                         output_func += '    DestroyUndestroyedObjects(%s);\n' % self.GetVulkanObjType(handle)
             output_func += '}\n'
@@ -368,6 +368,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         self.handle_types = GetHandleTypes(self.registry.tree)
         self.handle_parents = GetHandleParents(self.registry.tree)
         self.type_categories = GetTypeCategories(self.registry.tree)
+        self.is_aliased_type = GetHandleAliased(self.registry.tree)
 
         header_file = (genOpts.filename == 'object_tracker.h')
         source_file = (genOpts.filename == 'object_tracker.cpp')


### PR DESCRIPTION
Aliased handle types are still handle types and belong in this
dictionary. Add another dictionary to tell whether a type is an
alias, and use that to skip some redundant codegen for aliases.

There should be no effect on the generated files with the current XML.
