### PR TITLE
tracker: Retire work when checking Timeline Semaphore Value

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2362,6 +2362,22 @@ void ValidationStateTracker::PostCallRecordWaitSemaphoresKHR(VkDevice device, co
     RecordWaitSemaphores(device, pWaitInfo, timeout, result);
 }
 
+void ValidationStateTracker::RecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
+                                                            VkResult result) {
+    if (VK_SUCCESS != result) return;
+
+    RetireTimelineSemaphore(semaphore, *pValue);
+}
+
+void ValidationStateTracker::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
+                                                                    VkResult result) {
+    RecordGetSemaphoreCounterValue(device, semaphore, pValue, result);
+}
+void ValidationStateTracker::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
+                                                                       VkResult result) {
+    RecordGetSemaphoreCounterValue(device, semaphore, pValue, result);
+}
+
 void ValidationStateTracker::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, VkResult result) {
     if (VK_SUCCESS != result) return;
     RetireFence(fence);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -947,6 +947,8 @@ class ValidationStateTracker : public ValidationObject {
                                      uint64_t timeout, VkResult result);
     void PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout, VkResult result);
     void PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout, VkResult result);
+    void PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue, VkResult result);
+    void PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue, VkResult result);
     void PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo, VkResult result);
     void PostCallRecordReleaseProfilingLockKHR(VkDevice device);
 
@@ -1263,6 +1265,7 @@ class ValidationStateTracker : public ValidationObject {
     void RetireFence(VkFence fence);
     void RetireTimelineSemaphore(VkSemaphore semaphore, uint64_t until_payload);
     void RecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout, VkResult result);
+    void RecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue, VkResult result);
     void RetireWorkOnQueue(QUEUE_STATE* pQueue, uint64_t seq);
     static bool SetEventStageMask(VkEvent event, VkPipelineStageFlags stageMask, EventToStageMap* localEventToStageMap);
     void ResetCommandBufferPushConstantDataIfIncompatible(CMD_BUFFER_STATE* cb_state, VkPipelineLayout layout);


### PR DESCRIPTION
Retire Queue submissions when Timeline Semaphore value is checked.