### PR TITLE
[layers] Hide IsValid on Release builds.

### DIFF
--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -174,12 +174,14 @@ RangeEncoder::RangeEncoder(const VkImageSubresourceRange& full_range, const Aspe
     PopulateFunctionPointers();
 }
 
+#ifndef NDEBUG
 static bool IsValid(const RangeEncoder& encoder, const VkImageSubresourceRange& bounds) {
     const auto& limits = encoder.Limits();
     return (((bounds.aspectMask & limits.aspectMask) == bounds.aspectMask) &&
             (bounds.baseMipLevel + bounds.levelCount <= limits.mipLevel) &&
             (bounds.baseArrayLayer + bounds.layerCount <= limits.arrayLayer));
 }
+#endif  // NDEBUG
 
 // Create an iterator like "generator" that for each increment produces the next index range matching the
 // next contiguous (in index space) section of the VkImageSubresourceRange


### PR DESCRIPTION
Thi IsValid method witin subresource_adapter is only used within an
`assert` call. On older Clang on Ubuntu this causes a build error on
Release builds:

../../layers/subresource_adapter.cpp:177:13: warning: unused function 'IsValid' [-Wunused-function]
static bool IsValid(const RangeEncoder& encoder, const VkImageSubresourceRange& bounds) {
            ^
1 warning generated.

This Cl moves the method into a `ifndef NDEBUG` block to hide the method
in Release.