### PR TITLE
tests: Refactor DeviceExtensionSupported

### DIFF
--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -334,10 +334,7 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
 
     const vk_testing::PhysicalDevice device_obj(objs[0]);
 
-    // TODO: cannot enumare enabled layers because MockICD does not support that, so use m_instance_layer_names instead
-    // EXPECT_GE(VK_VERSION_PATCH(device_obj.properties().apiVersion), (uint32_t)13);  // assume device layers are deprecated
-    // const auto enabled_layers = device_obj.layers();
-    const auto enabled_layers = m_instance_layer_names;
+    const auto enabled_layers = m_instance_layer_names;  // assumes m_instance_layer_names contains enabled layers
 
     auto extensions = device_obj.extensions();
     for (const auto &layer : enabled_layers) {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -218,7 +218,11 @@ class VkRenderFramework : public VkTestFramework {
     bool EnableDeviceProfileLayer();
     bool InstanceExtensionSupported(const char *name, uint32_t specVersion = 0);
     bool InstanceExtensionEnabled(const char *name);
-    bool DeviceExtensionSupported(VkPhysicalDevice dev, const char *layer, const char *name, uint32_t specVersion = 0);
+    bool DeviceExtensionSupported(const char *extension_name, uint32_t spec_version = 0) const;
+    bool DeviceExtensionSupported(VkPhysicalDevice, const char *, const char *name,
+                                  uint32_t spec_version = 0) const {  // deprecated
+        return DeviceExtensionSupported(name, spec_version);
+    }
     bool DeviceExtensionEnabled(const char *name);
     bool DeviceIsMockICD();
     bool DeviceSimulation();

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -153,31 +153,25 @@ std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
 }
 
 /*
- * Return list of PhysicalDevice extensions provided by the ICD / Loader
- */
-std::vector<VkExtensionProperties> PhysicalDevice::extensions() const { return extensions(NULL); }
-
-/*
  * Return list of PhysicalDevice extensions provided by the specified layer
  * If pLayerName is NULL, will return extensions for ICD / loader.
  */
 std::vector<VkExtensionProperties> PhysicalDevice::extensions(const char *pLayerName) const {
-    std::vector<VkExtensionProperties> exts;
     VkResult err;
-
+    uint32_t extension_count;
+    std::vector<VkExtensionProperties> extensions;
     do {
-        uint32_t extCount = 0;
-        err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extCount, NULL);
+        err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extension_count, nullptr);
+        if (err || 0 == extension_count) return {};
 
-        if (err == VK_SUCCESS) {
-            exts.resize(extCount);
-            err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extCount, exts.data());
-        }
-    } while (err == VK_INCOMPLETE);
+        extensions.resize(extension_count);
+        err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extension_count, extensions.data());
+    } while (VK_INCOMPLETE == err);
 
-    assert(err == VK_SUCCESS);
+    if (err) return {};
+    extensions.resize(extension_count);
 
-    return exts;
+    return extensions;
 }
 
 bool PhysicalDevice::set_memory_type(const uint32_t type_bits, VkMemoryAllocateInfo *info, const VkFlags properties,
@@ -203,22 +197,21 @@ bool PhysicalDevice::set_memory_type(const uint32_t type_bits, VkMemoryAllocateI
  * Return list of PhysicalDevice layers
  */
 std::vector<VkLayerProperties> PhysicalDevice::layers() const {
-    std::vector<VkLayerProperties> layer_props;
     VkResult err;
-
+    uint32_t layer_count;
+    std::vector<VkLayerProperties> layers;
     do {
-        uint32_t layer_count = 0;
-        err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, NULL);
+        err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, nullptr);
+        if (err || 0 == layer_count) return {};
 
-        if (err == VK_SUCCESS) {
-            layer_props.reserve(layer_count);
-            err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, layer_props.data());
-        }
-    } while (err == VK_INCOMPLETE);
+        layers.resize(layer_count);
+        err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, layers.data());
+    } while (VK_INCOMPLETE == err);
 
-    assert(err == VK_SUCCESS);
+    if (err) return {};
+    layers.resize(layer_count);
 
-    return layer_props;
+    return layers;
 }
 
 QueueCreateInfoArray::QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties> &queue_props)

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016, 2019 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2019 Valve Corporation
- * Copyright (c) 2015-2016, 2019 LunarG, Inc.
+ * Copyright (c) 2015-2016, 2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020 Valve Corporation
+ * Copyright (c) 2015-2016, 2020 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,8 +163,7 @@ class PhysicalDevice : public internal::Handle<VkPhysicalDevice> {
                          const VkMemoryPropertyFlags forbid = 0) const;
 
     // vkEnumerateDeviceExtensionProperties()
-    std::vector<VkExtensionProperties> extensions() const;
-    std::vector<VkExtensionProperties> extensions(const char *pLayerName) const;
+    std::vector<VkExtensionProperties> extensions(const char *pLayerName = nullptr) const;
 
     // vkEnumerateLayers()
     std::vector<VkLayerProperties> layers() const;


### PR DESCRIPTION
- remove parameters the class already knows
- use pre-existing code for extension enumeration
- simplify it so it does not require `layer` parameter (enumerate extensions for all enabled layers)
- update enumeration code to be robust