### PR TITLE
Move some sparse VU to stateless

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1740,13 +1740,6 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
     }
 
-    if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.core.sparseResidencyAliased)) {
-        skip |=
-            LogError(device, "VUID-VkImageCreateInfo-flags-01924",
-                     "vkCreateImage(): the sparseResidencyAliased device feature is disabled: Images cannot be created with the "
-                     "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT set.");
-    }
-
     if (device_extensions.vk_khr_maintenance2) {
         if (pCreateInfo->flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
             if (!(FormatIsCompressed_BC(pCreateInfo->format) || FormatIsCompressed_ASTC(pCreateInfo->format) ||
@@ -4490,24 +4483,6 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     bool skip = false;
 
     // TODO: Add check for "VUID-vkCreateBuffer-flags-00911"        (sparse address space accounting)
-
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!enabled_features.core.sparseBinding)) {
-        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00915",
-                         "vkCreateBuffer(): the sparseBinding device feature is disabled: Buffers cannot be created with the "
-                         "VK_BUFFER_CREATE_SPARSE_BINDING_BIT set.");
-    }
-
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!enabled_features.core.sparseResidencyBuffer)) {
-        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00916",
-                         "vkCreateBuffer(): the sparseResidencyBuffer device feature is disabled: Buffers cannot be created with "
-                         "the VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT set.");
-    }
-
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.core.sparseResidencyAliased)) {
-        skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00917",
-                         "vkCreateBuffer(): the sparseResidencyAliased device feature is disabled: Buffers cannot be created with "
-                         "the VK_BUFFER_CREATE_SPARSE_ALIASED_BIT set.");
-    }
 
     auto chained_devaddr_struct = lvl_find_in_chain<VkBufferDeviceAddressCreateInfoEXT>(pCreateInfo->pNext);
     if (chained_devaddr_struct) {

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -549,6 +549,26 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
             }
         }
 
+        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-00915",
+                             "vkCreateBuffer(): the sparseBinding device feature is disabled: Buffers cannot be created with the "
+                             "VK_BUFFER_CREATE_SPARSE_BINDING_BIT set.");
+        }
+
+        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!physical_device_features.sparseResidencyBuffer)) {
+            skip |=
+                LogError(device, "VUID-VkBufferCreateInfo-flags-00916",
+                         "vkCreateBuffer(): the sparseResidencyBuffer device feature is disabled: Buffers cannot be created with "
+                         "the VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT set.");
+        }
+
+        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+            skip |=
+                LogError(device, "VUID-VkBufferCreateInfo-flags-00917",
+                         "vkCreateBuffer(): the sparseResidencyAliased device feature is disabled: Buffers cannot be created with "
+                         "the VK_BUFFER_CREATE_SPARSE_ALIASED_BIT set.");
+        }
+
         // If flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain
         // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
         if (((pCreateInfo->flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
@@ -692,6 +712,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00969",
                              "vkCreateImage(): pCreateInfo->flags contains VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
                              "VkPhysicalDeviceFeatures::sparseBinding feature is disabled.");
+        }
+
+        if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-flags-01924",
+                "vkCreateImage(): the sparseResidencyAliased device feature is disabled: Images cannot be created with the "
+                "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT set.");
         }
 
         // If flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain


### PR DESCRIPTION
Notices the `sparseResidencyImage` checks were in Stateless, but the `sparseResidencyBuffer` were in CoreCheck. Decided to make it all consistent and move all these stateless sparse checks out of CoreCheck