### PR TITLE
layers: Make FreeMemory remove memory from sparse_bindings

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1722,6 +1722,18 @@ void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMe
         }
 
         if (bindable_state) {
+            // Remove any sparse bindings bound to the resource that use this memory.
+            for (auto it = bindable_state->sparse_bindings.begin(); it != bindable_state->sparse_bindings.end();) {
+                auto nextit = it;
+                nextit++;
+
+                auto &sparse_mem_binding = *it;
+                if (sparse_mem_binding.mem_state.get() == mem_info) {
+                    bindable_state->sparse_bindings.erase(it);
+                }
+
+                it = nextit;
+            }
             bindable_state->UpdateBoundMemorySet();
         }
     }


### PR DESCRIPTION
I was running a test using sparse memory, and some memory that was previously bound to the sparse image was freed, then the image was used again. This caused this assert in ValidationStateTracker::GetStateStructPtrFromObject to fire, and then crash:

```
assert(object_struct.node == GetStateStructPtrFromObject(other));
```

I didn't see any code to ever actually erase elements from sparse_bindings, but the hook was there (UpdateBoundMemorySet) to recompute the bound_memory_set when freeing memory.