### PR TITLE
Fixed Multiview handling for RenderPass validation

### DIFF
--- a/layers/convert_to_renderpass2.cpp
+++ b/layers/convert_to_renderpass2.cpp
@@ -123,10 +123,20 @@ void ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& in_struc
     using std::vector;
     const auto multiview_info = lvl_find_in_chain<VkRenderPassMultiviewCreateInfo>(in_struct.pNext);
     const auto* input_attachment_aspect_info = lvl_find_in_chain<VkRenderPassInputAttachmentAspectCreateInfo>(in_struct.pNext);
+    const auto fragment_density_map_info = lvl_find_in_chain<VkRenderPassFragmentDensityMapCreateInfoEXT>(in_struct.pNext);
 
     out_struct->~safe_VkRenderPassCreateInfo2();
     out_struct->sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2_KHR;
-    out_struct->pNext = SafePnextCopy(in_struct.pNext);
+
+    // Fixup RPCI2 pNext chain.  Only FDM2 is valid on both chains.
+    if (fragment_density_map_info) {
+        out_struct->pNext = SafePnextCopy(fragment_density_map_info);
+        auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(out_struct->pNext);
+        const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
+    } else {
+        out_struct->pNext = nullptr;
+    }
+
     out_struct->flags = in_struct.flags;
     out_struct->attachmentCount = in_struct.attachmentCount;
     out_struct->pAttachments = nullptr;  // to be filled

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -594,6 +594,9 @@ struct RENDER_PASS_STATE : public BASE_NODE {
 
     VkRenderPass renderPass;
     safe_VkRenderPassCreateInfo2 createInfo;
+    bool multiview_supported;
+    std::vector<int32_t> mv_view_offsets;
+    std::vector<uint32_t> mv_view_masks;
     std::vector<std::vector<uint32_t>> self_dependencies;
     std::vector<DAGNode> subpassToNode;
     std::unordered_map<uint32_t, bool> attachment_first_read;
@@ -603,9 +606,47 @@ struct RENDER_PASS_STATE : public BASE_NODE {
     std::vector<SubpassDependencyGraphNode> subpass_dependencies;
     std::vector<std::vector<AttachmentTransition>> subpass_transitions;
 
-    RENDER_PASS_STATE(VkRenderPassCreateInfo2KHR const *pCreateInfo) : createInfo(pCreateInfo) {}
-    RENDER_PASS_STATE(VkRenderPassCreateInfo const *pCreateInfo) {
+    RENDER_PASS_STATE(VkRenderPassCreateInfo2KHR const *pCreateInfo) : createInfo(pCreateInfo), multiview_supported(false) {
+        mv_view_masks.resize(pCreateInfo->subpassCount);
+        for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
+            mv_view_masks[i] = pCreateInfo->pSubpasses[i].viewMask;
+            multiview_supported |= (pCreateInfo->pSubpasses[i].viewMask != 0);
+        }
+        if (!multiview_supported) return;
+        mv_view_offsets.resize(pCreateInfo->subpassCount);
+        if (pCreateInfo->dependencyCount == 0) {
+            for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
+                mv_view_offsets[i] = 0;
+            }
+        } else {
+            for (uint32_t i = 0; i < pCreateInfo->dependencyCount; i++) {
+                mv_view_offsets[i] = pCreateInfo->pDependencies[i].viewOffset;
+            }
+        }
+    }
+
+    RENDER_PASS_STATE(VkRenderPassCreateInfo const *pCreateInfo) : multiview_supported(false) {
         ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo, &createInfo);
+        const auto rpmvci = lvl_find_in_chain<VkRenderPassMultiviewCreateInfo>(pCreateInfo->pNext);
+        if (rpmvci) {
+            mv_view_masks.resize(rpmvci->subpassCount);
+            for (uint32_t i = 0; i < rpmvci->subpassCount; i++) {
+                mv_view_masks[i] = rpmvci->pViewMasks[i];
+                multiview_supported |= (rpmvci->pViewMasks[i] != 0);
+            }
+            if (multiview_supported) {
+                mv_view_offsets.resize(pCreateInfo->subpassCount);
+                if (rpmvci->dependencyCount == 0) {
+                    for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
+                        mv_view_offsets[i] = 0;
+                    }
+                } else {
+                    for (uint32_t i = 0; i < rpmvci->dependencyCount; i++) {
+                        mv_view_offsets[i] = rpmvci->pViewOffsets[i];
+                    }
+                }
+            }
+        }
     }
 };
 


### PR DESCRIPTION
The state_tracker and test code use the ConvertToRp2 functions to copy all the original `RenderPassCreateInfo `information into
`RenderPassCreateInfo2 `structures for convenience, but this was done incorrectly.

The entire pNext chain was copied from RPCI to RPCI2, but only `VkRenderPassFragmentDensityMapCreateInfoEXT `is valid for a RPCI2 struct. This also affected the Multiview handling in the Renderpass compatibility checks, as MV support in `CreateRenderPass `requires the `Multiview `extension, while the data is included in the dependent `CreateRenderPass2 `structures.

This is necessary for adding pNext-struct API version validation.
