### PR TITLE
Enable Warnings-As-Errors for Clang compiler on Travis CI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 
     # Treat warnings as errors for versions of GCC and Clang that are shipped on Ubuntu 18.04 or older.
     if((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
-       (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.0)))
+       (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.0)))
         add_compile_options(-Werror)
     endif()
 


### PR DESCRIPTION
Clang was already set to fail on warnings, but only did so for Ubuntu 16.04 LTS default clang versions (3.8.0 ?) or earlier.  Updated version to 6.0.0, the default version in Ubuntu 18.04 LTS.