### PR TITLE
Add Protected Resource VUIDs

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1810,6 +1810,22 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
     }
 
+    if ((pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) != 0) {
+        if (enabled_features.core11.protectedMemory == VK_FALSE) {
+            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-01890",
+                             "vkCreateImage(): the protectedMemory device feature is disabled: Images cannot be created with the "
+                             "VK_IMAGE_CREATE_PROTECTED_BIT set.");
+        }
+        const VkImageCreateFlags invalid_flags =
+            VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT;
+        if ((pCreateInfo->flags & invalid_flags) != 0) {
+            skip |= LogError(device, "VUID-VkImageCreateInfo-None-01891",
+                             "vkCreateImage(): VK_IMAGE_CREATE_PROTECTED_BIT is set so no sparse create flags can be used at same "
+                             "time (VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | "
+                             "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT).");
+        }
+    }
+
     skip |= ValidateImageFormatFeatures(pCreateInfo);
 
     return skip;
@@ -4542,6 +4558,22 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
         skip |= ValidateQueueFamilies(pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices, "vkCreateBuffer",
                                       "pCreateInfo->pQueueFamilyIndices", "VUID-VkBufferCreateInfo-sharingMode-01419",
                                       "VUID-VkBufferCreateInfo-sharingMode-01419", false);
+    }
+
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) != 0) {
+        if (enabled_features.core11.protectedMemory == VK_FALSE) {
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-flags-01887",
+                             "vkCreateBuffer(): the protectedMemory device feature is disabled: Buffers cannot be created with the "
+                             "VK_BUFFER_CREATE_PROTECTED_BIT set.");
+        }
+        const VkBufferCreateFlags invalid_flags =
+            VK_BUFFER_CREATE_SPARSE_BINDING_BIT | VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
+        if ((pCreateInfo->flags & invalid_flags) != 0) {
+            skip |= LogError(device, "VUID-VkBufferCreateInfo-None-01888",
+                             "vkCreateBuffer(): VK_BUFFER_CREATE_PROTECTED_BIT is set so no sparse create flags can be used at "
+                             "same time (VK_BUFFER_CREATE_SPARSE_BINDING_BIT | VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | "
+                             "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT).");
+        }
     }
 
     return skip;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3038,23 +3038,30 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                          "advertises %u memory types.",
                          pAllocateInfo->memoryTypeIndex, phys_dev_mem_props.memoryTypeCount);
     } else {
-        if (pAllocateInfo->allocationSize >
-            phys_dev_mem_props.memoryHeaps[phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex].heapIndex].size) {
-            skip |= LogError(
-                device, "VUID-vkAllocateMemory-pAllocateInfo-01713",
-                "vkAllocateMemory: attempting to allocate %" PRIu64
-                " bytes from heap %u,"
-                "but size of that heap is only %" PRIu64 " bytes.",
-                pAllocateInfo->allocationSize, phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex].heapIndex,
-                phys_dev_mem_props.memoryHeaps[phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex].heapIndex].size);
+        const VkMemoryType memory_type = phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex];
+        if (pAllocateInfo->allocationSize > phys_dev_mem_props.memoryHeaps[memory_type.heapIndex].size) {
+            skip |= LogError(device, "VUID-vkAllocateMemory-pAllocateInfo-01713",
+                             "vkAllocateMemory: attempting to allocate %" PRIu64
+                             " bytes from heap %u,"
+                             "but size of that heap is only %" PRIu64 " bytes.",
+                             pAllocateInfo->allocationSize, memory_type.heapIndex,
+                             phys_dev_mem_props.memoryHeaps[memory_type.heapIndex].size);
         }
 
         if (!enabled_features.device_coherent_memory_features.deviceCoherentMemory &&
-            ((phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex].propertyFlags &
-              VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD) != 0)) {
+            ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD) != 0)) {
             skip |= LogError(device, "VUID-vkAllocateMemory-deviceCoherentMemory-02790",
                              "vkAllocateMemory: attempting to allocate memory type %u, which includes the "
                              "VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD memory property, but the deviceCoherentMemory feature "
+                             "is not enabled.",
+                             pAllocateInfo->memoryTypeIndex);
+        }
+
+        if ((enabled_features.core11.protectedMemory == VK_FALSE) &&
+            ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) != 0)) {
+            skip |= LogError(device, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-01872",
+                             "vkAllocateMemory(): attempting to allocate memory type %u, which includes the "
+                             "VK_MEMORY_PROPERTY_PROTECTED_BIT memory property, but the protectedMemory feature "
                              "is not enabled.",
                              pAllocateInfo->memoryTypeIndex);
         }
