### PR TITLE
Best Practices - fix null pointer issue in PreCallRecordCreateInstance

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -150,7 +150,11 @@ bool BestPractices::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pC
 void BestPractices::PreCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                                 VkInstance* pInstance) {
     ValidationStateTracker::PreCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance);
-    instance_api_version = pCreateInfo->pApplicationInfo->apiVersion;
+
+    if (pCreateInfo != nullptr && pCreateInfo->pApplicationInfo != nullptr)
+        instance_api_version = pCreateInfo->pApplicationInfo->apiVersion;
+    else
+        instance_api_version = 0;
 }
 
 bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -216,7 +216,7 @@ class BestPractices : public ValidationStateTracker {
 #include "best_practices.h"
 
   private:
-    uint32_t instance_api_version;
+    uint32_t instance_api_version = 0;
     uint32_t num_mem_objects = 0;
 
     // Check that vendor-specific checks are enabled for at least one of the vendors


### PR DESCRIPTION
Should fix [this issue](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1739).

Additionally, leaving `instance_api_version` as zero by default should be sufficient, as checks are looking for `instance_api_version > [target_version]`.