### PR TITLE
Default initialize ACCELERATION_STRUCTURE_STATE members

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -515,19 +515,19 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           is_khr(false),
           create_infoNV(ci),
           memory_requirements{},
-          build_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
-          update_scratch_memory_requirements{},
-          update_scratch_memory_requirements_checked{} {}
+          build_scratch_memory_requirements{},
+          update_scratch_memory_requirements_checked{},
+          update_scratch_memory_requirements{} {}
     ACCELERATION_STRUCTURE_STATE(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci)
         : acceleration_structure(as),
           is_khr(true),
           create_infoKHR(ci),
           memory_requirements{},
-          build_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
-          update_scratch_memory_requirements{},
-          update_scratch_memory_requirements_checked{} {}
+          build_scratch_memory_requirements{},
+          update_scratch_memory_requirements_checked{},
+          update_scratch_memory_requirements{} {}
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;
 };
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -515,6 +515,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           is_khr(false),
           create_infoNV(ci),
           memory_requirements{},
+          build_scratch_memory_requirements{},
+          update_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
           update_scratch_memory_requirements_checked{} {}
     ACCELERATION_STRUCTURE_STATE(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci)
@@ -522,6 +524,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           is_khr(true),
           create_infoKHR(ci),
           memory_requirements{},
+          build_scratch_memory_requirements{},
+          update_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
           update_scratch_memory_requirements_checked{} {}
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -516,8 +516,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           create_infoNV(ci),
           memory_requirements{},
           build_scratch_memory_requirements{},
-          update_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
+          update_scratch_memory_requirements{},
           update_scratch_memory_requirements_checked{} {}
     ACCELERATION_STRUCTURE_STATE(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci)
         : acceleration_structure(as),
@@ -525,8 +525,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           create_infoKHR(ci),
           memory_requirements{},
           build_scratch_memory_requirements{},
-          update_scratch_memory_requirements{},
           build_scratch_memory_requirements_checked{},
+          update_scratch_memory_requirements{},
           update_scratch_memory_requirements_checked{} {}
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;
 };


### PR DESCRIPTION
ACCELERATION_STRUCTURE_STATE members VkMemoryRequirements2KHR structures build_scratch_memory_requirements and update_scratch_memory_requirements should be default initialized as VkMemoryRequirements2KHR structure memory_requirements is.