### PR TITLE
Validate protected command buffer and filter cubic, and some refactors

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1428,8 +1428,8 @@ bool BestPractices::ValidateIndexBufferArm(VkCommandBuffer commandBuffer, uint32
     const auto* cmd_state = GetCBState(commandBuffer);
     if (cmd_state == nullptr) return skip;
 
-    const auto* ib_state = GetBufferState(cmd_state->index_buffer_binding.buffer);
-    if (ib_state == nullptr) return skip;
+    const auto* ib_state = cmd_state->index_buffer_binding.buffer_state.get();
+    if (ib_state == nullptr || cmd_state->index_buffer_binding.buffer_state->destroyed) return skip;
 
     const VkIndexType ib_type = cmd_state->index_buffer_binding.index_type;
     const auto& ib_mem_state = *ib_state->binding.mem_state;

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -202,9 +202,11 @@ std::vector<ATTACHMENT_INFO> FRAMEBUFFER_STATE::GetUsedAttachments(
             attachment_views[attachment_index].usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
             attachment_views[attachment_index].layout = subpasses.pInputAttachments[index].layout;
             if (imageless) {
-                attachment_views[attachment_index].view = imagelessFramebufferAttachments[attachment_index]->image_view;
+                if (!imagelessFramebufferAttachments[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = imagelessFramebufferAttachments[attachment_index];
             } else {
-                attachment_views[attachment_index].view = createInfo.pAttachments[attachment_index];
+                if (!attachments_view_state[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = attachments_view_state[attachment_index].get();
             }
         }
     }
@@ -214,9 +216,11 @@ std::vector<ATTACHMENT_INFO> FRAMEBUFFER_STATE::GetUsedAttachments(
             attachment_views[attachment_index].usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
             attachment_views[attachment_index].layout = subpasses.pColorAttachments[index].layout;
             if (imageless) {
-                attachment_views[attachment_index].view = imagelessFramebufferAttachments[attachment_index]->image_view;
+                if (!imagelessFramebufferAttachments[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = imagelessFramebufferAttachments[attachment_index];
             } else {
-                attachment_views[attachment_index].view = createInfo.pAttachments[attachment_index];
+                if (!attachments_view_state[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = attachments_view_state[attachment_index].get();
             }
         }
         if (subpasses.pResolveAttachments) {
@@ -225,9 +229,11 @@ std::vector<ATTACHMENT_INFO> FRAMEBUFFER_STATE::GetUsedAttachments(
                 attachment_views[attachment_index2].usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
                 attachment_views[attachment_index2].layout = subpasses.pResolveAttachments[index].layout;
                 if (imageless) {
-                    attachment_views[attachment_index2].view = imagelessFramebufferAttachments[attachment_index2]->image_view;
+                    if (!imagelessFramebufferAttachments[attachment_index2]->destroyed)
+                        attachment_views[attachment_index2].view_state = imagelessFramebufferAttachments[attachment_index2];
                 } else {
-                    attachment_views[attachment_index2].view = createInfo.pAttachments[attachment_index2];
+                    if (!attachments_view_state[attachment_index2]->destroyed)
+                        attachment_views[attachment_index2].view_state = attachments_view_state[attachment_index2].get();
                 }
             }
         }
@@ -238,9 +244,11 @@ std::vector<ATTACHMENT_INFO> FRAMEBUFFER_STATE::GetUsedAttachments(
             attachment_views[attachment_index].usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             attachment_views[attachment_index].layout = subpasses.pDepthStencilAttachment->layout;
             if (imageless) {
-                attachment_views[attachment_index].view = imagelessFramebufferAttachments[attachment_index]->image_view;
+                if (!imagelessFramebufferAttachments[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = imagelessFramebufferAttachments[attachment_index];
             } else {
-                attachment_views[attachment_index].view = createInfo.pAttachments[attachment_index];
+                if (!attachments_view_state[attachment_index]->destroyed)
+                    attachment_views[attachment_index].view_state = attachments_view_state[attachment_index].get();
             }
         }
     }

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -413,44 +413,6 @@ bool IMAGE_VIEW_STATE::OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) 
     return true;
 }
 
-const cvdescriptorset::DescriptorSet *CMD_BUFFER_STATE::GetDescriptorSet(VkPipelineBindPoint bind_point, uint32_t set) const {
-    const auto last_bound_it = lastBound.find(bind_point);
-    if (last_bound_it == lastBound.cend()) {
-        return nullptr;
-    }
-    if (set >= last_bound_it->second.per_set.size()) {
-        return nullptr;
-    }
-    return last_bound_it->second.per_set[set].bound_descriptor_set;
-}
-
-const cvdescriptorset::Descriptor *CMD_BUFFER_STATE::GetDescriptor(VkShaderStageFlagBits shader_stage, uint32_t set,
-                                                                   uint32_t binding, uint32_t index) const {
-    VkPipelineBindPoint bind_point;
-
-    if (shader_stage & VK_SHADER_STAGE_ALL_GRAPHICS) {
-        bind_point = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    } else if (shader_stage & VK_SHADER_STAGE_COMPUTE_BIT) {
-        bind_point = VK_PIPELINE_BIND_POINT_COMPUTE;
-    } else {
-        bind_point = VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR;
-    }
-
-    return GetDescriptor(bind_point, set, binding, index);
-}
-
-const cvdescriptorset::Descriptor *CMD_BUFFER_STATE::GetDescriptor(VkPipelineBindPoint bind_point, uint32_t set, uint32_t binding,
-                                                                   uint32_t index) const {
-    const auto last_bound_it = lastBound.find(bind_point);
-    if (last_bound_it == lastBound.cend()) {
-        return nullptr;
-    }
-    if (set >= last_bound_it->second.per_set.size()) {
-        return nullptr;
-    }
-    return last_bound_it->second.per_set[set].bound_descriptor_set->GetDescriptorFromBinding(binding, index);
-}
-
 uint32_t FullMipChainLevels(uint32_t height, uint32_t width, uint32_t depth) {
     // uint cast applies floor()
     return 1u + (uint32_t)log2(std::max({height, width, depth}));

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -6146,56 +6146,56 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
 
 // Validates the image is allowed to be protected
 bool CoreChecks::ValidateProtectedImage(const CMD_BUFFER_STATE *cb_state, const IMAGE_STATE *image_state, const char *cmd_name,
-                                        const char *vuid) const {
+                                        const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == true) && (image_state->unprotected == false)) {
         LogObjectList objlist(cb_state->commandBuffer);
         objlist.add(image_state->image);
-        skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while image %s is a protected image", cmd_name,
+        skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while image %s is a protected image.%s", cmd_name,
                          report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(image_state->image).c_str());
+                         report_data->FormatHandle(image_state->image).c_str(), more_message);
     }
     return skip;
 }
 
 // Validates the image is allowed to be unprotected
 bool CoreChecks::ValidateUnprotectedImage(const CMD_BUFFER_STATE *cb_state, const IMAGE_STATE *image_state, const char *cmd_name,
-                                          const char *vuid) const {
+                                          const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == false) && (image_state->unprotected == true)) {
         LogObjectList objlist(cb_state->commandBuffer);
         objlist.add(image_state->image);
-        skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while image %s is an unprotected image", cmd_name,
+        skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while image %s is an unprotected image.%s", cmd_name,
                          report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(image_state->image).c_str());
+                         report_data->FormatHandle(image_state->image).c_str(), more_message);
     }
     return skip;
 }
 
 // Validates the buffer is allowed to be protected
 bool CoreChecks::ValidateProtectedBuffer(const CMD_BUFFER_STATE *cb_state, const BUFFER_STATE *buffer_state, const char *cmd_name,
-                                         const char *vuid) const {
+                                         const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == true) && (buffer_state->unprotected == false)) {
         LogObjectList objlist(cb_state->commandBuffer);
         objlist.add(buffer_state->buffer);
-        skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while buffer %s is a protected buffer", cmd_name,
+        skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while buffer %s is a protected buffer.%s", cmd_name,
                          report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(buffer_state->buffer).c_str());
+                         report_data->FormatHandle(buffer_state->buffer).c_str(), more_message);
     }
     return skip;
 }
 
 // Validates the buffer is allowed to be unprotected
 bool CoreChecks::ValidateUnprotectedBuffer(const CMD_BUFFER_STATE *cb_state, const BUFFER_STATE *buffer_state, const char *cmd_name,
-                                           const char *vuid) const {
+                                           const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == false) && (buffer_state->unprotected == true)) {
         LogObjectList objlist(cb_state->commandBuffer);
         objlist.add(buffer_state->buffer);
-        skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while buffer %s is an unprotected buffer", cmd_name,
+        skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while buffer %s is an unprotected buffer.%s", cmd_name,
                          report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(buffer_state->buffer).c_str());
