### PR TITLE
Add support for Descriptor Indexing Duplicate VUID

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4126,7 +4126,7 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
         phys_dev_ext_props.inline_uniform_block_props.maxPerStageDescriptorInlineUniformBlocks) {
         const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
                                                                           : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02212";
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214",
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): max per-stage inline uniform block bindings count (%d) exceeds device "
                          "maxPerStageDescriptorInlineUniformBlocks limit (%d).",
                          max_descriptors_per_stage[DSL_TYPE_INLINE_UNIFORM_BLOCK],

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4058,7 +4058,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     std::valarray<uint32_t> max_descriptors_per_stage = GetDescriptorCountMaxPerStage(&enabled_features, set_layouts, true);
     // Samplers
     if (max_descriptors_per_stage[DSL_TYPE_SAMPLERS] > phys_dev_props.limits.maxPerStageDescriptorSamplers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00287",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03016"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00287";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): max per-stage sampler bindings count (%d) exceeds device "
                          "maxPerStageDescriptorSamplers limit (%d).",
                          max_descriptors_per_stage[DSL_TYPE_SAMPLERS], phys_dev_props.limits.maxPerStageDescriptorSamplers);
@@ -4066,7 +4068,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Uniform buffers
     if (max_descriptors_per_stage[DSL_TYPE_UNIFORM_BUFFERS] > phys_dev_props.limits.maxPerStageDescriptorUniformBuffers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00288",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03017"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00288";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): max per-stage uniform buffer bindings count (%d) exceeds device "
                          "maxPerStageDescriptorUniformBuffers limit (%d).",
                          max_descriptors_per_stage[DSL_TYPE_UNIFORM_BUFFERS],
@@ -4075,7 +4079,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Storage buffers
     if (max_descriptors_per_stage[DSL_TYPE_STORAGE_BUFFERS] > phys_dev_props.limits.maxPerStageDescriptorStorageBuffers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00289",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03018"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00289";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): max per-stage storage buffer bindings count (%d) exceeds device "
                          "maxPerStageDescriptorStorageBuffers limit (%d).",
                          max_descriptors_per_stage[DSL_TYPE_STORAGE_BUFFERS],
@@ -4084,8 +4090,10 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Sampled images
     if (max_descriptors_per_stage[DSL_TYPE_SAMPLED_IMAGES] > phys_dev_props.limits.maxPerStageDescriptorSampledImages) {
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03019"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290";
         skip |=
-            LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00290",
+            LogError(device, vuid,
                      "vkCreatePipelineLayout(): max per-stage sampled image bindings count (%d) exceeds device "
                      "maxPerStageDescriptorSampledImages limit (%d).",
                      max_descriptors_per_stage[DSL_TYPE_SAMPLED_IMAGES], phys_dev_props.limits.maxPerStageDescriptorSampledImages);
@@ -4093,8 +4101,10 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Storage images
     if (max_descriptors_per_stage[DSL_TYPE_STORAGE_IMAGES] > phys_dev_props.limits.maxPerStageDescriptorStorageImages) {
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03020"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00291";
         skip |=
-            LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00291",
+            LogError(device, vuid,
                      "vkCreatePipelineLayout(): max per-stage storage image bindings count (%d) exceeds device "
                      "maxPerStageDescriptorStorageImages limit (%d).",
                      max_descriptors_per_stage[DSL_TYPE_STORAGE_IMAGES], phys_dev_props.limits.maxPerStageDescriptorStorageImages);
@@ -4102,7 +4112,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Input attachments
     if (max_descriptors_per_stage[DSL_TYPE_INPUT_ATTACHMENTS] > phys_dev_props.limits.maxPerStageDescriptorInputAttachments) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01676",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03021"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01676";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): max per-stage input attachment bindings count (%d) exceeds device "
                          "maxPerStageDescriptorInputAttachments limit (%d).",
                          max_descriptors_per_stage[DSL_TYPE_INPUT_ATTACHMENTS],
@@ -4112,6 +4124,8 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     // Inline uniform blocks
     if (max_descriptors_per_stage[DSL_TYPE_INLINE_UNIFORM_BLOCK] >
         phys_dev_ext_props.inline_uniform_block_props.maxPerStageDescriptorInlineUniformBlocks) {
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02212";
         skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214",
                          "vkCreatePipelineLayout(): max per-stage inline uniform block bindings count (%d) exceeds device "
                          "maxPerStageDescriptorInlineUniformBlocks limit (%d).",
@@ -4125,7 +4139,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     // Samplers
     uint32_t sum = sum_all_stages[VK_DESCRIPTOR_TYPE_SAMPLER] + sum_all_stages[VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER];
     if (sum > phys_dev_props.limits.maxDescriptorSetSamplers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01677",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03028"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01677";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of sampler bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetSamplers limit (%d).",
                          sum, phys_dev_props.limits.maxDescriptorSetSamplers);
@@ -4133,7 +4149,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Uniform buffers
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER] > phys_dev_props.limits.maxDescriptorSetUniformBuffers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01678",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03029"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01678";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of uniform buffer bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetUniformBuffers limit (%d).",
                          sum_all_stages[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER], phys_dev_props.limits.maxDescriptorSetUniformBuffers);
@@ -4141,7 +4159,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Dynamic uniform buffers
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC] > phys_dev_props.limits.maxDescriptorSetUniformBuffersDynamic) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01679",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03030"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01679";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of dynamic uniform buffer bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetUniformBuffersDynamic limit (%d).",
                          sum_all_stages[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC],
@@ -4150,7 +4170,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Storage buffers
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER] > phys_dev_props.limits.maxDescriptorSetStorageBuffers) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01680",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03031"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01680";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of storage buffer bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetStorageBuffers limit (%d).",
                          sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER], phys_dev_props.limits.maxDescriptorSetStorageBuffers);
