### PR TITLE
Blacklist Nexus Player in OOBGraphicsShaders

### DIFF
--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -31,6 +31,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         return;
     }
 
+    if (IsPlatform(kNexusPlayer)) {
+        printf("%s This test should not run on Nexus Player\n", kSkipPrefix);
+        return;
+    }
+
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;


### PR DESCRIPTION
For some reason the api version check is still letting the OOBGraphicsShaders test run on NP.
Blacklist the test until we get a chance to investigate