### PR TITLE
Add extension enable support for sync val

### DIFF
--- a/docs/synchronization_usage.md
+++ b/docs/synchronization_usage.md
@@ -101,13 +101,13 @@ Synchronization Validation is disabled by default. To turn on Synchronization Va
 `vk_layer_settings.txt`:
 
 ```code
-khronos_validation.enables = VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION
+khronos_validation.enables = VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT
 ```
 
 To enable using environment variables, set the following variable:
 
 ```code
-VK_LAYER_ENABLES=VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION
+VK_LAYER_ENABLES=VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT
 ```
 
 Some platforms do not support configuration of the validation layers with this configuration file.
@@ -122,7 +122,7 @@ The `VK_EXT_validation_features` extension can be used to enable Synchronization
 Here is sample code illustrating how to enable it:
 
 ```code
-VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION};
+VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
 VkValidationFeaturesEXT features = {};
 features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
 features.enabledValidationFeatureCount = 1;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "layer_options.h"
@@ -103,6 +104,10 @@ void SetValidationFeatureEnable(CHECK_ENABLED &enable_data, const VkValidationFe
             break;
         case VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT:
             enable_data[debug_printf] = true;
+            break;
+        case VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT:
+            enable_data[sync_validation] = true;
+            break;
         default:
             break;
     }

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "chassis.h"
@@ -48,6 +49,7 @@ static const std::unordered_map<std::string, VkValidationFeatureEnableEXT> VkVal
      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT},
     {"VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT", VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT},
     {"VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT", VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT},
+    {"VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT", VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT},
 };
 
 static const std::unordered_map<std::string, VkValidationFeatureEnable> VkValFeatureEnableLookup2 = {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -106,6 +106,8 @@
 #      validation
 #      VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT - enables processing of
 #      debug printf instructions in shaders and sending debug strings to the debug callback
+#      VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT - enables checks to
+#      identify resource access conflicts due to missing or incorrect synchronization
 #
 #   CUSTOM_STYPE_LIST:
 #   ==================

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3155,14 +3155,6 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
 
 void VkSyncValTest::InitSyncValFramework() {
     // Enable synchronization validation
-    VkLayerSettingValueDataEXT sy_setting_string_value{};
-    sy_setting_string_value.arrayString.pCharArray = "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION";
-    sy_setting_string_value.arrayString.count = sizeof(sy_setting_string_value.arrayString.pCharArray);
-    VkLayerSettingValueEXT sy_vendor_all_setting_val = {"enables", VK_LAYER_SETTING_VALUE_TYPE_STRING_ARRAY_EXT,
-                                                        sy_setting_string_value};
-    VkLayerSettingsEXT sy_settings{static_cast<VkStructureType>(VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT), nullptr, 1,
-                                   &sy_vendor_all_setting_val};
-    features_.pNext = &sy_settings;
     InitFramework(m_errorMonitor, &features_);
 }
 

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -309,10 +309,11 @@ class VkSyncValTest : public VkLayerTest {
     void InitSyncValFramework();
 
   protected:
+    VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
     VkValidationFeatureDisableEXT disables_[4] = {
         VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
         VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
-    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 0, nullptr, 4, disables_};
+    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
 };
 
 class VkBufferTest {


### PR DESCRIPTION
Add the VkValidationFeatureEnableEXT VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT enabling
support to the Khronos validation layer.

