### PR TITLE
Added check for testing redundant store, redundant clear and inefficient clears on render pass attachments (Arm)

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -134,5 +134,11 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_RobustBuffer
     "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess";
 static const char DECORATE_UNUSED *kVUID_BestPractices_EndRenderPass_DepthPrePassUsage =
     "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage";
+static const char DECORATE_UNUSED *kVUID_BestPractices_RenderPass_RedundantStore =
+    "UNASSIGNED-BestPractices-RenderPass-redundant-store";
+static const char DECORATE_UNUSED *kVUID_BestPractices_RenderPass_RedundantClear =
+    "UNASSIGNED-BestPractices-RenderPass-redundant-clear";
+static const char DECORATE_UNUSED *kVUID_BestPractices_RenderPass_InefficientClear =
+    "UNASSIGNED-BestPractices-RenderPass-inefficient-clear";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1105,6 +1105,24 @@ static inline bool RenderPassUsesAttachmentOnTile(const safe_VkRenderPassCreateI
     return false;
 }
 
+static inline bool RenderPassUsesAttachmentAsImageOnly(const safe_VkRenderPassCreateInfo2& createInfo, uint32_t attachment) {
+    if (RenderPassUsesAttachmentOnTile(createInfo, attachment)) {
+        return false;
+    }
+
+    for (uint32_t subpass = 0; subpass < createInfo.subpassCount; subpass++) {
+        auto& subpassInfo = createInfo.pSubpasses[subpass];
+
+        for (uint32_t i = 0; i < subpassInfo.inputAttachmentCount; i++) {
+            if (subpassInfo.pInputAttachments[i].attachment == attachment) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, RenderPassCreateVersion rp_version,
                                                const VkRenderPassBeginInfo* pRenderPassBegin) const {
     bool skip = false;
@@ -1159,6 +1177,149 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
     }
 
     return skip;
+}
+
+void BestPractices::ValidateImageView(IMAGE_VIEW_STATE* view, const IMAGE_ATTACHMENT_USAGE& usage) {
+    if (view) {
+        ValidateImage(GetImageState(view->create_info.image), usage, view->create_info.subresourceRange);
+    }
+}
+
+void BestPractices::ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage,
+                                  const VkImageSubresourceRange& subresource_range) {
+    uint32_t max_layers = image->createInfo.arrayLayers - subresource_range.baseArrayLayer;
+    uint32_t array_layers = std::min(subresource_range.layerCount, max_layers);
+    uint32_t max_levels = image->createInfo.mipLevels - subresource_range.baseMipLevel;
+    uint32_t mip_levels = std::min(image->createInfo.mipLevels, max_levels);
+
+    for (uint32_t layer = 0; layer < array_layers; layer++) {
+        for (uint32_t level = 0; level < mip_levels; level++) {
+            ValidateImage(image, usage, layer + subresource_range.baseArrayLayer, level + subresource_range.baseMipLevel);
+        }
+    }
+}
+
+void BestPractices::ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage,
+                                  const VkImageSubresourceLayers& subresource_layers) {
+    uint32_t max_layers = image->createInfo.arrayLayers - subresource_layers.baseArrayLayer;
+    uint32_t array_layers = std::min(subresource_layers.layerCount, max_layers);
+
+    for (uint32_t layer = 0; layer < array_layers; layer++) {
+        ValidateImage(image, usage, layer + subresource_layers.baseArrayLayer, subresource_layers.mipLevel);
+    }
+}
+
+void BestPractices::ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage, uint32_t array_layer,
+                                  uint32_t mip_level) {
+    // Resize usages
+    if (static_cast<uint32_t>(image->usages.size()) != image->createInfo.arrayLayers) {
+        image->usages.resize(image->createInfo.arrayLayers);
+    }
+    for (auto& mips : image->usages) {
+        if (static_cast<uint32_t>(mips.size()) != image->createInfo.mipLevels) {
+            mips.resize(image->createInfo.mipLevels, IMAGE_ATTACHMENT_USAGE::UNDEFINED);
+        }
+    }
+
+    IMAGE_ATTACHMENT_USAGE last_usage = image->usages[array_layer][mip_level];
+
+    // Swapchain images are implicitly read so clear after store is expected.
+    if (usage == IMAGE_ATTACHMENT_USAGE::RENDER_PASS_CLEARED && last_usage == IMAGE_ATTACHMENT_USAGE::RENDER_PASS_STORED &&
+        !image->is_swapchain_image) {
+        VendorCheckEnabled(kBPVendorArm) &&
+            LogPerformanceWarning(
+                device, kVUID_BestPractices_RenderPass_RedundantStore,
+                "%s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+                "image was used, it was written to with STORE_OP_STORE. "
+                "Storing to the image is probably redundant in this case, and wastes bandwidth on tile-based "
+                "architectures.",
+                VendorSpecificTag(kBPVendorArm), array_layer, mip_level);
+
+    } else if (usage == IMAGE_ATTACHMENT_USAGE::RENDER_PASS_CLEARED && last_usage == IMAGE_ATTACHMENT_USAGE::CLEARED) {
+        VendorCheckEnabled(kBPVendorArm) &&
+            LogPerformanceWarning(
+                device, kVUID_BestPractices_RenderPass_RedundantClear,
+                "%s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+                "image was used, it was written to with vkCmdClear*Image(). "
+                "Clearing the image with vkCmdClear*Image() is probably redundant in this case, and wastes bandwidth on "
+                "tile-based architectures."
+                "architectures.",
+                VendorSpecificTag(kBPVendorArm), array_layer, mip_level);
+    } else if (usage == IMAGE_ATTACHMENT_USAGE::RENDER_PASS_READ_TO_TILE && last_usage == IMAGE_ATTACHMENT_USAGE::CLEARED) {
+        VendorCheckEnabled(kBPVendorArm) &&
+            LogPerformanceWarning(
+                device, kVUID_BestPractices_RenderPass_InefficientClear,
+                "%s Subresource (arrayLayer: %u, mipLevel: %u) of image was loaded to tile as part of LOAD_OP_LOAD, but last "
+                "time image was used, it was written to with vkCmdClear*Image(). "
+                "Clearing the image with vkCmdClear*Image() is probably redundant in this case, and wastes bandwidth on "
+                "tile-based architectures. "
+                "Use LOAD_OP_CLEAR instead to clear the image for free.",
+                VendorSpecificTag(kBPVendorArm), array_layer, mip_level);
+    }
+
+    image->usages[array_layer][mip_level] = usage;
+}
+
+void BestPractices::PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                    VkSubpassContents contents) {
+    if (!pRenderPassBegin) {
+        return;
+    }
+
+    auto rp_state = GetRenderPassState(pRenderPassBegin->renderPass);
+    if (rp_state) {
+        // Check load ops
+        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
+            auto& attachment = rp_state->createInfo.pAttachments[att];
+
+            if (!RenderPassUsesAttachmentAsImageOnly(rp_state->createInfo, att) &&
+                !RenderPassUsesAttachmentOnTile(rp_state->createInfo, att)) {
+                continue;
+            }
+
+            IMAGE_ATTACHMENT_USAGE usage = IMAGE_ATTACHMENT_USAGE::UNDEFINED;
+
+            if ((!FormatIsStencilOnly(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) ||
+                (FormatHasStencil(attachment.format) && attachment.stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD)) {
+                usage = IMAGE_ATTACHMENT_USAGE::RENDER_PASS_READ_TO_TILE;
+            }
+
+            if ((!FormatIsStencilOnly(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) ||
+                (FormatHasStencil(attachment.format) && attachment.stencilLoadOp == VK_ATTACHMENT_LOAD_OP_CLEAR)) {
+                usage = IMAGE_ATTACHMENT_USAGE::RENDER_PASS_CLEARED;
+            }
+
+            if (RenderPassUsesAttachmentAsImageOnly(rp_state->createInfo, att)) {
+                usage = IMAGE_ATTACHMENT_USAGE::RESOURCE_READ;
+            }
+
+            auto framebuffer = GetFramebufferState(pRenderPassBegin->framebuffer);
+            auto image_view = GetImageViewState(framebuffer->createInfo.pAttachments[att]);
+
+            ValidateImageView(image_view, usage);
+        }
+
+        // Check store ops
+        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
+            auto& attachment = rp_state->createInfo.pAttachments[att];
+
+            if (!RenderPassUsesAttachmentOnTile(rp_state->createInfo, att)) {
+                continue;
+            }
+
+            IMAGE_ATTACHMENT_USAGE usage = IMAGE_ATTACHMENT_USAGE::RENDER_PASS_DISCARDED;
+
+            if ((!FormatIsStencilOnly(attachment.format) && attachment.storeOp == VK_ATTACHMENT_STORE_OP_STORE) ||
+                (FormatHasStencil(attachment.format) && attachment.stencilStoreOp == VK_ATTACHMENT_STORE_OP_STORE)) {
+                usage = IMAGE_ATTACHMENT_USAGE::RENDER_PASS_STORED;
+            }
+
+            auto framebuffer = GetFramebufferState(pRenderPassBegin->framebuffer);
+            auto image_view = GetImageViewState(framebuffer->createInfo.pAttachments[att]);
+
+            ValidateImageView(image_view, usage);
+        }
+    }
 }
 
 bool BestPractices::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
