### PR TITLE
Fix general external AHB tracking

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -251,6 +251,8 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, co
                      report_data->FormatHandle(image_state->create_from_swapchain).c_str(),
                      report_data->FormatHandle(image_state->bind_swapchain).c_str());
         }
+    } else if (image_state->external_ahb) {
+        // TODO look into how to properly check for a valid bound memory for an external AHB
     } else if (0 == (static_cast<uint32_t>(image_state->createInfo.flags) & VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
         result = VerifyBoundMemoryIsValid(image_state->binding.mem_state.get(), image_state->image,
                                           VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage), api_name, error_code);
@@ -2637,15 +2639,20 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
     return skip;
 }
 
-bool CoreChecks::ValidateGetImageMemoryRequirements2ANDROID(const VkImage image) const {
+bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const char *func_name) const {
     bool skip = false;
 
     const IMAGE_STATE *image_state = GetImageState(image);
-    if (image_state->imported_ahb && (0 == image_state->GetBoundMemory().size())) {
-        skip |= LogError(image, "VUID-VkImageMemoryRequirementsInfo2-image-01897",
-                         "vkGetImageMemoryRequirements2: Attempt to query layout from an image created with "
+    if (image_state->external_ahb && (0 == image_state->GetBoundMemory().size())) {
+        // TODO update when new VUID comes out
+        const char *vuid = strcmp(func_name, "vkGetImageMemoryRequirements()") == 0
+                               ? "UNASSIGNED-vkGetImageMemoryRequirements-image"
+                               : "VUID-VkImageMemoryRequirementsInfo2-image-01897";
+        skip |= LogError(image, vuid,
+                         "%s: Attempt get image memory requirements for an image created with a "
                          "VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID handleType, which has not yet been "
-                         "bound to memory.");
+                         "bound to memory.",
+                         func_name);
     }
     return skip;
 }
@@ -2698,7 +2705,7 @@ bool CoreChecks::ValidateCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbc
     return false;
 }
 
-bool CoreChecks::ValidateGetImageMemoryRequirements2ANDROID(const VkImage image) const { return false; }
+bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const char *func_name) const { return false; }
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
@@ -2755,6 +2762,15 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
         }
     }
 
