### PR TITLE
Update range_vector.h

### DIFF
--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -28,6 +28,7 @@
 #include <limits>
 #include <map>
 #include <utility>
+#include <cstdint>
 
 #define RANGE_ASSERT(b) assert(b)
 


### PR DESCRIPTION
Vulkan-ValidationLayers (media-libs/vulkan-layers-1.2.133-r1 on gentoo) fails to compile.
se bug#https://bugs.gentoo.org/712800#c6