@@ -1536,6 +1697,76 @@ void BestPractices::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer command
     RecordCmdDrawType(commandBuffer, count, "vkCmdDrawIndexedIndirect()");
 }
 
+void BestPractices::ValidateBoundDescriptorSets(VkCommandBuffer commandBuffer) {
+    const CMD_BUFFER_STATE* cb_state = GetCBState(commandBuffer);
+
+    if (cb_state) {
+        for (auto descriptor_set : cb_state->validated_descriptor_sets) {
+            for (uint32_t binding = 0; binding < descriptor_set->GetBindingCount(); ++binding) {
+                auto index_range = descriptor_set->GetGlobalIndexRangeFromBinding(binding);
+                for (uint32_t i = index_range.start; i < index_range.end; ++i) {
+                    VkImageView image_view = nullptr;
+
+                    auto descriptor = descriptor_set->GetDescriptorFromGlobalIndex(i);
+                    switch (descriptor->GetClass()) {
+                        case cvdescriptorset::DescriptorClass::Image: {
+                            if (const auto image_descriptor = static_cast<const cvdescriptorset::ImageDescriptor*>(descriptor)) {
+                                image_view = image_descriptor->GetImageView();
+                            }
+                        }
+                        case cvdescriptorset::DescriptorClass::ImageSampler: {
+                            if (const auto image_sampler_descriptor =
+                                    static_cast<const cvdescriptorset::ImageSamplerDescriptor*>(descriptor)) {
+                                image_view = image_sampler_descriptor->GetImageView();
+                            }
+                        }
+                    }
+
+                    if (image_view) {
+                        IMAGE_VIEW_STATE* image_view_state = GetImageViewState(image_view);
+
+                        if (descriptor_set->GetTypeFromIndex(i) == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
+                            ValidateImageView(image_view_state, IMAGE_ATTACHMENT_USAGE::RESOURCE_READ);
+                        }
+
+                        if (descriptor_set->GetTypeFromIndex(i) == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+                            ValidateImageView(image_view_state, IMAGE_ATTACHMENT_USAGE::RESOURCE_WRITE);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void BestPractices::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
+                                         uint32_t firstVertex, uint32_t firstInstance) {
+    ValidateBoundDescriptorSets(commandBuffer);
+}
+
+void BestPractices::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                 uint32_t drawCount, uint32_t stride) {
+    ValidateBoundDescriptorSets(commandBuffer);
+}
+
+void BestPractices::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
+                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
+    ValidationStateTracker::PreCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset,
+                                                        firstInstance);
+
+    CMD_BUFFER_STATE* cmd_state = GetCBState(commandBuffer);
+    if ((indexCount * instanceCount) <= kSmallIndexedDrawcallIndices) {
+        cmd_state->small_indexed_draw_call_count++;
+    }
+
+    ValidateBoundDescriptorSets(commandBuffer);
+}
+
+void BestPractices::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                        uint32_t drawCount, uint32_t stride) {
+    ValidateBoundDescriptorSets(commandBuffer);
+}
+
 bool BestPractices::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                uint32_t groupCountZ) const {
     bool skip = false;
@@ -1572,6 +1803,14 @@ bool BestPractices::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffe
     }
 
     return skip;
+}
+
+void BestPractices::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
+    ValidateBoundDescriptorSets(commandBuffer);
+}
+
+void BestPractices::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
+    ValidateBoundDescriptorSets(commandBuffer);
 }
 
 bool BestPractices::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice,
