### PR TITLE
Add test/check for new PERFORANCE_QUERY stride vuid

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3810,6 +3810,14 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
                     // Performance queries store results in a tightly packed array of VkPerformanceCounterResultsKHR
                     query_items = query_pool_state->perf_counter_index_count;
                     query_size = sizeof(VkPerformanceCounterResultKHR) * query_items;
+                    if (query_size && (query_size > stride)) {
+                        skip |= LogError(queryPool, "VUID-vkGetQueryPoolResults-queryType-04519",
+                                         "vkGetQueryPoolResults() on querypool %s specified stride %" PRIu64
+                                         " which must be at least counterIndexCount (%d) "
+                                         "multiplied by sizeof(VkPerformanceCounterResultKHR) (%d).",
+                                         report_data->FormatHandle(queryPool).c_str(), stride, query_items,
+                                         sizeof(VkPerformanceCounterResultKHR));
+                    }
                     break;
 
                 // These cases intentionally fall through to the default
@@ -3820,7 +3828,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
                     query_size = 0;
                     break;
             }
-            // TODO: Add new VU for stride check
+
             if (query_size && (((queryCount - 1) * stride + query_size) > dataSize)) {
                 skip |= LogError(queryPool, "VUID-vkGetQueryPoolResults-dataSize-00817",
                                  "vkGetQueryPoolResults() on querypool %s specified dataSize %zu which is "

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8215,6 +8215,16 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         std::vector<VkPerformanceCounterResultKHR> results;
         results.resize(counterIndices.size());
 
+        // The stride is too small to return the data
+        if (counterIndices.size() > 2) {
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetQueryPoolResults-queryType-04519");
+            vk::GetQueryPoolResults(m_device->device(), query_pool, 0, 1, sizeof(VkPerformanceCounterResultKHR) * results.size(),
+                                    &results[0], sizeof(VkPerformanceCounterResultKHR) * (results.size() - 1), 0);
+            m_errorMonitor->VerifyFound();
+        } else {
+            printf("%s Reqiure counterIndexCount > two for the PerformanceCounterResult stride test, skipping.\n", kSkipPrefix);
+        }
+
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetQueryPoolResults-queryType-03231");
         vk::GetQueryPoolResults(device(), query_pool, 0, 1, sizeof(VkPerformanceCounterResultKHR) * results.size(), &results[0],
                                 sizeof(VkPerformanceCounterResultKHR) * results.size(), VK_QUERY_RESULT_WAIT_BIT);


### PR DESCRIPTION
Last set of GetQueryPoolResults changes necessitated a spec change, and a new VUID which will be in the 158 header.   Added check and test.