### PR TITLE
layers: Fix crash when there are more blend attachments than subpass color attachments

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4628,7 +4628,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE *cb_st
     if (fb_state) {
         auto subpass_desc = &pipeline_state->rp_state->createInfo.pSubpasses[pipeline_state->graphicsPipelineCI.subpass];
 
-        for (size_t i = 0; i < pipeline_state->attachments.size(); i++) {
+        for (size_t i = 0; i < pipeline_state->attachments.size() && i < subpass_desc->colorAttachmentCount; i++) {
             const auto attachment = subpass_desc->pColorAttachments[i].attachment;
             if (attachment == VK_ATTACHMENT_UNUSED) continue;
 


### PR DESCRIPTION
The new check from #1693 will crash if there are more blend attachments than subpass color attachments. This means VUID-VkGraphicsPipelineCreateInfo-attachmentCount-00746 has already been violated, but it's still nice not to crash in this case.
