### PR TITLE
build: Add a virtual dtor to AspectParameters

### DIFF
--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -47,6 +47,7 @@ using split_op_keep_upper = sparse_container::split_op_keep_upper;
 // Interface for aspect specific traits objects (now isolated in the cpp file)
 class AspectParameters {
   public:
+    virtual ~AspectParameters() {}
     static const AspectParameters* Get(VkImageAspectFlags);
     typedef uint32_t (*MaskIndexFunc)(VkImageAspectFlags);
     virtual VkImageAspectFlags AspectMask() const = 0;


### PR DESCRIPTION
The warning -Wnon-virtual-dtor catches the following error:

  'subresource_adapter::AspectParameters' has virtual functions but
  non-virtual destruct

This adds a (empty) virtual dtor.