### PR TITLE
Validate blending on color attachment without blending support VU 02023

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4617,6 +4617,57 @@ static const char *GetPipelineTypeName(VkPipelineBindPoint pipelineBindPoint) {
     }
 }
 
+bool CoreChecks::ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE *cb_state, const PIPELINE_STATE *pipeline_state) const {
+    bool skip = false;
+    const FRAMEBUFFER_STATE *fb_state = GetFramebufferState(cb_state->activeFramebuffer);
+
+    if (fb_state) {
+        auto subpass_desc = &pipeline_state->rp_state->createInfo.pSubpasses[pipeline_state->graphicsPipelineCI.subpass];
+
+        for (size_t i = 0; i < pipeline_state->attachments.size(); i++) {
+            const auto attachment = subpass_desc->pColorAttachments[i].attachment;
+            if (attachment == VK_ATTACHMENT_UNUSED) continue;
+
+            const IMAGE_VIEW_STATE *imageview_state = GetImageViewState(fb_state->createInfo.pAttachments[attachment]);
+            if (!imageview_state) continue;
+
+            const IMAGE_STATE *image_state = GetImageState(imageview_state->create_info.image);
+            if (!image_state) continue;
+
+            VkImageTiling tiling = image_state->createInfo.tiling;
+            VkFormat format = pipeline_state->rp_state->createInfo.pAttachments[attachment].format;
+
+            VkFormatProperties properties = GetPDFormatProperties(format);
+            VkFormatFeatureFlags format_features;
+
+            switch (tiling) {
+                case VK_IMAGE_TILING_OPTIMAL:
+                case VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT:
+                    format_features = properties.optimalTilingFeatures;
+                    break;
+                case VK_IMAGE_TILING_LINEAR:
+                    format_features = properties.linearTilingFeatures;
+                    break;
+                default:
+                    // Invalid tiling
+                    continue;
+            }
+
+            if (pipeline_state->graphicsPipelineCI.pRasterizationState &&
+                !pipeline_state->graphicsPipelineCI.pRasterizationState->rasterizerDiscardEnable &&
+                pipeline_state->attachments[i].blendEnable && !(format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-blendEnable-02023",
+                                 "vkCreateGraphicsPipelines(): pipeline.pColorBlendState.pAttachments[" PRINTF_SIZE_T_SPECIFIER
+                                 "].blendEnable is VK_TRUE but format %s associated with this attachment does "
+                                 "not support VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT.",
+                                 i, string_VkFormat(format));
+            }
+        }
+    }
+
+    return skip;
+}
+
 bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                 VkPipeline pipeline) const {
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
@@ -4651,6 +4702,9 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                              "Cannot bind a pipeline of type %s to the ray-tracing pipeline bind point",
                              GetPipelineTypeName(pipeline_state_bind_point));
         }
+    } else {
+        if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS)
+            skip |= ValidateGraphicsPipelineBindPoint(cb_state, pipeline_state);
     }
 
     return skip;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -132,6 +132,7 @@ class CoreChecks : public ValidationStateTracker {
                                       const BUFFER_STATE* state_data) const;
     bool ValidateCreateSwapchain(const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo,
                                  const SURFACE_STATE* surface_state, const SWAPCHAIN_NODE* old_swapchain_state) const;
+    bool ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE* cb_state, const PIPELINE_STATE* pipeline_state) const;
     bool ValidatePipelineBindPoint(const CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point, const char* func_name,
                                    const std::map<VkPipelineBindPoint, std::string>& bind_errors) const;
     bool ValidateMemoryIsMapped(const char* funcName, uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges) const;


### PR DESCRIPTION
We got this bug report from the Angle team at Google : https://gitlab.freedesktop.org/mesa/mesa/-/issues/2743

After checking the spec I realized this should have been reported as an error in the validation layer but we're missing this VU.