### PR TITLE
layers: Relabel vkCmdDrawIndirectByteCountEXT VUs

### DIFF
--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -503,6 +503,9 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-sampleLocationsEnable-02689",
         "VUID-vkCmdDrawIndirectByteCountEXT-magFilter-04553",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02692",
+        "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-02646",
+        "UNASSIGNED-vkCmdDrawIndirectByteCountEXT-buffer", // TODO - Update when header are updated
+        "VUID-vkCmdDrawIndirectByteCountEXT-buffer-02290",
         "VUID-vkCmdDrawIndirectByteCountEXT-viewportCount-03417",
         "VUID-vkCmdDrawIndirectByteCountEXT-scissorCount-03418",
         "VUID-vkCmdDrawIndirectByteCountEXT-viewportCount-03419",
@@ -803,8 +806,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer comm
                                                             uint32_t firstInstance, VkBuffer counterBuffer,
                                                             VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                             uint32_t vertexStride) const {
-    return ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWINDIRECTBYTECOUNTEXT,
-                               "vkCmdDrawIndirectByteCountEXT()", VK_QUEUE_GRAPHICS_BIT);
+    bool skip = false;
+    skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWINDIRECTBYTECOUNTEXT,
+                                "vkCmdDrawIndirectByteCountEXT()", VK_QUEUE_GRAPHICS_BIT);
+    skip |= ValidateIndirectCmd(commandBuffer, counterBuffer, CMD_DRAWINDIRECTBYTECOUNTEXT, "vkCmdDrawIndirectByteCountEXT()");
+    return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -5044,6 +5044,12 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndirectByteCountEXT(VkCo
             vertexStride, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride);
     }
 
+    if ((counterOffset % 4) != 0) {
+        // TODO - Update when header are updated
+        skip |= LogError(commandBuffer, "UNASSIGNED-vkCmdDrawIndirectByteCountEXT-offset",
+                         "vkCmdDrawIndirectByteCountEXT(): offset (%" PRIu64 ") must be a multiple of 4.", counterOffset);
+    }
+
     return skip;
 }
 


### PR DESCRIPTION
These were just recently removed by accident in
https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/c505df6e9978052e184dbbd9b0183d208841797b#diff-e8d5d9f968d7cedb9e742c3ad9251260f6dfb15c79d9feea206df88d17e42061

I realize the issue was they weren't real VUs, so understand, but luckily I have the proper VUs for them

I would also point out to @mark-lunarg that the `struct DrawDispatchVuid` has grown out of size and hard to map the exact field to the list, which results it the commit above actually producing wrong results

Granted the best solution is to just have test for all these VUs, but think I might just make a PR adding the `// field_name` as trying to count where in the struct it is has become tedious