### PR TITLE
Verify valid image memory at vkCreateFramebuffer

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7727,6 +7727,11 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                                          string_VkSampleCountFlagBits(rpci->pAttachments[i].samples),
                                          report_data->FormatHandle(pCreateInfo->renderPass).c_str());
                         }
+
+                        // Verify that image memory is valid
+                        auto image_data = GetImageState(ivci.image);
+                        skip |= ValidateMemoryIsBoundToImage(image_data, "vkCreateFramebuffer()", "VUID-VkFramebufferCreateInfo-pAttachments-99999");
+
                         // Verify that view only has a single mip level
                         if (ivci.subresourceRange.levelCount != 1) {
                             skip |= LogError(

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7730,7 +7730,8 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
 
                         // Verify that image memory is valid
                         auto image_data = GetImageState(ivci.image);
-                        skip |= ValidateMemoryIsBoundToImage(image_data, "vkCreateFramebuffer()", "VUID-VkFramebufferCreateInfo-pAttachments-99999");
+                        skip |= ValidateMemoryIsBoundToImage(image_data, "vkCreateFramebuffer()",
+                                                             "VUID-VkFramebufferCreateInfo-pAttachments-99999");
 
                         // Verify that view only has a single mip level
                         if (ivci.subresourceRange.levelCount != 1) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4088,6 +4088,70 @@ TEST_F(VkLayerTest, InvalidCmdBufferFramebufferImageDestroyed) {
     vk::DestroyImageView(m_device->device(), view, nullptr);
 }
 
+TEST_F(VkLayerTest, FramebufferAttachmentMemoryFreed) {
+    TEST_DESCRIPTION("Attempt to create framebuffer with attachment which memory was freed.");
+    ASSERT_NO_FATAL_FAILURE(Init());
+    VkFormatProperties format_properties;
+    VkResult err = VK_SUCCESS;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
+    if (!(format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        printf("%s Image format doesn't support required features.\n", kSkipPrefix);
+        return;
+    }
+    VkFramebuffer fb;
+    VkImageView view;
+
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    {
+        VkImageCreateInfo image_ci = {};
+        image_ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        image_ci.pNext = NULL;
+        image_ci.imageType = VK_IMAGE_TYPE_2D;
+        image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
+        image_ci.extent.width = 32;
+        image_ci.extent.height = 32;
+        image_ci.extent.depth = 1;
+        image_ci.mipLevels = 1;
+        image_ci.arrayLayers = 1;
+        image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+        image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+        image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+        image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        image_ci.flags = 0;
+
+        vk_testing::Image image;
+        image.init_no_mem(*m_device, image_ci);
+
+        vk_testing::DeviceMemory *image_memory = new vk_testing::DeviceMemory;
+        image_memory->init(*m_device, vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, image.memory_requirements(), 0));
+        image.bind_memory(*image_memory, 0);
+
+        VkImageViewCreateInfo ivci = {
+            VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+            nullptr,
+            0,
+            image.handle(),
+            VK_IMAGE_VIEW_TYPE_2D,
+            VK_FORMAT_B8G8R8A8_UNORM,
+            {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A},
+            {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        };
+        err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
+        ASSERT_VK_SUCCESS(err);
+
+        VkFramebufferCreateInfo fci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, m_renderPass, 1, &view, 32, 32, 1};
+
+        // Introduce error:
+        // Free the attachment image memory, then create framebuffer.
+        delete image_memory;
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-99999");
+        err = vk::CreateFramebuffer(m_device->device(), &fci, nullptr, &fb);
+        m_errorMonitor->VerifyFound();
+    }
+
+    vk::DestroyImageView(m_device->device(), view, nullptr);
+}
+
 TEST_F(VkLayerTest, ImageMemoryNotBound) {
     TEST_DESCRIPTION("Attempt to draw with an image which has not had memory bound to it.");
     ASSERT_NO_FATAL_FAILURE(Init());


### PR DESCRIPTION
If memory of image was freed after imageView creation,
it was not detected at vkCreateFramebuffer.

What should I use instead of _VUID-VkFramebufferCreateInfo-pAttachments-99999_ placeholder?

Resolve KhronosGroup/Vulkan-ValidationLayers#1937