### PR TITLE
Fixed encoding error. (UnicodeDecodeError: 'cp949' codec can't decode…

### DIFF
--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -380,7 +380,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         self.valid_usage_path = genOpts.valid_usage_path
         vu_json_filename = os.path.join(self.valid_usage_path + os.sep, 'validusage.json')
         if os.path.isfile(vu_json_filename):
-            json_file = open(vu_json_filename, 'r')
+            json_file = open(vu_json_filename, 'r', encoding='utf-8')
             self.vuid_dict = json.load(json_file)
             json_file.close()
         if len(self.vuid_dict) == 0:

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -332,7 +332,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         self.valid_usage_path = genOpts.valid_usage_path
         vu_json_filename = os.path.join(self.valid_usage_path + os.sep, 'validusage.json')
         if os.path.isfile(vu_json_filename):
-            json_file = open(vu_json_filename, 'r')
+            json_file = open(vu_json_filename, 'r', encoding='utf-8')
             self.vuid_dict = json.load(json_file)
             json_file.close()
         if len(self.vuid_dict) == 0:

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -282,7 +282,7 @@ class ValidationSource:
         prepend = None
         for sf in self.source_files:
             line_num = 0
-            with open(sf) as f:
+            with open(sf, encoding='utf-8') as f:
                 for line in f:
                     line_num = line_num + 1
                     if True in [line.strip().startswith(comment) for comment in ['//', '/*']]:


### PR DESCRIPTION
Fixed encoding error. (UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 782848: illegal multibyte sequence)

The following bold character cannot be decoded with code page 'cp949'. 
"Formats requiring sampler Y**′**C<sub>B</sub>C<sub>R</sub> conversion"
(in Vulkan-Headers/registry/validusage.json, line 9991)
