### PR TITLE
If image view do atomic operations, the format MUST support VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1057,9 +1057,12 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                             if (descriptor.second.input_index < static_cast<int32_t>(subpass.inputAttachmentCount)) {
                                 subpass_input_in_fs[descriptor.second.input_index] = true;
                             } else {
-                                result |= LogError(cb_node->commandBuffer, vuid.subpass_input,
-                                                   "%s: Fragment Shader's input attachment index #%d doesn't exist in %s, subpass "
-                                                   "#%d.",
+                                LogObjectList objlist(cb_node->commandBuffer);
+                                objlist.add(cb_node->activeRenderPass->renderPass);
+                                result |= LogError(objlist, vuid.subpass_input,
+                                                   "%s: Fragment Shader's input attachment index #%" PRIu32
+                                                   " doesn't exist in %s, subpass "
+                                                   "#%" PRIu32 ".",
                                                    function, descriptor.second.input_index,
                                                    report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
                                                    cb_node->activeSubpass);
@@ -1069,8 +1072,11 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                     uint32_t index = 0;
                     for (const auto input : subpass_input_in_fs) {
                         if (!input && subpass.pInputAttachments[index].attachment != VK_ATTACHMENT_UNUSED) {
-                            result |= LogError(cb_node->commandBuffer, vuid.subpass_input,
-                                               "%s: %s, subpass #%d, input attachment #%d is not used in fragment shader.",
+                            LogObjectList objlist(cb_node->commandBuffer);
+                            objlist.add(cb_node->activeRenderPass->renderPass);
+                            result |= LogError(objlist, vuid.subpass_input,
+                                               "%s: %s, subpass #%" PRIu32 ", input attachment #%" PRIu32
+                                               " is not used in fragment shader.",
                                                function, report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
                                                cb_node->activeSubpass, index);
                         }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -53,6 +53,7 @@ struct DrawDispatchVuid {
     const char* primitive_topology;
     const char* corner_sampled_address_mode;
     const char* subpass_input;
+    const char* imageview_atomic;
 };
 
 typedef struct {
@@ -973,6 +974,12 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) const;
     bool PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                         uint32_t stride) const;
+    bool PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
+                                        uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
+                                        uint32_t groupCountZ) const;
+    bool PreCallValidateCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
+                                           uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
+                                           uint32_t groupCountZ) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
     bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -160,6 +160,8 @@ enum descriptor_req {
     DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT = DESCRIPTOR_REQ_MULTI_SAMPLE << 1,
     DESCRIPTOR_REQ_COMPONENT_TYPE_SINT = DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT << 1,
     DESCRIPTOR_REQ_COMPONENT_TYPE_UINT = DESCRIPTOR_REQ_COMPONENT_TYPE_SINT << 1,
+
+    DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION = DESCRIPTOR_REQ_COMPONENT_TYPE_UINT << 1,
 };
 
 extern unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt);
@@ -372,6 +374,7 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
     VkBufferView buffer_view;
     VkBufferViewCreateInfo create_info;
     std::shared_ptr<BUFFER_STATE> buffer_state;
+    VkFormatFeatureFlags format_features;
     BUFFER_VIEW_STATE(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci)
         : buffer_view(bv), create_info(*ci), buffer_state(bf){};
     BUFFER_VIEW_STATE(const BUFFER_VIEW_STATE &rh_obj) = delete;
@@ -801,6 +804,7 @@ struct interface_var {
     bool is_block_member;
     bool is_relaxed_precision;
     bool is_writable;
+    bool is_atomic_operation;
     // TODO: collect the name, too? Isn't required to be present.
 };
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -64,6 +64,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-primitiveTopology-03420",
         "VUID-vkCmdDraw-flags-02696",
         "VUID-vkCmdDraw-None-02686",
+        "VUID-vkCmdDraw-None-02691",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -87,6 +88,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-primitiveTopology-03420",
         "VUID-vkCmdDrawIndexed-flags-02696",
         "VUID-vkCmdDrawIndexed-None-02686",
