### PR TITLE
build: Handle glslang static lib dependency cycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,70 +192,29 @@ if(BUILD_TESTS OR BUILD_LAYERS)
         set(GLSLANG_SPIRV_INCLUDE_DIR "${GLSLANG_INSTALL_DIR}/include/glslang" CACHE PATH "Path to glslang spirv headers")
         set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include" CACHE PATH "Path to spirv-headers")
 
-        find_library(GLSLANG_LIB NAMES glslang HINTS ${GLSLANG_SEARCH_PATH})
-        find_library(OGLCompiler_LIB NAMES OGLCompiler HINTS ${GLSLANG_SEARCH_PATH})
-        find_library(OSDependent_LIB NAMES OSDependent HINTS ${GLSLANG_SEARCH_PATH})
-        find_library(HLSL_LIB NAMES HLSL HINTS ${GLSLANG_SEARCH_PATH})
-        find_library(SPIRV_LIB NAMES SPIRV HINTS ${GLSLANG_SEARCH_PATH})
-        find_library(SPIRV_REMAPPER_LIB NAMES SPVRemapper HINTS ${GLSLANG_SEARCH_PATH})
+        set(GLSLANG_LIBRARIES glslang OGLCompiler OSDependent MachineIndependent GenericCodeGen HLSL SPIRV SPVRemapper)
 
-        if(WIN32)
-            add_library(glslang STATIC IMPORTED)
-            add_library(OGLCompiler STATIC IMPORTED)
-            add_library(OSDependent STATIC IMPORTED)
-            add_library(HLSL STATIC IMPORTED)
-            add_library(SPIRV STATIC IMPORTED)
-            add_library(SPVRemapper STATIC IMPORTED)
+        # Add glslang static libraries as imported targets
+        foreach(GLSLANG_LIBRARY ${GLSLANG_LIBRARIES})
+            add_library(${GLSLANG_LIBRARY} STATIC IMPORTED)
+            find_library("${GLSLANG_LIBRARY}_PATH" NAMES "${GLSLANG_LIBRARY}" HINTS ${GLSLANG_SEARCH_PATH})
+            set_target_properties(${GLSLANG_LIBRARY}
+                                  PROPERTIES IMPORTED_LOCATION
+                                             "${${GLSLANG_LIBRARY}_PATH}")
+            if (WIN32)
+                find_library("${GLSLANG_LIBRARY}_DEBUG_PATH" NAMES "${GLSLANG_LIBRARY}d" HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
+                set_target_properties(${GLSLANG_LIBRARY}
+                                      PROPERTIES IMPORTED_LOCATION_DEBUG
+                                                 "${${GLSLANG_LIBRARY}_DEBUG_PATH}")
+            endif()
+        endforeach()
 
-            find_library(GLSLANG_DLIB NAMES glslangd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-            find_library(OGLCompiler_DLIB NAMES OGLCompilerd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-            find_library(OSDependent_DLIB NAMES OSDependentd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-            find_library(HLSL_DLIB NAMES HLSLd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-            find_library(SPIRV_DLIB NAMES SPIRVd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-            find_library(SPIRV_REMAPPER_DLIB NAMES SPVRemapperd HINTS ${GLSLANG_DEBUG_SEARCH_PATH})
-
-            set_target_properties(glslang
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${GLSLANG_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${GLSLANG_DLIB}")
-            set_target_properties(OGLCompiler
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${OGLCompiler_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${OGLCompiler_DLIB}")
-            set_target_properties(OSDependent
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${OSDependent_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${OSDependent_DLIB}")
-            set_target_properties(HLSL
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${HLSL_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${HLSL_DLIB}")
-            set_target_properties(SPIRV
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${SPIRV_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${SPIRV_DLIB}")
-            set_target_properties(SPVRemapper
-                                  PROPERTIES IMPORTED_LOCATION
-                                             "${SPIRV_REMAPPER_LIB}"
-                                             IMPORTED_LOCATION_DEBUG
-                                             "${SPIRV_REMAPPER_DLIB}")
-
-            set(GLSLANG_LIBRARIES glslang OGLCompiler OSDependent HLSL SPIRV SPVRemapper ${SPIRV_TOOLS_LIBRARIES})
-        else()
-            set(GLSLANG_LIBRARIES
-                ${GLSLANG_LIB}
-                ${OGLCompiler_LIB}
-                ${OSDependent_LIB}
-                ${HLSL_LIB}
-                ${SPIRV_LIB}
-                ${SPIRV_REMAPPER_LIB}
-                ${SPIRV_TOOLS_LIBRARIES})
-        endif()
+        # Circular dependencies exist between glslang static libs, add them all as link dependencies for each other
+        foreach(GLSLANG_LIBRARY ${GLSLANG_LIBRARIES})
+            set_target_properties(${GLSLANG_LIBRARY}
+                                  PROPERTIES INTERFACE_LINK_LIBRARIES
+                                             "${GLSLANG_LIBRARIES}")
+        endforeach()
     else()
         set(GLSLANG_SPIRV_INCLUDE_DIR "${glslang_SOURCE_DIR}" CACHE PATH "Path to glslang spirv headers")
         set(GLSLANG_LIBRARIES glslang SPIRV SPVRemapper)

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "e00d27c6d65b7d3e72506a311d7f053da4051295"
+#define SPIRV_TOOLS_COMMIT_ID "3ee5f2f1d3316e228916788b300d786bb574d337"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit" : "e00d27c6d65b7d3e72506a311d7f053da4051295",
+      "commit" : "3ee5f2f1d3316e228916788b300d786bb574d337",
       "prebuild" : [
         "python update_glslang_sources.py"
       ],


### PR DESCRIPTION
KhronosGroup/glslang@b8c3386ec00b9de2925732c0a29c588d60f8c8fd split up
the glslang static library and resulted in some dependency cycles
between the new libraries that the Linux linker could not handle
properly. This change tells CMake about the imported static library
target dependencies via INTERFACE_LINK_LIBRARIES so it can invoke the
linker correctly on Linux. This was also a good opportunity to move
duplicated CMake code for importing the glslang libs into a common loop.

1.2.148 SDK glslang known-good update.

All changes passed internal CI on the latest master.