### PR TITLE
Add support for VUID 01188

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6199,6 +6199,11 @@ bool CoreChecks::ValidateBarriers(const char *funcName, const CMD_BUFFER_STATE *
                                  funcName, report_data->FormatHandle(mem_barrier.buffer).c_str(),
                                  HandleToUint64(mem_barrier.offset), HandleToUint64(mem_barrier.size), HandleToUint64(buffer_size));
             }
+            if (mem_barrier.size == 0) {
+                skip |= LogError(cb_state->commandBuffer, "VUID-VkBufferMemoryBarrier-size-01188",
+                                 "%s: Buffer Barrier %s has a size of 0.", funcName,
+                                 report_data->FormatHandle(mem_barrier.buffer).c_str());
+            }
         }
     }
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4252,6 +4252,10 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     // Size greater than total size
     conc_test("", "VUID-VkBufferMemoryBarrier-size-01189");
 
+    conc_test.buffer_barrier_.size = 0;
+    // Size is zero
+    conc_test("", "VUID-VkBufferMemoryBarrier-size-01188");
+
     conc_test.buffer_barrier_.size = VK_WHOLE_SIZE;
 
     // Now exercise barrier aspect bit errors, first DS


### PR DESCRIPTION
VUID-VkBufferMemoryBarrier-size-01188

> If size is not equal to VK_WHOLE_SIZE, size must be greater than 0