### PR TITLE
Fix building on VS2019

### DIFF
--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -80,7 +80,7 @@ typedef enum DebugCallbackStatusBits {
 } DebugCallbackStatusBits;
 typedef VkFlags DebugCallbackStatusFlags;
 
-typedef struct {
+typedef struct VkLayerDbgFunctionState {
     DebugCallbackStatusFlags callback_status;
 
     // Debug report related information


### PR DESCRIPTION
Anonymous typedef'ed structs produce a warning on MSVC which is classified as an error.