### PR TITLE
Add VUID 01778

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11069,6 +11069,35 @@ bool CoreChecks::PreCallValidateImportFenceFdKHR(VkDevice device, const VkImport
     return ValidateImportFence(pImportFenceFdInfo->fence, "vkImportFenceFdKHR");
 }
 
+static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(VkSwapchainCreateInfoKHR const *pCreateInfo) {
+    VkImageCreateInfo result = {};
+    result.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    result.pNext = nullptr;
+
+    if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR)
+        result.flags |= VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
+    if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR) result.flags |= VK_IMAGE_CREATE_PROTECTED_BIT;
+    if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)
+        result.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+
+    result.imageType = VK_IMAGE_TYPE_2D;
+    result.format = pCreateInfo->imageFormat;
+    result.extent.width = pCreateInfo->imageExtent.width;
+    result.extent.height = pCreateInfo->imageExtent.height;
+    result.extent.depth = 1;
+    result.mipLevels = 1;
+    result.arrayLayers = pCreateInfo->imageArrayLayers;
+    result.samples = VK_SAMPLE_COUNT_1_BIT;
+    result.tiling = VK_IMAGE_TILING_OPTIMAL;
+    result.usage = pCreateInfo->imageUsage;
+    result.sharingMode = pCreateInfo->imageSharingMode;
+    result.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
+    result.pQueueFamilyIndices = pCreateInfo->pQueueFamilyIndices;
+    result.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    return result;
+}
+
 bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreateInfoKHR const *pCreateInfo,
                                          const SURFACE_STATE *surface_state, const SWAPCHAIN_NODE *old_swapchain_state) const {
     // All physical devices and queue families are required to be able to present to any native window on Android; require the
@@ -11383,6 +11412,93 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
                                                          "vkCreateBuffer", "pCreateInfo->pQueueFamilyIndices",
                                                          "VUID-VkSwapchainCreateInfoKHR-imageSharingMode-01428");
         if (skip1) return true;
+    }
+
+    // Validate pCreateInfo->imageUsage against GetPhysicalDeviceFormatProperties
+    const VkFormatProperties format_properties = GetPDFormatProperties(pCreateInfo->imageFormat);
+    const VkFormatFeatureFlags tiling_features = format_properties.optimalTilingFeatures;
+
+    if (tiling_features == 0) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL has no supported format features on this "
+                     "physical device.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    } else if ((pCreateInfo->imageUsage & VK_IMAGE_USAGE_SAMPLED_BIT) && !(tiling_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes "
+                     "VK_IMAGE_USAGE_SAMPLED_BIT.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    } else if ((pCreateInfo->imageUsage & VK_IMAGE_USAGE_STORAGE_BIT) && !(tiling_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes "
+                     "VK_IMAGE_USAGE_STORAGE_BIT.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    } else if ((pCreateInfo->imageUsage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) &&
+               !(tiling_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes "
+                     "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    } else if ((pCreateInfo->imageUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
+               !(tiling_features & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes "
+                     "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    } else if ((pCreateInfo->imageUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) &&
+               !(tiling_features & (VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT))) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s: pCreateInfo->imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes "
+                     "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.",
+                     func_name, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    }
+
+    const VkImageCreateInfo image_create_info = GetSwapchainImpliedImageCreateInfo(pCreateInfo);
+    VkImageFormatProperties image_properties = {};
+    const VkResult image_properties_result = DispatchGetPhysicalDeviceImageFormatProperties(
+        physical_device, image_create_info.format, image_create_info.imageType, image_create_info.tiling, image_create_info.usage,
+        image_create_info.flags, &image_properties);
+
+    if (!image_properties_result) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, "
+                     "when called for %s validation with following params: "
+                     "format: %s, imageType: %s, "
+                     "tiling: %s, usage: %s, "
+                     "flags: %s.",
+                     func_name, string_VkFormat(image_create_info.format), string_VkImageType(image_create_info.imageType),
+                     string_VkImageTiling(image_create_info.tiling), string_VkImageUsageFlags(image_create_info.usage).c_str(),
+                     string_VkImageCreateFlags(image_create_info.flags).c_str()))
+            return true;
+    }
+
+    // Validate pCreateInfo->imageArrayLayers against VkImageFormatProperties::maxArrayLayers
+    if (pCreateInfo->imageArrayLayers > image_properties.maxArrayLayers) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s called with a non-supported imageArrayLayers (i.e. %d). "
+                     "Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is %d "
+                     "for imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL",
+                     func_name, pCreateInfo->imageArrayLayers, image_properties.maxArrayLayers,
+                     string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
+    }
+
+    // Validate pCreateInfo->imageExtent against VkImageFormatProperties::maxExtent
+    if ((pCreateInfo->imageExtent.width > image_properties.maxExtent.width) ||
+        (pCreateInfo->imageExtent.height > image_properties.maxExtent.height)) {
+        if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778",
+                     "%s called with imageExtent = (%d,%d), which is bigger than max extent (%d,%d)"
+                     "returned by vkGetPhysicalDeviceImageFormatProperties(): "
+                     "for imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL",
+                     func_name, pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height, image_properties.maxExtent.width,
+                     image_properties.maxExtent.height, string_VkFormat(pCreateInfo->imageFormat)))
+            return true;
     }
 
     return skip;

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -11902,6 +11902,114 @@ TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
     vk::DestroyBuffer(device(), buffer_export, nullptr);
 }
 
