### PR TITLE
Add support for VUID 02801

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7701,8 +7701,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                                 function_name);
 
                 if (attachment_ref.aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) {
-                    vuid =
-                        use_rp2 ? kVUID_Core_DrawState_InvalidRenderpass : "VUID-VkInputAttachmentAspectReference-aspectMask-01964";
+                    vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-02801"
+                                   : "VUID-VkInputAttachmentAspectReference-aspectMask-01964";
                     skip |= LogError(
                         device, vuid,
                         "%s: Aspect mask for input attachment reference %d in subpass %d includes VK_IMAGE_ASPECT_METADATA_BIT.",

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -2898,6 +2898,10 @@ TEST_F(VkLayerTest, RenderPassCreate2SubpassInvalidInputAttachmentParameters) {
     // Test for invalid aspect mask bits
     reference.aspectMask = 0x40000000;  // invalid VkImageAspectFlagBits value
     TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), &rpci2, "VUID-VkSubpassDescription2-attachment-02799");
+
+    // Test for invalid use of VK_IMAGE_ASPECT_METADATA_BIT
+    reference.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
+    TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), &rpci2, "VUID-VkSubpassDescription2-attachment-02801");
 }
 
 TEST_F(VkLayerTest, RenderPassCreateInvalidSubpassDependencies) {


### PR DESCRIPTION
VUID-VkSubpassDescription2-attachment-02801

> If the attachment member of any element of pInputAttachments is not VK_ATTACHMENT_UNUSED, then the aspectMask member must not include VK_IMAGE_ASPECT_METADATA_BIT