### PR TITLE
Fix android video decoder hardware buffer import

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -52,7 +52,9 @@ static VkImageSubresourceRange RangeFromLayers(const VkImageSubresourceLayers &s
 static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &create_info) {
     const auto format = create_info.format;
     VkImageSubresourceRange init_range{0, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS};
-    if (FormatIsColor(format) || FormatIsMultiplane(format)) {
+    const VkExternalFormatANDROID *pExternalFormatANDROID = lvl_find_in_chain<VkExternalFormatANDROID>(&create_info);
+    bool isExternalFormatConversion = (pExternalFormatANDROID != nullptr && pExternalFormatANDROID->externalFormat != 0);
+    if (FormatIsColor(format) || FormatIsMultiplane(format) || isExternalFormatConversion) {
         init_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;  // Normalization will expand this for multiplane
     } else {
         init_range.aspectMask =
@@ -217,7 +219,17 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkIma
         // Cache a full normalization (for "full image/whole image" comparisons)
         // normalized_subresource_range = NormalizeSubresourceRange(*image_state, ci->subresourceRange);
         samples = image_state->createInfo.samples;
-        descriptor_format_bits = DescriptorRequirementsBitsFromFormat(create_info.format);
+
+        const VkExternalFormatANDROID *pExternalFormatANDROID =
+            lvl_find_in_chain<VkExternalFormatANDROID>(image_state->createInfo.pNext);
+        if (pExternalFormatANDROID != nullptr && pExternalFormatANDROID->externalFormat != 0) {
+            // When the image has a external format the views format must be VK_FORMAT_UNDEFINED and it is required to use a sampler
+            // Ycbcr conversion. Thus we can't extract any meaningful information from the format parameter. As a Sampler Ycbcr
+            // conversion must be used the shader type is always float.
+            descriptor_format_bits = DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT;
+        } else {
+            descriptor_format_bits = DescriptorRequirementsBitsFromFormat(create_info.format);
+        }
     }
 }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -52,8 +52,14 @@ static VkImageSubresourceRange RangeFromLayers(const VkImageSubresourceLayers &s
 static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &create_info) {
     const auto format = create_info.format;
     VkImageSubresourceRange init_range{0, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS};
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
     const VkExternalFormatANDROID *pExternalFormatANDROID = lvl_find_in_chain<VkExternalFormatANDROID>(&create_info);
     bool isExternalFormatConversion = (pExternalFormatANDROID != nullptr && pExternalFormatANDROID->externalFormat != 0);
+#else
+    bool isExternalFormatConversion = false;
+#endif
+
     if (FormatIsColor(format) || FormatIsMultiplane(format) || isExternalFormatConversion) {
         init_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;  // Normalization will expand this for multiplane
     } else {
@@ -220,9 +226,7 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkIma
         // normalized_subresource_range = NormalizeSubresourceRange(*image_state, ci->subresourceRange);
         samples = image_state->createInfo.samples;
 
-        const VkExternalFormatANDROID *pExternalFormatANDROID =
-            lvl_find_in_chain<VkExternalFormatANDROID>(image_state->createInfo.pNext);
-        if (pExternalFormatANDROID != nullptr && pExternalFormatANDROID->externalFormat != 0) {
+        if (image_state->has_ahb_format) {
             // When the image has a external format the views format must be VK_FORMAT_UNDEFINED and it is required to use a sampler
             // Ycbcr conversion. Thus we can't extract any meaningful information from the format parameter. As a Sampler Ycbcr
             // conversion must be used the shader type is always float.

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -5142,101 +5142,110 @@ bool StatelessValidation::ValidateCreateSamplerYcbcrConversion(VkDevice device,
         }
     }
 
+    const VkExternalFormatANDROID *pExternalFormatANDROID = lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo);
     const VkFormat format = pCreateInfo->format;
-    const VkComponentMapping components = pCreateInfo->components;
-    // XChroma Subsampled is same as "the format has a _422 or _420 suffix" from spec
-    if (FormatIsXChromaSubsampled(format) == true) {
-        if ((components.g != VK_COMPONENT_SWIZZLE_G) && (components.g != VK_COMPONENT_SWIZZLE_IDENTITY)) {
-            skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581",
+
+    // If there is a VkExternalFormatANDROID with externalFormat != 0, the value of components is ignored.
+    if (pExternalFormatANDROID == nullptr || pExternalFormatANDROID->externalFormat == 0) {
+        const VkComponentMapping components = pCreateInfo->components;
+        // XChroma Subsampled is same as "the format has a _422 or _420 suffix" from spec
+        if (FormatIsXChromaSubsampled(format) == true) {
+            if ((components.g != VK_COMPONENT_SWIZZLE_G) && (components.g != VK_COMPONENT_SWIZZLE_IDENTITY)) {
+                skip |=
+                    LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581",
                              "%s: When using a XChroma subsampled format (%s) the components.g needs to be VK_COMPONENT_SWIZZLE_G "
                              "or VK_COMPONENT_SWIZZLE_IDENTITY, but is %s.",
                              apiName, string_VkFormat(format), string_VkComponentSwizzle(components.g));
-        }
+            }
 
-        if ((components.a != VK_COMPONENT_SWIZZLE_A) && (components.a != VK_COMPONENT_SWIZZLE_IDENTITY) &&
-            (components.a != VK_COMPONENT_SWIZZLE_ONE) && (components.a != VK_COMPONENT_SWIZZLE_ZERO)) {
-            skip |=
-                LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02582",
-                         "%s: When using a XChroma subsampled format (%s) the components.a needs to be VK_COMPONENT_SWIZZLE_A or "
-                         "VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_ONE or VK_COMPONENT_SWIZZLE_ZERO, but is %s.",
-                         apiName, string_VkFormat(format), string_VkComponentSwizzle(components.a));
-        }
+            if ((components.a != VK_COMPONENT_SWIZZLE_A) && (components.a != VK_COMPONENT_SWIZZLE_IDENTITY) &&
+                (components.a != VK_COMPONENT_SWIZZLE_ONE) && (components.a != VK_COMPONENT_SWIZZLE_ZERO)) {
+                skip |= LogError(
+                    device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02582",
+                    "%s: When using a XChroma subsampled format (%s) the components.a needs to be VK_COMPONENT_SWIZZLE_A or "
+                    "VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_ONE or VK_COMPONENT_SWIZZLE_ZERO, but is %s.",
+                    apiName, string_VkFormat(format), string_VkComponentSwizzle(components.a));
+            }
 
-        if ((components.r != VK_COMPONENT_SWIZZLE_R) && (components.r != VK_COMPONENT_SWIZZLE_IDENTITY) &&
-            (components.r != VK_COMPONENT_SWIZZLE_B)) {
-            skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02583",
+            if ((components.r != VK_COMPONENT_SWIZZLE_R) && (components.r != VK_COMPONENT_SWIZZLE_IDENTITY) &&
+                (components.r != VK_COMPONENT_SWIZZLE_B)) {
+                skip |=
+                    LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02583",
                              "%s: When using a XChroma subsampled format (%s) the components.r needs to be VK_COMPONENT_SWIZZLE_R "
                              "or VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_B, but is %s.",
                              apiName, string_VkFormat(format), string_VkComponentSwizzle(components.r));
-        }
+            }
 
-        if ((components.b != VK_COMPONENT_SWIZZLE_B) && (components.b != VK_COMPONENT_SWIZZLE_IDENTITY) &&
-            (components.b != VK_COMPONENT_SWIZZLE_R)) {
-            skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02584",
+            if ((components.b != VK_COMPONENT_SWIZZLE_B) && (components.b != VK_COMPONENT_SWIZZLE_IDENTITY) &&
+                (components.b != VK_COMPONENT_SWIZZLE_R)) {
+                skip |=
+                    LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02584",
                              "%s: When using a XChroma subsampled format (%s) the components.b needs to be VK_COMPONENT_SWIZZLE_B "
                              "or VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_R, but is %s.",
                              apiName, string_VkFormat(format), string_VkComponentSwizzle(components.b));
-        }
+            }
 
-        // If one is identity, both need to be
-        const bool rIdentity = ((components.r == VK_COMPONENT_SWIZZLE_R) || (components.r == VK_COMPONENT_SWIZZLE_IDENTITY));
-        const bool bIdentity = ((components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY));
-        if ((rIdentity != bIdentity) && ((rIdentity == true) || (bIdentity == true))) {
-            skip |= LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02585",
+            // If one is identity, both need to be
+            const bool rIdentity = ((components.r == VK_COMPONENT_SWIZZLE_R) || (components.r == VK_COMPONENT_SWIZZLE_IDENTITY));
+            const bool bIdentity = ((components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY));
+            if ((rIdentity != bIdentity) && ((rIdentity == true) || (bIdentity == true))) {
+                skip |=
+                    LogError(device, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02585",
                              "%s: When using a XChroma subsampled format (%s) if either the components.r (%s) or components.b (%s) "
                              "are an identity swizzle, then both need to be an identity swizzle.",
                              apiName, string_VkFormat(format), string_VkComponentSwizzle(components.r),
                              string_VkComponentSwizzle(components.b));
-        }
-    }
-
-    if (pCreateInfo->ycbcrModel != VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY) {
-        // Checks same VU multiple ways in order to give a more useful error message
-        const char *vuid = "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655";
-        if ((components.r == VK_COMPONENT_SWIZZLE_ONE) || (components.r == VK_COMPONENT_SWIZZLE_ZERO) ||
-            (components.g == VK_COMPONENT_SWIZZLE_ONE) || (components.g == VK_COMPONENT_SWIZZLE_ZERO) ||
-            (components.b == VK_COMPONENT_SWIZZLE_ONE) || (components.b == VK_COMPONENT_SWIZZLE_ZERO)) {
-            skip |=
-                LogError(device, vuid,
-                         "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
-                         "components.g (%s), nor components.b (%s) can't be VK_COMPONENT_SWIZZLE_ZERO or VK_COMPONENT_SWIZZLE_ONE.",
-                         apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
-                         string_VkComponentSwizzle(components.b));
+            }
         }
 
-        // "must not correspond to a channel which contains zero or one as a consequence of conversion to RGBA"
-        // 4 channel format = no issue
-        // 3 = no [a]
-        // 2 = no [b,a]
-        // 1 = no [g,b,a]
-        // depth/stencil = no [g,b,a] (shouldn't ever occur, but no VU preventing it)
-        const uint32_t channels = (FormatIsDepthOrStencil(format) == true) ? 1 : FormatChannelCount(format);
+        if (pCreateInfo->ycbcrModel != VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY) {
+            // Checks same VU multiple ways in order to give a more useful error message
+            const char *vuid = "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655";
+            if ((components.r == VK_COMPONENT_SWIZZLE_ONE) || (components.r == VK_COMPONENT_SWIZZLE_ZERO) ||
+                (components.g == VK_COMPONENT_SWIZZLE_ONE) || (components.g == VK_COMPONENT_SWIZZLE_ZERO) ||
+                (components.b == VK_COMPONENT_SWIZZLE_ONE) || (components.b == VK_COMPONENT_SWIZZLE_ZERO)) {
+                skip |= LogError(
+                    device, vuid,
+                    "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
+                    "components.g (%s), nor components.b (%s) can't be VK_COMPONENT_SWIZZLE_ZERO or VK_COMPONENT_SWIZZLE_ONE.",
+                    apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
+                    string_VkComponentSwizzle(components.b));
+            }
 
-        if ((channels < 4) && ((components.r == VK_COMPONENT_SWIZZLE_A) || (components.g == VK_COMPONENT_SWIZZLE_A) ||
-                               (components.b == VK_COMPONENT_SWIZZLE_A))) {
-            skip |= LogError(device, vuid,
-                             "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
-                             "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_A.",
-                             apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
-                             string_VkComponentSwizzle(components.b));
-        } else if ((channels < 3) &&
-                   ((components.r == VK_COMPONENT_SWIZZLE_B) || (components.g == VK_COMPONENT_SWIZZLE_B) ||
-                    (components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY))) {
-            skip |= LogError(device, vuid,
-                             "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
-                             "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_B "
-                             "(components.b also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",
-                             apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
-                             string_VkComponentSwizzle(components.b));
-        } else if ((channels < 2) &&
-                   ((components.r == VK_COMPONENT_SWIZZLE_G) || (components.g == VK_COMPONENT_SWIZZLE_G) ||
-                    (components.g == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.b == VK_COMPONENT_SWIZZLE_G))) {
-            skip |= LogError(device, vuid,
-                             "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
-                             "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_G "
-                             "(components.g also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",
-                             apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
-                             string_VkComponentSwizzle(components.b));
+            // "must not correspond to a channel which contains zero or one as a consequence of conversion to RGBA"
+            // 4 channel format = no issue
+            // 3 = no [a]
+            // 2 = no [b,a]
+            // 1 = no [g,b,a]
+            // depth/stencil = no [g,b,a] (shouldn't ever occur, but no VU preventing it)
+            const uint32_t channels = (FormatIsDepthOrStencil(format) == true) ? 1 : FormatChannelCount(format);
+
+            if ((channels < 4) && ((components.r == VK_COMPONENT_SWIZZLE_A) || (components.g == VK_COMPONENT_SWIZZLE_A) ||
+                                   (components.b == VK_COMPONENT_SWIZZLE_A))) {
+                skip |= LogError(device, vuid,
+                                 "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
+                                 "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_A.",
+                                 apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
+                                 string_VkComponentSwizzle(components.b));
+            } else if ((channels < 3) &&
+                       ((components.r == VK_COMPONENT_SWIZZLE_B) || (components.g == VK_COMPONENT_SWIZZLE_B) ||
+                        (components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY))) {
+                skip |= LogError(device, vuid,
+                                 "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
+                                 "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_B "
+                                 "(components.b also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",
+                                 apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
+                                 string_VkComponentSwizzle(components.b));
+            } else if ((channels < 2) &&
+                       ((components.r == VK_COMPONENT_SWIZZLE_G) || (components.g == VK_COMPONENT_SWIZZLE_G) ||
+                        (components.g == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.b == VK_COMPONENT_SWIZZLE_G))) {
+                skip |= LogError(device, vuid,
+                                 "%s: The ycbcrModel is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
+                                 "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_G "
+                                 "(components.g also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",
+                                 apiName, string_VkComponentSwizzle(components.r), string_VkComponentSwizzle(components.g),
+                                 string_VkComponentSwizzle(components.b));
+            }
         }
     }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -5142,11 +5142,17 @@ bool StatelessValidation::ValidateCreateSamplerYcbcrConversion(VkDevice device,
         }
     }
 
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
     const VkExternalFormatANDROID *pExternalFormatANDROID = lvl_find_in_chain<VkExternalFormatANDROID>(pCreateInfo);
+    const bool isExternalFormat = pExternalFormatANDROID != nullptr && pExternalFormatANDROID->externalFormat != 0;
+#else
+    const bool isExternalFormat = false;
+#endif
+
     const VkFormat format = pCreateInfo->format;
 
     // If there is a VkExternalFormatANDROID with externalFormat != 0, the value of components is ignored.
-    if (pExternalFormatANDROID == nullptr || pExternalFormatANDROID->externalFormat == 0) {
+    if (!isExternalFormat) {
         const VkComponentMapping components = pCreateInfo->components;
         // XChroma Subsampled is same as "the format has a _422 or _420 suffix" from spec
         if (FormatIsXChromaSubsampled(format) == true) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5364,6 +5364,17 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
     vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->ExpectSuccess();
+    efa.externalFormat = AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420;
+    sycci.format = VK_FORMAT_UNDEFINED;
+    sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
+    sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+    // Spec says if we use VkExternalFormatANDROID value of components is ignored.
+    sycci.components = {VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO};
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    m_errorMonitor->VerifyNotFound();
+    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, nullptr);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferPhysDevImageFormatProp2) {


### PR DESCRIPTION
In my scenario I decode a video using the android media codec api. This produces a hardware buffer which I then import as an image into vulkan and render by reading it with a ycbcr sampler. While developing this code I found 3 false positives in the validation layer. One false positive even lead to an assert inside validation layer being triggered, which crashed my entire application, even though my vulkan code was correct. Due to this assert I'm currently unable to use the validation layer at all without these fixes. This PR fixes these issues. 