### PR TITLE
Remove redundant implicit VU checks

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3235,9 +3235,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
             auto clear_desc = &pAttachments[attachment_index];
             uint32_t fb_attachment = VK_ATTACHMENT_UNUSED;
 
-            if (0 == clear_desc->aspectMask) {
-                skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-requiredbitmask", " ");
-            } else if (clear_desc->aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) {
+            if (clear_desc->aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) {
                 skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-00020", " ");
             } else if (clear_desc->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
                 uint32_t color_attachment = VK_ATTACHMENT_UNUSED;
@@ -3271,11 +3269,6 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                     skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-00019", str, attachment_index);
                 }
             } else {  // Must be depth and/or stencil
-                if (((clear_desc->aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != VK_IMAGE_ASPECT_DEPTH_BIT) &&
-                    ((clear_desc->aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) != VK_IMAGE_ASPECT_STENCIL_BIT)) {
-                    char const str[] = "vkCmdClearAttachments() aspectMask [%d] is not a valid combination of bits.";
-                    skip |= LogError(commandBuffer, "VUID-VkClearAttachment-aspectMask-parameter", str, attachment_index);
-                }
                 if (!subpass_desc->pDepthStencilAttachment ||
                     (subpass_desc->pDepthStencilAttachment->attachment == VK_ATTACHMENT_UNUSED)) {
                     skip |= LogPerformanceWarning(

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5290,6 +5290,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
                                              const BufferImageCopyRegionType *pRegions, const IMAGE_STATE *image_state,
                                              const char *function, CopyCommandVersion version) const {
     bool skip = false;
+    const bool is_2khr = (version == COPY_COMMAND_VERSION_2);
+    const char *vuid;
 
     assert(image_state != nullptr);
     const VkFormat image_format = image_state->createInfo.format;
@@ -5330,9 +5332,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         // If not depth/stencil and not multi-plane
         if ((!FormatIsDepthAndStencil(image_format) && !FormatIsMultiplane(image_format)) &&
             SafeModulo(pRegions[i].bufferOffset, element_size) != 0) {
-            const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                   ? "VUID-vkCmdCopyBufferToImage-bufferOffset-01558"
-                                   : "VUID-vkCmdCopyBufferToImage-bufferOffset-00193";
+            vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-bufferOffset-01558"
+                                                                       : "VUID-vkCmdCopyBufferToImage-bufferOffset-00193";
             skip |= LogError(image_state->image, vuid,
                              "%s: pRegion[%d] bufferOffset 0x%" PRIxLEAST64
                              " must be a multiple of this format's texel size (%" PRIu32 ").",
@@ -5394,7 +5395,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         const int num_bits = sizeof(VkFlags) * CHAR_BIT;
         std::bitset<num_bits> aspect_mask_bits(region_aspect_mask);
         if (aspect_mask_bits.count() != 1) {
-            skip |= LogError(image_state->image, "VUID-VkBufferImageCopy-aspectMask-00212",
+            vuid = (is_2khr) ? "VUID-VkBufferImageCopy2KHR-aspectMask-00212" : "VUID-VkBufferImageCopy-aspectMask-00212";
+            skip |= LogError(image_state->image, vuid,
                              "%s: aspectMasks for imageSubresource in pRegion[%d] must have only a single bit set.", function, i);
         }
 
@@ -5412,9 +5414,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
 
             //  BufferRowLength must be a multiple of block width
             if (SafeModulo(pRegions[i].bufferRowLength, block_size.width) != 0) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-bufferRowLength-00203"
-                                       : "VUID-vkCmdCopyBufferToImage-bufferRowLength-00203";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-bufferRowLength-00203"
+                                                                           : "VUID-vkCmdCopyBufferToImage-bufferRowLength-00203";
                 skip |=
                     LogError(image_state->image, vuid,
                              "%s: pRegion[%d] bufferRowLength (%d) must be a multiple of the compressed image's texel width (%d)..",
@@ -5423,9 +5424,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
 
             //  BufferRowHeight must be a multiple of block height
             if (SafeModulo(pRegions[i].bufferImageHeight, block_size.height) != 0) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-bufferImageHeight-00204"
-                                       : "VUID-vkCmdCopyBufferToImage-bufferImageHeight-00204";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-bufferImageHeight-00204"
+                                                                           : "VUID-vkCmdCopyBufferToImage-bufferImageHeight-00204";
                 skip |= LogError(
                     image_state->image, vuid,
                     "%s: pRegion[%d] bufferImageHeight (%d) must be a multiple of the compressed image's texel height (%d)..",
@@ -5436,9 +5436,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             if ((SafeModulo(pRegions[i].imageOffset.x, block_size.width) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.y, block_size.height) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.z, block_size.depth) != 0)) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-imageOffset-00205"
-                                       : "VUID-vkCmdCopyBufferToImage-imageOffset-00205";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-imageOffset-00205"
+                                                                           : "VUID-vkCmdCopyBufferToImage-imageOffset-00205";
                 skip |= LogError(image_state->image, vuid,
                                  "%s: pRegion[%d] imageOffset(x,y) (%d, %d) must be multiples of the compressed image's texel "
                                  "width & height (%d, %d)..",
@@ -5449,9 +5448,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // bufferOffset must be a multiple of block size (linear bytes)
             uint32_t block_size_in_bytes = FormatElementSize(image_format);
             if (SafeModulo(pRegions[i].bufferOffset, block_size_in_bytes) != 0) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-bufferOffset-00206"
-                                       : "VUID-vkCmdCopyBufferToImage-bufferOffset-00206";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-bufferOffset-00206"
+                                                                           : "VUID-vkCmdCopyBufferToImage-bufferOffset-00206";
                 skip |= LogError(image_state->image, vuid,
                                  "%s: pRegion[%d] bufferOffset (0x%" PRIxLEAST64
                                  ") must be a multiple of the compressed image's texel block size (%" PRIu32 ")..",
@@ -5462,9 +5460,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             VkExtent3D mip_extent = GetImageSubresourceExtent(image_state, &(pRegions[i].imageSubresource));
             if ((SafeModulo(pRegions[i].imageExtent.width, block_size.width) != 0) &&
                 (pRegions[i].imageExtent.width + pRegions[i].imageOffset.x != mip_extent.width)) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-imageExtent-00207"
-                                       : "VUID-vkCmdCopyBufferToImage-imageExtent-00207";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-imageExtent-00207"
+                                                                           : "VUID-vkCmdCopyBufferToImage-imageExtent-00207";
                 skip |= LogError(image_state->image, vuid,
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block width "
                                  "(%d), or when added to offset.x (%d) must equal the image subresource width (%d)..",
@@ -5475,9 +5472,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // imageExtent height must be a multiple of block height, or extent+offset height must equal subresource height
             if ((SafeModulo(pRegions[i].imageExtent.height, block_size.height) != 0) &&
                 (pRegions[i].imageExtent.height + pRegions[i].imageOffset.y != mip_extent.height)) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-imageExtent-00208"
-                                       : "VUID-vkCmdCopyBufferToImage-imageExtent-00208";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-imageExtent-00208"
+                                                                           : "VUID-vkCmdCopyBufferToImage-imageExtent-00208";
                 skip |= LogError(image_state->image, vuid,
                                  "%s: pRegion[%d] extent height (%d) must be a multiple of the compressed texture block height "
                                  "(%d), or when added to offset.y (%d) must equal the image subresource height (%d)..",
@@ -5488,9 +5484,8 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // imageExtent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
             if ((SafeModulo(pRegions[i].imageExtent.depth, block_size.depth) != 0) &&
                 (pRegions[i].imageExtent.depth + pRegions[i].imageOffset.z != mip_extent.depth)) {
-                const char *vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
-                                       ? "VUID-vkCmdCopyBufferToImage-imageExtent-00209"
-                                       : "VUID-vkCmdCopyBufferToImage-imageExtent-00209";
+                vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion) ? "VUID-vkCmdCopyBufferToImage-imageExtent-00209"
+                                                                           : "VUID-vkCmdCopyBufferToImage-imageExtent-00209";
                 skip |= LogError(image_state->image, vuid,
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block depth "
                                  "(%d), or when added to offset.z (%d) must equal the image subresource depth (%d)..",

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -836,6 +836,38 @@ TEST_F(VkLayerTest, ClearColorAttachmentsZeroExtent) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(VkLayerTest, ClearAttachmentsImplicitCheck) {
+    TEST_DESCRIPTION("Check VkClearAttachment implicit VUs.");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    m_commandBuffer->begin();
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+
+    VkClearAttachment color_attachment;
+    color_attachment.clearValue.color.float32[0] = 0;
+    color_attachment.clearValue.color.float32[1] = 0;
+    color_attachment.clearValue.color.float32[2] = 0;
+    color_attachment.clearValue.color.float32[3] = 0;
+    color_attachment.colorAttachment = 0;
+    VkClearRect clear_rect = {};
+    clear_rect.rect.offset = {0, 0};
+    clear_rect.rect.extent = {1, 1};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    color_attachment.aspectMask = 0;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkClearAttachment-aspectMask-requiredbitmask");
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    color_attachment.aspectMask = 0xffffffff;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkClearAttachment-aspectMask-parameter");
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(VkLayerTest, ExecuteCommandsPrimaryCB) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands with a primary command buffer (should only be secondary)");
 


### PR DESCRIPTION
Addresses part of #2235

The first commit is to remove redundant check

- `VUID-VkClearAttachment-aspectMask-requiredbitmask`
- `VUID-VkClearAttachment-aspectMask-parameter`

second commit adds tests to confirm they are still being properly checked in the generated code

third commit labels `VUID-VkBufferImageCopy2KHR-aspectMask-00212`