+    bool imported_ahb = false;
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    //  "memory is not an imported Android Hardware Buffer" refers to VkImportAndroidHardwareBufferInfoANDROID with a non-NULL
+    //  buffer value. Memory imported has another VUID to check size and allocationSize match up
+    auto imported_ahb_info = lvl_find_in_chain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
+    if (imported_ahb_info != nullptr) {
+        imported_ahb = imported_ahb_info->buffer != nullptr;
+    }
+#endif
     auto dedicated_allocate_info = lvl_find_in_chain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext);
     if (dedicated_allocate_info) {
         if ((dedicated_allocate_info->buffer != VK_NULL_HANDLE) && (dedicated_allocate_info->image != VK_NULL_HANDLE)) {
@@ -2769,12 +2785,14 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                  "VK_IMAGE_CREATE_DISJOINT_BIT",
                                  report_data->FormatHandle(dedicated_allocate_info->image).c_str());
             } else {
-                if (pAllocateInfo->allocationSize != image_state->requirements.size) {
-                    skip |=
-                        LogError(device, "VUID-VkMemoryDedicatedAllocateInfo-image-01433",
-                                 "Allocation Size (%u) needs to be equal to VkImage %s VkMemoryRequirements::size (%u)",
-                                 pAllocateInfo->allocationSize, report_data->FormatHandle(dedicated_allocate_info->image).c_str(),
-                                 image_state->requirements.size);
+                if ((pAllocateInfo->allocationSize != image_state->requirements.size) && (imported_ahb == false)) {
+                    const char *vuid = (device_extensions.vk_android_external_memory_android_hardware_buffer)
+                                           ? "VUID-VkMemoryDedicatedAllocateInfo-image-02964"
+                                           : "VUID-VkMemoryDedicatedAllocateInfo-image-01433";
+                    skip |= LogError(
+                        device, vuid, "Allocation Size (%u) needs to be equal to VkImage %s VkMemoryRequirements::size (%u)",
+                        pAllocateInfo->allocationSize, report_data->FormatHandle(dedicated_allocate_info->image).c_str(),
+                        image_state->requirements.size);
                 }
                 if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
                     skip |= LogError(device, "VUID-VkMemoryDedicatedAllocateInfo-image-01434",
@@ -2786,11 +2804,14 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
         } else if (dedicated_allocate_info->buffer != VK_NULL_HANDLE) {
             // Dedicated VkBuffer
             const BUFFER_STATE *buffer_state = GetBufferState(dedicated_allocate_info->buffer);
-            if (pAllocateInfo->allocationSize != buffer_state->requirements.size) {
-                skip |= LogError(device, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435",
-                                 "Allocation Size (%u) needs to be equal to VkBuffer %s VkMemoryRequirements::size (%u)",
-                                 pAllocateInfo->allocationSize, report_data->FormatHandle(dedicated_allocate_info->buffer).c_str(),
-                                 buffer_state->requirements.size);
+            if ((pAllocateInfo->allocationSize != buffer_state->requirements.size) && (imported_ahb == false)) {
+                const char *vuid = (device_extensions.vk_android_external_memory_android_hardware_buffer)
+                                       ? "VUID-VkMemoryDedicatedAllocateInfo-buffer-02965"
+                                       : "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435";
+                skip |=
+                    LogError(device, vuid, "Allocation Size (%u) needs to be equal to VkBuffer %s VkMemoryRequirements::size (%u)",
+                             pAllocateInfo->allocationSize, report_data->FormatHandle(dedicated_allocate_info->buffer).c_str(),
+                             buffer_state->requirements.size);
             }
             if ((buffer_state->createInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0) {
                 skip |= LogError(device, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01436",
@@ -3299,14 +3320,18 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements(VkDevice device, VkIm
                 "%s must not have been created with the VK_IMAGE_CREATE_DISJOINT_BIT (need to use vkGetImageMemoryRequirements2).",
                 report_data->FormatHandle(image).c_str());
         }
+
+        if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
+            skip |= ValidateGetImageMemoryRequirementsANDROID(image, "vkGetImageMemoryRequirements()");
+        }
     }
     return skip;
 }
 
-bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2 *pInfo) const {
+bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2 *pInfo, const char *func_name) const {
     bool skip = false;
     if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
-        skip |= ValidateGetImageMemoryRequirements2ANDROID(pInfo->image);
+        skip |= ValidateGetImageMemoryRequirementsANDROID(pInfo->image, func_name);
     }
 
     const IMAGE_STATE *image_state = GetImageState(pInfo->image);
@@ -3318,26 +3343,26 @@ bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirem
     if ((FormatIsMultiplane(image_format)) && (0 != (image_state->createInfo.flags & VK_IMAGE_CREATE_DISJOINT_BIT)) &&
         (image_plane_info == nullptr)) {
         skip |= LogError(pInfo->image, "VUID-VkImageMemoryRequirementsInfo2-image-01589",
-                         "vkGetImageMemoryRequirements2: %s image was created with a multi-planar format (%s) and "
+                         "%s: %s image was created with a multi-planar format (%s) and "
                          "VK_IMAGE_CREATE_DISJOINT_BIT, but the current pNext doesn't include a "
                          "VkImagePlaneMemoryRequirementsInfo struct",
-                         report_data->FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
+                         func_name, report_data->FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
     }
 
     if ((0 == (image_state->createInfo.flags & VK_IMAGE_CREATE_DISJOINT_BIT)) && (image_plane_info != nullptr)) {
         skip |= LogError(pInfo->image, "VUID-VkImageMemoryRequirementsInfo2-image-01590",
-                         "vkGetImageMemoryRequirements2: %s image was not created with VK_IMAGE_CREATE_DISJOINT_BIT,"
+                         "%s: %s image was not created with VK_IMAGE_CREATE_DISJOINT_BIT,"
                          "but the current pNext includes a VkImagePlaneMemoryRequirementsInfo struct",
-                         report_data->FormatHandle(pInfo->image).c_str());
+                         func_name, report_data->FormatHandle(pInfo->image).c_str());
     }
 
     if ((FormatIsMultiplane(image_format) == false) && (image_tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) &&
         (image_plane_info != nullptr)) {
         skip |= LogError(pInfo->image, "VUID-VkImageMemoryRequirementsInfo2-image-02280",
-                         "vkGetImageMemoryRequirements2: %s image is a single-plane format (%s) and does not have tiling of "
+                         "%s: %s image is a single-plane format (%s) and does not have tiling of "
                          "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,"
                          "but the current pNext includes a VkImagePlaneMemoryRequirementsInfo struct",
-                         report_data->FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
+                         func_name, report_data->FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
     }
 
     if (image_plane_info != nullptr) {
@@ -3348,17 +3373,17 @@ bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirem
             if ((2 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT)) {
                 skip |= LogError(
                     pInfo->image, "VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281",
-                    "Image %s VkImagePlaneMemoryRequirementsInfo::planeAspect is %s but can only be VK_IMAGE_ASPECT_PLANE_0_BIT"
+                    "%s: Image %s VkImagePlaneMemoryRequirementsInfo::planeAspect is %s but can only be VK_IMAGE_ASPECT_PLANE_0_BIT"
                     "or VK_IMAGE_ASPECT_PLANE_1_BIT.",
-                    report_data->FormatHandle(image_state->image).c_str(), string_VkImageAspectFlags(aspect).c_str());
+                    func_name, report_data->FormatHandle(image_state->image).c_str(), string_VkImageAspectFlags(aspect).c_str());
             }
             if ((3 == planes) && (aspect != VK_IMAGE_ASPECT_PLANE_0_BIT) && (aspect != VK_IMAGE_ASPECT_PLANE_1_BIT) &&
                 (aspect != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
                 skip |= LogError(
                     pInfo->image, "VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281",
-                    "Image %s VkImagePlaneMemoryRequirementsInfo::planeAspect is %s but can only be VK_IMAGE_ASPECT_PLANE_0_BIT"
+                    "%s: Image %s VkImagePlaneMemoryRequirementsInfo::planeAspect is %s but can only be VK_IMAGE_ASPECT_PLANE_0_BIT"
                     "or VK_IMAGE_ASPECT_PLANE_1_BIT or VK_IMAGE_ASPECT_PLANE_2_BIT.",
-                    report_data->FormatHandle(image_state->image).c_str(), string_VkImageAspectFlags(aspect).c_str());
+                    func_name, report_data->FormatHandle(image_state->image).c_str(), string_VkImageAspectFlags(aspect).c_str());
             }
         }
     }
@@ -3367,12 +3392,12 @@ bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirem
 
 bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
                                                             VkMemoryRequirements2 *pMemoryRequirements) const {
-    return ValidateGetImageMemoryRequirements2(pInfo);
+    return ValidateGetImageMemoryRequirements2(pInfo, "vkGetImageMemoryRequirements2()");
 }
 
 bool CoreChecks::PreCallValidateGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
                                                                VkMemoryRequirements2 *pMemoryRequirements) const {
-    return ValidateGetImageMemoryRequirements2(pInfo);
+    return ValidateGetImageMemoryRequirements2(pInfo, "vkGetImageMemoryRequirements2KHR()");
 }
 
 bool CoreChecks::PreCallValidateGetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice physicalDevice,
