### PR TITLE
[WIP] Validate if push constant buffer is updated

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -54,6 +54,7 @@ struct DrawDispatchVuid {
     const char* corner_sampled_address_mode;
     const char* subpass_input;
     const char* imageview_atomic;
+    const char* push_constants_set;
     const char* image_subresources;
     const char* descriptor_valid;
     const char* sampler_imageview_type;
@@ -442,11 +443,10 @@ class CoreChecks : public ValidationStateTracker {
                                    spirv_inst_iter entrypoint) const;
     bool ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const* fs, spirv_inst_iter entrypoint,
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
-    bool ValidatePushConstantUsage(std::vector<VkPushConstantRange> const* push_constant_ranges, SHADER_MODULE_STATE const* src,
-                                   std::unordered_set<uint32_t> accessible_ids, VkShaderStageFlagBits stage) const;
-    bool ValidatePushConstantBlockAgainstPipeline(std::vector<VkPushConstantRange> const* push_constant_ranges,
-                                                  SHADER_MODULE_STATE const* src, spirv_inst_iter type,
-                                                  VkShaderStageFlagBits stage) const;
+    bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* src,
+                                   VkPipelineShaderStageCreateInfo const* pStage) const;
+    int ValidatePushConstantSetUpdate(const std::vector<int8_t>& push_constant_data_update,
+                                      const shader_struct_member& push_constant_used_in_shader, uint32_t& out_issue_index) const;
     bool ValidateSpecializationOffsets(VkPipelineShaderStageCreateInfo const* info) const;
     bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure) const;
     bool RequireFeature(VkBool32 feature, char const* feature_name) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -900,6 +900,7 @@ class safe_VkRayTracingPipelineCreateInfoCommon : public safe_VkRayTracingPipeli
     }
 };
 