@@ -3649,6 +3656,29 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, V
                                      string_VkExternalMemoryHandleTypeFlags(buffer_state->external_memory_handle).c_str());
                 }
             }
+
+            // Validate mix of protected buffer and memory
+            if ((buffer_state->unprotected == false) && (mem_info->unprotected == true)) {
+                // TODO label when spec change is upstreamed
+                const char *vuid =
+                    bind_buffer_mem_2 ? "UNASSIGNED-VkBindBufferMemoryInfo-protected" : "VUID-vkBindBufferMemory-None-01898";
+                LogObjectList objlist(buffer);
+                objlist.add(mem);
+                skip |= LogError(objlist, vuid,
+                                 "%s: The VkDeviceMemory (%s) was not created with protected memory but the VkBuffer (%s) was set "
+                                 "to use protected memory.",
+                                 api_name, report_data->FormatHandle(mem).c_str(), report_data->FormatHandle(buffer).c_str());
+            } else if ((buffer_state->unprotected == true) && (mem_info->unprotected == false)) {
+                // TODO label when spec change is upstreamed
+                const char *vuid =
+                    bind_buffer_mem_2 ? "UNASSIGNED-VkBindBufferMemoryInfo-protected" : "VUID-vkBindBufferMemory-None-01899";
+                LogObjectList objlist(buffer);
+                objlist.add(mem);
+                skip |= LogError(objlist, vuid,
+                                 "%s: The VkDeviceMemory (%s) was created with protected memory but the VkBuffer (%s) was not set "
+                                 "to use protected memory.",
+                                 api_name, report_data->FormatHandle(mem).c_str(), report_data->FormatHandle(buffer).c_str());
+            }
         }
     }
     return skip;
@@ -3888,8 +3918,17 @@ bool CoreChecks::PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPoo
 
 bool CoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool) const {
-    return ValidateDeviceQueueFamily(pCreateInfo->queueFamilyIndex, "vkCreateCommandPool", "pCreateInfo->queueFamilyIndex",
-                                     "VUID-vkCreateCommandPool-queueFamilyIndex-01937");
+    bool skip = false;
+    skip |= ValidateDeviceQueueFamily(pCreateInfo->queueFamilyIndex, "vkCreateCommandPool", "pCreateInfo->queueFamilyIndex",
+                                      "VUID-vkCreateCommandPool-queueFamilyIndex-01937");
+    if ((enabled_features.core11.protectedMemory == VK_FALSE) &&
+        ((pCreateInfo->flags & VK_COMMAND_POOL_CREATE_PROTECTED_BIT) != 0)) {
+        skip |= LogError(device, "VUID-VkCommandPoolCreateInfo-flags-02860",
+                         "vkCreateCommandPool(): the protectedMemory device feature is disabled: CommandPools cannot be created "
+                         "with the VK_COMMAND_POOL_CREATE_PROTECTED_BIT set.");
+    }
+
+    return skip;
 }
 
 bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
@@ -10323,6 +10362,31 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                          report_data->FormatHandle(bindInfo.image).c_str(),
                                          string_VkExternalMemoryHandleTypeFlags(image_state->external_memory_handle).c_str());
                     }