@@ -9259,17 +9284,11 @@ bool CoreChecks::ValidateBindImageMemory(const VkBindImageMemoryInfo &bindInfo, 
     if (image_state) {
         // Track objects tied to memory
         skip = ValidateSetMemBinding(bindInfo.memory, VulkanTypedHandle(bindInfo.image, kVulkanObjectTypeImage), api_name);
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-        if (image_state->external_format_android) {
-            if (image_state->memory_requirements_checked) {
-                skip |= LogError(bindInfo.image, kVUID_Core_BindImage_InvalidMemReqQuery,
-                                 "%s: Must not call vkGetImageMemoryRequirements on %s that will be bound to an external "
-                                 "Android hardware buffer.",
-                                 api_name, report_data->FormatHandle(bindInfo.image).c_str());
-            }
+
+        if (image_state->external_ahb) {
+            // TODO check what is valid to cover with external AHB below
             return skip;
         }
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
         const auto plane_info = lvl_find_in_chain<VkBindImagePlaneMemoryInfo>(bindInfo.pNext);
         const auto mem_info = GetDevMemState(bindInfo.memory);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -61,7 +61,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDeviceQueueFamily(uint32_t queue_family, const char* cmd_name, const char* parameter_name, const char* error_code,
                                    bool optional) const;
     bool ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset, const char* api_name) const;
-    bool ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2* pInfo) const;
+    bool ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirementsInfo2* pInfo, const char* func_name) const;
     bool CheckCommandBuffersInFlight(const COMMAND_POOL_STATE* pPool, const char* action, const char* error_code) const;
     bool CheckCommandBufferInFlight(const CMD_BUFFER_STATE* cb_node, const char* action, const char* error_code) const;
     bool VerifyQueueStateToFence(VkFence fence) const;
