### PR TITLE
Add Sampler YCbCr Conversion Format Feature VUIDs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -759,6 +759,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator,
                                                         VkSamplerYcbcrConversion* pYcbcrConversion) const;
+    bool PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkSampler* pSampler) const;
     bool PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) const;
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator);
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) const;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -74,10 +74,16 @@ void ValidationStateTracker::RecordCreateImageANDROID(const VkImageCreateInfo *c
 }
 
 void ValidationStateTracker::RecordCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo *create_info,
-                                                                       VkSamplerYcbcrConversion ycbcr_conversion) {
+                                                                       VkSamplerYcbcrConversion ycbcr_conversion,
+                                                                       SAMPLER_YCBCR_CONVERSION_STATE *ycbcr_state) {
     const VkExternalFormatANDROID *ext_format_android = lvl_find_in_chain<VkExternalFormatANDROID>(create_info->pNext);
     if (ext_format_android && (0 != ext_format_android->externalFormat)) {
         ycbcr_conversion_ahb_fmt_map.emplace(ycbcr_conversion, ext_format_android->externalFormat);
+        // VUID 01894 will catch if not found in map
+        auto it = ahb_ext_formats_map.find(ext_format_android->externalFormat);
+        if (it != ahb_ext_formats_map.end()) {
+            ycbcr_state->format_features = it->second;
+        }
     }
 };
 
@@ -99,7 +105,8 @@ void ValidationStateTracker::PostCallRecordGetAndroidHardwareBufferPropertiesAND
 void ValidationStateTracker::RecordCreateImageANDROID(const VkImageCreateInfo *create_info, IMAGE_STATE *is_node) {}
 
 void ValidationStateTracker::RecordCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo *create_info,
-                                                                       VkSamplerYcbcrConversion ycbcr_conversion){};
+                                                                       VkSamplerYcbcrConversion ycbcr_conversion,
+                                                                       SAMPLER_YCBCR_CONVERSION_STATE *ycbcr_state){};
 
 void ValidationStateTracker::RecordDestroySamplerYcbcrConversionANDROID(VkSamplerYcbcrConversion ycbcr_conversion){};
 
@@ -934,6 +941,30 @@ BASE_NODE *ValidationStateTracker::GetStateStructPtrFromObject(const VulkanTyped
             break;
     }
     return base_ptr;
+}
+
+VkFormatFeatureFlags ValidationStateTracker::GetPotentialFormatFeatures(VkFormat format) const {
+    VkFormatFeatureFlags format_features = 0;
+
+    if (format != VK_FORMAT_UNDEFINED) {
+        VkFormatProperties format_properties;
+        DispatchGetPhysicalDeviceFormatProperties(physical_device, format, &format_properties);
+        format_features |= format_properties.linearTilingFeatures;
+        format_features |= format_properties.optimalTilingFeatures;
+        if (device_extensions.vk_ext_image_drm_format_modifier) {
+            // VK_KHR_get_physical_device_properties2 is required in this case
+            VkFormatProperties2 format_properties_2 = {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2};
+            VkDrmFormatModifierPropertiesListEXT drm_properties_list = {VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
+                                                                        nullptr};
+            format_properties_2.pNext = (void *)&drm_properties_list;
+            DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &format_properties_2);
+            for (uint32_t i = 0; i < drm_properties_list.drmFormatModifierCount; i++) {
+                format_features |= drm_properties_list.pDrmFormatModifierProperties[i].drmFormatModifierTilingFeatures;
+            }
+        }
+    }
+
+    return format_features;
 }
 
 // Tie the VulkanTypedHandle to the cmd buffer which includes:
@@ -4807,9 +4838,22 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
 
 void ValidationStateTracker::RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo *create_info,
                                                                      VkSamplerYcbcrConversion ycbcr_conversion) {
+    auto ycbcr_state = std::make_shared<SAMPLER_YCBCR_CONVERSION_STATE>();
+
     if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
-        RecordCreateSamplerYcbcrConversionANDROID(create_info, ycbcr_conversion);
+        RecordCreateSamplerYcbcrConversionANDROID(create_info, ycbcr_conversion, ycbcr_state.get());
     }
+
+    const VkFormat conversion_format = create_info->format;
+
+    if (conversion_format != VK_FORMAT_UNDEFINED) {
+        // If format is VK_FORMAT_UNDEFINED, will be set by external AHB features
+        ycbcr_state->format_features = GetPotentialFormatFeatures(conversion_format);
+    }
+
+    ycbcr_state->chromaFilter = create_info->chromaFilter;
+    ycbcr_state->format = conversion_format;
+    samplerYcbcrConversionMap[ycbcr_conversion] = std::move(ycbcr_state);
 }
 
 void ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device,
@@ -4830,21 +4874,27 @@ void ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDev
     RecordCreateSamplerYcbcrConversionState(pCreateInfo, *pYcbcrConversion);
 }
 
