### PR TITLE
Use conversion format in some Ycbcr conversion VUs

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11586,13 +11586,13 @@ bool CoreChecks::ValidateCreateSamplerYcbcrConversion(const char *func_name,
                          func_name, string_VkFormat(conversion_format));
     }
     if ((format_features & VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT) == 0) {
-        if (create_info->xChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
+        if (FormatIsXChromaSubsampled(conversion_format) && create_info->xChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
             skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651",
                              "%s: Format %s does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so xChromaOffset can't "
                              "be VK_CHROMA_LOCATION_COSITED_EVEN",
                              func_name, string_VkFormat(conversion_format));
         }
-        if (create_info->yChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
+        if (FormatIsYChromaSubsampled(conversion_format) && create_info->yChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
             skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651",
                              "%s: Format %s does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so yChromaOffset can't "
                              "be VK_CHROMA_LOCATION_COSITED_EVEN",
@@ -11600,13 +11600,13 @@ bool CoreChecks::ValidateCreateSamplerYcbcrConversion(const char *func_name,
         }
     }
     if ((format_features & VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT) == 0) {
-        if (create_info->xChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
+        if (FormatIsXChromaSubsampled(conversion_format) && create_info->xChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
             skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652",
                              "%s: Format %s does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so xChromaOffset can't "
                              "be VK_CHROMA_LOCATION_MIDPOINT",
                              func_name, string_VkFormat(conversion_format));
         }
-        if (create_info->yChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
+        if (FormatIsYChromaSubsampled(conversion_format) && create_info->yChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
             skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652",
                              "%s: Format %s does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so yChromaOffset can't "
                              "be VK_CHROMA_LOCATION_MIDPOINT",

--- a/layers/vk_format_utils.cpp
+++ b/layers/vk_format_utils.cpp
@@ -1411,3 +1411,62 @@ VK_LAYER_EXPORT bool FormatRequiresYcbcrConversion(VkFormat format) {
     auto it = vk_formats_requiring_ycbcr_conversion.find(format);
     return (it != vk_formats_requiring_ycbcr_conversion.end());
 }
+
+VK_LAYER_EXPORT bool FormatIsXChromaSubsampled(VkFormat format) {
+    bool is_x_chroma_subsampled = false;
+
+    switch (format) {
+        case VK_FORMAT_G8B8G8R8_422_UNORM:
+        case VK_FORMAT_B8G8R8G8_422_UNORM:
+        case VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_420_UNORM:
+        case VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_422_UNORM:
+        case VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16:
+        case VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16:
+        case VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16:
+        case VK_FORMAT_G16B16G16R16_422_UNORM:
+        case VK_FORMAT_B16G16R16G16_422_UNORM:
+        case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
+        case VK_FORMAT_G16_B16R16_2PLANE_420_UNORM:
+        case VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM:
+        case VK_FORMAT_G16_B16R16_2PLANE_422_UNORM:
+            is_x_chroma_subsampled = true;
+            break;
+        default:
+            break;
+    }
+
+    return is_x_chroma_subsampled;
+}
+
+VK_LAYER_EXPORT bool FormatIsYChromaSubsampled(VkFormat format) {
+    bool is_y_chroma_subsampled = false;
+
+    switch (format) {
+        case VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM:
+        case VK_FORMAT_G8_B8R8_2PLANE_420_UNORM:
+        case VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16:
+        case VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM:
+        case VK_FORMAT_G16_B16R16_2PLANE_420_UNORM:
+            is_y_chroma_subsampled = true;
+            break;
+
+        default:
+            break;
+    }
+
+    return is_y_chroma_subsampled;
+}

--- a/layers/vk_format_utils.h
+++ b/layers/vk_format_utils.h
@@ -163,6 +163,8 @@ VK_LAYER_EXPORT bool FormatIsPacked(VkFormat format);
 VK_LAYER_EXPORT bool FormatElementIsTexel(VkFormat format);
 VK_LAYER_EXPORT bool FormatSizesAreEqual(VkFormat srcFormat, VkFormat dstFormat, uint32_t region_count, const VkImageCopy *regions);
 VK_LAYER_EXPORT bool FormatRequiresYcbcrConversion(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsXChromaSubsampled(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsYChromaSubsampled(VkFormat format);
 
 VK_LAYER_EXPORT uint32_t FormatDepthSize(VkFormat format);
 VK_LAYER_EXPORT VkFormatNumericalType FormatDepthNumericalType(VkFormat format);


### PR DESCRIPTION
Take conversion format into account to avoid reporting errors related to
xChromaOffset and yChromaOffset when the format is not
chroma-subsampled.

Fixes #1971 