### PR TITLE
Don't validate initial layout on external resource acquire

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1185,10 +1185,17 @@ void CoreChecks::RecordTransitionImageLayout(CMD_BUFFER_STATE *cb_state, const I
         normalized_isr.layerCount = image_create_info.extent.depth;  // Treat each depth slice as a layer subresource
     }
 
+    VkImageLayout initial_layout = mem_barrier.oldLayout;
+
+    // Layout transitions in external instance are not tracked, so don't validate initial layout.
+    if (QueueFamilyIsSpecial(mem_barrier.srcQueueFamilyIndex)) {
+        initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    }
+
     if (is_release_op) {
         SetImageInitialLayout(cb_state, *image_state, normalized_isr, mem_barrier.oldLayout);
     } else {
-        SetImageLayout(cb_state, *image_state, normalized_isr, mem_barrier.newLayout, mem_barrier.oldLayout);
+        SetImageLayout(cb_state, *image_state, normalized_isr, mem_barrier.newLayout, initial_layout);
     }
 }
 


### PR DESCRIPTION
We can't see layout transfers that occur on a resource while it is owned
by a different instance, so don't validate the initial layout in this
case.

Bug: 1438