### PR TITLE
Remove VulkanTools, Vulkan-Tools from VVL Known-Good

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,21 +136,22 @@ script:
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
-      # Build VulkanTools
-      # Note: VulkanTools has a build dependency on Vulkan-ValidationLayers so it must be built after V-VL is built
-      pushd ${TRAVIS_BUILD_DIR}/external/VulkanTools
+      # Build DevSim in VulkanTools to run Vulkan-ValidationLayer tests
+      cd ${TRAVIS_BUILD_DIR}/external
+      git clone https://github.com/LunarG/VulkanTools.git
+      cd VulkanTools
       ./update_external_sources.sh
       mkdir build
       cd build
       cmake -DCMAKE_BUILD_TYPE=Debug \
             -DBUILD_VIA=NO -DBUILD_VKTRACE=NO -DBUILD_VLF=NO -DBUILD_TESTS=NO -DBUILD_LAYERMGR=NO \
+            -DBUILD_MONITOR=NO -DBUILD_SCREENSHOT=NO -DBUILD_APIDUMP=NO \
             -DBUILD_VKTRACEVIEWER=NO -DBUILD_VKTRACE_LAYER=NO -DBUILD_VKTRACE_REPLAY=NO \
             -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Headers/build/install \
             -DVULKAN_LOADER_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install \
             -DVULKAN_VALIDATIONLAYERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/build/install \
             ..
       cmake --build . --target VkLayer_device_simulation -- -j $core_count
-      popd
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,28 @@ script:
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
+      # Build MockICD in Vulkan-Tools to run Vulkan-ValidationLayer tests
+      cd ${TRAVIS_BUILD_DIR}/external
+      git clone https://github.com/KhronosGroup/Vulkan-Tools.git
+      cd Vulkan-Tools
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -DINSTALL_ICD=OFF \
+            -DVULKAN_HEADERS_INSTALL_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Headers/build/install \
+            ..
+      pushd ../icd/generated
+      VVL_REG_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Headers/registry
+      VT_SCRIPTS_DIR=${TRAVIS_BUILD_DIR}/external/Vulkan-Tools/scripts
+      python3 ${TRAVIS_BUILD_DIR}/scripts/lvl_genvk.py -registry ${VVL_REG_DIR}/vk.xml vk_typemap_helper.h
+      python3 ${VT_SCRIPTS_DIR}/kvt_genvk.py -registry ${VVL_REG_DIR}/vk.xml mock_icd.cpp
+      python3 ${VT_SCRIPTS_DIR}/kvt_genvk.py -registry ${VVL_REG_DIR}/vk.xml mock_icd.h
+      popd
+      cmake --build . --target VkICD_mock_icd -- -j $core_count
+      cp ../icd/linux/VkICD_mock_icd.json icd
+    fi
+  - |
+    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Run Tests
       cd ${TRAVIS_BUILD_DIR}
       export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/external/Vulkan-Loader/build/install/lib:${LD_LIBRARY_PATH}

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -21,36 +21,6 @@
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
       "commit" : "v1.2.135"
-    },
-    {
-      "name" : "Vulkan-Tools",
-      "url" : "https://github.com/KhronosGroup/Vulkan-Tools.git",
-      "sub_dir" : "Vulkan-Tools",
-      "build_dir" : "Vulkan-Tools/build",
-      "install_dir" : "Vulkan-Tools/build/install",
-      "commit" : "v1.2.135",
-      "deps" : [
-        {
-          "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-Headers"
-        },
-        {
-          "var_name" : "GLSLANG_INSTALL_DIR",
-          "repo_name" : "glslang"
-        },
-        {
-          "var_name" : "MOLTENVK_REPO_ROOT",
-          "repo_name" : "MoltenVK"
-        }
-      ],
-      "cmake_options" : [
-        "-DBUILD_CUBE=NO",
-        "-DBUILD_VULKANINFO=NO",
-        "-DINSTALL_ICD=ON"
-      ],
-      "ci_only" : [
-        "TRAVIS"
-      ]
     }
   ],
   "install_names" : {

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -23,44 +23,6 @@
       "commit" : "v1.2.135"
     },
     {
-      "name" : "VulkanTools",
-      "url" : "https://github.com/LunarG/VulkanTools.git",
-      "sub_dir" : "VulkanTools",
-      "build_dir" : "VulkanTools/build",
-      "install_dir" : "VulkanTools/build/install",
-      "commit" : "6460b29c47ecdd7d06f6eb1679a720e23c4e9a09",
-      "deps" : [
-        {
-          "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-Headers"
-        },
-        {
-          "var_name" : "VULKAN_LOADER_INSTALL_DIR",
-          "repo_name" : "Vulkan-Loader"
-        },
-        {
-          "var_name" : "VULKAN_VALIDATIONLAYERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-ValidationLayers"
-        }
-      ],
-      "prebuild_linux" : [
-        "bash update_external_sources.sh"
-      ],
-      "prebuild_windows" : [
-        ".\\update_external_sources.bat"
-      ],
-      "cmake_options" : [
-        "-DBUILD_TESTS=NO",
-        "-DBUILD_VKTRACE=NO",
-        "-DBUILD_VLF=NO",
-        "-DBUILD_VIA=NO"
-      ],
-      "ci_only" : [
-        "TRAVIS"
-      ],
-      "build_step" : "skip"
-    },
-    {
       "name" : "Vulkan-Tools",
       "url" : "https://github.com/KhronosGroup/Vulkan-Tools.git",
       "sub_dir" : "Vulkan-Tools",


### PR DESCRIPTION
These repos are unneeded for validation layers and are solely used for Travis CI.  Removed them from known good and updated` .travis.yml` to clone those repos and build using the VVL-specified sub-components.

TOT should be fine for the `MockICD `and `device_simulation` layers, more so since they're built using VVL-specified headers.  If there is an issue, it can be fixed in the source repos and pushed there _requiring no update_ of `known_good.json` files.

This should simplify Vulkan header updates for the VVL repo.