@@ -1933,6 +2172,81 @@ bool BestPractices::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
                                   VendorSpecificTag(kBPVendorArm));
 
     return skip;
+}
+
+void BestPractices::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                                 const VkImageResolve* pRegions) {
+    auto* src = GetImageState(srcImage);
+    auto* dst = GetImageState(dstImage);
+
+    for (uint32_t i = 0; i < regionCount; i++) {
+        ValidateImage(src, IMAGE_ATTACHMENT_USAGE::RESOURCE_READ, pRegions[i].srcSubresource);
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::RESOURCE_WRITE, pRegions[i].dstSubresource);
+    }
+}
+
+void BestPractices::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                    const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                    const VkImageSubresourceRange* pRanges) {
+    auto* dst = GetImageState(image);
+
+    for (uint32_t i = 0; i < rangeCount; i++) {
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::CLEARED, pRanges[i]);
+    }
+}
+
+void BestPractices::PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                           const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                           const VkImageSubresourceRange* pRanges) {
+    auto* dst = GetImageState(image);
+
+    for (uint32_t i = 0; i < rangeCount; i++) {
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::CLEARED, pRanges[i]);
+    }
+}
+
+void BestPractices::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                              const VkImageCopy* pRegions) {
+    auto* src = GetImageState(srcImage);
+    auto* dst = GetImageState(dstImage);
+
+    for (uint32_t i = 0; i < regionCount; i++) {
+        ValidateImage(src, IMAGE_ATTACHMENT_USAGE::RESOURCE_READ, pRegions[i].srcSubresource);
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::RESOURCE_WRITE, pRegions[i].dstSubresource);
+    }
+}
+
+void BestPractices::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
+                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
+                                                      const VkBufferImageCopy* pRegions) {
+    auto* dst = GetImageState(dstImage);
+
+    for (uint32_t i = 0; i < regionCount; i++) {
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::RESOURCE_WRITE, pRegions[i].imageSubresource);
+    }
+}
+
+void BestPractices::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                                      VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions) {
+    auto* src = GetImageState(srcImage);
+
+    for (uint32_t i = 0; i < regionCount; i++) {
+        ValidateImage(src, IMAGE_ATTACHMENT_USAGE::RESOURCE_READ, pRegions[i].imageSubresource);
+    }
+}
+
+void BestPractices::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                              const VkImageBlit* pRegions, VkFilter filter) {
+    auto* src = GetImageState(srcImage);
+    auto* dst = GetImageState(dstImage);
+
+    for (uint32_t i = 0; i < regionCount; i++) {
+        ValidateImage(src, IMAGE_ATTACHMENT_USAGE::RESOURCE_READ, pRegions[i].srcSubresource);
+        ValidateImage(dst, IMAGE_ATTACHMENT_USAGE::RESOURCE_WRITE, pRegions[i].dstSubresource);
+    }
 }
 
 bool BestPractices::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1642,6 +1642,8 @@ void BestPractices::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, u
     if ((indexCount * instanceCount) <= kSmallIndexedDrawcallIndices) {
         cmd_state->small_indexed_draw_call_count++;
     }