+                         report_data->FormatHandle(buffer_state->buffer).c_str(), more_message);
     }
     return skip;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1072,11 +1072,9 @@ static bool VerifySetLayoutCompatibility(const debug_report_data *report_data, c
 bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TYPE cmd_type, const bool indexed,
                                          const VkPipelineBindPoint bind_point, const char *function) const {
     const DrawDispatchVuid vuid = GetDrawDispatchVuid(cmd_type);
-    const auto last_bound_it = cb_node->lastBound.find(bind_point);
-    const PIPELINE_STATE *pPipe = nullptr;
-    if (last_bound_it != cb_node->lastBound.cend()) {
-        pPipe = last_bound_it->second.pipeline_state;
-    }
+    const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
+    const auto &state = cb_node->lastBound[lv_bind_point];
+    const auto *pPipe = state.pipeline_state;
 
     if (nullptr == pPipe) {
         return LogError(cb_node->commandBuffer, vuid.pipeline_bound,
@@ -1087,7 +1085,6 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     }
 
     bool result = false;
-    auto const &state = last_bound_it->second;
     std::vector<ATTACHMENT_INFO> attachments;
 
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point) {
@@ -1190,10 +1187,10 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                         state.per_set[setIndex].validated_set_binding_req_map.begin(),
                                         state.per_set[setIndex].validated_set_binding_req_map.end(),
                                         std::inserter(delta_reqs, delta_reqs.begin()));
-                    result |= ValidateDrawState(bind_point, descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets,
+                    result |= ValidateDrawState(descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets,
                                                 cb_node, attachments, function, vuid);
                 } else {
-                    result |= ValidateDrawState(bind_point, descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets,
+                    result |= ValidateDrawState(descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets,
                                                 cb_node, attachments, function, vuid);
                 }
             }
@@ -12618,23 +12615,22 @@ bool CoreChecks::PreCallValidateCmdSetSampleLocationsEXT(VkCommandBuffer command
     // Minimal validation for command buffer state
     skip |= ValidateCmd(cb_state, CMD_SETSAMPLELOCATIONSEXT, "vkCmdSetSampleLocationsEXT()");
     skip |= ValidateSampleLocationsInfo(pSampleLocationsInfo, "vkCmdSetSampleLocationsEXT");
-    const auto last_bound_it = cb_state->lastBound.find(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    if (last_bound_it != cb_state->lastBound.cend()) {
-        const PIPELINE_STATE *pPipe = last_bound_it->second.pipeline_state;
-        if (pPipe != nullptr) {
-            // Check same error with different log messages
-            const safe_VkPipelineMultisampleStateCreateInfo *multisample_state = pPipe->graphicsPipelineCI.pMultisampleState;
-            if (multisample_state == nullptr) {
-                skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
-                                 "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel must be equal to "
-                                 "rasterizationSamples, but the bound graphics pipeline was created without a multisample state");
-            } else if (multisample_state->rasterizationSamples != pSampleLocationsInfo->sampleLocationsPerPixel) {
-                skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
-                                 "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel (%s) is not equal to "
-                                 "the last bound pipeline's rasterizationSamples (%s)",
-                                 string_VkSampleCountFlagBits(pSampleLocationsInfo->sampleLocationsPerPixel),
-                                 string_VkSampleCountFlagBits(multisample_state->rasterizationSamples));
-            }
+
+    const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    const auto *pPipe = cb_state->lastBound[lv_bind_point].pipeline_state;
+    if (pPipe != nullptr) {
+        // Check same error with different log messages
+        const safe_VkPipelineMultisampleStateCreateInfo *multisample_state = pPipe->graphicsPipelineCI.pMultisampleState;
+        if (multisample_state == nullptr) {
+            skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
+                                "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel must be equal to "
+                                "rasterizationSamples, but the bound graphics pipeline was created without a multisample state");
+        } else if (multisample_state->rasterizationSamples != pSampleLocationsInfo->sampleLocationsPerPixel) {
+            skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
+                                "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel (%s) is not equal to "
+                                "the last bound pipeline's rasterizationSamples (%s)",
+                                string_VkSampleCountFlagBits(pSampleLocationsInfo->sampleLocationsPerPixel),
+                                string_VkSampleCountFlagBits(multisample_state->rasterizationSamples));
         }
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2829,7 +2829,7 @@ bool CoreChecks::ValidateCommandBuffersForSubmit(VkQueue queue, const VkSubmitIn
                             std::string error;
                             std::vector<uint32_t> dynamicOffsets;
                             // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
-                            skip |= ValidateDescriptorSetBindingData(cmd_info.bind_point, cb_node, set_node, dynamicOffsets,
+                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamicOffsets,
                                                                      binding_info, cmd_info.framebuffer, cmd_info.attachments,
                                                                      function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
                         }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1187,11 +1187,11 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                         state.per_set[setIndex].validated_set_binding_req_map.begin(),
                                         state.per_set[setIndex].validated_set_binding_req_map.end(),
                                         std::inserter(delta_reqs, delta_reqs.begin()));
-                    result |= ValidateDrawState(descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets,
-                                                cb_node, attachments, function, vuid);
+                    result |= ValidateDrawState(descriptor_set, delta_reqs, state.per_set[setIndex].dynamicOffsets, cb_node,
+                                                attachments, function, vuid);
                 } else {
-                    result |= ValidateDrawState(descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets,
-                                                cb_node, attachments, function, vuid);
+                    result |= ValidateDrawState(descriptor_set, binding_req_map, state.per_set[setIndex].dynamicOffsets, cb_node,
+                                                attachments, function, vuid);
                 }
             }
         }
@@ -1226,10 +1226,10 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 }
 
                 uint32_t issue_index = 0;
-                int ret = ValidatePushConstantSetUpdate(it->second, entrypoint->push_constant_used_in_shader, issue_index);
+                const auto ret = ValidatePushConstantSetUpdate(it->second, entrypoint->push_constant_used_in_shader, issue_index);
 
                 // "not set" error has been printed in ValidatePushConstantUsage.
-                if (ret == 2) {
+                if (ret == PC_Byte_Not_Updated) {
                     const auto loc_descr = entrypoint->push_constant_used_in_shader.GetLocationDesc(issue_index);
                     LogObjectList objlist(cb_node->commandBuffer);
                     objlist.add(pipeline_layout->layout);
@@ -2826,8 +2826,8 @@ bool CoreChecks::ValidateCommandBuffersForSubmit(VkQueue queue, const VkSubmitIn
                             std::string error;
                             std::vector<uint32_t> dynamicOffsets;
                             // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
-                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamicOffsets,
-                                                                     binding_info, cmd_info.framebuffer, cmd_info.attachments,
+                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamicOffsets, binding_info,
+                                                                     cmd_info.framebuffer, cmd_info.attachments,
                                                                      function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
                         }
                     }
@@ -12623,14 +12623,14 @@ bool CoreChecks::PreCallValidateCmdSetSampleLocationsEXT(VkCommandBuffer command
         const safe_VkPipelineMultisampleStateCreateInfo *multisample_state = pPipe->graphicsPipelineCI.pMultisampleState;
         if (multisample_state == nullptr) {
             skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
-                                "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel must be equal to "
-                                "rasterizationSamples, but the bound graphics pipeline was created without a multisample state");
+                             "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel must be equal to "
+                             "rasterizationSamples, but the bound graphics pipeline was created without a multisample state");
         } else if (multisample_state->rasterizationSamples != pSampleLocationsInfo->sampleLocationsPerPixel) {
             skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdSetSampleLocationsEXT-sampleLocationsPerPixel-01529",
-                                "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel (%s) is not equal to "
-                                "the last bound pipeline's rasterizationSamples (%s)",
-                                string_VkSampleCountFlagBits(pSampleLocationsInfo->sampleLocationsPerPixel),
-                                string_VkSampleCountFlagBits(multisample_state->rasterizationSamples));
+                             "vkCmdSetSampleLocationsEXT(): pSampleLocationsInfo->sampleLocationsPerPixel (%s) is not equal to "
+                             "the last bound pipeline's rasterizationSamples (%s)",
+                             string_VkSampleCountFlagBits(pSampleLocationsInfo->sampleLocationsPerPixel),
+                             string_VkSampleCountFlagBits(multisample_state->rasterizationSamples));
         }
     }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -386,12 +386,11 @@ class CoreChecks : public ValidationStateTracker {
     VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                 void* pData);
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
-    bool ValidateDrawState(VkPipelineBindPoint bind_point, const cvdescriptorset::DescriptorSet* descriptor_set,
-                           const BindingReqMap& bindings, const std::vector<uint32_t>& dynamic_offsets,
-                           const CMD_BUFFER_STATE* cb_node, const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,
+    bool ValidateDrawState(const cvdescriptorset::DescriptorSet* descriptor_set, const BindingReqMap& bindings,
+                           const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE* cb_node,
+                           const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,
                            const DrawDispatchVuid& vuids) const;
-    bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node,
-                                          const cvdescriptorset::DescriptorSet* descriptor_set,
+    bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node, const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets,
                                           std::pair<const uint32_t, DescriptorRequirement>& binding_info, VkFramebuffer framebuffer,
                                           const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -455,10 +455,11 @@ class CoreChecks : public ValidationStateTracker {
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* src,
                                    VkPipelineShaderStageCreateInfo const* pStage) const;
-    int ValidatePushConstantSetUpdate(const std::vector<int8_t>& push_constant_data_update,
-                                      const shader_struct_member& push_constant_used_in_shader, uint32_t& out_issue_index) const;
     bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* src, const std::unordered_set<uint32_t>& accessible_ids,
                                VkShaderStageFlagBits stage) const;
+    PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
+                                                        const shader_struct_member& push_constant_used_in_shader,
+                                                        uint32_t& out_issue_index) const;
     bool ValidateSpecializationOffsets(VkPipelineShaderStageCreateInfo const* info) const;
     bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure) const;
     bool RequireFeature(VkBool32 feature, char const* feature_name) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -62,6 +62,12 @@ struct DrawDispatchVuid {
     const char* sampler_bias_offset;
     const char* vertex_binding_attribute;
     const char* dynamic_state_setting_commands;
+    const char* unprotected_command_buffer;
+    const char* protected_command_buffer;
+    const char*
+        max_multiview_instance_index;  // TODO: Some instance values are in VkBuffer.The validation in those Cmds is skipped.
+    const char* filter_cubic;
+    const char* filter_cubic_min_max;
 };
 
 typedef struct {
@@ -152,13 +158,13 @@ class CoreChecks : public ValidationStateTracker {
                                         const VkDeviceQueueCreateInfo* infos) const;
 
     bool ValidateProtectedImage(const CMD_BUFFER_STATE* cb_state, const IMAGE_STATE* image_state, const char* cmd_name,
-                                const char* vuid) const;
+                                const char* vuid, const char* more_message = "") const;
     bool ValidateUnprotectedImage(const CMD_BUFFER_STATE* cb_state, const IMAGE_STATE* image_state, const char* cmd_name,
-                                  const char* vuid) const;
+                                  const char* vuid, const char* more_message = "") const;
     bool ValidateProtectedBuffer(const CMD_BUFFER_STATE* cb_state, const BUFFER_STATE* buffer_state, const char* cmd_name,
-                                 const char* vuid) const;
+                                 const char* vuid, const char* more_message = "") const;
     bool ValidateUnprotectedBuffer(const CMD_BUFFER_STATE* cb_state, const BUFFER_STATE* buffer_state, const char* cmd_name,
-                                   const char* vuid) const;
+                                   const char* vuid, const char* more_message = "") const;
 
     bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
                                         const VkGraphicsPipelineCreateInfo* pipe_cis) const;
@@ -495,7 +501,8 @@ class CoreChecks : public ValidationStateTracker {
                                                               const char* variable_name) const;
     template <typename RegionType>
     bool ValidateBufferImageCopyData(const CMD_BUFFER_STATE* cb_node, uint32_t regionCount, const RegionType* pRegions,
-                                     const IMAGE_STATE* image_state, const char* function, CopyCommandVersion version, bool image_to_buffer) const;
+                                     const IMAGE_STATE* image_state, const char* function, CopyCommandVersion version,
+                                     bool image_to_buffer) const;
     bool ValidateBufferViewRange(const BUFFER_STATE* buffer_state, const VkBufferViewCreateInfo* pCreateInfo,
                                  const VkPhysicalDeviceLimits* device_limits) const;
     bool ValidateBufferViewBuffer(const BUFFER_STATE* buffer_state, const VkBufferViewCreateInfo* pCreateInfo) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -388,9 +388,9 @@ class CoreChecks : public ValidationStateTracker {
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(VkPipelineBindPoint bind_point, const cvdescriptorset::DescriptorSet* descriptor_set,
                            const BindingReqMap& bindings, const std::vector<uint32_t>& dynamic_offsets,
-                           const CMD_BUFFER_STATE* cb_node, const std::vector<ATTACHMENT_INFO>& attachments,
-                           const char* caller, const DrawDispatchVuid& vuids) const;
-    bool ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point, const CMD_BUFFER_STATE* cb_node,
+                           const CMD_BUFFER_STATE* cb_node, const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,
+                           const DrawDispatchVuid& vuids) const;
+    bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node,
                                           const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets,
                                           std::pair<const uint32_t, DescriptorRequirement>& binding_info, VkFramebuffer framebuffer,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -176,7 +176,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateImageBarrierAttachment(const char* funcName, CMD_BUFFER_STATE const* cb_state,
                                         const FRAMEBUFFER_STATE* framebuffer, uint32_t active_subpass,
                                         const safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,
-                                        uint32_t img_index, const VkImageMemoryBarrier& img_barrier) const;
+                                        uint32_t img_index, const VkImageMemoryBarrier& img_barrier,
+                                        const CMD_BUFFER_STATE* primary_cb_state = nullptr) const;
     static bool ValidateConcurrentBarrierAtSubmit(const ValidationStateTracker* state_data, const QUEUE_STATE* queue_data,
                                                   const char* func_name, const CMD_BUFFER_STATE* cb_state,
                                                   const VulkanTypedHandle& typed_handle, uint32_t src_queue_family,
@@ -388,12 +389,13 @@ class CoreChecks : public ValidationStateTracker {
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const cvdescriptorset::DescriptorSet* descriptor_set, const BindingReqMap& bindings,
                            const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE* cb_node,
-                           const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,
-                           const DrawDispatchVuid& vuids) const;
+                           const std::vector<IMAGE_VIEW_STATE*>* attachments, const std::vector<SUBPASS_INFO>& subpasses,
+                           const char* caller, const DrawDispatchVuid& vuids) const;
     bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node, const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets,
                                           std::pair<const uint32_t, DescriptorRequirement>& binding_info, VkFramebuffer framebuffer,
