### PR TITLE
VUID-02721 validate vertex binding & VUID-02859 validate dynamic state setting commands.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -766,12 +766,21 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 if (SafeModulo(attrib_address, vtx_attrib_req_alignment) != 0) {
                     LogObjectList objlist(current_vtx_bfr_binding_info[vertex_binding].buffer);
                     objlist.add(state.pipeline_state->pipeline);
-                    skip |= LogError(objlist, kVUID_Core_DrawState_InvalidVtxAttributeAlignment,
+                    skip |= LogError(objlist, vuid.vertex_binding_attribute,
                                      "%s: Invalid attribAddress alignment for vertex attribute " PRINTF_SIZE_T_SPECIFIER
-                                     " from %s and vertex %s.",
-                                     caller, i, report_data->FormatHandle(state.pipeline_state->pipeline).c_str(),
+                                     ", %s,from of %s and vertex %s.",
+                                     caller, i, string_VkFormat(attribute_description.format),
+                                     report_data->FormatHandle(state.pipeline_state->pipeline).c_str(),
                                      report_data->FormatHandle(current_vtx_bfr_binding_info[vertex_binding].buffer).c_str());
                 }
+            } else {
+                LogObjectList objlist(pCB->commandBuffer);
+                objlist.add(state.pipeline_state->pipeline);
+                skip |= LogError(objlist, vuid.vertex_binding_attribute,
+                                 "%s: binding #%" PRIu32
+                                 " in pVertexAttributeDescriptions of %s is invalid in vkCmdBindVertexBuffers of %s.",
+                                 caller, vertex_binding, report_data->FormatHandle(state.pipeline_state->pipeline).c_str(),
+                                 report_data->FormatHandle(pCB->commandBuffer).c_str());
             }
         }
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -60,6 +60,7 @@ struct DrawDispatchVuid {
     const char* sampler_imageview_type;
     const char* sampler_implicitLod_dref_proj;
     const char* sampler_bias_offset;
+    const char* vertex_binding_attribute;
 };
 
 typedef struct {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -61,6 +61,7 @@ struct DrawDispatchVuid {
     const char* sampler_implicitLod_dref_proj;
     const char* sampler_bias_offset;
     const char* vertex_binding_attribute;
+    const char* dynamic_state_setting_commands;
 };
 
 typedef struct {

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -102,7 +102,7 @@ static const char DECORATE_UNUSED *kVUID_Core_DrawState_SwapchainReplaced = "UNA
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_SwapchainUnsupportedQueue = "UNASSIGNED-CoreValidation-DrawState-SwapchainUnsupportedQueue";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_ViewportScissorMismatch = "UNASSIGNED-CoreValidation-DrawState-ViewportScissorMismatch";
 //static const char DECORATE_UNUSED *kVUID_Core_DrawState_VtxIndexOutOfBounds = "UNASSIGNED-CoreValidation-DrawState-VtxIndexOutOfBounds";
-static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidVtxAttributeAlignment = "UNASSIGNED-CoreValidation-DrawState-InvalidVtxAttributeAlignment";
+//static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidVtxAttributeAlignment = "UNASSIGNED-CoreValidation-DrawState-InvalidVtxAttributeAlignment";
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidImageView = "UNASSIGNED-CoreValidation-DrawState-InvalidImageView";
 // Previously defined but unused - uncomment as needed
 //static const char DECORATE_UNUSED *kVUID_Core_DrawState_BeginCommandBufferInvalidState = "UNASSIGNED-CoreValidation-DrawState-BeginCommandBufferInvalidState";

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -672,9 +672,16 @@ enum CBStatusFlagBits {
     CBSTATUS_DEPTH_BOUNDS_TEST_ENABLE_SET    = 0x00800000,
     CBSTATUS_STENCIL_TEST_ENABLE_SET         = 0x01000000,
     CBSTATUS_STENCIL_OP_SET                  = 0x02000000,
-    CBSTATUS_ALL_STATE_SET                   = 0x03FFFDFF,   // All state set (intentionally exclude index buffer)
+    CBSTATUS_DISCARD_RECTANGLE_SET           = 0x04000000,
+    CBSTATUS_SAMPLE_LOCATIONS_SET            = 0x08000000,
+    CBSTATUS_COARSE_SAMPLE_ORDER_SET         = 0x10000000,
+    CBSTATUS_ALL_STATE_SET                   = 0x1FFFFDFF,   // All state set (intentionally exclude index buffer)
     // clang-format on
 };
+
+VkDynamicState ConvertToDynamicState(CBStatusFlagBits flag);
+CBStatusFlagBits ConvertToCBStatusFlagBits(VkDynamicState state);
+std::string DynamicStateString(CBStatusFlags input_value);
 
 struct QueryObject {
     VkQueryPool pool;
@@ -1218,6 +1225,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     CBStatusFlags status;                              // Track status of various bindings on cmd buffer
     CBStatusFlags static_status;                       // All state bits provided by current graphics pipeline
                                                        // rather than dynamic state
+    CBStatusFlags dynamic_status;                      // dynamic state set up in pipeline
     // Currently storing "lastBound" objects on per-CB basis
     //  long-term may want to create caches of "lastBound" states and could have
     //  each individual CMD_NODE referencing its own "lastBound" state

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -71,6 +71,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-None-02702",
         "VUID-vkCmdDraw-None-02703",
         "VUID-vkCmdDraw-None-02704",
+        "VUID-vkCmdDraw-None-02721",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -101,6 +102,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-None-02702",
         "VUID-vkCmdDrawIndexed-None-02703",
         "VUID-vkCmdDrawIndexed-None-02704",
+        "VUID-vkCmdDrawIndexed-None-02721",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -131,6 +133,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-None-02702",
         "VUID-vkCmdDrawIndirect-None-02703",
         "VUID-vkCmdDrawIndirect-None-02704",
+        "VUID-vkCmdDrawIndirect-None-02721",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -161,6 +164,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-None-02702",
         "VUID-vkCmdDrawIndexedIndirect-None-02703",
         "VUID-vkCmdDrawIndexedIndirect-None-02704",
+        "VUID-vkCmdDrawIndexedIndirect-None-02721",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -191,6 +195,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatch-None-02702",
         "VUID-vkCmdDispatch-None-02703",
         "VUID-vkCmdDispatch-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -221,6 +226,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchIndirect-None-02702",
         "VUID-vkCmdDispatchIndirect-None-02703",
         "VUID-vkCmdDispatchIndirect-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -251,6 +257,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-None-02702",
         "VUID-vkCmdDrawIndirectCount-None-02703",
         "VUID-vkCmdDrawIndirectCount-None-02704",
+        "VUID-vkCmdDrawIndirectCount-None-02721",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -281,6 +288,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-None-02702",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02703",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02704",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02721",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -311,6 +319,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysNV-None-02702",
         "VUID-vkCmdTraceRaysNV-None-02703",
         "VUID-vkCmdTraceRaysNV-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -341,6 +350,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-None-02702",
         "VUID-vkCmdTraceRaysKHR-None-02703",
         "VUID-vkCmdTraceRaysKHR-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -371,6 +381,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysIndirectKHR-None-02702",
         "VUID-vkCmdTraceRaysIndirectKHR-None-02703",
         "VUID-vkCmdTraceRaysIndirectKHR-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -401,6 +412,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-None-02702",
         "VUID-vkCmdDrawMeshTasksNV-None-02703",
         "VUID-vkCmdDrawMeshTasksNV-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -431,6 +443,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02702",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02703",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -461,6 +474,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02702",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02703",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -491,6 +505,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02702",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02703",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02704",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02721",
     }},
     {CMD_DISPATCHBASE, {
         "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
@@ -521,6 +536,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchBase-None-02702",
         "VUID-vkCmdDispatchBase-None-02703",
         "VUID-vkCmdDispatchBase-None-02704",
+        kVUIDUndefined, // vertex_binding_attribute
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -72,6 +72,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-None-02703",
         "VUID-vkCmdDraw-None-02704",
         "VUID-vkCmdDraw-None-02721",
+        "VUID-vkCmdDraw-None-02859",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -103,6 +104,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-None-02703",
         "VUID-vkCmdDrawIndexed-None-02704",
         "VUID-vkCmdDrawIndexed-None-02721",
+        "VUID-vkCmdDrawIndexed-None-02859",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -134,6 +136,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-None-02703",
         "VUID-vkCmdDrawIndirect-None-02704",
         "VUID-vkCmdDrawIndirect-None-02721",
+        "VUID-vkCmdDrawIndirect-None-02859",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -165,6 +168,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-None-02703",
         "VUID-vkCmdDrawIndexedIndirect-None-02704",
         "VUID-vkCmdDrawIndexedIndirect-None-02721",
+        "VUID-vkCmdDrawIndexedIndirect-None-02859",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -196,6 +200,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatch-None-02703",
         "VUID-vkCmdDispatch-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDispatch-None-02859",
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -227,6 +232,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchIndirect-None-02703",
         "VUID-vkCmdDispatchIndirect-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDispatchIndirect-None-02859",
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -258,6 +264,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-None-02703",
         "VUID-vkCmdDrawIndirectCount-None-02704",
         "VUID-vkCmdDrawIndirectCount-None-02721",
+        "VUID-vkCmdDrawIndirectCount-None-02859",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -289,6 +296,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-None-02703",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02704",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02721",
+        "VUID-vkCmdDrawIndexedIndirectCount-None-02859",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -320,6 +328,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysNV-None-02703",
         "VUID-vkCmdTraceRaysNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdTraceRaysNV-None-02859",
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -351,6 +360,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-None-02703",
         "VUID-vkCmdTraceRaysKHR-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdTraceRaysKHR-None-02859",
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -382,6 +392,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysIndirectKHR-None-02703",
         "VUID-vkCmdTraceRaysIndirectKHR-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdTraceRaysIndirectKHR-None-02859",
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -413,6 +424,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-None-02703",
         "VUID-vkCmdDrawMeshTasksNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDrawMeshTasksNV-None-02859",
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -444,6 +456,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02703",
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDrawMeshTasksIndirectNV-None-02859",
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -475,6 +488,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02703",
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02859",
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -506,6 +520,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02703",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02704",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02721",
+        "VUID-vkCmdDrawIndirectByteCountEXT-None-02859",
     }},
     {CMD_DISPATCHBASE, {
         "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
@@ -537,9 +552,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchBase-None-02703",
         "VUID-vkCmdDispatchBase-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
+        "VUID-vkCmdDispatchBase-None-02859",
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -40,6 +40,135 @@ const char *CommandTypeString(CMD_TYPE type) {
     return command_name_list[type];
 }
 
+VkDynamicState ConvertToDynamicState(CBStatusFlagBits flag) {
+    switch (flag) {
+        case CBSTATUS_LINE_WIDTH_SET:
+            return VK_DYNAMIC_STATE_LINE_WIDTH;
+        case CBSTATUS_DEPTH_BIAS_SET:
+            return VK_DYNAMIC_STATE_DEPTH_BIAS;
+        case CBSTATUS_BLEND_CONSTANTS_SET:
+            return VK_DYNAMIC_STATE_BLEND_CONSTANTS;
+        case CBSTATUS_DEPTH_BOUNDS_SET:
+            return VK_DYNAMIC_STATE_DEPTH_BOUNDS;
+        case CBSTATUS_STENCIL_READ_MASK_SET:
+            return VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK;
+        case CBSTATUS_STENCIL_WRITE_MASK_SET:
+            return VK_DYNAMIC_STATE_STENCIL_WRITE_MASK;
+        case CBSTATUS_STENCIL_REFERENCE_SET:
+            return VK_DYNAMIC_STATE_STENCIL_REFERENCE;
+        case CBSTATUS_VIEWPORT_SET:
+            return VK_DYNAMIC_STATE_VIEWPORT;
+        case CBSTATUS_SCISSOR_SET:
+            return VK_DYNAMIC_STATE_SCISSOR;
+        case CBSTATUS_EXCLUSIVE_SCISSOR_SET:
+            return VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV;
+        case CBSTATUS_SHADING_RATE_PALETTE_SET:
+            return VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV;
+        case CBSTATUS_LINE_STIPPLE_SET:
+            return VK_DYNAMIC_STATE_LINE_STIPPLE_EXT;
+        case CBSTATUS_VIEWPORT_W_SCALING_SET:
+            return VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV;
+        case CBSTATUS_CULL_MODE_SET:
+            return VK_DYNAMIC_STATE_CULL_MODE_EXT;
+        case CBSTATUS_FRONT_FACE_SET:
+            return VK_DYNAMIC_STATE_FRONT_FACE_EXT;
+        case CBSTATUS_PRIMITIVE_TOPOLOGY_SET:
+            return VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT;
+        case CBSTATUS_VIEWPORT_WITH_COUNT_SET:
+            return VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT;
+        case CBSTATUS_SCISSOR_WITH_COUNT_SET:
+            return VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT;
+        case CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET:
+            return VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT;
+        case CBSTATUS_DEPTH_TEST_ENABLE_SET:
+            return VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT;
+        case CBSTATUS_DEPTH_WRITE_ENABLE_SET:
+            return VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT;
+        case CBSTATUS_DEPTH_COMPARE_OP_SET:
+            return VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT;
+        case CBSTATUS_DEPTH_BOUNDS_TEST_ENABLE_SET:
+            return VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT;
+        case CBSTATUS_STENCIL_TEST_ENABLE_SET:
+            return VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE_EXT;
+        case CBSTATUS_STENCIL_OP_SET:
+            return VK_DYNAMIC_STATE_STENCIL_OP_EXT;
+        case CBSTATUS_DISCARD_RECTANGLE_SET:
+            return VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT;
+        case CBSTATUS_SAMPLE_LOCATIONS_SET:
+            return VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT;
+        case CBSTATUS_COARSE_SAMPLE_ORDER_SET:
+            return VK_DYNAMIC_STATE_VIEWPORT_COARSE_SAMPLE_ORDER_NV;
+        default:
+            // CBSTATUS_INDEX_BUFFER_BOUND is not in VkDynamicState
+            return VK_DYNAMIC_STATE_MAX_ENUM;
+    }
+    return VK_DYNAMIC_STATE_MAX_ENUM;
+}
+
+CBStatusFlagBits ConvertToCBStatusFlagBits(VkDynamicState state) {
+    switch (state) {
+        case VK_DYNAMIC_STATE_VIEWPORT:
+            return CBSTATUS_VIEWPORT_SET;
+        case VK_DYNAMIC_STATE_SCISSOR:
+            return CBSTATUS_SCISSOR_SET;
+        case VK_DYNAMIC_STATE_LINE_WIDTH:
+            return CBSTATUS_LINE_WIDTH_SET;
+        case VK_DYNAMIC_STATE_DEPTH_BIAS:
+            return CBSTATUS_DEPTH_BIAS_SET;
+        case VK_DYNAMIC_STATE_BLEND_CONSTANTS:
+            return CBSTATUS_BLEND_CONSTANTS_SET;
+        case VK_DYNAMIC_STATE_DEPTH_BOUNDS:
+            return CBSTATUS_DEPTH_BOUNDS_SET;
+        case VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK:
+            return CBSTATUS_STENCIL_READ_MASK_SET;
+        case VK_DYNAMIC_STATE_STENCIL_WRITE_MASK:
+            return CBSTATUS_STENCIL_WRITE_MASK_SET;
+        case VK_DYNAMIC_STATE_STENCIL_REFERENCE:
+            return CBSTATUS_STENCIL_REFERENCE_SET;
+        case VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV:
+            return CBSTATUS_VIEWPORT_W_SCALING_SET;
+        case VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT:
+            return CBSTATUS_DISCARD_RECTANGLE_SET;
+        case VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT:
+            return CBSTATUS_SAMPLE_LOCATIONS_SET;
+        case VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV:
+            return CBSTATUS_SHADING_RATE_PALETTE_SET;
+        case VK_DYNAMIC_STATE_VIEWPORT_COARSE_SAMPLE_ORDER_NV:
+            return CBSTATUS_COARSE_SAMPLE_ORDER_SET;
+        case VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV:
+            return CBSTATUS_EXCLUSIVE_SCISSOR_SET;
+        case VK_DYNAMIC_STATE_LINE_STIPPLE_EXT:
+            return CBSTATUS_LINE_STIPPLE_SET;
+        case VK_DYNAMIC_STATE_CULL_MODE_EXT:
+            return CBSTATUS_CULL_MODE_SET;
+        case VK_DYNAMIC_STATE_FRONT_FACE_EXT:
+            return CBSTATUS_FRONT_FACE_SET;
+        case VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT:
+            return CBSTATUS_PRIMITIVE_TOPOLOGY_SET;
+        case VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT:
+            return CBSTATUS_VIEWPORT_WITH_COUNT_SET;
+        case VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT:
+            return CBSTATUS_SCISSOR_WITH_COUNT_SET;
+        case VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT:
+            return CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET;
+        case VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT:
+            return CBSTATUS_DEPTH_TEST_ENABLE_SET;
+        case VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT:
+            return CBSTATUS_DEPTH_WRITE_ENABLE_SET;
+        case VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT:
+            return CBSTATUS_DEPTH_COMPARE_OP_SET;
+        case VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT:
+            return CBSTATUS_DEPTH_BOUNDS_TEST_ENABLE_SET;
+        case VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE_EXT:
+            return CBSTATUS_STENCIL_TEST_ENABLE_SET;
+        case VK_DYNAMIC_STATE_STENCIL_OP_EXT:
+            return CBSTATUS_STENCIL_OP_SET;
+        default:
+            return CBSTATUS_NONE;
+    }
+    return CBSTATUS_NONE;
+}
+
 void ValidationStateTracker::InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
     if (add_obj) {
         instance_state = reinterpret_cast<ValidationStateTracker *>(GetValidationObject(inst_obj->object_dispatch, container_type));
@@ -3371,88 +3500,9 @@ CBStatusFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *ds) {
 
     if (ds) {
         for (uint32_t i = 0; i < ds->dynamicStateCount; i++) {
-            switch (ds->pDynamicStates[i]) {
-                case VK_DYNAMIC_STATE_LINE_WIDTH:
-                    flags &= ~CBSTATUS_LINE_WIDTH_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_BIAS:
-                    flags &= ~CBSTATUS_DEPTH_BIAS_SET;
-                    break;
-                case VK_DYNAMIC_STATE_BLEND_CONSTANTS:
-                    flags &= ~CBSTATUS_BLEND_CONSTANTS_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_BOUNDS:
-                    flags &= ~CBSTATUS_DEPTH_BOUNDS_SET;
-                    break;
-                case VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK:
-                    flags &= ~CBSTATUS_STENCIL_READ_MASK_SET;
-                    break;
-                case VK_DYNAMIC_STATE_STENCIL_WRITE_MASK:
-                    flags &= ~CBSTATUS_STENCIL_WRITE_MASK_SET;
-                    break;
-                case VK_DYNAMIC_STATE_STENCIL_REFERENCE:
-                    flags &= ~CBSTATUS_STENCIL_REFERENCE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_SCISSOR:
-                    flags &= ~CBSTATUS_SCISSOR_SET;
-                    break;
-                case VK_DYNAMIC_STATE_VIEWPORT:
-                    flags &= ~CBSTATUS_VIEWPORT_SET;
-                    break;
-                case VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV:
-                    flags &= ~CBSTATUS_EXCLUSIVE_SCISSOR_SET;
-                    break;
-                case VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV:
-                    flags &= ~CBSTATUS_SHADING_RATE_PALETTE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_LINE_STIPPLE_EXT:
-                    flags &= ~CBSTATUS_LINE_STIPPLE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV:
-                    flags &= ~CBSTATUS_VIEWPORT_W_SCALING_SET;
-                    break;
-                case VK_DYNAMIC_STATE_CULL_MODE_EXT:
-                    flags &= ~CBSTATUS_CULL_MODE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_FRONT_FACE_EXT:
-                    flags &= ~CBSTATUS_FRONT_FACE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT:
-                    flags &= ~CBSTATUS_PRIMITIVE_TOPOLOGY_SET;
-                    break;
-                case VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT:
-                    flags &= ~CBSTATUS_VIEWPORT_WITH_COUNT_SET;
-                    break;
-                case VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT:
-                    flags &= ~CBSTATUS_SCISSOR_WITH_COUNT_SET;
-                    break;
-                case VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT:
-                    flags &= ~CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT:
-                    flags &= ~CBSTATUS_DEPTH_TEST_ENABLE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT:
-                    flags &= ~CBSTATUS_DEPTH_WRITE_ENABLE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT:
-                    flags &= ~CBSTATUS_DEPTH_COMPARE_OP_SET;
-                    break;
-                case VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT:
-                    flags &= ~CBSTATUS_DEPTH_BOUNDS_TEST_ENABLE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE_EXT:
-                    flags &= ~CBSTATUS_STENCIL_TEST_ENABLE_SET;
-                    break;
-                case VK_DYNAMIC_STATE_STENCIL_OP_EXT:
-                    flags &= ~CBSTATUS_STENCIL_OP_SET;
-                    break;
-                default:
-                    break;
-            }
+            flags &= ~ConvertToCBStatusFlagBits(ds->pDynamicStates[i]);
         }
     }
-
     return flags;
 }
 
@@ -3497,6 +3547,7 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
         cb_state->status &= ~cb_state->static_status;
         cb_state->static_status = MakeStaticStateMask(pipe_state->graphicsPipelineCI.ptr()->pDynamicState);
         cb_state->status |= cb_state->static_status;
+        cb_state->dynamic_status = CBSTATUS_ALL_STATE_SET & (~cb_state->static_status);
     }
     ResetCommandBufferPushConstantDataIfIncompatible(cb_state, pipe_state->pipeline_layout->layout);
     cb_state->lastBound[pipelineBindPoint].pipeline_state = pipe_state;
@@ -6038,4 +6089,28 @@ void ValidationStateTracker::PreCallRecordCmdSetStencilOpEXT(VkCommandBuffer com
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     cb_state->status |= CBSTATUS_STENCIL_OP_SET;
     cb_state->static_status &= ~CBSTATUS_STENCIL_OP_SET;
+}
+
+void ValidationStateTracker::PreCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
+                                                                    uint32_t discardRectangleCount,
+                                                                    const VkRect2D *pDiscardRectangles) {
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    cb_state->status |= CBSTATUS_DISCARD_RECTANGLE_SET;
+    cb_state->static_status &= ~CBSTATUS_DISCARD_RECTANGLE_SET;
+}
+
+void ValidationStateTracker::PreCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
+                                                                   const VkSampleLocationsInfoEXT *pSampleLocationsInfo) {
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    cb_state->status |= CBSTATUS_SAMPLE_LOCATIONS_SET;
+    cb_state->static_status &= ~CBSTATUS_SAMPLE_LOCATIONS_SET;
+}
+
+void ValidationStateTracker::PreCallRecordCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer,
+                                                                    VkCoarseSampleOrderTypeNV sampleOrderType,
+                                                                    uint32_t customSampleOrderCount,
+                                                                    const VkCoarseSampleOrderCustomNV *pCustomSampleOrders) {
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    cb_state->status |= CBSTATUS_COARSE_SAMPLE_ORDER_SET;
+    cb_state->static_status &= ~CBSTATUS_COARSE_SAMPLE_ORDER_SET;
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1316,6 +1316,12 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable);
     void PreCallRecordCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                          VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp);
+    void PreCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
+                                                uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles);
+    void PreCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer, const VkSampleLocationsInfoEXT* pSampleLocationsInfo);
+    void PreCallRecordCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType,
+                                                uint32_t customSampleOrderCount,
+                                                const VkCoarseSampleOrderCustomNV* pCustomSampleOrders);
 
     DeviceFeatures enabled_features = {};
     // Device specific data

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -6797,6 +6797,8 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
     pipe.AddDefaultColorAttachment();
     pipe.AddShader(&vs);
     pipe.AddShader(&fs);
+    pipe.MakeDynamic(VK_DYNAMIC_STATE_VIEWPORT);
+    pipe.MakeDynamic(VK_DYNAMIC_STATE_SCISSOR);
     pipe.CreateVKPipeline(pipeline_layout.handle(), m_renderPass);
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;


### PR DESCRIPTION
VUID-vkCmdDrawIndexed-None-02721
For a given vertex buffer binding, any attribute data fetched must be entirely contained within the corresponding vertex buffer binding, as described in Vertex Input Description

1) Changed kVUID_Core_DrawState_InvalidVtxAttributeAlignment into VUID-02721

2) Print a message when vertex input binding doesn't match with the binding in VkVertexInputAttributeDescription 