### PR TITLE
Add braces around array initializer.

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3441,7 +3441,7 @@ QueryState ValidationStateTracker::GetQueryState(const QueryMap *localQueryToSta
                                                  uint32_t queryIndex) const {
     QueryObject query = {queryPool, queryIndex};
 
-    const std::array<const decltype(queryToStateMap) *, 2> map_list = {localQueryToStateMap, &queryToStateMap};
+    const std::array<const decltype(queryToStateMap) *, 2> map_list = {{localQueryToStateMap, &queryToStateMap}};
 
     for (const auto map : map_list) {
         auto query_data = map->find(query);


### PR DESCRIPTION
This CL adds an extra set of braces around the array initializer. This
works around a warning being received from Clang5 for -Wmissing-braces
which turnes into an error due to the -Werror being enabled.