### PR TITLE
Validate VK_EXT_pipeline_creation_cache_control

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -110,6 +110,8 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis) const;
+    bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, uint32_t index, const char* caller_name,
+                                           const char* vuid) const;
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const char* func_name, CMD_BUFFER_STATE* cb_state,
                                                          uint32_t imageMemBarrierCount,
                                                          const VkImageMemoryBarrier* pImageMemBarriers);
@@ -682,6 +684,8 @@ class CoreChecks : public ValidationStateTracker {
                                                      const VkSamplerYcbcrConversionCreateInfo* create_info) const;
     bool ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
                                                                 const VkImageFormatProperties2* pImageFormatProperties) const;
+    bool PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache) const;
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1255,6 +1255,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fragment_density_map_features;
     VkPhysicalDeviceCustomBorderColorFeaturesEXT custom_border_color_features;
+    VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipeline_creation_cache_control_features;
 };
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1425,6 +1425,12 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         state_tracker->enabled_features.custom_border_color_features = *custom_border_color_features;
     }
 
+    const auto *pipeline_creation_cache_control_features =
+        lvl_find_in_chain<VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>(pCreateInfo->pNext);
+    if (pipeline_creation_cache_control_features) {
+        state_tracker->enabled_features.pipeline_creation_cache_control_features = *pipeline_creation_cache_control_features;
+    }
+
     // Store physical device properties and physical device mem limits into CoreChecks structs
     DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
     DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);


### PR DESCRIPTION
Add VUIDs for VK_EXT_pipeline_creation_cache_control

VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878
VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875
VUID-VkPipelineCacheCreateInfo-pipelineCreationCacheControl-02892
VUID-VkRayTracingPipelineCreateInfoNV-pipelineCreationCacheControl-02905
VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905