### PR TITLE
layers: Add missing skip handling to commands

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -216,14 +216,14 @@ bool CoreChecks::VerifyBoundMemoryIsValid(const DEVICE_MEMORY_STATE *mem_state, 
     bool result = false;
     auto type_name = object_string[typed_handle.type];
     if (!mem_state) {
-        result =
+        result |=
             LogError(object, error_code, "%s: %s used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
                      api_name, report_data->FormatHandle(typed_handle).c_str(), type_name + 2);
     } else if (mem_state->destroyed) {
-        result = LogError(object, error_code,
-                          "%s: %s used with no memory bound and previously bound memory was freed. Memory must not be freed "
-                          "prior to this operation.",
-                          api_name, report_data->FormatHandle(typed_handle).c_str());
+        result |= LogError(object, error_code,
+                           "%s: %s used with no memory bound and previously bound memory was freed. Memory must not be freed "
+                           "prior to this operation.",
+                           api_name, report_data->FormatHandle(typed_handle).c_str());
     }
     return result;
 }
@@ -235,27 +235,29 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, co
         if (image_state->bind_swapchain == VK_NULL_HANDLE) {
             LogObjectList objlist(image_state->image);
             objlist.add(image_state->create_from_swapchain);
-            LogError(objlist, error_code,
-                     "%s: %s is created by %s, and the image should be bound by calling vkBindImageMemory2(), and the pNext chain "
-                     "includes VkBindImageMemorySwapchainInfoKHR.",
-                     api_name, report_data->FormatHandle(image_state->image).c_str(),
-                     report_data->FormatHandle(image_state->create_from_swapchain).c_str());
+            result |= LogError(
+                objlist, error_code,
+                "%s: %s is created by %s, and the image should be bound by calling vkBindImageMemory2(), and the pNext chain "
+                "includes VkBindImageMemorySwapchainInfoKHR.",
+                api_name, report_data->FormatHandle(image_state->image).c_str(),
+                report_data->FormatHandle(image_state->create_from_swapchain).c_str());
         } else if (image_state->create_from_swapchain != image_state->bind_swapchain) {
             LogObjectList objlist(image_state->image);
             objlist.add(image_state->create_from_swapchain);
             objlist.add(image_state->bind_swapchain);
-            LogError(objlist, error_code,
-                     "%s: %s is created by %s, but the image is bound by %s. The image should be created and bound by the same "
-                     "swapchain",
-                     api_name, report_data->FormatHandle(image_state->image).c_str(),
-                     report_data->FormatHandle(image_state->create_from_swapchain).c_str(),
-                     report_data->FormatHandle(image_state->bind_swapchain).c_str());
+            result |=
+                LogError(objlist, error_code,
+                         "%s: %s is created by %s, but the image is bound by %s. The image should be created and bound by the same "
+                         "swapchain",
+                         api_name, report_data->FormatHandle(image_state->image).c_str(),
+                         report_data->FormatHandle(image_state->create_from_swapchain).c_str(),
+                         report_data->FormatHandle(image_state->bind_swapchain).c_str());
         }
     } else if (image_state->external_ahb) {
         // TODO look into how to properly check for a valid bound memory for an external AHB
     } else if (0 == (static_cast<uint32_t>(image_state->createInfo.flags) & VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
-        result = VerifyBoundMemoryIsValid(image_state->binding.mem_state.get(), image_state->image,
-                                          VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage), api_name, error_code);
+        result |= VerifyBoundMemoryIsValid(image_state->binding.mem_state.get(), image_state->image,
+                                           VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage), api_name, error_code);
     }
     return result;
 }
@@ -265,8 +267,8 @@ bool CoreChecks::ValidateMemoryIsBoundToBuffer(const BUFFER_STATE *buffer_state,
                                                const char *error_code) const {
     bool result = false;
     if (0 == (static_cast<uint32_t>(buffer_state->createInfo.flags) & VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
-        result = VerifyBoundMemoryIsValid(buffer_state->binding.mem_state.get(), buffer_state->buffer,
-                                          VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer), api_name, error_code);
+        result |= VerifyBoundMemoryIsValid(buffer_state->binding.mem_state.get(), buffer_state->buffer,
+                                           VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer), api_name, error_code);
     }
     return result;
 }
@@ -787,7 +789,8 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     auto const &state = last_bound_it->second;
 
     // First check flag states
