### PR TITLE
cmake: check minimum version of Vulkan headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ if (TARGET Vulkan::Headers)
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
     get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
 else()
+    set(VK_HDR_MIN_VER "1.2.141")
+
     find_package(VulkanHeaders REQUIRED)
+    if ("${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}" VERSION_LESS "${VK_HDR_MIN_VER}")
+        message(FATAL_ERROR "Minimum version of Vulkan headers is ${VK_HDR_MIN_VER}")
+    endif()
 
     # xxxnsubtil: this should eventually be replaced by exported targets
     add_library(Vulkan-Headers INTERFACE)

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -32,6 +32,13 @@
 #   VulkanRegistry_FOUND         - True if VulkanRegistry was found
 #   VulkanRegistry_DIRS          - directories for VulkanRegistry
 #
+#   VulkanHeaders_VERSION_MAJOR  - The Major API version of the latest version
+#                                  contained in the Vulkan header
+#   VulkanHeaders_VERSION_MINOR  - The Minor API version of the latest version
+#                                  contained in the Vulkan header
+#   VulkanHeaders_VERSION_PATCH  - The Patch API version of the latest version
+#                                  contained in the Vulkan header
+#
 # The module will also define two cache variables::
 #
 #   VulkanHeaders_INCLUDE_DIR    - the VulkanHeaders include directory
@@ -67,9 +74,10 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
 else()
   # If VULKAN_HEADERS_INSTALL_DIR, or one of its variants was not specified,
   # do a normal search without hints.
-  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
+  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h HINTS "${CMAKE_CURRENT_SOURCE_DIR}/external/Vulkan-Headers/include")
   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT})
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry
+    "${VULKAN_REGISTRY_PATH_HINT}/registry")
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})
@@ -84,3 +92,61 @@ find_package_handle_standard_args(VulkanRegistry
     VulkanRegistry_DIR)
 
 mark_as_advanced(VulkanHeaders_INCLUDE_DIR VulkanRegistry_DIR)
+
+# Determine the major/minor/patch version from the vulkan header
+set(VulkanHeaders_VERSION_MAJOR "0")
+set(VulkanHeaders_VERSION_MINOR "0")
+set(VulkanHeaders_VERSION_PATCH "0")
+
+# First, determine which header we need to grab the version information from.
+# Starting with Vulkan 1.1, we should use vulkan_core.h, but prior to that,
+# the information was in vulkan.h.
+if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h")
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h)
+else()
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.h)
+endif()
+
+# Find all lines in the header file that contain any version we may be interested in
+#  NOTE: They start with #define and then have other keywords
+file(STRINGS
+        ${VulkanHeaders_main_header}
+        VulkanHeaders_lines
+        REGEX "^#define (VK_API_VERSION.*VK_MAKE_VERSION|VK_HEADER_VERSION)")
+
+foreach(VulkanHeaders_line ${VulkanHeaders_lines})
+
+    # First, handle the case where we have a major/minor version
+    #   Format is:
+    #        #define VK_API_VERSION_X_Y VK_MAKE_VERSION(X, Y, 0)
+    #   We grab the major version (X) and minor version (Y) out of the parentheses
+    string(REGEX MATCH "VK_MAKE_VERSION\\(.*\\)" VulkanHeaders_out ${VulkanHeaders_line})
+    string(REGEX MATCHALL "[0-9]+" VulkanHeaders_MAJOR_MINOR "${VulkanHeaders_out}")
+    if (VulkanHeaders_MAJOR_MINOR)
+        list (GET VulkanHeaders_MAJOR_MINOR 0 VulkanHeaders_cur_major)
+        list (GET VulkanHeaders_MAJOR_MINOR 1 VulkanHeaders_cur_minor)
+        if (${VulkanHeaders_cur_major} GREATER ${VulkanHeaders_VERSION_MAJOR})
+            set(VulkanHeaders_VERSION_MAJOR ${VulkanHeaders_cur_major})
+            set(VulkanHeaders_VERSION_MINOR ${VulkanHeaders_cur_minor})
+        endif()
+        if (${VulkanHeaders_cur_major} EQUAL ${VulkanHeaders_VERSION_MAJOR} AND
+            ${VulkanHeaders_cur_minor} GREATER ${VulkanHeaders_VERSION_MINOR})
+            set(VulkanHeaders_VERSION_MINOR ${VulkanHeaders_cur_minor})
+        endif()
+    endif()
+
+    # Second, handle the case where we have the patch version
+    #   Format is:
+    #      #define VK_HEADER_VERSION Z
+    #   Where Z is the patch version which we just grab off the end
+    string(REGEX MATCH "define.*VK_HEADER_VERSION[^_].*[0-9]+" VulkanHeaders_out ${VulkanHeaders_line})
+    list(LENGTH VulkanHeaders_out VulkanHeaders_len)
+    if (VulkanHeaders_len)
+        string(REGEX MATCH "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")
+    endif()
+
+endforeach()
+MESSAGE(STATUS
+        "Detected Vulkan Version ${VulkanHeaders_VERSION_MAJOR}."
+        "${VulkanHeaders_VERSION_MINOR}."
+        "${VulkanHeaders_VERSION_PATCH}")


### PR DESCRIPTION
cmake/FindVulkanHeaders.cmake is copied from https://github.com/KhronosGroup/Vulkan-Loader/blob/master/cmake/FindVulkanHeaders.cmake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/khronosgroup/vulkan-validationlayers/1951)
<!-- Reviewable:end -->
