### PR TITLE
tests: avoid more dialog boxes

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3349,6 +3349,9 @@ int main(int argc, char **argv) {
 #endif
     // Avoid "Abort, Retry, Ignore" dialog boxes
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
It turns out Windows has a separate mechanism for pretty much anything
that can cause a test to fail.  Without these changes, there are still
a class of errors that can cause a broken test to hang, which wreaks
havoc with CI testing.

With these changes, the same commits that were causing trouble last
week now will issue messages to stderr and will exit, which
allows the error process to finish more quickly (~11 minutes, instead
of a timeout at 45), provides useful information as to what went
wrong, and (most importantly) doesn't leave a hung process on
the test system that can interfere with future test jobs.