### PR TITLE
Make GN build problems hard failures for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: CHECK_COMMIT_FORMAT=ON
-    - env: VULKAN_BUILD_TARGET=GN
   include:
     # Android build.
     - os: linux


### PR DESCRIPTION
GN builds could fail, but these were 'allowed' and would not fail a travis build. Made them hard failures.