+TEST_F(VkLayerTest, ValidSwapchainImageParams) {
+    TEST_DESCRIPTION("Swapchain with invalid implied image creation parameters");
+    const char *vuid = "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778";
+
+    if (!AddSurfaceInstanceExtension()) {
+        printf("%s surface extensions not supported, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (!AddSwapchainDeviceExtension()) {
+        printf("%s swapchain extensions not supported, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (!InitSurface()) {
+        printf("%s Cannot create surface, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    VkSurfaceCapabilitiesKHR capabilities;
+    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(m_device->phy().handle(), m_surface, &capabilities);
+
+    uint32_t format_count;
+    vk::GetPhysicalDeviceSurfaceFormatsKHR(m_device->phy().handle(), m_surface, &format_count, nullptr);
+    vector<VkSurfaceFormatKHR> formats;
+    if (format_count != 0) {
+        formats.resize(format_count);
+        vk::GetPhysicalDeviceSurfaceFormatsKHR(m_device->phy().handle(), m_surface, &format_count, formats.data());
+    }
+
+    uint32_t present_mode_count;
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(m_device->phy().handle(), m_surface, &present_mode_count, nullptr);
+    vector<VkPresentModeKHR> present_modes;
+    if (present_mode_count != 0) {
+        present_modes.resize(present_mode_count);
+        vk::GetPhysicalDeviceSurfacePresentModesKHR(m_device->phy().handle(), m_surface, &present_mode_count, present_modes.data());
+    }
+
+    VkSwapchainCreateInfoKHR good_create_info = {};
+    good_create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    good_create_info.pNext = 0;
+    good_create_info.surface = m_surface;
+    good_create_info.minImageCount = capabilities.minImageCount;
+    good_create_info.imageFormat = formats[0].format;
+    good_create_info.imageColorSpace = formats[0].colorSpace;
+    good_create_info.imageExtent = {capabilities.minImageExtent.width, capabilities.minImageExtent.height};
+    good_create_info.imageArrayLayers = 1;
+    good_create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    good_create_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    good_create_info.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    good_create_info.compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+#else
+    good_create_info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+#endif
+    good_create_info.presentMode = present_modes[0];
+    good_create_info.clipped = VK_FALSE;
+    good_create_info.oldSwapchain = 0;
+
+    VkSwapchainCreateInfoKHR create_info_bad_usage = good_create_info;
+    bool found_bad_usage = false;
+    // Trying to find format+usage combination supported by surface, but not supported by image.
+    const std::array<VkImageUsageFlags, 5> kImageUsageFlags = {{
+        VK_IMAGE_USAGE_SAMPLED_BIT,
+        VK_IMAGE_USAGE_STORAGE_BIT,
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+        VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT,
+    }};
+
+    for (uint32_t i = 0; i < kImageUsageFlags.size() && !found_bad_usage; ++i) {
+        if ((capabilities.supportedUsageFlags & kImageUsageFlags[i]) != 0) {
+            for (uint32_t j = 0; j < format_count; ++j) {
+                VkImageFormatProperties image_format_properties = {};
+                VkResult image_format_properties_result = vk::GetPhysicalDeviceImageFormatProperties(
+                    m_device->phy().handle(), formats[j].format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, kImageUsageFlags[i], 0,
+                    &image_format_properties);
+
+                if (image_format_properties_result != VK_SUCCESS) {
+                    create_info_bad_usage.imageFormat = formats[j].format;
+                    create_info_bad_usage.imageUsage = kImageUsageFlags[i];
+                    found_bad_usage = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!found_bad_usage) {
+        printf(
+            "%s could not find imageFormat and imageUsage values, supported by "
+            "surface but unsupported by image, skipping test\n",
+            kSkipPrefix);
+        return;
+    }
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkSwapchainCreateInfoKHR-surface-01270");
+    vk::CreateSwapchainKHR(device(), &create_info_bad_usage, nullptr, &m_swapchain);
+    m_errorMonitor->VerifyFound();
+
+    DestroySwapchain();
+}
+
 TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     if (DeviceExtensionSupported(gpu(), nullptr, VK_AMD_BUFFER_MARKER_EXTENSION_NAME)) {


### PR DESCRIPTION
Implemented validation VUID-VkSwapchainCreateInfoKHR-imageFormat-01778. 
_The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties_

Also added test for this VUID. Test is running vkCreateSwapchainKHR with imageUsage and imageFormat params, that meet GetPhysicalDeviceSurfaceCapabilitiesKHR capabilities, but confirmed to fail vkGetPhysicalDeviceImageFormatProperties function. Not trying to make it fail with imageArrayLayers or imageExtent params, since I wasn't able to get right values for that in my setup.

Partially used code from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/496 pull request that was adding same VUID, but hasn't been merged ever since, and outdated a bit.

In Mesa we already had several issues created which should have been avoided if this validation was present, i.e. https://gitlab.freedesktop.org/mesa/mesa/-/issues/3201 and https://gitlab.freedesktop.org/mesa/mesa/-/issues/178