-                                          const std::vector<ATTACHMENT_INFO>& attachments, const char* caller,
+                                          const std::vector<IMAGE_VIEW_STATE*>* attachments,
+                                          const std::vector<SUBPASS_INFO>& subpasses, const char* caller,
                                           const DrawDispatchVuid& vuids) const;
 
     // Validate contents of a CopyUpdate
@@ -526,7 +528,8 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, uint32_t attachment_index,
                                        const FRAMEBUFFER_STATE* framebuffer, uint32_t fb_attachment, const VkRect2D& render_area,
-                                       uint32_t rect_count, const VkClearRect* clear_rects) const;
+                                       uint32_t rect_count, const VkClearRect* clear_rects,
+                                       const CMD_BUFFER_STATE* primary_cb_state = nullptr) const;
 
     template <typename ImageCopyRegionType>
     bool ValidateImageCopyData(const uint32_t regionCount, const ImageCopyRegionType* ic_regions, const IMAGE_STATE* src_state,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -256,6 +256,8 @@ class CoreChecks : public ValidationStateTracker {
                                uint32_t queryCount) const;
 
     const DrawDispatchVuid& GetDrawDispatchVuid(CMD_TYPE cmd_type) const;
+    bool ValidateCmdDrawInstance(VkCommandBuffer commandBuffer, uint32_t instanceCount, uint32_t firstInstance, CMD_TYPE cmd_type,
+                                 const char* caller) const;
     bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, bool indexed, VkPipelineBindPoint bind_point, CMD_TYPE cmd_type,
                              const char* caller, VkQueueFlags queue_flags) const;
     bool ValidateCmdNextSubpass(RenderPassCreateVersion rp_version, VkCommandBuffer commandBuffer) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -180,10 +180,12 @@ struct less<SamplerUsedByImage> {
 
 struct DescriptorRequirement {
     descriptor_req reqs;
+    bool is_writable;
     std::vector<std::map<SamplerUsedByImage, std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *>>>
         samplers_used_by_image;  // Copy from StageState.interface_var. BUT it combines from plural shader stages.
                                  // The index of array is index of image.
-    DescriptorRequirement() : reqs(descriptor_req(0)) {}
+
+    DescriptorRequirement() : reqs(descriptor_req(0)), is_writable(false) {}
 };
 
 inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) NOEXCEPT { return a.reqs == b.reqs; }

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1340,7 +1340,8 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::vector<uint8_t> push_constant_data;
     PushConstantRangesId push_constant_data_ranges;
 
-    std::map<VkShaderStageFlagBits, std::vector<int8_t>> push_constant_data_update;  // -1: not set, 0: not update, 1: update,
+    std::map<VkShaderStageFlagBits, std::vector<uint8_t>>
+        push_constant_data_update;  // vector's value is enum PushConstantByteState.
     VkPipelineLayout push_constant_pipeline_layout_set;
 
     // Used for Best Practices tracking

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -285,8 +285,9 @@ struct MEM_BINDING {
     VkDeviceSize size;
 };
 
+class BUFFER_STATE;
 struct BufferBinding {
-    VkBuffer buffer;
+    std::shared_ptr<BUFFER_STATE> buffer_state;
     VkDeviceSize size;
     VkDeviceSize offset;
     VkDeviceSize stride;
@@ -1387,9 +1388,9 @@ struct MT_FB_ATTACHMENT_INFO {
 struct ATTACHMENT_INFO {
     VkImageUsageFlagBits usage;
     VkImageLayout layout;
-    VkImageView view;
+    IMAGE_VIEW_STATE* view_state;
 
-    ATTACHMENT_INFO() : usage(VkImageUsageFlagBits(0)), layout(VK_IMAGE_LAYOUT_UNDEFINED), view(VK_NULL_HANDLE) {}
+    ATTACHMENT_INFO() : usage(VkImageUsageFlagBits(0)), layout(VK_IMAGE_LAYOUT_UNDEFINED), view_state(nullptr) {}
 };
 
 class FRAMEBUFFER_STATE : public BASE_NODE {
@@ -1397,6 +1398,7 @@ class FRAMEBUFFER_STATE : public BASE_NODE {
     VkFramebuffer framebuffer;
     safe_VkFramebufferCreateInfo createInfo;
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_state;
     FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate)
         : framebuffer(fb), createInfo(pCreateInfo), rp_state(rpstate){};
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -520,6 +520,7 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     VkSampleCountFlagBits samples;
     unsigned descriptor_format_bits;
     VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
+    VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props;
     VkFormatFeatureFlags format_features;
     std::shared_ptr<IMAGE_STATE> image_state;
     IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1442,6 +1442,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceCustomBorderColorFeaturesEXT custom_border_color_features;
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipeline_creation_cache_control_features;
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
+    VkPhysicalDeviceMultiviewFeatures multiview_features;
 };
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -178,11 +178,12 @@ struct less<SamplerUsedByImage> {
 };
 }  // namespace std
 
+struct SAMPLER_STATE;
 struct DescriptorRequirement {
     descriptor_req reqs;
     bool is_writable;
-    std::vector<std::map<SamplerUsedByImage, std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *>>>
-        samplers_used_by_image;  // Copy from StageState.interface_var. BUT it combines from plural shader stages.
+    std::vector<std::map<SamplerUsedByImage, const cvdescriptorset::Descriptor *>>
+        samplers_used_by_image;  // Copy from StageState.interface_var. It combines from plural shader stages.
                                  // The index of array is index of image.
 
     DescriptorRequirement() : reqs(descriptor_req(0)), is_writable(false) {}
@@ -1243,7 +1244,6 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     std::map<uint32_t, LAST_BOUND_STATE> lastBound;
 
     struct CmdDrawDispatchInfo {
-        VkPipelineBindPoint bind_point;
         CMD_TYPE cmd_type;
         std::string function;
         std::vector<std::pair<const uint32_t, DescriptorRequirement>> binding_infos;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -836,10 +836,10 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     desc_writes[0].dstBinding = 3;
     DispatchUpdateDescriptorSets(device, desc_count, desc_writes, 0, NULL);
 
-    auto iter = cb_node->lastBound.find(bind_point);  // find() allows read-only access to cb_state
-    if (iter != cb_node->lastBound.end()) {
-        auto pipeline_state = iter->second.pipeline_state;
-        if (pipeline_state && (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index)) {
+    const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
+    const auto *pipeline_state = cb_node->lastBound[lv_bind_point].pipeline_state;
+    if (pipeline_state) {
+        if (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index) {
             DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout, desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -697,10 +697,10 @@ unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt) {
 //  This includes validating that all descriptors in the given bindings are updated,
 //  that any update buffers are valid, and that any dynamic offsets are within the bounds of their buffers.
 // Return true if state is acceptable, or false and write an error message into error string
-bool CoreChecks::ValidateDrawState(VkPipelineBindPoint bind_point, const DescriptorSet *descriptor_set,
-                                   const BindingReqMap &bindings, const std::vector<uint32_t> &dynamic_offsets,
-                                   const CMD_BUFFER_STATE *cb_node, const std::vector<ATTACHMENT_INFO> &attachments,
-                                   const char *caller, const DrawDispatchVuid &vuids) const {
+bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const BindingReqMap &bindings,
+                                   const std::vector<uint32_t> &dynamic_offsets, const CMD_BUFFER_STATE *cb_node,
+                                   const std::vector<ATTACHMENT_INFO> &attachments, const char *caller,
+                                   const DrawDispatchVuid &vuids) const {
     bool result = false;
     VkFramebuffer framebuffer = cb_node->activeFramebuffer ? cb_node->activeFramebuffer->framebuffer : VK_NULL_HANDLE;
     for (auto binding_pair : bindings) {

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -875,6 +875,17 @@ bool CoreChecks::ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point
                                 }
                             }
                         }
+                        if (enabled_features.core11.protectedMemory == VK_TRUE) {
+                            if (ValidateProtectedBuffer(cb_node, buffer_node, caller, vuids.unprotected_command_buffer,
+                                                        "Buffer is in a descriptorSet")) {
+                                return true;
+                            }
+                            if (binding_info.second.is_writable &&
+                                ValidateUnprotectedBuffer(cb_node, buffer_node, caller, vuids.protected_command_buffer,
+                                                          "Buffer is in a descriptorSet")) {
+                                return true;
+                            }
+                        }
                     }
                 } else if (descriptor_class == DescriptorClass::ImageSampler || descriptor_class == DescriptorClass::Image) {
                     VkImageView image_view;
@@ -1047,6 +1058,17 @@ bool CoreChecks::ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point
                                 }
                                 ++view_index;
                             }
+                            if (enabled_features.core11.protectedMemory == VK_TRUE) {
+                                if (ValidateProtectedImage(cb_node, image_view_state->image_state.get(), caller,
+                                                           vuids.unprotected_command_buffer, "Image is in a descriptorSet")) {
+                                    return true;
+                                }
+                                if (binding_info.second.is_writable &&
+                                    ValidateUnprotectedImage(cb_node, image_view_state->image_state.get(), caller,
+                                                             vuids.protected_command_buffer, "Image is in a descriptorSet")) {
+                                    return true;
+                                }
+                            }
                         }
 
                         // Here is some unnormalizedCoordinates sampler validations. But because it might take long time to find out
@@ -1182,6 +1204,17 @@ bool CoreChecks::ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point
                                 report_data->FormatHandle(set).c_str(), caller, binding, index,
                                 report_data->FormatHandle(buffer_view).c_str(),
                                 string_VkFormat(buffer_view_state->create_info.format));
+                        }
+                        if (enabled_features.core11.protectedMemory == VK_TRUE) {
+                            if (ValidateProtectedBuffer(cb_node, buffer_view_state->buffer_state.get(), caller,
+                                                        vuids.unprotected_command_buffer, "Buffer is in a descriptorSet")) {
+                                return true;
+                            }
+                            if (binding_info.second.is_writable &&
+                                ValidateUnprotectedBuffer(cb_node, buffer_view_state->buffer_state.get(), caller,
+                                                          vuids.protected_command_buffer, "Buffer is in a descriptorSet")) {
+                                return true;
+                            }
                         }
                     }
                 } else if (descriptor_class == DescriptorClass::AccelerationStructure) {

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -727,31 +727,6 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const Bi
     return result;
 }
 