+
+    ValidateBoundDescriptorSets(commandBuffer);
 }
 
 void BestPractices::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
@@ -1748,19 +1750,6 @@ void BestPractices::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t
 
 void BestPractices::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                  uint32_t drawCount, uint32_t stride) {
-    ValidateBoundDescriptorSets(commandBuffer);
-}
-
-void BestPractices::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
-                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-    ValidationStateTracker::PreCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset,
-                                                        firstInstance);
-
-    CMD_BUFFER_STATE* cmd_state = GetCBState(commandBuffer);
-    if ((indexCount * instanceCount) <= kSmallIndexedDrawcallIndices) {
-        cmd_state->small_indexed_draw_call_count++;
-    }
-
     ValidateBoundDescriptorSets(commandBuffer);
 }
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1705,7 +1705,7 @@ void BestPractices::ValidateBoundDescriptorSets(VkCommandBuffer commandBuffer) {
             for (uint32_t binding = 0; binding < descriptor_set->GetBindingCount(); ++binding) {
                 auto index_range = descriptor_set->GetGlobalIndexRangeFromBinding(binding);
                 for (uint32_t i = index_range.start; i < index_range.end; ++i) {
-                    VkImageView image_view = nullptr;
+                    VkImageView image_view{VK_NULL_HANDLE};
 
                     auto descriptor = descriptor_set->GetDescriptorFromGlobalIndex(i);
                     switch (descriptor->GetClass()) {
@@ -1720,6 +1720,8 @@ void BestPractices::ValidateBoundDescriptorSets(VkCommandBuffer commandBuffer) {
                                 image_view = image_sampler_descriptor->GetImageView();
                             }
                         }
+                        default:
+                            continue;
                     }
 
                     if (image_view) {

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -180,6 +180,7 @@ class BestPractices : public ValidationStateTracker {
                                            const VkSubpassBeginInfo* pSubpassBeginInfo);
     void PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                               const VkSubpassBeginInfo* pSubpassBeginInfo);
+    bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const;
     bool PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                                 uint32_t firstInstance) const;
     void PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
@@ -202,10 +203,10 @@ class BestPractices : public ValidationStateTracker {
                               uint32_t firstInstance);
     void PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                       uint32_t stride);
-    void PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
-                                     uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
     void PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                              uint32_t drawCount, uint32_t stride);
+    void PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
+                                              uint32_t stride);
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) const;
     void PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z);

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -162,12 +162,16 @@ class BestPractices : public ValidationStateTracker {
     void PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, RenderPassCreateVersion rp_version,
                                     const VkRenderPassBeginInfo* pRenderPassBegin) const;
+
+    void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                         VkSubpassContents contents);
     bool PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                            VkSubpassContents contents) const;
     bool PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                const VkSubpassBeginInfoKHR* pSubpassBeginInfo) const;
     bool PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                             const VkSubpassBeginInfoKHR* pSubpassBeginInfo) const;
+    void ValidateBoundDescriptorSets(VkCommandBuffer commandBuffer);
     void RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, RenderPassCreateVersion rp_version,
                                   const VkRenderPassBeginInfo* pRenderPassBegin);
     void PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
@@ -194,11 +198,18 @@ class BestPractices : public ValidationStateTracker {
                                        uint32_t stride);
     bool PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                uint32_t drawCount, uint32_t stride) const;
-    void PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
-                                              uint32_t stride);
+    void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
+                              uint32_t firstInstance);
+    void PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
+                                      uint32_t stride);
+    void PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
+                                     uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
+    void PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                             uint32_t drawCount, uint32_t stride);
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) const;
-    bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const;
+    void PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z);
+    void PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, const char* api_name) const;
     bool PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                             uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) const;
