### PR TITLE
tests: Remove clang 10 warning for string copy

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -550,7 +550,7 @@ void NegHeightViewportTests(VkDeviceObj *m_device, VkCommandBufferObj *m_command
                                          {{0.0, max_bound, 64.0, 1.0, 0.0, 1.0}, {"VUID-VkViewport-y-01233"}}};
 
     for (const auto &test_case : test_cases) {
-        for (const auto vuid : test_case.vuids) {
+        for (const auto &vuid : test_case.vuids) {
             if (vuid == "VUID-Undefined")
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "is less than VkPhysicalDeviceLimits::viewportBoundsRange[0]");
             else

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -181,7 +181,7 @@ void ErrorMonitor::VerifyFound() {
     // Not receiving expected message(s) is a failure. /Before/ throwing, dump any other messages
     if (!AllDesiredMsgsFound()) {
         DumpFailureMsgs();
-        for (const auto desired_msg : desired_message_strings_) {
+        for (const auto &desired_msg : desired_message_strings_) {
             ADD_FAILURE() << "Did not receive expected error '" << desired_msg << "'";
         }
     } else if (GetOtherFailureMsgs().size() > 0) {
@@ -204,7 +204,7 @@ void ErrorMonitor::VerifyNotFound() {
     // ExpectSuccess() configured us to match anything. Any error is a failure.
     if (AnyDesiredMsgFound()) {
         DumpFailureMsgs();
-        for (const auto msg : failure_message_strings_) {
+        for (const auto &msg : failure_message_strings_) {
             ADD_FAILURE() << "Expected to succeed but got error: " << msg;
         }
     } else if (GetOtherFailureMsgs().size() > 0) {
@@ -1150,7 +1150,7 @@ void VkImageObj::ImageMemoryBarrier(VkCommandBufferObj *cmd_buf, VkImageAspectFl
                                     VK_ACCESS_SHADER_WRITE_BIT |
                                     VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
                                     VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
-                                    VK_MEMORY_OUTPUT_COPY_BIT*/, 
+                                    VK_MEMORY_OUTPUT_COPY_BIT*/,
                                     VkFlags input_mask /*=
                                     VK_ACCESS_HOST_READ_BIT |
                                     VK_ACCESS_INDIRECT_COMMAND_READ_BIT |


### PR DESCRIPTION
Updating my clang to version 10 displayed the follow warnings on build
```
loop variable ... creates a copy from type
const std::__cxx11::basic_string<char> [-Wrange-loop-construct]
```