-    if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point) result = ValidateDrawStateFlags(cb_node, pPipe, indexed, vuid.dynamic_state);
+    if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point)
+        result |= ValidateDrawStateFlags(cb_node, pPipe, indexed, vuid.dynamic_state);
 
     // Now complete other state checks
     string errorString;
@@ -7801,9 +7804,9 @@ bool CoreChecks::AddAttachmentUse(RenderPassCreateVersion rp_version, uint32_t s
     if (uses & new_use) {
         if (attachment_layouts[attachment] != new_layout) {
             vuid = use_rp2 ? "VUID-VkSubpassDescription2-layout-02528" : "VUID-VkSubpassDescription-layout-02519";
-            LogError(device, vuid, "%s: subpass %u already uses attachment %u with a different image layout (%s vs %s).",
-                     function_name, subpass, attachment, string_VkImageLayout(attachment_layouts[attachment]),
-                     string_VkImageLayout(new_layout));
+            skip |= LogError(device, vuid, "%s: subpass %u already uses attachment %u with a different image layout (%s vs %s).",
+                             function_name, subpass, attachment, string_VkImageLayout(attachment_layouts[attachment]),
+                             string_VkImageLayout(new_layout));
         }
     } else if (uses & ~ATTACHMENT_INPUT || (uses && (new_use == ATTACHMENT_RESOLVE || new_use == ATTACHMENT_PRESERVE))) {
         /* Note: input attachments are assumed to be done first. */
@@ -9070,12 +9073,12 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                     layout_type = "initial";
                 }
                 if ((cb_layout != kInvalidLayout) && (cb_layout != sub_layout)) {
-                    LogError(pCommandBuffers[i], "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
-                             "%s: Executed secondary command buffer using %s (subresource: aspectMask 0x%X array layer %u, "
-                             "mip level %u) which expects layout %s--instead, image %s layout is %s.",
-                             "vkCmdExecuteCommands():", report_data->FormatHandle(image).c_str(), subresource.aspectMask,
-                             subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(sub_layout), layout_type,
-                             string_VkImageLayout(cb_layout));
+                    skip |= LogError(pCommandBuffers[i], "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
+                                     "%s: Executed secondary command buffer using %s (subresource: aspectMask 0x%X array layer %u, "
+                                     "mip level %u) which expects layout %s--instead, image %s layout is %s.",
+                                     "vkCmdExecuteCommands():", report_data->FormatHandle(image).c_str(), subresource.aspectMask,
+                                     subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(sub_layout), layout_type,
+                                     string_VkImageLayout(cb_layout));
                 }
             }
         }

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -473,9 +473,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     }
 
     // Init dispatch array and call registration functions
+    bool skip = false;
     for (auto intercept : local_object_dispatch) {
         auto lock = intercept->read_lock();
-        (const_cast<const ValidationObject*>(intercept))->PreCallValidateCreateInstance(pCreateInfo, pAllocator, pInstance);
+        skip |= (const_cast<const ValidationObject*>(intercept))->PreCallValidateCreateInstance(pCreateInfo, pAllocator, pInstance);
+        if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : local_object_dispatch) {
         auto lock = intercept->write_lock();
@@ -525,9 +527,11 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocati
     auto layer_data = GetLayerDataPtr(key, layer_data_map);
     ActivateInstanceDebugCallbacks(layer_data->report_data);
 
+    bool skip = false;
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->read_lock();
-        (const_cast<const ValidationObject*>(intercept))->PreCallValidateDestroyInstance(instance, pAllocator);
+        skip |= (const_cast<const ValidationObject*>(intercept))->PreCallValidateDestroyInstance(instance, pAllocator);
+        //if (skip) return; // WORKAROUD: does not currently work properly
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
@@ -651,9 +655,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(device);
     auto layer_data = GetLayerDataPtr(key, layer_data_map);
+    bool skip = false;
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->read_lock();
-        (const_cast<const ValidationObject*>(intercept))->PreCallValidateDestroyDevice(device, pAllocator);
+        skip |= (const_cast<const ValidationObject*>(intercept))->PreCallValidateDestroyDevice(device, pAllocator);
+        if (skip) return;
     }
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -86,11 +86,11 @@ class ObjectLifetimes : public ValidationObject {
         if (!inserted) {
             // The object should not already exist. If we couldn't add it to the map, there was probably
             // a race condition in the app. Report an error and move on.
-            LogError(object, kVUID_ObjectTracker_Info,
-                     "Couldn't insert %s Object 0x%" PRIxLEAST64
-                     ", already existed. This should not happen and may indicate a "
-                     "race condition in the application.",
-                     object_string[object_type], object_handle);
+            (void)LogError(object, kVUID_ObjectTracker_Info,
+                           "Couldn't insert %s Object 0x%" PRIxLEAST64
+                           ", already existed. This should not happen and may indicate a "
+                           "race condition in the application.",
+                           object_string[object_type], object_handle);
         }
     }
 
