### PR TITLE
Some bug fixed for shader validation and perf improvement

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -276,6 +276,17 @@ bool IMAGE_VIEW_STATE::OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) 
     return true;
 }
 
+const cvdescriptorset::DescriptorSet *CMD_BUFFER_STATE::GetDescriptorSet(VkPipelineBindPoint bind_point, uint32_t set) const {
+    const auto last_bound_it = lastBound.find(bind_point);
+    if (last_bound_it == lastBound.cend()) {
+        return nullptr;
+    }
+    if (set >= last_bound_it->second.per_set.size()) {
+        return nullptr;
+    }
+    return last_bound_it->second.per_set[set].bound_descriptor_set;
+}
+
 const cvdescriptorset::Descriptor *CMD_BUFFER_STATE::GetDescriptor(VkShaderStageFlagBits shader_stage, uint32_t set,
                                                                    uint32_t binding, uint32_t index) const {
     VkPipelineBindPoint bind_point;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1121,11 +1121,11 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                         state.per_set[setIndex].validated_set_binding_req_map.begin(),
                                         state.per_set[setIndex].validated_set_binding_req_map.end(),
                                         std::inserter(delta_reqs, delta_reqs.begin()));
-                    result |= ValidateDrawState(descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets, cb_node,
-                                                attachment_views, function, vuid);
+                    result |= ValidateDrawState(bind_point, descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets,
+                                                cb_node, attachment_views, function, vuid);
                 } else {
-                    result |= ValidateDrawState(descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets, cb_node,
-                                                attachment_views, function, vuid);
+                    result |= ValidateDrawState(bind_point, descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets,
+                                                cb_node, attachment_views, function, vuid);
                 }
             }
         }
@@ -2760,8 +2760,8 @@ bool CoreChecks::ValidateCommandBuffersForSubmit(VkQueue queue, const VkSubmitIn
                             std::string error;
                             std::vector<uint32_t> dynamicOffsets;
                             // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
-                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamicOffsets, binding_info,
-                                                                     cmd_info.framebuffer, cmd_info.attachment_views,
+                            skip |= ValidateDescriptorSetBindingData(cmd_info.bind_point, cb_node, set_node, dynamicOffsets,
+                                                                     binding_info, cmd_info.framebuffer, cmd_info.attachment_views,
                                                                      function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
                         }
                     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -376,13 +376,14 @@ class CoreChecks : public ValidationStateTracker {
     VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                 void* pData);
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
-    bool ValidateDrawState(const cvdescriptorset::DescriptorSet* descriptor_set,
+    bool ValidateDrawState(VkPipelineBindPoint bind_point, const cvdescriptorset::DescriptorSet* descriptor_set,
                            const std::map<uint32_t, DescriptorReqirement>& bindings, const std::vector<uint32_t>& dynamic_offsets,
                            const CMD_BUFFER_STATE* cb_node, const std::vector<VkImageView>& attachment_views, const char* caller,
                            const DrawDispatchVuid& vuids) const;
-    bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node, const cvdescriptorset::DescriptorSet* descriptor_set,
+    bool ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point, const CMD_BUFFER_STATE* cb_node,
+                                          const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets,
-                                          std::pair<uint32_t, DescriptorReqirement> binding_info, VkFramebuffer framebuffer,
+                                          std::pair<const uint32_t, DescriptorReqirement>& binding_info, VkFramebuffer framebuffer,
                                           const std::vector<VkImageView>& attachment_views, const char* caller,
                                           const DrawDispatchVuid& vuids) const;
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -169,15 +169,22 @@ extern unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt);
 typedef std::pair<unsigned, unsigned> descriptor_slot_t;
 
 struct SamplerUsedByImage {
-    uint32_t image_index;
     descriptor_slot_t sampler_slot;
     uint32_t sampler_index;
 };
 
+namespace std {
+template <>
+struct less<SamplerUsedByImage> {
+    bool operator()(const SamplerUsedByImage &left, const SamplerUsedByImage &right) const { return false; }
+};
+}  // namespace std
+
 struct DescriptorReqirement {
     descriptor_req reqs;
-    std::map<VkShaderStageFlagBits, const std::vector<SamplerUsedByImage> *>
-        samplers_used_by_image;  // Refer from StageState.interface_var
+    std::vector<std::map<SamplerUsedByImage, std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *>>>
+        samplers_used_by_image;  // Copy from StageState.interface_var. BUT it combines from plural shader stages.
+                                 // The index of array is index of image.
     DescriptorReqirement() : reqs(descriptor_req(0)) {}
 };
 
