### PR TITLE
layers: Fix vkconfig setting path lookup (Admin)

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -201,7 +201,7 @@ static inline bool IsHighIntegrity() {
         uint8_t mandatory_label_buffer[SECURITY_MAX_SID_SIZE + sizeof(uint32_t)];
         uint32_t buffer_size;
         if (GetTokenInformation(process_token, TokenIntegrityLevel, mandatory_label_buffer, sizeof(mandatory_label_buffer),
-                                &buffer_size) != 0) {
+                                reinterpret_cast<PDWORD>(&buffer_size)) != 0) {
             const TOKEN_MANDATORY_LABEL *mandatory_label = (const TOKEN_MANDATORY_LABEL *)mandatory_label_buffer;
             const uint32_t sub_authority_count = *GetSidSubAuthorityCount(mandatory_label->Label.Sid);
             const uint32_t integrity_level = *GetSidSubAuthority(mandatory_label->Label.Sid, sub_authority_count - 1);
@@ -232,8 +232,9 @@ string ConfigFile::FindSettings() {
         if (err == ERROR_SUCCESS) {
             char name[2048];
             uint32_t i = 0, name_size, type, value, value_size;
-            while (ERROR_SUCCESS == RegEnumValue(key, i++, name, &(name_size = sizeof(name)), nullptr, &type,
-                                                 reinterpret_cast<LPBYTE>(&value), &(value_size = sizeof(value)))) {
+            while (ERROR_SUCCESS == RegEnumValue(key, i++, name, reinterpret_cast<LPDWORD>(&(name_size = sizeof(name))), nullptr,
+                                                 reinterpret_cast<LPDWORD>(&type), reinterpret_cast<LPBYTE>(&value),
+                                                 reinterpret_cast<LPDWORD>(&(value_size = sizeof(value))))) {
                 // Check if the registry entry is a dword with a value of zero
                 if (type != REG_DWORD || value != 0) {
                     continue;

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -198,13 +198,13 @@ static inline bool IsHighIntegrity() {
     HANDLE process_token;
     if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY | TOKEN_QUERY_SOURCE, &process_token)) {
         // Maximum possible size of SID_AND_ATTRIBUTES is maximum size of a SID + size of attributes DWORD.
-        uint8_t mandatory_label_buffer[SECURITY_MAX_SID_SIZE + sizeof(DWORD)];
-        DWORD buffer_size;
+        uint8_t mandatory_label_buffer[SECURITY_MAX_SID_SIZE + sizeof(uint32_t)];
+        uint32_t buffer_size;
         if (GetTokenInformation(process_token, TokenIntegrityLevel, mandatory_label_buffer, sizeof(mandatory_label_buffer),
                                 &buffer_size) != 0) {
             const TOKEN_MANDATORY_LABEL *mandatory_label = (const TOKEN_MANDATORY_LABEL *)mandatory_label_buffer;
-            const DWORD sub_authority_count = *GetSidSubAuthorityCount(mandatory_label->Label.Sid);
-            const DWORD integrity_level = *GetSidSubAuthority(mandatory_label->Label.Sid, sub_authority_count - 1);
+            const uint32_t sub_authority_count = *GetSidSubAuthorityCount(mandatory_label->Label.Sid);
+            const uint32_t integrity_level = *GetSidSubAuthority(mandatory_label->Label.Sid, sub_authority_count - 1);
 
             CloseHandle(process_token);
             return integrity_level > SECURITY_MANDATORY_MEDIUM_RID;
@@ -231,7 +231,7 @@ string ConfigFile::FindSettings() {
         LSTATUS err = RegOpenKeyEx(hives[hive_index], "Software\\Khronos\\Vulkan\\Settings", 0, KEY_READ, &key);
         if (err == ERROR_SUCCESS) {
             char name[2048];
-            DWORD i = 0, name_size, type, value, value_size;
+            uint32_t i = 0, name_size, type, value, value_size;
             while (ERROR_SUCCESS == RegEnumValue(key, i++, name, &(name_size = sizeof(name)), nullptr, &type,
                                                  reinterpret_cast<LPBYTE>(&value), &(value_size = sizeof(value)))) {
                 // Check if the registry entry is a dword with a value of zero

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -26,6 +26,13 @@
 #include "vulkan/vk_layer.h"
 #include "vulkan/vulkan.h"
 
+#if defined(WIN32)
+#define DEFAULT_VK_REGISTRY_HIVE HKEY_LOCAL_MACHINE
+#define DEFAULT_VK_REGISTRY_HIVE_STR "HKEY_LOCAL_MACHINE"
+#define SECONDARY_VK_REGISTRY_HIVE HKEY_CURRENT_USER
+#define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Settings lookup for windows registry was hardcoded to HKCU.
Use HKLM when in running as admin.
When running as standard user, additionally check HKCU.

fix #2094