### PR TITLE
build-gn: Keep generate*.py identical across repos

### DIFF
--- a/build-gn/generate_vulkan_layers_json.py
+++ b/build-gn/generate_vulkan_layers_json.py
@@ -79,7 +79,7 @@ def main():
             data[data_key]['library_path'] = prev_name
 
         target_fname = os.path.join(target_dir, os.path.basename(json_fname))
-        with open(target_fname, 'wb') as outfile:
+        with open(target_fname, 'w') as outfile:
             json.dump(data, outfile)
 
     # Get the Vulkan version from the vulkan_core.h file


### PR DESCRIPTION
Bring over commit: https://github.com/KhronosGroup/Vulkan-Tools/commit/94ed4c384c3425963b459a735045706e5f83f01b to keep the build-gn/generate*.py scripts identical across repos.

See the Vulkan-Tools commit for rationale of the change.

Change-Id: I8b132147d9ffff13fbfbbcc644e26ae0c23a50e8