### PR TITLE
layers: Fix Descriptor ImageLayout check

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6640,9 +6640,7 @@ TEST_F(VkLayerTest, InvalidStorageImageLayout) {
 
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
-                                         " of VK_DESCRIPTOR_TYPE_STORAGE_IMAGE type is being updated with layout "
-                                         "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL but according to spec ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkWriteDescriptorSet-descriptorType");
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
I have a spec fix to add the 2 unassigned VUID label which should be ready when 1.2.152 gets merged in the future

There are 2 fixes here

1. Add `VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT` to being checked for image layouts
2. replace the `image_node->shared_presentable` check with `device_extensions.vk_khr_shared_presentable_image` as this part of the function is only checking the given image layouts are valid

currently

> VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR is valid only for shared presentable images, and must be used for any usage the image supports.

is not a proper VU and needs to be added to the spec and check regardless of the descriptor type (as in it was currently only checked in `case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:` in the removed code)