### PR TITLE
Add support for VUID 01762

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4522,12 +4522,16 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             }
         } else {
             // Format MUST be IDENTICAL to the format the image was created with
-            if (image_format != view_format) {
+            // Unless it is a multi-planar color bit aspect
+            if ((image_format != view_format) &&
+                ((FormatIsMultiplane(image_format) == false) || (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT))) {
+                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-VkImageViewCreateInfo-image-01762"
+                                                                                       : "VUID-VkImageViewCreateInfo-image-01019";
                 std::stringstream ss;
                 ss << "vkCreateImageView() format " << string_VkFormat(view_format) << " differs from "
                    << report_data->FormatHandle(pCreateInfo->image).c_str() << " format " << string_VkFormat(image_format)
                    << ".  Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT BIT was set on image creation.";
-                skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01019", "%s", ss.str().c_str());
+                skip |= LogError(pCreateInfo->image, vuid, "%s", ss.str().c_str());
             }
         }
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4486,7 +4486,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ivci.format = VK_FORMAT_R5G6B5_UNORM_PACK16;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02399");
     // Also causes "view format different from image format"
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-01019");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-01762");
     vk::CreateImageView(dev, &ivci, NULL, &image_view);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
VUID-VkImageViewCreateInfo-image-01762

Note: There were 2 tests for `VUID-VkImageViewCreateInfo-image-01019` and only 1 was changed so now both VUID are covered in tests