### PR TITLE
Add blurb to BUILD.md for using update_deps.py to change architectures

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -173,6 +173,10 @@ specific requirements for configuring and building these components.
 
 - You may need to adjust some of the CMake options based on your platform. See
   the platform-specific sections later in this document.
+- When using update_deps.py to change architectures, for example, from x64 to Win32,
+  it is strongly recommended to add the '--clean-repo' parameter. This avoids
+  architecture incompatibilities among dependent components.
+  dependent components will produce consistent build artifacts.
 - The `update_deps.py` script fetches and builds the dependent repositories in
   the current directory when it is invoked. In this case, they are built in
   the `build` directory.

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -420,9 +420,12 @@ class GoodRepo(object):
         # Use the CMake -A option to select the platform architecture
         # without needing a Visual Studio generator.
         if platform.system() == 'Windows':
-            if self._args.arch == '64' or self._args.arch == 'x64' or self._args.arch == 'win64':
+            if self._args.arch.lower() == '64' or self._args.arch == 'x64' or self._args.arch == 'win64':
                 cmake_cmd.append('-A')
                 cmake_cmd.append('x64')
+            else:
+                cmake_cmd.append('-A')
+                cmake_cmd.append('Win32')
 
         # Apply a generator, if one is specified.  This can be used to supply
         # a specific generator for the dependent repositories to match

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -250,6 +250,7 @@ import platform
 import multiprocessing
 import shlex
 import shutil
+import stat
 
 KNOWN_GOOD_FILE_NAME = 'known_good.json'
 
@@ -264,6 +265,14 @@ VERBOSE = False
 
 DEVNULL = open(os.devnull, 'wb')
 
+
+def on_rm_error( func, path, exc_info):
+    """Error handler for recursively removing a directory. The
+    shutil.rmtree function can fail on Windows due to read-only files.
+    This handler will change the permissions for tha file and continue.
+    """
+    os.chmod( path, stat.S_IWRITE )
+    os.unlink( path )
 
 def command_output(cmd, directory, fail_ok=False):
     """Runs a command in a directory and returns its standard output stream.
@@ -343,7 +352,7 @@ class GoodRepo(object):
     def Checkout(self):
         print('Checking out {n} in {d}'.format(n=self.name, d=self.repo_dir))
         if self._args.do_clean_repo:
-            shutil.rmtree(self.repo_dir, ignore_errors=True)
+            shutil.rmtree(self.repo_dir, onerror = on_rm_error)
         if not os.path.exists(os.path.join(self.repo_dir, '.git')):
             self.Clone()
         self.Fetch()


### PR DESCRIPTION
Changing architectures doesn't filter down to the glslang dependent repo in the `external `directory, so switching from `win32 `to `x64 `(or back) will cause build failures.  Using the `--clean-repo` argument causes a refresh and avoids build errors.

Fixes #1681.