### PR TITLE
Fix CMake instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -147,7 +147,8 @@ A common convention is to place the build directory in the top directory of
 the repository with a name of `build` and place the install directory as a
 child of the build directory with the name `install`. The remainder of these
 instructions follow this convention, although you can use any name for these
-directories and place them in any location.
+directories and place them in any location (see option `--dir` in the
+[notes](#notes)).
 
 ### Building Dependent Repositories with Known-Good Revisions
 
@@ -168,7 +169,7 @@ For all platforms, start with:
 For 64-bit Linux and MacOS, continue with:
 
     ../scripts/update_deps.py
-    cmake -C helper.cmake ..
+    cmake -C build/helper.cmake ..
     cmake --build .
 
 For 64-bit Windows, continue with:

--- a/BUILD.md
+++ b/BUILD.md
@@ -174,13 +174,13 @@ For 64-bit Linux and MacOS, continue with:
 For 64-bit Windows, continue with:
 
     ..\scripts\update_deps.py --arch x64
-    cmake -A x64 -C helper.cmake ..
+    cmake -A x64 -C build\helper.cmake ..
     cmake --build .
 
 For 32-bit Windows, continue with:
 
     ..\scripts\update_deps.py --arch Win32
-    cmake -A Win32 -C helper.cmake ..
+    cmake -A Win32 -C build\helper.cmake ..
     cmake --build .
 
 Please see the more detailed build information later in this file if you have


### PR DESCRIPTION
On Windows at least, CMake cannot find `helper.cmake`:

```
> cmake -A x64 -C helper.cmake ..
loading initial cache file helper.cmake
CMake Error: Error processing file: helper.cmake
```

It works if I add the build directory like this instead: `cmake -A x64 -C build\helper.cmake ..`