### PR TITLE
Fix timeline semaphore value difference validations on binary semaphores

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2646,20 +2646,16 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(submit->pNext);
         if (info) {
-            // If there are any timeline semaphores, this condition gets checked before the early return above
-            if (info->waitSemaphoreValueCount)
-                for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
-                    VkSemaphore semaphore = submit->pWaitSemaphores[i];
-                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
-                                                                        "VUID-VkSubmitInfo-pWaitSemaphores-03243");
-                }
-            // If there are any timeline semaphores, this condition gets checked before the early return above
-            if (info->signalSemaphoreValueCount)
-                for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
-                    VkSemaphore semaphore = submit->pSignalSemaphores[i];
-                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
-                                                                        "VUID-VkSubmitInfo-pSignalSemaphores-03244");
-                }
+            for (uint32_t i = 0; i < info->waitSemaphoreValueCount; ++i) {
+                VkSemaphore semaphore = submit->pWaitSemaphores[i];
+                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
+                                                                    "VUID-VkSubmitInfo-pWaitSemaphores-03243");
+            }
+            for (uint32_t i = 0; i < info->signalSemaphoreValueCount; ++i) {
+                VkSemaphore semaphore = submit->pSignalSemaphores[i];
+                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
+                                                                    "VUID-VkSubmitInfo-pSignalSemaphores-03244");
+            }
         }
     }
 
@@ -10787,22 +10783,16 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
         const VkBindSparseInfo *bindInfo = &pBindInfo[bindIdx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(bindInfo->pNext);
         if (info) {
-            // If there are any timeline semaphores, this condition gets checked before the early return above
-            if (info->waitSemaphoreValueCount)
-                for (uint32_t i = 0; i < bindInfo->waitSemaphoreCount; ++i) {
-                    VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
-                    skip |=
-                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
+            for (uint32_t i = 0; i < info->waitSemaphoreValueCount; ++i) {
+                VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
+                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pWaitSemaphores-03250");
-                }
-            // If there are any timeline semaphores, this condition gets checked before the early return above
-            if (info->signalSemaphoreValueCount)
-                for (uint32_t i = 0; i < bindInfo->signalSemaphoreCount; ++i) {
-                    VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
-                    skip |=
-                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
+            }
+            for (uint32_t i = 0; i < info->signalSemaphoreValueCount; ++i) {
+                VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
+                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pSignalSemaphores-03251");
-                }
+            }
         }
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2646,16 +2646,20 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(submit->pNext);
         if (info) {
-            for (uint32_t i = 0; i < info->waitSemaphoreValueCount; ++i) {
-                VkSemaphore semaphore = submit->pWaitSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
-                                                                    "VUID-VkSubmitInfo-pWaitSemaphores-03243");
-            }
-            for (uint32_t i = 0; i < info->signalSemaphoreValueCount; ++i) {
-                VkSemaphore semaphore = submit->pSignalSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
-                                                                    "VUID-VkSubmitInfo-pSignalSemaphores-03244");
-            }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->waitSemaphoreValueCount)
+                for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = submit->pWaitSemaphores[i];
+                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
+                                                                        "VUID-VkSubmitInfo-pWaitSemaphores-03243");
+                }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->signalSemaphoreValueCount)
+                for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = submit->pSignalSemaphores[i];
+                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
+                                                                        "VUID-VkSubmitInfo-pSignalSemaphores-03244");
+                }
         }
     }
 
@@ -10783,16 +10787,22 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
         const VkBindSparseInfo *bindInfo = &pBindInfo[bindIdx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(bindInfo->pNext);
         if (info) {
-            for (uint32_t i = 0; i < info->waitSemaphoreValueCount; ++i) {
-                VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->waitSemaphoreValueCount)
+                for (uint32_t i = 0; i < bindInfo->waitSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
+                    skip |=
+                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pWaitSemaphores-03250");
-            }
-            for (uint32_t i = 0; i < info->signalSemaphoreValueCount; ++i) {
-                VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
+                }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->signalSemaphoreValueCount)
+                for (uint32_t i = 0; i < bindInfo->signalSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
+                    skip |=
+                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pSignalSemaphores-03251");
-            }
+                }
         }
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2508,6 +2508,9 @@ bool CoreChecks::ValidateMaxTimelineSemaphoreValueDifference(VkSemaphore semapho
                                                              const char *vuid) const {
     bool skip = false;
     const auto pSemaphore = GetSemaphoreState(semaphore);
+
+    if (pSemaphore->type != VK_SEMAPHORE_TYPE_TIMELINE_KHR) return false;
+
     uint64_t diff = value > pSemaphore->payload ? value - pSemaphore->payload : pSemaphore->payload - value;
 
     if (diff > phys_dev_props_core12.maxTimelineSemaphoreValueDifference) {
@@ -2643,16 +2646,20 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(submit->pNext);
         if (info) {
-            for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
-                VkSemaphore semaphore = submit->pWaitSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
-                                                                    "VUID-VkSubmitInfo-pWaitSemaphores-03243");
-            }
-            for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
-                VkSemaphore semaphore = submit->pSignalSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
-                                                                    "VUID-VkSubmitInfo-pSignalSemaphores-03244");
-            }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->waitSemaphoreValueCount)
+                for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = submit->pWaitSemaphores[i];
+                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueSubmit",
+                                                                        "VUID-VkSubmitInfo-pWaitSemaphores-03243");
+                }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->signalSemaphoreValueCount)
+                for (uint32_t i = 0; i < submit->signalSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = submit->pSignalSemaphores[i];
+                    skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueSubmit",
+                                                                        "VUID-VkSubmitInfo-pSignalSemaphores-03244");
+                }
         }
     }
 
