### PR TITLE
Add support for VUID 00968

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -724,6 +724,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 }
             }
         }
+
+        if ((!physical_device_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
+            (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
+            skip |= LogError(device, "VUID-VkImageCreateInfo-usage-00968",
+                             "vkCreateImage(): usage contains VK_IMAGE_USAGE_STORAGE_BIT and the multisampled storage images "
+                             "feature is not enabled, image samples must be VK_SAMPLE_COUNT_1_BIT");
+        }
     }
 
     return skip;

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6655,6 +6655,16 @@ TEST_F(VkLayerTest, CreateImageMiscErrors) {
         image_ci.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-initialLayout-00993");
     }
+
+    // Storage usage can't be multisample if feature not set
+    {
+        // Feature should not have been set for these tests
+        ASSERT_TRUE(features.shaderStorageImageMultisample == VK_FALSE);
+        VkImageCreateInfo image_ci = safe_image_ci;
+        image_ci.usage = VK_IMAGE_USAGE_STORAGE_BIT;
+        image_ci.samples = VK_SAMPLE_COUNT_2_BIT;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00968");
+    }
 }
 
 TEST_F(VkLayerTest, CreateImageMinLimitsViolation) {


### PR DESCRIPTION
VUID-VkImageCreateInfo-usage-00968

> If the multisampled storage images feature is not enabled, and usage contains VK_IMAGE_USAGE_STORAGE_BIT, samples must be VK_SAMPLE_COUNT_1_BIT