@@ -237,6 +248,30 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                         VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                         const VkImageResolve* pRegions) const;
+
+    void ValidateImageView(IMAGE_VIEW_STATE* view, const IMAGE_ATTACHMENT_USAGE& usage);
+    void ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage, const VkImageSubresourceRange& subresource_range);
+    void ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage, const VkImageSubresourceLayers& range);
+    void ValidateImage(IMAGE_STATE* image, const IMAGE_ATTACHMENT_USAGE& usage, uint32_t array_layer, uint32_t mip_level);
+
+    void PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                      VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                      const VkImageResolve* pRegions);
+    void PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                         const VkClearColorValue* pColor, uint32_t rangeCount,
+                                         const VkImageSubresourceRange* pRanges);
+    void PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                const VkImageSubresourceRange* pRanges);
+    void PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
+                                   VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy* pRegions);
+    void PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
+                                           VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy* pRegions);
+    void PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                           VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions);
+    void PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
+                                   VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageBlit* pRegions,
+                                   VkFilter filter);
     bool PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                       const VkAllocationCallbacks* pAllocator, VkSampler* pSampler) const;
     void ManualPostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, VkResult result);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -389,6 +389,17 @@ struct SAMPLER_STATE : public BASE_NODE {
     }
 };
 
+enum IMAGE_ATTACHMENT_USAGE {
+    UNDEFINED,  // If it has never been used
+    RENDER_PASS_CLEARED,
+    RENDER_PASS_READ_TO_TILE,
+    CLEARED,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    RENDER_PASS_STORED,
+    RENDER_PASS_DISCARDED
+};
+
 class IMAGE_STATE : public BINDABLE {
   public:
     VkImage image;
@@ -422,6 +433,9 @@ class IMAGE_STATE : public BINDABLE {
     const image_layout_map::Encoder subresource_encoder;                             // Subresource resolution encoder
     std::unique_ptr<const subresource_adapter::ImageRangeEncoder> fragment_encoder;  // Fragment resolution encoder
     const VkDevice store_device_as_workaround;                                       // TODO REMOVE WHEN encoder can be const
+
+    // A 2d vector for all the array layers and mip levels
+    std::vector<std::vector<IMAGE_ATTACHMENT_USAGE>> usages;
 
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
     IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCreateInfo);

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -8,7 +8,7 @@
       "install_dir" : "glslang/build/install",
       "commit" : "e00d27c6d65b7d3e72506a311d7f053da4051295",
       "prebuild" : [
-        "python update_glslang_sources.py"
+        "python3 update_glslang_sources.py"
       ],
       "cmake_options" : [
         "-DUSE_CCACHE=ON"

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1187,6 +1187,139 @@ VkBufferTest::~VkBufferTest() {
     }
 }
 
+VkArmBestPracticesLayerTest::Image VkArmBestPracticesLayerTest::CreateImage(VkFormat format, const uint32_t width,
+                                                                            const uint32_t height) {
+    VkImage image{VK_NULL_HANDLE};
+    VkDeviceMemory memory{VK_NULL_HANDLE};
+    VkImageView view{VK_NULL_HANDLE};
+
+    // Create image and imageview
+    VkImageCreateInfo image_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+    image_info.imageType = VK_IMAGE_TYPE_2D;
+    image_info.format = format;
+    image_info.extent.width = width;
+    image_info.extent.height = height;
+    image_info.extent.depth = 1;
+    image_info.mipLevels = 1;
+    image_info.arrayLayers = 1;
+    image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                       VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    vk::CreateImage(m_device->handle(), &image_info, nullptr, &image);
+
+    VkMemoryRequirements memory_requirements;
+    vk::GetImageMemoryRequirements(m_device->handle(), image, &memory_requirements);
+
+    uint32_t memory_type = ~0u;
+    for (uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++) {
+        if (memory_requirements.memoryTypeBits & (1u << i)) {
+            memory_type = i;
+            break;
+        }
+    }
+
+    // Allocate memory
+    VkMemoryAllocateInfo alloc = {VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    alloc.allocationSize = memory_requirements.size;
+    alloc.memoryTypeIndex = memory_type;
+    vk::AllocateMemory(m_device->handle(), &alloc, nullptr, &memory);
+
+    // Bind
+    vk::BindImageMemory(m_device->handle(), image, memory, 0);
+
+    // Create image view
+    VkImageViewCreateInfo image_view_info = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+    image_view_info.image = image;
+    image_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    image_view_info.format = format;
+    image_view_info.components.r = VK_COMPONENT_SWIZZLE_R;
+    image_view_info.components.g = VK_COMPONENT_SWIZZLE_G;
+    image_view_info.components.b = VK_COMPONENT_SWIZZLE_B;
+    image_view_info.components.a = VK_COMPONENT_SWIZZLE_A;
+    image_view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    image_view_info.subresourceRange.levelCount = 1;
+    image_view_info.subresourceRange.layerCount = 1;
+
+    vk::CreateImageView(m_device->handle(), &image_view_info, nullptr, &view);
+
+    return {image, memory, view};
+}
+
+VkRenderPass VkArmBestPracticesLayerTest::CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op,
+                                                           VkAttachmentStoreOp store_op) {
+    VkRenderPass renderpass{VK_NULL_HANDLE};
+
+    // Create renderpass
+    VkAttachmentDescription attachment = {};
+    attachment.format = format;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = load_op;
+    attachment.storeOp = store_op;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkAttachmentReference attachment_reference = {};
+    attachment_reference.attachment = 0;
+    attachment_reference.layout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkSubpassDescription subpass = {};
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &attachment_reference;
+
+    VkRenderPassCreateInfo rpinf = {
+        VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+    };
+    rpinf.attachmentCount = 1;
+    rpinf.pAttachments = &attachment;
+    rpinf.subpassCount = 1;
+    rpinf.pSubpasses = &subpass;
+    rpinf.dependencyCount = 0;
+    rpinf.pDependencies = nullptr;
+
+    vk::CreateRenderPass(m_device->handle(), &rpinf, nullptr, &renderpass);
+
+    return renderpass;
+}
+
+VkFramebuffer VkArmBestPracticesLayerTest::CreateFramebuffer(const uint32_t width, const uint32_t height, VkImageView image_view,
+                                                             VkRenderPass renderpass) {
+    VkFramebuffer framebuffer{VK_NULL_HANDLE};
+
+    VkFramebufferCreateInfo framebuffer_create_info = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO};
+    framebuffer_create_info.renderPass = renderpass;
+    framebuffer_create_info.attachmentCount = 1;
+    framebuffer_create_info.pAttachments = &image_view;
+    framebuffer_create_info.width = width;
+    framebuffer_create_info.height = height;
+    framebuffer_create_info.layers = 1;
+
+    vk::CreateFramebuffer(m_device->handle(), &framebuffer_create_info, nullptr, &framebuffer);
+
+    return framebuffer;
+}
+
+VkSampler VkArmBestPracticesLayerTest::CreateDefaultSampler() {
+    VkSampler sampler{VK_NULL_HANDLE};
+
+    VkSamplerCreateInfo sampler_create_info = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
+    sampler_create_info.magFilter = VK_FILTER_NEAREST;
+    sampler_create_info.minFilter = VK_FILTER_NEAREST;
+    sampler_create_info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_create_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    sampler_create_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    sampler_create_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    sampler_create_info.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+    sampler_create_info.maxLod = VK_LOD_CLAMP_NONE;
+
+    vk::CreateSampler(m_device->handle(), &sampler_create_info, nullptr, &sampler);
+
+    return sampler;
+}
+
 bool VkBufferTest::GetBufferCurrent() { return AllocateCurrent && BoundCurrent && CreateCurrent; }
 
 const VkBuffer &VkBufferTest::GetBuffer() { return VulkanBuffer; }

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -279,7 +279,20 @@ class VkBestPracticesLayerTest : public VkLayerTest {
     VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
 };
 
