### PR TITLE
Arm PerfDoc Check 24 - Pipeline Bubble Tracking

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -140,5 +140,6 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_RobustBuffer
     "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess";
 static const char DECORATE_UNUSED *kVUID_BestPractices_EndRenderPass_DepthPrePassUsage =
     "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage";
+static const char DECORATE_UNUSED *kVUID_BestPractices_PipelineBubble = "UNASSIGNED-BestPractices-pipeline-bubble";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2354,3 +2354,87 @@ BestPractices::QueueTracker::StageFlags BestPractices::QueueTracker::vkStagesToT
 
     return flags;
 }
+
+void BestPractices::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                                 const VkImageResolve* pRegions) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
+                                               uint32_t regionCount, const VkBufferCopy* pRegions) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                              const VkImageCopy* pRegions) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
+                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
+                                                      const VkBufferImageCopy* pRegions) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                                      VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                              const VkImageBlit* pRegions, VkFilter filter) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
+                                               VkDeviceSize size, uint32_t data) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
+                                                 VkDeviceSize dataSize, const void* pData) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                    const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                    const VkImageSubresourceRange* pRanges) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                           const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                           const VkImageSubresourceRange* pRanges) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
+                                                         uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
+                                                         VkDeviceSize stride, VkQueryResultFlags flags) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_TRANSFER); });
+}
+
+void BestPractices::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
+                                             uint32_t groupCountZ) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_COMPUTE); });
+}
+
+void BestPractices::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
+    enqueued_fn_map[commandBuffer].push_back(
+        [this](VkQueue queue) { return queue_tracker_map[queue].pushWork(*this, QueueTracker::STAGE_COMPUTE); });
+}

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -264,6 +264,40 @@ class BestPractices : public ValidationStateTracker {
                                                      const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                      const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                      VkResult result, void* cgpl_state_data);
+    void PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                      VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
+                                      const VkImageResolve* pRegions);
+    void PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
+                                    const VkBufferCopy* pRegions);
+    void PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
+                                   VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy* pRegions);
+    void PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
+                                           VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy* pRegions);
+    void PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
+                                           VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions);
+    void PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
+                                   VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageBlit* pRegions,
+                                   VkFilter filter);
+    void PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize size,
+                                    uint32_t data);
+    void PreCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
+                                      VkDeviceSize dataSize, const void* pData);
+    void PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                         const VkClearColorValue* pColor, uint32_t rangeCount,
+                                         const VkImageSubresourceRange* pRanges);
+    void PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                const VkImageSubresourceRange* pRanges);
+    void PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
+                                              uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize stride,
+                                              VkQueryResultFlags flags);
+    void PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ);
+    void PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
+    void ManualPostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkEvent* event, VkResult result);
+    void ManualPostCalldRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator);
+    void ManualPostCallRecordResetEvent(VkDevice device, VkEvent event, VkResult result);
+    void ManualPostCallRecordSetEvent(VkDevice device, VkEvent event, VkResult result);
 
 // Include code-generated functions
 #include "best_practices.h"

--- a/layers/generated/best_practices.cpp
+++ b/layers/generated/best_practices.cpp
@@ -347,6 +347,7 @@ void BestPractices::PostCallRecordCreateEvent(
     VkEvent*                                    pEvent,
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateEvent(device, pCreateInfo, pAllocator, pEvent, result);
+    ManualPostCallRecordCreateEvent(device, pCreateInfo, pAllocator, pEvent, result);
     if (result != VK_SUCCESS) {
         static const std::vector<VkResult> error_codes = {VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY};
         static const std::vector<VkResult> success_codes = {};
@@ -371,6 +372,7 @@ void BestPractices::PostCallRecordSetEvent(
     VkEvent                                     event,
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetEvent(device, event, result);
+    ManualPostCallRecordSetEvent(device, event, result);
     if (result != VK_SUCCESS) {
         static const std::vector<VkResult> error_codes = {VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY};
         static const std::vector<VkResult> success_codes = {};
@@ -383,6 +385,7 @@ void BestPractices::PostCallRecordResetEvent(
     VkEvent                                     event,
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordResetEvent(device, event, result);
+    ManualPostCallRecordResetEvent(device, event, result);
     if (result != VK_SUCCESS) {
         static const std::vector<VkResult> error_codes = {VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY};
         static const std::vector<VkResult> success_codes = {};

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -110,6 +110,10 @@ class BestPracticesOutputGenerator(OutputGenerator):
             'vkQueuePresentKHR',
             'vkQueueBindSparse',
             'vkCreateGraphicsPipelines',
+            'vkCreateEvent',
+            'vkDestroyEvent',
+            'vkSetEvent',
+            'vkResetEvent',
             ]
 
         self.extension_info = dict()

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -279,7 +279,11 @@ class VkBestPracticesLayerTest : public VkLayerTest {
     VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
 };
 
-class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
+  protected:
+    // Allocates and submits a command buffer, defined by the lambda parameter, suitably for testing pipeline bubbles.
+    void SubmitPipelineBubbleTestWork(const std::function<void(VkCommandBuffer)> &work);
+};
 
 class VkWsiEnabledLayerTest : public VkLayerTest {
   public:


### PR DESCRIPTION
Hey there,

Here are some checks pertaining to tracking pipeline bubbles based on: work pushed to pipeline stages + various types of dependencies between pipeline stages (including pipeline barriers, subpass dependencies, and `VkEvent` dependencies).

These are some of the last checks explicitly ported from the original PerfDoc. Attilio started this quite a while ago, and I've since finished everything.

Let me know what you think.

Thanks,
Sam Walls