### PR TITLE
Fix descriptor_sets.cpp error messages for proper object handing

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3448,17 +3448,15 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE *pCB, const G
                 assert(initial_layout_state);  // There's no way we should have an initial layout without matching state...
                 bool matches = ImageLayoutMatches(initial_layout_state->aspect_mask, image_layout, initial_layout);
                 if (!matches) {
-                    std::string formatted_label = FormatDebugLabel(" ", pCB->debug_label);
                     // We can report all the errors for the intersected range directly
                     for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->range_encoder.Decode(index);
                         skip |= LogError(
                             pCB->commandBuffer, kVUID_Core_DrawState_InvalidImageLayout,
                             "Submitted command buffer expects %s (subresource: aspectMask 0x%X array layer %u, mip level %u) "
-                            "to be in layout %s--instead, current layout is %s.%s",
+                            "to be in layout %s--instead, current layout is %s.",
                             report_data->FormatHandle(image).c_str(), subresource.aspectMask, subresource.arrayLayer,
-                            subresource.mipLevel, string_VkImageLayout(initial_layout), string_VkImageLayout(image_layout),
-                            formatted_label.c_str());
+                            subresource.mipLevel, string_VkImageLayout(initial_layout), string_VkImageLayout(image_layout));
                     }
                 }
             }

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -510,8 +510,6 @@ class SWAPCHAIN_NODE : public BASE_NODE {
         : createInfo(pCreateInfo), swapchain(swapchain) {}
 };
 
-std::string FormatDebugLabel(const char *prefix, const LoggingLabel &label);
-
 extern bool ImageLayoutMatches(const VkImageAspectFlags aspect_mask, VkImageLayout a, VkImageLayout b);
 
 // Store the DAG.

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -747,7 +747,7 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                     if (!buffer_node || buffer_node->destroyed) {
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " is using buffer "
-                                  << report_data->FormatHandle(buffer).c_str() << " that is invalid or has been destroyed.";
+                                  << report_data->FormatHandle(buffer) << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     } else if (!buffer_node->sparse) {
@@ -810,7 +810,7 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                         //  as "invalid" (updated = false) at DestroyImageView() time and detect this error at bind time
                         std::stringstream error_str;
                         error_str << "Descriptor in binding #" << binding << " index " << index << " is using imageView "
-                                  << report_data->FormatHandle(image_view).c_str() << " that is invalid or has been destroyed.";
+                                  << report_data->FormatHandle(image_view) << " that is invalid or has been destroyed.";
                         *error = error_str.str();
                         return false;
                     }