-std::vector<const SAMPLER_STATE *> GetUnnormalizedCoordinatesSamplerStatesFromDescriptorSet(
-    const cvdescriptorset::DescriptorClass descriptor_class, const cvdescriptorset::Descriptor &descriptor,
-    const CMD_BUFFER_STATE &cb_node, std::pair<const uint32_t, DescriptorRequirement> &binding_info, uint32_t image_index) {
-    std::vector<const SAMPLER_STATE *> sampler_states;
-
-    if (descriptor_class == cvdescriptorset::DescriptorClass::ImageSampler) {
-        const cvdescriptorset::ImageSamplerDescriptor *image_descriptor =
-            static_cast<const cvdescriptorset::ImageSamplerDescriptor *>(&descriptor);
-        const auto *sampler_state = image_descriptor->GetSamplerState();
-
-        if (sampler_state->createInfo.unnormalizedCoordinates) sampler_states.emplace_back(sampler_state);
-
-    } else if (descriptor_class == cvdescriptorset::DescriptorClass::Image &&
-               binding_info.second.samplers_used_by_image.size() > image_index) {
-        for (auto &sampler : binding_info.second.samplers_used_by_image[image_index]) {
-            if (sampler.second) {
-                const auto *sampler_state =
-                    static_cast<const cvdescriptorset::SamplerDescriptor *>(sampler.second)->GetSamplerState();
-                if (sampler_state && sampler_state->createInfo.unnormalizedCoordinates) sampler_states.emplace_back(sampler_state);
-            }
-        }
-    }
-    return sampler_states;
-}
-
 bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_node, const DescriptorSet *descriptor_set,
                                                   const std::vector<uint32_t> &dynamic_offsets,
                                                   std::pair<const uint32_t, DescriptorRequirement> &binding_info,
@@ -871,17 +846,29 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                     VkImageView image_view;
                     VkImageLayout image_layout;
                     const IMAGE_VIEW_STATE *image_view_state;
+                    std::vector<const SAMPLER_STATE *> sampler_states;
 
                     if (descriptor_class == DescriptorClass::ImageSampler) {
                         const ImageSamplerDescriptor *image_descriptor = static_cast<const ImageSamplerDescriptor *>(descriptor);
                         image_view = image_descriptor->GetImageView();
                         image_view_state = image_descriptor->GetImageViewState();
                         image_layout = image_descriptor->GetImageLayout();
+                        sampler_states.emplace_back(image_descriptor->GetSamplerState());
                     } else {
                         const ImageDescriptor *image_descriptor = static_cast<const ImageDescriptor *>(descriptor);
                         image_view = image_descriptor->GetImageView();
                         image_view_state = image_descriptor->GetImageViewState();
                         image_layout = image_descriptor->GetImageLayout();
+
+                        if (binding_info.second.samplers_used_by_image.size() > index) {
+                            for (auto &sampler : binding_info.second.samplers_used_by_image[index]) {
+                                if (sampler.second) {
+                                    const auto *sampler_state =
+                                        static_cast<const cvdescriptorset::SamplerDescriptor *>(sampler.second)->GetSamplerState();
+                                    if (sampler_state) sampler_states.emplace_back(sampler_state);
+                                }
+                            }
+                        }
                     }
 
                     if ((!image_view_state && !enabled_features.robustness2_features.nullDescriptor) ||
@@ -899,6 +886,8 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                     }
                     if (image_view) {
                         const auto &image_view_ci = image_view_state->create_info;
+                        const auto *image_state = image_view_state->image_state.get();
+
                         if (reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
                             if (~reqs & (1 << image_view_ci.viewType)) {
                                 auto set = descriptor_set->GetSet();
@@ -1055,80 +1044,154 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                             }
                         }
 
-                        // Here is some unnormalizedCoordinates sampler validations. But because it might take long time to find out
-                        // samplers, it will look for them when it needs.
-                        std::vector<const SAMPLER_STATE *> unnormalizedCoordinates_sampler_states;
-                        bool update_unnormalizedCoordinates_sampler_states = false;
+                        for (const auto *sampler_state : sampler_states) {
+                            if (!sampler_state || sampler_state->destroyed) {
+                                continue;
+                            }
 
-                        // If ImageView is used by a unnormalizedCoordinates sampler, it needs to check ImageView type
-                        if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
-                            image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY ||
-                            image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY ||
-                            image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
-                            update_unnormalizedCoordinates_sampler_states = true;
-                            unnormalizedCoordinates_sampler_states = GetUnnormalizedCoordinatesSamplerStatesFromDescriptorSet(
-                                descriptor_class, *descriptor, *cb_node, binding_info, index);
-
-                            for (const auto *sampler_state : unnormalizedCoordinates_sampler_states) {
+                            // TODO: Validate 04015 for DescriptorClass::PlainSampler
+                            if ((sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
+                                 sampler_state->createInfo.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) &&
+                                (sampler_state->customCreateInfo.format == VK_FORMAT_UNDEFINED)) {
+                                if (image_view_state->create_info.format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 ||
+                                    image_view_state->create_info.format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
+                                    image_view_state->create_info.format == VK_FORMAT_B5G5R5A1_UNORM_PACK16) {
+                                    auto set = descriptor_set->GetSet();
+                                    LogObjectList objlist(set);
+                                    objlist.add(sampler_state->sampler);
+                                    objlist.add(image_view_state->image_view);
+                                    return LogError(objlist, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015",
+                                                    "%s encountered the following validation error at %s time: Sampler %s in "
+                                                    "binding #%" PRIu32 " index %" PRIu32
+                                                    " has a custom border color with format = VK_FORMAT_UNDEFINED and is used to "
+                                                    "sample an image view %s with format %s",
+                                                    report_data->FormatHandle(set).c_str(), caller,
+                                                    report_data->FormatHandle(sampler_state->sampler).c_str(), binding, index,
+                                                    report_data->FormatHandle(image_view_state->image_view).c_str(),
+                                                    string_VkFormat(image_view_state->create_info.format));
+                                }
+                            }
+                            VkFilter sampler_mag_filter = sampler_state->createInfo.magFilter;
+                            VkFilter sampler_min_filter = sampler_state->createInfo.minFilter;
+                            VkBool32 sampler_compare_enable = sampler_state->createInfo.compareEnable;
+                            if ((sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) &&
+                                (sampler_compare_enable == VK_FALSE) &&
+                                !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
                                 auto set = descriptor_set->GetSet();
                                 LogObjectList objlist(set);
-                                objlist.add(image_view);
                                 objlist.add(sampler_state->sampler);
-                                return LogError(objlist, vuids.sampler_imageview_type,
-                                                "%s encountered the following validation error at %s time: %s, type: %s in "
-                                                "Descriptor in binding #%" PRIu32 " index %" PRIu32 "is used by %s.",
-                                                report_data->FormatHandle(set).c_str(), caller,
-                                                report_data->FormatHandle(image_view).c_str(),
-                                                string_VkImageViewType(image_view_ci.viewType), binding, index,
-                                                report_data->FormatHandle(sampler_state->sampler).c_str());
+                                objlist.add(image_view_state->image_view);
+                                return LogError(objlist, vuids.linear_sampler,
+                                                "sampler (%s) in descriptor set (%s) "
+                                                "is set to use VK_FILTER_LINEAR, then image view's (%s"
+                                                ") format (%s) MUST "
+                                                "contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
+                                                report_data->FormatHandle(sampler_state->sampler).c_str(),
+                                                report_data->FormatHandle(set).c_str(),
+                                                report_data->FormatHandle(image_view_state->image_view).c_str(),
+                                                string_VkFormat(image_view_state->create_info.format));
                             }
-                        }
-
-                        // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample* instructions
-                        // with ImplicitLod, Dref or Proj in their name
-                        if (reqs & DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ) {
-                            if (!update_unnormalizedCoordinates_sampler_states) {
-                                update_unnormalizedCoordinates_sampler_states = true;
-                                unnormalizedCoordinates_sampler_states = GetUnnormalizedCoordinatesSamplerStatesFromDescriptorSet(
-                                    descriptor_class, *descriptor, *cb_node, binding_info, index);
-                            }
-
-                            for (const auto *sampler_state : unnormalizedCoordinates_sampler_states) {
+                            if ((sampler_mag_filter == VK_FILTER_CUBIC_EXT || sampler_min_filter == VK_FILTER_CUBIC_EXT) &&
+                                !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
                                 auto set = descriptor_set->GetSet();
                                 LogObjectList objlist(set);
-                                objlist.add(image_view);
                                 objlist.add(sampler_state->sampler);
-                                return LogError(objlist, vuids.sampler_implicitLod_dref_proj,
-                                                "%s encountered the following validation error at %s time: %s in "
-                                                "Descriptor in binding #%" PRIu32 " index %" PRIu32
-                                                " is used by %s that uses invalid operator.",
-                                                report_data->FormatHandle(set).c_str(), caller,
-                                                report_data->FormatHandle(image_view).c_str(), binding, index,
-                                                report_data->FormatHandle(sampler_state->sampler).c_str());
-                            }
-                        }
-
-                        // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample* instructions
-                        // that includes a LOD bias or any offset values
-                        if (reqs & DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET) {
-                            if (!update_unnormalizedCoordinates_sampler_states) {
-                                update_unnormalizedCoordinates_sampler_states = true;
-                                unnormalizedCoordinates_sampler_states = GetUnnormalizedCoordinatesSamplerStatesFromDescriptorSet(
-                                    descriptor_class, *descriptor, *cb_node, binding_info, index);
+                                objlist.add(image_view_state->image_view);
+                                return LogError(
+                                    objlist, vuids.cubic_sampler,
+                                    "sampler (%s) in descriptor set (%s) "
+                                    "is set to use VK_FILTER_CUBIC_EXT, then image view's (%s"
+                                    ") format (%s) MUST "
+                                    "contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
+                                    report_data->FormatHandle(sampler_state->sampler).c_str(),
+                                    report_data->FormatHandle(set).c_str(),
+                                    report_data->FormatHandle(image_view_state->image_view).c_str(),
+                                    string_VkFormat(image_view_state->create_info.format));
                             }
 
-                            for (const auto *sampler_state : unnormalizedCoordinates_sampler_states) {
+                            if ((image_state->createInfo.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) &&
+                                (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
+                                 sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
+                                 sampler_state->createInfo.addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)) {
+                                std::string address_mode_letter =
+                                    (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)   ? "U"
+                                    : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ? "V"
+                                                                                                                        : "W";
+                                VkSamplerAddressMode address_mode =
+                                    (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+                                        ? sampler_state->createInfo.addressModeU
+                                    : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+                                        ? sampler_state->createInfo.addressModeV
+                                        : sampler_state->createInfo.addressModeW;
                                 auto set = descriptor_set->GetSet();
                                 LogObjectList objlist(set);
-                                objlist.add(image_view);
                                 objlist.add(sampler_state->sampler);
-                                return LogError(objlist, vuids.sampler_bias_offset,
-                                                "%s encountered the following validation error at %s time: %s in "
-                                                "Descriptor in binding #%" PRIu32 " index %" PRIu32
-                                                " is used by %s that uses invalid bias or offset operator.",
-                                                report_data->FormatHandle(set).c_str(), caller,
-                                                report_data->FormatHandle(image_view).c_str(), binding, index,
-                                                report_data->FormatHandle(sampler_state->sampler).c_str());
+                                objlist.add(image_state->image);
+                                objlist.add(image_view_state->image_view);
+                                return LogError(objlist, vuids.corner_sampled_address_mode,
+                                                "image (%s) in image view (%s) in descriptor set (%s) is created with flag "
+                                                "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
+                                                "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
+                                                "createInfo.addressMode%s set to %s.",
+                                                report_data->FormatHandle(image_state->image).c_str(),
+                                                report_data->FormatHandle(image_view_state->image_view).c_str(),
+                                                report_data->FormatHandle(set).c_str(),
+                                                report_data->FormatHandle(sampler_state->sampler).c_str(),
+                                                address_mode_letter.c_str(), string_VkSamplerAddressMode(address_mode));
+                            }
+
+                            // UnnormalizedCoordinates sampler validations
+                            if (sampler_state->createInfo.unnormalizedCoordinates) {
+                                // If ImageView is used by a unnormalizedCoordinates sampler, it needs to check ImageView type
+                                if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D ||
+                                    image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
+                                    image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY ||
+                                    image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY ||
+                                    image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
+                                    auto set = descriptor_set->GetSet();
+                                    LogObjectList objlist(set);
+                                    objlist.add(image_view);
+                                    objlist.add(sampler_state->sampler);
+                                    return LogError(objlist, vuids.sampler_imageview_type,
+                                                    "%s encountered the following validation error at %s time: %s, type: %s in "
+                                                    "Descriptor in binding #%" PRIu32 " index %" PRIu32 "is used by %s.",
+                                                    report_data->FormatHandle(set).c_str(), caller,
+                                                    report_data->FormatHandle(image_view).c_str(),
+                                                    string_VkImageViewType(image_view_ci.viewType), binding, index,
+                                                    report_data->FormatHandle(sampler_state->sampler).c_str());
+                                }
+
+                                // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
+                                // instructions with ImplicitLod, Dref or Proj in their name
+                                if (reqs & DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ) {
+                                    auto set = descriptor_set->GetSet();
+                                    LogObjectList objlist(set);
+                                    objlist.add(image_view);
+                                    objlist.add(sampler_state->sampler);
+                                    return LogError(objlist, vuids.sampler_implicitLod_dref_proj,
+                                                    "%s encountered the following validation error at %s time: %s in "
+                                                    "Descriptor in binding #%" PRIu32 " index %" PRIu32
+                                                    " is used by %s that uses invalid operator.",
+                                                    report_data->FormatHandle(set).c_str(), caller,
+                                                    report_data->FormatHandle(image_view).c_str(), binding, index,
+                                                    report_data->FormatHandle(sampler_state->sampler).c_str());
+                                }
+
+                                // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
+                                // instructions that includes a LOD bias or any offset values
+                                if (reqs & DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET) {
+                                    auto set = descriptor_set->GetSet();
+                                    LogObjectList objlist(set);
+                                    objlist.add(image_view);
+                                    objlist.add(sampler_state->sampler);
+                                    return LogError(objlist, vuids.sampler_bias_offset,
+                                                    "%s encountered the following validation error at %s time: %s in "
+                                                    "Descriptor in binding #%" PRIu32 " index %" PRIu32
+                                                    " is used by %s that uses invalid bias or offset operator.",
+                                                    report_data->FormatHandle(set).c_str(), caller,
+                                                    report_data->FormatHandle(image_view).c_str(), binding, index,
+                                                    report_data->FormatHandle(sampler_state->sampler).c_str());
+                                }
                             }
                         }
                     }
@@ -1228,6 +1291,10 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                         }
                     }
                 }
