### PR TITLE
Fix crash in vkAcquirePerformanceConfigurationINTEL

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -7062,11 +7062,10 @@ VkResult DispatchAcquirePerformanceConfigurationINTEL(
 {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     if (!wrap_handles) return layer_data->device_dispatch_table.AcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration);
-    {
-        pConfiguration = layer_data->Unwrap(pConfiguration);
-    }
     VkResult result = layer_data->device_dispatch_table.AcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration);
-
+    if (VK_SUCCESS == result) {
+        *pConfiguration = layer_data->WrapNew(*pConfiguration);
+    }
     return result;
 }
 

--- a/layers/generated/object_tracker.h
+++ b/layers/generated/object_tracker.h
@@ -2309,6 +2309,11 @@ bool PreCallValidateAcquirePerformanceConfigurationINTEL(
     VkDevice                                    device,
     const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
     VkPerformanceConfigurationINTEL*            pConfiguration) const;
+void PostCallRecordAcquirePerformanceConfigurationINTEL(
+    VkDevice                                    device,
+    const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
+    VkPerformanceConfigurationINTEL*            pConfiguration,
+    VkResult                                    result);
 bool PreCallValidateReleasePerformanceConfigurationINTEL(
     VkDevice                                    device,
     VkPerformanceConfigurationINTEL             configuration) const;

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -927,6 +927,13 @@ bool ObjectLifetimes::PreCallValidateAcquirePerformanceConfigurationINTEL(
     return skip;
 }
 
+void ObjectLifetimes::PostCallRecordAcquirePerformanceConfigurationINTEL(
+    VkDevice device, const VkPerformanceConfigurationAcquireInfoINTEL *pAcquireInfo,
+    VkPerformanceConfigurationINTEL *pConfiguration, VkResult result) {
+    if (result != VK_SUCCESS) return;
+    CreateObject(*pConfiguration, kVulkanObjectTypePerformanceConfigurationINTEL, nullptr);
+}
+
 bool ObjectLifetimes::PreCallValidateReleasePerformanceConfigurationINTEL(VkDevice device,
                                                                           VkPerformanceConfigurationINTEL configuration) const {
     bool skip = false;

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1757,8 +1757,8 @@ void DispatchGetPrivateDataEXT(
             elif type in struct_member_dict:
                 if self.struct_contains_ndo(type) == True:
                     islocal = True
-            isdestroy = True if True in [destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free']] else False
-            iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent']] else False
+            isdestroy = True if True in [destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free', 'ReleasePerformanceConfigurationINTEL']] else False
+            iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL']] else False
             extstructs = self.registry.validextensionstructs[type] if name == 'pNext' else None
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -910,10 +910,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         struct_member_dict = dict(self.structMembers)
 
         # Set command invariant information needed at a per member level in validate...
-        is_create_command = any(filter(lambda pat: pat in cmdname, ('Create', 'Allocate', 'Enumerate', 'RegisterDeviceEvent', 'RegisterDisplayEvent')))
+        is_create_command = any(filter(lambda pat: pat in cmdname, ('Create', 'Allocate', 'Enumerate', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL')))
         last_member_is_pointer = len(members) and self.paramIsPointer(members[-1])
         iscreate = is_create_command or ('vkGet' in cmdname and last_member_is_pointer)
-        isdestroy = any([destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free']])
+        isdestroy = any([destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free', 'ReleasePerformanceConfigurationINTEL']])
 
         # Generate member info
         membersInfo = []


### PR DESCRIPTION
The issue is that this entry point isn't considered as a create
function so it would try to dereference one of the argument which
hasn't been filled by the implementation.