### PR TITLE
Remove CB device tracking

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1077,7 +1077,6 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     VkCommandBufferAllocateInfo createInfo = {};
     VkCommandBufferBeginInfo beginInfo;
     VkCommandBufferInheritanceInfo inheritanceInfo;
-    VkDevice device;  // device this CB belongs to
     std::shared_ptr<const COMMAND_POOL_STATE> command_pool;
     bool hasDrawCmd;
     bool hasTraceRaysCmd;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2990,7 +2990,6 @@ void ValidationStateTracker::PostCallRecordAllocateCommandBuffers(VkDevice devic
             pPool->commandBuffers.insert(pCommandBuffer[i]);
             auto pCB = std::make_shared<CMD_BUFFER_STATE>();
             pCB->createInfo = *pCreateInfo;
-            pCB->device = device;
             pCB->command_pool = pPool;
             // Add command buffer to map
             commandBufferMap[pCommandBuffer[i]] = std::move(pCB);


### PR DESCRIPTION
Discussed in #1855 how this seems to be unused and misleading as StateTracker is a per-device object