@@ -10780,16 +10787,22 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
         const VkBindSparseInfo *bindInfo = &pBindInfo[bindIdx];
         auto *info = lvl_find_in_chain<VkTimelineSemaphoreSubmitInfoKHR>(bindInfo->pNext);
         if (info) {
-            for (uint32_t i = 0; i < bindInfo->waitSemaphoreCount; ++i) {
-                VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->waitSemaphoreValueCount)
+                for (uint32_t i = 0; i < bindInfo->waitSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = bindInfo->pWaitSemaphores[i];
+                    skip |=
+                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pWaitSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pWaitSemaphores-03250");
-            }
-            for (uint32_t i = 0; i < bindInfo->signalSemaphoreCount; ++i) {
-                VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
-                skip |= ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
+                }
+            // If there are any timeline semaphores, this condition gets checked before the early return above
+            if (info->signalSemaphoreValueCount)
+                for (uint32_t i = 0; i < bindInfo->signalSemaphoreCount; ++i) {
+                    VkSemaphore semaphore = bindInfo->pSignalSemaphores[i];
+                    skip |=
+                        ValidateMaxTimelineSemaphoreValueDifference(semaphore, info->pSignalSemaphoreValues[i], "VkQueueBindSparse",
                                                                     "VUID-VkBindSparseInfo-pSignalSemaphores-03251");
-            }
+                }
         }
     }
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8679,7 +8679,7 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
     semaphore_signal_info.semaphore = semaphore[1];
     ASSERT_VK_SUCCESS(vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
 
-    // Check if we can test violations of maxTimmelineSemaphoreValueDifference
+    // Check if we can test violations of maxTimelineSemaphoreValueDifference
     if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
         VkSemaphore sem;
 
@@ -8697,6 +8697,48 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
         ASSERT_VK_SUCCESS(vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
 
         vk::DestroySemaphore(m_device->device(), sem, nullptr);
+
+        // Regression test for value difference validations ran against binary semaphores
+        {
+            VkSemaphore timeline_sem;
+            VkSemaphore binary_sem;
+
+            semaphore_type_create_info.initialValue = 0;
+            ASSERT_VK_SUCCESS(vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &timeline_sem));
+
+            VkSemaphoreCreateInfo binary_semaphore_create_info{};
+            binary_semaphore_create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+            ASSERT_VK_SUCCESS(vk::CreateSemaphore(m_device->device(), &binary_semaphore_create_info, nullptr, &binary_sem));
+
+            signalValue = 1;
+            uint64_t offendingValue = timelineproperties.maxTimelineSemaphoreValueDifference + 1;
+
+            submit_info.waitSemaphoreCount = 1;
+            submit_info.pWaitSemaphores = &timeline_sem;
+            submit_info.signalSemaphoreCount = 1;
+            submit_info.pSignalSemaphores = &binary_sem;
+
+            timeline_semaphore_submit_info.waitSemaphoreValueCount = 1;
+            timeline_semaphore_submit_info.pWaitSemaphoreValues = &signalValue;
+
+            // These two assignments are not required by the spec, but would segfault on older versions of validation layers
+            timeline_semaphore_submit_info.signalSemaphoreValueCount = 1;
+            timeline_semaphore_submit_info.pSignalSemaphoreValues = &offendingValue;
+
+            m_errorMonitor->ExpectSuccess();
+
+            vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+
+            semaphore_signal_info.semaphore = timeline_sem;
+            semaphore_signal_info.value = 1;
+            vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info);
+
+            m_errorMonitor->VerifyNotFound();
+
+            vk::DestroySemaphore(m_device->device(), binary_sem, nullptr);
+            vk::DestroySemaphore(m_device->device(), timeline_sem, nullptr);
+        }
     }
 
     ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));


### PR DESCRIPTION
Fixes #1786 

The scenario that was breaking was where you had binary semaphores in one bucket (wait/signal), but you had at least one timeline semaphore in the other. Having all semaphores be binary skips the `*SemaphoreValueCount` validation here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/2f609275c00c66f4258f9bd07217d47d58a2f73b/layers/core_validation.cpp#L2127-L2134

And rightfully so, because the spec states:
> [...] and **any** element of pSignalSemaphores was created with a VkSemaphoreType of VK_SEMAPHORE_TYPE_TIMELINE, then its signalSemaphoreValueCount member must equal signalSemaphoreCount

But, when that is skipped, the validation code does not bail out early and is allowed to fall through to value difference checks, which assume that the value count parameter was validated.

To address the false positive message about value difference on binary semaphores, I added a guard inside of `ValidateMaxTimelineSemaphoreValueDifference`. We already use semaphore state there, and `PreCallValidateSignalSemaphore` (one of the call sites) verifies semaphore type on its own, so it should be a safe addition.

To prevent SEGFAULTs on a null pointer, I've added guards outside of function calls to check for ValueCount. I considered checking directly for the null pointer, but I think parameter validation does it already and the call sites operate on count arguments.

An alternative implementation of `ValidateMaxTimelineSemaphoreValueDifference` could accept a lambda to get the payload, instead of always being provided a payload. That kind of laziness would let us defer using that value until it's necessary, avoiding a segfault and a guard outside the function call.

The test suite here fails for me with `SIGFPE` in `[ RUN      ] VkLayerTest.CreatePipelineExceedMaxTessellationControlInputOutputComponents`, so I wasn't able to add a regression test. I'll do a second attempt later.
