### PR TITLE
Fixes crashing some Android devices

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1517,9 +1517,10 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         if (!lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo->pNext))
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
-            skip |=
-                LogError(device, kVUIDUndefined, "vkCreateImage(): Format %s is not supported for this combination of parameters.",
-                         string_VkFormat(pCreateInfo->format));
+            skip |= LogError(device, kVUID_Core_Image_FormatNotSupported,
+                             "vkCreateImage(): Format %s is not supported for this combination of parameters and "
+                             "VkGetPhysicalDeviceImageFormatProperties returned back VK_ERROR_FORMAT_NOT_SUPPORTED.",
+                             string_VkFormat(pCreateInfo->format));
     } else {
         if (pCreateInfo->mipLevels > format_limits.maxMipLevels) {
             const char *format_string = string_VkFormat(pCreateInfo->format);

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -236,6 +236,7 @@ static const char DECORATE_UNUSED *kVUID_Core_BindImageMemory_Swapchain = "UNASS
 
 static const char DECORATE_UNUSED *kVUID_Core_Image_InvalidFormatLimitsViolation = "UNASSIGNED-CoreValidation-Image-InvalidFormatLimitsViolation";
 static const char DECORATE_UNUSED *kVUID_Core_Image_ZeroAreaSubregion = "UNASSIGNED-CoreValidation-Image-ZeroAreaSubregion";
+static const char DECORATE_UNUSED *kVUID_Core_Image_FormatNotSupported = "UNASSIGNED-CoreValidation-Image-FormatNotSupported";
 
 static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_TemplateType = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-descriptorUpdateTemplate-templateType";
 static const char DECORATE_UNUSED *kVUID_Core_PushDescriptorUpdate_Template_SetMismatched = "UNASSIGNED-CoreValidation-vkCmdPushDescriptorSetWithTemplateKHR-set";

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -551,10 +551,13 @@ void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, 
 void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, std::string code) {
     VkResult err;
     VkImage image = VK_NULL_HANDLE;
-    if (code.length())
+    if (code.length()) {
         test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
-    else
+        // Very possible a test didn't check for VK_ERROR_FORMAT_NOT_SUPPORTED
+        test.Monitor().SetUnexpectedError("UNASSIGNED-CoreValidation-Image-FormatNotSupported");
+    } else {
         test.Monitor().ExpectSuccess();
+    }
 
     err = vk::CreateImage(test.device(), pCreateInfo, NULL, &image);
     if (code.length())

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -3420,7 +3420,11 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
         pipe.InitState();
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&descriptor_set.layout_});
-        pipe.CreateGraphicsPipeline();
+        err = pipe.CreateGraphicsPipeline();
+        if (err != VK_SUCCESS) {
+            printf("%s Unable to compile shader, skipping.\n", kSkipPrefix);
+            return;
+        }
 
         m_commandBuffer->begin();
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);


### PR DESCRIPTION
Many small fixes for various tests ran on Android (cc #1726)

- Add `kVUID_Core_Image_FormatNotSupported` as some Android devices didn't support combination of create image features. Also made message more clear what is wrong
- Checked if `CreateGraphicsPipeline` was successful as some devices have compilers that fail to compiler the pipeline and will lead to the layers crashing when trying to reference a `PIPELINE_STATE` that doesn't exists
- Some Android device don't support multiple viewports so firstScissor must be 0 (VUID-vkCmdSetScissor-firstScissor-00593). These test were triggering two VUs while test only expected one
- Check for support before calling to `vkGetPhysicalDeviceProperties2` which otherwise crashed a device