### PR TITLE
layers: Removed incorrect vkCmdDraw warnings

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -5501,7 +5501,6 @@ bool StatelessValidation::PreCallValidateCmdDraw(
     uint32_t                                    firstInstance) const {
     bool skip = false;
     // No xml-driven validation
-    if (!skip) skip |= manual_PreCallValidateCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     return skip;
 }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -3430,23 +3430,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer 
     return skip;
 }
 
-bool StatelessValidation::manual_PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                                        uint32_t firstVertex, uint32_t firstInstance) const {
-    bool skip = false;
-    if (vertexCount == 0) {
-        // TODO: Verify against Valid Usage section. I don't see a non-zero vertexCount listed, may need to add that and make
-        // this an error or leave as is.
-        skip |= LogWarning(device, kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t vertexCount, is 0");
-    }
-
-    if (instanceCount == 0) {
-        // TODO: Verify against Valid Usage section. I don't see a non-zero instanceCount listed, may need to add that and make
-        // this an error or leave as is.
-        skip |= LogWarning(device, kVUID_PVError_RequiredParameter, "vkCmdDraw parameter, uint32_t instanceCount, is 0");
-    }
-    return skip;
-}
-
 bool StatelessValidation::manual_PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                 uint32_t count, uint32_t stride) const {
     bool skip = false;

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1320,9 +1320,6 @@ class StatelessValidation : public ValidationObject {
                                              const VkRect2D *pScissors) const;
     bool manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) const;
 
-    bool manual_PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                       uint32_t firstVertex, uint32_t firstInstance) const;
-
     bool manual_PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                                uint32_t stride) const;
 

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -165,7 +165,6 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetViewport',
             'vkCmdSetScissor',
             'vkCmdSetLineWidth',
-            'vkCmdDraw',
             'vkCmdDrawIndirect',
             'vkCmdDrawIndexedIndirect',
             'vkCmdClearAttachments',


### PR DESCRIPTION
From internal issue 2326

Agreed in working group that it is indeed valid to have a `vertexCount` and `instanceCount` of zero. There is also already a best practice layer that checks for `instanceCount` of zero

This PR was fueled by the "start labeling unassigned VUs" effort