### PR TITLE
[WIP] Hotfix for Null Pointer Dereference in BestPractices::PreCallValidateCreateInstance

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -132,16 +132,17 @@ bool BestPractices::ValidateDeprecatedExtensions(const char* api_name, const cha
 bool BestPractices::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                                   VkInstance* pInstance) const {
     bool skip = false;
-
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceExtensionNames)) {
             skip |= LogWarning(instance, kVUID_BestPractices_CreateInstance_ExtensionMismatch,
                                "vkCreateInstance(): Attempting to enable Device Extension %s at CreateInstance time.",
                                pCreateInfo->ppEnabledExtensionNames[i]);
         }
-        skip |= ValidateDeprecatedExtensions("CreateInstance", pCreateInfo->ppEnabledExtensionNames[i],
-                                             pCreateInfo->pApplicationInfo->apiVersion,
-                                             kVUID_BestPractices_CreateInstance_DeprecatedExtension);
+        if (pCreateInfo->pApplicationInfo != nullptr) {
+            skip |= ValidateDeprecatedExtensions("CreateInstance", pCreateInfo->ppEnabledExtensionNames[i],
+                                                 pCreateInfo->pApplicationInfo->apiVersion,
+                                                 kVUID_BestPractices_CreateInstance_DeprecatedExtension);
+        }
     }
 
     return skip;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -92,6 +92,40 @@ TEST_F(VkBestPracticesLayerTest, ValidateReturnCodes) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(VkBestPracticesLayerTest, CreateInstanceWithNullApplicationInfo) {
+    TEST_DESCRIPTION("Attempt to create a Vulkan instance with a null VkApplicationInfo. This should not cause an error.");
+
+    InitBestPracticesFramework();
+
+    VkInstanceCreateInfo ici = GetInstanceCreateInfo();
+    ici.pApplicationInfo = nullptr;
+
+    VkInstance instance;
+    m_errorMonitor->ExpectSuccess();
+    VkResult result = vk::CreateInstance(&ici, nullptr, &instance);
+    ASSERT_VK_SUCCESS(result);
+    m_errorMonitor->VerifyNotFound();
+}
+
+TEST_F(VkBestPracticesLayerTest, CreateInstanceWithNullApplicationInfoWithExtensions) {
+    TEST_DESCRIPTION(
+        "Attempt to create a Vulkan instance with a null VkApplicationInfo and some enabled extensions. This should not cause an "
+        "error.");
+
+    InitBestPracticesFramework();
+
+    VkInstanceCreateInfo ici = GetInstanceCreateInfo();
+    ici.pApplicationInfo = nullptr;
+    ici.ppEnabledExtensionNames = m_instance_extension_names.data();
+    ici.enabledExtensionCount = m_instance_extension_names.size();
+
+    VkInstance instance;
+    m_errorMonitor->ExpectSuccess();
+    VkResult result = vk::CreateInstance(&ici, nullptr, &instance);
+    ASSERT_VK_SUCCESS(result);
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     TEST_DESCRIPTION("Create an instance with a deprecated extension.");
 


### PR DESCRIPTION
This is the same issue that came up in this PR: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1750

However, it's in a different place.

I've added tests here to make sure this won't happen in the future. However, currently the tests don't seem to be able to hook into PreCallValidateCreateInstance / PostCallRecordCreateInstance. I'm not sure why.