### PR TITLE
Add GetDeviceQueue VUIDs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -213,8 +213,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCommandBufferState(const CMD_BUFFER_STATE* cb_state, const char* call_source, int current_submit_count,
                                     const char* vu_id) const;
     bool ValidateCommandBufferSimultaneousUse(const CMD_BUFFER_STATE* pCB, int current_submit_count) const;
-    bool ValidateGetDeviceQueue(uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue, const char* valid_qfi_vuid,
-                                const char* qfi_in_range_vuid) const;
     bool ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_version, const VkRenderPassCreateInfo2KHR* pCreateInfo,
                                            const char* function_name) const;
     bool AddAttachmentUse(RenderPassCreateVersion rp_version, uint32_t subpass, std::vector<uint8_t>& attachment_uses,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1553,8 +1553,11 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     // Store queue family data
     if (pCreateInfo->pQueueCreateInfos != nullptr) {
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
+            const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
             state_tracker->queue_family_index_map.insert(
-                std::make_pair(pCreateInfo->pQueueCreateInfos[i].queueFamilyIndex, pCreateInfo->pQueueCreateInfos[i].queueCount));
+                std::make_pair(queue_create_info.queueFamilyIndex, queue_create_info.queueCount));
+            state_tracker->queue_family_create_flags_map.insert(
+                std::make_pair(queue_create_info.queueFamilyIndex, queue_create_info.flags));
         }
     }
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1178,6 +1178,7 @@ class ValidationStateTracker : public ValidationObject {
 
     // Map for queue family index to queue count
     unordered_map<uint32_t, uint32_t> queue_family_index_map;
+    unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_create_flags_map;
     bool performance_lock_acquired = false;
 
     template <typename ExtProp>


### PR DESCRIPTION
Adds support for
- VUID-vkGetDeviceQueue-flags-01841
- VUID-VkDeviceQueueCreateInfo-flags-02861

Labeled from unassigned
- VUID-VkDeviceCreateInfo-pNext-00373

Tests using `vkGetDeviceQueue` need Vulkan Loader fix here:
https://github.com/KhronosGroup/Vulkan-Loader/pull/385