### PR TITLE
Syncval alpha sdk patch

### DIFF
--- a/docs/synchronization_usage.md
+++ b/docs/synchronization_usage.md
@@ -14,7 +14,7 @@
 
 Synchronization Validation (alpha release)
 
-Synchronization Validation is implemented in the `VK_LAYER_KHRONOS_validation layer`. When enabled, the Synchronization Object is intended to identify resource access conflicts due do missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.
+Synchronization Validation is implemented in the `VK_LAYER_KHRONOS_validation layer`. When enabled, the Synchronization Object is intended to identify resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.
 
 Synchronization will ideally be run periodically after resolving any outstanding validation checks from all other validation objects, so that issues may be addressed in early stages of development.
 

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -319,9 +319,9 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
 
 IndexType ImageRangeEncoder::Encode(const VkImageSubresource& subres, uint32_t layer, VkOffset3D offset) const {
     const auto& subres_layout = SubresourceLayout(subres);
-    return static_cast<IndexType>(ceil(layer * subres_layout.arrayPitch + offset.z * subres_layout.depthPitch +
-                                       offset.y * subres_layout.rowPitch +
-                                       offset.x * texel_sizes_[LowerBoundFromMask(subres.aspectMask)] + subres_layout.offset));
+    return static_cast<IndexType>(floor(layer * subres_layout.arrayPitch + offset.z * subres_layout.depthPitch +
+                                        offset.y * subres_layout.rowPitch +
+                                        offset.x * texel_sizes_[LowerBoundFromMask(subres.aspectMask)] + subres_layout.offset));
 }
 
 void ImageRangeEncoder::Decode(const VkImageSubresource& subres, const IndexType& encode, uint32_t& out_layer,
@@ -413,8 +413,8 @@ void ImageRangeGenerator::SetPos() {
             pos_.end += (subres_layout_->rowPitch * offset_y_count_);
         }
     } else {
-        pos_.end += static_cast<IndexType>(ceil(encoder_->TexelSize(aspect_index_) *
-                                                ((extent_.width > subres_extent.width) ? subres_extent.width : extent_.width)));
+        pos_.end += static_cast<IndexType>(floor(encoder_->TexelSize(aspect_index_) *
+                                                 ((extent_.width > subres_extent.width) ? subres_extent.width : extent_.width)));
     }
     offset_layer_base_ = pos_;
     offset_offset_y_base_ = pos_;


### PR DESCRIPTION
1. fixed log message.

2. Used floor instead of ceil. If using ceil to calculate memory address, it might be out of the memory size.