### PR TITLE
Fixed VUID-02686 bug

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -820,7 +820,7 @@ struct interface_var {
     uint32_t id;
     uint32_t type_id;
     uint32_t offset;
-    int32_t input_index;  // index = -1 means that it's not input attachment.
+    uint32_t input_index;  // index = VK_ATTACHMENT_UNUSED means that it's not input attachment.
 
     std::vector<SamplerUsedByImage> samplers_used_by_image;  // List of samplers that sample a given image
 
@@ -837,7 +837,7 @@ struct interface_var {
         : id(0),
           type_id(0),
           offset(0),
-          input_index(-1),
+          input_index(VK_ATTACHMENT_UNUSED),
           is_patch(false),
           is_block_member(false),
           is_relaxed_precision(false),

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -8076,9 +8076,6 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     };
     std::vector<VkAttachmentReference> inputAttachments;
     inputAttachments.push_back(inputRef);
-    // index 1 is not used in fragment shader, it causes a desired failure.
-    inputRef.attachment = 1;
-    inputAttachments.push_back(inputRef);
 
     const VkSubpassDescription subpass = {
         0u,
@@ -8169,7 +8166,6 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
                               &g_pipe.descriptor_set_->set_, 0, nullptr);
 
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-None-02686");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-None-02686");
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Fixed https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2171

It removed checking if subpass sets input index, but shader doesn't do it. It only checks if shader sets input index, but sbupass doesn't setup it or VK_ATTACHMENT_UNUSED.