### PR TITLE
syncval: Rework sync model to correct order independence of barrier batches and subpass dependencies

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -855,17 +855,19 @@ bool AccessContext::ValidateLoadOperation(const SyncValidator &sync_state, const
             auto hazard_range = view.normalized_subresource_range;
             bool checked_stencil = false;
             if (is_color) {
-                hazard = DetectHazard(*image, load_index, view.normalized_subresource_range, offset, extent);
+                hazard = DetectHazard(*image, load_index, view.normalized_subresource_range, kColorAttachmentRasterOrder, offset,
+                                      extent);
                 aspect = "color";
             } else {
                 if (has_depth) {
                     hazard_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-                    hazard = DetectHazard(*image, load_index, hazard_range, offset, extent);
+                    hazard = DetectHazard(*image, load_index, hazard_range, kDepthStencilAttachmentRasterOrder, offset, extent);
                     aspect = "depth";
                 }
                 if (!hazard.hazard && has_stencil) {
                     hazard_range.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
-                    hazard = DetectHazard(*image, stencil_load_index, hazard_range, offset, extent);
+                    hazard =
+                        DetectHazard(*image, stencil_load_index, hazard_range, kDepthStencilAttachmentRasterOrder, offset, extent);
                     aspect = "stencil";
                     checked_stencil = true;
                 }

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1454,6 +1454,7 @@ void AccessContext::RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, u
                                             const std::vector<const IMAGE_VIEW_STATE *> &attachment_views,
                                             const ResourceUsageTag &tag) {
     const auto &transitions = rp_state.subpass_transitions[subpass];
+    const ResourceAccessState empty_infill;
     for (const auto &transition : transitions) {
         const auto prev_pass = transition.prev_pass;
         const auto attachment_view = attachment_views[transition.attachment];
@@ -1472,7 +1473,7 @@ void AccessContext::RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, u
         auto &target_map = GetAccessStateMap(address_type);
         ApplySubpassTransitionBarriersAction barrier_action(trackback->barriers);
         prev_context->ResolveAccessRange(*image, attachment_view->normalized_subresource_range, barrier_action, address_type,
-                                         &target_map, nullptr);
+                                         &target_map, &empty_infill);
     }
 
     // If there were no transitions skip this global map walk

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -204,7 +204,6 @@ class ResourceAccessState : public SyncStageAccess {
     static constexpr VkPipelineStageFlags kInvalidAttachmentStage = ~VkPipelineStageFlags(0);
     bool IsWriteHazard(SyncStageAccessFlagBits usage) const { return 0 != (usage & ~write_barriers); }
     bool IsRAWHazard(VkPipelineStageFlagBits usage_stage, SyncStageAccessFlagBits usage) const;
-    bool IsWARHazard(VkPipelineStageFlagBits usage_stage, SyncStageAccessFlagBits usage) const;
     bool InSourceScopeOrChain(VkPipelineStageFlags src_exec_scope, SyncStageAccessFlags src_access_scope) const {
         return (src_access_scope & last_write) || (write_dependency_chain & src_exec_scope);
     }
@@ -327,9 +326,6 @@ class AccessContext {
     // TODO: See if returning the lower_bound would be useful from a performance POV -- look at the lower_bound overhead
     // Would need to add a "hint" overload to parallel_iterator::invalidate_[AB] call, if so.
     void ResolvePreviousAccess(AddressType type, const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
-                               const ResourceAccessState *infill_state) const;
-    void ResolvePreviousAccess(const IMAGE_STATE &image_state, const VkImageSubresourceRange &subresource_range,
-                               AddressType address_type, ResourceAccessRangeMap *descent_map,
                                const ResourceAccessState *infill_state) const;
     template <typename BarrierAction>
     void ResolveAccessRange(const IMAGE_STATE &image_state, const VkImageSubresourceRange &subresource_range,

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -14151,17 +14151,13 @@ TEST_F(VkSyncValTest, RenderPassLoadHazardVsInitialLayout) {
 
     m_commandBuffer->begin();
 
-    // If we have no accesses, then we have no accesses to validate against, so create an access record the barriers can
-    // be applied against.
-    VkClearColorValue black = {};
-    VkImageSubresourceRange full_subresource_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vk::CmdClearColorImage(m_commandBuffer->handle(), image_input.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &black, 1,
-                           &full_subresource_range);
     m_renderPassBeginInfo.renderArea = {{0, 0}, {32, 32}};
     m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-READ_AFTER_WRITE");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_WRITE");
+    // Even though we have no accesses prior, the layout transition *is* an access, so load can be validated vs. layout transition
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -13279,9 +13279,13 @@ TEST_F(VkSyncValTest, SyncRenderPassBeginTransitionHazard) {
     // A global execution barrier that the implict external dependency can chain with should work...
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 0,
                            nullptr);
-    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    m_commandBuffer->EndRenderPass();
     m_errorMonitor->VerifyNotFound();
+
+    // With the barrier above, the layout transition has a chained "availability" memory sync operation, but the default
+    // implict VkSubpassDependency doesn't safe the load op clear vs. the layout transition... so we fail there.
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_WRITE");
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
@@ -14079,7 +14083,7 @@ TEST_F(VkSyncValTest, SyncCmdDrawDepthStencil) {
     vk::DestroyFramebuffer(m_device->device(), fb_st, nullptr);
 }
 
-TEST_F(VkSyncValTest, SyncRenderPassWithWrongInitialLayout) {
+TEST_F(VkSyncValTest, RenderPassLoadHazardVsInitialLayout) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -14104,7 +14108,7 @@ TEST_F(VkSyncValTest, SyncRenderPassWithWrongInitialLayout) {
         // Input attachment
         {(VkAttachmentDescriptionFlags)0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD,
          VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
-         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL}};
+         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL}};
 
     const VkAttachmentReference resultAttachmentRef = {0u, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
     const VkAttachmentReference inputAttachmentRef = {1u, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
@@ -14122,9 +14126,9 @@ TEST_F(VkSyncValTest, SyncRenderPassWithWrongInitialLayout) {
 
     const VkSubpassDependency subpassDependency = {VK_SUBPASS_EXTERNAL,
                                                    0,
-                                                   VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                                   VK_PIPELINE_STAGE_TRANSFER_BIT,
                                                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                                                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                                   VK_ACCESS_TRANSFER_WRITE_BIT,
                                                    VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT,
                                                    VK_DEPENDENCY_BY_REGION_BIT};
 
@@ -14144,12 +14148,21 @@ TEST_F(VkSyncValTest, SyncRenderPassWithWrongInitialLayout) {
     VkFramebufferCreateInfo fbci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp, 2, attachments, 32, 32, 1};
     ASSERT_VK_SUCCESS(vk::CreateFramebuffer(device(), &fbci, nullptr, &fb));
 
+    image_input.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
     m_commandBuffer->begin();
+
+    // If we have no accesses, then we have no accesses to validate against, so create an access record the barriers can
+    // be applied against.
+    VkClearColorValue black = {};
+    VkImageSubresourceRange full_subresource_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vk::CmdClearColorImage(m_commandBuffer->handle(), image_input.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &black, 1,
+                           &full_subresource_range);
     m_renderPassBeginInfo.renderArea = {{0, 0}, {32, 32}};
     m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;
 
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_WRITE");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-READ_AFTER_WRITE");
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Fixes errors in barrier application model s.t. unintended dependency chains are no longer created for barriers within the same "batch" whether a barrier command or subpass definition.

Includes clean of subpass transition/load store validation/record as they were affected by the model changes, and the plumbing needed to support them.