### PR TITLE
Fix GPU-AV for promoted buffer device address

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -251,8 +251,8 @@ void GpuAssisted::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, co
     CreateAccelerationStructureBuildValidationState(device_gpu_assisted);
 }
 
-void GpuAssisted::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo,
-                                                          VkDeviceAddress address) {
+void GpuAssisted::PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo,
+                                                       VkDeviceAddress address) {
     BUFFER_STATE *buffer_state = GetBufferState(pInfo->buffer);
     // Validate against the size requested when the buffer was created
     if (buffer_state) {
@@ -261,14 +261,14 @@ void GpuAssisted::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const
     }
 }
 
+void GpuAssisted::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo,
+                                                          VkDeviceAddress address) {
+    PostCallRecordGetBufferDeviceAddress(device, pInfo, address);
+}
+
 void GpuAssisted::PostCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfoEXT *pInfo,
                                                           VkDeviceAddress address) {
-    BUFFER_STATE *buffer_state = GetBufferState(pInfo->buffer);
-    // Validate against the size requested when the buffer was created
-    if (buffer_state) {
-        buffer_map[address] = buffer_state->createInfo.size;
-        buffer_state->deviceAddress = address;
-    }
+    PostCallRecordGetBufferDeviceAddress(device, pInfo, address);
 }
 
 void GpuAssisted::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -125,6 +125,7 @@ class GpuAssisted : public ValidationStateTracker {
                                    safe_VkDeviceCreateInfo* modified_create_info);
     void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
+    void PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo, VkDeviceAddress address);
     void PostCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo,
                                                  VkDeviceAddress address);
     void PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo,


### PR DESCRIPTION
I missed this in the 1.2 promotion update