### PR TITLE
Adding check and test for presentation mode

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -126,5 +126,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_BeginCommandBuffer_OneTim
     "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit";
 static const char DECORATE_UNUSED *kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback =
     "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateSwapchain_PresentMode =
+    "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -295,6 +295,15 @@ bool BestPractices::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkS
             pCreateInfo->minImageCount);
     }
 
+    if (VendorCheckEnabled(kBPVendorArm) && (pCreateInfo->presentMode != VK_PRESENT_MODE_FIFO_KHR)) {
+        skip |= LogWarning(device, kVUID_BestPractices_CreateSwapchain_PresentMode,
+                           "%s Warning: Swapchain is not being created with presentation mode \"VK_PRESENT_MODE_FIFO_KHR\". "
+                           "Prefer using \"VK_PRESENT_MODE_FIFO_KHR\" to avoid unnecessary CPU and GPU load and save power. "
+                           "Presentation modes which are not FIFO will present the latest available frame and discard other "
+                           "frame(s) if any.",
+                           VendorSpecificTag(kBPVendorArm));
+    }
+
     return skip;
 }
 


### PR DESCRIPTION
Adding a warning with some details and a test if VK_PRESENT_MODE_FIFO_KHR is not used for presentation mode.
Warning:
Swapchain is not being created with presentation mode "VK_PRESENT_MODE_FIFO_KHR". Prefer using \"VK_PRESENT_MODE_FIFO_KHR\" to avoid unnecessary CPU and GPU load and save power. Presentation modes which are not FIFO will present the latest available frame and discard other frame(s) if any.
