### PR TITLE
scripts: update_deps retry on clone or fetch failure

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -2,8 +2,7 @@
 
 # Copyright 2017 The Glslang Authors. All rights reserved.
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We see spurious failures to connect to github when trying to
run update_deps.py (up to 7% of runs, depending on the machine).
This is an annoyance when running by hand, but a headache and
a serious resource waste when running in automation (as a single
broken "git clone" or "git fetch" can cause the whole run to fail).

These changes allow update_deps.py to automatically retry
"git fetch" and "git clone" operations on failure.

These changes will be duplicated in follow-on PRs to the
other repositories that include "update_deps.py", to keep
them all in sync.  These are KhronosGroup/Vulkan-Tools,
KhronosGroup/Vulkan-Loader, LunarG/VulkanSamples, and
LunarG/VulkanTools.

I'm also including a "technical debt" update here, because
VulkanTools/scripts/update_deps.py had diverged from the other
"update_deps.py" versions, to add a way to avoid building a
dependency if that dependency is not supported on the current
build platform.  This should be harmless to the other
repositories (though potentially useful in the future).  The
original commit was aaabc9df034f1fdf9a976a6293d0983b079143ee
with description:

    In update deps, this will check that a dependency is actually supported
    on the platform being built. This is needed because the loader is a
    dependency on all platforms other than Windows.