### PR TITLE
Fix deprecated extension checks

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -108,12 +108,12 @@ bool BestPractices::ValidateDeprecatedExtensions(const char* api_name, const cha
     auto dep_info_it = deprecated_extensions.find(extension_name);
     if (dep_info_it != deprecated_extensions.end()) {
         auto dep_info = dep_info_it->second;
-        if ((dep_info.target.compare("VK_VERSION_1_1") && (version >= VK_VERSION_1_1)) ||
-            (dep_info.target.compare("VK_VERSION_1_2") && (version >= VK_VERSION_1_2))) {
+        if (((dep_info.target.compare("VK_VERSION_1_1") == 0) && (version >= VK_API_VERSION_1_1)) ||
+            ((dep_info.target.compare("VK_VERSION_1_2") == 0) && (version >= VK_API_VERSION_1_2))) {
             skip |=
                 LogWarning(instance, vuid, "%s(): Attempting to enable deprecated extension %s, but this extension has been %s %s.",
                            api_name, extension_name, DepReasonToString(dep_info.reason), (dep_info.target).c_str());
-        } else if (!dep_info.target.find("VK_VERSION")) {
+        } else if (dep_info.target.find("VK_VERSION") == std::string::npos) {
             if (dep_info.target.length() == 0) {
                 skip |= LogWarning(instance, vuid,
                                    "%s(): Attempting to enable deprecated extension %s, but this extension has been deprecated "

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -107,7 +107,9 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
         printf("%s Did not find %s extension, skipped.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
 
+    // Create a 1.1 vulkan instance and request an extension promoted to core in 1.1
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension");
     VkInstance dummy;
     auto features = features_;
@@ -116,6 +118,19 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     ici.pNext = &features;
     vk::CreateInstance(&ici, nullptr, &dummy);
     m_errorMonitor->VerifyFound();
+
+    // Create a 1.0 vulkan instance and request an extension promoted to core in 1.1
+    m_errorMonitor->ExpectSuccess(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT);
+    VkApplicationInfo* new_info = new VkApplicationInfo;
+    new_info->apiVersion = VK_API_VERSION_1_0;
+    new_info->pApplicationName = ici.pApplicationInfo->pApplicationName;
+    new_info->applicationVersion = ici.pApplicationInfo->applicationVersion;
+    new_info->pEngineName = ici.pApplicationInfo->pEngineName;
+    new_info->engineVersion = ici.pApplicationInfo->engineVersion;
+    ici.pApplicationInfo = new_info;
+    vk::CreateInstance(&ici, nullptr, &dummy);
+    vk::DestroyInstance(dummy, nullptr);
+    m_errorMonitor->VerifyNotFound();
 }
 
 TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {


### PR DESCRIPTION
VK_VERSION_1_0, VK_VERSION_1_1 and VK_VERSION_1_2 all evaluate to 1 or 0.  Fixed these use cases along with some string comparison errors and added a test case.

Fixes [LunarXchange issue 927](https://vulkan.lunarg.com/issue/view/5ebb1a53e0d2a35980e52eec).