### PR TITLE
Fix stores and atomics feature enabling in GPU-AV

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1031,7 +1031,7 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                                                 "%s encountered the following validation error at %s time: Sampler %s in "
                                                 "binding #%" PRIu32 " index %" PRIu32
                                                 " has a custom border color with format = VK_FORMAT_UNDEFINED and is used to "
-                                                "sample an image view %" PRIu64 " with format %s",
+                                                "sample an image view %s with format %s",
                                                 report_data->FormatHandle(set).c_str(), caller,
                                                 report_data->FormatHandle(sampler).c_str(), binding, index,
                                                 report_data->FormatHandle(image_view_state->image_view).c_str(),

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -255,10 +255,15 @@ void UtilPreCallRecordCreateDevice(VkPhysicalDevice gpu, safe_VkDeviceCreateInfo
     }
     if (features) {
         VkBool32 *desired = reinterpret_cast<VkBool32 *>(&desired_features);
-        VkBool32 *featurePtr = reinterpret_cast<VkBool32 *>(&features);
+        VkBool32 *featurePtr = reinterpret_cast<VkBool32 *>(features);
         VkBool32 *supported = reinterpret_cast<VkBool32 *>(&supported_features);
         for (size_t i = 0; i < sizeof(VkPhysicalDeviceFeatures); i += (sizeof(VkBool32))) {
-            *featurePtr++ |= (*supported++ & *desired++);
+            if (*supported && *desired) {
+                *featurePtr = true;
+            }
+            supported++;
+            desired++;
+            featurePtr++;
         }
     } else {
         VkPhysicalDeviceFeatures new_features = {};

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -245,8 +245,7 @@ void GpuAssisted::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, co
         return;
     }
 
-    if (!device_gpu_assisted->enabled_features.core.fragmentStoresAndAtomics ||
-        !device_gpu_assisted->enabled_features.core.vertexPipelineStoresAndAtomics) {
+    if (!supported_features.fragmentStoresAndAtomics || !supported_features.vertexPipelineStoresAndAtomics) {
         ReportSetupProblem(device,
                            "GPU-Assisted validation requires fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics.  "
                            "GPU-Assisted Validation disabled.");
@@ -255,11 +254,11 @@ void GpuAssisted::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, co
     }
 
     if ((device_extensions.vk_ext_buffer_device_address || device_extensions.vk_khr_buffer_device_address) &&
-        !device_gpu_assisted->enabled_features.core.shaderInt64) {
+        !supported_features.shaderInt64) {
         LogWarning(device, "UNASSIGNED-GPU-Assisted Validation Warning",
                    "shaderInt64 feature is not available.  No buffer device address checking will be attempted");
     }
-    device_gpu_assisted->shaderInt64 = device_gpu_assisted->enabled_features.core.shaderInt64;
+    device_gpu_assisted->shaderInt64 = supported_features.shaderInt64;
     device_gpu_assisted->physicalDevice = physicalDevice;
     device_gpu_assisted->device = *pDevice;
     device_gpu_assisted->output_buffer_size = sizeof(uint32_t) * (spvtools::kInstMaxOutCnt + 1);

--- a/tests/layers/vk_lunarg_device_profile_api_layer.h
+++ b/tests/layers/vk_lunarg_device_profile_api_layer.h
@@ -45,6 +45,10 @@ typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)(VkP
                                                                              const VkFormatProperties2 *properties);
 typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                      const VkFormatProperties2 newProperties);
+typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice,
+                                                                    const VkPhysicalDeviceFeatures *features);
+typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice,
+                                                            const VkPhysicalDeviceFeatures newFeatures);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Also needed to fix a test that uses the lack of stores and atomics to get GPU-AV to abort