### PR TITLE
Add function name prefix to more logs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -267,7 +267,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDeviceMaskToRenderPass(const CMD_BUFFER_STATE* pCB, uint32_t deviceMask, const char* VUID) const;
 
     bool ValidateDepthStencilResolve(const VkPhysicalDeviceVulkan12Properties& core12_props,
-                                     const VkRenderPassCreateInfo2* pCreateInfo) const;
+                                     const VkRenderPassCreateInfo2* pCreateInfo, const char* function_name) const;
 
     bool ValidateBindAccelerationStructureMemory(VkDevice device, const VkBindAccelerationStructureMemoryInfoKHR& info) const;
     // Prototypes for CoreChecks accessor functions


### PR DESCRIPTION
Started with a few functions and decided to just go through and do a batch fix of many logs that don't have the function prefix. This is useful as I have found from people internally using the tool are not always Vulkan spec experts and seeing the function call that blew things up help save time to find where to triage their issue