### PR TITLE
tests: Fix push-constant test

### DIFF
--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -8902,7 +8902,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineOverlappingPushConstantRange) {
         "#version 450\n"
         "\n"
         "layout(push_constant, std430) uniform foo { float x[4]; } constants;\n"
+        "layout(location=0) out vec4 o;\n"
         "void main(){\n"
+        "   o = vec4(constants.x[0]);\n"
         "}\n";
 
     VkShaderObj const vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);


### PR DESCRIPTION
This test wasn't actually testing what it claimed because the
push-constant block was being optimized away.

Change-Id: Iecb599ee1f0d7d6bc17ee843a1a7d2d3a201643f