### PR TITLE
Add support for VUID 02260

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1479,7 +1479,14 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo *pCreateInf
                                                                    : format_properties.optimalTilingFeatures;
     }
 
-    // TODO add VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260 support here
+    // Lack of disjoint format feature support while using the flag
+    if (FormatIsMultiplane(image_format) && ((pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0) &&
+        ((tiling_features & VK_FORMAT_FEATURE_DISJOINT_BIT) == 0)) {
+        skip |= LogError(device, "VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260",
+                         "vkCreateImage(): can't use VK_IMAGE_CREATE_DISJOINT_BIT because %s doesn't support "
+                         "VK_FORMAT_FEATURE_DISJOINT_BIT based on imageCreateFormatFeatures.",
+                         string_VkFormat(pCreateInfo->format));
+    }
 
     return skip;
 }


### PR DESCRIPTION
VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260

> If format is a multi-planar format, and if imageCreateFormatFeatures (as defined in Image Creation Limits) does not contain VK_FORMAT_FEATURE_DISJOINT_BIT, then flags must not contain VK_IMAGE_CREATE_DISJOINT_BIT