@@ -210,10 +210,10 @@ class ObjectLifetimes : public ValidationObject {
         if (item == object_map[object_type].end()) {
             // We've already checked that the object exists. If we couldn't find and atomically remove it
             // from the map, there must have been a race condition in the app. Report an error and move on.
-            LogError(device, kVUID_ObjectTracker_Info,
-                     "Couldn't destroy %s Object 0x%" PRIxLEAST64
-                     ", not found. This should not happen and may indicate a race condition in the application.",
-                     object_string[object_type], object_handle);
+            (void)LogError(device, kVUID_ObjectTracker_Info,
+                           "Couldn't destroy %s Object 0x%" PRIxLEAST64
+                           ", not found. This should not happen and may indicate a race condition in the application.",
+                           object_string[object_type], object_handle);
 
             return;
         }

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -288,10 +288,9 @@ bool ObjectLifetimes::ReportLeakedDeviceObjects(VkDevice device, VulkanObjectTyp
 bool ObjectLifetimes::PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) const {
     bool skip = false;
 
-    // We validate here for coverage, though we'd not have made it this for with a bad instance.
+    // We validate here for coverage, though we'd not have made it this far with a bad instance.
     skip |= ValidateObject(instance, kVulkanObjectTypeInstance, true, "VUID-vkDestroyInstance-instance-parameter", kVUIDUndefined);
 
-    // Validate that child devices have been destroyed
     auto snapshot = object_map[kVulkanObjectTypeDevice].snapshot();
     for (const auto &iit : snapshot) {
         auto pNode = iit.second;
@@ -313,9 +312,8 @@ bool ObjectLifetimes::PreCallValidateDestroyInstance(VkInstance instance, const 
                                       "VUID-vkDestroyInstance-instance-00631");
     }
 
-    // Throw errors if any instance objects created on this instance have not been destroyed
-    ValidateDestroyObject(instance, kVulkanObjectTypeInstance, pAllocator, "VUID-vkDestroyInstance-instance-00630",
-                          "VUID-vkDestroyInstance-instance-00631");
+    skip |= ValidateDestroyObject(instance, kVulkanObjectTypeInstance, pAllocator, "VUID-vkDestroyInstance-instance-00630",
+                                  "VUID-vkDestroyInstance-instance-00631");
 
     // Report any remaining instance objects
     skip |= ReportUndestroyedInstanceObjects(instance, "VUID-vkDestroyInstance-instance-00629");

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -3010,9 +3010,10 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyImageToBuffer(VkCommandBu
 
     if (pRegions != nullptr) {
         if ((pRegions->imageSubresource.aspectMask & legal_aspect_flags) == 0) {
-            LogError(device, kVUID_PVError_UnrecognizedValue,
-                     "vkCmdCopyImageToBuffer parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an unrecognized "
-                     "enumerator");
+            skip |= LogError(
+                device, kVUID_PVError_UnrecognizedValue,
+                "vkCmdCopyImageToBuffer parameter, VkImageAspect pRegions->imageSubresource.aspectMask, is an unrecognized "
+                "enumerator");
         }
     }
     return skip;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -270,6 +270,9 @@ class VkBestPracticesLayerTest : public VkLayerTest {
     void InitBestPracticesFramework();
 
   protected:
+    VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
+    VkValidationFeatureDisableEXT disables_[1] = {VK_VALIDATION_FEATURE_DISABLE_ALL_EXT};
+    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 1, disables_};
 };
 
 class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {};

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -4162,12 +4162,6 @@ TEST_F(VkLayerTest, ExecuteSecondaryCBWithLayoutMismatch) {
     vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
 
-    // Validate that we've tracked the changes from the secondary CB correctly
-    m_errorMonitor->ExpectSuccess();
-    pipeline(*m_commandBuffer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL);
-    m_errorMonitor->VerifyNotFound();
-    m_commandBuffer->end();
-
     m_commandBuffer->reset();
     secondary.reset();
 


### PR DESCRIPTION
Add missing skip handling of debug callback for `vkCreateInstance`.

Should fix #1713 and remove necessity for the workarounds in #810.