### PR TITLE
Move vma allocator destroy to after state tracker

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -97,6 +97,12 @@ void DebugPrintf::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, co
 
 void DebugPrintf::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
     UtilPreCallRecordDestroyDevice(this);
+    ValidationStateTracker::PreCallRecordDestroyDevice(device, pAllocator);
+    // State Tracker can end up making vma calls through callbacks - don't destroy allocator until ST is done
+    if (vmaAllocator) {
+        vmaDestroyAllocator(vmaAllocator);
+    }
+    desc_set_manager.reset();
 }
 
 // Modify the pipeline layout to include our debug descriptor set and any needed padding with the dummy descriptor set.

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -126,11 +126,6 @@ void UtilPreCallRecordDestroyDevice(ObjectType *object_ptr) {
         DispatchDestroyDescriptorSetLayout(object_ptr->device, object_ptr->dummy_desc_layout, NULL);
         object_ptr->dummy_desc_layout = VK_NULL_HANDLE;
     }
-    object_ptr->desc_set_manager.reset();
-
-    if (object_ptr->vmaAllocator) {
-        vmaDestroyAllocator(object_ptr->vmaAllocator);
-    }
 }
 
 template <typename ObjectType>

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -309,6 +309,11 @@ void GpuAssisted::PreCallRecordDestroyDevice(VkDevice device, const VkAllocation
     DestroyAccelerationStructureBuildValidationState();
     UtilPreCallRecordDestroyDevice(this);
     ValidationStateTracker::PreCallRecordDestroyDevice(device, pAllocator);
+    // State Tracker can end up making vma calls through callbacks - don't destroy allocator until ST is done
+    if (vmaAllocator) {
+        vmaDestroyAllocator(vmaAllocator);
+    }
+    desc_set_manager.reset();
 }
 
 void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *device_gpuav) {


### PR DESCRIPTION
State tracker cleans up leftover command buffers and can make vma and descriptor set manager
calls, so don't destroy or reset those until after state tracker has finished.