### PR TITLE
Fix memory leaks

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4637,8 +4637,8 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalD
                                                                      VkPhysicalDeviceFeatures *pFeatures) {
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
-    physical_device_state->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    physical_device_state->features2.pNext = nullptr;
+    // Reset the features2 safe struct before setting up the features field.
+    physical_device_state->features2 = safe_VkPhysicalDeviceFeatures2();
     physical_device_state->features2.features = *pFeatures;
 }
 

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1389,6 +1389,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
         intercept->PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
     }
 
+    // Delete unused validation objects to avoid memory leak.
+    std::vector<ValidationObject*> local_objs = {
+        thread_checker_obj, object_tracker_obj, parameter_validation_obj,
+        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
+    };
+    for (auto obj : local_objs) {
+        if (std::find(local_object_dispatch.begin(), local_object_dispatch.end(), obj) == local_object_dispatch.end()) {
+            delete obj;
+        }
+    }
+
     InstanceExtensionWhitelist(framework, pCreateInfo, *pInstance);
     DeactivateInstanceDebugCallbacks(report_data);
     return result;
@@ -1513,6 +1524,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     auto debug_printf_obj = new DebugPrintf;
     debug_printf_obj->InitDeviceValidationObject(enables[debug_printf], instance_interceptor, device_interceptor);
+
+    // Delete unused validation objects to avoid memory leak.
+    std::vector<ValidationObject *> local_objs = {
+        thread_safety_obj, stateless_validation_obj, object_tracker_obj,
+        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
+    };
+    for (auto obj : local_objs) {
+        if (std::find(device_interceptor->object_dispatch.begin(), device_interceptor->object_dispatch.end(), obj) ==
+            device_interceptor->object_dispatch.end()) {
+            delete obj;
+        }
+    }
 
     for (auto intercept : instance_interceptor->object_dispatch) {
         auto lock = intercept->write_lock();


### PR DESCRIPTION
This change fixes a few memory leaks within the validation layers:

* Unused ValidationObjects created in vkCreateInstance() and
  vkCreateDevice() should be destroyed immediately.

* When modifying value of safe structs, we should reset the existing
  safe struct first.