### PR TITLE
[WIP] Arm PerfDoc Checks 18 through 20 - Compute Shader Analysis

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -97,6 +97,12 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SuboptimalSwapchainImageC
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =
     "UNASSIGNED-BestPractices-vkAllocateDescriptorSets-suboptimal-reuse";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateComputePipelines_ComputeThreadGroupAlignment =
+    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateComputePipelines_ComputeWorkGroupSize =
+    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateComputePipelines_ComputeSpatialLocality =
+    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-spatial-locality";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreatePipelines_MultisampledBlending =
     "UNASSIGNED-BestPractices-vkCreatePipelines-multisampled-blending";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateImage_TooLargeSampleCount =

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -68,6 +68,12 @@ static const int kDepthPrePassNumDrawCallsArm = 20;
 // Maximum sample count for full throughput on Mali GPUs
 static const VkSampleCountFlagBits kMaxEfficientSamplesArm = VK_SAMPLE_COUNT_4_BIT;
 
+// On Arm Mali architectures, it's generally best to align work group dimensions to 4.
+static const uint32_t kThreadGroupDispatchCountAlignmentArm = 4;
+
+// Maximum number of threads which can efficiently be part of a compute workgroup when using thread group barriers.
+static const uint32_t kMaxEfficientWorkGroupThreadCountArm = 64;
+
 class BestPractices : public ValidationStateTracker {
   public:
     using StateTracker = ValidationStateTracker;
@@ -140,6 +146,7 @@ class BestPractices : public ValidationStateTracker {
                                                const VkComputePipelineCreateInfo* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                void* pipe_state) const;
+    bool ValidateCreateComputePipelineArm(const VkComputePipelineCreateInfo& createInfo) const;
 
     bool CheckPipelineStageFlags(std::string api_name, const VkPipelineStageFlags flags) const;
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) const;

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -328,6 +328,12 @@ spirv_inst_iter FindEntrypoint(SHADER_MODULE_STATE const *src, char const *name,
 // converting parts of this to be generated from the machine-readable spec instead.
 std::unordered_set<uint32_t> MarkAccessibleIds(SHADER_MODULE_STATE const *src, spirv_inst_iter entrypoint);
 
+// Returns an int32_t corresponding to the spv::Dim of the given resource, when positive, and corresponding to an unknown type, when
+// negative.
+int32_t GetShaderResourceDimensionality(const SHADER_MODULE_STATE *module, const interface_var &resource);
+
+bool FindLocalSize(SHADER_MODULE_STATE const *src, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z);
+
 void ProcessExecutionModes(SHADER_MODULE_STATE const *src, const spirv_inst_iter &entrypoint, PIPELINE_STATE *pipeline);
 
 std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescriptorSlot(

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1396,3 +1396,191 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
 
     m_commandBuffer->end();
 }
+
+TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest) {
+    TEST_DESCRIPTION(
+        "Testing for cases where compute shaders will be dispatched in an inefficient way, due to work group dispatch counts on "
+        "Arm Mali architectures.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    VkShaderObj compute_4_1_1(m_device,
+                              "#version 320 es\n"
+                              "\n"
+                              "layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;\n\n"
+                              "void main() {}\n",
+                              VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    VkShaderObj compute_4_1_3(m_device,
+                              "#version 320 es\n"
+                              "\n"
+                              "layout(local_size_x = 4, local_size_y = 1, local_size_z = 3) in;\n\n"
+                              "void main() {}\n",
+                              VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    VkShaderObj compute_16_8_1(m_device,
+                               "#version 320 es\n"
+                               "\n"
+                               "layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;\n\n"
+                               "void main() {}\n",
+                               VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    CreateComputePipelineHelper pipe(*this);
+
+    auto makePipelineWithShader = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage) {
+        pipe.InitInfo();
+        pipe.InitState();
+        pipe.cp_ci_.stage = stage;
+        pipe.dsl_bindings_ = {};
+
+        pipe.CreateComputePipeline(true, false);
+    };
+
+    // these two pipelines should not cause any warning
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+    makePipelineWithShader(pipe, compute_4_1_1.GetStageCreateInfo());
+    m_errorMonitor->VerifyNotFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+    makePipelineWithShader(pipe, compute_16_8_1.GetStageCreateInfo());
+    m_errorMonitor->VerifyNotFound();
+
+    // this pipeline should cause a warning due to bad work group alignment
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+    makePipelineWithShader(pipe, compute_4_1_3.GetStageCreateInfo());
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
+    TEST_DESCRIPTION(
+        "Testing for cases where the number of work groups spawned is greater than advised for Arm Mali architectures.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    VkShaderObj compute_4_1_1(m_device,
+                              "#version 320 es\n"
+                              "\n"
+                              "layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;\n\n"
+                              "void main() {}\n",
+                              VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    VkShaderObj compute_4_1_3(m_device,
+                              "#version 320 es\n"
+                              "\n"
+                              "layout(local_size_x = 4, local_size_y = 1, local_size_z = 3) in;\n\n"
+                              "void main() {}\n",
+                              VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    VkShaderObj compute_16_8_1(m_device,
+                               "#version 320 es\n"
+                               "\n"
+                               "layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;\n\n"
+                               "void main() {}\n",
+                               VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    CreateComputePipelineHelper pipe(*this);
+
+    auto make_pipeline_with_shader = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage) {
+        pipe.InitInfo();
+        pipe.InitState();
+        pipe.cp_ci_.stage = stage;
+        pipe.dsl_bindings_ = {};
+
+        pipe.CreateComputePipeline(true, false);
+    };
+
+    // these two pipelines should not cause any warning
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+    make_pipeline_with_shader(pipe, compute_4_1_1.GetStageCreateInfo());
+    m_errorMonitor->VerifyNotFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+    make_pipeline_with_shader(pipe, compute_4_1_3.GetStageCreateInfo());
+    m_errorMonitor->VerifyNotFound();
+
+    // this pipeline should cause a warning due to the total workgroup count
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+    make_pipeline_with_shader(pipe, compute_16_8_1.GetStageCreateInfo());
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocalityTest) {
+    TEST_DESCRIPTION(
+        "Testing for cases where a compute shader's configuration makes poor use of spatial locality, on Arm Mali architectures, "
+        "for one or more of its resources.");
+
+    InitBestPracticesFramework();
+    InitState();
+
+    VkShaderObj compute_sampler_2d_8_8_1(m_device,
+                                         "#version 450\n"
+                                         "layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;\n\n"
+                                         "layout(set = 0, binding = 0) uniform sampler2D uSampler;\n"
+                                         "void main() {\n"
+                                         "    vec4 value = textureLod(uSampler, vec2(0.5), 0.0);\n"
+                                         "}\n",
+                                         VK_SHADER_STAGE_COMPUTE_BIT, this);
+    VkShaderObj compute_sampler_1d_64_1_1(m_device,
+                                          "#version 450\n"
+                                          "layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;\n\n"
+                                          "layout(set = 0, binding = 0) uniform sampler1D uSampler;\n"
+                                          "void main() {\n"
+                                          "    vec4 value = textureLod(uSampler, 0.5, 0.0);\n"
+                                          "}\n",
+                                          VK_SHADER_STAGE_COMPUTE_BIT, this);
+    VkShaderObj compute_sampler_2d_64_1_1(m_device,
+                                          "#version 450\n"
+                                          "layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;\n\n"
+                                          "layout(set = 0, binding = 0) uniform sampler2D uSampler;\n"
+                                          "void main() {\n"
+                                          "    vec4 value = textureLod(uSampler, vec2(0.5), 0.0);\n"
+                                          "}\n",
+                                          VK_SHADER_STAGE_COMPUTE_BIT, this);
+
+    CreateComputePipelineHelper pipe(*this);
+
+    auto make_pipeline_with_shader = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage) {
+        VkDescriptorSetLayoutBinding sampler_binding = {};
+        sampler_binding.binding = 0;
+        sampler_binding.descriptorCount = 1;
+        sampler_binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        sampler_binding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+        pipe.InitInfo();
+        pipe.InitState();
+        auto ds_layout = std::unique_ptr<VkDescriptorSetLayoutObj>(new VkDescriptorSetLayoutObj(m_device, {sampler_binding}));
+        auto pipe_layout = std::unique_ptr<VkPipelineLayoutObj>(new VkPipelineLayoutObj(m_device, {ds_layout.get()}));
+        pipe.cp_ci_.stage = stage;
+        pipe.cp_ci_.layout = pipe_layout->handle();
+
+        pipe.CreateComputePipeline(true, false);
+    };
+
+    auto test_spatial_locality = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage,
+                                     bool positive_test, const std::vector<std::string>& allowed = {}) {
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                             "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-spatial-locality");
+        make_pipeline_with_shader(pipe, stage);
+        if (positive_test) {
+            m_errorMonitor->VerifyFound();
+        } else {
+            m_errorMonitor->VerifyNotFound();
+        }
+    };
+
+    test_spatial_locality(pipe, compute_sampler_2d_8_8_1.GetStageCreateInfo(), false);
+    test_spatial_locality(pipe, compute_sampler_1d_64_1_1.GetStageCreateInfo(), false);
+    test_spatial_locality(pipe, compute_sampler_2d_64_1_1.GetStageCreateInfo(), true);
+}


### PR DESCRIPTION
~~This pull request has another round of changes ported from PerfDoc. Here, we add SPIRV-Cross as a dependency to the `known_good.json` file, and integrate its usage into checks for a few different performance warnings regarding compute shaders.~~

~~I've added SPIRV-Cross support in the CMakeLists.txt file, with observed Windows and Unix support. However, I'm unsure if this will work on android. Is there anything else we would need to do to make that work?~~

EDIT: I've removed SPIRV-Cross, and implemented the checks another way - see the conversation below.