### PR TITLE
Take separate stencil usage flags into account

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -341,6 +341,10 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     }
 
     auto image_usage = image_state->createInfo.usage;
+    const auto stencil_usage_info = lvl_find_in_chain<VkImageStencilUsageCreateInfo>(image_state->createInfo.pNext);
+    if (stencil_usage_info) {
+        image_usage |= stencil_usage_info->stencilUsage;
+    }
 
     // Check for layouts that mismatch image usages in the framebuffer
     if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6949,7 +6949,12 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2KHR *att
                         if (view_state) {
                             const VkImageCreateInfo *ici = &GetImageState(view_state->create_info.image)->createInfo;
                             if (ici != nullptr) {
-                                if ((ici->usage & usage_flag) == 0) {
+                                auto creation_usage = ici->usage;
+                                const auto stencil_usage_info = lvl_find_in_chain<VkImageStencilUsageCreateInfo>(ici->pNext);
+                                if (stencil_usage_info) {
+                                    creation_usage |= stencil_usage_info->stencilUsage;
+                                }
+                                if ((creation_usage & usage_flag) == 0) {
                                     skip |= LogError(device, error_code,
                                                      "vkCreateFramebuffer:  Framebuffer Attachment (%d) conflicts with the image's "
                                                      "IMAGE_USAGE flags (%s).",

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1420,6 +1420,10 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
 
     format = image_node->createInfo.format;
     usage = image_node->createInfo.usage;
+    const auto stencil_usage_info = lvl_find_in_chain<VkImageStencilUsageCreateInfo>(image_node->createInfo.pNext);
+    if (stencil_usage_info) {
+        usage |= stencil_usage_info->stencilUsage;
+    }
     // Validate that memory is bound to image
     // TODO: This should have its own valid usage id apart from 2524 which is from CreateImageView case. The only
     //  the error here occurs is if memory bound to a created imageView has been freed.


### PR DESCRIPTION
When images are created using a separate VkImageStencilUsageCreateInfo
structure as part of the creation information chain, the stencil usage
flags need to be taken into account in several validations.

Closes #1697.