### PR TITLE
Add PhysicalDeviceFormatProperties2 for Device Profile API

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1055,6 +1055,24 @@ bool VkLayerTest::LoadDeviceProfileLayer(
     return 1;
 }
 
+bool VkLayerTest::LoadDeviceProfileLayer(
+    PFN_vkSetPhysicalDeviceFormatProperties2EXT &fpvkSetPhysicalDeviceFormatProperties2EXT,
+    PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT &fpvkGetOriginalPhysicalDeviceFormatProperties2EXT) {
+    // Load required functions
+    fpvkSetPhysicalDeviceFormatProperties2EXT =
+        (PFN_vkSetPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatProperties2EXT");
+    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT =
+        (PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(
+            instance(), "vkGetOriginalPhysicalDeviceFormatProperties2EXT");
+
+    if (!(fpvkSetPhysicalDeviceFormatProperties2EXT) || !(fpvkGetOriginalPhysicalDeviceFormatProperties2EXT)) {
+        printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
+        return false;
+    }
+
+    return true;
+}
+
 bool VkBufferTest::GetTestConditionValid(VkDeviceObj *aVulkanDevice, eTestEnFlags aTestFlag, VkBufferUsageFlags aBufferUsage) {
     if (eInvalidDeviceOffset != aTestFlag && eInvalidMemoryOffset != aTestFlag) {
         return true;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -244,6 +244,9 @@ class VkLayerTest : public VkRenderFramework {
     bool LoadDeviceProfileLayer(
         PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
         PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT);
+    bool LoadDeviceProfileLayer(
+        PFN_vkSetPhysicalDeviceFormatProperties2EXT &fpvkSetPhysicalDeviceFormatProperties2EXT,
+        PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT &fpvkGetOriginalPhysicalDeviceFormatProperties2EXT);
 
     VkLayerTest();
 };

--- a/tests/layers/vk_lunarg_device_profile_api_layer.h
+++ b/tests/layers/vk_lunarg_device_profile_api_layer.h
@@ -1,7 +1,8 @@
 /*
  *
- * Copyright (c) 2016-2017 Valve Corporation
- * Copyright (c) 2016-2017 LunarG, Inc.
+ * Copyright (c) 2016-2020 Valve Corporation
+ * Copyright (c) 2016-2020 LunarG, Inc.
+ * Copyright (c) 2016-2020 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +41,10 @@ typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)(VkPh
                                                                             const VkFormatProperties *properties);
 typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFormatPropertiesEXT)(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                     const VkFormatProperties newProperties);
+typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                                             const VkFormatProperties2 *properties);
+typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                                     const VkFormatProperties2 newProperties);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
This is added for future YCbCr tests I wrote that are waiting for other PR to get merged in first (in VVL and Spec). Those tests need to call `vkGetPhysicalDeviceFormatProperties2` and realized I wasn't able to use the device profile api layer with current lack of support.

Until then, broke this logic out into own commit as it will be needed