### PR TITLE
Make all tests use the same api version check

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1052,8 +1052,9 @@ uint32_t VkLayerTest::SetTargetApiVersion(uint32_t target_api_version) {
     }
     return m_target_api_version;
 }
+
 uint32_t VkLayerTest::DeviceValidationVersion() {
-    // The validation layers, assume the version we are validating to is the apiVersion unless the device apiVersion is lower
+    // The validation layers assume the version we are validating to is the apiVersion unless the device apiVersion is lower
     return std::min(m_target_api_version, physDevProps().apiVersion);
 }
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -7582,7 +7582,7 @@ TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {
     }
 
     // These tests rely on having the Maintenance1 extension not being enabled, and are invalid on all but version 1.0
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         // Try baseArrayLayer >= image.arrayLayers with VK_REMAINING_ARRAY_LAYERS
         {
             const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, VK_REMAINING_ARRAY_LAYERS};

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -345,7 +345,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReadOnlyButCleared) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (m_device->props.apiVersion >= VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         maintenance2Supported = true;
     }
 
@@ -1444,7 +1444,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidSubpassDependencies) {
     VkPhysicalDeviceFeatures features = {0};
     ASSERT_NO_FATAL_FAILURE(InitState(&features));
 
-    if (m_device->props.apiVersion >= VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         multiviewSupported = true;
     }
 
@@ -1862,7 +1862,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    if (m_device->props.apiVersion >= VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         maintenance2Supported = true;
     }
 
@@ -2372,7 +2372,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-attachmentCount-00876");
 
     bool rp2_supported = CheckCreateRenderPass2Support(this, m_device_extension_names);
-    bool multiviewSupported = rp2_supported || (m_device->props.apiVersion >= VK_API_VERSION_1_1);
+    bool multiviewSupported = rp2_supported || (DeviceValidationVersion() >= VK_API_VERSION_1_1);
 
     if (!multiviewSupported && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -57,7 +57,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s GPU-Assisted validation test requires Vulkan 1.1+.\n", kSkipPrefix);
         return;
     }
@@ -528,7 +528,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     }
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s GPU-Assisted validation test requires Vulkan 1.1+.\n", kSkipPrefix);
         return;
     }
@@ -1262,7 +1262,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s GPU-Assisted validation test requires Vulkan 1.1+.\n", kSkipPrefix);
         return;
     }
@@ -1472,7 +1472,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s GPU-Assisted printf test requires Vulkan 1.1+.\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1309,7 +1309,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (m_instance_api_version < VK_API_VERSION_1_1) {
+    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
         return;
     }
@@ -1417,7 +1417,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (m_instance_api_version < VK_API_VERSION_1_1) {
+    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
         return;
     }
@@ -1518,7 +1518,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (m_instance_api_version < VK_API_VERSION_1_1) {
+    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
         return;
     }
@@ -4317,7 +4317,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferPhysDevImageFormatProp2) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if ((m_instance_api_version < VK_API_VERSION_1_1) &&
+    if ((DeviceValidationVersion() < VK_API_VERSION_1_1) &&
         !InstanceExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         printf("%s %s extension not supported, skipping test\n", kSkipPrefix,
                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);


### PR DESCRIPTION
Some tests were using the instance's api_version field which is really the loader version.  Use physical device properties to determine available api version.