### PR TITLE
Install SPIRV-Headers for validation layers build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,11 +173,17 @@ if(BUILD_TESTS OR BUILD_LAYERS)
         set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
     endif()
 
+    # CMake command line option overrides environment variable
+    if(NOT SPIRV_HEADERS_INSTALL_DIR)
+        set(SPIRV_HEADERS_INSTALL_DIR $ENV{SPIRV_HEADERS_INSTALL_DIR})
+    endif()
+
     if (NOT TARGET glslang)
         message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
         set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
         set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
         set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include/glslang" CACHE PATH "Path to glslang spirv headers")
+        set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include" CACHE PATH "Path to spirv-headers")
 
         find_library(GLSLANG_LIB NAMES glslang HINTS ${GLSLANG_SEARCH_PATH})
         find_library(OGLCompiler_LIB NAMES OGLCompiler HINTS ${GLSLANG_SEARCH_PATH})

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -60,7 +60,8 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/image_layout_map.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/subresource_adapter.cpp
 LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
-                    $(LOCAL_PATH)/$(SRC_DIR)/layers/generated
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers/generated \
+                    $(LOCAL_PATH)/$(THIRD_PARTY)/shaderc/third_party/spirv-tools/external/spirv-headers/include
 LOCAL_STATIC_LIBRARIES += layer_utils glslang SPIRV-Tools SPIRV-Tools-opt
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -237,6 +237,7 @@ if(BUILD_LAYERS)
     # Khronos validation additional dependencies
     target_include_directories(VkLayer_khronos_validation PRIVATE ${GLSLANG_SPIRV_INCLUDE_DIR})
     target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
+    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
 
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -24,7 +24,7 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv-tools/optimizer.hpp"
 #include "spirv-tools/instrument.hpp"
-#include <SPIRV/spirv.hpp>
+#include <spirv/unified1/spirv.hpp>
 #include <algorithm>
 #include <regex>
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -31,7 +31,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <SPIRV/spirv.hpp>
+#include <spirv/unified1/spirv.hpp>
 #include "vk_loader_platform.h"
 #include "vk_enum_string_helper.h"
 #include "vk_layer_data.h"

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "vulkan/vulkan.h"
-#include <SPIRV/spirv.hpp>
+#include <spirv/unified1/spirv.hpp>
 #include <generated/spirv_tools_commit_id.h>
 #include "spirv-tools/optimizer.hpp"
 #include "core_validation_types.h"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,16 +15,25 @@
       ]
     },
     {
-      "name" : "Vulkan-Headers",
-      "url" : "https://github.com/KhronosGroup/Vulkan-Headers.git",
-      "sub_dir" : "Vulkan-Headers",
-      "build_dir" : "Vulkan-Headers/build",
-      "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.2.137"
+      "name": "Vulkan-Headers",
+      "url": "https://github.com/KhronosGroup/Vulkan-Headers.git",
+      "sub_dir": "Vulkan-Headers",
+      "build_dir": "Vulkan-Headers/build",
+      "install_dir": "Vulkan-Headers/build/install",
+      "commit": "v1.2.137"
+    },
+    {
+      "name": "SPIRV-Headers",
+      "url": "https://github.com/KhronosGroup/SPIRV-Headers.git",
+      "sub_dir": "SPIRV-Headers",
+      "build_dir": "SPIRV-Headers/build",
+      "install_dir": "SPIRV-Headers/build/install",
+      "commit": "master"
     }
   ],
   "install_names" : {
       "glslang" : "GLSLANG_INSTALL_DIR",
-      "Vulkan-Headers" : "VULKAN_HEADERS_INSTALL_DIR"
-    }
+      "Vulkan-Headers" : "VULKAN_HEADERS_INSTALL_DIR",
+      "SPIRV-Headers" : "SPIRV_HEADERS_INSTALL_DIR"
+  }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ target_include_directories(vk_layer_validation_tests
                                   ${PROJECT_SOURCE_DIR}/layers/generated
                                   ${GLSLANG_SPIRV_INCLUDE_DIR}
                                   ${SPIRV_TOOLS_INCLUDE_DIR}
+                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_BINARY_DIR}
                                   ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
Was using a deprecated copy from deep inside the glslang build tree.  With this change, we now install and use a selectable version from known-good.  We have been unequivocally assured from the glslang folks that using TOT will always work for this specific header (spirv.hpp).  Passed internal CI.

Pinging @dj2.

Fixes #1768.