### PR TITLE
tests: Fix AHB Test not covering 02251

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4632,8 +4632,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
 
     // undefined format
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01975");
+    // Various extra errors for having VK_FORMAT_UNDEFINED without VkExternalFormatANDROID
     m_errorMonitor->SetUnexpectedError("VUID_Undefined");
     m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Image-FormatNotSupported");
+    m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
     vk::CreateImage(dev, &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
     reset_img();


### PR DESCRIPTION
This is my fault, I usually test my PR on my Pixel device and either messed it up and/or forgot with #1963 