### PR TITLE
Add multi subpass dependency support

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -575,12 +575,12 @@ struct SubpassDependencyGraphNode {
         Dependency(const VkSubpassDependency2 *dependency_, const SubpassDependencyGraphNode *node_)
             : dependency(dependency_), node(node_) {}
     };
-    std::vector<Dependency> prev;
-    std::vector<Dependency> next;
+    std::map<const SubpassDependencyGraphNode *, std::vector<const VkSubpassDependency2 *>> prev;
+    std::map<const SubpassDependencyGraphNode *, std::vector<const VkSubpassDependency2 *>> next;
     std::vector<uint32_t> async;  // asynchronous subpasses with a lower subpass index
 
-    const VkSubpassDependency2 *barrier_from_external;
-    const VkSubpassDependency2 *barrier_to_external;
+    std::vector<const VkSubpassDependency2 *> barrier_from_external;
+    std::vector<const VkSubpassDependency2 *> barrier_to_external;
     std::unique_ptr<VkSubpassDependency2> implicit_barrier_from_external;
     std::unique_ptr<VkSubpassDependency2> implicit_barrier_to_external;
 };

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -225,11 +225,13 @@ class AccessContext {
         kDetectAll = (kDetectPrevious | kDetectAsync)
     };
 
+    // WIP TODO WIP Multi-dep -- change track back to support barrier vector, not just last.
     struct TrackBack {
         SyncBarrier barrier;
         const AccessContext *context;
-        TrackBack(const AccessContext *context_, VkQueueFlags queue_flags_, const VkSubpassDependency2 &subpass_barrier_)
-            : barrier(queue_flags_, subpass_barrier_), context(context_) {}
+        TrackBack(const AccessContext *context_, VkQueueFlags queue_flags_,
+                  const std::vector<const VkSubpassDependency2 *> &subpass_barrier_)
+            : barrier(queue_flags_, *subpass_barrier_.back()), context(context_) {}
         TrackBack &operator=(const TrackBack &) = default;
         TrackBack() = default;
     };


### PR DESCRIPTION
Add support to correctly allow for multiple VKSubpassDependency structures between the same srcSubpass/dstSubpass pair.  This is a first pass fix for #2088 . It quashes false positives but is somewhat too generous (taking the union of the `src*Mask` and `dst*Mask` fields, which can generate unintended implied barrier effects, relative to treating the VkSubpassDependency's definitions as fully independent.  

Exact fix will take some detailed changes that will need careful testing.