### PR TITLE
Check what bytes of push constants are used in shader

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -953,6 +953,9 @@ class PIPELINE_STATE : public BASE_NODE {
     VkPrimitiveTopology topology_at_rasterizer;
     VkBool32 sample_location_enabled;
 
+    std::vector<uint8_t> push_constant_used_in_shader;  // vector's index is the byte location. If the value is 0, it means the byte
+                                                        // isn't used in shader. 1 means used.
+
     // Default constructor
     PIPELINE_STATE()
         : pipeline{},
@@ -981,6 +984,7 @@ class PIPELINE_STATE : public BASE_NODE {
         VkRayTracingPipelineCreateInfoKHR emptyRayTracingCI = {};
         raytracingPipelineCI.initialize(&emptyRayTracingCI);
         stage_state.clear();
+        push_constant_used_in_shader.clear();
         fragmentShader_writable_output_location_list.clear();
     }
 
@@ -1314,7 +1318,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     PushConstantRangesId push_constant_data_ranges;
 
     std::vector<uint8_t> push_constant_data_set;  // If a byte is set or a byte is not used in push_constant_rage, the value of byte
-                                                  // is 0, so if the whole is set, the whole value is 0.
+                                                  // is 1.
     VkPipelineLayout push_constant_pipeline_layout_set;
 
     // Used for Best Practices tracking

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1079,6 +1079,62 @@ std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescr
     return out;
 }
 
