### PR TITLE
Use all locations for samplerYcbcrConversion

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -4877,8 +4877,11 @@ bool StatelessValidation::ValidateCreateSamplerYcbcrConversion(VkDevice device,
     // Check samplerYcbcrConversion feature is set
     const auto *ycbcr_features = lvl_find_in_chain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(device_createinfo_pnext);
     if ((ycbcr_features == nullptr) || (ycbcr_features->samplerYcbcrConversion == VK_FALSE)) {
-        skip |= LogError(device, "VUID-vkCreateSamplerYcbcrConversion-None-01648",
-                         "samplerYcbcrConversion must be enabled to call %s.", apiName);
+        const auto *vulkan_11_features = lvl_find_in_chain<VkPhysicalDeviceVulkan11Features>(device_createinfo_pnext);
+        if ((vulkan_11_features == nullptr) || (vulkan_11_features->samplerYcbcrConversion == VK_FALSE)) {
+            skip |= LogError(device, "VUID-vkCreateSamplerYcbcrConversion-None-01648",
+                             "samplerYcbcrConversion must be enabled to call %s.", apiName);
+        }
     }
     return skip;
 }


### PR DESCRIPTION
When checking if the samplerYcbcrConversion feature has been enabled for
the device, take VkPhysicalDeviceVulkan11Features into account.

Fixes #1969 