### PR TITLE
Validate if push constants doesn't update and image subresources are used in attachments and descriptor sets

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1174,6 +1174,29 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point)
         result |= ValidatePipelineDrawtimeState(state, cb_node, cmd_type, pPipe, function);
 
+    // Verify if push constants have been set
+    if (pipeline_layout->push_constant_ranges != cb_node->push_constant_data_ranges) {
+        LogObjectList objlist(cb_node->commandBuffer);
+        objlist.add(cb_node->push_constant_pipeline_layout_set);
+        objlist.add(pipeline_layout->layout);
+        objlist.add(pPipe->pipeline);
+        result |= LogError(
+            objlist, vuid.push_constants_set, "The active push constants of %s isn't compatible with %s of active %s.",
+            report_data->FormatHandle(cb_node->push_constant_pipeline_layout_set).c_str(),
+            report_data->FormatHandle(pipeline_layout->layout).c_str(), report_data->FormatHandle(pPipe->pipeline).c_str());
+    } else {
+        const auto size = cb_node->push_constant_data_set.size();
+        if (size > 0) {
+            const auto *data = cb_node->push_constant_data_set.data();
+            if ((*data != 0) || std::memcmp(data, data + 1, size - 1) != 0) {
+                LogObjectList objlist(cb_node->commandBuffer);
+                objlist.add(pipeline_layout->layout);
+                result |=
+                    LogError(objlist, vuid.push_constants_set, "Not every byte in the push constant ranges of %s have been set.",
+                             report_data->FormatHandle(pipeline_layout->layout).c_str());
+            }
+        }
+    }
     return result;
 }
 
@@ -7962,12 +7985,14 @@ bool CoreChecks::PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, 
             if ((offset >= range.offset) && (offset + size <= range.offset + range.size)) {
                 VkShaderStageFlags matching_stages = range.stageFlags & stageFlags;
                 if (matching_stages != range.stageFlags) {
-                    skip |= LogError(commandBuffer, "VUID-vkCmdPushConstants-offset-01796",
-                                     "vkCmdPushConstants(): stageFlags (0x%" PRIx32 ", offset (%" PRIu32 "), and size (%" PRIu32
-                                     "),  must contain all stages in overlapping VkPushConstantRange stageFlags (0x%" PRIx32
-                                     "), offset (%" PRIu32 "), and size (%" PRIu32 ") in %s.",
-                                     (uint32_t)stageFlags, offset, size, (uint32_t)range.stageFlags, range.offset, range.size,
-                                     report_data->FormatHandle(layout).c_str());
+                    skip |=
+                        LogError(commandBuffer, "VUID-vkCmdPushConstants-offset-01796",
+                                 "vkCmdPushConstants(): stageFlags (%s, offset (%" PRIu32 "), and size (%" PRIu32
+                                 "),  must contain all stages in overlapping VkPushConstantRange stageFlags (%s), offset (%" PRIu32
+                                 "), and size (%" PRIu32 ") in %s.",
+                                 string_VkShaderStageFlags(stageFlags).c_str(), offset, size,
+                                 string_VkShaderStageFlags(range.stageFlags).c_str(), range.offset, range.size,
+                                 report_data->FormatHandle(layout).c_str());
                 }
 
                 // Accumulate all stages we've found

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1039,6 +1039,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
 
     bool result = false;
     auto const &state = last_bound_it->second;
+    std::vector<VkImageView> attachment_views;
 
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point) {
         // First check flag states
@@ -1085,6 +1086,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 }
             }
         }
+        attachment_views = cb_node->activeFramebuffer->GetUsedAttachments(subpass);
     }
     // Now complete other state checks
     string errorString;
