### PR TITLE
Fix bug for multiple compute pipelines

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3905,7 +3905,7 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
     auto *ccpl_state = reinterpret_cast<create_compute_pipeline_api_state *>(ccpl_state_data);
     for (uint32_t i = 0; i < count; i++) {
         // TODO: Add Compute Pipeline Verification
-        skip |= ValidateComputePipelineShaderState(ccpl_state->pipe_state.back().get());
+        skip |= ValidateComputePipelineShaderState(ccpl_state->pipe_state[i].get());
     }
     return skip;
 }


### PR DESCRIPTION
Seeing how 

```
for (uint32_t i = 0; i < count; i++) {
    skip |= ValidatePipelineUnlocked(cgpl_state->pipe_state[i].get(), i);
}
```

I realized the compute pipeline loop is only grabbing the last item instead of looping through each