### PR TITLE
shader_validation.h: avoid build error with -Wstringop-truncation

### DIFF
--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -301,9 +301,11 @@ class ValidationCache {
         // Convert sha1_str from a hex string to binary. We only need VK_UUID_SIZE bytes of
         // output, so pad with zeroes if the input string is shorter than that, and truncate
         // if it's longer.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         char padded_sha1_str[2 * VK_UUID_SIZE + 1] = {};  // 2 hex digits == 1 byte
         std::strncpy(padded_sha1_str, sha1_str, 2 * VK_UUID_SIZE);
-
+#pragma GCC diagnostic pop
         for (uint32_t i = 0; i < VK_UUID_SIZE; ++i) {
             const char byte_str[] = {padded_sha1_str[2 * i + 0], padded_sha1_str[2 * i + 1], '\0'};
             uuid[i] = static_cast<uint8_t>(std::strtoul(byte_str, nullptr, 16));


### PR DESCRIPTION
From the comment it appears truncating the string is the intended
behaviour. Thus disable this warning for this piece of code.

|                  from /build-wayland/tmp/work/aarch64-mx8m-poky-linux/vulkan-validationlayers/1.1.121-r0/git/layers/core_validation.cpp:64:
| /build-wayland/tmp/work/aarch64-mx8m-poky-linux/vulkan-validationlayers/1.1.121-r0/git/layers/shader_validation.h: In function 'void ValidationCache::Sha1ToVkUuid(const char*, uint8_t*)':
| /build-wayland/tmp/work/aarch64-mx8m-poky-linux/vulkan-validationlayers/1.1.121-r0/git/layers/shader_validation.h:293:21: warning: 'char* strncpy(char*, const char*, size_t)' output truncated copying 32 bytes from a string of length 40 [-Wstringop-truncation]
|   293 |         std::strncpy(padded_sha1_str, sha1_str, 2 * VK_UUID_SIZE);
|       |         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ninja: build stopped: subcommand failed.
| WARNING: exit code 1 from a shell command.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>