### PR TITLE
Add has_atomic_descriptors to check if vertexPipelineStoresAndAtomics & fragmentStoresAndAtomics eanble

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -931,8 +931,10 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     if (entrypoint == module->end()) return false;
 
     bool has_writeable_descriptors = false;
+    bool has_atomic_descriptors = false;
     auto accessible_ids = MarkAccessibleIds(module, entrypoint);
-    auto descriptor_uses = CollectInterfaceByDescriptorSlot(module, accessible_ids, &has_writeable_descriptors);
+    auto descriptor_uses =
+        CollectInterfaceByDescriptorSlot(module, accessible_ids, &has_writeable_descriptors, &has_atomic_descriptors);
 
     unsigned dimensions = 0;
     if (x > 1) dimensions++;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -425,7 +425,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint,
                                       VkShaderStageFlagBits stage) const;
     bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage) const;
-    bool ValidateShaderStageWritableDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor) const;
+    bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
+                                                       bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                               const PIPELINE_STATE* pipeline, spirv_inst_iter entrypoint) const;
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const PIPELINE_STATE* pipeline) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -843,13 +843,24 @@ struct interface_var {
     uint32_t id;
     uint32_t type_id;
     uint32_t offset;
-    int32_t input_index;
+    int32_t input_index;  // index = -1 means that it's not input attachment.
     bool is_patch;
     bool is_block_member;
     bool is_relaxed_precision;
     bool is_writable;
     bool is_atomic_operation;
     // TODO: collect the name, too? Isn't required to be present.
+
+    interface_var()
+        : id(0),
+          type_id(0),
+          offset(0),
+          input_index(-1),
+          is_patch(false),
+          is_block_member(false),
+          is_relaxed_precision(false),
+          is_writable(false),
+          is_atomic_operation(false) {}
 };
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;
 
@@ -912,6 +923,7 @@ class PIPELINE_STATE : public BASE_NODE {
         std::unordered_set<uint32_t> accessible_ids;
         std::vector<std::pair<descriptor_slot_t, interface_var>> descriptor_uses;
         bool has_writable_descriptor;
+        bool has_atomic_descriptor;
         VkShaderStageFlagBits stage_flag;
     };
 

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -337,7 +337,8 @@ bool FindLocalSize(SHADER_MODULE_STATE const *src, uint32_t &local_size_x, uint3
 void ProcessExecutionModes(SHADER_MODULE_STATE const *src, const spirv_inst_iter &entrypoint, PIPELINE_STATE *pipeline);
 
 std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescriptorSlot(
-    SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids, bool *has_writable_descriptor);
+    SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids, bool *has_writable_descriptor,
+    bool *has_atomic_descriptor);
 
 std::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const SHADER_MODULE_STATE &module,
                                                                const VkPipelineShaderStageCreateInfo &stage_info);

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5704,8 +5704,8 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
     stage_state->accessible_ids = MarkAccessibleIds(module, entrypoint);
     ProcessExecutionModes(module, entrypoint, pipeline);
 
-    stage_state->descriptor_uses =
-        CollectInterfaceByDescriptorSlot(module, stage_state->accessible_ids, &stage_state->has_writable_descriptor);
+    stage_state->descriptor_uses = CollectInterfaceByDescriptorSlot(
+        module, stage_state->accessible_ids, &stage_state->has_writable_descriptor, &stage_state->has_atomic_descriptor);
     // Capture descriptor uses for the pipeline
     for (auto use : stage_state->descriptor_uses) {
         // While validating shaders capture which slots are used by the pipeline

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -8500,6 +8500,104 @@ TEST_F(VkLayerTest, CreatePipelineDynamicUniformIndex) {
     }
 }
 
+TEST_F(VkLayerTest, vertexStoresAndAtomicsFeatureDisable) {
+    TEST_DESCRIPTION("Run shader with StoreOp or AtomicOp to verify if vertexPipelineStoresAndAtomics disable.");
+
+    VkPhysicalDeviceFeatures features{};
+    features.vertexPipelineStoresAndAtomics = VK_FALSE;
+    ASSERT_NO_FATAL_FAILURE(Init(&features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Test StoreOp
+    {
+        char const *vsSource =
+            "#version 450\n"
+            "layout(set=0, binding=0, rgba8) uniform image2D si0;\n "
+            "void main() {\n"
+            "      imageStore(si0, ivec2(0), vec4(0));\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+
+        auto info_override = [&](CreatePipelineHelper &info) {
+            info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
+            info.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
+        };
+
+        CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                          "Shader requires vertexPipelineStoresAndAtomics but is not enabled on the device");
+    }
+
+    // Test AtomicOp
+    {
+        char const *vsSource =
+            "#version 450\n"
+            "layout(set=0, binding=0, rgba8) uniform image2D si0;\n "
+            "void main() {\n"
+            "      imageAtomicExchange(si0, ivec2(0), 1);\n"
+            "}\n";
+
+        VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+
+        auto info_override = [&](CreatePipelineHelper &info) {
+            info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
+            info.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
+        };
+
+        CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                          "Shader requires vertexPipelineStoresAndAtomics but is not enabled on the device");
+    }
+}
+
+TEST_F(VkLayerTest, fragmentStoresAndAtomicsFeatureDisable) {
+    TEST_DESCRIPTION("Run shader with StoreOp or AtomicOp to verify if fragmentStoresAndAtomics disable.");
+
+    VkPhysicalDeviceFeatures features{};
+    features.fragmentStoresAndAtomics = VK_FALSE;
+    ASSERT_NO_FATAL_FAILURE(Init(&features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Test StoreOp
+    {
+        char const *fsSource =
+            "#version 450\n"
+            "layout(set=0, binding=0, rgba8) uniform image2D si0;\n "
+            "void main() {\n"
+            "      imageStore(si0, ivec2(0), vec4(0));\n"
+            "}\n";
+
+        VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        auto info_override = [&](CreatePipelineHelper &info) {
+            info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+            info.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+        };
+
+        CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                          "Shader requires fragmentStoresAndAtomics but is not enabled on the device");
+    }
+
+    // Test AtomicOp
+    {
+        char const *fsSource =
+            "#version 450\n"
+            "layout(set=0, binding=0, rgba8) uniform image2D si0;\n "
+            "void main() {\n"
+            "      imageAtomicExchange(si0, ivec2(0), 1);\n"
+            "}\n";
+
+        VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+        auto info_override = [&](CreatePipelineHelper &info) {
+            info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+            info.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+        };
+
+        CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                          "Shader requires fragmentStoresAndAtomics but is not enabled on the device");
+    }
+}
+
 TEST_F(VkLayerTest, DuplicateDynamicStates) {
     TEST_DESCRIPTION("Create a pipeline with duplicate dynamic states set.");
 


### PR DESCRIPTION
If a shader stage has a writable descriptor or a atomic descriptor, it should check if vertexPipelineStoresAndAtomics or fragmentStoresAndAtomics enable.
 
It original only checked has_writable_descriptors. Now add  checking has_atomic_descriptors.