### PR TITLE
Clean up create-instance/device validation object setup and initialization

### DIFF
--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -66,6 +66,8 @@ class BestPractices : public ValidationStateTracker {
   public:
     using StateTracker = ValidationStateTracker;
 
+    BestPractices() { container_type = LayerObjectTypeBestPractices; }
+
     std::string GetAPIVersionName(uint32_t version) const;
 
     bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* caller) const;

--- a/layers/command_counter.h
+++ b/layers/command_counter.h
@@ -20,7 +20,7 @@
 
 class CommandCounter : public ValidationObject {
   public:
-    CommandCounter(CoreChecks *coreChecks) : coreChecks(coreChecks) {}
+    CommandCounter(CoreChecks *coreChecks) : coreChecks(coreChecks) { container_type = LayerObjectTypeCommandCounter; }
     virtual ~CommandCounter() {}
 
     virtual write_lock_guard_t write_lock() { return coreChecks->write_lock(); }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -51,6 +51,9 @@ class CoreChecks : public ValidationStateTracker {
 
     CoreChecks() { container_type = LayerObjectTypeCoreValidation; }
 
+    // Override base class, we have some extra work to do here
+    void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj);
+
     void IncrementCommandCount(VkCommandBuffer commandBuffer);
 
     bool VerifyQueueStateToSeq(const QUEUE_STATE* initial_queue, uint64_t initial_seq) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -49,6 +49,8 @@ class CoreChecks : public ValidationStateTracker {
     GlobalQFOTransferBarrierMap<VkBufferMemoryBarrier> qfo_release_buffer_barrier_map;
     GlobalImageLayoutMap imageLayoutMap;
 
+    CoreChecks() { container_type = LayerObjectTypeCoreValidation; }
+
     void IncrementCommandCount(VkCommandBuffer commandBuffer);
 
     bool VerifyQueueStateToSeq(const QUEUE_STATE* initial_queue, uint64_t initial_seq) const;

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -75,6 +75,8 @@ class DebugPrintf : public ValidationStateTracker {
     uint32_t output_buffer_size;
 
   public:
+    DebugPrintf() { container_type = LayerObjectTypeDebugPrintf; }
+
     bool aborted = false;
     bool verbose = false;
     bool use_stdout = false;

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -47,7 +47,6 @@ bool wrap_handles = true;
 // Include layer validation object definitions
 #include "best_practices_validation.h"
 #include "core_validation.h"
-#include "command_counter.h"
 #include "gpu_validation.h"
 #include "object_lifetime_validation.h"
 #include "debug_printf.h"
@@ -611,71 +610,30 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_interceptor->instance = instance_interceptor->instance;
     device_interceptor->report_data = instance_interceptor->report_data;
 
-    // Note that this defines the order in which the layer validation objects are called
-    auto thread_safety = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
-    thread_safety->container_type = LayerObjectTypeThreading;
-    if (!instance_interceptor->disabled.thread_safety) {
-        device_interceptor->object_dispatch.emplace_back(thread_safety);
-    }
-    auto stateless_validation = new StatelessValidation;
-    stateless_validation->container_type = LayerObjectTypeParameterValidation;
-    if (!instance_interceptor->disabled.stateless_checks) {
-        device_interceptor->object_dispatch.emplace_back(stateless_validation);
-    }
-    auto object_tracker = new ObjectLifetimes;
-    object_tracker->container_type = LayerObjectTypeObjectTracker;
-    if (!instance_interceptor->disabled.object_tracking) {
-        device_interceptor->object_dispatch.emplace_back(object_tracker);
-    }
-    auto core_checks = new CoreChecks;
-    core_checks->container_type = LayerObjectTypeCoreValidation;
-    core_checks->instance_state = reinterpret_cast<CoreChecks *>(
-        core_checks->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeCoreValidation));
-    if (!instance_interceptor->disabled.core_checks) {
-        // Only enable the command counters when needed.
-        if (device_extensions.vk_khr_performance_query) {
-            auto command_counter = new CommandCounter(core_checks);
-            command_counter->container_type = LayerObjectTypeDevice;
-            device_interceptor->object_dispatch.emplace_back(command_counter);
-        }
-        device_interceptor->object_dispatch.emplace_back(core_checks);
-    }
-    auto best_practices = new BestPractices;
-    best_practices->container_type = LayerObjectTypeBestPractices;
-    best_practices->instance_state = reinterpret_cast<BestPractices *>(
-        best_practices->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeBestPractices));
-    if (instance_interceptor->enabled.best_practices) {
-        device_interceptor->object_dispatch.emplace_back(best_practices);
-    }
-    auto gpu_assisted = new GpuAssisted;
-    gpu_assisted->container_type = LayerObjectTypeGpuAssisted;
-    gpu_assisted->instance_state = reinterpret_cast<GpuAssisted *>(
-        gpu_assisted->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeGpuAssisted));
-    if (instance_interceptor->enabled.gpu_validation) {
-        device_interceptor->object_dispatch.emplace_back(gpu_assisted);
-    }
-    auto debug_printf = new DebugPrintf;
-    debug_printf->container_type = LayerObjectTypeDebugPrintf;
-    debug_printf->instance_state = reinterpret_cast<DebugPrintf *>(
-        debug_printf->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeDebugPrintf));
-    if (instance_interceptor->enabled.debug_printf) {
-        device_interceptor->object_dispatch.emplace_back(debug_printf);
-    }
+    // Note that this DEFINES THE ORDER IN WHICH THE LAYER VALIDATION OBJECTS ARE CALLED
+    auto disables = instance_interceptor->disabled;
+    auto enables = instance_interceptor->enabled;
 
