### PR TITLE
Add persitant storage for renderpass/framebuffer, and sanify initial layout

### DIFF
--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -671,7 +671,7 @@ TEST_F(VkArmBestPracticesLayerTest, MultisampledBlending) {
     rp_info.pSubpasses = &subpass;
 
     vk::CreateRenderPass(m_device->device(), &rp_info, nullptr, &m_renderPass);
-    renderPass_info_ = rp_info;
+    m_renderPass_info = rp_info;
 
     VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = {};
     pipe_ms_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -207,7 +207,7 @@ class VkRenderFramework : public VkTestFramework {
     VkDeviceObj *DeviceObj() const { return m_device; }
     VkPhysicalDevice gpu();
     VkRenderPass renderPass() { return m_renderPass; }
-    const VkRenderPassCreateInfo &RenderPassInfo() const { return renderPass_info_; };
+    const VkRenderPassCreateInfo &RenderPassInfo() const { return m_renderPass_info; };
     VkFramebuffer framebuffer() { return m_framebuffer; }
     ErrorMonitor &Monitor();
 
@@ -269,8 +269,15 @@ class VkRenderFramework : public VkTestFramework {
     VkCommandPoolObj *m_commandPool;
     VkCommandBufferObj *m_commandBuffer;
     VkRenderPass m_renderPass;
-    VkRenderPassCreateInfo renderPass_info_ = {};
+    VkRenderPassCreateInfo m_renderPass_info = {};
+    std::vector<VkAttachmentDescription> m_renderPass_attachments;
+    std::vector<VkSubpassDescription> m_renderPass_subpasses;
+    std::vector<VkSubpassDependency> m_renderPass_dependencies;
+
     VkFramebuffer m_framebuffer;
+    VkFramebufferCreateInfo m_framebuffer_info;
+    std::vector<VkImageView> m_framebuffer_attachments;
+
     VkSurfaceKHR m_surface;
     VkSwapchainKHR m_swapchain;
     std::vector<VkViewport> m_viewports;


### PR DESCRIPTION
Add correctly scoped storage for previously function scoped stack
storage in the renderpass and framebuffer create info.  The renderpass ci was pointer to stale pointers (stack std::vector data)

Also, changed the initial layout away from UNDEFINED for loadOpLoad targets, as that doesn't make *any* sense given that an transition away from UNDEFINED results in undefined contents that wouldn't make sense to *load*.