+struct SHADER_MODULE_STATE;
 class PIPELINE_STATE : public BASE_NODE {
   public:
     struct StageState {
@@ -908,6 +909,8 @@ class PIPELINE_STATE : public BASE_NODE {
         bool has_writable_descriptor;
         bool has_atomic_descriptor;
         VkShaderStageFlagBits stage_flag;
+        std::string entry_point_name;
+        std::shared_ptr<const SHADER_MODULE_STATE> shader_state;
     };
 
     VkPipeline pipeline;
@@ -1290,6 +1293,9 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
 
     std::vector<uint8_t> push_constant_data;
     PushConstantRangesId push_constant_data_ranges;
+
+    std::map<VkShaderStageFlagBits, std::vector<int8_t>> push_constant_data_update;  // -1: not set, 0: not update, 1: update,
+    VkPipelineLayout push_constant_pipeline_layout_set;
 
     // Used for Best Practices tracking
     uint32_t small_indexed_draw_call_count;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -65,6 +65,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-flags-02696",
         "VUID-vkCmdDraw-None-02686",
         "VUID-vkCmdDraw-None-02691",
+        "VUID-vkCmdDraw-None-02698",
         "VUID-vkCmdDraw-None-02687",
         "VUID-vkCmdDraw-None-02699",
         "VUID-vkCmdDraw-None-02702",
@@ -94,6 +95,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-flags-02696",
         "VUID-vkCmdDrawIndexed-None-02686",
         "VUID-vkCmdDrawIndexed-None-02691",
+        "VUID-vkCmdDrawIndexed-None-02698",
         "VUID-vkCmdDrawIndexed-None-02687",
         "VUID-vkCmdDrawIndexed-None-02699",
         "VUID-vkCmdDrawIndexed-None-02702",
@@ -123,6 +125,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-flags-02696",
         "VUID-vkCmdDrawIndirect-None-02686",
         "VUID-vkCmdDrawIndirect-None-02691",
+        "VUID-vkCmdDrawIndirect-None-02698",
         "VUID-vkCmdDrawIndirect-None-02687",
         "VUID-vkCmdDrawIndirect-None-02699",
         "VUID-vkCmdDrawIndirect-None-02702",
@@ -152,6 +155,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-flags-02696",
         "VUID-vkCmdDrawIndexedIndirect-None-02686",
         "VUID-vkCmdDrawIndexedIndirect-None-02691",
+        "VUID-vkCmdDrawIndexedIndirect-None-02698",
         "VUID-vkCmdDrawIndexedIndirect-None-02687",
         "VUID-vkCmdDrawIndexedIndirect-None-02699",
         "VUID-vkCmdDrawIndexedIndirect-None-02702",
@@ -181,6 +185,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          "VUID-vkCmdDispatch-flags-02696",
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatch-None-02691",
+         "VUID-vkCmdDispatch-None-02698",
          kVUIDUndefined, // image_subresources
         "VUID-vkCmdDispatch-None-02699",
         "VUID-vkCmdDispatch-None-02702",
@@ -210,6 +215,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchIndirect-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdDispatchIndirect-None-02691",
+        "VUID-vkCmdDispatchIndirect-None-02698",
         kVUIDUndefined, // image_subresources
         "VUID-vkCmdDispatchIndirect-None-02699",
         "VUID-vkCmdDispatchIndirect-None-02702",
@@ -239,6 +245,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndirectCount-None-02686",
         "VUID-vkCmdDrawIndirectCount-None-02691",
+        "VUID-vkCmdDrawIndirectCount-None-02698",
         "VUID-vkCmdDrawIndirectCount-None-02687",
         "VUID-vkCmdDrawIndirectCount-None-02699",
         "VUID-vkCmdDrawIndirectCount-None-02702",
@@ -268,6 +275,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-flags-02696",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02686",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02691",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02698",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02687",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02699",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02702",
@@ -297,6 +305,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysNV-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysNV-None-02691",
+        "VUID-vkCmdTraceRaysNV-None-02698",
          kVUIDUndefined, // image_subresources
         "VUID-vkCmdTraceRaysNV-None-02699",
         "VUID-vkCmdTraceRaysNV-None-02702",
@@ -326,6 +335,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysKHR-None-02691",
+		"VUID-vkCmdTraceRaysKHR-None-02698",
         kVUIDUndefined, // image_subresources
         "VUID-vkCmdTraceRaysKHR-None-02699",
         "VUID-vkCmdTraceRaysKHR-None-02702",
@@ -355,6 +365,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysIndirectKHR-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysIndirectKHR-None-02691",
+        "VUID-vkCmdTraceRaysIndirectKHR-None-02698",
         kVUIDUndefined, // image_subresources
         "VUID-vkCmdTraceRaysIndirectKHR-None-02699",
         "VUID-vkCmdTraceRaysIndirectKHR-None-02702",
@@ -384,6 +395,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksNV-None-02686",
         "VUID-vkCmdDrawMeshTasksNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksNV-None-02698",
         "VUID-vkCmdDrawMeshTasksNV-None-02687",
         "VUID-vkCmdDrawMeshTasksNV-None-02699",
         "VUID-vkCmdDrawMeshTasksNV-None-02702",
@@ -413,6 +425,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-None-02698",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02687",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02699",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02702",
@@ -442,6 +455,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-flags-02696",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02686",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02691",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02698",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02687",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02699",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02702",
@@ -471,6 +485,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-flags-02696",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02686",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02691",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02698",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02687",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02699",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02702",
@@ -500,6 +515,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
          "VUID-vkCmdDispatchBase-flags-02696",
          kVUIDUndefined, // subpass_input
          "VUID-vkCmdDispatchBase-None-02691",
+         "VUID-vkCmdDispatchBase-None-02698",
          kVUIDUndefined, // image_subresources
         "VUID-vkCmdDispatchBase-None-02699",
         "VUID-vkCmdDispatchBase-None-02702",
@@ -508,6 +524,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -120,6 +120,70 @@ struct decoration_set {
     void add(uint32_t decoration, uint32_t value);
 };
 
+struct function_set {
+    unsigned id;
+    unsigned offset;
+    unsigned length;
+    std::unordered_multimap<uint32_t, uint32_t> op_lists;  // key: spv::Op,  value: offset
+
+    function_set() : id(0), offset(0), length(0) {}
+};
+
+struct shader_struct_member {
+    uint32_t offset;
+    uint32_t size;                                 // A scalar size or a struct size. Not consider array
+    std::vector<uint32_t> array_length_hierarchy;  // multi-dimensional array, mat, vec. mat is combined with 2 array.
+                                                   // e.g :array[2] -> {2}, array[2][3][4] -> {2,3,4}, mat4[2] ->{2,4,4},
+    std::vector<uint32_t> array_block_size;        // When index increases, how many data increases.
+                                             // e.g : array[2][3][4] -> {12,4,1}, it means if the first index increases one, the
+                                             // array gets 12 data. If the second index increases one, the array gets 4 data.
+    std::vector<shader_struct_member> struct_members;  // If the data is not a struct, it's empty.
+    shader_struct_member *root;
+
+    shader_struct_member() : offset(0), size(0), root(nullptr) {}
+
+    bool IsUsed() const {
+        if (!root) return false;
+        return root->used_bytes.size() ? true : false;
+    }
+
+    std::vector<uint8_t> *GetUsedbytes() const {
+        if (!root) return nullptr;
+        return &root->used_bytes;
+    }
+
+    std::string GetLocationDesc(uint32_t index_used_bytes) const {
+        std::string desc = "";
+        if (array_length_hierarchy.size() > 0) {
+            desc += " index:";
+            for (const auto block_size : array_block_size) {
+                desc += "[";
+                desc += std::to_string(index_used_bytes / (block_size * size));
+                desc += "]";
+                index_used_bytes = index_used_bytes % (block_size * size);
+            }
+        }
+        const int struct_members_size = static_cast<int>(struct_members.size());
+        if (struct_members_size > 0) {
+            desc += " member:";
+            for (int i = struct_members_size - 1; i >= 0; --i) {
+                if (index_used_bytes > struct_members[i].offset) {
+                    desc += std::to_string(i);
+                    desc += struct_members[i].GetLocationDesc(index_used_bytes - struct_members[i].offset);
+                    break;
+                }
+            }
+        } else {
+            desc += " offset:";
+            desc += std::to_string(index_used_bytes);
+        }
+        return desc;
+    }
+
+  private:
+    std::vector<uint8_t> used_bytes;  // This only works for root. 0: not used. 1: used. The totally array * size.
+};
+
 struct SHADER_MODULE_STATE : public BASE_NODE {
     // The spirv image itself
     std::vector<uint32_t> words;
@@ -129,7 +193,10 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::unordered_map<unsigned, decoration_set> decorations;
     struct EntryPoint {
         uint32_t offset;
-        VkShaderStageFlags stage;
+        VkShaderStageFlagBits stage;
+        std::unordered_multimap<unsigned, unsigned> decorate_list;  // key: spv::Op,  value: offset
+        std::vector<function_set> function_set_list;
+        shader_struct_member push_constant_used_in_shader;
     };
     std::unordered_multimap<std::string, EntryPoint> entry_points;
     bool has_valid_spirv;
@@ -317,6 +384,8 @@ class ValidationCache {
     }
 };
 
+const SHADER_MODULE_STATE::EntryPoint *FindEntrypointStruct(SHADER_MODULE_STATE const *src, char const *name,
+                                                            VkShaderStageFlagBits stageBits);
 spirv_inst_iter FindEntrypoint(SHADER_MODULE_STATE const *src, char const *name, VkShaderStageFlagBits stageBits);
 
 // For some analyses, we need to know about all ids referenced by the static call tree of a particular entrypoint. This is
@@ -340,6 +409,8 @@ std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescr
     SHADER_MODULE_STATE const *src, std::unordered_set<uint32_t> const &accessible_ids, bool *has_writable_descriptor,
     bool *has_atomic_descriptor);
 
+void SetPushConstantUsedInShader(SHADER_MODULE_STATE &src);
+
 std::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const SHADER_MODULE_STATE &module,
                                                                const VkPipelineShaderStageCreateInfo &stage_info);
 
