### PR TITLE
Revert "layers: Fix wrong if statement"

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -3078,8 +3078,8 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet *dest_set, const 
                             }
                         }
                     }
-
-                    if (sampler && FormatIsMultiplane(image_state->createInfo.format)) {
+                    // If there is an immutable sampler then |sampler| isn't used, so the following VU does not apply.
+                    if (sampler && !desc->IsImmutableSampler() && FormatIsMultiplane(image_state->createInfo.format)) {
                         // multiplane formats must be created with mutable format bit
                         if (0 == (image_state->createInfo.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
                             *error_code = "VUID-VkDescriptorImageInfo-sampler-01564";


### PR DESCRIPTION
VUID-VkDescriptorImageInfo-sampler-01564 only applies if the sampler is
"used", and "sampler is a sampler handle, and is used [...]
if the binding being updated does not use immutable samplers." So if the
binding uses immutable samplers then the VU should not apply.

This reverts commit 95d480bbab0a7633520d82cea385f7a464e25e9a.