+
+                // If the validation is related to both of image and sampler,
+                // please leave it in (descriptor_class == DescriptorClass::ImageSampler || descriptor_class == DescriptorClass::Image)
+                // Here is to validate for only sampler.
                 if (descriptor_class == DescriptorClass::ImageSampler || descriptor_class == DescriptorClass::PlainSampler) {
                     // Verify Sampler still valid
                     VkSampler sampler;
@@ -1258,102 +1325,6 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                                             report_data->FormatHandle(sampler).c_str(),
                                             report_data->FormatHandle(descriptor_set->GetSet()).c_str(),
                                             report_data->FormatHandle(sampler_state->samplerConversion).c_str());
-                        }
-                    }
-                    // TODO: Validate 04015 for DescriptorClass::PlainSampler
-                    if (descriptor_class == DescriptorClass::ImageSampler) {
-                        const IMAGE_VIEW_STATE *image_view_state;
-                        image_view_state = static_cast<const ImageSamplerDescriptor *>(descriptor)->GetImageViewState();
-                        if (image_view_state) {
-                            if ((sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
-                                 sampler_state->createInfo.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) &&
-                                (sampler_state->customCreateInfo.format == VK_FORMAT_UNDEFINED)) {
-                                if (image_view_state->create_info.format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 ||
-                                    image_view_state->create_info.format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
-                                    image_view_state->create_info.format == VK_FORMAT_B5G5R5A1_UNORM_PACK16) {
-                                    auto set = descriptor_set->GetSet();
-                                    LogObjectList objlist(set);
-                                    objlist.add(sampler);
-                                    objlist.add(image_view_state->image_view);
-                                    return LogError(objlist, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015",
-                                                    "%s encountered the following validation error at %s time: Sampler %s in "
-                                                    "binding #%" PRIu32 " index %" PRIu32
-                                                    " has a custom border color with format = VK_FORMAT_UNDEFINED and is used to "
-                                                    "sample an image view %s with format %s",
-                                                    report_data->FormatHandle(set).c_str(), caller,
-                                                    report_data->FormatHandle(sampler).c_str(), binding, index,
-                                                    report_data->FormatHandle(image_view_state->image_view).c_str(),
-                                                    string_VkFormat(image_view_state->create_info.format));
-                                }
-                            }
-                            VkFilter sampler_mag_filter = sampler_state->createInfo.magFilter;
-                            VkFilter sampler_min_filter = sampler_state->createInfo.minFilter;
-                            VkBool32 sampler_compare_enable = sampler_state->createInfo.compareEnable;
-                            if ((sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) &&
-                                (sampler_compare_enable == VK_FALSE) &&
-                                !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
-                                auto set = descriptor_set->GetSet();
-                                LogObjectList objlist(set);
-                                objlist.add(sampler);
-                                objlist.add(image_view_state->image_view);
-                                return LogError(objlist, vuids.linear_sampler,
-                                                "sampler (%s) in descriptor set (%s) "
-                                                "is set to use VK_FILTER_LINEAR, then image view's (%s"
-                                                ") format (%s) MUST "
-                                                "contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                                report_data->FormatHandle(sampler).c_str(), report_data->FormatHandle(set).c_str(),
-                                                report_data->FormatHandle(image_view_state->image_view).c_str(),
-                                                string_VkFormat(image_view_state->create_info.format));
-                            }
-                            if ((sampler_mag_filter == VK_FILTER_CUBIC_EXT || sampler_min_filter == VK_FILTER_CUBIC_EXT) &&
-                                !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
-                                auto set = descriptor_set->GetSet();
-                                LogObjectList objlist(set);
-                                objlist.add(sampler);
-                                objlist.add(image_view_state->image_view);
-                                return LogError(
-                                    objlist, vuids.cubic_sampler,
-                                    "sampler (%s) in descriptor set (%s) "
-                                    "is set to use VK_FILTER_CUBIC_EXT, then image view's (%s"
-                                    ") format (%s) MUST "
-                                    "contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
-                                    report_data->FormatHandle(sampler).c_str(), report_data->FormatHandle(set).c_str(),
-                                    report_data->FormatHandle(image_view_state->image_view).c_str(),
-                                    string_VkFormat(image_view_state->create_info.format));
-                            }
-
-                            const IMAGE_STATE *image_state;
-                            image_state = GetImageState(image_view_state->create_info.image);
-                            if ((image_state->createInfo.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) &&
-                                (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
-                                 sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
-                                 sampler_state->createInfo.addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)) {
-                                std::string address_mode_letter =
-                                    (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                                        ? "U"
-                                        : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ? "V"
-                                                                                                                            : "W";
-                                VkSamplerAddressMode address_mode =
-                                    (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                                        ? sampler_state->createInfo.addressModeU
-                                        : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                                              ? sampler_state->createInfo.addressModeV
-                                              : sampler_state->createInfo.addressModeW;
-                                auto set = descriptor_set->GetSet();
-                                LogObjectList objlist(set);
-                                objlist.add(sampler);
-                                objlist.add(image_state->image);
-                                objlist.add(image_view_state->image_view);
-                                return LogError(
-                                    objlist, vuids.corner_sampled_address_mode,
-                                    "image (%s) in image view (%s) in descriptor set (%s) is created with flag "
-                                    "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
-                                    "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has createInfo.addressMode%s set to %s.",
-                                    report_data->FormatHandle(image_state->image).c_str(),
-                                    report_data->FormatHandle(image_view_state->image_view).c_str(),
-                                    report_data->FormatHandle(set).c_str(), report_data->FormatHandle(sampler).c_str(),
-                                    address_mode_letter.c_str(), string_VkSamplerAddressMode(address_mode));
-                            }
                         }
                     }
                 }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -669,7 +669,7 @@ class DescriptorSet : public BASE_NODE {
     const Descriptor *GetDescriptorFromGlobalIndex(const uint32_t index) const { return descriptors_[index].get(); }
     const Descriptor *GetDescriptorFromBinding(const uint32_t binding, const uint32_t index = 0) const {
         const auto range = GetGlobalIndexRangeFromBinding(binding);
-        if ((range.start + index) > range.end) {
+        if ((range.start + index) >= range.end) {
             return nullptr;
         }
         return descriptors_[range.start + index].get();

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -73,6 +73,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDraw-None-02704",
         "VUID-vkCmdDraw-None-02721",
         "VUID-vkCmdDraw-None-02859",
+        "VUID-vkCmdDraw-commandBuffer-02707",
+        "VUID-vkCmdDraw-commandBuffer-02712",
+        "VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDraw-filterCubic-02694",
+        "VUID-vkCmdDraw-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDEXED, {
         "VUID-vkCmdDrawIndexed-commandBuffer-cmdpool",
@@ -105,6 +110,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexed-None-02704",
         "VUID-vkCmdDrawIndexed-None-02721",
         "VUID-vkCmdDrawIndexed-None-02859",
+        "VUID-vkCmdDrawIndexed-commandBuffer-02707",
+        "VUID-vkCmdDrawIndexed-commandBuffer-02712",
+        "VUID-vkCmdDrawIndexed-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndexed-filterCubic-02694",
+        "VUID-vkCmdDrawIndexed-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDIRECT, {
         "VUID-vkCmdDrawIndirect-commandBuffer-cmdpool",
@@ -137,6 +147,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirect-None-02704",
         "VUID-vkCmdDrawIndirect-None-02721",
         "VUID-vkCmdDrawIndirect-None-02859",
+        "VUID-vkCmdDrawIndirect-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawIndirect-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndirect-filterCubic-02694",
+        "VUID-vkCmdDrawIndirect-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDEXEDINDIRECT, {
         "VUID-vkCmdDrawIndexedIndirect-commandBuffer-cmdpool",
@@ -169,6 +184,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirect-None-02704",
         "VUID-vkCmdDrawIndexedIndirect-None-02721",
         "VUID-vkCmdDrawIndexedIndirect-None-02859",
+        "VUID-vkCmdDrawIndexedIndirect-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawIndexedIndirect-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndexedIndirect-filterCubic-02694",
+        "VUID-vkCmdDrawIndexedIndirect-filterCubicMinmax-02695",
     }},
     {CMD_DISPATCH, {
         "VUID-vkCmdDispatch-commandBuffer-cmdpool",
@@ -201,6 +221,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatch-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDispatch-None-02859",
+        "VUID-vkCmdDispatch-commandBuffer-02707",
+        "VUID-vkCmdDispatch-commandBuffer-02712",
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdDispatch-filterCubic-02694",
+        "VUID-vkCmdDispatch-filterCubicMinmax-02695",
     }},
     {CMD_DISPATCHINDIRECT, {
         "VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool",
@@ -233,6 +258,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchIndirect-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDispatchIndirect-None-02859",
+        "VUID-vkCmdDispatchIndirect-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdDispatchIndirect-filterCubic-02694",
+        "VUID-vkCmdDispatchIndirect-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDIRECTCOUNT, {
         "VUID-vkCmdDrawIndirectCount-commandBuffer-cmdpool",
@@ -265,6 +295,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectCount-None-02704",
         "VUID-vkCmdDrawIndirectCount-None-02721",
         "VUID-vkCmdDrawIndirectCount-None-02859",
+        "VUID-vkCmdDrawIndirectCount-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawIndirectCount-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndirectCount-filterCubic-02694",
+        "VUID-vkCmdDrawIndirectCount-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDEXEDINDIRECTCOUNT,{
         "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-cmdpool",
@@ -297,6 +332,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndexedIndirectCount-None-02704",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02721",
         "VUID-vkCmdDrawIndexedIndirectCount-None-02859",
+        "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawIndexedIndirectCount-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndexedIndirectCount-filterCubic-02694",
+        "VUID-vkCmdDrawIndexedIndirectCount-filterCubicMinmax-02695",
     }},
     {CMD_TRACERAYSNV, {
         "VUID-vkCmdTraceRaysNV-commandBuffer-cmdpool",
@@ -322,13 +362,18 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysNV-None-02691",
         "VUID-vkCmdTraceRaysNV-None-02698",
-         kVUIDUndefined, // image_subresources
+        kVUIDUndefined, // image_subresources
         "VUID-vkCmdTraceRaysNV-None-02699",
         "VUID-vkCmdTraceRaysNV-None-02702",
         "VUID-vkCmdTraceRaysNV-None-02703",
         "VUID-vkCmdTraceRaysNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdTraceRaysNV-None-02859",
+        "VUID-vkCmdTraceRaysNV-commandBuffer-02707",
+        "VUID-vkCmdTraceRaysNV-commandBuffer-02712",
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdTraceRaysNV-filterCubic-02694",
+        "VUID-vkCmdTraceRaysNV-filterCubicMinmax-02695",
     }},
     {CMD_TRACERAYSKHR, {
         "VUID-vkCmdTraceRaysKHR-commandBuffer-cmdpool",
@@ -353,7 +398,7 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-flags-02696",
         kVUIDUndefined, // subpass_input
         "VUID-vkCmdTraceRaysKHR-None-02691",
-		"VUID-vkCmdTraceRaysKHR-None-02698",
+        "VUID-vkCmdTraceRaysKHR-None-02698",
         kVUIDUndefined, // image_subresources
         "VUID-vkCmdTraceRaysKHR-None-02699",
         "VUID-vkCmdTraceRaysKHR-None-02702",
@@ -361,6 +406,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysKHR-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdTraceRaysKHR-None-02859",
+        "VUID-vkCmdTraceRaysKHR-commandBuffer-02707",
+        "VUID-vkCmdTraceRaysKHR-commandBuffer-02712",
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdTraceRaysKHR-filterCubic-02694",
+        "VUID-vkCmdTraceRaysKHR-filterCubicMinmax-02695",
     }},
     {CMD_TRACERAYSINDIRECTKHR, {
         "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool",
@@ -393,6 +443,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdTraceRaysIndirectKHR-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdTraceRaysIndirectKHR-None-02859",
+        "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdTraceRaysIndirectKHR-filterCubic-02694",
+        "VUID-vkCmdTraceRaysIndirectKHR-filterCubicMinmax-02695",
     }},
     {CMD_DRAWMESHTASKSNV, {
         "VUID-vkCmdDrawMeshTasksNV-commandBuffer-cmdpool",
@@ -425,6 +480,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDrawMeshTasksNV-None-02859",
+        "VUID-vkCmdDrawMeshTasksNV-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawMeshTasksNV-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawMeshTasksNV-filterCubic-02694",
+        "VUID-vkCmdDrawMeshTasksNV-filterCubicMinmax-02695",
     }},
     {CMD_DRAWMESHTASKSINDIRECTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-cmdpool",
@@ -457,6 +517,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDrawMeshTasksIndirectNV-None-02859",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawMeshTasksIndirectNV-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubic-02694",
+        "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubicMinmax-02695",
     }},
     {CMD_DRAWMESHTASKSINDIRECTCOUNTNV, {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-cmdpool",
@@ -489,6 +554,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02859",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubic-02694",
+        "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubicMinmax-02695",
     }},
     {CMD_DRAWINDIRECTBYTECOUNTEXT, {
         "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-cmdpool",
@@ -521,6 +591,11 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02704",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02721",
         "VUID-vkCmdDrawIndirectByteCountEXT-None-02859",
+        "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        "VUID-vkCmdDrawIndirectByteCountEXT-maxMultiviewInstanceIndex-02688",
+        "VUID-vkCmdDrawIndirectByteCountEXT-filterCubic-02694",
+        "VUID-vkCmdDrawIndirectByteCountEXT-filterCubicMinmax-02695",
     }},
     {CMD_DISPATCHBASE, {
         "VUID-vkCmdDispatchBase-commandBuffer-cmdpool",
@@ -553,9 +628,19 @@ static const std::map<CMD_TYPE, DrawDispatchVuid> drawdispatch_vuid = {
         "VUID-vkCmdDispatchBase-None-02704",
         kVUIDUndefined, // vertex_binding_attribute
         "VUID-vkCmdDispatchBase-None-02859",
+        "VUID-vkCmdDispatchBase-commandBuffer-02707",
+        kVUIDUndefined, // protected_command_buffer
+        kVUIDUndefined, // maxMultiviewInstanceIndex
+        "VUID-vkCmdDispatchBase-filterCubic-02694",
+        "VUID-vkCmdDispatchBase-filterCubicMinmax-02695",
     }},
     // Used if invalid cmd_type is used
     {CMD_NONE, {
+        kVUIDUndefined,
+        kVUIDUndefined,
+        kVUIDUndefined,
+        kVUIDUndefined,
+        kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,
         kVUIDUndefined,

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -723,7 +723,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
         VkDeviceSize end_offset = (index_size * ((VkDeviceSize)firstIndex + indexCount)) + index_buffer_binding.offset;
         if (end_offset > index_buffer_binding.size) {
             skip |=
-                LogError(index_buffer_binding.buffer, "VUID-vkCmdDrawIndexed-indexSize-00463",
+                LogError(index_buffer_binding.buffer_state->buffer, "VUID-vkCmdDrawIndexed-indexSize-00463",
                          "vkCmdDrawIndexed() index size (%d) * (firstIndex (%d) + indexCount (%d)) "
                          "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
                          " bytes, which is greater than the index buffer size (%" PRIuLEAST64 ").",

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -640,6 +640,22 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
                                                                                      : format_properties.optimalTilingFeatures;
     }
 
+    // filter_cubic_props is used in CmdDraw validation. But it takes a lot of performance if it does in CmdDraw.
+    image_view_state->filter_cubic_props = lvl_init_struct<VkFilterCubicImageViewImageFormatPropertiesEXT>();
+    if (IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
+        auto imageview_format_info = lvl_init_struct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+        imageview_format_info.imageViewType = pCreateInfo->viewType;
+        auto image_format_info = lvl_init_struct<VkPhysicalDeviceImageFormatInfo2>(&imageview_format_info);
+        image_format_info.type = image_state->createInfo.imageType;
+        image_format_info.format = image_state->createInfo.format;
+        image_format_info.tiling = image_state->createInfo.tiling;
+        image_format_info.usage = image_state->createInfo.usage;
+        image_format_info.flags = image_state->createInfo.flags;
+
+        auto image_format_properties = lvl_init_struct<VkImageFormatProperties2>(&image_view_state->filter_cubic_props);
+
+        DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
+    }
     imageViewMap.insert(std::make_pair(*pView, std::move(image_view_state)));
 }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3554,6 +3554,26 @@ void SetPipelineState(PIPELINE_STATE *pPipe) {
     }
 }
 
+void UpdateSamplerDescriptorsUsedByImage(LAST_BOUND_STATE &last_bound_state) {
+    if (!last_bound_state.pipeline_state) return;
+    if (last_bound_state.per_set.empty()) return;
+
+    for (auto &slot : last_bound_state.pipeline_state->active_slots) {
+        for (auto &req : slot.second) {
+            for (auto &samplers : req.second.samplers_used_by_image) {
+                for (auto &sampler : samplers) {
+                    if (sampler.first.sampler_slot.first < last_bound_state.per_set.size() &&
+                        last_bound_state.per_set[sampler.first.sampler_slot.first].bound_descriptor_set) {
+                        sampler.second = last_bound_state.per_set[sampler.first.sampler_slot.first]
+                                                     .bound_descriptor_set->GetDescriptorFromBinding(
+                                                         sampler.first.sampler_slot.second, sampler.first.sampler_index);
+                    }
+                }
+            }
+        }
+    }
+}
+
 void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                           VkPipeline pipeline) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
@@ -3570,6 +3590,17 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
     cb_state->lastBound[pipelineBindPoint].pipeline_state = pipe_state;
     SetPipelineState(pipe_state);
     AddCommandBufferBinding(pipe_state->cb_bindings, VulkanTypedHandle(pipeline, kVulkanObjectTypePipeline), cb_state);
+
+    for (auto &slot : pipe_state->active_slots) {
+        for (auto &req : slot.second) {
+            for (auto &sampler : req.second.samplers_used_by_image) {
+                for (auto &des : sampler) {
+                    des.second = nullptr;
+                }
+            }
+        }
+    }
+    UpdateSamplerDescriptorsUsedByImage(cb_state->lastBound[pipelineBindPoint]);
 }
 
 void ValidationStateTracker::PreCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport,
@@ -3975,6 +4006,7 @@ void ValidationStateTracker::PreCallRecordCmdBindDescriptorSets(VkCommandBuffer 
                                   dynamicOffsetCount, pDynamicOffsets);
     cb_state->lastBound[pipelineBindPoint].pipeline_layout = layout;
     ResetCommandBufferPushConstantDataIfIncompatible(cb_state, layout);
+    UpdateSamplerDescriptorsUsedByImage(cb_state->lastBound[pipelineBindPoint]);
 }
 
 void ValidationStateTracker::RecordCmdPushDescriptorSetState(CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint pipelineBindPoint,
@@ -5853,11 +5885,10 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
             if (use.second.samplers_used_by_image.size() > samplers_used_by_image.size()) {
                 samplers_used_by_image.resize(use.second.samplers_used_by_image.size());
             }
-            std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *> sampler_descriptors;
             uint32_t image_index = 0;
             for (const auto &samplers : use.second.samplers_used_by_image) {
                 for (const auto &sampler : samplers) {
-                    samplers_used_by_image[image_index].emplace(sampler, sampler_descriptors);
+                    samplers_used_by_image[image_index].emplace(sampler, nullptr);
                 }
                 ++image_index;
             }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4066,7 +4066,7 @@ void ValidationStateTracker::PostCallRecordCmdPushConstants(VkCommandBuffer comm
                 const auto it = cb_state->push_constant_data_update.find(flag);
 
                 if (it != cb_state->push_constant_data_update.end()) {
-                    std::memset(it->second.data() + offset, 1, static_cast<std::size_t>(size));
+                    std::memset(it->second.data() + offset, PC_Byte_Updated, static_cast<std::size_t>(size));
                 }
             }
             flags = flags >> 1;
@@ -5931,15 +5931,15 @@ void ValidationStateTracker::ResetCommandBufferPushConstantDataIfIncompatible(CM
 
                     if (it != cb_state->push_constant_data_update.end()) {
                         if (it->second.size() < push_constant_range.offset) {
-                            it->second.resize(push_constant_range.offset, -1);
+                            it->second.resize(push_constant_range.offset, PC_Byte_Not_Set);
                         }
                         if (it->second.size() < size) {
-                            it->second.resize(size, 0);
+                            it->second.resize(size, PC_Byte_Not_Updated);
                         }
                     } else {
-                        std::vector<int8_t> bytes;
-                        bytes.resize(push_constant_range.offset, -1);
-                        bytes.resize(size, 0);
+                        std::vector<uint8_t> bytes;
+                        bytes.resize(push_constant_range.offset, PC_Byte_Not_Set);
+                        bytes.resize(size, PC_Byte_Not_Updated);
                         cb_state->push_constant_data_update[flag] = bytes;
                     }
                 }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5837,6 +5837,7 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
     for (const auto &use : stage_state->descriptor_uses) {
         // While validating shaders capture which slots are used by the pipeline
         const uint32_t slot = use.first.first;
+        pipeline->active_slots[slot][use.first.second].is_writable |= use.second.is_writable;
         auto &reqs = pipeline->active_slots[slot][use.first.second].reqs;
         reqs = descriptor_req(reqs | DescriptorTypeToReqs(module, use.second.type_id));
         if (use.second.is_atomic_operation) reqs = descriptor_req(reqs | DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION);

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1832,6 +1832,11 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         state_tracker->enabled_features.extended_dynamic_state_features = *extended_dynamic_state_features;
     }
 
+    const auto *multiview_features = lvl_find_in_chain<VkPhysicalDeviceMultiviewFeatures>(pCreateInfo->pNext);
+    if (multiview_features) {
+        state_tracker->enabled_features.multiview_features = *multiview_features;
+    }
+
     // Store physical device properties and physical device mem limits into CoreChecks structs
     DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
     DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);
@@ -1924,6 +1929,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_performance_query, &phys_dev_props->performance_query_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_sample_locations, &phys_dev_props->sample_locations_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_custom_border_color, &phys_dev_props->custom_border_color_props);
+    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_multiview, &phys_dev_props->multiview_props);
 
     if (!state_tracker->device_extensions.vk_feature_version_1_2 && dev_ext.vk_khr_timeline_semaphore) {
         VkPhysicalDeviceTimelineSemaphorePropertiesKHR timeline_semaphore_props;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1350,6 +1350,7 @@ class ValidationStateTracker : public ValidationObject {
         VkPhysicalDevicePerformanceQueryPropertiesKHR performance_query_props;
         VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props;
         VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_border_color_props;
+        VkPhysicalDeviceMultiviewProperties multiview_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -340,6 +340,12 @@ static inline VkDeviceSize GetBufferSizeFromCopyImage(const BufferImageCopyRegio
     return buffer_size;
 }
 
+enum PushConstantByteState {
+    PC_Byte_Updated = 0,
+    PC_Byte_Not_Set = 1,
+    PC_Byte_Not_Updated = 2,
+};
+
 struct SHADER_MODULE_STATE;
 
 class ValidationStateTracker : public ValidationObject {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -596,9 +596,10 @@ class ValidationStateTracker : public ValidationObject {
     SURFACE_STATE* GetSurfaceState(VkSurfaceKHR surface) { return Get<SURFACE_STATE>(surface); }
 
     // Class Declarations for helper functions
-    IMAGE_VIEW_STATE* GetAttachmentImageViewState(CMD_BUFFER_STATE* cb, FRAMEBUFFER_STATE* framebuffer, uint32_t index);
-    const IMAGE_VIEW_STATE* GetAttachmentImageViewState(const CMD_BUFFER_STATE* cb, const FRAMEBUFFER_STATE* framebuffer,
-                                                        uint32_t index) const;
+    IMAGE_VIEW_STATE* GetActiveAttachmentImageViewState(const CMD_BUFFER_STATE* cb, uint32_t index,
+                                                        const CMD_BUFFER_STATE* primary_cb = nullptr);
+    const IMAGE_VIEW_STATE* GetActiveAttachmentImageViewState(const CMD_BUFFER_STATE* cb, uint32_t index,
+                                                              const CMD_BUFFER_STATE* primary_cb = nullptr) const;
     const EVENT_STATE* GetEventState(VkEvent event) const;
     EVENT_STATE* GetEventState(VkEvent event);
     const QUEUE_STATE* GetQueueState(VkQueue queue) const;

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1751,9 +1751,9 @@ bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32
         const auto &binding_description = pPipe->vertex_binding_descriptions_[i];
         if (binding_description.binding < binding_buffers_size) {
             const auto &binding_buffer = binding_buffers[binding_description.binding];
-            if (binding_buffer.buffer == VK_NULL_HANDLE) continue;
+            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->destroyed) continue;
 
-            auto *buf_state = sync_state_->Get<BUFFER_STATE>(binding_buffer.buffer);
+            auto *buf_state = binding_buffer.buffer_state.get();
             const ResourceAccessRange range = GetBufferRange(binding_buffer.offset, buf_state->createInfo.size, firstVertex,
                                                              vertexCount, binding_description.stride);
             auto hazard = current_context_->DetectHazard(*buf_state, SYNC_VERTEX_INPUT_VERTEX_ATTRIBUTE_READ, range);
@@ -1781,9 +1781,9 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
         const auto &binding_description = pPipe->vertex_binding_descriptions_[i];
         if (binding_description.binding < binding_buffers_size) {
             const auto &binding_buffer = binding_buffers[binding_description.binding];
-            if (binding_buffer.buffer == VK_NULL_HANDLE) continue;
+            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->destroyed) continue;
 
-            auto *buf_state = sync_state_->Get<BUFFER_STATE>(binding_buffer.buffer);
+            auto *buf_state = binding_buffer.buffer_state.get();
             const ResourceAccessRange range = GetBufferRange(binding_buffer.offset, buf_state->createInfo.size, firstVertex,
                                                              vertexCount, binding_description.stride);
             current_context_->UpdateAccessState(*buf_state, SYNC_VERTEX_INPUT_VERTEX_ATTRIBUTE_READ, range, tag);
@@ -1793,9 +1793,10 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
 
 bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const char *func_name) const {
     bool skip = false;
-    if (cb_state_->index_buffer_binding.buffer == VK_NULL_HANDLE) return skip;
+    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->destroyed)
+        return skip;
 
-    auto *index_buf_state = sync_state_->Get<BUFFER_STATE>(cb_state_->index_buffer_binding.buffer);
+    auto *index_buf_state = cb_state_->index_buffer_binding.buffer_state.get();
     const auto index_size = GetIndexAlignment(cb_state_->index_buffer_binding.index_type);
     const ResourceAccessRange range = GetBufferRange(cb_state_->index_buffer_binding.offset, index_buf_state->createInfo.size,
                                                      firstIndex, indexCount, index_size);
@@ -1814,9 +1815,9 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t indexCount, ui
 }
 
 void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const ResourceUsageTag &tag) {
-    if (cb_state_->index_buffer_binding.buffer == VK_NULL_HANDLE) return;
+    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->destroyed) return;
 
-    auto *index_buf_state = sync_state_->Get<BUFFER_STATE>(cb_state_->index_buffer_binding.buffer);
+    auto *index_buf_state = cb_state_->index_buffer_binding.buffer_state.get();
     const auto index_size = GetIndexAlignment(cb_state_->index_buffer_binding.index_type);
     const ResourceAccessRange range = GetBufferRange(cb_state_->index_buffer_binding.offset, index_buf_state->createInfo.size,
                                                      firstIndex, indexCount, index_size);

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7247,7 +7247,9 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     buffer_create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     buffer_create_info.pNext = nullptr;
     buffer_create_info.size = 1 << 20;  // 1 MB
-    buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                               VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
+                               VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
@@ -7258,7 +7260,10 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     // Create actual protected and unprotected images
     VkImageObj image_protected(m_device);
     VkImageObj image_unprotected(m_device);
+    VkImageObj image_protected_descriptor(m_device);
+    VkImageObj image_unprotected_descriptor(m_device);
     VkImageView image_views[2];
+    VkImageView image_views_descriptor[2];
     VkImageCreateInfo image_create_info = {};
     image_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     image_create_info.pNext = nullptr;
@@ -7266,8 +7271,8 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_create_info.usage =
-        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.arrayLayers = 1;
     image_create_info.mipLevels = 1;
@@ -7277,10 +7282,18 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     image_protected.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     image_views[0] = image_protected.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
+    image_protected_descriptor.init_no_mem(*m_device, image_create_info);
+    image_protected_descriptor.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
+    image_views_descriptor[0] = image_protected_descriptor.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
     image_create_info.flags = 0;
     image_unprotected.init_no_mem(*m_device, image_create_info);
     image_unprotected.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     image_views[1] = image_unprotected.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
+    image_unprotected_descriptor.init_no_mem(*m_device, image_create_info);
+    image_unprotected_descriptor.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
+    image_views_descriptor[1] = image_unprotected_descriptor.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
     // Create protected and unproteced memory
     VkDeviceMemory memory_protected = VK_NULL_HANDLE;
@@ -7397,7 +7410,42 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
                                               {VK_IMAGE_ASPECT_COLOR_BIT, 1, {m_clear_color}}};
     VkClearRect clear_rect[2] = {{render_area, 0, 1}, {render_area, 0, 1}};
 