@@ -1161,10 +1163,10 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                         state.per_set[setIndex].validated_set_binding_req_map.end(),
                                         std::inserter(delta_reqs, delta_reqs.begin()));
                     result |= ValidateDrawState(descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets, cb_node,
-                                                setIndex, function, vuid);
+                                                attachment_views, function, vuid);
                 } else {
                     result |= ValidateDrawState(descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets, cb_node,
-                                                setIndex, function, vuid);
+                                                attachment_views, function, vuid);
                 }
             }
         }
@@ -2769,14 +2771,16 @@ bool CoreChecks::ValidateCommandBuffersForSubmit(VkQueue queue, const VkSubmitIn
             for (auto descriptorSet : cb_node->validate_descriptorsets_in_queuesubmit) {
                 const cvdescriptorset::DescriptorSet *set_node = GetSetNode(descriptorSet.first);
                 if (set_node) {
-                    for (auto pipe : descriptorSet.second) {
-                        for (auto binding : pipe.second) {
+                    for (auto cmd_info : descriptorSet.second) {
+                        std::string function = "vkQueueSubmit(), ";
+                        function += cmd_info.function;
+                        for (auto binding : cmd_info.binding_infos) {
                             std::string error;
                             std::vector<uint32_t> dynamicOffsets;
                             // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
-                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamicOffsets, binding.first,
-                                                                     binding.second.requirements, "vkQueueSubmit()",
-                                                                     GetDrawDispatchVuid(binding.second.cmd_type));
+                            skip |= ValidateDescriptorSetBindingData(
+                                cb_node, set_node, dynamicOffsets, binding.binding, binding.requirements, cmd_info.framebuffer,
+                                cmd_info.attachment_views, function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
                         }
                     }
                 }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -55,6 +55,7 @@ struct DrawDispatchVuid {
     const char* subpass_input;
     const char* imageview_atomic;
     const char* push_constants_set;
+    const char* image_subresources;
 };
 
 typedef struct {
@@ -372,10 +373,12 @@ class CoreChecks : public ValidationStateTracker {
                                                 void* pData);
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const cvdescriptorset::DescriptorSet* descriptor_set, const std::map<uint32_t, descriptor_req>& bindings,
-                           const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE* cb_node, uint32_t setIndex,
-                           const char* caller, const DrawDispatchVuid& vuids) const;
+                           const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE* cb_node,
+                           const std::vector<VkImageView>& attachment_views, const char* caller,
+                           const DrawDispatchVuid& vuids) const;
     bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node, const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets, uint32_t binding, descriptor_req reqs,
+                                          VkFramebuffer framebuffer, const std::vector<VkImageView>& attachment_views,
                                           const char* caller, const DrawDispatchVuid& vuids) const;
 
     // Validate contents of a CopyUpdate

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -54,6 +54,7 @@ struct DrawDispatchVuid {
     const char* corner_sampled_address_mode;
     const char* subpass_input;
     const char* imageview_atomic;
+    const char* push_constants_set;
 };
 
 typedef struct {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1250,6 +1250,10 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::vector<uint8_t> push_constant_data;
     PushConstantRangesId push_constant_data_ranges;
 
+    std::vector<uint8_t> push_constant_data_set;  // If a byte is set or a byte is not used in push_constant_rage, the value of byte
+                                                  // is 0, so if the whole is set, the whole value is 0.
+    VkPipelineLayout push_constant_pipeline_layout_set;
+
     // Used for Best Practices tracking
     uint32_t small_indexed_draw_call_count;
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -629,7 +629,7 @@ class DescriptorSet : public BASE_NODE {
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *, CMD_TYPE cmd_type, const PIPELINE_STATE *,
-                         const std::map<uint32_t, descriptor_req> &);
+                         const std::map<uint32_t, descriptor_req> &, const char *function);
 
     // Track work that has been bound or validated to avoid duplicate work, important when large descriptor arrays
     // are present

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -66,6 +66,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-None-02686",
         "VUID-vkCmdDraw-None-02691",
         "VUID-vkCmdDraw-None-02698",
+        "VUID-vkCmdDraw-None-02687",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -91,6 +92,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-None-02686",
         "VUID-vkCmdDrawIndexed-None-02691",
         "VUID-vkCmdDrawIndexed-None-02698",
+        "VUID-vkCmdDrawIndexed-None-02687",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -116,6 +118,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-None-02686",
         "VUID-vkCmdDrawIndirect-None-02691",
         "VUID-vkCmdDrawIndirect-None-02698",
+        "VUID-vkCmdDrawIndirect-None-02687",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -141,6 +144,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-None-02686",
         "VUID-vkCmdDrawIndexedIndirect-None-02691",
         "VUID-vkCmdDrawIndexedIndirect-None-02698",
+        "VUID-vkCmdDrawIndexedIndirect-None-02687",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -166,6 +170,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatch-None-02691",
          "VUID-vkCmdDispatch-None-02698",
+         kVUIDUndefined, // image_subresources
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -191,6 +196,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdDispatchIndirect-None-02691",
         "VUID-vkCmdDispatchIndirect-None-02698",
+        kVUIDUndefined, // image_subresources
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -216,6 +222,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-None-02686",
         "VUID-vkCmdDrawIndirectCount-None-02691",
         "VUID-vkCmdDrawIndirectCount-None-02698",
+        "VUID-vkCmdDrawIndirectCount-None-02687",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -241,6 +248,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-None-02686",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02691",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02698",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02687",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -266,6 +274,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysNV-None-02691",
         "VUID-vkCmdTraceRaysNV-None-02698",
+         kVUIDUndefined, // image_subresources
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -291,6 +300,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysKHR-None-02691",
         "VUID-vkCmdTraceRaysKHR-None-02698",
+         kVUIDUndefined, // image_subresources
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -316,6 +326,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysIndirectKHR-None-02691",
         "VUID-vkCmdTraceRaysIndirectKHR-None-02698",
+         kVUIDUndefined, // image_subresources
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -341,6 +352,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-None-02686",
         "VUID-vkCmdDrawMeshTasksNV-None-02691",
         "VUID-vkCmdDrawMeshTasksNV-None-02698",
+        "VUID-vkCmdDrawMeshTasksNV-None-02687",
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -366,6 +378,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02691",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02698",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-None-02687",
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -391,6 +404,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02691",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02698",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02687",
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -416,6 +430,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02686",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02691",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02698",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02687",
     }},
     {CMD_DISPATCHBASE, {
         "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
@@ -441,9 +456,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatchBase-None-02691",
          "VUID-vkCmdDispatchBase-None-02698",
+         kVUIDUndefined, // image_subresources
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
@@ -742,7 +759,7 @@ void CoreChecks::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkB
                                               VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                               uint32_t width, uint32_t height, uint32_t depth) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSNV, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV);
