### PR TITLE
[WIP] Use the new Vulkan::Headers installed target

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,8 @@ before_build:
   - cd %APPVEYOR_BUILD_FOLDER%/external/googletest
   - git checkout tags/release-1.8.1
   - cd %APPVEYOR_BUILD_FOLDER%
-  - python scripts/update_deps.py --dir=external --arch=%PLATFORM% --config=%CONFIGURATION%
+  # WIP: always use master branch of VulkanHeaders
+  - python scripts/update_deps.py --dir=external --arch=%PLATFORM% --config=%CONFIGURATION% --ref=master
   - echo Verifying consistency between source file generators and output
   - python scripts/generate_source.py --verify external/Vulkan-Headers/registry
   - echo Generating Vulkan-ValidationLayers CMake files for %PLATFORM% %CONFIGURATION%

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,8 @@ script:
       cd ${TRAVIS_BUILD_DIR}/external
       git clone https://github.com/KhronosGroup/Vulkan-Loader.git
       cd Vulkan-Loader
-      python scripts/update_deps.py --dir=external
+      # WIP: always use master branch
+      python scripts/update_deps.py --dir=external --ref=master
       mkdir build
       cd build
       cmake -DCMAKE_BUILD_TYPE=Debug -C../external/helper.cmake -DCMAKE_INSTALL_PREFIX=install ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,17 +45,24 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(PythonInterp 3 QUIET)
 
-if (TARGET Vulkan::Headers)
-    message(STATUS "Using Vulkan headers from Vulkan::Headers target")
+# Find Vulkan::Headers target
+if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
+    set(VulkanHeaders_DIR "${VULKAN_HEADERS_INSTALL_DIR}/share/cmake/VulkanHeaders")
+    message(STATUS "VULKAN_HEADERS_INSTALL_DIR is set. Using it to set VulkanHeaders_DIR to '${VulkanHeaders_DIR}'")
+endif()
+find_package(VulkanHeaders CONFIG REQUIRED)
+# Check if required version information is set
+if("${VulkanHeaders_VERSION}" STREQUAL "")
+    message(FATAL_ERROR "VulkanHeaders found, but required variable VulkanHeaders_VERSION not defined!")
+endif()
+message(STATUS "Found VulkanHeaders version ${VulkanHeaders_VERSION}")
+if("${VulkanHeaders_INCLUDE_DIRS}" STREQUAL "")
+    # no Headers include directory set, get it from target
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
+endif()
+if("${VulkanRegistry_DIR}" STREQUAL "")
+    # no Registry directory set, get it from target
     get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
-else()
-    find_package(VulkanHeaders REQUIRED)
-
-    # xxxnsubtil: this should eventually be replaced by exported targets
-    add_library(Vulkan-Headers INTERFACE)
-    target_include_directories(Vulkan-Headers INTERFACE ${VulkanHeaders_INCLUDE_DIRS})
-    add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 endif()
 
 option(USE_CCACHE "Use ccache" OFF)
@@ -336,18 +343,6 @@ if(NOT TARGET uninstall)
                    @ONLY)
     add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
     set_target_properties(uninstall PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-endif()
-
-# Fetch header version from vulkan_core.h ----------------------------------------------------------------------------------------
-file(STRINGS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
-list(LENGTH lines len)
-if(${len} EQUAL 1)
-    string(REGEX MATCHALL
-                 "[0-9]+"
-                 vk_header_version
-                 ${lines})
-else()
-    message(FATAL_ERROR "Unable to fetch version from vulkan_core.h")
 endif()
 
 # Optional codegen target --------------------------------------------------------------------------------------------------------

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -253,7 +253,7 @@ if(BUILD_LAYERS)
     # TARGET_FILE_DIR, specifically)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
     foreach(TARGET_NAME ${TARGET_NAMES})
-        set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=1.2.${vk_header_version})
+        set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=${VulkanHeaders_VERSION}})
         # If this json file is not a metalayer, get the needed properties from that target
         if(TARGET ${TARGET_NAME})
             set(CONFIG_DEFINES
@@ -278,7 +278,7 @@ if(BUILD_LAYERS)
             set(INSTALL_DEFINES
                 -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
                 -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json"
-                -DVK_VERSION=1.2.${vk_header_version})
+                -DVK_VERSION=${VulkanHeaders_VERSION}})
             # If this json file is not a metalayer, get the needed properties from that target
             if(TARGET ${TARGET_NAME})
                 set(INSTALL_DEFINES ${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY="$<TARGET_FILE_NAME:${TARGET_NAME}>")

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -16,11 +16,11 @@
     },
     {
       "name": "Vulkan-Headers",
-      "url": "https://github.com/KhronosGroup/Vulkan-Headers.git",
+      "url" : "https://github.com/NeroBurner/Vulkan-Headers.git",
       "sub_dir": "Vulkan-Headers",
       "build_dir": "Vulkan-Headers/build",
       "install_dir": "Vulkan-Headers/build/install",
-      "commit": "v1.2.140"
+      "commit" : "cmake_install"
     },
     {
       "name": "SPIRV-Headers",


### PR DESCRIPTION
With the PR https://github.com/KhronosGroup/Vulkan-Headers/pull/110
merged Vulkan-Headers installs a Vulkan::Headers target. The installed
target also provides the version with the `VulkanHeaders_VERSION`
variable.

With this commit use and require the installed Vulkan::Headers target.

Fixes: https://github.com/KhronosGroup/Vulkan-Headers/issues/111#issuecomment-617975441