### PR TITLE
layers: Remove unnecessary FDM tiling check

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -981,11 +981,6 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                  "vkCreateImage: if usage includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, "
                                  "samples must be VK_SAMPLE_COUNT_1_BIT.");
             }
-            if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                skip |= LogError(device, "VUID-VkImageCreateInfo-tiling-02084",
-                                 "vkCreateImage: if usage includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, "
-                                 "tiling must be VK_IMAGE_TILING_OPTIMAL.");
-            }
         }
         if (pCreateInfo->flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {


### PR DESCRIPTION
Currently, the validation layers check for VUID 02084 in 2 spots, one
for images with usage VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV and one
for VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT. However, VUID 02084
only applies to VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, not FDM,
so this check can be removed for the FDM path.