### PR TITLE
layers: Add Android 24 and 25 support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -655,6 +655,15 @@ level 3.
   - SDK Tools > Android SDK Tools
   - SDK Tools > NDK
 
+#### Android Hardware Buffer support
+
+The Validation Layers by default build and release for Android 26 (Android Oreo). While Vulkan is supported in Android 24 and 25, there is no AHardwareBuffer support. To build a version of the Validation Layers for use with Android that will not require AHB support, simply addjust the `APP_PLATFORM` in [build-android/jni/Application.mk](build-android/jni/Application.mk)
+
+```patch
+-APP_PLATFORM := android-26
++APP_PLATFORM := android-24
+```
+
 #### Add Android specifics to environment
 
 For each of the below, you may need to specify a different build-tools

--- a/layers/android_ndk_types.h
+++ b/layers/android_ndk_types.h
@@ -21,20 +21,33 @@
 #ifndef ANDROID_NDK_TYPES_H_
 #define ANDROID_NDK_TYPES_H_
 
+// Everyone should be able to include this file and ignore it if not building for Android
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 
 // All eums referenced by VK_ANDROID_external_memory_android_hardware_buffer are present in
 // the platform-29 (Android Q) versions of the header files.  A partial set exists in the
 // platform-26 (O) headers, where hardware_buffer.h first appears in the NDK.
 //
-// Building Vulkan validation with NDK header files prior to platform-26 is not supported due to
-// Android 24 and 25 devices do not support Android Hardware Buffers.
-//
 // Decoder ring for Android compile symbols found here: https://github.com/android-ndk/ndk/issues/407
 
 #ifdef __ANDROID__  // Compiling for Android
 #include <android/api-level.h>
 #include <android/hardware_buffer.h>  // First appearance in Android O (platform-26)
+
+// Building Vulkan validation with NDK header files prior to platform-26 is supported, but will remove
+// all validation checks for Android Hardware Buffers.
+// This is due to AHB not being introduced until Android 26 (Android Oreo)
+//
+// NOTE: VK_USE_PLATFORM_ANDROID_KHR != Android Hardware Buffer
+//       AHB is all things not found in the Vulkan Spec
+#if __ANDROID_API__ < 24
+#error "Vulkan not supported on Android 23 and below"
+#elif __ANDROID_API__ < 26
+#pragma message("Building for Android without Android Hardward Buffer support")
+#else
+// This is used to allow building for Android without AHB support
+#define AHB_VALIDATION_SUPPORT
+#endif  // __ANDROID_API__
 
 // If NDK is O (platform-26 or -27), supplement the missing enums with pre-processor defined literals
 // If Android P or later, then all required enums are already defined
@@ -56,7 +69,7 @@
 // should use GPU_FRAMEBUFFER, but need to define here for older NDK versions
 #ifndef AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER
 #define AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT
-#endif
+#endif  // AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER
 
 #else  // Not __ANDROID__, but VK_USE_PLATFORM_ANDROID_KHR
 // This combination should not be seen in the wild, but can be used to allow testing

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -52,9 +52,7 @@
 #include <memory>
 #include <list>
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include "android_ndk_types.h"
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 // Fwd declarations -- including descriptor_set.h creates an ugly include loop
 namespace cvdescriptorset {

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -538,7 +538,7 @@ WRAPPER_PARENT_INSTANCE(uint64_t)
         if (iter != command_pool_map.end()) {
             VkCommandPool pool = iter->second;
             // We set up a read guard against the "Contents" counter to catch conflict vs. vkResetCommandPool and vkDestroyCommandPool
-            // while *not* establishing a read guard against the command pool counter itself to avoid false postives for
+            // while *not* establishing a read guard against the command pool counter itself to avoid false positive for
             // non-externally sync'd command buffers
             c_VkCommandPoolContents.StartRead(pool, api_name);
         }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -966,7 +966,7 @@ void ValidationStateTracker::AddMemObjInfo(void *object, const VkDeviceMemory me
         mem_info->is_import = true;
         mem_info->import_handle_type_flags = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
     }
-#endif
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
     const VkMemoryType memory_type = phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex];
     mem_info->unprotected = ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) == 0);

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -576,7 +576,7 @@ WRAPPER_PARENT_INSTANCE(uint64_t)
         if (iter != command_pool_map.end()) {
             VkCommandPool pool = iter->second;
             // We set up a read guard against the "Contents" counter to catch conflict vs. vkResetCommandPool and vkDestroyCommandPool
-            // while *not* establishing a read guard against the command pool counter itself to avoid false postives for
+            // while *not* establishing a read guard against the command pool counter itself to avoid false positive for
             // non-externally sync'd command buffers
             c_VkCommandPoolContents.StartRead(pool, api_name);
         }
@@ -1530,7 +1530,7 @@ void ThreadSafety::PostCallRecordGetRandROutputDisplayEXT(
             return paramdecl
     def beginFile(self, genOpts):
         OutputGenerator.beginFile(self, genOpts)
-        
+
         # Initialize members that require the tree
         self.handle_types = GetHandleTypes(self.registry.tree)
         self.is_aliased_type = GetHandleAliased(self.registry.tree)

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4876,8 +4876,8 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     vk::DestroyImageView(m_device->device(), view, NULL);
 }
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include "android_ndk_types.h"
+#ifdef AHB_VALIDATION_SUPPORT
 
 TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer image create info.");
@@ -6216,7 +6216,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     vk::FreeMemory(m_device->device(), memory, nullptr);
 }
 
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#endif  // AHB_VALIDATION_SUPPORT
 
 TEST_F(VkLayerTest, ValidateStride) {
     TEST_DESCRIPTION("Validate Stride.");

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -9783,8 +9783,8 @@ TEST_F(VkPositiveLayerTest, SwapchainExclusiveModeQueueFamilyPropertiesReference
 }
 
 // Android Hardware Buffer Positive Tests
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include "android_ndk_types.h"
+#ifdef AHB_VALIDATION_SUPPORT
 TEST_F(VkPositiveLayerTest, AndroidHardwareBufferMemoryRequirements) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer doesn't conflict with memory requirements.");
 
@@ -10299,4 +10299,4 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportImage) {
     vk::DestroyImage(device(), image, nullptr);
 }
 
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#endif  // AHB_VALIDATION_SUPPORT


### PR DESCRIPTION
closes #2287 

- This adds a `AHB_VALIDATION_SUPPORT` macro depending on building for Android and the version
  - replaced `VK_USE_PLATFORM_ANDROID_KHR` with new macro where needed
- BUILD.md update how to switch to `android-24` (which will work with `android-25`)
- added a `CheckAndroidVersion` call to run before `dlopen` so that if another developer runs into this same issue it will point them to what is wrong and hopefully save them time

----

@izhido I applied the following patch and built the layers, here are binary drops so they should work on your device

```patch
diff --git a/build-android/jni/Application.mk b/build-android/jni/Application.mk
index 243c28538..db1323a15 100644
--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a
 # APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
-APP_PLATFORM := android-26
+APP_PLATFORM := android-24
 APP_STL := c++_static
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .
diff --git a/build-android/jni/shaderc/Application.mk b/build-android/jni/shaderc/Application.mk
index 5447415eb..214d05a7e 100644
--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := all
+APP_ABI := armeabi-v7a arm64-v8a
 APP_BUILD_SCRIPT := Android.mk
 APP_STL := c++_static
 APP_PLATFORM := android-23
```

[PR_build.zip](https://github.com/KhronosGroup/Vulkan-ValidationLayers/files/5489680/PR_build.zip)
