### PR TITLE
Fix GPU-AV for RayTracing

### DIFF
--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -691,7 +691,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBRayTracingShaders) {
     TEST_DESCRIPTION(
         "GPU validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors for "
         "ray tracing shaders using gpu assited validation.");
-    OOBRayTracingShadersTestBody(false);
+    OOBRayTracingShadersTestBody(true);
 }
 
 TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationInvalidHandle) {


### PR DESCRIPTION
vkGetAccelerationStructureMemoryRequirementsNV no longer returns anything other than zero in memoryTypeBits, causing vma to fail to find matching memory.  Just use vmaCreateBuffer instead of create, allocate, bind.  Also re-enable the GPU-AV ray tracing test that was mistakenly disabled.