### PR TITLE
layers: fix logic error in semaphore validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10181,7 +10181,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                 "VkQueuePresent: %s is not a VK_SEMAPHORE_TYPE_BINARY_KHR",
                 report_data->FormatHandle(pPresentInfo->pWaitSemaphores[i]).c_str());
         }
-        if (pSemaphore && (!pSemaphore->signaled || !SemaphoreWasSignaled(pPresentInfo->pWaitSemaphores[i]))) {
+        if (pSemaphore && !pSemaphore->signaled && !SemaphoreWasSignaled(pPresentInfo->pWaitSemaphores[i])) {
             LogObjectList objlist(queue);
             objlist.add(pPresentInfo->pWaitSemaphores[i]);
             skip |= LogError(objlist, "VUID-vkQueuePresentKHR-pWaitSemaphores-03268",


### PR DESCRIPTION
The way this check is written implies a false positive unless *both*
pSemaphore->signaled and SemaphoreWasSignaled() are true. But based on
the rest of the code, the intent here is clearly to assume a semaphore
is signalled if *either* of the two return true.

Fixes #1712.