+                }
+
+                // Validate mix of protected buffer and memory
+                if ((image_state->unprotected == false) && (mem_info->unprotected == true)) {
+                    // TODO label when spec change is upstreamed
+                    const char *vuid =
+                        bind_image_mem_2 ? "UNASSIGNED-VkBindImageMemoryInfo-protected" : "VUID-vkBindImageMemory-None-01901";
+                    LogObjectList objlist(bindInfo.image);
+                    objlist.add(bindInfo.memory);
+                    skip |= LogError(objlist, vuid,
+                                     "%s: The VkDeviceMemory (%s) was not created with protected memory but the VkImage (%s) was "
+                                     "set to use protected memory.",
+                                     api_name, report_data->FormatHandle(bindInfo.memory).c_str(),
+                                     report_data->FormatHandle(bindInfo.image).c_str());
+                } else if ((image_state->unprotected == true) && (mem_info->unprotected == false)) {
+                    // TODO label when spec change is upstreamed
+                    const char *vuid =
+                        bind_image_mem_2 ? "UNASSIGNED-VkBindImageMemoryInfo-protected" : "VUID-vkBindImageMemory-None-01902";
+                    LogObjectList objlist(bindInfo.image);
+                    objlist.add(bindInfo.memory);
+                    skip |= LogError(objlist, vuid,
+                                     "%s: The VkDeviceMemory (%s) was created with protected memory but the VkImage (%s) was not "
+                                     "set to use protected memory.",
+                                     api_name, report_data->FormatHandle(bindInfo.memory).c_str(),
+                                     report_data->FormatHandle(bindInfo.image).c_str());
                 }
             }
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -208,6 +208,7 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
     bool is_export;
     bool is_import;
     bool is_import_ahb;  // The VUID check depends on if the imported memory is for AHB
+    bool unprotected;    // can't be used for protected memory
     VkExternalMemoryHandleTypeFlags export_handle_type_flags;
     VkExternalMemoryHandleTypeFlags import_handle_type_flags;
     std::unordered_set<VulkanTypedHandle> obj_bindings;  // objects bound to this memory
@@ -233,6 +234,7 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
           is_export(false),
           is_import(false),
           is_import_ahb(false),
+          unprotected(true),
           export_handle_type_flags(0),
           import_handle_type_flags(0),
           mapped_range{},
@@ -291,6 +293,7 @@ class BINDABLE : public BASE_NODE {
     std::unordered_set<MEM_BINDING> sparse_bindings;
     // True if memory will be imported/exported from/to an Android Hardware Buffer
     bool external_ahb;
+    bool unprotected;  // can't be used for protected memory
 
     small_unordered_set<DEVICE_MEMORY_STATE *, 1> bound_memory_set_;
 
@@ -302,6 +305,7 @@ class BINDABLE : public BASE_NODE {
           external_memory_handle(0),
           sparse_bindings{},
           external_ahb(false),
+          unprotected(true),
           bound_memory_set_{} {};
 
     // Update the cached set of memory bindings.

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -213,6 +213,8 @@ void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const Vk
 
     AddImageStateProps(*is_node, device, physical_device);
 
+    is_node->unprotected = ((pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0);
+
     imageMap.insert(std::make_pair(*pImage, std::move(is_node)));
 }
 
@@ -311,6 +313,8 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
     if (buffer_state->external_ahb == false) {
         DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
     }
+
+    buffer_state->unprotected = ((pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0);
 
     bufferMap.insert(std::make_pair(*pBuffer, std::move(buffer_state)));
 }
@@ -644,6 +648,9 @@ void ValidationStateTracker::AddMemObjInfo(void *object, const VkDeviceMemory me
         mem_info->import_handle_type_flags = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
     }
 #endif
+
+    const VkMemoryType memory_type = phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex];
+    mem_info->unprotected = ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) == 0);
 }
 
 // Create binding link between given sampler and command buffer node


### PR DESCRIPTION
Addresses some of #1996 

VUID-VkCommandPoolCreateInfo-flags-02860
VUID-VkBufferCreateInfo-flags-01887
VUID-VkImageCreateInfo-flags-01890

VUID-VkBufferCreateInfo-None-01888
VUID-VkImageCreateInfo-None-01891

VUID-vkBindBufferMemory-None-01898
VUID-vkBindBufferMemory-None-01899
VUID-vkBindImageMemory-None-01901
VUID-vkBindImageMemory-None-01902

VUID-VkMemoryAllocateInfo-memoryTypeIndex-01872