### PR TITLE
layers: Add a couple of missing % to printf specifiers

### DIFF
--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -738,14 +738,14 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
     if (miss_shader_buffer_state && missShaderBindingOffset >= miss_shader_buffer_state->createInfo.size) {
         skip |= LogError(commandBuffer, "VUID-vkCmdTraceRaysNV-missShaderBindingOffset-02457",
                          "vkCmdTraceRaysNV: missShaderBindingOffset %" PRIu64
-                         " must be less than the size of missShaderBindingTableBuffer" PRIu64 " .",
+                         " must be less than the size of missShaderBindingTableBuffer %" PRIu64 " .",
                          missShaderBindingOffset, miss_shader_buffer_state->createInfo.size);
     }
     auto raygen_shader_buffer_state = (BUFFER_STATE *)GetBufferState(raygenShaderBindingTableBuffer);
     if (raygenShaderBindingOffset >= raygen_shader_buffer_state->createInfo.size) {
         skip |= LogError(commandBuffer, "VUID-vkCmdTraceRaysNV-raygenShaderBindingOffset-02455",
                          "vkCmdTraceRaysNV: raygenShaderBindingOffset %" PRIu64
-                         " must be less than the size of raygenShaderBindingTableBuffer" PRIu64 " .",
+                         " must be less than the size of raygenShaderBindingTableBuffer %" PRIu64 " .",
                          raygenShaderBindingOffset, raygen_shader_buffer_state->createInfo.size);
     }
     return skip;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -3142,7 +3142,7 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                                  pDescriptorWrites[i].pBufferInfo[descriptorIndex].range != VK_WHOLE_SIZE)) {
                                 skip |= LogError(device, "VUID-VkDescriptorBufferInfo-buffer-02999",
                                                  "%s(): if pDescriptorWrites[%d].buffer is VK_NULL_HANDLE, "
-                                                 "offset (" PRIu64 ") must be zero and range (" PRIu64 ") must be VK_WHOLE_SIZE.",
+                                                 "offset (%" PRIu64 ") must be zero and range (%" PRIu64 ") must be VK_WHOLE_SIZE.",
                                                  vkCallingFunction, i, pDescriptorWrites[i].pBufferInfo[descriptorIndex].offset,
                                                  pDescriptorWrites[i].pBufferInfo[descriptorIndex].range);
                             }

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -529,7 +529,7 @@ class StatelessValidation : public ValidationObject {
                         ((strncmp(api_name, "vkCreateDevice", strlen(api_name)) != 0) ||
                          (current->sType != VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO))) {
                         if (cycle_check.find(current->pNext) != cycle_check.end()) {
-                            std::string message = "%s: %s chain contains a cycle -- pNext pointer " PRIx64 " is repeated.";
+                            std::string message = "%s: %s chain contains a cycle -- pNext pointer %" PRIx64 " is repeated.";
                             skip_call |= LogError(device, kVUID_PVError_InvalidStructPNext, message.c_str(), api_name,
                                                   parameter_name.get_name().c_str(), reinterpret_cast<uint64_t>(next));
                             break;


### PR DESCRIPTION
I ran into one of these (the null descriptor message) and grep found a few more. When using the `PRIu64` etc specifiers they don't include the prefixing `%` so if it's accidentally omitted all you'll get is `llu` instead of the actual value in the resulting message.