+    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSNV, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, "vkCmdTraceRaysNV()");
     cb_state->hasTraceRaysCmd = true;
 }
 
@@ -764,7 +781,7 @@ void CoreChecks::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                                const VkStridedBufferRegionKHR *pCallableShaderBindingTable, uint32_t width,
                                                uint32_t height, uint32_t depth) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSKHR, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSKHR, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "vkCmdTraceRaysKHR()");
     cb_state->hasTraceRaysCmd = true;
 }
 
@@ -788,7 +805,8 @@ void CoreChecks::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBu
                                                        VkDeviceSize offset) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
-    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSINDIRECTKHR, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+    UpdateStateCmdDrawDispatchType(cb_state, CMD_TRACERAYSINDIRECTKHR, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
+                                   "vkCmdTraceRaysIndirectKHR()");
     cb_state->hasTraceRaysCmd = true;
     AddCommandBufferBindingBuffer(cb_state, buffer_state);
 }

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -65,6 +65,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-flags-02696",
         "VUID-vkCmdDraw-None-02686",
         "VUID-vkCmdDraw-None-02691",
+        "VUID-vkCmdDraw-None-02698",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -89,6 +90,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-flags-02696",
         "VUID-vkCmdDrawIndexed-None-02686",
         "VUID-vkCmdDrawIndexed-None-02691",
