### PR TITLE
Remove vuid 02686

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -52,7 +52,7 @@ struct DrawDispatchVuid {
     const char* viewport_scissor_count;
     const char* primitive_topology;
     const char* corner_sampled_address_mode;
-    const char* subpass_input;
+    const char* subpass_input;  // It doesn't validate anything because those stuff have done in ValidateCreateGraphicsPipelines.
     const char* imageview_atomic;
     const char* image_subresources;
     const char* descriptor_valid;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -820,7 +820,6 @@ struct interface_var {
     uint32_t id;
     uint32_t type_id;
     uint32_t offset;
-    uint32_t input_index;  // index = VK_ATTACHMENT_UNUSED means that it's not input attachment.
 
     std::vector<SamplerUsedByImage> samplers_used_by_image;  // List of samplers that sample a given image
 
@@ -837,7 +836,6 @@ struct interface_var {
         : id(0),
           type_id(0),
           offset(0),
-          input_index(VK_ATTACHMENT_UNUSED),
           is_patch(false),
           is_block_member(false),
           is_relaxed_precision(false),

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1138,9 +1138,6 @@ std::vector<std::pair<descriptor_slot_t, interface_var>> CollectInterfaceByDescr
                                      !(d.flags & decoration_set::nonwritable_bit), v, operators);
             if (v.is_writable) *has_writable_descriptor = true;
             if (v.is_atomic_operation) *has_atomic_descriptor = true;
-            if (d.flags & decoration_set::input_attachment_index_bit) {
-                v.input_index = d.input_attachment_index;
-            }
             out.emplace_back(std::make_pair(set, binding), v);
         }
     }

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -8068,7 +8068,6 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     };
     std::vector<VkAttachmentDescription> attachmentDescs;
     attachmentDescs.push_back(inputAttachment);
-    attachmentDescs.push_back(inputAttachment);
 
     VkAttachmentReference inputRef = {
         0,
@@ -8119,7 +8118,7 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     // It causes desired failures.
     char const *fsSource_fail =
         "#version 450\n"
-        "layout(input_attachment_index=2, set=0, binding=1) uniform subpassInput x;\n"
+        "layout(input_attachment_index=1, set=0, binding=1) uniform subpassInput x;\n"
         "void main() {\n"
         "   vec4 color = subpassLoad(x);\n"
         "}\n";
@@ -8138,40 +8137,6 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkGraphicsPipelineCreateInfo-layout-00756");
     g_pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
-
-    char const *fsSource =
-        "#version 450\n"
-        "layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;\n"
-        "layout(input_attachment_index=2, set=0, binding=0) uniform subpassInput x2;\n"
-        "void main() {\n"
-        "   vec4 color = subpassLoad(x);\n"
-        "   color = subpassLoad(x2);\n"
-        "}\n";
-    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
-
-    g_pipe.InitState();
-    g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    ASSERT_VK_SUCCESS(g_pipe.CreateGraphicsPipeline());
-
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_input, sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
-    g_pipe.descriptor_set_->UpdateDescriptorSets();
-
-    m_commandBuffer->begin();
-    m_renderPassBeginInfo.renderArea = {{0, 0}, {64, 64}};
-    m_renderPassBeginInfo.renderPass = rp;
-    m_renderPassBeginInfo.framebuffer = fb;
-
-    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
-    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
-                              &g_pipe.descriptor_set_->set_, 0, nullptr);
-
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-None-02686");
-    vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
-    m_errorMonitor->VerifyFound();
-
-    m_commandBuffer->EndRenderPass();
-    m_commandBuffer->end();
 }
 
 TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) {


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2243

VUID-vkCmdDraw-None-02686
Every input attachment used by the current subpass must be bound to the pipeline via a descriptor set

I made a mistake between input attachment index and attachment index, so it causes false positive. But it seems nothing need to do for 02686.

Verify if input attachment index matches between shader and subpass that have done in kVUID_Core_Shader_MissingInputAttachment, so removed VUID-02686.

Plus, verify if descriptor slot matches between shader and descriptorSet layout have done in VUID-VkGraphicsPipelineCreateInfo-layout-00756.

Verify if descriptorSet is updated that have done, too.