### PR TITLE
layers: Split EXT buffer_device_address features from KHR

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4178,7 +4178,8 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     }
 
     if ((pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR) &&
-        !enabled_features.core12.bufferDeviceAddressCaptureReplay) {
+        !enabled_features.core12.bufferDeviceAddressCaptureReplay &&
+        !enabled_features.buffer_device_address_ext.bufferDeviceAddressCaptureReplay) {
         skip |= LogError(
             device, "VUID-VkBufferCreateInfo-flags-03338",
             "vkCreateBuffer(): the bufferDeviceAddressCaptureReplay device feature is disabled: Buffers cannot be created with "

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10638,12 +10638,13 @@ bool CoreChecks::ValidateGetBufferDeviceAddress(VkDevice device, const VkBufferD
                                                 const char *apiName) const {
     bool skip = false;
 
-    if (!enabled_features.core12.bufferDeviceAddress) {
+    if (!enabled_features.core12.bufferDeviceAddress && !enabled_features.buffer_device_address_ext.bufferDeviceAddress) {
         skip |= LogError(pInfo->buffer, "VUID-vkGetBufferDeviceAddress-bufferDeviceAddress-03324",
                          "The bufferDeviceAddress feature must: be enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.core12.bufferDeviceAddressMultiDevice) {
+    if (physical_device_count > 1 && !enabled_features.core12.bufferDeviceAddressMultiDevice &&
+        !enabled_features.buffer_device_address_ext.bufferDeviceAddressMultiDevice) {
         skip |= LogError(pInfo->buffer, "VUID-vkGetBufferDeviceAddress-device-03325",
                          "If device was created with multiple physical devices, then the "
                          "bufferDeviceAddressMultiDevice feature must: be enabled.");

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1221,6 +1221,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vtx_attrib_divisor_features;
+    VkPhysicalDeviceBufferDeviceAddressFeaturesEXT buffer_device_address_ext;
     VkPhysicalDeviceCooperativeMatrixFeaturesNV cooperative_matrix_features;
     VkPhysicalDeviceComputeShaderDerivativesFeaturesNV compute_shader_derivatives_features;
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV fragment_shader_barycentric_features;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1172,11 +1172,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
 
     const auto *buffer_device_address_ext = lvl_find_in_chain<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT>(pCreateInfo->pNext);
     if (buffer_device_address_ext) {
-        state_tracker->enabled_features.core12.bufferDeviceAddress = buffer_device_address_ext->bufferDeviceAddress;
-        state_tracker->enabled_features.core12.bufferDeviceAddressCaptureReplay =
-            buffer_device_address_ext->bufferDeviceAddressCaptureReplay;
-        state_tracker->enabled_features.core12.bufferDeviceAddressMultiDevice =
-            buffer_device_address_ext->bufferDeviceAddressMultiDevice;
+        state_tracker->enabled_features.buffer_device_address_ext = *buffer_device_address_ext;
     }
 
     const auto *cooperative_matrix_features = lvl_find_in_chain<VkPhysicalDeviceCooperativeMatrixFeaturesNV>(pCreateInfo->pNext);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -7892,7 +7892,22 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
     vkGetBufferDeviceAddressEXT(m_device->device(), &info);
     m_errorMonitor->VerifyFound();
 
+    VkMemoryRequirements buffer_mem_reqs = {};
+    vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_alloc_info = {};
+    buffer_alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
+    m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+    VkDeviceMemory buffer_mem;
+    err = vk::AllocateMemory(m_device->device(), &buffer_alloc_info, NULL, &buffer_mem);
+    ASSERT_VK_SUCCESS(err);
+
+    m_errorMonitor->ExpectSuccess();
+    vk::BindBufferMemory(m_device->device(), buffer, buffer_mem, 0);
+
+    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    m_errorMonitor->VerifyNotFound();
 }
 
 TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {


### PR DESCRIPTION
These structures don't alias and have slightly different meaning. Split them
so VUID-vkBindBufferMemory-bufferDeviceAddress-03339 only applies to KHR/core.

Fixes #1661 