### PR TITLE
refactor: Move CALL_STATE into best_practices

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1698,7 +1698,7 @@ bool BestPractices::PreCallValidateGetSwapchainImagesKHR(VkDevice device, VkSwap
 
     if (swapchain_state && pSwapchainImages) {
         // Compare the preliminary value of *pSwapchainImageCount with the value this time:
-        if (swapchain_state->vkGetSwapchainImagesKHRState == UNCALLED) {
+        if (!swapchain_state->vkGetSwapchainImagesKHRCalled) {
             skip |=
                 LogWarning(device, kVUID_Core_Swapchain_PriorCount,
                            "vkGetSwapchainImagesKHR() called with non-NULL pSwapchainImageCount; but no prior positive value has "

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -71,12 +71,6 @@ struct CMD_BUFFER_STATE;
 class CoreChecks;
 class ValidationStateTracker;
 
-enum CALL_STATE {
-    UNCALLED,       // Function has not been called
-    QUERY_COUNT,    // Function called once to query a count
-    QUERY_DETAILS,  // Function called w/ a count to query details
-};
-
 class BASE_NODE {
   public:
     // Track when object is being used by an in-flight command buffer
@@ -551,7 +545,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     std::vector<SWAPCHAIN_IMAGE> images;
     bool retired = false;
     bool shared_presentable = false;
-    CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
+    bool vkGetSwapchainImagesKHRCalled = false;
     uint32_t get_swapchain_image_count = 0;
     SWAPCHAIN_NODE(const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain)
         : createInfo(pCreateInfo), swapchain(swapchain) {}

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5749,8 +5749,8 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
     if (*pSwapchainImageCount > swapchain_state->images.size()) swapchain_state->images.resize(*pSwapchainImageCount);
 
     if (pSwapchainImages) {
-        if (swapchain_state->vkGetSwapchainImagesKHRState < QUERY_DETAILS) {
-            swapchain_state->vkGetSwapchainImagesKHRState = QUERY_DETAILS;
+        if (!swapchain_state->vkGetSwapchainImagesKHRCalled) {
+            swapchain_state->vkGetSwapchainImagesKHRCalled = true;
         }
         for (uint32_t i = 0; i < *pSwapchainImageCount; ++i) {
             if (swapchain_state->images[i].image != VK_NULL_HANDLE) continue;  // Already retrieved this.
@@ -5799,8 +5799,8 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
     }
 
     if (*pSwapchainImageCount) {
-        if (swapchain_state->vkGetSwapchainImagesKHRState < QUERY_COUNT) {
-            swapchain_state->vkGetSwapchainImagesKHRState = QUERY_COUNT;
+        if (!swapchain_state->vkGetSwapchainImagesKHRCalled) {
+            swapchain_state->vkGetSwapchainImagesKHRCalled = true;
         }
         swapchain_state->get_swapchain_image_count = *pSwapchainImageCount;
     }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -118,6 +118,12 @@ class QUEUE_FAMILY_PERF_COUNTERS {
     std::vector<VkPerformanceCounterKHR> counters;
 };
 
+enum CALL_STATE {
+    UNCALLED,       // Function has not been called
+    QUERY_COUNT,    // Function called once to query a count
+    QUERY_DETAILS,  // Function called w/ a count to query details
+};
+
 struct PHYSICAL_DEVICE_STATE {
     // Track the call state and array sizes for various query functions
     CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState = UNCALLED;


### PR DESCRIPTION
Moves the CALL_STATE enum outside of core validation and into the state
tracker (used by best practices).

Change-Id: Iab9a782b4a0b9aab499b4aafad0dbe8b6384eee5