### PR TITLE
Adding check and test for depthbias usage

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -126,5 +126,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_BeginCommandBuffer_OneTim
     "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit";
 static const char DECORATE_UNUSED *kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback =
     "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreatePipelines_DepthBias_Zero =
+    "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -813,6 +813,19 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             }
         }
 
+        if ((pCreateInfos[i].pRasterizationState->depthBiasEnable) &&
+            (pCreateInfos[i].pRasterizationState->depthBiasConstantFactor == 0.0f) &&
+            (pCreateInfos[i].pRasterizationState->depthBiasSlopeFactor == 0.0f)) {
+            skip |= VendorCheckEnabled(kBPVendorArm) &&
+                    LogPerformanceWarning(
+                        device, kVUID_BestPractices_CreatePipelines_DepthBias_Zero,
+                        "%s Performance Warning: This vkCreateGraphicsPipelines call is created with depthBiasEnable set to true "
+                        "and both depthBiasConstantFactor and depthBiasSlopeFactor are set to 0. This can cause reduced "
+                        "efficiency during rasterization. Consider disabling depthBias or increasing either "
+                        "depthBiasConstantFactor or depthBiasSlopeFactor.",
+                        VendorSpecificTag(kBPVendorArm));
+        }
+
         skip |= VendorCheckEnabled(kBPVendorArm) && ValidateMultisampledBlendingArm(createInfoCount, pCreateInfos);
     }
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1147,3 +1147,30 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     ASSERT_VK_SUCCESS(err)
     DestroySwapchain();
 }
+
+TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {
+    TEST_DESCRIPTION("Test for unnecessary rasterization due to using 0 for depthBiasConstantFactor and depthBiasSlopeFactor");
+
+    InitBestPracticesFramework();
+    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.rs_state_ci_.depthBiasEnable = VK_TRUE;
+    pipe.rs_state_ci_.depthBiasConstantFactor = 0.0f;
+    pipe.rs_state_ci_.depthBiasSlopeFactor = 0.0f;
+    pipe.InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+
+    pipe.rs_state_ci_.depthBiasEnable = VK_FALSE;
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyNotFound();
+}


### PR DESCRIPTION
Raise a warning if depthBiasEnable set to true and both depthBiasConstantFactor and depthBiasSlopeFactor are set to 0 as this can cause bad performance on Mali.
Warning message:
"Performance Warning: This vkCreateGraphicsPipelines call is created with depthBiasEnable set to true and both depthBiasConstantFactor and depthBiasSlopeFactor are set to 0. This can cause reduced efficiency during rasterization. Consider disabling depthBias or increasing either depthBiasConstantFactor or depthBiasSlopeFactor."