### PR TITLE
layers: label VUID 04441

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4461,16 +4461,11 @@ bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 st
     }
 
     if (!correct_usage) {
-        if (msgCode == kVUIDUndefined) {
-            // TODO: Fix callers with kVUIDUndefined to use correct validation checks.
-            skip = LogError(object, kVUID_Core_MemTrack_InvalidUsageFlag,
-                            "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
-                            report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
-        } else {
-            skip = LogError(object, msgCode,
-                            "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
-                            report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
-        }
+        // All callers should have a valid VUID
+        assert(msgCode != kVUIDUndefined);
+        skip =
+            LogError(object, msgCode, "Invalid usage flag for %s used by %s. In this case, %s should have %s set during creation.",
+                     report_data->FormatHandle(typed_handle).c_str(), func_name, type_str, usage_str);
     }
     return skip;
 }
@@ -5035,10 +5030,11 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             ValidateImageUsageFlags(image_state,
                                     VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
                                         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-                                        VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV | VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT,
-                                    false, kVUIDUndefined, "vkCreateImageView()",
+                                        VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV |
+                                        VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT,
+                                    false, "VUID-VkImageViewCreateInfo-image-04441", "vkCreateImageView()",
                                     "VK_IMAGE_USAGE_[SAMPLED|STORAGE|COLOR_ATTACHMENT|DEPTH_STENCIL_ATTACHMENT|INPUT_ATTACHMENT|"
-                                    "SHADING_RATE_IMAGE|FRAGMENT_DENSITY_MAP]_BIT");
+                                    "TRANSIENT_ATTACHMENT|SHADING_RATE_IMAGE|FRAGMENT_DENSITY_MAP]_BIT");
         // If this isn't a sparse image, it needs to have memory backing it at CreateImageView time
         skip |= ValidateMemoryIsBoundToImage(image_state, "vkCreateImageView()", "VUID-VkImageViewCreateInfo-image-01020");
         // Checks imported from image layer

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -39,7 +39,7 @@ static const char DECORATE_UNUSED *kVUID_Core_Bound_Resource_FreedMemoryAccess =
 // static const char DECORATE_UNUSED *kVUID_Core_MemTrack_FenceState = "UNASSIGNED-CoreValidation-MemTrack-FenceState";
 static const char DECORATE_UNUSED *kVUID_Core_MemTrack_InvalidMap = "UNASSIGNED-CoreValidation-MemTrack-InvalidMap";
 static const char DECORATE_UNUSED *kVUID_Core_MemTrack_InvalidState = "UNASSIGNED-CoreValidation-MemTrack-InvalidState";
-static const char DECORATE_UNUSED *kVUID_Core_MemTrack_InvalidUsageFlag = "UNASSIGNED-CoreValidation-MemTrack-InvalidUsageFlag";
+// static const char DECORATE_UNUSED *kVUID_Core_MemTrack_InvalidUsageFlag = "UNASSIGNED-CoreValidation-MemTrack-InvalidUsageFlag";
 static const char DECORATE_UNUSED *kVUID_Core_MemTrack_RebindObject = "UNASSIGNED-CoreValidation-MemTrack-RebindObject";
 // Previously defined but unused - uncomment as needed
 //static const char DECORATE_UNUSED *kVUID_Core_MemTrack_InternalError = "UNASSIGNED-CoreValidation-MemTrack-InternalError";

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -899,7 +899,7 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
     dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
     // Create a view with depth / stencil aspect for image with different usage
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-MemTrack-InvalidUsageFlag");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-04441");
     vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
Recently got `VUID-VkImageViewCreateInfo-image-04441` added as it was the only caller of `ValidateUsageFlags` that was `kVUIDUndefined` so we are able to remove that check