+    const char fsSource[] =
+        "#version 450\n"
+        "layout(set=0, binding=0) uniform foo { int x; int y; } bar;\n"
+        "layout(set=0, binding=1, rgba8) uniform image2D si1;\n"
+        "layout(location=0) out vec4 x;\n"
+        "void main(){\n"
+        "   x = vec4(bar.y);\n"
+        "   imageStore(si1, ivec2(0), vec4(0));\n"
+        "}\n";
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    CreatePipelineHelper g_pipe(*this);
+    g_pipe.InitInfo();
+    g_pipe.gp_ci_.renderPass = render_pass;
+    g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                            {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+    std::array<VkPipelineColorBlendAttachmentState, 2> color_blend_attachments;
+    color_blend_attachments[0] = g_pipe.cb_attachments_;
+    color_blend_attachments[1] = g_pipe.cb_attachments_;
+    g_pipe.cb_ci_.attachmentCount = color_blend_attachments.size();
+    g_pipe.cb_ci_.pAttachments = color_blend_attachments.data();
+    g_pipe.InitState();
+    ASSERT_VK_SUCCESS(g_pipe.CreateGraphicsPipeline());
+
+    VkSampler sampler;
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
+    ASSERT_VK_SUCCESS(err);
+
     // Use protected resources in unprotected command buffer
+    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_protected, 1024);
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[0], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    g_pipe.descriptor_set_->UpdateDescriptorSets();
+
     m_commandBuffer->begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBlitImage-commandBuffer-01834");