+        "VUID-vkCmdDrawIndexed-None-02691",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -110,6 +112,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-primitiveTopology-03420",
         "VUID-vkCmdDrawIndirect-flags-02696",
         "VUID-vkCmdDrawIndirect-None-02686",
+        "VUID-vkCmdDrawIndirect-None-02691",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -133,6 +136,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-primitiveTopology-03420",
         "VUID-vkCmdDrawIndexedIndirect-flags-02696",
         "VUID-vkCmdDrawIndexedIndirect-None-02686",
+        "VUID-vkCmdDrawIndexedIndirect-None-02691",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -156,6 +160,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          kVUIDUndefined, // primitive_topology
          "VUID-vkCmdDispatch-flags-02696",
          kVUIDUndefined, // subpass_input
+         "VUID-vkCmdDispatch-None-02691",
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -179,6 +184,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // primitive_topology
         "VUID-vkCmdDispatchIndirect-flags-02696",
         kVUIDUndefined, // subpass_input
+        "VUID-vkCmdDispatchIndirect-None-02691",
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -202,6 +208,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-primitiveTopology-03420",
         "VUID-vkCmdDrawIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndirectCount-None-02686",
+        "VUID-vkCmdDrawIndirectCount-None-02691",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -225,6 +232,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-primitiveTopology-03420",
         "VUID-vkCmdDrawIndexedIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02686",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02691",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -248,6 +256,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // primitive_topology
         "VUID-vkCmdTraceRaysNV-flags-02696",
         kVUIDUndefined, // subpass_input
+        "VUID-vkCmdTraceRaysNV-None-02691",
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -271,6 +280,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // primitive_topology
         "VUID-vkCmdTraceRaysKHR-flags-02696",
         kVUIDUndefined, // subpass_input
+        "VUID-vkCmdTraceRaysKHR-None-02691",
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -294,6 +304,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // primitive_topology
         "VUID-vkCmdTraceRaysIndirectKHR-flags-02696",
         kVUIDUndefined, // subpass_input
+        "VUID-vkCmdTraceRaysIndirectKHR-None-02691",
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -317,6 +328,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-primitiveTopology-03420",
         "VUID-vkCmdDrawMeshTasksNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksNV-None-02686",
+        "VUID-vkCmdDrawMeshTasksNV-None-02691",
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -340,6 +352,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-primitiveTopology-03420",
         "VUID-vkCmdDrawMeshTasksIndirectNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02686",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-None-02691",
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -363,6 +376,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-primitiveTopology-03420",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02686",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02691",
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -386,9 +400,36 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-primitiveTopology-03420",
         "VUID-vkCmdDrawIndirectByteCountEXT-flags-02696",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02686",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02691",
