### PR TITLE
Modify renderpass compatibility Multiview check to work for Vulkan 1.2

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -594,6 +594,25 @@ bool CoreChecks::ValidateSubpassCompatibility(const char *type1_string, const RE
     }
     skip |= ValidateAttachmentCompatibility(type1_string, rp1_state, type2_string, rp2_state, primary_depthstencil_attach,
                                             secondary_depthstencil_attach, caller, error_code);
+
+    // Both renderpasses must agree on Multiview usage
+    if (primary_desc.viewMask && secondary_desc.viewMask) {
+        if (primary_desc.viewMask != secondary_desc.viewMask) {
+            std::stringstream ss;
+            ss << "For subpass " << subpass << ", they have a different viewMask. The first has view mask " << primary_desc.viewMask
+               << " while the second has view mask " << secondary_desc.viewMask << ".";
+            skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
+        }
+    } else if (primary_desc.viewMask) {
+        skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state,
+                                       "The first uses Multiview (has non-zero viewMasks) while the second one does not.", caller,
+                                       error_code);
+    } else if (secondary_desc.viewMask) {
+        skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state,
+                                       "The second uses Multiview (has non-zero viewMasks) while the first one does not.", caller,
+                                       error_code);
+    }
+
     return skip;
 }
 
@@ -646,36 +665,6 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
     } else if (fdm2) {
         skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state,
                                        "The second uses a Fragment Density Map while the first one does not.", caller, error_code);
-    }
-
-    // Both renderpasses must agree on usage of a Multiview type
-    if (rp1_state->multiview_supported && rp2_state->multiview_supported) {
-        if (rp1_state->mv_view_masks.size() == rp2_state->mv_view_masks.size()) {
-            for (uint32_t i = 0; i < rp1_state->mv_view_masks.size(); i++) {
-                if (rp1_state->mv_view_masks[i] != rp2_state->mv_view_masks[i]) {
-                    std::stringstream ss;
-                    ss << "For subpass " << i << ", they have different pViewMasks. The first has view mask "
-                       << rp1_state->mv_view_masks[i] << " while the second has view mask " << rp2_state->mv_view_masks[i] << ".";
-                    skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller,
-                                                   error_code);
-                }
-            }
-        } else {
-            LogObjectList objlist(rp1_state->renderPass);
-            objlist.add(rp2_state->renderPass);
-            skip |= LogError(objlist, error_code,
-                             "%s: RenderPasses incompatible between %s w/ %s and %s w/ %s: Both renderpasses use Multiview but "
-                             "have a differing number of viewmasks (%d and %d, respectively).",
-                             caller, type1_string, report_data->FormatHandle(rp1_state->renderPass).c_str(), type2_string,
-                             report_data->FormatHandle(rp2_state->renderPass).c_str(), rp1_state->mv_view_masks.size(),
-                             rp2_state->mv_view_masks.size());
-        }
-    } else if (rp1_state->multiview_supported) {
-        skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state,
-                                       "The first uses Multiview while the second one does not.", caller, error_code);
-    } else if (rp2_state->multiview_supported) {
-        skip |= LogInvalidPnextMessage(type1_string, rp1_state, type2_string, rp2_state,
-                                       "The second uses Multiview while the first one does not.", caller, error_code);
     }
 
     return skip;


### PR DESCRIPTION
This goes back to pull request https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2080 where I originally added renderpass compatibility checks and tests for FDM and Multiview use. I wasn't previously aware that the Multiview now had the viewMask parameter directly in Vulkan 1.2 structs and no longer required the MultiviewCreateInfo struct to be attached through pNext. Only after I made these changes did I realize that this was addressed in this commit: https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/799a92b2f344c46f9d3495298148974a2504b930. Still, I present a solution for the check that shouldn't require the extra multiview_supported, my_view_offsets and my_view_masks parameters needed there and I've made the Multiview test more complete by incorporating the different incompatibility cases for both versions of the vkCreateRenderPass() call.