+        "VUID-vkCmdDrawIndexed-None-02698",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -113,6 +115,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-flags-02696",
         "VUID-vkCmdDrawIndirect-None-02686",
         "VUID-vkCmdDrawIndirect-None-02691",
+        "VUID-vkCmdDrawIndirect-None-02698",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -137,6 +140,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-flags-02696",
         "VUID-vkCmdDrawIndexedIndirect-None-02686",
         "VUID-vkCmdDrawIndexedIndirect-None-02691",
+        "VUID-vkCmdDrawIndexedIndirect-None-02698",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -161,6 +165,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          "VUID-vkCmdDispatch-flags-02696",
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatch-None-02691",
+         "VUID-vkCmdDispatch-None-02698",
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -185,6 +190,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchIndirect-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdDispatchIndirect-None-02691",
+        "VUID-vkCmdDispatchIndirect-None-02698",
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -209,6 +215,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndirectCount-None-02686",
         "VUID-vkCmdDrawIndirectCount-None-02691",
+        "VUID-vkCmdDrawIndirectCount-None-02698",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -233,6 +240,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02686",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02691",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02698",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -257,6 +265,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysNV-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysNV-None-02691",
+        "VUID-vkCmdTraceRaysNV-None-02698",
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -281,6 +290,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysKHR-None-02691",
+        "VUID-vkCmdTraceRaysKHR-None-02698",
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -305,6 +315,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysIndirectKHR-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysIndirectKHR-None-02691",
+        "VUID-vkCmdTraceRaysIndirectKHR-None-02698",
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -329,6 +340,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksNV-None-02686",
         "VUID-vkCmdDrawMeshTasksNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksNV-None-02698",
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -353,6 +365,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-None-02698",
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -377,6 +390,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02698",
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -401,6 +415,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-flags-02696",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02686",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02691",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02698",
     }},
     {CMD_DISPATCHBASE, {
         "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
@@ -425,9 +440,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          "VUID-vkCmdDispatchBase-flags-02696",
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatchBase-None-02691",
+         "VUID-vkCmdDispatchBase-None-02698",
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3878,6 +3878,8 @@ void ValidationStateTracker::PostCallRecordCmdPushConstants(VkCommandBuffer comm
         auto &push_constant_data = cb_state->push_constant_data;
         assert((offset + size) <= static_cast<uint32_t>(push_constant_data.size()));
         std::memcpy(push_constant_data.data() + offset, pValues, static_cast<std::size_t>(size));
+        std::memset(cb_state->push_constant_data_set.data() + offset, 0, static_cast<std::size_t>(size));
+        cb_state->push_constant_pipeline_layout_set = layout;
     }
 }
 
@@ -5727,6 +5729,12 @@ void ValidationStateTracker::ResetCommandBufferPushConstantDataIfIncompatible(CM
             size_needed = std::max(size_needed, (push_constant_range.offset + push_constant_range.size));
         }
         cb_state->push_constant_data.resize(size_needed, 0);
+        cb_state->push_constant_data_set.resize(size_needed, 0);
+
+        for (auto push_constant_range : *cb_state->push_constant_data_ranges) {
+            std::memset(cb_state->push_constant_data_set.data() + push_constant_range.offset, 1,
+                        static_cast<std::size_t>(push_constant_range.size));
+        }
     }
 }
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1040,7 +1040,7 @@ class ValidationStateTracker : public ValidationObject {
                                        uint32_t stride);
     void RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                            VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                           uint32_t stride);
+                                           uint32_t stride, const char* function);
     void PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                      uint32_t stride);
@@ -1048,7 +1048,7 @@ class ValidationStateTracker : public ValidationObject {
                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                   uint32_t stride);
     void RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer,