@@ -7467,10 +7515,30 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     vk::CmdClearAttachments(m_commandBuffer->handle(), 2, clear_attachments, 2, clear_rect);
     m_errorMonitor->VerifyFound();
 
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
+                              &g_pipe.descriptor_set_->set_, 0, nullptr);
+    VkDeviceSize offset = 0;
+    vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0, 1, &buffer_protected, &offset);
+    vk::CmdBindIndexBuffer(m_commandBuffer->handle(), buffer_protected, 0, VK_INDEX_TYPE_UINT16);
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02707");  // color attachment
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02707");  // buffer descriptorSet
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02707");  // image descriptorSet
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02707");  // vertex
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02707");  // index
+
+    vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 0, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
     vk::CmdEndRenderPass(m_commandBuffer->handle());
     m_commandBuffer->end();
 
     // Use unprotected resources in protected command buffer
+    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 1024);
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[1], sampler);
+    g_pipe.descriptor_set_->UpdateDescriptorSets();
+
     protectedCommandBuffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBlitImage-commandBuffer-01836");
@@ -7514,6 +7582,17 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-commandBuffer-02505");
     vk::CmdClearAttachments(protectedCommandBuffer.handle(), 2, clear_attachments, 2, clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    vk::CmdBindPipeline(protectedCommandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
+    vk::CmdBindDescriptorSets(protectedCommandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0,
+                              1, &g_pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdBindVertexBuffers(protectedCommandBuffer.handle(), 0, 1, &buffer_unprotected, &offset);
+    vk::CmdBindIndexBuffer(protectedCommandBuffer.handle(), buffer_unprotected, 0, VK_INDEX_TYPE_UINT16);
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02712");  // color attachment
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexed-commandBuffer-02712");  // descriptorSet
+    vk::CmdDrawIndexed(protectedCommandBuffer.handle(), 1, 0, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
     vk::CmdEndRenderPass(protectedCommandBuffer.handle());
@@ -7844,6 +7923,167 @@ TEST_F(VkLayerTest, VerifyDynamicStateSettingCommands) {
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-None-02859");
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}
+
+TEST_F(VkLayerTest, VerifyFilterCubicSamplerInCmdDraw) {
+    TEST_DESCRIPTION("Verify if sampler is filter cubic, image view needs to support it.");
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_1);
+    if (version < VK_API_VERSION_1_1) {
+        printf("%s At least Vulkan version 1.1 is required, skipping test.\n", kSkipPrefix);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_FILTER_CUBIC_EXTENSION_NAME)) {
+        m_device_extension_names.push_back(VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
+    } else {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
+    VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_2D;
+
+    auto imageview_format_info = lvl_init_struct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+    imageview_format_info.imageViewType = imageViewType;
+    auto image_format_info = lvl_init_struct<VkPhysicalDeviceImageFormatInfo2>(&imageview_format_info);
+    image_format_info.type = image_ci.imageType;
+    image_format_info.format = image_ci.format;
+    image_format_info.tiling = image_ci.tiling;
+    image_format_info.usage = image_ci.usage;
+    image_format_info.flags = image_ci.flags;
+
+    auto filter_cubic_props = lvl_init_struct<VkFilterCubicImageViewImageFormatPropertiesEXT>();
+    auto image_format_properties = lvl_init_struct<VkImageFormatProperties2>(&filter_cubic_props);
+
+    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+
+    if (filter_cubic_props.filterCubic || filter_cubic_props.filterCubicMinmax) {
+        printf("%s Image and ImageView supports filter cubic ; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    VkImageObj image(m_device);
+    image.Init(image_ci);
+    VkImageView imageView = image.targetView(format, imageViewType);
+
+    auto sampler_ci = lvl_init_struct<VkSamplerCreateInfo>();
+    sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
+    sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
+    VkSampler sampler;
+    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+
+    auto reduction_mode_ci = lvl_init_struct<VkSamplerReductionModeCreateInfo>();
+    reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
+    sampler_ci.pNext = &reduction_mode_ci;
+    VkSampler sampler_rediction;
+    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler_rediction);
+
+    VkShaderObj fs(m_device, bindStateFragSamplerShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    CreatePipelineHelper g_pipe(*this);
+    g_pipe.InitInfo();
+    g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+    g_pipe.InitState();
+    ASSERT_VK_SUCCESS(g_pipe.CreateGraphicsPipeline());
+
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler_rediction);
+    g_pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
+                              &g_pipe.descriptor_set_->set_, 0, nullptr);
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-filterCubicMinmax-02695");
+    m_commandBuffer->Draw(1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+    m_commandBuffer->reset();
+
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler);
+    g_pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
+                              &g_pipe.descriptor_set_->set_, 0, nullptr);
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-filterCubic-02694");
+    m_commandBuffer->Draw(1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}
+
+TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
+    TEST_DESCRIPTION("Verify if instance index in CmdDraw is greater than maxMultiviewInstanceIndex.");
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_1);
+    if (version < VK_API_VERSION_1_1) {
+        printf("%s At least Vulkan version 1.1 is required, skipping test.\n", kSkipPrefix);
+        return;
+    }
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix,
+               VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
+        m_device_extension_names.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    } else {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_MULTIVIEW_EXTENSION_NAME);
+        return;
+    }
+
+    auto multiview_features = lvl_init_struct<VkPhysicalDeviceMultiviewFeatures>();
+    multiview_features.multiview = VK_TRUE;
+    VkPhysicalDeviceFeatures2 pd_features2 = {};
+    pd_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    pd_features2.pNext = &multiview_features;
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
+        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto multiview_props = lvl_init_struct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceProperties2KHR properties2 = lvl_init_struct<VkPhysicalDeviceProperties2KHR>(&multiview_props);
+    vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    if (multiview_props.maxMultiviewInstanceIndex == std::numeric_limits<uint32_t>::max()) {
+        printf("%s maxMultiviewInstanceIndex is uint32_t max, skipping tests\n", kSkipPrefix);
+        return;
+    }
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.InitState();
+    pipe.CreateGraphicsPipeline();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688");
+    m_commandBuffer->Draw(1, multiview_props.maxMultiviewInstanceIndex + 1, 0, 0);
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->EndRenderPass();


### PR DESCRIPTION
> VUID-vkCmdDraw-commandBuffer-02707
> If commandBuffer is an unprotected command buffer, any resource accessed by the VkPipeline object bound to the pipeline bind point used by this command must not be a protected resource

Validate the image and buffer in DescriptorSet. If the commandbuffer is unprotected, they MUST be unprotected.

> VUID-vkCmdTraceRaysNV-commandBuffer-02712
> If commandBuffer is a protected command buffer, any resource written to by the VkPipeline object bound to the pipeline bind point used by this command must not be an unprotected resource

Validate the image and buffer in DescriptorSet. If the commandbuffer is protected, they MUST be protected or only-read unprotected.

> VUID-vkCmdDraw-filterCubic-02694
> Any VkImageView being sampled with VK_FILTER_CUBIC_EXT as a result of this command must have a VkImageViewType and format that supports cubic filtering, as specified by VkFilterCubicImageViewImageFormatPropertiesEXT::filterCubic returned by vkGetPhysicalDeviceImageFormatProperties2

In PostCallRecordCreateImageView, it saves the result of VkFilterCubicImageViewImageFormatPropertiesEXT in IMAGE_VIEW_STATE, and then validate both sampler and image descriptors. If sampler is VK_FILTER_CUBIC_EXT, the image view needs to support filterCubic.

> VUID-vkCmdDraw-filterCubicMinmax-02695
> Any VkImageView being sampled with VK_FILTER_CUBIC_EXT with a reduction mode of either VK_SAMPLER_REDUCTION_MODE_MIN or VK_SAMPLER_REDUCTION_MODE_MAX as a result of this command must have a VkImageViewType and format that supports cubic filtering together with minmax filtering, as specified by VkFilterCubicImageViewImageFormatPropertiesEXT::filterCubicMinmax returned by vkGetPhysicalDeviceImageFormatProperties2

Validate both sampler and image descriptors. If sampler is VK_FILTER_CUBIC_EXT and either VK_SAMPLER_REDUCTION_MODE_MIN or VK_SAMPLER_REDUCTION_MODE_MAX , the image view needs to support filterCubicMinmax.

> VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688
> If the draw is recorded in a render pass instance with multiview enabled, the maximum instance index must be less than or equal to VkPhysicalDeviceMultiviewProperties::maxMultiviewInstanceIndex

Save VkPhysicalDeviceMultiviewFeatures in PostCallRecordCreateDevice. Validate if commandbuffer is bind with a renderpass, and then if multiview feature is true, and then (instanceCount + firstInstance) MUST be eqaul or less than maxMultiviewInstanceIndex. Some Cmd's instance value is in VkBuffer. Skip those Cmd.