@@ -669,7 +669,7 @@ class CoreChecks : public ValidationStateTracker {
                                const char* array_parameter_name, const char* unique_error_code, const char* valid_error_code,
                                bool optional) const;
     bool ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo* alloc_info) const;
-    bool ValidateGetImageMemoryRequirements2ANDROID(const VkImage image) const;
+    bool ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const char* func_name) const;
     bool ValidateCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo* create_info) const;
     bool ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
                                                                 const VkImageFormatProperties2* pImageFormatProperties) const;

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
- * Copyright (C) 2015-2019 Google Inc.
+/* Copyright (c) 2015-2020 The Khronos Group Inc.
+ * Copyright (c) 2015-2020 Valve Corporation
+ * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (C) 2015-2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,7 +241,8 @@ static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_TemplateType 
 static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_Template_SetMismatched = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-set";
 static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_Template_LayoutMismatched = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-layout";
 
-static const char DECORATE_UNUSED *kVUID_Core_BindImage_InvalidMemReqQuery = "UNASSIGNED-CoreValidation-vkBindImageMemory-invalid-requirements";
+// Previously defined but unused - uncomment as needed
+// static const char DECORATE_UNUSED *kVUID_Core_BindImage_InvalidMemReqQuery = "UNASSIGNED-CoreValidation-vkBindImageMemory-invalid-requirements";
 static const char DECORATE_UNUSED *kVUID_Core_BindImage_NoMemReqQuery = "UNASSIGNED-CoreValidation-vkBindImageMemory-memory-requirements";
 static const char DECORATE_UNUSED *kVUID_Core_BindBuffer_NoMemReqQuery = "UNASSIGNED-CoreValidation-vkBindBufferMemory-memory-requirements";
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -380,7 +380,7 @@ class IMAGE_STATE : public BINDABLE {
     bool get_sparse_reqs_called;         // Track if GetImageSparseMemoryRequirements() has been called for this image
     bool sparse_metadata_required;       // Track if sparse metadata aspect is required for this image
     bool sparse_metadata_bound;          // Track if sparse metadata aspect is bound to this image
-    bool imported_ahb;                   // True if image was imported from an Android Hardware Buffer
+    bool external_ahb;                   // True if image will be imported/exported from/to an Android Hardware Buffer
     bool has_ahb_format;                 // True if image was created with an external Android format
     bool is_swapchain_image;             // True if image is a swapchain image
     uint64_t ahb_format;                 // External Android format, if provided
@@ -396,10 +396,6 @@ class IMAGE_STATE : public BINDABLE {
     bool plane1_memory_requirements_checked = false;
     VkMemoryRequirements plane2_requirements;
     bool plane2_memory_requirements_checked = false;
-
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-    uint64_t external_format_android;
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
     IMAGE_STATE(VkImage img, const VkImageCreateInfo *pCreateInfo);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -9267,14 +9267,26 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     memory_allocate_info.allocationSize = normal_image_memory_req.size - 1;
     dedicated_allocate_info.image = normal_image;
     dedicated_allocate_info.buffer = VK_NULL_HANDLE;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-image-01433");
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    const char *image_vuid = DeviceExtensionEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
+                                 ? "VUID-VkMemoryDedicatedAllocateInfo-image-02964"
+                                 : "VUID-VkMemoryDedicatedAllocateInfo-image-01433";
+    const char *buffer_vuid = DeviceExtensionEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
+                                  ? "VUID-VkMemoryDedicatedAllocateInfo-buffer-02965"
+                                  : "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435";
+#else
+    const char *image_vuid = "VUID-VkMemoryDedicatedAllocateInfo-image-01433";
+    const char *buffer_vuid = "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435";
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, image_vuid);
     vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
     m_errorMonitor->VerifyFound();
 
     memory_allocate_info.allocationSize = normal_buffer_memory_req.size - 1;
     dedicated_allocate_info.image = VK_NULL_HANDLE;
     dedicated_allocate_info.buffer = normal_buffer;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, buffer_vuid);
     vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
So this fixes up a few issues with external AHB tracking

The big change is instead of tracking "imported ahb" I am tracking "external ahb" which can be imported or exported as there is no way to know if it will be imported or exported upon creating an image/buffer

This makes fixes to upcoming spec fixes that alter the use of dedicated memory VU if its an external AHB

Lastly made changes to the fact you can't call vkGet*MemoryRequirements for an external AHB until the memory is bound

More changes to come in future, this is just to clean things up a little first