-                                    VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride);
+                                    VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride, const char* function);
     void PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                               uint32_t stride);
@@ -1281,9 +1281,11 @@ class ValidationStateTracker : public ValidationObject {
                                        const PIPELINE_LAYOUT_STATE* pipeline_layout, uint32_t first_set, uint32_t set_count,
                                        const VkDescriptorSet* pDescriptorSets, cvdescriptorset::DescriptorSet* push_descriptor_set,
                                        uint32_t dynamic_offset_count, const uint32_t* p_dynamic_offsets);
-    void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, VkPipelineBindPoint bind_point);
-    void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, VkPipelineBindPoint bind_point);
-    void UpdateDrawState(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, const VkPipelineBindPoint bind_point);
+    void UpdateStateCmdDrawDispatchType(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, VkPipelineBindPoint bind_point,
+                                        const char* function);
+    void UpdateStateCmdDrawType(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, VkPipelineBindPoint bind_point,
+                                const char* function);
+    void UpdateDrawState(CMD_BUFFER_STATE* cb_state, CMD_TYPE cmd_type, const VkPipelineBindPoint bind_point, const char* function);
     void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*) const;
     void PostCallRecordCmdBuildAccelerationStructureKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                         const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -460,7 +460,9 @@ class VkImageObj : public vk_testing::Image {
 
     VkImage image() const { return handle(); }
 
-    VkImageView targetView(VkFormat format, VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT) {
+    VkImageView targetView(VkFormat format, VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT, uint32_t baseMipLevel = 0,
+                           uint32_t levelCount = VK_REMAINING_MIP_LEVELS, uint32_t baseArrayLayer = 0,
+                           uint32_t layerCount = VK_REMAINING_ARRAY_LAYERS) {
         if (!m_targetView.initialized()) {
             VkImageViewCreateInfo createView = {};
             createView.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -471,7 +473,7 @@ class VkImageObj : public vk_testing::Image {
             createView.components.g = VK_COMPONENT_SWIZZLE_G;
             createView.components.b = VK_COMPONENT_SWIZZLE_B;
             createView.components.a = VK_COMPONENT_SWIZZLE_A;
-            createView.subresourceRange = {aspect, 0, 1, 0, 1};
+            createView.subresourceRange = {aspect, baseMipLevel, levelCount, baseArrayLayer, layerCount};
             createView.flags = 0;
             m_targetView.init(*m_device, createView);
         }


### PR DESCRIPTION
```
VUID-vkCmdDraw-None-02698
VUID-vkCmdDrawIndexed-None-02698
VUID-vkCmdDrawIndirect-None-02698
VUID-vkCmdDrawIndirectCount-None-02698
VUID-vkCmdDrawIndexedIndirect-None-02698
VUID-vkCmdDrawIndexedIndirectCount-None-02698
VUID-vkCmdDrawIndirectByteCountEXT-None-02698
VUID-vkCmdDrawMeshTasksNV-None-02698
VUID-vkCmdDrawMeshTasksIndirectNV-None-02698
VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02698
VUID-vkCmdDispatch-None-02698
VUID-vkCmdDispatchIndirect-None-02698
VUID-vkCmdDispatchBase-None-02698
VUID-vkCmdExecuteGeneratedCommandsNV-None-02698
VUID-vkCmdTraceRaysNV-None-02698
VUID-vkCmdTraceRaysKHR-None-02698
VUID-vkCmdTraceRaysIndirectKHR-None-02698

For each push constant that is statically used by the VkPipeline bound to the pipeline bind point used by this command, a push constant value must have been set for the same pipeline bind point, with a VkPipelineLayout that is compatible for push constants, with the VkPipelineLayout used to create the current VkPipeline, as described in Pipeline Layout Compatibility
```
#135 & #306 
Check if update of push constants of VkPipelinLayout is compatible with binding VkPipelineLayout of VkPipeline. Plus, check if every byte of push constants update.