@@ -821,7 +828,8 @@ struct interface_var {
     uint32_t type_id;
     uint32_t offset;
 
-    std::vector<SamplerUsedByImage> samplers_used_by_image;  // List of samplers that sample a given image
+    std::vector<std::set<SamplerUsedByImage>> samplers_used_by_image;  // List of samplers that sample a given image.
+                                                                       // The index of array is index of image.
 
     bool is_patch;
     bool is_block_member;
@@ -1225,9 +1233,10 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::map<uint32_t, LAST_BOUND_STATE> lastBound;
 
     struct CmdDrawDispatchInfo {
+        VkPipelineBindPoint bind_point;
         CMD_TYPE cmd_type;
         std::string function;
-        std::vector<std::pair<uint32_t, DescriptorReqirement>> binding_infos;
+        std::vector<std::pair<const uint32_t, DescriptorReqirement>> binding_infos;
         VkFramebuffer framebuffer;
         std::vector<VkImageView> attachment_views;  // vector index is attachment index. If the value is VK_NULL_HANDLE(0),
                                                     // it means the attachment isn't used in this command.
@@ -1301,6 +1310,8 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::vector<IMAGE_VIEW_STATE *> imagelessFramebufferAttachments;
 
     bool transform_feedback_active{false};
+
+    const cvdescriptorset::DescriptorSet *GetDescriptorSet(VkPipelineBindPoint bind_point, uint32_t set) const;
 
     const cvdescriptorset::Descriptor *GetDescriptor(VkShaderStageFlagBits shader_stage, uint32_t set, uint32_t binding,
                                                      uint32_t index) const;

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1122,8 +1122,11 @@ static void IsSpecificDescriptorType(SHADER_MODULE_STATE const *module, const sp
                             sampler_index = GetConstantValue(module, accesschain_it->second.second);
                         }
                         auto sampler_dec = module->get_decorations(sampler_id);
-                        out_interface_var.samplers_used_by_image.emplace_back(SamplerUsedByImage{
-                            image_index, descriptor_slot_t{sampler_dec.descriptor_set, sampler_dec.binding}, sampler_index});
+                        if (image_index >= out_interface_var.samplers_used_by_image.size()) {
+                            out_interface_var.samplers_used_by_image.resize(image_index + 1);
+                        }
+                        out_interface_var.samplers_used_by_image[image_index].emplace(
+                            SamplerUsedByImage{descriptor_slot_t{sampler_dec.descriptor_set, sampler_dec.binding}, sampler_index});
                     }
                 }
             }

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1005,9 +1005,15 @@ struct shader_module_used_operators {
                     break;
                 }
                 case spv::OpAccessChain: {
-                    // 2: AccessChain id, 3: object id, 4: object id of array index
-                    accesschain_members.insert(
-                        std::make_pair(insn.word(2), std::pair<unsigned, unsigned>(insn.word(3), insn.word(4))));
+                    if (insn.len() == 4) {
+                        // If it is for struct, the length is only 4.
+                        // 2: AccessChain id, 3: object id
+                        accesschain_members.insert(std::make_pair(insn.word(2), std::pair<unsigned, unsigned>(insn.word(3), 0)));
+                    } else {
+                        // 2: AccessChain id, 3: object id, 4: object id of array index
+                        accesschain_members.insert(
+                            std::make_pair(insn.word(2), std::pair<unsigned, unsigned>(insn.word(3), insn.word(4))));
+                    }
                     break;
                 }
                 case spv::OpImageTexelPointer: {
@@ -1089,6 +1095,11 @@ static void IsSpecificDescriptorType(SHADER_MODULE_STATE const *module, const sp
                                 if (accesschain_it->second.first != id) {
                                     continue;
                                 }
+                                if (used_operators.load_members.end() !=
+                                    used_operators.load_members.find(accesschain_it->second.second)) {
+                                    // image_index isn't a constant, skip.
+                                    break;
+                                }
                                 image_index = GetConstantValue(module, accesschain_it->second.second);
                             }
                         }
@@ -1102,6 +1113,11 @@ static void IsSpecificDescriptorType(SHADER_MODULE_STATE const *module, const sp
                         uint32_t sampler_index = 0;
                         auto accesschain_it = used_operators.accesschain_members.find(load_it->second);
                         if (accesschain_it != used_operators.accesschain_members.end()) {
+                            if (used_operators.load_members.end() !=
+                                used_operators.load_members.find(accesschain_it->second.second)) {
+                                // sampler_index isn't a constant, skip.
+                                break;
+                            }
                             sampler_id = accesschain_it->second.first;
                             sampler_index = GetConstantValue(module, accesschain_it->second.second);
                         }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5783,8 +5783,18 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
 
         pipeline->max_active_slot = std::max(pipeline->max_active_slot, slot);
         if (use.second.samplers_used_by_image.size()) {
-            pipeline->active_slots[slot][use.first.second].samplers_used_by_image[stage_state->stage_flag] =
-                &use.second.samplers_used_by_image;
+            auto &samplers_used_by_image = pipeline->active_slots[slot][use.first.second].samplers_used_by_image;
+            if (use.second.samplers_used_by_image.size() > samplers_used_by_image.size()) {
+                samplers_used_by_image.resize(use.second.samplers_used_by_image.size());
+            }
+            std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *> sampler_descriptors;
+            uint32_t image_index = 0;
+            for (const auto &samplers : use.second.samplers_used_by_image) {
+                for (const auto &sampler : samplers) {
+                    samplers_used_by_image[image_index].emplace(sampler, sampler_descriptors);
+                }
+                ++image_index;
+            }
         }
     }
 


### PR DESCRIPTION
The index of Images or Samplers in shader might not be a constant. Skip it if the index is not a constant.

This bug fix is related to 
VUID-vkCmdTraceRaysIndirectKHR-None-02702
If the VkPipeline object bound to the pipeline bind point used by this command accesses a VkSampler object that uses unnormalized coordinates, that sampler must not be used to sample from any VkImage with a VkImageView of the type VK_IMAGE_VIEW_TYPE_3D, VK_IMAGE_VIEW_TYPE_CUBE, VK_IMAGE_VIEW_TYPE_1D_ARRAY, VK_IMAGE_VIEW_TYPE_2D_ARRAY or VK_IMAGE_VIEW_TYPE_CUBE_ARRAY, in any shader stage.