### PR TITLE
layers: adjust shared_mutex usage

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -214,14 +214,14 @@ static inline int u_ffs(int val) {
 }
 #endif
 
-// shared_mutex support added in MSVC 2015 update 2
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+// Minimum Visual Studio 2015 Update 2, or libc++ with C++17
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
 #include <shared_mutex>
 #endif
 
 class ReadWriteLock {
   private:
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
     typedef std::shared_mutex lock_t;
 #else
     typedef std::mutex lock_t;
@@ -231,7 +231,7 @@ class ReadWriteLock {
     void lock() { m_lock.lock(); }
     bool try_lock() { return m_lock.try_lock(); }
     void unlock() { m_lock.unlock(); }
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
     void lock_shared() { m_lock.lock_shared(); }
     bool try_lock_shared() { return m_lock.try_lock_shared(); }
     void unlock_shared() { m_lock.unlock_shared(); }
@@ -244,7 +244,7 @@ class ReadWriteLock {
     lock_t m_lock;
 };
 
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
 typedef std::shared_lock<ReadWriteLock> read_lock_guard_t;
 typedef std::unique_lock<ReadWriteLock> write_lock_guard_t;
 #else

--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -3136,8 +3136,8 @@ the containers.
 #endif
 
 #ifndef VMA_USE_STL_SHARED_MUTEX
-    // Minimum Visual Studio 2015 Update 2
-    #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+    // Minimum Visual Studio 2015 Update 2, or libc++ with C++17
+    #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
         #define VMA_USE_STL_SHARED_MUTEX 1
     #endif
 #endif


### PR DESCRIPTION
When compiling with libc++ shared_mutex is only available in C++17 mode.
The current checks only detect the availability of shared_mutex when
building with Microsoft's standard library. This adds a __cplusplus
version check when _LIBCPP_VERSION is defined.

This fixes issue 1921