+void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &src, const std::unordered_set<uint32_t> &accessible_ids,
+                                 std::vector<uint8_t> &push_constant_used_in_shader) {
+    for (auto id : accessible_ids) {
+        auto def_insn = src.get_def(id);
+        if (def_insn.opcode() == spv::OpVariable && def_insn.word(3) == spv::StorageClassPushConstant) {
+            spirv_inst_iter type = src.get_def(def_insn.word(1));
+            type = GetStructType(&src, type, false);
+            assert(type != src.end());
+
+            std::vector<uint32_t> struct_member;
+            for (uint32_t i = 2; i < type.len(); ++i) {
+                struct_member.emplace_back(type.word(i));
+            }
+            uint32_t struct_member_index = 0;
+
+            for (auto insn : src) {
+                if (insn.opcode() == spv::OpMemberDecorate && insn.word(1) == type.word(1)) {
+                    if (insn.word(3) == spv::DecorationOffset) {
+                        auto def_member = src.get_def(struct_member[struct_member_index]);
+                        auto size = 1;
+
+                        if (def_member.opcode() == spv::OpTypeArray) {
+                            const auto len_id = def_member.word(3);
+                            const auto def_len = src.get_def(len_id);
+                            size *= def_len.word(3);  // array length
+                            def_member = src.get_def(def_member.word(2));
+                        }
+
+                        if (def_member.opcode() == spv::OpTypeMatrix) {
+                            size *= def_member.word(3);  // matrix's columns. matrix's row is vector.
+                            def_member = src.get_def(def_member.word(2));
+                        }
+
+                        if (def_member.opcode() == spv::OpTypeVector) {
+                            size *= def_member.word(3);  // vector length
+                            def_member = src.get_def(def_member.word(2));
+                        }
+
+                        // Get scalar type size. The value in SPRV-R is bit. It needs to translate to byte.
+                        size *= (def_member.word(2) / 8);
+
+                        auto const offset = insn.word(4);
+                        auto const end = offset + size;
+
+                        if (push_constant_used_in_shader.size() < end) {
+                            push_constant_used_in_shader.resize(end, 0);
+                        }
+                        std::memset(push_constant_used_in_shader.data() + offset, 1, static_cast<std::size_t>(size));
+                        ++struct_member_index;
+                    }
+                }
+            }
+        }
+    }
+}
+
 std::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const SHADER_MODULE_STATE &module,
                                                                const VkPipelineShaderStageCreateInfo &stage_info) {
     std::unordered_set<uint32_t> location_list;
@@ -1489,14 +1545,40 @@ bool CoreChecks::ValidatePushConstantBlockAgainstPipeline(std::vector<VkPushCons
     type = GetStructType(src, type, false);
     assert(type != src->end());
 
+    std::vector<uint32_t> struct_member;
+    for (uint32_t i = 2; i < type.len(); ++i) {
+        struct_member.emplace_back(type.word(i));
+    }
+    uint32_t struct_member_index = 0;
     // Validate directly off the offsets. this isn't quite correct for arrays and matrices, but is a good first step.
-    // TODO: arrays, matrices, weird sizes
+    // TODO: weird sizes
     for (auto insn : *src) {
         if (insn.opcode() == spv::OpMemberDecorate && insn.word(1) == type.word(1)) {
             if (insn.word(3) == spv::DecorationOffset) {
+                auto def_member = src->get_def(struct_member[struct_member_index]);
+                auto size = 1;
+
+                if (def_member.opcode() == spv::OpTypeArray) {
+                    const auto len_id = def_member.word(3);
+                    const auto def_len = src->get_def(len_id);
+                    size *= def_len.word(3);  // array length
+                    def_member = src->get_def(def_member.word(2));
+                }
+
+                if (def_member.opcode() == spv::OpTypeMatrix) {
+                    size *= def_member.word(3);  // matrix's columns. matrix's row is vector.
+                    def_member = src->get_def(def_member.word(2));
+                }
+
+                if (def_member.opcode() == spv::OpTypeVector) {
+                    size *= def_member.word(3);  // vector length
+                }
+
+                // Get scalar type size. The value in SPRV-R is bit. It needs to translate to byte.
+                size *= (def_member.word(2) / 8);
+
                 auto const member = insn.word(2);
                 auto const offset = insn.word(4);
-                auto const size = 4;  // Bytes; TODO: calculate this based on the type
 
                 bool found_range = false;
                 for (auto const &range : *push_constant_ranges) {
@@ -1507,6 +1589,7 @@ bool CoreChecks::ValidatePushConstantBlockAgainstPipeline(std::vector<VkPushCons
                         break;
                     }
                 }
+                ++struct_member_index;
 
                 if (!found_range) {
                     skip |= LogError(device, kVUID_Core_Shader_PushConstantOutOfRange,

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -340,6 +340,9 @@ std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescr
     SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids, bool *has_writable_descriptor,
     bool *has_atomic_descriptor);
 
+void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &src, const std::unordered_set<uint32_t> &accessible_ids,
+                                 std::vector<uint8_t> &push_constant_used_in_shader);
+
 std::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const SHADER_MODULE_STATE &module,
                                                                const VkPipelineShaderStageCreateInfo &stage_info);
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3881,7 +3881,7 @@ void ValidationStateTracker::PostCallRecordCmdPushConstants(VkCommandBuffer comm
         auto &push_constant_data = cb_state->push_constant_data;
         assert((offset + size) <= static_cast<uint32_t>(push_constant_data.size()));
         std::memcpy(push_constant_data.data() + offset, pValues, static_cast<std::size_t>(size));
-        std::memset(cb_state->push_constant_data_set.data() + offset, 0, static_cast<std::size_t>(size));
+        std::memset(cb_state->push_constant_data_set.data() + offset, 1, static_cast<std::size_t>(size));
         cb_state->push_constant_pipeline_layout_set = layout;
     }
 }
@@ -5715,7 +5715,7 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
         if (use.second.is_atomic_operation) reqs = descriptor_req(reqs | DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION);
         pipeline->max_active_slot = std::max(pipeline->max_active_slot, slot);
     }
-
+    SetPushConstantUsedInShader(*module, stage_state->accessible_ids, pipeline->push_constant_used_in_shader);
     if (pStage->stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
         pipeline->fragmentShader_writable_output_location_list = CollectWritableOutputLocationinFS(*module, *pStage);
     }
@@ -5740,11 +5740,6 @@ void ValidationStateTracker::ResetCommandBufferPushConstantDataIfIncompatible(CM
         }
         cb_state->push_constant_data.resize(size_needed, 0);
         cb_state->push_constant_data_set.resize(size_needed, 0);
-
-        for (auto push_constant_range : *cb_state->push_constant_data_ranges) {
-            std::memset(cb_state->push_constant_data_set.data() + push_constant_range.offset, 1,
-                        static_cast<std::size_t>(push_constant_range.size));
-        }
     }
 }
 


### PR DESCRIPTION
A bug fix for 

VUID-vkCmdDraw-None-02698
For each push constant that is statically used by the VkPipeline bound to the pipeline bind point used by this command, a push constant value must have been set for the same pipeline bind point, with a VkPipelineLayout that is compatible for push constants, with the VkPipelineLayout used to create the current VkPipeline, as described in Pipeline Layout Compatibility


The original code checked if every byte of push constants is updated. The fix added that only checked if the byte is used in shaders.

And get more accurate data size of push constants. Consider array, vector, matrix, and scalar type.