### PR TITLE
Removing false positive for release/acquire with external queue families

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6591,7 +6591,7 @@ class ValidatorState {
     inline bool KhrExternalMem() const { return mem_ext_; }
     inline bool IsValid(uint32_t queue_family) const { return (queue_family < limit_); }
     inline bool IsValidOrSpecial(uint32_t queue_family) const {
-        return IsValid(queue_family) || (mem_ext_ && QueueFamilyIsSpecial(queue_family));
+        return IsValid(queue_family) || (mem_ext_ && QueueFamilyIsExternal(queue_family));
     }
 
     // Helpers for LogMsg
@@ -6644,8 +6644,8 @@ bool Validate(const CoreChecks *device_data, const char *func_name, const CMD_BU
             if (!(src_ignored || dst_ignored)) {
                 skip |= val.LogMsg(kSrcOrDstMustBeIgnore, src_queue_family, dst_queue_family);
             }
-            if ((src_ignored && !(dst_ignored || QueueFamilyIsSpecial(dst_queue_family))) ||
-                (dst_ignored && !(src_ignored || QueueFamilyIsSpecial(src_queue_family)))) {
+            if ((src_ignored && !(dst_ignored || QueueFamilyIsExternal(dst_queue_family))) ||
+                (dst_ignored && !(src_ignored || QueueFamilyIsExternal(src_queue_family)))) {
                 skip |= val.LogMsg(kSpecialOrIgnoreOnly, src_queue_family, dst_queue_family);
             }
         } else {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -122,7 +122,7 @@ static bool IsAcquireOp(const COMMAND_POOL_STATE *pool, const Barrier *barrier) 
     return (assume_transfer || IsTransferOp(barrier)) && (pool->queueFamilyIndex == barrier->dstQueueFamilyIndex);
 }
 
-static inline bool QueueFamilyIsSpecial(const uint32_t queue_family_index) {
+static inline bool QueueFamilyIsExternal(const uint32_t queue_family_index) {
     return (queue_family_index == VK_QUEUE_FAMILY_EXTERNAL_KHR) || (queue_family_index == VK_QUEUE_FAMILY_FOREIGN_EXT);
 }
 


### PR DESCRIPTION
As a corner case, it's arguably legal to release/acquire to and from an external queue family within a single command buffer.  As such, validation shouldn't complain.  Fixes #1919 