### PR TITLE
Adding check and test for robustBufferAccess usage

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -130,5 +130,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateSwapchain_PresentMo
     "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreatePipelines_DepthBias_Zero =
     "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_RobustBufferAccess =
+    "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -193,6 +193,17 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
                            "vkCreateDevice() called before getting physical device features from vkGetPhysicalDeviceFeatures().");
     }
 
+    if ((VendorCheckEnabled(kBPVendorArm)) && (pCreateInfo->pEnabledFeatures != nullptr) &&
+        (pCreateInfo->pEnabledFeatures->robustBufferAccess == VK_TRUE)) {
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreateDevice_RobustBufferAccess,
+            "%s vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during "
+            "development. Enabling it causes loss in performance for accesses to uniform buffers and shader storage "
+            "buffers. Disable robustBufferAccess in release builds. Only leave it enabled if the application use-case "
+            "requires the additional level of reliability due to the use of unverified user-supplied draw parameters.",
+            VendorSpecificTag(kBPVendorArm));
+    }
+
     return skip;
 }
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1248,3 +1248,41 @@ TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyNotFound();
 }
+
+TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
+    TEST_DESCRIPTION("Test for appropriate warnings to be thrown when robustBufferAccess is enabled.");
+
+    InitBestPracticesFramework();
+
+    VkDevice local_device;
+    VkDeviceQueueCreateInfo queue_info = {};
+    queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_info.pNext = nullptr;
+    queue_info.queueFamilyIndex = 0;
+    queue_info.queueCount = 1;
+    queue_info.pQueuePriorities = nullptr;
+    VkDeviceCreateInfo dev_info = {};
+    dev_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dev_info.pNext = nullptr;
+    dev_info.queueCreateInfoCount = 1;
+    dev_info.pQueueCreateInfos = &queue_info;
+    dev_info.enabledLayerCount = 0;
+    dev_info.ppEnabledLayerNames = nullptr;
+    dev_info.enabledExtensionCount = m_device_extension_names.size();
+    dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
+
+    VkPhysicalDeviceFeatures supportedFeatures;
+    vk::GetPhysicalDeviceFeatures(this->gpu(), &supportedFeatures);
+    if (supportedFeatures.robustBufferAccess) {
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                             "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess");
+        VkPhysicalDeviceFeatures deviceFeatures = {};
+        deviceFeatures.robustBufferAccess = VK_TRUE;
+        dev_info.pEnabledFeatures = &deviceFeatures;
+        vk::CreateDevice(this->gpu(), &dev_info, nullptr, &local_device);
+        m_errorMonitor->VerifyFound();
+    } else {
+        printf("%s robustBufferAccess is not available, skipping test\n", kSkipPrefix);
+        return;
+    }
+}


### PR DESCRIPTION
Adding a warning if robustBufferAccess is enabled.
Warning message:
vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during development. Enabling it causes loss in performance for accesses to uniform buffers and shader storage buffers. Disable robustBufferAccess in release builds. Only leave it enabled if the application use-case requires the additional level of reliability due to the use of unverified user-supplied draw parameters.