### PR TITLE
Add Logging support for multiple objects

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BUILD_LAYER_SUPPORT_FILES)
         vk_layer_utils.h
         vk_layer_utils.cpp
         vk_loader_platform.h
+        xxhash.h
         generated/vk_validation_error_messages.h
         generated/vk_layer_dispatch_table.h
         generated/vk_dispatch_table_helper.h

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -475,7 +475,10 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
     const DEVICE_MEMORY_STATE* mem_info = ValidationStateTracker::GetDevMemState(memory);
 
     for (auto& obj : mem_info->obj_bindings) {
-        skip |= LogWarning(device, layer_name.c_str(), "VK Object %s still has a reference to mem obj %s.",
+        LogObjectList objlist(device);
+        objlist.add(obj);
+        objlist.add(mem_info->mem);
+        skip |= LogWarning(objlist, layer_name.c_str(), "VK Object %s still has a reference to mem obj %s.",
                            report_data->FormatHandle(obj).c_str(), report_data->FormatHandle(mem_info->mem).c_str());
     }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -329,6 +329,10 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     const bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);
 
     if (!image_state) {
+        LogObjectList objlist(image);
+        objlist.add(renderpass);
+        objlist.add(framebuffer);
+        objlist.add(image_view);
         skip |= LogError(image, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
                          "Render Pass begin with %s uses %s where pAttachments[%" PRIu32 "] = %s, which refers to an invalid image",
                          report_data->FormatHandle(renderpass).c_str(), report_data->FormatHandle(framebuffer).c_str(),
@@ -341,8 +345,12 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     // Check for layouts that mismatch image usages in the framebuffer
     if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03094" : "VUID-vkCmdBeginRenderPass-initialLayout-00895";
+        LogObjectList objlist(image);
+        objlist.add(renderpass);
+        objlist.add(framebuffer);
+        objlist.add(image_view);
         skip |=
-            LogError(image, vuid,
+            LogError(objlist, vuid,
                      "Layout/usage mismatch for attachment %u in %s"
                      " - the %s is %s but the image attached to %s via %s"
                      " was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT",
@@ -353,8 +361,12 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     if (layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
         !(image_usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03097" : "VUID-vkCmdBeginRenderPass-initialLayout-00897";
+        LogObjectList objlist(image);
+        objlist.add(renderpass);
+        objlist.add(framebuffer);
+        objlist.add(image_view);
         skip |=
-            LogError(image, vuid,
+            LogError(objlist, vuid,
                      "Layout/usage mismatch for attachment %u in %s"
                      " - the %s is %s but the image attached to %s via %s"
                      " was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT",
@@ -364,8 +376,12 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03098" : "VUID-vkCmdBeginRenderPass-initialLayout-00898";
+        LogObjectList objlist(image);
+        objlist.add(renderpass);
+        objlist.add(framebuffer);
+        objlist.add(image_view);
         skip |=
-            LogError(image, vuid,
+            LogError(objlist, vuid,
                      "Layout/usage mismatch for attachment %u in %s"
                      " - the %s is %s but the image attached to %s via %s"
                      " was not created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
@@ -375,8 +391,12 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03099" : "VUID-vkCmdBeginRenderPass-initialLayout-00899";
+        LogObjectList objlist(image);
+        objlist.add(renderpass);
+        objlist.add(framebuffer);
+        objlist.add(image_view);
         skip |=
-            LogError(image, vuid,
+            LogError(objlist, vuid,
                      "Layout/usage mismatch for attachment %u in %s"
                      " - the %s is %s but the image attached to %s via %s"
                      " was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT",
@@ -391,7 +411,11 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) &&
             !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
             vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03096" : "VUID-vkCmdBeginRenderPass-initialLayout-01758";
-            skip |= LogError(image, vuid,
+            LogObjectList objlist(image);
+            objlist.add(renderpass);
+            objlist.add(framebuffer);
+            objlist.add(image_view);
+            skip |= LogError(objlist, vuid,
                              "Layout/usage mismatch for attachment %u in %s"
                              " - the %s is %s but the image attached to %s via %s"
                              " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
@@ -404,7 +428,11 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
         if ((layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL ||
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) &&
             !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= LogError(image, "VUID-vkCmdBeginRenderPass-initialLayout-00896",
+            LogObjectList objlist(image);
+            objlist.add(renderpass);
+            objlist.add(framebuffer);
+            objlist.add(image_view);
+            skip |= LogError(objlist, "VUID-vkCmdBeginRenderPass-initialLayout-00896",
                              "Layout/usage mismatch for attachment %u in %s"
                              " - the %s is %s but the image attached to %s via %s"
                              " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
@@ -444,7 +472,10 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
             auto view_state = GetImageViewState(image_view);
 
             if (!view_state) {
-                skip |= LogError(pRenderPassBegin->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                LogObjectList objlist(pRenderPassBegin->renderPass);
+                objlist.add(framebuffer_state->framebuffer);
+                objlist.add(image_view);
+                skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
                                  "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
                                  report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
                                  report_data->FormatHandle(image_view).c_str());
@@ -455,7 +486,11 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
             const IMAGE_STATE *image_state = GetImageState(image);
 
             if (!image_state) {
-                skip |= LogError(pRenderPassBegin->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                LogObjectList objlist(pRenderPassBegin->renderPass);
+                objlist.add(framebuffer_state->framebuffer);
+                objlist.add(image_view);
+                objlist.add(image);
+                skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
                                  "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
                                  report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
                                  report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
@@ -965,7 +1000,10 @@ bool CoreChecks::ValidateAndUpdateQFOScoreboard(const debug_report_data *report_
     auto inserted = scoreboard->insert(std::make_pair(barrier, cb_state));
     if (!inserted.second && inserted.first->second != cb_state) {
         // This is a duplication (but don't report duplicates from the same CB, as we do that at record time
-        skip = LogWarning(cb_state->commandBuffer, BarrierRecord::ErrMsgDuplicateQFOInSubmit(),
+        LogObjectList objlist(cb_state->commandBuffer);
+        objlist.add(barrier.handle);
+        objlist.add(inserted.first->second->commandBuffer);
+        skip = LogWarning(objlist, BarrierRecord::ErrMsgDuplicateQFOInSubmit(),
                           "%s: %s %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
                           " to dstQueueFamilyIndex %" PRIu32 " duplicates existing barrier submitted in this batch from %s.",
                           "vkQueueSubmit()", BarrierRecord::BarrierName(), operation, BarrierRecord::HandleName(),

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1811,8 +1811,10 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t write_count, const VkWrit
         std::string error_code;
         std::string error_str;
         if (!ValidateCopyUpdate(&p_cds[i], dst_node, src_node, func_name, &error_code, &error_str)) {
+            LogObjectList objlist(dst_set);
+            objlist.add(src_set);
             skip |=
-                LogError(dst_set, error_code, "%s failed copy update from %s to %s with error: %s.", func_name,
+                LogError(objlist, error_code, "%s failed copy update from %s to %s with error: %s.", func_name,
                          report_data->FormatHandle(src_set).c_str(), report_data->FormatHandle(dst_set).c_str(), error_str.c_str());
         }
     }

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2769,10 +2769,8 @@ class ValidationObject {
             return nullptr;
         };
 
-        // Debug Logging Templates
-        template <typename HANDLE_T>
-        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-
+        // Debug Logging Helpers
+        bool LogError(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
             std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
@@ -2786,9 +2784,44 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            return LogMsgLocked(report_data, kErrorBit, objects, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kErrorBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        template <typename HANDLE_T>
+        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kErrorBit, single_object, vuid_text, str);
+
+        };
+
+        bool LogWarning(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kWarningBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -2806,9 +2839,25 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kWarningBit, single_object, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kWarningBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        bool LogPerformanceWarning(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kPerformanceWarningBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -2826,9 +2875,25 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kPerformanceWarningBit, single_object, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kPerformanceWarningBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        bool LogInfo(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kInformationBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -2846,9 +2911,8 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
-
-            return LogMsgLocked(report_data, kInformationBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kInformationBit, single_object, vuid_text, str);
         };
 
         // Handle Wrapping Data

--- a/layers/generated/vk_object_types.h
+++ b/layers/generated/vk_object_types.h
@@ -172,47 +172,49 @@ const VkDebugReportObjectTypeEXT get_debug_report_enum[] = {
     VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,   // kVulkanObjectTypeIndirectCommandsLayoutNV
 };
 
-// Helper array to get Official Vulkan VkObjectType enum from the internal layers version
-const VkObjectType get_object_type_enum[] = {
-    VK_OBJECT_TYPE_UNKNOWN, // kVulkanObjectTypeUnknown
-    VK_OBJECT_TYPE_INSTANCE,   // kVulkanObjectTypeInstance
-    VK_OBJECT_TYPE_PHYSICAL_DEVICE,   // kVulkanObjectTypePhysicalDevice
-    VK_OBJECT_TYPE_DEVICE,   // kVulkanObjectTypeDevice
-    VK_OBJECT_TYPE_QUEUE,   // kVulkanObjectTypeQueue
-    VK_OBJECT_TYPE_SEMAPHORE,   // kVulkanObjectTypeSemaphore
-    VK_OBJECT_TYPE_COMMAND_BUFFER,   // kVulkanObjectTypeCommandBuffer
-    VK_OBJECT_TYPE_FENCE,   // kVulkanObjectTypeFence
-    VK_OBJECT_TYPE_DEVICE_MEMORY,   // kVulkanObjectTypeDeviceMemory
-    VK_OBJECT_TYPE_BUFFER,   // kVulkanObjectTypeBuffer
-    VK_OBJECT_TYPE_IMAGE,   // kVulkanObjectTypeImage
-    VK_OBJECT_TYPE_EVENT,   // kVulkanObjectTypeEvent
-    VK_OBJECT_TYPE_QUERY_POOL,   // kVulkanObjectTypeQueryPool
-    VK_OBJECT_TYPE_BUFFER_VIEW,   // kVulkanObjectTypeBufferView
-    VK_OBJECT_TYPE_IMAGE_VIEW,   // kVulkanObjectTypeImageView
-    VK_OBJECT_TYPE_SHADER_MODULE,   // kVulkanObjectTypeShaderModule
-    VK_OBJECT_TYPE_PIPELINE_CACHE,   // kVulkanObjectTypePipelineCache
-    VK_OBJECT_TYPE_PIPELINE_LAYOUT,   // kVulkanObjectTypePipelineLayout
-    VK_OBJECT_TYPE_RENDER_PASS,   // kVulkanObjectTypeRenderPass
-    VK_OBJECT_TYPE_PIPELINE,   // kVulkanObjectTypePipeline
-    VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT,   // kVulkanObjectTypeDescriptorSetLayout
-    VK_OBJECT_TYPE_SAMPLER,   // kVulkanObjectTypeSampler
-    VK_OBJECT_TYPE_DESCRIPTOR_POOL,   // kVulkanObjectTypeDescriptorPool
-    VK_OBJECT_TYPE_DESCRIPTOR_SET,   // kVulkanObjectTypeDescriptorSet
-    VK_OBJECT_TYPE_FRAMEBUFFER,   // kVulkanObjectTypeFramebuffer
-    VK_OBJECT_TYPE_COMMAND_POOL,   // kVulkanObjectTypeCommandPool
-    VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION,   // kVulkanObjectTypeSamplerYcbcrConversion
-    VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE,   // kVulkanObjectTypeDescriptorUpdateTemplate
-    VK_OBJECT_TYPE_SURFACE_KHR,   // kVulkanObjectTypeSurfaceKHR
-    VK_OBJECT_TYPE_SWAPCHAIN_KHR,   // kVulkanObjectTypeSwapchainKHR
-    VK_OBJECT_TYPE_DISPLAY_KHR,   // kVulkanObjectTypeDisplayKHR
-    VK_OBJECT_TYPE_DISPLAY_MODE_KHR,   // kVulkanObjectTypeDisplayModeKHR
-    VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR,   // kVulkanObjectTypeDeferredOperationKHR
-    VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT,   // kVulkanObjectTypeDebugReportCallbackEXT
-    VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT,   // kVulkanObjectTypeDebugUtilsMessengerEXT
-    VK_OBJECT_TYPE_VALIDATION_CACHE_EXT,   // kVulkanObjectTypeValidationCacheEXT
-    VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR,   // kVulkanObjectTypeAccelerationStructureKHR
-    VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL,   // kVulkanObjectTypePerformanceConfigurationINTEL
-    VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV,   // kVulkanObjectTypeIndirectCommandsLayoutNV
+// Helper function to get Official Vulkan VkObjectType enum from the internal layers version
+static inline VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {
+    switch (internal_type) {
+        case kVulkanObjectTypeInstance: return VK_OBJECT_TYPE_INSTANCE;
+        case kVulkanObjectTypePhysicalDevice: return VK_OBJECT_TYPE_PHYSICAL_DEVICE;
+        case kVulkanObjectTypeDevice: return VK_OBJECT_TYPE_DEVICE;
+        case kVulkanObjectTypeQueue: return VK_OBJECT_TYPE_QUEUE;
+        case kVulkanObjectTypeSemaphore: return VK_OBJECT_TYPE_SEMAPHORE;
+        case kVulkanObjectTypeCommandBuffer: return VK_OBJECT_TYPE_COMMAND_BUFFER;
+        case kVulkanObjectTypeFence: return VK_OBJECT_TYPE_FENCE;
+        case kVulkanObjectTypeDeviceMemory: return VK_OBJECT_TYPE_DEVICE_MEMORY;
+        case kVulkanObjectTypeBuffer: return VK_OBJECT_TYPE_BUFFER;
+        case kVulkanObjectTypeImage: return VK_OBJECT_TYPE_IMAGE;
+        case kVulkanObjectTypeEvent: return VK_OBJECT_TYPE_EVENT;
+        case kVulkanObjectTypeQueryPool: return VK_OBJECT_TYPE_QUERY_POOL;
+        case kVulkanObjectTypeBufferView: return VK_OBJECT_TYPE_BUFFER_VIEW;
+        case kVulkanObjectTypeImageView: return VK_OBJECT_TYPE_IMAGE_VIEW;
+        case kVulkanObjectTypeShaderModule: return VK_OBJECT_TYPE_SHADER_MODULE;
+        case kVulkanObjectTypePipelineCache: return VK_OBJECT_TYPE_PIPELINE_CACHE;
+        case kVulkanObjectTypePipelineLayout: return VK_OBJECT_TYPE_PIPELINE_LAYOUT;
+        case kVulkanObjectTypeRenderPass: return VK_OBJECT_TYPE_RENDER_PASS;
+        case kVulkanObjectTypePipeline: return VK_OBJECT_TYPE_PIPELINE;
+        case kVulkanObjectTypeDescriptorSetLayout: return VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT;
+        case kVulkanObjectTypeSampler: return VK_OBJECT_TYPE_SAMPLER;
+        case kVulkanObjectTypeDescriptorPool: return VK_OBJECT_TYPE_DESCRIPTOR_POOL;
+        case kVulkanObjectTypeDescriptorSet: return VK_OBJECT_TYPE_DESCRIPTOR_SET;
+        case kVulkanObjectTypeFramebuffer: return VK_OBJECT_TYPE_FRAMEBUFFER;
+        case kVulkanObjectTypeCommandPool: return VK_OBJECT_TYPE_COMMAND_POOL;
+        case kVulkanObjectTypeSamplerYcbcrConversion: return VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION;
+        case kVulkanObjectTypeDescriptorUpdateTemplate: return VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE;
+        case kVulkanObjectTypeSurfaceKHR: return VK_OBJECT_TYPE_SURFACE_KHR;
+        case kVulkanObjectTypeSwapchainKHR: return VK_OBJECT_TYPE_SWAPCHAIN_KHR;
+        case kVulkanObjectTypeDisplayKHR: return VK_OBJECT_TYPE_DISPLAY_KHR;
+        case kVulkanObjectTypeDisplayModeKHR: return VK_OBJECT_TYPE_DISPLAY_MODE_KHR;
+        case kVulkanObjectTypeDeferredOperationKHR: return VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR;
+        case kVulkanObjectTypeDebugReportCallbackEXT: return VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT;
+        case kVulkanObjectTypeDebugUtilsMessengerEXT: return VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT;
+        case kVulkanObjectTypeValidationCacheEXT: return VK_OBJECT_TYPE_VALIDATION_CACHE_EXT;
+        case kVulkanObjectTypeAccelerationStructureKHR: return VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR;
+        case kVulkanObjectTypePerformanceConfigurationINTEL: return VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL;
+        case kVulkanObjectTypeIndirectCommandsLayoutNV: return VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV;
+        default: return VK_OBJECT_TYPE_UNKNOWN;
+    }
 };
 
 // Helper function to get internal layers object ids from the official Vulkan VkObjectType enum

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -108,7 +108,10 @@ bool ObjectLifetimes::ValidateCommandBuffer(VkCommandPool command_pool, VkComman
         if (pNode->parent_object != HandleToUint64(command_pool)) {
             // We know that the parent *must* be a command pool
             const auto parent_pool = CastFromUint64<VkCommandPool>(pNode->parent_object);
-            skip |= LogError(command_buffer, "VUID-vkFreeCommandBuffers-pCommandBuffers-parent",
+            LogObjectList objlist(command_buffer);
+            objlist.add(parent_pool);
+            objlist.add(command_pool);
+            skip |= LogError(objlist, "VUID-vkFreeCommandBuffers-pCommandBuffers-parent",
                              "FreeCommandBuffers is attempting to free %s belonging to %s from %s).",
                              report_data->FormatHandle(command_buffer).c_str(), report_data->FormatHandle(parent_pool).c_str(),
                              report_data->FormatHandle(command_pool).c_str());
@@ -144,7 +147,10 @@ bool ObjectLifetimes::ValidateDescriptorSet(VkDescriptorPool descriptor_pool, Vk
         if (dsItem->second->parent_object != HandleToUint64(descriptor_pool)) {
             // We know that the parent *must* be a descriptor pool
             const auto parent_pool = CastFromUint64<VkDescriptorPool>(dsItem->second->parent_object);
-            skip |= LogError(descriptor_set, "VUID-vkFreeDescriptorSets-pDescriptorSets-parent",
+            LogObjectList objlist(descriptor_set);
+            objlist.add(parent_pool);
+            objlist.add(descriptor_pool);
+            skip |= LogError(objlist, "VUID-vkFreeDescriptorSets-pDescriptorSets-parent",
                              "FreeDescriptorSets is attempting to free %s"
                              " belonging to %s from %s).",
                              report_data->FormatHandle(descriptor_set).c_str(), report_data->FormatHandle(parent_pool).c_str(),
@@ -247,7 +253,9 @@ bool ObjectLifetimes::ReportLeakedInstanceObjects(VkInstance instance, VulkanObj
     auto snapshot = object_map[object_type].snapshot();
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
-        skip |= LogError(instance, error_code, "OBJ ERROR : For %s, %s has not been destroyed.",
+        LogObjectList objlist(instance);
+        objlist.add(ObjTrackStateTypedHandle(*object_info));
+        skip |= LogError(objlist, error_code, "OBJ ERROR : For %s, %s has not been destroyed.",
                          report_data->FormatHandle(instance).c_str(),
                          report_data->FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
     }
@@ -261,7 +269,9 @@ bool ObjectLifetimes::ReportLeakedDeviceObjects(VkDevice device, VulkanObjectTyp
     auto snapshot = object_map[object_type].snapshot();
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
-        skip |= LogError(device, error_code, "OBJ ERROR : For %s, %s has not been destroyed.",
+        LogObjectList objlist(device);
+        objlist.add(ObjTrackStateTypedHandle(*object_info));
+        skip |= LogError(objlist, error_code, "OBJ ERROR : For %s, %s has not been destroyed.",
                          report_data->FormatHandle(device).c_str(),
                          report_data->FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
     }

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -39,6 +39,7 @@
 #include <vector>
 #include <unordered_map>
 #include <utility>
+#include <cstring>
 
 #include "vk_typemap_helper.h"
 #include "vk_layer_config.h"
@@ -46,10 +47,12 @@
 #include "vk_loader_platform.h"
 #include "vulkan/vk_layer.h"
 #include "vk_object_types.h"
+#include "vk_enum_string_helper.h"
 #include "cast_utils.h"
 #include "vk_validation_error_messages.h"
 #include "vk_layer_dispatch_table.h"
 #include "vk_safe_struct.h"
+#include "xxhash.h"
 
 // Suppress unused warning on Linux
 #if defined(__GNUC__)
@@ -79,6 +82,25 @@ typedef enum DebugCallbackStatusBits {
     DEBUG_CALLBACK_INSTANCE = 0x00000004,  // An internally created temporary instance callback
 } DebugCallbackStatusBits;
 typedef VkFlags DebugCallbackStatusFlags;
+
+struct LogObjectList {
+    std::vector<VulkanTypedHandle> object_list;
+
+    template <typename HANDLE_T>
+    void add(HANDLE_T object) {
+        VulkanTypedHandle v_t_handle(object, ConvertCoreObjectToVulkanObject(VkHandleInfo<HANDLE_T>::kVkObjectType));
+        object_list.push_back(v_t_handle);
+    }
+
+    void add(VulkanTypedHandle typed_handle) { object_list.push_back(typed_handle); }
+
+    template <typename HANDLE_T>
+    LogObjectList(HANDLE_T object) {
+        add(object);
+    }
+
+    LogObjectList(){};
+};
 
 typedef struct {
     DebugCallbackStatusFlags callback_status;
@@ -273,9 +295,8 @@ static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, 
 }
 
 // Forward Declarations
-static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkObjectType object_type,
-                                 uint64_t src_object, size_t location, const char *layer_prefix, const char *message,
-                                 const char *text_vuid);
+static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
+                                 const char *layer_prefix, const char *message, const char *text_vuid);
 
 static void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
     // For all callback in list, return their complete set of severities and modes
@@ -314,89 +335,109 @@ static inline void RemoveAllMessageCallbacks(debug_report_data *debug_data, std:
     callbacks.clear();
 }
 
-static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, VkObjectType object_type,
-                                 uint64_t src_object, size_t location, const char *layer_prefix, const char *message,
-                                 const char *text_vuid) {
+static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
+                                 const char *layer_prefix, const char *message, const char *text_vuid) {
     bool bail = false;
+    std::vector<VkDebugUtilsLabelEXT> queue_labels;
+    std::vector<VkDebugUtilsLabelEXT> cmd_buf_labels;
 
-    VkDebugUtilsMessageSeverityFlagsEXT severity;
+    // Convert the info to the VK_EXT_debug_utils format
     VkDebugUtilsMessageTypeFlagsEXT types;
-    VkDebugUtilsMessengerCallbackDataEXT callback_data;
-    VkDebugUtilsObjectNameInfoEXT object_name_info;
-
-    // Convert the info to the VK_EXT_debug_utils form in case we need it.
+    VkDebugUtilsMessageSeverityFlagsEXT severity;
     DebugReportFlagsToAnnotFlags(msg_flags, true, &severity, &types);
-    object_name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-    object_name_info.pNext = NULL;
-    object_name_info.objectType = object_type;
-    object_name_info.objectHandle = (uint64_t)(uintptr_t)src_object;
-    object_name_info.pObjectName = NULL;
-    std::string object_label = {};
 
+    std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_info;
+    object_name_info.resize(objects.object_list.size());
+    for (uint32_t i = 0; i < objects.object_list.size(); i++) {
+        object_name_info[i].sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        object_name_info[i].pNext = NULL;
+        object_name_info[i].objectType = ConvertVulkanObjectToCoreObject(objects.object_list[i].type);
+        object_name_info[i].objectHandle = objects.object_list[i].handle;
+        object_name_info[i].pObjectName = NULL;
+
+        std::string object_label = {};
+        // Look for any debug utils or marker names to use for this object
+        object_label = debug_data->DebugReportGetUtilsObjectName(objects.object_list[i].handle);
+        if (object_label.empty()) {
+            object_label = debug_data->DebugReportGetMarkerObjectName(objects.object_list[i].handle);
+        }
+        if (!object_label.empty()) {
+            char *local_obj_name = new char[object_label.length() + 1];
+            std::strcpy(local_obj_name, object_label.c_str());
+            object_name_info[i].pObjectName = local_obj_name;
+        }
+
+        // If this is a queue, add any queue labels to the callback data.
+        if (VK_OBJECT_TYPE_QUEUE == object_name_info[i].objectType) {
+            auto label_iter = debug_data->debugUtilsQueueLabels.find(reinterpret_cast<VkQueue>(object_name_info[i].objectHandle));
+            if (label_iter != debug_data->debugUtilsQueueLabels.end()) {
+                auto found_queue_labels = label_iter->second->Export();
+                queue_labels.insert(queue_labels.end(), found_queue_labels.begin(), found_queue_labels.end());
+            }
+            // If this is a command buffer, add any command buffer labels to the callback data.
+        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info[i].objectType) {
+            auto label_iter =
+                debug_data->debugUtilsCmdBufLabels.find(reinterpret_cast<VkCommandBuffer>(object_name_info[i].objectHandle));
+            if (label_iter != debug_data->debugUtilsCmdBufLabels.end()) {
+                auto found_cmd_buf_labels = label_iter->second->Export();
+                cmd_buf_labels.insert(cmd_buf_labels.end(), found_cmd_buf_labels.begin(), found_cmd_buf_labels.end());
+            }
+        }
+    }
+
+    size_t location = 0;
+    if (text_vuid != nullptr) {
+        // Hash for vuid text
+        location = XXH32(text_vuid, strlen(text_vuid), 8);
+    }
+
+    VkDebugUtilsMessengerCallbackDataEXT callback_data;
     callback_data.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
     callback_data.pNext = NULL;
     callback_data.flags = 0;
     callback_data.pMessageIdName = text_vuid;
-    callback_data.messageIdNumber = 0;  // deprecated, validation layers use only the pMessageIdName
+    callback_data.messageIdNumber = static_cast<int32_t>(location);
     callback_data.pMessage = NULL;
-    callback_data.queueLabelCount = 0;
-    callback_data.pQueueLabels = NULL;
-    callback_data.cmdBufLabelCount = 0;
-    callback_data.pCmdBufLabels = NULL;
-    callback_data.objectCount = 1;
-    callback_data.pObjects = &object_name_info;
+    callback_data.queueLabelCount = static_cast<uint32_t>(queue_labels.size());
+    callback_data.pQueueLabels = queue_labels.empty() ? nullptr : queue_labels.data();
+    callback_data.cmdBufLabelCount = static_cast<uint32_t>(cmd_buf_labels.size());
+    callback_data.pCmdBufLabels = cmd_buf_labels.empty() ? nullptr : cmd_buf_labels.data();
+    callback_data.objectCount = static_cast<uint32_t>(object_name_info.size());
+    callback_data.pObjects = object_name_info.data();
 
-    std::vector<VkDebugUtilsLabelEXT> queue_labels;
-    std::vector<VkDebugUtilsLabelEXT> cmd_buf_labels;
-    std::string composite_message = "";
     std::ostringstream oss;
-
-    if (0 != src_object) {
-        oss << "Object: 0x" << std::hex << src_object;
-        // If this is a queue, add any queue labels to the callback data.
-        if (VK_OBJECT_TYPE_QUEUE == object_name_info.objectType) {
-            auto label_iter = debug_data->debugUtilsQueueLabels.find(reinterpret_cast<VkQueue>(src_object));
-            if (label_iter != debug_data->debugUtilsQueueLabels.end()) {
-                queue_labels = label_iter->second->Export();
-                callback_data.queueLabelCount = static_cast<uint32_t>(queue_labels.size());
-                callback_data.pQueueLabels = queue_labels.empty() ? nullptr : queue_labels.data();
-            }
-            // If this is a command buffer, add any command buffer labels to the callback data.
-        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info.objectType) {
-            auto label_iter = debug_data->debugUtilsCmdBufLabels.find(reinterpret_cast<VkCommandBuffer>(src_object));
-            if (label_iter != debug_data->debugUtilsCmdBufLabels.end()) {
-                cmd_buf_labels = label_iter->second->Export();
-                callback_data.cmdBufLabelCount = static_cast<uint32_t>(cmd_buf_labels.size());
-                callback_data.pCmdBufLabels = cmd_buf_labels.empty() ? nullptr : cmd_buf_labels.data();
-            }
-        }
-
-        // Look for any debug utils or marker names to use for this object
-        object_label = debug_data->DebugReportGetUtilsObjectName(src_object);
-        if (object_label.empty()) {
-            object_label = debug_data->DebugReportGetMarkerObjectName(src_object);
-        }
-        if (!object_label.empty()) {
-            object_name_info.pObjectName = object_label.c_str();
-            oss << " (Name = " << object_label << " : Type = ";
-        } else {
-            oss << " (Type = ";
-        }
-        oss << std::to_string(object_type) << ")";
-    } else {
-        oss << "Object: VK_NULL_HANDLE (Type = " << std::to_string(object_type) << ")";
+    if (msg_flags & kErrorBit) {
+        oss << "Validation Error: ";
+    } else if (msg_flags & kWarningBit) {
+        oss << "Validation Warning: ";
+    } else if (msg_flags & kPerformanceWarningBit) {
+        oss << "Validation Performance Warning: ";
+    } else if (msg_flags & kInformationBit) {
+        oss << "Validation Information: ";
+    } else if (msg_flags & kDebugBit) {
+        oss << "DEBUG: ";
     }
-
-    composite_message += oss.str();
-    composite_message += " | ";
-    composite_message += message;
     if (text_vuid != nullptr) {
-        composite_message.insert(0, " ] ");
-        composite_message.insert(0, text_vuid);
-        composite_message.insert(0, "[ ");
+        oss << "[ " << text_vuid << " ] ";
     }
-    const auto callback_list = &debug_data->debug_callback_list;
+    uint32_t index = 0;
+    for (auto src_object : object_name_info) {
+        if (0 != src_object.objectHandle) {
+            oss << "Object " << index++ << ": handle = 0x" << std::hex << src_object.objectHandle;
+            if (src_object.pObjectName) {
+                oss << ", name = " << src_object.pObjectName << ", type = ";
+            } else {
+                oss << ", type = ";
+            }
+            oss << string_VkObjectType(src_object.objectType) << "; ";
+        } else {
+            oss << "Object " << index++ << ": VK_NULL_HANDLE, type = " << string_VkObjectType(src_object.objectType) << "; ";
+        }
+    }
+    oss << "| MessageID = 0x" << std::hex << location << " | " << message;
+    std::string composite = oss.str();
 
+    const auto callback_list = &debug_data->debug_callback_list;
     // We only output to default callbacks if there are no non-default callbacks
     bool use_default_callbacks = true;
     for (auto current_callback : *callback_list) {
@@ -407,19 +448,19 @@ static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags ms
         // Skip callback if it's a default callback and there are non-default callbacks present
         if (current_callback.IsDefault() && !use_default_callbacks) continue;
 
-        // VK_EXT_debug_report callback (deprecated)
-        if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
-            if (current_callback.debug_report_callback_function_ptr(msg_flags, convertCoreObjectToDebugReportObject(object_type),
-                                                                    src_object, location, 0, layer_prefix,
-                                                                    composite_message.c_str(), current_callback.pUserData)) {
-                bail = true;
-            }
-            // VK_EXT_debug_utils callback
-        } else if (current_callback.IsUtils() && (current_callback.debug_utils_msg_flags & severity) &&
-                   (current_callback.debug_utils_msg_type & types)) {
-            callback_data.pMessage = composite_message.c_str();
+        // VK_EXT_debug_utils callback
+        if (current_callback.IsUtils() && (current_callback.debug_utils_msg_flags & severity) &&
+            (current_callback.debug_utils_msg_type & types)) {
+            callback_data.pMessage = composite.c_str();
             if (current_callback.debug_utils_callback_function_ptr(static_cast<VkDebugUtilsMessageSeverityFlagBitsEXT>(severity),
                                                                    types, &callback_data, current_callback.pUserData)) {
+                bail = true;
+            }
+        } else if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
+            // VK_EXT_debug_report callback (deprecated)
+            if (current_callback.debug_report_callback_function_ptr(
+                    msg_flags, convertCoreObjectToDebugReportObject(object_name_info[0].objectType),
+                    object_name_info[0].objectHandle, location, 0, layer_prefix, composite.c_str(), current_callback.pUserData)) {
                 bail = true;
             }
         }
@@ -608,9 +649,8 @@ static inline int vasprintf(char **strp, char const *fmt, va_list ap) {
 }
 #endif
 
-// This must be called with the debug_output_mutex already held
-static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg_flags, VkObjectType object_type,
-                                uint64_t src_object, const std::string &vuid_text, char *err_msg) {
+static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
+                                const std::string &vuid_text, char *err_msg) {
     std::string str_plus_spec_text(err_msg ? err_msg : "Allocation failure");
 
     // Append the spec error text to the error message, unless it's an UNASSIGNED or UNDEFINED vuid
@@ -632,8 +672,7 @@ static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg
         }
     }
 
-    bool result = debug_log_msg(debug_data, msg_flags, object_type, src_object, 0, "Validation", str_plus_spec_text.c_str(),
-                                vuid_text.c_str());
+    bool result = debug_log_msg(debug_data, msg_flags, objects, "Validation", str_plus_spec_text.c_str(), vuid_text.c_str());
     free(err_msg);
     return result;
 }

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -844,14 +844,16 @@ class HelperFileOutputGenerator(OutputGenerator):
         # Output a conversion routine from the layer object definitions to the core object type definitions
         # This will intentionally *fail* for unmatched types as the VK_OBJECT_TYPE list should match the kVulkanObjectType list
         object_types_header += '\n'
-        object_types_header += '// Helper array to get Official Vulkan VkObjectType enum from the internal layers version\n'
-        object_types_header += 'const VkObjectType get_object_type_enum[] = {\n'
-        object_types_header += '    VK_OBJECT_TYPE_UNKNOWN, // kVulkanObjectTypeUnknown\n' # no unknown handle, so must be here explicitly
+        object_types_header += '// Helper function to get Official Vulkan VkObjectType enum from the internal layers version\n'
+        object_types_header += 'static inline VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {\n'
+        object_types_header += '    switch (internal_type) {\n'
 
         for object_type in type_list:
             kenum_type = vko_dict[kenum_to_key(object_type)]
-            object_types_header += '    %s,   // %s\n' % (kenum_type, object_type)
+            object_types_header += '        case %s: return %s;\n' % (object_type, kenum_type)
             object_type_info[object_type]['VkoType'] = kenum_type
+        object_types_header += '        default: return VK_OBJECT_TYPE_UNKNOWN;\n'
+        object_types_header += '    }\n'
         object_types_header += '};\n'
 
         # Output a function converting from core object type definitions to the Vulkan object type enums

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -370,10 +370,8 @@ class ValidationObject {
             return nullptr;
         };
 
-        // Debug Logging Templates
-        template <typename HANDLE_T>
-        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-
+        // Debug Logging Helpers
+        bool LogError(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
             std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
             // Avoid logging cost if msg is to be ignored
             if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
@@ -387,9 +385,44 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            return LogMsgLocked(report_data, kErrorBit, objects, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kErrorBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        template <typename HANDLE_T>
+        bool LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kErrorBit, single_object, vuid_text, str);
+
+        };
+
+        bool LogWarning(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kWarningBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -407,9 +440,25 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kWarningBit, single_object, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kWarningBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        bool LogPerformanceWarning(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kPerformanceWarningBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -427,9 +476,25 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kPerformanceWarningBit, single_object, vuid_text, str);
+        };
 
-            return LogMsgLocked(report_data, kPerformanceWarningBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+        bool LogInfo(const LogObjectList &objects, const std::string &vuid_text, const char *format, ...) const {
+            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
+            // Avoid logging cost if msg is to be ignored
+            if (!(report_data->active_severities & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) ||
+                !(report_data->active_types & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
+                return false;
+            }
+            va_list argptr;
+            va_start(argptr, format);
+            char *str;
+            if (-1 == vasprintf(&str, format, argptr)) {
+                str = nullptr;
+            }
+            va_end(argptr);
+            return LogMsgLocked(report_data, kInformationBit, objects, vuid_text, str);
         };
 
         template <typename HANDLE_T>
@@ -447,9 +512,8 @@ class ValidationObject {
                 str = nullptr;
             }
             va_end(argptr);
-
-            return LogMsgLocked(report_data, kInformationBit, VkHandleInfo<HANDLE_T>::kVkObjectType,
-                HandleToUint64(src_object), vuid_text, str);
+            LogObjectList single_object(src_object);
+            return LogMsgLocked(report_data, kInformationBit, single_object, vuid_text, str);
         };
 
         // Handle Wrapping Data

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -756,7 +756,7 @@ TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
     vk::FreeMemory(m_device->device(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, RebindMemory) {
+TEST_F(VkLayerTest, RebindMemory_MultiObjectDebugUtils) {
     VkResult err;
     bool pass;
 
@@ -820,7 +820,11 @@ TEST_F(VkLayerTest, RebindMemory) {
     // Introduce validation failure, try to bind a different memory object to
     // the same image object
     err = vk::BindImageMemory(m_device->device(), image, mem2, 0);
+    m_errorMonitor->VerifyFound();
 
+    // This particular VU should output three objects in its error message. Verify this works correctly.
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VK_OBJECT_TYPE_IMAGE");
+    err = vk::BindImageMemory(m_device->device(), image, mem2, 0);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyImage(m_device->device(), image, NULL);


### PR DESCRIPTION
DebugUtils can take a list of Vulkan objects and pass that list to a Messenger callback.  This PR adds:

- overloads to `LogError`, `LogWarning`, etc, to take a list of Vulkan objects instead of a single object (The single-object versions are unaffected)
- back-end support to output all objects in the log message, including their handle value, type (in plain text) and their name or label, should it exist
- adds a hash of the VUID text (only) and returns it in the `location `field
- a fix for one of the object-conversion helper functions, which did not work for non-core objects
- a prepended identifier indicating the message type (error, warning, etc.) (I know, right!)
- object lists for all identified LogXxx functions that included multiple objects in their output
- a test for the multiple object output

Example new message build and output:
```
    LogObjectList objlist(mem);
    objlist.add(typed_handle);
    objlist.add(prev_binding->mem);
    skip |=
        LogError(objlist, "VUID-vkBindImageMemory-image-01044", "In %s, attempting to bind %s to %s which has already been bound to %s.",
                 apiName, report_data->FormatHandle(mem).c_str(), report_data->FormatHandle(typed_handle).c_str(),
                 report_data->FormatHandle(prev_binding->mem).c_str());
```


`Validation Error: [ VUID-vkBindImageMemory-image-01044 ] Object 0: handle = 0x6dc7200000000005, type = VK_OBJECT_TYPE_DEVICE_MEMORY; Object 1: handle = 0x983e60000000003, type = VK_OBJECT_TYPE_IMAGE; Object 2: handle = 0x5d11410000000004, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x6f3eac96 | In vkBindImageMemory(), attempting to bind VkDeviceMemory 0x6dc7200000000005[] to VkImage 0x983e60000000003[] which has already been bound to VkDeviceMemory 0x5d11410000000004[]. The Vulkan spec states: image must not already be backed by a memory object (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkBindImageMemory-image-01044)`