### PR TITLE
layers: Better timeline semaphore error messages

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -110,7 +110,7 @@ class CoreChecks : public ValidationStateTracker {
                                uint32_t count, const uint32_t* indices) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence, const char* inflight_vuid, const char* retired_vuid,
                                 const char* func_name) const;
-    bool ValidateSemaphoresForSubmit(VkQueue queue, const VkSubmitInfo* submit,
+    bool ValidateSemaphoresForSubmit(VkQueue queue, const VkSubmitInfo* submit, uint32_t submit_index,
                                      std::unordered_set<VkSemaphore>* unsignaled_sema_arg,
                                      std::unordered_set<VkSemaphore>* signaled_sema_arg,
                                      std::unordered_set<VkSemaphore>* internal_sema_arg) const;


### PR DESCRIPTION
Was playing around with VK_KHR_timeline_semaphore and realized some of the error messages were less than desired to figure out the issue. Fixed up the vkQueueSubmit and vkQueueBindSparse messages to be more useful