### PR TITLE
Fix some noisy warnings when compiling with GCC 9.1

### DIFF
--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -220,7 +220,7 @@ const InitialLayoutState* ImageSubresourceLayoutMap::GetSubresourceInitialLayout
 
 // TODO: make sure this paranoia check is sufficient and not too much.
 uintptr_t ImageSubresourceLayoutMap::CompatibilityKey() const {
-    return (reinterpret_cast<const uintptr_t>(&image_state_) ^ encoder_.AspectMask());
+    return (reinterpret_cast<uintptr_t>(&image_state_) ^ encoder_.AspectMask());
 }
 
 bool ImageSubresourceLayoutMap::UpdateFrom(const ImageSubresourceLayoutMap& other) {

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2170,7 +2170,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                          "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.");
                     }
                 } else {
-                    if (static_cast<const uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
+                    if (static_cast<uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
                                          "vkCreateGraphicsPipelines parameter pCreateInfos->basePipelineIndex (%d) must be a valid"
                                          "index into the pCreateInfos array, of size %d.",

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -111,6 +111,7 @@ struct range {
 
     range() : begin(), end() {}
     range(const index_type &begin_, const index_type &end_) : begin(begin_), end(end_) {}
+    range(const range &other) : begin(other.begin), end(other.end) {}
 };
 
 template <typename Range>
@@ -472,6 +473,10 @@ class range_map {
         friend range_map;
 
       public:
+        const_iterator &operator=(const const_iterator &other) {
+            Base::operator=(other);
+            return *this;
+        }
         const_iterator(const const_iterator &other) : Base(other){};
         const_iterator(const iterator &it) : Base(ImplConstIterator(it.get_pos())) {}
         const_iterator() : Base() {}
@@ -712,6 +717,7 @@ class small_range_map {
 
         // At end()
         IteratorImpl() : map_(nullptr), pos_(N) {}
+        IteratorImpl(const IteratorImpl &other) : map_(other.map_), pos_(other.pos_) {}
 
         // Raw getters to allow for const_iterator conversion below
         Map *get_map() const { return map_; }

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -415,6 +415,8 @@ class BothRangeMap {
         }
         bool operator!=(const IteratorImpl& other) const { return !(*this == other); }
         IteratorImpl() : small_it_(), big_it_(), mode_(BothRangeMapMode::kTristate) {}
+        IteratorImpl(const IteratorImpl& original)
+            : small_it_(original.small_it_), big_it_(original.big_it_), mode_(original.mode_) {}
 
       private:
         IteratorImpl(BothRangeMapMode mode) : small_it_(), big_it_(), mode_(mode) {}

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -389,16 +389,21 @@ class BothRangeMap {
         }
         IteratorImpl& operator=(const IteratorImpl& other) {
             if (other.Tristate()) {
-                // Tranisition to tristate
-                *this = IteratorImpl();
-            } else {
-                if (other.SmallMode()) {
-                    small_it_ = other.small_it_;
-                } else {
-                    big_it_ = other.big_it_;
+                // Transition to tristate
+                small_it_ = SmallIt();
+                big_it_ = BigIt();
+            } else if (other.SmallMode()) {
+                small_it_ = other.small_it_;
+                if (mode_ != other.mode_) {
+                    big_it_ = BigIt();
                 }
-                mode_ = other.mode_;  // For transitions from Tristate.
+            } else {
+                big_it_ = other.big_it_;
+                if (mode_ != other.mode_) {
+                    small_it_ = SmallIt();
+                }
             }
+            mode_ = other.mode_;
             return *this;
         }
         bool operator==(const IteratorImpl& other) const {
@@ -415,8 +420,10 @@ class BothRangeMap {
         }
         bool operator!=(const IteratorImpl& other) const { return !(*this == other); }
         IteratorImpl() : small_it_(), big_it_(), mode_(BothRangeMapMode::kTristate) {}
-        IteratorImpl(const IteratorImpl& original)
-            : small_it_(original.small_it_), big_it_(original.big_it_), mode_(original.mode_) {}
+        IteratorImpl(const IteratorImpl& other)
+            : small_it_(other.SmallMode() ? other.small_it_ : SmallIt()),
+              big_it_(other.BigMode() ? other.big_it_ : BigIt()),
+              mode_(other.mode_){};
 
       private:
         IteratorImpl(BothRangeMapMode mode) : small_it_(), big_it_(), mode_(mode) {}

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -287,7 +287,7 @@ class SubresourceGenerator : public Subresource {
     // General purpose and slow, when we have no other information to update the generator
     void Seek(IndexType index) {
         // skip forward past discontinuities
-        *static_cast<Subresource* const>(this) = encoder_->Decode(index);
+        *static_cast<Subresource*>(this) = encoder_->Decode(index);
     }
 
     const VkImageSubresource& operator*() const { return *this; }


### PR DESCRIPTION
Small cleanup pass to eliminate warnings [-Wdeprecated-copy](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy) and [-Wignored-qualifiers](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/Warning-Options.html#index-Wignored-qualifiers) with recent versions of GCC.

-Wdeprecated-copy is particularly noisy and makes it difficult sort through other compiler output.