### PR TITLE
Change CreateDevice special parameter from safe_VkDeviceCreateInfo* to void*

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -36,12 +36,13 @@ void DebugPrintf::ReportSetupProblem(T object, const char *const specific_messag
 // Turn on necessary device features.
 void DebugPrintf::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *create_info,
                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                            safe_VkDeviceCreateInfo *modified_create_info) {
+                                            void *modified_create_info) {
     DispatchGetPhysicalDeviceFeatures(gpu, &supported_features);
     VkPhysicalDeviceFeatures features = {};
     features.vertexPipelineStoresAndAtomics = true;
     features.fragmentStoresAndAtomics = true;
-    UtilPreCallRecordCreateDevice(gpu, modified_create_info, supported_features, features);
+    UtilPreCallRecordCreateDevice(gpu, reinterpret_cast<safe_VkDeviceCreateInfo *>(modified_create_info), supported_features,
+                                  features);
 }
 
 // Perform initializations that can be done at Create Device time.

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -104,8 +104,7 @@ class DebugPrintf : public ValidationStateTracker {
     template <typename T>
     void ReportSetupProblem(T object, const char* const specific_message) const;
     void PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
-                                   safe_VkDeviceCreateInfo* modified_create_info);
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void* modified_create_info);
     void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator);

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -4652,7 +4652,7 @@ class ValidationObject {
         };
 
         // Modify a parameter to CreateDevice
-        virtual void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, safe_VkDeviceCreateInfo *modified_create_info) {
+        virtual void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void *modified_create_info) {
             PreCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
         };
 };

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -221,13 +221,14 @@ void GpuAssisted::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreat
 // Turn on necessary device features.
 void GpuAssisted::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *create_info,
                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                            safe_VkDeviceCreateInfo *modified_create_info) {
+                                            void *modified_create_info) {
     DispatchGetPhysicalDeviceFeatures(gpu, &supported_features);
     VkPhysicalDeviceFeatures features = {};
     features.vertexPipelineStoresAndAtomics = true;
     features.fragmentStoresAndAtomics = true;
     features.shaderInt64 = true;
-    UtilPreCallRecordCreateDevice(gpu, modified_create_info, supported_features, features);
+    UtilPreCallRecordCreateDevice(gpu, reinterpret_cast<safe_VkDeviceCreateInfo *>(modified_create_info), supported_features,
+                                  features);
 }
 // Perform initializations that can be done at Create Device time.
 void GpuAssisted::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -123,8 +123,7 @@ class GpuAssisted : public ValidationStateTracker {
     void ReportSetupProblem(T object, const char* const specific_message) const;
     bool CheckForDescriptorIndexing(DeviceFeatures enabled_features) const;
     void PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
-                                   safe_VkDeviceCreateInfo* modified_create_info);
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void* modified_create_info);
     void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
     void PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfoEXT* pInfo, VkDeviceAddress address);

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1633,7 +1633,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
         };
 
         // Modify a parameter to CreateDevice
-        virtual void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, safe_VkDeviceCreateInfo *modified_create_info) {
+        virtual void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void *modified_create_info) {
             PreCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
         };
 """


### PR DESCRIPTION
Unlike the other 'special' chassis APIs, `PreCallRecordCreateDevice `didn't use a `void*` -- changed for consistency.
