### PR TITLE
Remove redundant checking of memory requirements

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2143,36 +2143,33 @@ void ValidationStateTracker::PostCallRecordBindBufferMemory2KHR(VkDevice device,
     }
 }
 
-void ValidationStateTracker::RecordGetBufferMemoryRequirementsState(VkBuffer buffer, VkMemoryRequirements *pMemoryRequirements) {
+void ValidationStateTracker::RecordGetBufferMemoryRequirementsState(VkBuffer buffer) {
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     if (buffer_state) {
-        buffer_state->requirements = *pMemoryRequirements;
         buffer_state->memory_requirements_checked = true;
     }
 }
 
 void ValidationStateTracker::PostCallRecordGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
                                                                        VkMemoryRequirements *pMemoryRequirements) {
-    RecordGetBufferMemoryRequirementsState(buffer, pMemoryRequirements);
+    RecordGetBufferMemoryRequirementsState(buffer);
 }
 
 void ValidationStateTracker::PostCallRecordGetBufferMemoryRequirements2(VkDevice device,
                                                                         const VkBufferMemoryRequirementsInfo2KHR *pInfo,
                                                                         VkMemoryRequirements2KHR *pMemoryRequirements) {
-    RecordGetBufferMemoryRequirementsState(pInfo->buffer, &pMemoryRequirements->memoryRequirements);
+    RecordGetBufferMemoryRequirementsState(pInfo->buffer);
 }
 
 void ValidationStateTracker::PostCallRecordGetBufferMemoryRequirements2KHR(VkDevice device,
                                                                            const VkBufferMemoryRequirementsInfo2KHR *pInfo,
                                                                            VkMemoryRequirements2KHR *pMemoryRequirements) {
-    RecordGetBufferMemoryRequirementsState(pInfo->buffer, &pMemoryRequirements->memoryRequirements);
+    RecordGetBufferMemoryRequirementsState(pInfo->buffer);
 }
 
-void ValidationStateTracker::RecordGetImageMemoryRequirementsState(VkImage image, const VkImageMemoryRequirementsInfo2 *pInfo,
-                                                                   VkMemoryRequirements *pMemoryRequirements) {
+void ValidationStateTracker::RecordGetImageMemoryRequirementsState(VkImage image, const VkImageMemoryRequirementsInfo2 *pInfo) {
     const VkImagePlaneMemoryRequirementsInfo *plane_info =
         (pInfo == nullptr) ? nullptr : lvl_find_in_chain<VkImagePlaneMemoryRequirementsInfo>(pInfo->pNext);
-    // TODO does the VkMemoryRequirements need to be saved here if PostCallRecordCreateImage tracks it regardless
     IMAGE_STATE *image_state = GetImageState(image);
     if (image_state) {
         if (plane_info != nullptr) {
@@ -2180,17 +2177,13 @@ void ValidationStateTracker::RecordGetImageMemoryRequirementsState(VkImage image
             image_state->memory_requirements_checked = false;  // Each image plane needs to be checked itself
             if (plane_info->planeAspect == VK_IMAGE_ASPECT_PLANE_0_BIT) {
                 image_state->plane0_memory_requirements_checked = true;
-                image_state->plane0_requirements = *pMemoryRequirements;
             } else if (plane_info->planeAspect == VK_IMAGE_ASPECT_PLANE_1_BIT) {
                 image_state->plane1_memory_requirements_checked = true;
-                image_state->plane1_requirements = *pMemoryRequirements;
             } else if (plane_info->planeAspect == VK_IMAGE_ASPECT_PLANE_2_BIT) {
                 image_state->plane2_memory_requirements_checked = true;
-                image_state->plane2_requirements = *pMemoryRequirements;
             }
         } else {
             // Single Plane image
-            image_state->requirements = *pMemoryRequirements;
             image_state->memory_requirements_checked = true;
         }
     }
@@ -2198,18 +2191,18 @@ void ValidationStateTracker::RecordGetImageMemoryRequirementsState(VkImage image
 
 void ValidationStateTracker::PostCallRecordGetImageMemoryRequirements(VkDevice device, VkImage image,
                                                                       VkMemoryRequirements *pMemoryRequirements) {
-    RecordGetImageMemoryRequirementsState(image, nullptr, pMemoryRequirements);
+    RecordGetImageMemoryRequirementsState(image, nullptr);
 }
 
 void ValidationStateTracker::PostCallRecordGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
                                                                        VkMemoryRequirements2 *pMemoryRequirements) {
-    RecordGetImageMemoryRequirementsState(pInfo->image, pInfo, &pMemoryRequirements->memoryRequirements);
+    RecordGetImageMemoryRequirementsState(pInfo->image, pInfo);
 }
 
 void ValidationStateTracker::PostCallRecordGetImageMemoryRequirements2KHR(VkDevice device,
                                                                           const VkImageMemoryRequirementsInfo2 *pInfo,
                                                                           VkMemoryRequirements2 *pMemoryRequirements) {
-    RecordGetImageMemoryRequirementsState(pInfo->image, pInfo, &pMemoryRequirements->memoryRequirements);
+    RecordGetImageMemoryRequirementsState(pInfo->image, pInfo);
 }
 
 static void RecordGetImageSparseMemoryRequirementsState(IMAGE_STATE *image_state,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1073,11 +1073,10 @@ class ValidationStateTracker : public ValidationObject {
     void RecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters(VkPhysicalDevice physicalDevice,
                                                                           uint32_t queueFamilyIndex, uint32_t* pCounterCount,
                                                                           VkPerformanceCounterKHR* pCounters);
-    void RecordGetBufferMemoryRequirementsState(VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
+    void RecordGetBufferMemoryRequirementsState(VkBuffer buffer);
     void RecordGetDeviceQueueState(uint32_t queue_family_index, VkQueue queue);
     void RecordGetExternalFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBitsKHR handle_type);
-    void RecordGetImageMemoryRequirementsState(VkImage image, const VkImageMemoryRequirementsInfo2* pInfo,
-                                               VkMemoryRequirements* pMemoryRequirements);
+    void RecordGetImageMemoryRequirementsState(VkImage image, const VkImageMemoryRequirementsInfo2* pInfo);
     void RecordImportSemaphoreState(VkSemaphore semaphore, VkExternalSemaphoreHandleTypeFlagBitsKHR handle_type,
                                     VkSemaphoreImportFlagsKHR flags);
     void RecordGetPhysicalDeviceDisplayPlanePropertiesState(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,


### PR DESCRIPTION
When I made #1644 I realized that when the image (and buffer) is created the layers check the memory requirements as it is not invalid to not do so from the app side (the Best Practice will yell though)

Its seems error prone to have it being tracked in two spots, so I wrote the TODO I am removing here. I wrote a test to validate the layers throw the same error regardless of the memory requirements being checked or not prior