### PR TITLE
build: Don't set MSVC pragma for Win32 GCC/Clang

### DIFF
--- a/layers/generated/vk_enum_string_helper.h
+++ b/layers/generated/vk_enum_string_helper.h
@@ -31,7 +31,7 @@
 
 
 #pragma once
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning( disable : 4065 )
 #endif
 

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -418,7 +418,7 @@ class HelperFileOutputGenerator(OutputGenerator):
     def GenerateEnumStringHelperHeader(self):
             enum_string_helper_header = '\n'
             enum_string_helper_header += '#pragma once\n'
-            enum_string_helper_header += '#ifdef _WIN32\n'
+            enum_string_helper_header += '#ifdef _MSC_VER\n'
             enum_string_helper_header += '#pragma warning( disable : 4065 )\n'
             enum_string_helper_header += '#endif\n'
             enum_string_helper_header += '\n'

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -45,7 +45,7 @@
 #include <vulkan/vk_sdk_platform.h>
 #include <vulkan/vulkan.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(push)
 /*
     warnings 4251 and 4275 have to do with potential dll-interface mismatch
@@ -78,7 +78,7 @@
 #pragma pop_macro("None")
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 #include "vktestbinding.h"


### PR DESCRIPTION
Fixes warning seen downstream in https://github.com/godotengine/godot when building with Clang on Windows: https://github.com/godotengine/godot/pull/37492#issuecomment-607271991
```
thirdparty\\vulkan\\vk_enum_string_helper.h:35:9: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
#pragma warning( disable : 4065 )
```

I reviewed other uses of `disable :` to ensure that they checked `_MSC_VER` and not `_WIN32`.