### PR TITLE
Add index to pipeline log messages

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -2316,25 +2316,28 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
                         skip |=
                             LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00724",
-                                     "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineHandle, must be "
+                                     "vkCreateGraphicsPipelines parameter, pCreateInfos[%u]->basePipelineHandle, must be "
                                      "VK_NULL_HANDLE if pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag "
-                                     "and pCreateInfos->basePipelineIndex is not -1.");
+                                     "and pCreateInfos->basePipelineIndex is not -1.",
+                                     i);
                     }
                 }
 
                 if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
                     if (pCreateInfos[i].basePipelineIndex != -1) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00725",
-                                         "vkCreateGraphicsPipelines parameter, pCreateInfos->basePipelineIndex, must be -1 if "
+                                         "vkCreateGraphicsPipelines parameter, pCreateInfos[%u]->basePipelineIndex, must be -1 if "
                                          "pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag and "
-                                         "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.");
+                                         "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.",
+                                         i);
                     }
                 } else {
                     if (static_cast<uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
-                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
-                                         "vkCreateGraphicsPipelines parameter pCreateInfos->basePipelineIndex (%d) must be a valid"
-                                         "index into the pCreateInfos array, of size %d.",
-                                         pCreateInfos[i].basePipelineIndex, createInfoCount);
+                        skip |=
+                            LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
+                                     "vkCreateGraphicsPipelines parameter pCreateInfos[%u]->basePipelineIndex (%d) must be a valid"
+                                     "index into the pCreateInfos array, of size %d.",
+                                     i, pCreateInfos[i].basePipelineIndex, createInfoCount);
                     }
                 }
             }
@@ -2351,8 +2354,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                (physical_device_features.fillModeNonSolid == false)) {
                         skip |= LogError(device, kVUID_PVError_DeviceFeature,
                                          "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                         "pCreateInfos->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
-                                         "VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
+                                         "pCreateInfos[%u]->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
+                                         "VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false.",
+                                         i);
                     }
                 } else {
                     if ((pCreateInfos[i].pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL) &&
@@ -2361,8 +2365,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         skip |=
                             LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507",
                                      "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                     "pCreateInfos->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
-                                     "VK_POLYGON_MODE_FILL_RECTANGLE_NV if VkPhysicalDeviceFeatures->fillModeNonSolid is false.");
+                                     "pCreateInfos[%u]->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
+                                     "VK_POLYGON_MODE_FILL_RECTANGLE_NV if VkPhysicalDeviceFeatures->fillModeNonSolid is false.",
+                                     i);
                     }
                 }
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -195,9 +195,7 @@ TEST_F(VkLayerTest, DisabledIndependentBlend) {
     features.independentBlend = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(Init(&features));
 
-    m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit,
-        "Invalid Pipeline CreateInfo: If independent blend feature not enabled, all elements of pAttachments must be identical");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605");
 
     VkDescriptorSetObj descriptorSet(m_device);
     descriptorSet.AppendDummy();
@@ -1676,7 +1674,7 @@ TEST_F(VkLayerTest, InvalidPipelineCreateState) {
     VkPipelineShaderStageCreateInfo shaderStage = fs.GetStageCreateInfo();  // should be: vs.GetStageCreateInfo();
 
     auto set_info = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {shaderStage}; };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Invalid Pipeline CreateInfo State: Vertex Shader required");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-stage-00727");
 
     // Finally, check the string validation for the shader stage pName variable.  Correct the shader stage data, and bork the
     // string before calling again


### PR DESCRIPTION
I went through and added the index of the pipeline in pPipelineCreateInfo to the LogMessage. Ran into this when developer was creating multiple pipelines and error message didn't help narrow down which of the pipelines in the array was the issue