-class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
+  public:
+    struct Image {
+        VkImage image;
+        VkDeviceMemory memory;
+        VkImageView image_view;
+    };
+
+    Image CreateImage(VkFormat format, const uint32_t width, const uint32_t height);
+    VkRenderPass CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op = VK_ATTACHMENT_LOAD_OP_CLEAR,
+                                  VkAttachmentStoreOp store_op = VK_ATTACHMENT_STORE_OP_STORE);
+    VkFramebuffer CreateFramebuffer(const uint32_t width, const uint32_t height, VkImageView image_view, VkRenderPass renderpass);
+    VkSampler CreateDefaultSampler();
+};
 
 class VkWsiEnabledLayerTest : public VkLayerTest {
   public:

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -212,6 +212,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
 
     // Call for full-sized FB Color attachment prior to issuing a Draw
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+
     vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
     m_errorMonitor->VerifyFound();
 }
@@ -610,6 +611,9 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-clear");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -1285,6 +1289,306 @@ TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
         printf("%s robustBufferAccess is not available, skipping test\n", kSkipPrefix);
         return;
     }
+}
+
+TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
+    TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant store is used.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-store");
+
+    const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
+    const uint32_t WIDTH = 512, HEIGHT = 512;
+
+    std::vector<VkArmBestPracticesLayerTest::Image> images;
+    std::vector<VkRenderPass> renderpasses;
+    std::vector<VkFramebuffer> framebuffers;
+
+    images.push_back(CreateImage(FMT, WIDTH, HEIGHT));
+    renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE));
+    framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[0].image_view, renderpasses[0]));
+
+    images.push_back(CreateImage(FMT, WIDTH, HEIGHT));
+    renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_DONT_CARE));
+    framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[1].image_view, renderpasses[1]));
+
+    CreatePipelineHelper graphics_pipeline(*this);
+
+    graphics_pipeline.vs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this));
+    graphics_pipeline.fs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateFragSamplerShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this));
+    graphics_pipeline.InitInfo();
+
+    graphics_pipeline.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    graphics_pipeline.InitState();
+
+    graphics_pipeline.gp_ci_.renderPass = renderpasses[1];
+    graphics_pipeline.gp_ci_.flags = 0;
+
+    graphics_pipeline.CreateGraphicsPipeline();
+
+    VkDescriptorPool pool;
+
+    VkDescriptorPoolCreateInfo descriptor_pool_create_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+
+    VkDescriptorPoolSize pool_size = {};
+    pool_size.descriptorCount = 1;
+    pool_size.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+
+    descriptor_pool_create_info.maxSets = 1;
+    descriptor_pool_create_info.poolSizeCount = 1;
+    descriptor_pool_create_info.pPoolSizes = &pool_size;
+    vk::CreateDescriptorPool(m_device->handle(), &descriptor_pool_create_info, nullptr, &pool);
+
+    VkSampler sampler = CreateDefaultSampler();
+
+    VkDescriptorSet descriptor_set{VK_NULL_HANDLE};
+
+    VkDescriptorSetAllocateInfo descriptor_set_allocate_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+    descriptor_set_allocate_info.descriptorPool = pool;
+    descriptor_set_allocate_info.descriptorSetCount = 1;
+    descriptor_set_allocate_info.pSetLayouts = &graphics_pipeline.descriptor_set_->layout_.handle();
+    vk::AllocateDescriptorSets(m_device->handle(), &descriptor_set_allocate_info, &descriptor_set);
+
+    VkDescriptorImageInfo image_info = {};
+    image_info.imageView = images[0].image_view;
+    image_info.sampler = sampler;
+    image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkWriteDescriptorSet write = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+    write.descriptorCount = 1;
+    write.dstBinding = 0;
+    write.dstSet = descriptor_set;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    write.pImageInfo = &image_info;
+    vk::UpdateDescriptorSets(m_device->handle(), 1, &write, 0, nullptr);
+
+    VkClearValue clear_values[3];
+    memset(clear_values, 0, sizeof(clear_values));
+
+    VkRenderPassBeginInfo render_pass_begin_info = {};
+    render_pass_begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    render_pass_begin_info.renderPass = renderpasses[0];
+    render_pass_begin_info.framebuffer = framebuffers[0];
+    render_pass_begin_info.clearValueCount = 3;
+    render_pass_begin_info.pClearValues = clear_values;
+
+    const auto execute_work = [&](const std::function<void(VkCommandBufferObj & command_buffer)>& work) {
+        m_commandBuffer->begin();
+
+        work(*m_commandBuffer);
+
+        m_commandBuffer->end();
+
+        VkSubmitInfo submit = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
+        submit.commandBufferCount = 1;
+        submit.pCommandBuffers = &m_commandBuffer->handle();
+        vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
+        vk::QueueWaitIdle(m_device->m_queue);
+    };
+
+    const auto start_and_end_renderpass = [&](VkCommandBufferObj& command_buffer) {
+        command_buffer.BeginRenderPass(render_pass_begin_info);
+        command_buffer.EndRenderPass();
+    };
+
+    execute_work(start_and_end_renderpass);
+
+    // Use the image somehow.
+    execute_work([&](VkCommandBufferObj& command_buffer) {
+        VkRenderPassBeginInfo rpbi = {};
+        rpbi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rpbi.renderPass = renderpasses[1];
+        rpbi.framebuffer = framebuffers[1];
+        rpbi.clearValueCount = 3;
+        rpbi.pClearValues = clear_values;
+
+        command_buffer.BeginRenderPass(rpbi);
+
+        vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, graphics_pipeline.pipeline_);
+        vk::CmdBindDescriptorSets(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                  graphics_pipeline.pipeline_layout_.handle(), 0, 1, &descriptor_set, 0, nullptr);
+
+        VkViewport viewport;
+        viewport.x = 0.0f;
+        viewport.y = 0.0f;
+        viewport.width = static_cast<float>(WIDTH);
+        viewport.height = static_cast<float>(HEIGHT);
+        viewport.minDepth = 0.0f;
+        viewport.maxDepth = 1.0f;
+        command_buffer.SetViewport(0, 1, &viewport);
+        command_buffer.Draw(3, 1, 0, 0);
+        command_buffer.EndRenderPass();
+    });
+
+    execute_work(start_and_end_renderpass);
+
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
+    TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant clear is used.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-clear");
+
+    const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
+    const uint32_t WIDTH = 512, HEIGHT = 512;
+
+    std::vector<VkArmBestPracticesLayerTest::Image> images;
+    std::vector<VkRenderPass> renderpasses;
+    std::vector<VkFramebuffer> framebuffers;
+
+    images.push_back(CreateImage(FMT, WIDTH, HEIGHT));
+    renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE));
+    framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[0].image_view, renderpasses[0]));
+
+    CreatePipelineHelper graphics_pipeline(*this);
+
+    graphics_pipeline.vs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this));
+    graphics_pipeline.fs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this));
+    graphics_pipeline.InitInfo();
+
+    graphics_pipeline.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    graphics_pipeline.InitState();
+
+    graphics_pipeline.gp_ci_.renderPass = renderpasses[0];
+    graphics_pipeline.gp_ci_.flags = 0;
+
+    graphics_pipeline.CreateGraphicsPipeline();
+
+    VkClearValue clear_values[3];
+    memset(clear_values, 0, sizeof(clear_values));
+
+    VkRenderPassBeginInfo render_pass_begin_info = {};
+    render_pass_begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    render_pass_begin_info.renderPass = renderpasses[0];
+    render_pass_begin_info.framebuffer = framebuffers[0];
+    render_pass_begin_info.clearValueCount = 3;
+    render_pass_begin_info.pClearValues = clear_values;
+
+    m_commandBuffer->begin();
+
+    VkClearColorValue clear_color_value = {};
+    VkImageSubresourceRange subresource_range = {};
+    subresource_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    subresource_range.layerCount = VK_REMAINING_ARRAY_LAYERS;
+    subresource_range.levelCount = VK_REMAINING_MIP_LEVELS;
+    m_commandBuffer->ClearColorImage(images[0].image, VK_IMAGE_LAYOUT_GENERAL, &clear_color_value, 1, &subresource_range);
+
+    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+
+    VkViewport viewport;
+    viewport.x = 0.0f;
+    viewport.y = 0.0f;
+    viewport.width = static_cast<float>(WIDTH);
+    viewport.height = static_cast<float>(HEIGHT);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    m_commandBuffer->SetViewport(0, 1, &viewport);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, graphics_pipeline.pipeline_);
+    m_commandBuffer->Draw(3, 1, 0, 0);
+
+    m_commandBuffer->EndRenderPass();
+
+    m_commandBuffer->end();
+
+    VkSubmitInfo submit = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &m_commandBuffer->handle();
+    vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(m_device->m_queue);
+
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
+    TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant clear is used on a LOAD_OP_LOAD attachment.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
+
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+
+    const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
+    const uint32_t WIDTH = 512, HEIGHT = 512;
+
+    std::vector<VkArmBestPracticesLayerTest::Image> images;
+    std::vector<VkRenderPass> renderpasses;
+    std::vector<VkFramebuffer> framebuffers;
+
+    images.push_back(CreateImage(FMT, WIDTH, HEIGHT));
+    renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE));
+    framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[0].image_view, renderpasses[0]));
+
+    CreatePipelineHelper graphics_pipeline(*this);
+
+    graphics_pipeline.vs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this));
+    graphics_pipeline.fs_ =
+        std::unique_ptr<VkShaderObj>(new VkShaderObj(m_device, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this));
+    graphics_pipeline.InitInfo();
+
+    graphics_pipeline.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    graphics_pipeline.InitState();
+
+    graphics_pipeline.gp_ci_.renderPass = renderpasses[0];
+    graphics_pipeline.gp_ci_.flags = 0;
+
+    graphics_pipeline.CreateGraphicsPipeline();
+
+    VkClearValue clear_values[3];
+    memset(clear_values, 0, sizeof(clear_values));
+
+    VkRenderPassBeginInfo render_pass_begin_info = {};
+    render_pass_begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    render_pass_begin_info.renderPass = renderpasses[0];
+    render_pass_begin_info.framebuffer = framebuffers[0];
+    render_pass_begin_info.clearValueCount = 3;
+    render_pass_begin_info.pClearValues = clear_values;
+
+    m_commandBuffer->begin();
+
+    VkClearColorValue clear_color_value = {};
+    VkImageSubresourceRange subresource_range = {};
+    subresource_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    subresource_range.layerCount = VK_REMAINING_ARRAY_LAYERS;
+    subresource_range.levelCount = VK_REMAINING_MIP_LEVELS;
+    m_commandBuffer->ClearColorImage(images[0].image, VK_IMAGE_LAYOUT_GENERAL, &clear_color_value, 1, &subresource_range);
+
+    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+
+    VkViewport viewport;
+    viewport.x = 0.0f;
+    viewport.y = 0.0f;
+    viewport.width = static_cast<float>(WIDTH);
+    viewport.height = static_cast<float>(HEIGHT);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    m_commandBuffer->SetViewport(0, 1, &viewport);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, graphics_pipeline.pipeline_);
+    m_commandBuffer->Draw(3, 1, 0, 0);
+
+    m_commandBuffer->EndRenderPass();
+
+    m_commandBuffer->end();
+
+    VkSubmitInfo submit = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &m_commandBuffer->handle();
+    vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(m_device->m_queue);
+
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {


### PR DESCRIPTION
Added image subresource usage tracking (for every mip and array layer within an image a usage will be remembered when it is used). 

The previous usage is then checked against current usages to check and spit out a warning for redundant stores, redundant clears, and inefficient clears (on Arm Mali).

Added three tests respectively that each check for these warnings.