### PR TITLE
Add a missing "not" to ValidateGreaterThan

### DIFF
--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -145,7 +145,7 @@ class StatelessValidation : public ValidationObject {
 
         if (value <= lower_bound) {
             std::ostringstream ss;
-            ss << api_name << ": parameter " << parameter_name.get_name() << " (= " << value << ") is greater than " << lower_bound;
+            ss << api_name << ": parameter " << parameter_name.get_name() << " (= " << value << ") is not greater than " << lower_bound;
             skip_call |= LogError(device, vuid, "%s", ss.str().c_str());
         }
 


### PR DESCRIPTION
Led to curious messages such as `parameter pCreateInfo->mipLevels (= 0) is greater than 0`