@@ -4158,7 +4180,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Dynamic storage buffers
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC] > phys_dev_props.limits.maxDescriptorSetStorageBuffersDynamic) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01681",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03032"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01681";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of dynamic storage buffer bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetStorageBuffersDynamic limit (%d).",
                          sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC],
@@ -4169,7 +4193,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     sum = sum_all_stages[VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE] + sum_all_stages[VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER] +
           sum_all_stages[VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER];
     if (sum > phys_dev_props.limits.maxDescriptorSetSampledImages) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01682",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03033"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01682";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of sampled image bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetSampledImages limit (%d).",
                          sum, phys_dev_props.limits.maxDescriptorSetSampledImages);
@@ -4178,7 +4204,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     //  Storage images
     sum = sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_IMAGE] + sum_all_stages[VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER];
     if (sum > phys_dev_props.limits.maxDescriptorSetStorageImages) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01683",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03034"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01683";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of storage image bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetStorageImages limit (%d).",
                          sum, phys_dev_props.limits.maxDescriptorSetStorageImages);
@@ -4186,8 +4214,10 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 
     // Input attachments
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT] > phys_dev_props.limits.maxDescriptorSetInputAttachments) {
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03035"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01684";
         skip |=
-            LogError(device, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-01684",
+            LogError(device, vuid,
                      "vkCreatePipelineLayout(): sum of input attachment bindings among all stages (%d) exceeds device "
                      "maxDescriptorSetInputAttachments limit (%d).",
                      sum_all_stages[VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT], phys_dev_props.limits.maxDescriptorSetInputAttachments);
@@ -4196,7 +4226,9 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     // Inline uniform blocks
     if (sum_all_stages[VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT] >
         phys_dev_ext_props.inline_uniform_block_props.maxDescriptorSetInlineUniformBlocks) {
-        skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216",
+        const char *vuid = (device_extensions.vk_ext_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"
+                                                                          : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02213";
+        skip |= LogError(device, vuid,
                          "vkCreatePipelineLayout(): sum of inline uniform block bindings among all stages (%d) exceeds device "
                          "maxDescriptorSetInlineUniformBlocks limit (%d).",
                          sum_all_stages[VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT],

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -168,6 +168,14 @@ VkPhysicalDeviceSubgroupProperties GetSubgroupProperties(VkInstance instance, Vk
     return subgroup_prop;
 }
 
+VkPhysicalDeviceDescriptorIndexingProperties GetDescriptorIndexingProperties(VkInstance instance, VkPhysicalDevice gpu) {
+    auto descriptor_indexing_prop = lvl_init_struct<VkPhysicalDeviceDescriptorIndexingProperties>();
+
+    auto prop2 = lvl_init_struct<VkPhysicalDeviceProperties2>(&descriptor_indexing_prop);
+    vk::GetPhysicalDeviceProperties2(gpu, &prop2);
+    return descriptor_indexing_prop;
+}
+
 bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs) {
     bool is_equal = (rhs.color[0] == lhs.color[0]) && (rhs.color[1] == lhs.color[1]) && (rhs.color[2] == lhs.color[2]) &&
                     (rhs.color[3] == lhs.color[3]);

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -605,6 +605,9 @@ VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstan
 // Subgroup properties helper
 VkPhysicalDeviceSubgroupProperties GetSubgroupProperties(VkInstance instance, VkPhysicalDevice gpu);
 
+// Descriptor Indexing properties helper
+VkPhysicalDeviceDescriptorIndexingProperties GetDescriptorIndexingProperties(VkInstance instance, VkPhysicalDevice gpu);
+
 class BarrierQueueFamilyTestHelper {
   public:
     struct QueueFamilyObjs {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -7868,8 +7868,12 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216");
+    const char *max_inline_vuid = (supportsDescriptorIndexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
+                                                               : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02212";
+    const char *max_all_inline_vuid = (supportsDescriptorIndexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"
+                                                                   : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02213";
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, max_inline_vuid);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, max_all_inline_vuid);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02215");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02217");
 


### PR DESCRIPTION
This adds support for various VUID tied to an `ifdef` around the Descriptor Indexing extension

VUID-VkPipelineLayoutCreateInfo-descriptorType-03016
VUID-VkPipelineLayoutCreateInfo-descriptorType-03017
VUID-VkPipelineLayoutCreateInfo-descriptorType-03018
VUID-VkPipelineLayoutCreateInfo-descriptorType-03019
VUID-VkPipelineLayoutCreateInfo-descriptorType-03020
VUID-VkPipelineLayoutCreateInfo-descriptorType-03021
VUID-VkPipelineLayoutCreateInfo-descriptorType-02212
VUID-VkPipelineLayoutCreateInfo-descriptorType-03028
VUID-VkPipelineLayoutCreateInfo-descriptorType-03029
VUID-VkPipelineLayoutCreateInfo-descriptorType-03028
VUID-VkPipelineLayoutCreateInfo-descriptorType-03030
VUID-VkPipelineLayoutCreateInfo-descriptorType-03031
VUID-VkPipelineLayoutCreateInfo-descriptorType-03032
VUID-VkPipelineLayoutCreateInfo-descriptorType-03033
VUID-VkPipelineLayoutCreateInfo-descriptorType-03034
VUID-VkPipelineLayoutCreateInfo-descriptorType-03035
VUID-VkPipelineLayoutCreateInfo-descriptorType-02213