@@ -349,5 +420,8 @@ spv_target_env PickSpirvEnv(uint32_t api_version, bool spirv_1_4);
 
 void AdjustValidatorOptions(const DeviceExtensions device_extensions, const DeviceFeatures enabled_features,
                             spvtools::ValidatorOptions &options);
+
+void RunUsedStruct(const SHADER_MODULE_STATE &src, uint32_t offset, uint32_t access_chain_word_index,
+                   spirv_inst_iter &access_chain_it, const shader_struct_member &data);
 
 #endif  // VULKAN_SHADER_VALIDATION_H

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -3581,8 +3581,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckShaderPushConstantNotDeclared) {
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {}, {push_constant_range});
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
-                                         "Shader push-constant buffer member 0 at offset 0 is not declared in pipeline layout");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-Shader-PushConstantOutOfRange");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -5040,7 +5039,7 @@ TEST_F(VkLayerTest, CreatePipelinePushConstantsNotInLayout) {
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {});
     /* should have generated an error -- no push constant ranges provided! */
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "not declared in pipeline layout");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-Shader-PushConstantOutOfRange");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
1) In CreateShaderModule, analyze shader code to get declarations of push constants, and then check if they are used in functions. SHADER_MODULE_STATE has a struct to save this result.

2) In Create*Pipeline, validate if push constant range of pipeline layout matches the struct in SHADER_MODULE_STATE.

3) In CmdPushConstants, record what byte of push constant is updated.

4)  In CmdDraw, validate if push constant that is used in shader is updated or match pipelline layouts' push constants range

It doesn't consider **Specialization Constants** situation.

Implements part of #135