+void ValidationStateTracker::RecordDestroySamplerYcbcrConversionState(VkSamplerYcbcrConversion ycbcr_conversion) {
+    if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
+        RecordDestroySamplerYcbcrConversionANDROID(ycbcr_conversion);
+    }
+
+    auto ycbcr_state = GetSamplerYcbcrConversionState(ycbcr_conversion);
+    ycbcr_state->destroyed = true;
+    samplerYcbcrConversionMap.erase(ycbcr_conversion);
+}
+
 void ValidationStateTracker::PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                          const VkAllocationCallbacks *pAllocator) {
     if (!ycbcrConversion) return;
-    if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
-        RecordDestroySamplerYcbcrConversionANDROID(ycbcrConversion);
-    }
+    RecordDestroySamplerYcbcrConversionState(ycbcrConversion);
 }
 
 void ValidationStateTracker::PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device,
                                                                             VkSamplerYcbcrConversion ycbcrConversion,
                                                                             const VkAllocationCallbacks *pAllocator) {
     if (!ycbcrConversion) return;
-    if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
-        RecordDestroySamplerYcbcrConversionANDROID(ycbcrConversion);
-    }
+    RecordDestroySamplerYcbcrConversionState(ycbcrConversion);
 }
 
 void ValidationStateTracker::RecordResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -94,6 +94,13 @@ class QUERY_POOL_STATE : public BASE_NODE {
     uint32_t n_performance_passes = 0;
 };
 
+class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
+  public:
+    VkFormatFeatureFlags format_features;
+    VkFormat format;
+    VkFilter chromaFilter;
+};
+
 class QUEUE_FAMILY_PERF_COUNTERS {
   public:
     std::vector<VkPerformanceCounterKHR> counters;
@@ -289,6 +296,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkFence, FENCE_STATE, fenceMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkQueryPool, QUERY_POOL_STATE, queryPoolMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkSemaphore, SEMAPHORE_STATE, semaphoreMap)
+    VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, SAMPLER_YCBCR_CONVERSION_STATE, samplerYcbcrConversionMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE, accelerationStructureMap)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
 
@@ -465,6 +473,12 @@ class ValidationStateTracker : public ValidationObject {
     QUERY_POOL_STATE* GetQueryPoolState(VkQueryPool query_pool) { return Get<QUERY_POOL_STATE>(query_pool); }
     const SEMAPHORE_STATE* GetSemaphoreState(VkSemaphore semaphore) const { return Get<SEMAPHORE_STATE>(semaphore); }
     SEMAPHORE_STATE* GetSemaphoreState(VkSemaphore semaphore) { return Get<SEMAPHORE_STATE>(semaphore); }
+    const SAMPLER_YCBCR_CONVERSION_STATE* GetSamplerYcbcrConversionState(VkSamplerYcbcrConversion samplerYcbcrConversion) const {
+        return Get<SAMPLER_YCBCR_CONVERSION_STATE>(samplerYcbcrConversion);
+    }
+    SAMPLER_YCBCR_CONVERSION_STATE* GetSamplerYcbcrConversionState(VkSamplerYcbcrConversion samplerYcbcrConversion) {
+        return Get<SAMPLER_YCBCR_CONVERSION_STATE>(samplerYcbcrConversion);
+    }
     const ACCELERATION_STRUCTURE_STATE* GetAccelerationStructureState(VkAccelerationStructureNV as) const {
         return Get<ACCELERATION_STRUCTURE_STATE>(as);
     }
@@ -1039,6 +1053,7 @@ class ValidationStateTracker : public ValidationObject {
                                  const VkCommandBuffer* command_buffers);
     void FreeDescriptorSet(cvdescriptorset::DescriptorSet* descriptor_set);
     BASE_NODE* GetStateStructPtrFromObject(const VulkanTypedHandle& object_struct);
+    VkFormatFeatureFlags GetPotentialFormatFeatures(VkFormat format) const;
     void IncrementBoundObjects(CMD_BUFFER_STATE const* cb_node);
     void IncrementResources(CMD_BUFFER_STATE* cb_node);
     void InsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, DEVICE_MEMORY_STATE* mem_info,
@@ -1070,9 +1085,11 @@ class ValidationStateTracker : public ValidationObject {
     void RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo* create_info,
                                                  VkSamplerYcbcrConversion ycbcr_conversion);
     void RecordCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo* create_info,
-                                                   VkSamplerYcbcrConversion ycbcr_conversion);
+                                                   VkSamplerYcbcrConversion ycbcr_conversion,
+                                                   SAMPLER_YCBCR_CONVERSION_STATE* ycbcr_state);
     void RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain,
                                     SURFACE_STATE* surface_state, SWAPCHAIN_NODE* old_swapchain_state);
+    void RecordDestroySamplerYcbcrConversionState(VkSamplerYcbcrConversion ycbcr_conversion);
     void RecordDestroySamplerYcbcrConversionANDROID(VkSamplerYcbcrConversion ycbcr_conversion);
     void RecordEnumeratePhysicalDeviceGroupsState(uint32_t* pPhysicalDeviceGroupCount,
                                                   VkPhysicalDeviceGroupPropertiesKHR* pPhysicalDeviceGroupProperties);


### PR DESCRIPTION
Adds support for 

- VUID-VkSamplerYcbcrConversionCreateInfo-format-01650
- VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651
- VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652
- VUID-VkSamplerYcbcrConversionCreateInfo-forceExplicitReconstruction-01656 (might be longest VUID name out there 🤣)
- VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-01657
- VUID-VkSamplerCreateInfo-minFilter-01645

Adds state tracking for `VkSamplerYcbcrConversions` for use in checking `VUID-VkSamplerCreateInfo-minFilter-01645`
 
The `GetPotentialFormatFeatures` function will also be reused for future Render Pass VUID that also check for the same style Format Feature VUIDs