### PR TITLE
Add fix for renderpass compatibility

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -638,12 +638,12 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
     if (rp1_state->createInfo.flags != rp2_state->createInfo.flags) {
         LogObjectList objlist(rp1_state->renderPass);
         objlist.add(rp2_state->renderPass);
-        skip |= LogError(objlist, error_code,
-            "%s: RenderPasses incompatible between %s w/ %s with flags of %u and %s w/ "
-            "%s with a flags of %u.",
-            caller, type1_string, report_data->FormatHandle(rp1_state->renderPass).c_str(),
-            rp1_state->createInfo.flags, type2_string, report_data->FormatHandle(rp2_state->renderPass).c_str(),
-            rp2_state->createInfo.flags);
+        skip |=
+            LogError(objlist, error_code,
+                     "%s: RenderPasses incompatible between %s w/ %s with flags of %u and %s w/ "
+                     "%s with a flags of %u.",
+                     caller, type1_string, report_data->FormatHandle(rp1_state->renderPass).c_str(), rp1_state->createInfo.flags,
+                     type2_string, report_data->FormatHandle(rp2_state->renderPass).c_str(), rp2_state->createInfo.flags);
     }
 
     if (rp1_state->createInfo.subpassCount != rp2_state->createInfo.subpassCount) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -634,6 +634,18 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
                                                  const char *error_code) const {
     bool skip = false;
 
+    // createInfo flags must be identical for the renderpasses to be compatible.
+    if (rp1_state->createInfo.flags != rp2_state->createInfo.flags) {
+        LogObjectList objlist(rp1_state->renderPass);
+        objlist.add(rp2_state->renderPass);
+        skip |= LogError(objlist, error_code,
+            "%s: RenderPasses incompatible between %s w/ %s with flags of %u and %s w/ "
+            "%s with a flags of %u.",
+            caller, type1_string, report_data->FormatHandle(rp1_state->renderPass).c_str(),
+            rp1_state->createInfo.flags, type2_string, report_data->FormatHandle(rp2_state->renderPass).c_str(),
+            rp2_state->createInfo.flags);
+    }
+
     if (rp1_state->createInfo.subpassCount != rp2_state->createInfo.subpassCount) {
         LogObjectList objlist(rp1_state->renderPass);
         objlist.add(rp2_state->renderPass);


### PR DESCRIPTION
The [Renderpass Compatibility Rules](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#renderpass-compatibility) require that for two renderpass to be compatible, they must be identical (with special compatibility rules for the attachments, and certain other enumerated exceptions).

> Two render passes are compatible if their corresponding color, input, resolve, and depth/stencil attachment references are compatible **and if they are otherwise identical** except for...

This change specifically adds a check that the VkRenderPassCreateFlags must be identical for the renderpasses to be compatible.