### PR TITLE
layers: Do not reset counter on vkGetDeviceQueue

### DIFF
--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -131,7 +131,7 @@ public:
     vl_concurrent_unordered_map<T, std::shared_ptr<ObjectUseData>, 6> object_table;
 
     void CreateObject(T object) {
-        object_table.insert_or_assign(object, std::make_shared<ObjectUseData>());
+        object_table.insert(object, std::make_shared<ObjectUseData>());
     }
 
     void DestroyObject(T object) {

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -258,7 +258,7 @@ public:
     vl_concurrent_unordered_map<T, std::shared_ptr<ObjectUseData>, 6> object_table;
 
     void CreateObject(T object) {
-        object_table.insert_or_assign(object, std::make_shared<ObjectUseData>());
+        object_table.insert(object, std::make_shared<ObjectUseData>());
     }
 
     void DestroyObject(T object) {


### PR DESCRIPTION
Do not reset counter on `vkGetDeviceQueue`.

When `vkGetDeviceQueue` gets called it calls `CreateObject`, which rewrites the counter. But if `vkGetDeviceQueue` was already called before and same `VkQueue` was already received, the access counters get reset to `0`. If some parallel command is using this `VkQueue` and finishes, then it decrements the access count to `-1`, which upon next access causes a threading validation error (because `accesscount != 0`).

https://stackoverflow.com/questions/61310092/vulkan-theaded-application-get-error-message-on-queue-submissions-under-mutex
https://github.com/KhronosGroup/Vulkan-Docs/issues/1254