-    // Set per-intercept common data items
-    for (auto dev_intercept : device_interceptor->object_dispatch) {
-        dev_intercept->device = *pDevice;
-        dev_intercept->physical_device = gpu;
-        dev_intercept->instance = instance_interceptor->instance;
-        dev_intercept->report_data = device_interceptor->report_data;
-        dev_intercept->device_dispatch_table = device_interceptor->device_dispatch_table;
-        dev_intercept->api_version = device_interceptor->api_version;
-        dev_intercept->disabled = instance_interceptor->disabled;
-        dev_intercept->enabled = instance_interceptor->enabled;
-        dev_intercept->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
-        dev_intercept->instance_extensions = instance_interceptor->instance_extensions;
-        dev_intercept->device_extensions = device_interceptor->device_extensions;
-    }
+    auto thread_safety = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
+    thread_safety->InitDeviceValidationObject(!disables.thread_safety, instance_interceptor, device_interceptor);
+
+    auto stateless_validation = new StatelessValidation;
+    stateless_validation->InitDeviceValidationObject(!disables.stateless_checks, instance_interceptor, device_interceptor);
+
+    auto object_tracker = new ObjectLifetimes;
+    object_tracker->InitDeviceValidationObject(!disables.object_tracking, instance_interceptor, device_interceptor);
+
+    auto core_checks = new CoreChecks;
+    core_checks->InitDeviceValidationObject(!disables.core_checks, instance_interceptor, device_interceptor);
+
+    auto best_practices = new BestPractices;
+    best_practices->InitDeviceValidationObject(enables.best_practices, instance_interceptor, device_interceptor);
+
+    auto gpu_assisted = new GpuAssisted;
+    gpu_assisted->InitDeviceValidationObject(enables.gpu_validation, instance_interceptor, device_interceptor);
+
+    auto debug_printf = new DebugPrintf;
+    debug_printf->InitDeviceValidationObject(enables.debug_printf, instance_interceptor, device_interceptor);
 
     for (auto intercept : instance_interceptor->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2662,6 +2662,7 @@ enum LayerObjectTypeId {
     LayerObjectTypeBestPractices,               // Instance or device best practices layer object
     LayerObjectTypeGpuAssisted,                 // Instance or device gpu assisted validation layer object
     LayerObjectTypeDebugPrintf,                 // Instance or device shader debug printf layer object
+    LayerObjectTypeCommandCounter,              // Command Counter validation object, child of corechecks
     LayerObjectTypeMaxEnum,                     // Max enum count
 };
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2767,6 +2767,21 @@ class ValidationObject {
             return write_lock_guard_t(validation_object_mutex);
         }
 
+        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
+            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
+            if (vo_enabled) {
+                api_version = instance_api_version;
+                report_data = instance_report_data;
+                dispatch_list.emplace_back(this);
+            }
+        }
+
+        void FinalizeInstanceValidationObject(ValidationObject *framework) {
+            instance_dispatch_table = framework->instance_dispatch_table;
+            enabled = framework->enabled;
+            disabled = framework->disabled;
+        }
+
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2782,6 +2782,23 @@ class ValidationObject {
             disabled = framework->disabled;
         }
 
