### PR TITLE
travis: Improve ccache efficiency on Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ matrix:
   include:
     # Android build.
     - os: linux
-      compiler: gcc
       env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-26 ANDROID_ABI=armeabi-v7a
     # Android 64-bit build.
     - os: linux
-      compiler: gcc
       env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-26 ANDROID_ABI=arm64-v8a
     # Linux GCC debug build.
     - os: linux
@@ -82,7 +80,10 @@ before_install:
     fi
   # Misc setup
   - export core_count=$(nproc || echo 4) && echo core_count = $core_count
+  - ccache --version
   - ccache --zero-stats
+  - export CCACHE_COMPRESS=true
+  - export CCACHE_COMPRESSLEVEL=9
   - set +e
 
 script:
@@ -195,7 +196,7 @@ script:
       git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
       export PATH=$PATH:$PWD/depot_tools
       ./build-gn/update_deps.sh
-      gn gen out/Debug
+      gn gen out/Debug --args="cc_wrapper=\"ccache\""
       ninja -C out/Debug
     fi
   - ccache --show-stats


### PR DESCRIPTION
- Turn on CCACHE_COMPRESSION
- Enable ccache for GN builds

For some time, the ccache hit rate in Travis-CI builds has been
very low, often 0 hits per run.

This happens because there is a limit on the ccache size imposed
by Travis-CI and our builds are easily exceeding it, resulting in
severe cache thrashing.

In particular, glslang/spirv-tools are built first, filling up the
cache. Then the rest of the build objects push the glslang/spriv-tools
objects out of the cache, replacing them with their own.

In the next Travis-CI build, the retrieved cache does not contain the
glslang/spirv-tools objects, so they get recompiled and push
the other objects out, continuing the thrashing.

Turning on CCACHE_COMPRESSION lets the entire build fit into the
cache.  This is especially beneficial for the glslang/spriv-tools
code since it changes only when the known-good versions are updated.