### PR TITLE
Fix inadvertent StateTracker validation object state-sharing

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -577,8 +577,12 @@ bool cvdescriptorset::ValidateDescriptorSetLayoutCreateInfo(
     return skip;
 }
 
-cvdescriptorset::AllocateDescriptorSetsData::AllocateDescriptorSetsData(uint32_t count)
-    : required_descriptors_by_type{}, layout_nodes(count, nullptr) {}
+void cvdescriptorset::AllocateDescriptorSetsData::Init(uint32_t count) {
+    layout_nodes.resize(count);
+    for (auto node : layout_nodes) {
+        node = nullptr;
+    }
+}
 
 cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool_state,
                                               const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -541,7 +541,8 @@ struct alignas(alignof(AnyDescriptor)) DescriptorBackingStore {
 struct AllocateDescriptorSetsData {
     std::map<uint32_t, uint32_t> required_descriptors_by_type;
     std::vector<std::shared_ptr<DescriptorSetLayout const>> layout_nodes;
-    AllocateDescriptorSetsData(uint32_t);
+    void Init(uint32_t);
+    AllocateDescriptorSetsData(){};
 };
 // Helper functions for descriptor set functions that cross multiple sets
 // "Validate" will make sure an update is ok without actually performing it

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -1092,11 +1092,13 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-    cvdescriptorset::AllocateDescriptorSetsData ads_state(pAllocateInfo->descriptorSetCount);
+    cvdescriptorset::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
 
     for (auto intercept : layer_data->object_dispatch) {
+        ads_state[intercept->container_type].Init(pAllocateInfo->descriptorSetCount);
         auto lock = intercept->read_lock();
-        skip |= (const_cast<const ValidationObject*>(intercept))->PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, &ads_state);
+        skip |= (const_cast<const ValidationObject*>(intercept))->PreCallValidateAllocateDescriptorSets(device,
+            pAllocateInfo, pDescriptorSets, &(ads_state[intercept->container_type]));
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (auto intercept : layer_data->object_dispatch) {
@@ -1106,7 +1108,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     VkResult result = DispatchAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
     for (auto intercept : layer_data->object_dispatch) {
         auto lock = intercept->write_lock();
-        intercept->PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, result, &ads_state);
+        intercept->PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets,
+            result, &(ads_state[intercept->container_type]));
     }
     return result;
 }


### PR DESCRIPTION
`PostCallRecord `steps for `AllocateDescriptorSets `were inadvertently causing redundant state updates, causing false positives.

Modified the `AllocateDescriptorSets `chassis to use a dataset per VO, just as the `CreateXxxPipelines `chassis do.

Fixes #1981.