+        virtual void InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
+            if (add_obj) {
+                dev_obj->object_dispatch.emplace_back(this);
+                device = dev_obj->device;
+                physical_device = dev_obj->physical_device;
+                instance = inst_obj->instance;
+                report_data = inst_obj->report_data;
+                device_dispatch_table = dev_obj->device_dispatch_table;
+                api_version = dev_obj->api_version;
+                disabled = inst_obj->disabled;
+                enabled = inst_obj->enabled;
+                instance_dispatch_table = inst_obj->instance_dispatch_table;
+                instance_extensions = inst_obj->instance_extensions;
+                device_extensions = dev_obj->device_extensions;
+            }
+        }
+
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -413,7 +413,9 @@ public:
 #else   // DISTINCT_NONDISPATCHABLE_HANDLES
           c_uint64_t("NON_DISPATCHABLE_HANDLE", kVulkanObjectTypeUnknown, this)
 #endif  // DISTINCT_NONDISPATCHABLE_HANDLES
-              {};
+    {
+        container_type = LayerObjectTypeThreading;
+    };
 
 #define WRAPPER(type)                                                \
     void StartWriteObject(type object, const char *api_name) {       \

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -93,6 +93,8 @@ class GpuAssisted : public ValidationStateTracker {
     GpuAssistedAccelerationStructureBuildValidationState acceleration_structure_validation_state;
 
   public:
+    GpuAssisted() { container_type = LayerObjectTypeGpuAssisted; }
+
     bool aborted = false;
     VkDevice device;
     VkPhysicalDevice physicalDevice;

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -77,7 +77,7 @@ class ObjectLifetimes : public ValidationObject {
     object_map_type swapchainImageMap;
 
     // Constructor for object lifetime tracking
-    ObjectLifetimes() : num_objects{}, num_total_objects(0) {}
+    ObjectLifetimes() : num_objects{}, num_total_objects(0) { container_type = LayerObjectTypeObjectTracker; }
 
     template <typename T1>
     void InsertObject(object_map_type &map, T1 object, VulkanObjectType object_type, std::shared_ptr<ObjTrackState> pNode) {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -44,6 +44,14 @@ using std::unordered_map;
 using std::unordered_set;
 using std::vector;
 
+void ValidationStateTracker::InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
+    if (add_obj) {
+        instance_state = reinterpret_cast<ValidationStateTracker *>(GetValidationObject(inst_obj->object_dispatch, container_type));
+        // Call base class
+        ValidationObject::InitDeviceValidationObject(add_obj, inst_obj, dev_obj);
+    }
+}
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 // Android-specific validation that uses types defined only with VK_USE_PLATFORM_ANDROID_KHR
 // This could also move into a seperate core_validation_android.cpp file... ?

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -265,6 +265,9 @@ class ValidationStateTracker : public ValidationObject {
         using MapType = unordered_map<HandleType, MappedType>;
     };
 
+    // Override base class, we have some extra work to do here
+    void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj);
+
     VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, RENDER_PASS_STATE, renderPassMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout, descriptorSetLayoutMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, SAMPLER_STATE, samplerMap)

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -111,7 +111,7 @@ class StatelessValidation : public ValidationObject {
     std::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
 
     // Constructor for stateles validation tracking
-    // StatelessValidation() : {}
+    StatelessValidation() { container_type = LayerObjectTypeParameterValidation; }
     /**
      * Validate a minimum value.
      *

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -263,6 +263,7 @@ enum LayerObjectTypeId {
     LayerObjectTypeBestPractices,               // Instance or device best practices layer object
     LayerObjectTypeGpuAssisted,                 // Instance or device gpu assisted validation layer object
     LayerObjectTypeDebugPrintf,                 // Instance or device shader debug printf layer object
+    LayerObjectTypeCommandCounter,              // Command Counter validation object, child of corechecks
     LayerObjectTypeMaxEnum,                     // Max enum count
 };
 

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -368,6 +368,21 @@ class ValidationObject {
             return write_lock_guard_t(validation_object_mutex);
         }
 
+        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
+            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
+            if (vo_enabled) {
+                api_version = instance_api_version;
+                report_data = instance_report_data;
+                dispatch_list.emplace_back(this);
+            }
+        }
+
+        void FinalizeInstanceValidationObject(ValidationObject *framework) {
+            instance_dispatch_table = framework->instance_dispatch_table;
+            enabled = framework->enabled;
+            disabled = framework->disabled;
+        }
+
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {
@@ -1029,56 +1044,28 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     // Create temporary dispatch vector for pre-calls until instance is created
     std::vector<ValidationObject*> local_object_dispatch;
+
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
     auto thread_checker = new ThreadSafety(nullptr);
-    if (!local_disables.thread_safety) {
-        local_object_dispatch.emplace_back(thread_checker);
-    }
-    thread_checker->container_type = LayerObjectTypeThreading;
-    thread_checker->api_version = api_version;
-    thread_checker->report_data = report_data;
+    thread_checker->RegisterValidationObject(!local_disables.thread_safety, api_version, report_data, local_object_dispatch);
+
     auto parameter_validation = new StatelessValidation;
-    if (!local_disables.stateless_checks) {
-        local_object_dispatch.emplace_back(parameter_validation);
-    }
-    parameter_validation->container_type = LayerObjectTypeParameterValidation;
-    parameter_validation->api_version = api_version;
-    parameter_validation->report_data = report_data;
+    parameter_validation->RegisterValidationObject(!local_disables.stateless_checks, api_version, report_data, local_object_dispatch);
+
     auto object_tracker = new ObjectLifetimes;
-    if (!local_disables.object_tracking) {
-        local_object_dispatch.emplace_back(object_tracker);
-    }
-    object_tracker->container_type = LayerObjectTypeObjectTracker;
-    object_tracker->api_version = api_version;
-    object_tracker->report_data = report_data;
+    object_tracker->RegisterValidationObject(!local_disables.object_tracking, api_version, report_data, local_object_dispatch);
+
     auto core_checks = new CoreChecks;
-    if (!local_disables.core_checks) {
-        local_object_dispatch.emplace_back(core_checks);
-    }
-    core_checks->container_type = LayerObjectTypeCoreValidation;
-    core_checks->api_version = api_version;
-    core_checks->report_data = report_data;
+    core_checks->RegisterValidationObject(!local_disables.core_checks, api_version, report_data, local_object_dispatch);
+
     auto best_practices = new BestPractices;
-    if (local_enables.best_practices) {
-        local_object_dispatch.emplace_back(best_practices);
-    }
-    best_practices->container_type = LayerObjectTypeBestPractices;
-    best_practices->api_version = api_version;
-    best_practices->report_data = report_data;
+    best_practices->RegisterValidationObject(local_enables.best_practices, api_version, report_data, local_object_dispatch);
+
     auto gpu_assisted = new GpuAssisted;
-    if (local_enables.gpu_validation) {
-        local_object_dispatch.emplace_back(gpu_assisted);
-    }
-    gpu_assisted->container_type = LayerObjectTypeGpuAssisted;
-    gpu_assisted->api_version = api_version;
-    gpu_assisted->report_data = report_data;
+    gpu_assisted->RegisterValidationObject(local_enables.gpu_validation, api_version, report_data, local_object_dispatch);
+
     auto debug_printf = new DebugPrintf;
-    if (local_enables.debug_printf) {
-        local_object_dispatch.emplace_back(debug_printf);
-    }
-    debug_printf->container_type = LayerObjectTypeDebugPrintf;
-    debug_printf->api_version = api_version;
-    debug_printf->report_data = report_data;
+    debug_printf->RegisterValidationObject(local_enables.debug_printf, api_version, report_data, local_object_dispatch);
 
     // If handle wrapping is disabled via the ValidationFeatures extension, override build flag
     if (local_disables.handle_wrapping) {
@@ -1111,29 +1098,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     layer_debug_messenger_actions(framework->report_data, pAllocator, OBJECT_LAYER_DESCRIPTION);
 
-    object_tracker->instance_dispatch_table = framework->instance_dispatch_table;
-    object_tracker->enabled = framework->enabled;
-    object_tracker->disabled = framework->disabled;
-    thread_checker->instance_dispatch_table = framework->instance_dispatch_table;
-    thread_checker->enabled = framework->enabled;
-    thread_checker->disabled = framework->disabled;
-    parameter_validation->instance_dispatch_table = framework->instance_dispatch_table;
-    parameter_validation->enabled = framework->enabled;
-    parameter_validation->disabled = framework->disabled;
-    core_checks->instance_dispatch_table = framework->instance_dispatch_table;
+    thread_checker->FinalizeInstanceValidationObject(framework);
+    object_tracker->FinalizeInstanceValidationObject(framework);
+    parameter_validation->FinalizeInstanceValidationObject(framework);
+    core_checks->FinalizeInstanceValidationObject(framework);
     core_checks->instance = *pInstance;
-    core_checks->enabled = framework->enabled;
-    core_checks->disabled = framework->disabled;
     core_checks->instance_state = core_checks;
-    best_practices->instance_dispatch_table = framework->instance_dispatch_table;
-    best_practices->enabled = framework->enabled;
-    best_practices->disabled = framework->disabled;
-    gpu_assisted->instance_dispatch_table = framework->instance_dispatch_table;
-    gpu_assisted->enabled = framework->enabled;
-    gpu_assisted->disabled = framework->disabled;
-    debug_printf->instance_dispatch_table = framework->instance_dispatch_table;
-    debug_printf->enabled = framework->enabled;
-    debug_printf->disabled = framework->disabled;
+    best_practices->FinalizeInstanceValidationObject(framework);
+    gpu_assisted->FinalizeInstanceValidationObject(framework);
+    debug_printf->FinalizeInstanceValidationObject(framework);
 
     for (auto intercept : framework->object_dispatch) {
         intercept->PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -475,7 +475,9 @@ COUNTER_CLASS_INSTANCES_TEMPLATE
 #else   // DISTINCT_NONDISPATCHABLE_HANDLES
           c_uint64_t("NON_DISPATCHABLE_HANDLE", kVulkanObjectTypeUnknown, this)
 #endif  // DISTINCT_NONDISPATCHABLE_HANDLES
-              {};
+    {
+        container_type = LayerObjectTypeThreading;
+    };
 
 #define WRAPPER(type)                                                \\
     void StartWriteObject(type object, const char *api_name) {       \\


### PR DESCRIPTION
Moved much of the per-validation-object setup into constructors/init functions.  