### PR TITLE
Fixes to AHB VUs and Tests

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10408,7 +10408,11 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
             if (mem_info) {
                 // Validate bound memory range information
-                skip |= ValidateInsertImageMemoryRange(bindInfo.image, mem_info, bindInfo.memoryOffset, error_prefix);
+                // if memory is exported to an AHB then the mem_info->allocationSize must be zero and this check is not needed
+                if ((mem_info->is_export == false) || ((mem_info->export_handle_type_flags &
+                                                        VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) == 0)) {
+                    skip |= ValidateInsertImageMemoryRange(bindInfo.image, mem_info, bindInfo.memoryOffset, error_prefix);
+                }
 
                 // Validate dedicated allocation
                 if (mem_info->is_dedicated) {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -429,10 +429,7 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
         RecordCreateBufferANDROID(pCreateInfo, buffer_state.get());
     }
     // Get a set of requirements in the case the app does not
-    // External AHB memory can't be queried until after memory is bound
-    if (buffer_state->external_ahb == false) {
-        DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
-    }
+    DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
 
     buffer_state->unprotected = ((pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0);
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5230,6 +5230,11 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
+    if (IsPlatform(kGalaxyS10)) {
+        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
+        return;
+    }
+
     if ((DeviceExtensionSupported(gpu(), nullptr, VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)) &&
         // Also skip on devices that advertise AHB, but not the pre-requisite foreign_queue extension
         (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME))) {
@@ -5696,8 +5701,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
         return;
     }
 
-    VkDeviceMemory memory;
-    vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkResult result = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
+    if ((memory == VK_NULL_HANDLE) || (result != VK_SUCCESS)) {
+        printf("%s This test failed to allocate memory for importing\n", kSkipPrefix);
+        return;
+    }
 
     if (mem_reqs.alignment > 1) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memoryOffset-01036");


### PR DESCRIPTION
closes #2004

The first commit is a need dependency that removes
`VUID-vkGetBufferMemoryRequirements-buffer-04003`
`VUID-VkBufferMemoryRequirementsInfo2-buffer-04005`
From internal Vulkan MR 3982, it was decided these should never have been added (and will be gone in a future header now). I have written positive tests to prevent regression

Added positive test to check for export AHB from both a `vkBuffer` and `vkImage` which caught the issue reported in #2004 from calling `ValidateInsertImageMemoryRange()` when it is an export `VkImage` AHB and `allocationSize` is suppose to be `0`