### PR TITLE
Add option to limit validation message repetitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,17 +8,20 @@ The source code for The Vulkan-ValidationLayer components is sponsored by Khrono
 
 ### **The Vulkan Ecosystem Needs Your Help**
 
-The Vulkan validation layers are one of the larger and more important components in this repository.
+The Vulkan validation layers make up a significant part of the Vulkan ecosystem.
 While there are often active and organized development efforts underway to improve their coverage,
-there are always opportunities for anyone to help by contributing additional validation layer checks
-and tests for these validation checks.
+opportunities always exist for anyone to help by contributing additional validation layer checks
+and tests.
 
 There are a couple of methods to identify areas of need:
 * Examine the [issues list](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues)
 in this repository and look for issues that are of interest
-* Alternatively, run the `vk_validation_stats.py` script (in the scripts directory) with the `-todo`
+* Examine the Validation Layer 'Coverage - html' page at [the Vulkan SDK
+documentation page](https://vulkan.lunarg.com/doc/sdk/) -- it lists all published Vulkan VUIDs and their status.
+* Run the `vk_validation_stats.py` script (in the scripts directory) with the `-todo`
 command line argument to see a list of as-yet unimplemented validation checks.
-* Having selected a validation check to work on, it is often efficient to implement a block of related checks
+
+Having selected a validation check to work on, it is often efficient to implement a block of related checks
 at once. Refer to the validation database output from `vk_validation_stats.py` (available in text, html,
 or csv format) to identify related checks that may be implemented simultaneously.
 
@@ -46,12 +49,15 @@ to work on an issue that is assigned, simply coordinate with the current assigne
 * Use the existing GitHub forking and pull request process.
   This will involve [forking the repository](https://help.github.com/articles/fork-a-repo/),
   creating a branch with your commits, and then [submitting a pull request](https://help.github.com/articles/using-pull-requests/).
-* Please read and adhere to the style and process [guidelines ](#coding-conventions-and-formatting) enumerated below.
-* Please base your fixes on the master branch.  SDK branches are generally not updated except for critical fixes needed to repair an SDK release.
+* Please read and adhere to the style and process [guidelines ](#coding-conventions-and-formatting) enumerated below. Some highlights:
+  - Source code must follow the repo coding style guidelines, including a pass through a clang-format utility
+  - Implemented VUID checks must be accompanied by relevant tests
+  - Validation source code should be in a separate commit from the tests, unless there are interdependencies. The repo should compile and
+    pass all tests after each commit.
+* Please base your fixes on the master branch. SDK branches are generally not updated except for critical fixes needed to repair an SDK release.
 * The resulting Pull Request will be assigned to a repository maintainer. It is the maintainer's responsibility to ensure the Pull Request
   passes the Google/LunarG internal CI processes. Once the Pull Request has been approved and is passing internal CI, a repository maintainer
   will merge the PR.
-
 
 #### **Coding Conventions and Formatting**
 * Use the **[Google style guide](https://google.github.io/styleguide/cppguide.html)** for source code with the following exceptions:
@@ -122,7 +128,9 @@ checks that require (mostly) no state at all. Please inquire if you are unsure o
 validation objects (thread_safety, object lifetimes) are more special-purpose and are mostly code-generated from the specification.
 * **Validation Error/Warning Messages:**  Strive to give specific information describing the particulars of the failure, including
 output all of the applicable Vulkan Objects and related values. Also, ensure that when messages can give suggestions about _how_ to
-fix the problem, they should do so to better assist the user.
+fix the problem, they should do so to better assist the user. Note that Vulkan object handles must be output via the `FormatHandle()`
+function, and that all object handles visible in a message should also be included in the callback data.  If more than a single object is
+output, the LogObjectList structure should be used.
 * **Validation Statistics:** The `vk_validation_stats.py` script (in the scripts directory) inspects the layer and test source files
 and reports a variety of statistics on validation completeness and correctness. Before submitting a change you should run this
 script with the consistency check (`-c`) argument to ensure that your changes have not introduced any inconsistencies in the code.

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -393,18 +393,43 @@ void SetCustomStypeInfo(std::string raw_id_list, std::string delimiter) {
     }
 }
 
-// Process enables and disables set though the vk_layer_settings.txt config file or through an environment variable
-void ProcessConfigAndEnvSettings(const char* layer_description, CHECK_ENABLED &enables, CHECK_DISABLED &disables,
-    std::vector<uint32_t> &message_filter_list) {
+uint32_t SetMessageDuplicateLimit(std::string &config_message_limit, std::string &env_message_limit) {
+    uint32_t limit = 0;
+    auto GetNum = [](std::string &source_string) {
+        uint32_t limit = 0;
+        int radix = ((source_string.find("0x") == 0) ? 16 : 10);
+        limit = std::strtoul(source_string.c_str(), nullptr, radix);
+        return limit;
+    };
+    // ENV var takes precedence over settings file
+    limit = GetNum(env_message_limit);
+    if (limit == 0) {
+        limit = GetNum(config_message_limit);
+    }
+    return limit;
+}
 
-    std::string enable_key(layer_description);
-    std::string disable_key(layer_description);
-    std::string stypes_key(layer_description);
-    std::string filter_msg_key(layer_description);
+typedef struct {
+    const char* layer_description;
+    CHECK_ENABLED &enables;
+    CHECK_DISABLED &disables;
+    std::vector<uint32_t> &message_filter_list;
+    int32_t *duplicate_message_limit;
+} ConfigAndEnvSettings;
+
+
+// Process enables and disables set though the vk_layer_settings.txt config file or through an environment variable
+void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
+    std::string enable_key(settings_data->layer_description);
+    std::string disable_key(settings_data->layer_description);
+    std::string stypes_key(settings_data->layer_description);
+    std::string filter_msg_key(settings_data->layer_description);
+    std::string message_limit(settings_data->layer_description);
     enable_key.append(".enables");
     disable_key.append(".disables");
-    filter_msg_key.append(".message_id_filter");
     stypes_key.append(".custom_stype_list");
+    filter_msg_key.append(".message_id_filter");
+    message_limit.append(".duplicate_message_limit");
     std::string list_of_config_enables = getLayerOption(enable_key.c_str());
     std::string list_of_env_enables = GetLayerEnvVar("VK_LAYER_ENABLES");
     std::string list_of_config_disables = getLayerOption(disable_key.c_str());
@@ -413,22 +438,30 @@ void ProcessConfigAndEnvSettings(const char* layer_description, CHECK_ENABLED &e
     std::string list_of_env_filter_ids = GetLayerEnvVar("VK_LAYER_MESSAGE_ID_FILTER");
     std::string list_of_config_stypes = getLayerOption(stypes_key.c_str());
     std::string list_of_env_stypes = GetLayerEnvVar("VK_LAYER_CUSTOM_STYPE_LIST");
+    std::string config_message_limit = getLayerOption(message_limit.c_str());
+    std::string env_message_limit = GetLayerEnvVar("VK_LAYER_DUPLICATE_MESSAGE_LIMIT");
+
 #if defined(_WIN32)
     std::string env_delimiter = ";";
 #else
     std::string env_delimiter = ":";
 #endif
     // Process layer enables and disable settings
-    SetLocalEnableSetting(list_of_config_enables, ",", enables);
-    SetLocalEnableSetting(list_of_env_enables, env_delimiter, enables);
-    SetLocalDisableSetting(list_of_config_disables, ",", disables);
-    SetLocalDisableSetting(list_of_env_disables, env_delimiter, disables);
+    SetLocalEnableSetting(list_of_config_enables, ",", settings_data->enables);
+    SetLocalEnableSetting(list_of_env_enables, env_delimiter, settings_data->enables);
+    SetLocalDisableSetting(list_of_config_disables, ",", settings_data->disables);
+    SetLocalDisableSetting(list_of_env_disables, env_delimiter, settings_data->disables);
     // Process message filter ID list
-    CreateFilterMessageIdList(list_of_config_filter_ids, ",", message_filter_list);
-    CreateFilterMessageIdList(list_of_env_filter_ids, env_delimiter, message_filter_list);
+    CreateFilterMessageIdList(list_of_config_filter_ids, ",", settings_data->message_filter_list);
+    CreateFilterMessageIdList(list_of_env_filter_ids, env_delimiter, settings_data->message_filter_list);
     // Process custom stype struct list
     SetCustomStypeInfo(list_of_config_stypes, ",");
     SetCustomStypeInfo(list_of_env_stypes, env_delimiter);
+    // Process message limit
+    uint32_t config_limit_setting = SetMessageDuplicateLimit(config_message_limit, env_message_limit);
+    if (config_limit_setting != 0) {
+        *settings_data->duplicate_message_limit = config_limit_setting;
+    }
 }
 
 const VkLayerSettingsEXT *FindSettingsInChain(const void *next) {
@@ -613,6 +646,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
             } else if (name == "message_id_filter") {
                 std::string data(cur_setting.data.arrayString.pCharArray);
                 CreateFilterMessageIdList(data, ",", report_data->filter_message_ids);
+            } else if (name == "duplicate_message_limit") {
+                report_data->duplicate_message_limit = cur_setting.data.value32;
             } else if (name == "custom_stype_list") {
                 if (cur_setting.type == VK_LAYER_SETTING_VALUE_TYPE_STRING_ARRAY_EXT) {
                     std::string data(cur_setting.data.arrayString.pCharArray);
@@ -643,7 +678,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     if (validation_flags_ext) {
         SetValidationFlags(local_disables, validation_flags_ext);
     }
-    ProcessConfigAndEnvSettings(OBJECT_LAYER_DESCRIPTION, local_enables, local_disables, report_data->filter_message_ids);
+    ConfigAndEnvSettings config_and_env_settings_data {OBJECT_LAYER_DESCRIPTION, local_enables, local_disables,
+        report_data->filter_message_ids, &report_data->duplicate_message_limit};
+    ProcessConfigAndEnvSettings(&config_and_env_settings_data);
     layer_debug_messenger_actions(report_data, pAllocator, OBJECT_LAYER_DESCRIPTION);
 
     // Create temporary dispatch vector for pre-calls until instance is created

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -201,6 +201,8 @@ typedef struct _debug_report_data {
     // This mutex is defined as mutable since the normal usage for a debug report object is as 'const'. The mutable keyword allows
     // the layers to continue this pattern, but also allows them to use/change this specific member for synchronization purposes.
     mutable std::mutex debug_output_mutex;
+    int32_t duplicate_message_limit = 0;
+    mutable std::unordered_map<uint32_t, int32_t> duplicate_message_count_map{};
     const void *instance_pnext_chain{};
 
     void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
@@ -334,6 +336,22 @@ static inline void RemoveAllMessageCallbacks(debug_report_data *debug_data, std:
     callbacks.clear();
 }
 
+// Returns TRUE if the number of times this message has been logged is over the set limit
+static inline bool UpdateLogMsgCounts(const debug_report_data *debug_data, int32_t vuid_hash) {
+    auto vuid_count_it = debug_data->duplicate_message_count_map.find(vuid_hash);
+    if (vuid_count_it == debug_data->duplicate_message_count_map.end()) {
+        debug_data->duplicate_message_count_map.insert({vuid_hash, 1});
+        return false;
+    } else {
+        if (vuid_count_it->second >= debug_data->duplicate_message_limit) {
+            return true;
+        } else {
+            vuid_count_it->second++;
+            return false;
+        }
+    }
+}
+
 static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
                                  const char *layer_prefix, const char *message, const char *text_vuid) {
     bool bail = false;
@@ -384,10 +402,14 @@ static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags ms
         }
     }
 
-    size_t location = 0;
+    int32_t location = 0;
     if (text_vuid != nullptr) {
         // Hash for vuid text
         location = XXH32(text_vuid, strlen(text_vuid), 8);
+        if ((debug_data->duplicate_message_limit > 0) && UpdateLogMsgCounts(debug_data, location)) {
+            // Count for this particular message is over the limit, ignore it
+            return false;
+        }
     }
 
     VkDebugUtilsMessengerCallbackDataEXT callback_data;

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -55,6 +55,13 @@
 #    a validation message, for example:
 #        0xdf3391a2 or 3744698786.
 #
+#   DUPLICATE_MESSAGE_LIMIT:
+#   =======================
+#   <LayerIdentifier>.duplicate_message_limit: This is an unsigned integer
+#    which signifies the limit for the number of times any validation
+#    message can be output by the layers. Any non-zero value will be respected,
+#    and the default is no limit.
+#
 #   LOG_FILENAME:
 #   =============
 #   <LayerIdentifier>.log_filename : output filename. Can be relative to
@@ -119,7 +126,10 @@ khronos_validation.log_filename = stdout
 #khronos_validation.message_id_filter = 3744698786,0xdf3391a2,"VUID-vkCmdPipelineBarrier-image-02635"
 
 # Example entry showing how to declare custom non-Vulkan structure types
-khronos_validation.custom_stype_list=1100297000,32,0x478b1428,0x20
+#khronos_validation.custom_stype_list=1100297000,32,0x478b1428,0x20
+
+# Example entry showing how to limit the number of repeated validation messages
+#khronos_validation.duplicate_message_limit = 25
 
 # Example entry showing how to disable threading checks and validation at DestroyPipeline time
 #khronos_validation.disables = VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,VALIDATION_CHECK_DISABLE_DESTROY_PIPELINE


### PR DESCRIPTION
Adds a new Khronos layer option, `duplicate_message_limit `that allows user control of the number of times a particular validation error is output by the layer.

No setting or a setting of zero (default) corresponds to no limit.  

Also took care of a couple of suggestions in the CONTRIBUTING doc.
Fixes #831.  