### PR TITLE
Update BUILD.md to use correct helper.cmake path

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -169,19 +169,19 @@ For all platforms, start with:
 For 64-bit Linux and MacOS, continue with:
 
     ../scripts/update_deps.py
-    cmake -C build/helper.cmake ..
+    cmake -C helper.cmake ..
     cmake --build .
 
 For 64-bit Windows, continue with:
 
     ..\scripts\update_deps.py --arch x64
-    cmake -A x64 -C build\helper.cmake ..
+    cmake -A x64 -C helper.cmake ..
     cmake --build .
 
 For 32-bit Windows, continue with:
 
     ..\scripts\update_deps.py --arch Win32
-    cmake -A Win32 -C build\helper.cmake ..
+    cmake -A Win32 -C helper.cmake ..
     cmake --build .
 
 Please see the more detailed build information later in this file if you have


### PR DESCRIPTION
Fix BUILD.md common case build instructions. Remove "build" folder prefix.