@@ -1453,7 +1453,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             if ((aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != VK_IMAGE_ASPECT_COLOR_BIT) {
                 std::stringstream error_str;
                 error_str
-                    << "ImageView (" << report_data->FormatHandle(image_view).c_str()
+                    << "ImageView (" << report_data->FormatHandle(image_view)
                     << ") uses layout VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL but does not have VK_IMAGE_ASPECT_COLOR_BIT set.";
                 *error_msg = error_str.str();
                 return false;
@@ -1461,7 +1461,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             // format must NOT be DS
             if (ds) {
                 std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str()
+                error_str << "ImageView (" << report_data->FormatHandle(image_view)
                           << ") uses layout VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL but the image format is "
                           << string_VkFormat(format) << " which is not a color format.";
                 *error_msg = error_str.str();
@@ -1475,7 +1475,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                 if (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                     // both  must NOT be set
                     std::stringstream error_str;
-                    error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str()
+                    error_str << "ImageView (" << report_data->FormatHandle(image_view)
                               << ") has both STENCIL and DEPTH aspects set";
                     *error_msg = error_str.str();
                     return false;
@@ -1483,7 +1483,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             } else if (!(aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT)) {
                 // Neither were set
                 std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str() << ") has layout "
+                error_str << "ImageView (" << report_data->FormatHandle(image_view) << ") has layout "
                           << string_VkImageLayout(image_layout) << " but does not have STENCIL or DEPTH aspects set";
                 *error_msg = error_str.str();
                 return false;
@@ -1491,7 +1491,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             // format must be DS
             if (!ds) {
                 std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str() << ") has layout "
+                error_str << "ImageView (" << report_data->FormatHandle(image_view) << ") has layout "
                           << string_VkImageLayout(image_layout) << " but the image format is " << string_VkFormat(format)
                           << " which is not a depth/stencil format.";
                 *error_msg = error_str.str();
@@ -1505,7 +1505,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                     if (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                         // both  must NOT be set
                         std::stringstream error_str;
-                        error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str() << ") has layout "
+                        error_str << "ImageView (" << report_data->FormatHandle(image_view) << ") has layout "
                                   << string_VkImageLayout(image_layout) << " and is using depth/stencil image of format "
                                   << string_VkFormat(format)
                                   << " but it has both STENCIL and DEPTH aspects set, which is illegal. When using a depth/stencil "
@@ -1545,7 +1545,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                 // TODO : Need to create custom enum error codes for these cases
                 if (image_node->shared_presentable) {
                     if (VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR != image_layout) {
-                        error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str()
+                        error_str << "ImageView (" << report_data->FormatHandle(image_view)
                                   << ") of VK_DESCRIPTOR_TYPE_STORAGE_IMAGE type with a front-buffered image is being updated with "
                                      "layout "
                                   << string_VkImageLayout(image_layout)
@@ -1556,7 +1556,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                         return false;
                     }
                 } else if (VK_IMAGE_LAYOUT_GENERAL != image_layout) {
-                    error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str()
+                    error_str << "ImageView (" << report_data->FormatHandle(image_view)
                               << ") of VK_DESCRIPTOR_TYPE_STORAGE_IMAGE type is being updated with layout "
                               << string_VkImageLayout(image_layout)
                               << " but according to spec section 13.1 Descriptor Types, 'Load and store operations on storage "
@@ -1579,9 +1579,9 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     }
     if (error_usage_bit) {
         std::stringstream error_str;
-        error_str << "ImageView (" << report_data->FormatHandle(image_view).c_str() << ") with usage mask " << std::hex
-                  << std::showbase << usage << " being used for a descriptor update of type " << string_VkDescriptorType(type)
-                  << " does not have " << error_usage_bit << " set.";
+        error_str << "ImageView (" << report_data->FormatHandle(image_view) << ") with usage mask " << std::hex << std::showbase
+                  << usage << " being used for a descriptor update of type " << string_VkDescriptorType(type) << " does not have "
+                  << error_usage_bit << " set.";
         *error_msg = error_str.str();
         return false;
     }
@@ -1613,8 +1613,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             std::stringstream error_str;
             error_str << "Descriptor update with descriptorType " << string_VkDescriptorType(type)
                       << " is being updated with invalid imageLayout " << string_VkImageLayout(image_layout) << " for image "
-                      << report_data->FormatHandle(image).c_str() << " in imageView "
-                      << report_data->FormatHandle(image_view).c_str()
+                      << report_data->FormatHandle(image) << " in imageView " << report_data->FormatHandle(image_view)
                       << ". Allowed layouts are: VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
                       << "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL";
             for (auto &ext_layout : extended_layouts) {
@@ -2720,7 +2719,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet *dest_set, const 
                         error_str << "image " << report_data->FormatHandle(image_state->image)
                                   << " combined image sampler is a multi-planar "
                                   << "format and " << report_data->FormatHandle(iv_state->image_view)
-                                  << " aspectMask must only include " << string_VkImageAspectFlags(legal_aspect_flags).c_str();
+                                  << " aspectMask must only include " << string_VkImageAspectFlags(legal_aspect_flags);
                         *error_msg = error_str.str();
                         return false;
                     }

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1040,19 +1040,21 @@ bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet *update, const Des
     // Verify dst layout still valid
     if (dst_layout->destroyed) {
         *error_code = "VUID-VkCopyDescriptorSet-dstSet-parameter";
-        string_sprintf(error_msg, "Cannot call %s to perform copy update on dstSet %s created with destroyed %s.", func_name,
-                       report_data->FormatHandle(dst_set->GetSet()).c_str(),
-                       report_data->FormatHandle(dst_layout->GetDescriptorSetLayout()).c_str());
+        std::ostringstream str;
+        str << "Cannot call " << func_name << " to perform copy update on dstSet " << report_data->FormatHandle(dst_set->GetSet())
+            << " created with destroyed " << report_data->FormatHandle(dst_layout->GetDescriptorSetLayout()) << ".";
+        *error_msg = str.str();
         return false;
     }
 
     // Verify src layout still valid
     if (src_layout->destroyed) {
         *error_code = "VUID-VkCopyDescriptorSet-srcSet-parameter";
-        string_sprintf(error_msg, "Cannot call %s to perform copy update of dstSet %s from srcSet %s created with destroyed %s.",
-                       func_name, report_data->FormatHandle(dst_set->GetSet()).c_str(),
-                       report_data->FormatHandle(src_set->GetSet()).c_str(),
-                       report_data->FormatHandle(src_layout->GetDescriptorSetLayout()).c_str());
+        std::ostringstream str;
+        str << "Cannot call " << func_name << " to perform copy update on dstSet " << report_data->FormatHandle(dst_set->GetSet())
+            << " from srcSet " << report_data->FormatHandle(src_set->GetSet()) << " created with destroyed "
+            << report_data->FormatHandle(src_layout->GetDescriptorSetLayout()) << ".";
+        *error_msg = str.str();
         return false;
     }
 
@@ -1998,12 +2000,14 @@ std::string cvdescriptorset::DescriptorSet::StringifySetAndLayout() const {
     std::string out;
     auto layout_handle = p_layout_->GetDescriptorSetLayout();
     if (IsPushDescriptor()) {
-        string_sprintf(&out, "Push Descriptors defined with VkDescriptorSetLayout %s",
-                       state_data_->report_data->FormatHandle(layout_handle).c_str());
+        std::ostringstream str;
+        str << "Push Descriptors defined with VkDescriptorSetLayout " << state_data_->report_data->FormatHandle(layout_handle);
+        out = str.str();
     } else {
-        string_sprintf(&out, "VkDescriptorSet %s allocated with VkDescriptorSetLayout %s",
-                       state_data_->report_data->FormatHandle(set_).c_str(),
-                       state_data_->report_data->FormatHandle(layout_handle).c_str());
+        std::ostringstream str;
+        str << "VkDescriptorSet " << state_data_->report_data->FormatHandle(set_) << " allocated with VkDescriptorSetLayout "
+            << state_data_->report_data->FormatHandle(layout_handle);
+        out = str.str();
     }
     return out;
 };
@@ -2483,8 +2487,10 @@ bool CoreChecks::ValidateWriteUpdate(const DescriptorSet *dest_set, const VkWrit
     // Verify dst layout still valid
     if (dest_layout->destroyed) {
         *error_code = "VUID-VkWriteDescriptorSet-dstSet-00320";
-        string_sprintf(error_msg, "Cannot call %s to perform write update on %s which has been destroyed", func_name,
-                       dest_set->StringifySetAndLayout().c_str());
+        std::ostringstream str;
+        str << "Cannot call " << func_name << " to perform write update on " << dest_set->StringifySetAndLayout()
+            << " which has been destroyed";
+        *error_msg = str.str();
         return false;
     }
     // Verify dst binding exists

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -555,11 +555,13 @@ void PerformUpdateDescriptorSets(ValidationStateTracker *, uint32_t, const VkWri
 // TODO: migrate out of descriptor_set.cpp/h
 // For a particular binding starting at offset and having update_count descriptors
 // updated, verify that for any binding boundaries crossed, the update is consistent
-bool VerifyUpdateConsistency(DescriptorSetLayout::ConstBindingIterator current_binding, uint32_t offset, uint32_t update_count,
-                             const char *type, const VkDescriptorSet set, std::string *error_msg);
+bool VerifyUpdateConsistency(debug_report_data *report_data, DescriptorSetLayout::ConstBindingIterator current_binding,
+                             uint32_t offset, uint32_t update_count, const char *type, const VkDescriptorSet set,
+                             std::string *error_msg);
 
 // Validate buffer descriptor update info
-bool ValidateBufferUsage(BUFFER_STATE const *buffer_node, VkDescriptorType type, std::string *error_code, std::string *error_msg);
+bool ValidateBufferUsage(debug_report_data *report_data, BUFFER_STATE const *buffer_node, VkDescriptorType type,
+                         std::string *error_code, std::string *error_msg);
 
 // Helper class to encapsulate the descriptor update template decoding logic
 struct DecodedTemplateUpdate {

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -187,8 +187,6 @@ struct LoggingLabelState {
     }
 };
 
-static inline int string_sprintf(std::string *output, const char *fmt, ...);
-
 typedef struct _debug_report_data {
     std::vector<VkLayerDbgFunctionState> debug_callback_list;
     VkDebugUtilsMessageSeverityFlagsEXT active_severities{0};
@@ -613,25 +611,6 @@ static inline void DeactivateInstanceDebugCallbacks(debug_report_data *debug_dat
     for (auto item : instance_report_callback_handles) {
         layer_destroy_callback(debug_data, item, nullptr);
     }
-}
-
-#ifndef WIN32
-static inline int string_sprintf(std::string *output, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-#endif
-static inline int string_sprintf(std::string *output, const char *fmt, ...) {
-    std::string &formatted = *output;
-    va_list argptr;
-    va_start(argptr, fmt);
-    int reserve = vsnprintf(nullptr, 0, fmt, argptr);
-    va_end(argptr);
-    formatted.reserve(reserve + 1);  // Set the storage length long enough to hold the output + null
-    formatted.resize(reserve);       // Set the *logical* length to be what vsprintf will write
-    va_start(argptr, fmt);
-    int result = vsnprintf((char *)formatted.data(), formatted.capacity(), fmt, argptr);
-    va_end(argptr);
-    assert(result == reserve);
-    assert((formatted.size() == strlen(formatted.c_str())));
-    return result;
 }
 
 #ifdef WIN32

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -246,9 +246,9 @@ typedef struct _debug_report_data {
             handle_name = DebugReportGetMarkerObjectName(handle);
         }
 
-        std::string ret;
-        string_sprintf(&ret, "%s 0x%" PRIxLEAST64 "[%s]", handle_type_name, handle, handle_name.c_str());
-        return ret;
+        std::ostringstream str;
+        str << handle_type_name << " 0x" << std::hex << handle << "[" << handle_name.c_str() << "]";
+        return str.str();
     }
 
     std::string FormatHandle(const VulkanTypedHandle &handle) const {


### PR DESCRIPTION
Dozens of these error messages were not using `FormatHandle()`, resulting in object names and types missing from error messages.

Fixes #1695.  