### PR TITLE
scripts: Make safe structs 'union' or 'struct' to match the Vulkan headers

### DIFF
--- a/layers/generated/vk_safe_struct.cpp
+++ b/layers/generated/vk_safe_struct.cpp
@@ -27411,13 +27411,9 @@ void safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::initialize(const
     pNext = SafePnextCopy(copy_src->pNext);
 }
 
-safe_VkPerformanceValueDataINTEL::safe_VkPerformanceValueDataINTEL(const VkPerformanceValueDataINTEL* in_struct) :
-    value32(in_struct->value32),
-    value64(in_struct->value64),
-    valueFloat(in_struct->valueFloat),
-    valueBool(in_struct->valueBool)
+safe_VkPerformanceValueDataINTEL::safe_VkPerformanceValueDataINTEL(const VkPerformanceValueDataINTEL* in_struct)
 {
-    valueString = SafeStringCopy(in_struct->valueString);
+    initialize(in_struct);
 }
 
 safe_VkPerformanceValueDataINTEL::safe_VkPerformanceValueDataINTEL() :
@@ -31381,10 +31377,9 @@ void safe_VkDeviceDiagnosticsConfigCreateInfoNV::initialize(const safe_VkDeviceD
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
 
-safe_VkDeviceOrHostAddressKHR::safe_VkDeviceOrHostAddressKHR(const VkDeviceOrHostAddressKHR* in_struct) :
-    deviceAddress(in_struct->deviceAddress),
-    hostAddress(in_struct->hostAddress)
+safe_VkDeviceOrHostAddressKHR::safe_VkDeviceOrHostAddressKHR(const VkDeviceOrHostAddressKHR* in_struct)
 {
+    initialize(in_struct);
 }
 
 safe_VkDeviceOrHostAddressKHR::safe_VkDeviceOrHostAddressKHR() :
@@ -31428,10 +31423,9 @@ void safe_VkDeviceOrHostAddressKHR::initialize(const safe_VkDeviceOrHostAddressK
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
 
-safe_VkDeviceOrHostAddressConstKHR::safe_VkDeviceOrHostAddressConstKHR(const VkDeviceOrHostAddressConstKHR* in_struct) :
-    deviceAddress(in_struct->deviceAddress),
-    hostAddress(in_struct->hostAddress)
+safe_VkDeviceOrHostAddressConstKHR::safe_VkDeviceOrHostAddressConstKHR(const VkDeviceOrHostAddressConstKHR* in_struct)
 {
+    initialize(in_struct);
 }
 
 safe_VkDeviceOrHostAddressConstKHR::safe_VkDeviceOrHostAddressConstKHR() :

--- a/layers/generated/vk_safe_struct.h
+++ b/layers/generated/vk_safe_struct.h
@@ -6368,7 +6368,7 @@ struct safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL {
     VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL const *ptr() const { return reinterpret_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL const *>(this); }
 };
 
-struct safe_VkPerformanceValueDataINTEL {
+union safe_VkPerformanceValueDataINTEL {
     uint32_t value32;
     uint64_t value64;
     float valueFloat;
@@ -7379,7 +7379,7 @@ struct safe_VkDeviceDiagnosticsConfigCreateInfoNV {
 };
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-struct safe_VkDeviceOrHostAddressKHR {
+union safe_VkDeviceOrHostAddressKHR {
     VkDeviceAddress deviceAddress;
     void* hostAddress;
     safe_VkDeviceOrHostAddressKHR(const VkDeviceOrHostAddressKHR* in_struct);
@@ -7395,7 +7395,7 @@ struct safe_VkDeviceOrHostAddressKHR {
 #endif // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-struct safe_VkDeviceOrHostAddressConstKHR {
+union safe_VkDeviceOrHostAddressConstKHR {
     VkDeviceAddress deviceAddress;
     const void* hostAddress;
     safe_VkDeviceOrHostAddressConstKHR(const VkDeviceOrHostAddressConstKHR* in_struct);


### PR DESCRIPTION
Without this, the type sizes won't match and the code to copy arrays is broken.

Fixes #1647.
