### PR TITLE
Fix error text and change non-VK_SUCCESS success code warning to infos

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -519,12 +519,12 @@ void BestPractices::ValidateReturnCodes(const char* api_name, VkResult result, c
                                         const std::vector<VkResult>& success_codes) const {
     auto error = std::find(error_codes.begin(), error_codes.end(), result);
     if (error != error_codes.end()) {
-        LogWarning(instance, kVUID_BestPractices_NonSuccess_Result, "%s(): Returned error %s.", api_name, string_VkResult(result));
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", api_name, string_VkResult(result));
         return;
     }
     auto success = std::find(success_codes.begin(), success_codes.end(), result);
     if (success != success_codes.end()) {
-        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned non-success return code %s.", api_name,
+        LogWarning(instance, kVUID_BestPractices_NonSuccess_Result, "%s(): Returned non-success return code %s.", api_name,
                    string_VkResult(result));
     }
 }


### PR DESCRIPTION
If you get a TIMEOUT, SUBOPTIMAL, or other 'success' code that's not VK_SUCCESS, an INFORMATION-level message will be output instead of a WARNING-level one.

Added tests for Error code and non-success success code.

Fixes #1788.