### PR TITLE
Fix cubearray test from failing on device not supporting feature

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4771,13 +4771,6 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             }
         }
 
-        // Validate feature set if using CUBE_ARRAY
-        if ((view_type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (enabled_features.core.imageCubeArray == false)) {
-            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-viewType-01004",
-                             "vkCreateImageView(): pCreateInfo->viewType can't be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY without "
-                             "enabling the imageCubeArray feature.");
-        }
-
         // Validate correct image aspect bits for desired formats and format consistency
         skip |= ValidateImageAspectMask(image_state->image, image_format, aspect_mask, "vkCreateImageView()");
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -769,16 +769,24 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
     bool skip = false;
 
     if (pCreateInfo != nullptr) {
+        // Validate feature set if using CUBE_ARRAY
+        if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (physical_device_features.imageCubeArray == false)) {
+            skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-viewType-01004",
+                             "vkCreateImageView(): pCreateInfo->viewType can't be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY without "
+                             "enabling the imageCubeArray feature.");
+        }
+
         if (pCreateInfo->subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS) {
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE && pCreateInfo->subresourceRange.layerCount != 6) {
                 skip |= LogError(device, "VUID-VkImageViewCreateInfo-viewType-02960",
-                                 "vkCreateImageView(): subresourceRange.layerCount (%d) must be 6",
+                                 "vkCreateImageView(): subresourceRange.layerCount (%d) must be 6 or VK_REMAINING_ARRAY_LAYERS.",
                                  pCreateInfo->subresourceRange.layerCount);
             }
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && (pCreateInfo->subresourceRange.layerCount % 6) != 0) {
-                skip |= LogError(device, "VUID-VkImageViewCreateInfo-viewType-02961",
-                                 "vkCreateImageView(): subresourceRange.layerCount (%d) must be a multiple of 6",
-                                 pCreateInfo->subresourceRange.layerCount);
+                skip |= LogError(
+                    device, "VUID-VkImageViewCreateInfo-viewType-02961",
+                    "vkCreateImageView(): subresourceRange.layerCount (%d) must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
+                    pCreateInfo->subresourceRange.layerCount);
             }
         }
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -7196,6 +7196,7 @@ TEST_F(VkLayerTest, CreateImageViewDifferentClass) {
         cubeImgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         cubeImgViewInfo.format = VK_FORMAT_R8_UINT;  // compatiable format
         cubeImgViewInfo.image = cubeImage.handle();
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-viewType-02961");
         CreateImageViewTest(*this, &cubeImgViewInfo, "VUID-VkImageViewCreateInfo-viewType-01004");
     }
 }
@@ -7278,7 +7279,9 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
 TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {
     TEST_DESCRIPTION("Passing bad image subrange to CreateImageView");
 
+    VkPhysicalDeviceFeatures device_features = {};
     ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&device_features));
 
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
@@ -7414,33 +7417,36 @@ TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {
             img_view_info.subresourceRange = range;
             CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02962");
         }
-        {
-            const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 12};
-            VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
-            img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-            img_view_info.subresourceRange = range;
-            CreateImageViewTest(*this, &img_view_info);
-        }
-        {
-            const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 13};
-            VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
-            img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-            img_view_info.subresourceRange = range;
-            CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02961");
-        }
-        {
-            const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 6, VK_REMAINING_ARRAY_LAYERS};
-            VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
-            img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-            img_view_info.subresourceRange = range;
-            CreateImageViewTest(*this, &img_view_info);
-        }
-        {
-            const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 11, VK_REMAINING_ARRAY_LAYERS};
-            VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
-            img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
-            img_view_info.subresourceRange = range;
-            CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02963");
+
+        if (device_features.imageCubeArray == VK_TRUE) {
+            {
+                const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 12};
+                VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
+                img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+                img_view_info.subresourceRange = range;
+                CreateImageViewTest(*this, &img_view_info);
+            }
+            {
+                const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 13};
+                VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
+                img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+                img_view_info.subresourceRange = range;
+                CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02961");
+            }
+            {
+                const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 6, VK_REMAINING_ARRAY_LAYERS};
+                VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
+                img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+                img_view_info.subresourceRange = range;
+                CreateImageViewTest(*this, &img_view_info);
+            }
+            {
+                const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 11, VK_REMAINING_ARRAY_LAYERS};
+                VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
+                img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+                img_view_info.subresourceRange = range;
+                CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02963");
+            }
         }
     }
 }


### PR DESCRIPTION
This is failing on devices that don't support the `imageCubeArray` feature