+    }},
+    {CMD_DISPATCHBASE, {
+        "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
+        "VUID-vkCmdDispatchBase-renderpass",
+        "VUID-vkCmdDispatchBase-None-02700",
+         kVUIDUndefined, // dynamic_state
+         kVUIDUndefined, // vertex_binding
+         kVUIDUndefined, // vertex_binding_null
+         "VUID-vkCmdDispatchBase-None-02697",
+         kVUIDUndefined, // render_pass_compatible
+         kVUIDUndefined, // subpass_index
+         kVUIDUndefined, // sample_location
+         "VUID-vkCmdDispatchBase-None-02690",
+         "VUID-vkCmdDispatchBase-None-02692",
+         kVUIDUndefined, // indirect_protected_cb
+         kVUIDUndefined, // indirect_contiguous_memory;
+         kVUIDUndefined, // indirect_buffer_bit
+         kVUIDUndefined, // viewport_count
+         kVUIDUndefined, // scissor_count
+         kVUIDUndefined, // viewport_scissor_count
+         kVUIDUndefined, // primitive_topology
+         "VUID-vkCmdDispatchBase-flags-02696",
+         kVUIDUndefined, // subpass_input
+         "VUID-vkCmdDispatchBase-None-02691",
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
@@ -512,6 +553,24 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBu
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) const {
     bool skip = false;
     skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCH, "vkCmdDispatch()",
+                                VK_QUEUE_COMPUTE_BIT);
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
+                                                uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
+                                                uint32_t groupCountZ) const {
+    bool skip = false;
+    skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCHBASE, "vkCmdDispatchBase()",
+                                VK_QUEUE_COMPUTE_BIT);
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
+                                                   uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
+                                                   uint32_t groupCountZ) const {
+    bool skip = false;
+    skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_COMPUTE, CMD_DISPATCHBASE, "vkCmdDispatchBaseKHR()",
                                 VK_QUEUE_COMPUTE_BIT);
     return skip;
 }

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -188,6 +188,9 @@ bool ImageFormatAndFeaturesSupported(VkPhysicalDevice phy, VkFormat format, VkIm
 bool ImageFormatAndFeaturesSupported(const VkInstance inst, const VkPhysicalDevice phy, const VkImageCreateInfo info,
                                      const VkFormatFeatureFlags features);
 
+// Returns true if format and *all* requested features are available.
+bool BufferFormatAndFeaturesSupported(VkPhysicalDevice phy, VkFormat format, VkFormatFeatureFlags features);
+
 // Simple sane SamplerCreateInfo boilerplate
 VkSamplerCreateInfo SafeSaneSamplerCreateInfo();
 
@@ -377,20 +380,21 @@ struct OneOffDescriptorSet {
     typedef std::vector<VkDescriptorSetLayoutBinding> Bindings;
     std::vector<VkDescriptorBufferInfo> buffer_infos;
     std::vector<VkDescriptorImageInfo> image_infos;
+    std::vector<VkBufferView> buffer_views;
     std::vector<VkWriteDescriptorSet> descriptor_writes;
 
     OneOffDescriptorSet(VkDeviceObj *device, const Bindings &bindings, VkDescriptorSetLayoutCreateFlags layout_flags = 0,
                         void *layout_pnext = NULL, VkDescriptorPoolCreateFlags poolFlags = 0, void *allocate_pnext = NULL,
-                        int buffer_info_size = 10, int image_info_size = 10);
+                        int buffer_info_size = 10, int image_info_size = 10, int buffer_view_size = 10);
     ~OneOffDescriptorSet();
     bool Initialized();
     void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize size,
-                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uint32_t count = 1);
     void WriteDescriptorBufferView(int binding, VkBufferView &buffer_view,
-                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, uint32_t count = 1);
     void WriteDescriptorImageInfo(int binding, VkImageView image_view, VkSampler sampler,
                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                  VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                                  VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, uint32_t count = 1);
     void UpdateDescriptorSets();
 };
 


### PR DESCRIPTION
#135 
```
VUID-vkCmdDraw-None-02691
VUID-vkCmdDrawIndexed-None-02691
VUID-vkCmdDrawIndirect-None-02691
VUID-vkCmdDrawIndirectCount-None-02691
VUID-vkCmdDrawIndexedIndirect-None-02691
VUID-vkCmdDrawIndexedIndirectCount-None-02691
VUID-vkCmdDrawIndirectByteCountEXT-None-02691
VUID-vkCmdDrawMeshTasksNV-None-02691
VUID-vkCmdDrawMeshTasksIndirectNV-None-02691
VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02691
VUID-vkCmdDispatch-None-02691
VUID-vkCmdDispatchIndirect-None-02691
VUID-vkCmdTraceRaysNV-None-02691
VUID-vkCmdTraceRaysKHR-None-02691
VUID-vkCmdTraceRaysIndirectKHR-None-02691
VUID-vkCmdDispatchBase-None-02691 vkCmdDispatchBaseKHR

If a VkImageView is accessed using atomic operations as a result of this command, then the image view’s format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT
```