### PR TITLE
Add drm format aspect planes

### DIFF
--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -1246,11 +1246,18 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidInputAttachmentReferences) {
 
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, &rpiaaci, 0, 1, &attach, 1, &subpass, 0, nullptr};
 
-    // Invalid meta data aspect
+    // Invalid aspect masks
     // Cannot/should not avoid getting the unxpected ones too
+    iaar.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo-pNext-01963");
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
     TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964",
+                         nullptr);
+
+    iaar.aspectMask = VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo-pNext-01963");
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
+    TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-02250",
                          nullptr);
 
     // Aspect not present


### PR DESCRIPTION
Address part of #2235

- VUID-VkClearAttachment-aspectMask-02246
- VUID-VkImageSubresourceLayers-aspectMask-02247
- VUID-VkInputAttachmentAspectReference-aspectMask-02250

Fixed up labeling on `VUID-VkClearAttachment-aspectMask-00020`

The `UNASSIGNED-VkSubpassDescription2-attachment` was brought up my me in an internal WG meeting and just waiting for it to propagate through, will update when it lands in a header update