### PR TITLE
layers: Generate SPIR-V Capability/Extension

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -101,6 +101,7 @@ core_validation_sources = [
   "layers/range_vector.h",
   "layers/shader_validation.cpp",
   "layers/shader_validation.h",
+  "layers/generated/spirv_validation_helper.cpp",
   "layers/state_tracker.cpp",
   "layers/state_tracker.h",
   "layers/subresource_adapter.cpp",

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(VkLayer_khronos_validation SHARED
         ${SRC_DIR}/layers/descriptor_sets.cpp
         ${SRC_DIR}/layers/buffer_validation.cpp
         ${SRC_DIR}/layers/shader_validation.cpp
+        ${SRC_DIR}/layers/generated/spirv_validation_helper.cpp
         ${SRC_DIR}/layers/gpu_validation.cpp
         ${SRC_DIR}/layers/gpu_utils.cpp
         ${SRC_DIR}/layers/debug_printf.cpp

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -41,6 +41,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/drawdispatch.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/descriptor_sets.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_validation.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/spirv_validation_helper.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/debug_printf.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -194,6 +194,7 @@ set(CORE_VALIDATION_LIBRARY_FILES
     buffer_validation.h
     shader_validation.cpp
     shader_validation.h
+    generated/spirv_validation_helper.cpp
     gpu_validation.cpp
     xxhash.c)
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -453,7 +453,7 @@ class CoreChecks : public ValidationStateTracker {
                                       VkShaderStageFlagBits stage) const;
     bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src,
                                           spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
-    bool ValidateShaderCapabilities(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage) const;
+    bool ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const* src) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
                                                        bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
@@ -476,9 +476,9 @@ class CoreChecks : public ValidationStateTracker {
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;
     bool ValidateSpecializationOffsets(VkPipelineShaderStageCreateInfo const* info) const;
-    bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure) const;
-    bool RequireFeature(VkBool32 feature, char const* feature_name) const;
-    bool RequireExtension(bool extension, char const* extension_name) const;
+    bool RequirePropertyFlag(VkBool32 check, char const* flag, char const* structure, const char* vuid) const;
+    bool RequireFeature(VkBool32 feature, char const* feature_name, const char* vuid) const;
+    bool RequireApiVersion(uint32_t version, const char* vuid) const;
     bool ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const* producer, spirv_inst_iter producer_entrypoint,
                                         shader_stage_attributes const* producer_stage, SHADER_MODULE_STATE const* consumer,
                                         spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1493,6 +1493,12 @@ struct DeviceFeatures {
     VkPhysicalDeviceMultiviewFeatures multiview_features;
     VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features;
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features;
+    VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL shader_integer_functions2_features;
+    VkPhysicalDeviceShaderSMBuiltinsFeaturesNV shader_sm_builtins_feature;
+    VkPhysicalDeviceShaderAtomicFloatFeaturesEXT shader_atomic_float_feature;
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT shader_image_atomic_int64_feature;
+    // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
+    // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -968,7 +968,7 @@ VkResult DispatchDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarker
             local_tag_info.object = it->second;
         }
     }
-    VkResult result = layer_data->device_dispatch_table.DebugMarkerSetObjectTagEXT(device, 
+    VkResult result = layer_data->device_dispatch_table.DebugMarkerSetObjectTagEXT(device,
                                                                                    reinterpret_cast<VkDebugMarkerObjectTagInfoEXT *>(&local_tag_info));
     return result;
 }

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -1,0 +1,679 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See spirv_validation_generator.py for modifications
+
+
+/***************************************************************************
+ *
+ * Copyright (c) 2020 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Spencer Fricke <s.fricke@samsung.com>
+ *
+ ****************************************************************************/
+
+#include <unordered_map>
+#include <string>
+#include <functional>
+#include <spirv/unified1/spirv.hpp>
+#include "vk_extension_helper.h"
+#include "core_validation_types.h"
+#include "core_validation.h"
+
+struct FeaturePointer {
+    // Callable object to test if this feature is enabled in the given aggregate feature struct
+    const std::function<VkBool32(const DeviceFeatures &)> IsEnabled;
+
+    // Test if feature pointer is populated
+    explicit operator bool() const { return static_cast<bool>(IsEnabled); }
+
+    // Default and nullptr constructor to create an empty FeaturePointer
+    FeaturePointer() : IsEnabled(nullptr) {}
+    FeaturePointer(std::nullptr_t ptr) : IsEnabled(nullptr) {}
+
+    // Constructors to populate FeaturePointer based on given pointer to member
+    FeaturePointer(VkBool32 VkPhysicalDeviceFeatures::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.core.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceVulkan11Features::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.core11.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceVulkan12Features::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.core12.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceTransformFeedbackFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.transform_feedback_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceCooperativeMatrixFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.cooperative_matrix_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.compute_shader_derivatives_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.fragment_shader_barycentric_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderImageFootprintFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shader_image_footprint_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.fragment_shader_interlock_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.demote_to_helper_invocation_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceRayQueryFeaturesKHR::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.ray_query_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceRayTracingPipelineFeaturesKHR::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.ray_tracing_pipeline_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceAccelerationStructureFeaturesKHR::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.ray_tracing_acceleration_structure_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceFragmentDensityMapFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.fragment_density_map_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.buffer_device_address_ext.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceFragmentShadingRateFeaturesKHR::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.fragment_shading_rate_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shader_integer_functions2_features.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shader_sm_builtins_feature.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShadingRateImageFeaturesNV::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shading_rate_image.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shader_atomic_float_feature.*ptr; }) {}
+    FeaturePointer(VkBool32 VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::*ptr)
+        : IsEnabled([=](const DeviceFeatures &features) { return features.shader_image_atomic_int64_feature.*ptr; }) {}
+};
+
+// Each instance of the struct will only have a singel field non-null
+struct RequiredSpirvInfo {
+    uint32_t version;
+    FeaturePointer feature;
+    ExtEnabled DeviceExtensions::*extension;
+    const char* property; // For human readability and make some capabilities unique
+};
+
+// clang-format off
+static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirvCapabilities = {
+    {spv::CapabilityAtomicFloat32AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32AtomicAdd, nullptr, ""}},
+    {spv::CapabilityAtomicFloat32AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat32AtomicAdd, nullptr, ""}},
+    {spv::CapabilityAtomicFloat32AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderImageFloat32AtomicAdd, nullptr, ""}},
+    {spv::CapabilityAtomicFloat32AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::sparseImageFloat32AtomicAdd, nullptr, ""}},
+    {spv::CapabilityAtomicFloat64AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat64AtomicAdd, nullptr, ""}},
+    {spv::CapabilityAtomicFloat64AddEXT, {0, &VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat64AtomicAdd, nullptr, ""}},
+    {spv::CapabilityClipDistance, {0, &VkPhysicalDeviceFeatures::shaderClipDistance, nullptr, ""}},
+    {spv::CapabilityComputeDerivativeGroupLinearNV, {0, &VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupLinear, nullptr, ""}},
+    {spv::CapabilityComputeDerivativeGroupQuadsNV, {0, &VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupQuads, nullptr, ""}},
+    {spv::CapabilityCooperativeMatrixNV, {0, &VkPhysicalDeviceCooperativeMatrixFeaturesNV::cooperativeMatrix, nullptr, ""}},
+    {spv::CapabilityCullDistance, {0, &VkPhysicalDeviceFeatures::shaderCullDistance, nullptr, ""}},
+    {spv::CapabilityDemoteToHelperInvocationEXT, {0, &VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT::shaderDemoteToHelperInvocation, nullptr, ""}},
+    {spv::CapabilityDenormFlushToZero, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormFlushToZeroFloat16 & VK_TRUE) != 0"}},
+    {spv::CapabilityDenormFlushToZero, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormFlushToZeroFloat32 & VK_TRUE) != 0"}},
+    {spv::CapabilityDenormFlushToZero, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormFlushToZeroFloat64 & VK_TRUE) != 0"}},
+    {spv::CapabilityDenormPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormPreserveFloat16 & VK_TRUE) != 0"}},
+    {spv::CapabilityDenormPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormPreserveFloat32 & VK_TRUE) != 0"}},
+    {spv::CapabilityDenormPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderDenormPreserveFloat64 & VK_TRUE) != 0"}},
+    {spv::CapabilityDerivativeControl, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityDeviceGroup, {VK_API_VERSION_1_1, nullptr, nullptr, ""}},
+    {spv::CapabilityDeviceGroup, {0, nullptr, &DeviceExtensions::vk_khr_device_group, ""}},
+    {spv::CapabilityDrawParameters, {0, &VkPhysicalDeviceVulkan11Features::shaderDrawParameters, nullptr, ""}},
+    {spv::CapabilityDrawParameters, {0, nullptr, &DeviceExtensions::vk_khr_shader_draw_parameters, ""}},
+    {spv::CapabilityFloat16, {0, &VkPhysicalDeviceVulkan12Features::shaderFloat16, nullptr, ""}},
+    {spv::CapabilityFloat16, {0, nullptr, &DeviceExtensions::vk_amd_gpu_shader_half_float, ""}},
+    {spv::CapabilityFloat64, {0, &VkPhysicalDeviceFeatures::shaderFloat64, nullptr, ""}},
+    {spv::CapabilityFragmentBarycentricNV, {0, &VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV::fragmentShaderBarycentric, nullptr, ""}},
+    {spv::CapabilityFragmentDensityEXT, {0, &VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMap, nullptr, ""}},
+    {spv::CapabilityFragmentMaskAMD, {0, nullptr, &DeviceExtensions::vk_amd_shader_fragment_mask, ""}},
+    {spv::CapabilityFragmentShaderPixelInterlockEXT, {0, &VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderPixelInterlock, nullptr, ""}},
+    {spv::CapabilityFragmentShaderSampleInterlockEXT, {0, &VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderSampleInterlock, nullptr, ""}},
+    {spv::CapabilityFragmentShaderShadingRateInterlockEXT, {0, &VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderShadingRateInterlock, nullptr, ""}},
+    {spv::CapabilityFragmentShaderShadingRateInterlockEXT, {0, &VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage, nullptr, ""}},
+    {spv::CapabilityFragmentShadingRateKHR, {0, &VkPhysicalDeviceFragmentShadingRateFeaturesKHR::pipelineFragmentShadingRate, nullptr, ""}},
+    {spv::CapabilityFragmentShadingRateKHR, {0, &VkPhysicalDeviceFragmentShadingRateFeaturesKHR::primitiveFragmentShadingRate, nullptr, ""}},
+    {spv::CapabilityFragmentShadingRateKHR, {0, &VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate, nullptr, ""}},
+    {spv::CapabilityGeometry, {0, &VkPhysicalDeviceFeatures::geometryShader, nullptr, ""}},
+    {spv::CapabilityGeometryPointSize, {0, &VkPhysicalDeviceFeatures::shaderTessellationAndGeometryPointSize, nullptr, ""}},
+    {spv::CapabilityGeometryShaderPassthroughNV, {0, nullptr, &DeviceExtensions::vk_nv_geometry_shader_passthrough, ""}},
+    {spv::CapabilityGeometryStreams, {0, &VkPhysicalDeviceTransformFeedbackFeaturesEXT::geometryStreams, nullptr, ""}},
+    {spv::CapabilityGroupNonUniform, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_BASIC_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformArithmetic, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformBallot, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_BALLOT_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformClustered, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_CLUSTERED_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformPartitionedNV, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV) != 0"}},
+    {spv::CapabilityGroupNonUniformQuad, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_QUAD_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformShuffle, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformShuffleRelative, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT) != 0"}},
+    {spv::CapabilityGroupNonUniformVote, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan11Properties::subgroupSupportedOperations & VK_SUBGROUP_FEATURE_VOTE_BIT) != 0"}},
+    {spv::CapabilityImage1D, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityImageBuffer, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityImageCubeArray, {0, &VkPhysicalDeviceFeatures::imageCubeArray, nullptr, ""}},
+    {spv::CapabilityImageFootprintNV, {0, &VkPhysicalDeviceShaderImageFootprintFeaturesNV::imageFootprint, nullptr, ""}},
+    {spv::CapabilityImageGatherBiasLodAMD, {0, nullptr, &DeviceExtensions::vk_amd_texture_gather_bias_lod, ""}},
+    {spv::CapabilityImageGatherExtended, {0, &VkPhysicalDeviceFeatures::shaderImageGatherExtended, nullptr, ""}},
+    {spv::CapabilityImageMSArray, {0, &VkPhysicalDeviceFeatures::shaderStorageImageMultisample, nullptr, ""}},
+    {spv::CapabilityImageQuery, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityImageReadWriteLodAMD, {0, nullptr, &DeviceExtensions::vk_amd_shader_image_load_store_lod, ""}},
+    {spv::CapabilityInputAttachment, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityInputAttachmentArrayDynamicIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityInputAttachmentArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityInt16, {0, &VkPhysicalDeviceFeatures::shaderInt16, nullptr, ""}},
+    {spv::CapabilityInt64, {0, &VkPhysicalDeviceFeatures::shaderInt64, nullptr, ""}},
+    {spv::CapabilityInt64Atomics, {0, &VkPhysicalDeviceVulkan12Features::shaderBufferInt64Atomics, nullptr, ""}},
+    {spv::CapabilityInt64Atomics, {0, &VkPhysicalDeviceVulkan12Features::shaderSharedInt64Atomics, nullptr, ""}},
+    {spv::CapabilityInt64ImageEXT, {0, &VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::shaderImageInt64Atomics, nullptr, ""}},
+    {spv::CapabilityInt8, {0, &VkPhysicalDeviceVulkan12Features::shaderInt8, nullptr, ""}},
+    {spv::CapabilityIntegerFunctions2INTEL, {0, &VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::shaderIntegerFunctions2, nullptr, ""}},
+    {spv::CapabilityInterpolationFunction, {0, &VkPhysicalDeviceFeatures::sampleRateShading, nullptr, ""}},
+    {spv::CapabilityMatrix, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityMeshShadingNV, {0, nullptr, &DeviceExtensions::vk_nv_mesh_shader, ""}},
+    {spv::CapabilityMinLod, {0, &VkPhysicalDeviceFeatures::shaderResourceMinLod, nullptr, ""}},
+    {spv::CapabilityMultiView, {0, &VkPhysicalDeviceVulkan11Features::multiview, nullptr, ""}},
+    {spv::CapabilityMultiViewport, {0, &VkPhysicalDeviceFeatures::multiViewport, nullptr, ""}},
+    {spv::CapabilityPerViewAttributesNV, {0, nullptr, &DeviceExtensions::vk_nvx_multiview_per_view_attributes, ""}},
+    {spv::CapabilityPhysicalStorageBufferAddresses, {0, &VkPhysicalDeviceVulkan12Features::bufferDeviceAddress, nullptr, ""}},
+    {spv::CapabilityPhysicalStorageBufferAddresses, {0, &VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::bufferDeviceAddress, nullptr, ""}},
+    {spv::CapabilityRayQueryKHR, {0, &VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery, nullptr, ""}},
+    {spv::CapabilityRayTracingKHR, {0, &VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipeline, nullptr, ""}},
+    {spv::CapabilityRayTracingNV, {0, nullptr, &DeviceExtensions::vk_nv_ray_tracing, ""}},
+    {spv::CapabilityRayTraversalPrimitiveCullingKHR, {0, &VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTraversalPrimitiveCulling, nullptr, ""}},
+    {spv::CapabilityRoundingModeRTE, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTEFloat16 & VK_TRUE) != 0"}},
+    {spv::CapabilityRoundingModeRTE, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTEFloat32 & VK_TRUE) != 0"}},
+    {spv::CapabilityRoundingModeRTE, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTEFloat64 & VK_TRUE) != 0"}},
+    {spv::CapabilityRoundingModeRTZ, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat16 & VK_TRUE) != 0"}},
+    {spv::CapabilityRoundingModeRTZ, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat32 & VK_TRUE) != 0"}},
+    {spv::CapabilityRoundingModeRTZ, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat64 & VK_TRUE) != 0"}},
+    {spv::CapabilityRuntimeDescriptorArray, {0, &VkPhysicalDeviceVulkan12Features::runtimeDescriptorArray, nullptr, ""}},
+    {spv::CapabilitySampleMaskOverrideCoverageNV, {0, nullptr, &DeviceExtensions::vk_nv_sample_mask_override_coverage, ""}},
+    {spv::CapabilitySampleMaskPostDepthCoverage, {0, nullptr, &DeviceExtensions::vk_ext_post_depth_coverage, ""}},
+    {spv::CapabilitySampleRateShading, {0, &VkPhysicalDeviceFeatures::sampleRateShading, nullptr, ""}},
+    {spv::CapabilitySampled1D, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilitySampledBuffer, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilitySampledCubeArray, {0, &VkPhysicalDeviceFeatures::imageCubeArray, nullptr, ""}},
+    {spv::CapabilitySampledImageArrayDynamicIndexing, {0, &VkPhysicalDeviceFeatures::shaderSampledImageArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilitySampledImageArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderSampledImageArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityShader, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityShaderClockKHR, {0, nullptr, &DeviceExtensions::vk_khr_shader_clock, ""}},
+    {spv::CapabilityShaderLayer, {0, &VkPhysicalDeviceVulkan12Features::shaderOutputLayer, nullptr, ""}},
+    {spv::CapabilityShaderNonUniform, {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {spv::CapabilityShaderNonUniform, {0, nullptr, &DeviceExtensions::vk_ext_descriptor_indexing, ""}},
+    {spv::CapabilityShaderSMBuiltinsNV, {0, &VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::shaderSMBuiltins, nullptr, ""}},
+    {spv::CapabilityShaderViewportIndex, {0, &VkPhysicalDeviceVulkan12Features::shaderOutputViewportIndex, nullptr, ""}},
+    {spv::CapabilityShaderViewportIndexLayerEXT, {0, nullptr, &DeviceExtensions::vk_ext_shader_viewport_index_layer, ""}},
+    {spv::CapabilityShaderViewportIndexLayerNV, {0, nullptr, &DeviceExtensions::vk_nv_viewport_array2, ""}},
+    {spv::CapabilityShaderViewportMaskNV, {0, nullptr, &DeviceExtensions::vk_nv_viewport_array2, ""}},
+    {spv::CapabilityShadingRateNV, {0, &VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage, nullptr, ""}},
+    {spv::CapabilitySignedZeroInfNanPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderSignedZeroInfNanPreserveFloat16 & VK_TRUE) != 0"}},
+    {spv::CapabilitySignedZeroInfNanPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderSignedZeroInfNanPreserveFloat32 & VK_TRUE) != 0"}},
+    {spv::CapabilitySignedZeroInfNanPreserve, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderSignedZeroInfNanPreserveFloat64 & VK_TRUE) != 0"}},
+    {spv::CapabilitySparseResidency, {0, &VkPhysicalDeviceFeatures::shaderResourceResidency, nullptr, ""}},
+    {spv::CapabilityStencilExportEXT, {0, nullptr, &DeviceExtensions::vk_ext_shader_stencil_export, ""}},
+    {spv::CapabilityStorageBuffer16BitAccess, {0, &VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess, nullptr, ""}},
+    {spv::CapabilityStorageBuffer8BitAccess, {0, &VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess, nullptr, ""}},
+    {spv::CapabilityStorageBufferArrayDynamicIndexing, {0, &VkPhysicalDeviceFeatures::shaderStorageBufferArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityStorageBufferArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderStorageBufferArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityStorageImageArrayDynamicIndexing, {0, &VkPhysicalDeviceFeatures::shaderStorageImageArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityStorageImageArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderStorageImageArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityStorageImageExtendedFormats, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
+    {spv::CapabilityStorageImageMultisample, {0, &VkPhysicalDeviceFeatures::shaderStorageImageMultisample, nullptr, ""}},
+    {spv::CapabilityStorageImageReadWithoutFormat, {0, &VkPhysicalDeviceFeatures::shaderStorageImageReadWithoutFormat, nullptr, ""}},
+    {spv::CapabilityStorageImageWriteWithoutFormat, {0, &VkPhysicalDeviceFeatures::shaderStorageImageWriteWithoutFormat, nullptr, ""}},
+    {spv::CapabilityStorageInputOutput16, {0, &VkPhysicalDeviceVulkan11Features::storageInputOutput16, nullptr, ""}},
+    {spv::CapabilityStoragePushConstant16, {0, &VkPhysicalDeviceVulkan11Features::storagePushConstant16, nullptr, ""}},
+    {spv::CapabilityStoragePushConstant8, {0, &VkPhysicalDeviceVulkan12Features::storagePushConstant8, nullptr, ""}},
+    {spv::CapabilityStorageTexelBufferArrayDynamicIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityStorageTexelBufferArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilitySubgroupBallotKHR, {0, nullptr, &DeviceExtensions::vk_ext_shader_subgroup_ballot, ""}},
+    {spv::CapabilitySubgroupVoteKHR, {0, nullptr, &DeviceExtensions::vk_ext_shader_subgroup_vote, ""}},
+    {spv::CapabilityTessellation, {0, &VkPhysicalDeviceFeatures::tessellationShader, nullptr, ""}},
+    {spv::CapabilityTessellationPointSize, {0, &VkPhysicalDeviceFeatures::shaderTessellationAndGeometryPointSize, nullptr, ""}},
+    {spv::CapabilityTransformFeedback, {0, &VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedback, nullptr, ""}},
+    {spv::CapabilityUniformAndStorageBuffer16BitAccess, {0, &VkPhysicalDeviceVulkan11Features::uniformAndStorageBuffer16BitAccess, nullptr, ""}},
+    {spv::CapabilityUniformAndStorageBuffer8BitAccess, {0, &VkPhysicalDeviceVulkan12Features::uniformAndStorageBuffer8BitAccess, nullptr, ""}},
+    {spv::CapabilityUniformBufferArrayDynamicIndexing, {0, &VkPhysicalDeviceFeatures::shaderUniformBufferArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityUniformBufferArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderUniformBufferArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityUniformTexelBufferArrayDynamicIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayDynamicIndexing, nullptr, ""}},
+    {spv::CapabilityUniformTexelBufferArrayNonUniformIndexing, {0, &VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayNonUniformIndexing, nullptr, ""}},
+    {spv::CapabilityVariablePointers, {0, &VkPhysicalDeviceVulkan11Features::variablePointers, nullptr, ""}},
+    {spv::CapabilityVariablePointersStorageBuffer, {0, &VkPhysicalDeviceVulkan11Features::variablePointersStorageBuffer, nullptr, ""}},
+    {spv::CapabilityVulkanMemoryModel, {0, &VkPhysicalDeviceVulkan12Features::vulkanMemoryModel, nullptr, ""}},
+    {spv::CapabilityVulkanMemoryModelDeviceScope, {0, &VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope, nullptr, ""}},
+};
+// clang-format on
+
+// clang-format off
+static const std::unordered_multimap<std::string, RequiredSpirvInfo> spirvExtensions = {
+    {"SPV_AMD_gcn_shader", {0, nullptr, &DeviceExtensions::vk_amd_gcn_shader, ""}},
+    {"SPV_AMD_gpu_shader_half_float", {0, nullptr, &DeviceExtensions::vk_amd_gpu_shader_half_float, ""}},
+    {"SPV_AMD_gpu_shader_int16", {0, nullptr, &DeviceExtensions::vk_amd_gpu_shader_int16, ""}},
+    {"SPV_AMD_shader_ballot", {0, nullptr, &DeviceExtensions::vk_amd_shader_ballot, ""}},
+    {"SPV_AMD_shader_explicit_vertex_parameter", {0, nullptr, &DeviceExtensions::vk_amd_shader_explicit_vertex_parameter, ""}},
+    {"SPV_AMD_shader_fragment_mask", {0, nullptr, &DeviceExtensions::vk_amd_shader_fragment_mask, ""}},
+    {"SPV_AMD_shader_image_load_store_lod", {0, nullptr, &DeviceExtensions::vk_amd_shader_image_load_store_lod, ""}},
+    {"SPV_AMD_shader_trinary_minmax", {0, nullptr, &DeviceExtensions::vk_amd_shader_trinary_minmax, ""}},
+    {"SPV_AMD_texture_gather_bias_lod", {0, nullptr, &DeviceExtensions::vk_amd_texture_gather_bias_lod, ""}},
+    {"SPV_EXT_demote_to_helper_invocation", {0, nullptr, &DeviceExtensions::vk_ext_shader_demote_to_helper_invocation, ""}},
+    {"SPV_EXT_descriptor_indexing", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_EXT_descriptor_indexing", {0, nullptr, &DeviceExtensions::vk_ext_descriptor_indexing, ""}},
+    {"SPV_EXT_fragment_invocation_density", {0, nullptr, &DeviceExtensions::vk_ext_fragment_density_map, ""}},
+    {"SPV_EXT_fragment_shader_interlock", {0, nullptr, &DeviceExtensions::vk_ext_fragment_shader_interlock, ""}},
+    {"SPV_EXT_physical_storage_buffer", {0, nullptr, &DeviceExtensions::vk_ext_buffer_device_address, ""}},
+    {"SPV_EXT_shader_image_int64", {0, nullptr, &DeviceExtensions::vk_ext_shader_image_atomic_int64, ""}},
+    {"SPV_EXT_shader_stencil_export", {0, nullptr, &DeviceExtensions::vk_ext_shader_stencil_export, ""}},
+    {"SPV_EXT_shader_viewport_index_layer", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_EXT_shader_viewport_index_layer", {0, nullptr, &DeviceExtensions::vk_ext_shader_viewport_index_layer, ""}},
+    {"SPV_GOOGLE_decorate_string", {0, nullptr, &DeviceExtensions::vk_google_decorate_string, ""}},
+    {"SPV_GOOGLE_hlsl_functionality1", {0, nullptr, &DeviceExtensions::vk_google_hlsl_functionality1, ""}},
+    {"SPV_GOOGLE_user_type", {0, nullptr, &DeviceExtensions::vk_google_user_type, ""}},
+    {"SPV_KHR_16bit_storage", {VK_API_VERSION_1_1, nullptr, nullptr, ""}},
+    {"SPV_KHR_16bit_storage", {0, nullptr, &DeviceExtensions::vk_khr_16bit_storage, ""}},
+    {"SPV_KHR_8bit_storage", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_KHR_8bit_storage", {0, nullptr, &DeviceExtensions::vk_khr_8bit_storage, ""}},
+    {"SPV_KHR_float_controls", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_KHR_float_controls", {0, nullptr, &DeviceExtensions::vk_khr_shader_float_controls, ""}},
+    {"SPV_KHR_fragment_shading_rate", {0, nullptr, &DeviceExtensions::vk_khr_fragment_shading_rate, ""}},
+    {"SPV_KHR_non_semantic_info", {0, nullptr, &DeviceExtensions::vk_khr_shader_non_semantic_info, ""}},
+    {"SPV_KHR_physical_storage_buffer", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_KHR_physical_storage_buffer", {0, nullptr, &DeviceExtensions::vk_khr_buffer_device_address, ""}},
+    {"SPV_KHR_post_depth_coverage", {0, nullptr, &DeviceExtensions::vk_ext_post_depth_coverage, ""}},
+    {"SPV_KHR_ray_query", {0, nullptr, &DeviceExtensions::vk_khr_ray_query, ""}},
+    {"SPV_KHR_ray_tracing", {0, nullptr, &DeviceExtensions::vk_khr_ray_tracing_pipeline, ""}},
+    {"SPV_KHR_shader_ballot", {0, nullptr, &DeviceExtensions::vk_ext_shader_subgroup_ballot, ""}},
+    {"SPV_KHR_shader_clock", {0, nullptr, &DeviceExtensions::vk_khr_shader_clock, ""}},
+    {"SPV_KHR_shader_draw_parameters", {VK_API_VERSION_1_1, nullptr, nullptr, ""}},
+    {"SPV_KHR_shader_draw_parameters", {0, nullptr, &DeviceExtensions::vk_khr_shader_draw_parameters, ""}},
+    {"SPV_KHR_storage_buffer_storage_class", {VK_API_VERSION_1_1, nullptr, nullptr, ""}},
+    {"SPV_KHR_storage_buffer_storage_class", {0, nullptr, &DeviceExtensions::vk_khr_storage_buffer_storage_class, ""}},
+    {"SPV_KHR_subgroup_vote", {0, nullptr, &DeviceExtensions::vk_ext_shader_subgroup_vote, ""}},
+    {"SPV_KHR_terminate_invocation", {0, nullptr, &DeviceExtensions::vk_khr_shader_terminate_invocation, ""}},
+    {"SPV_KHR_variable_pointers", {VK_API_VERSION_1_1, nullptr, nullptr, ""}},
+    {"SPV_KHR_variable_pointers", {0, nullptr, &DeviceExtensions::vk_khr_variable_pointers, ""}},
+    {"SPV_KHR_vulkan_memory_model", {VK_API_VERSION_1_2, nullptr, nullptr, ""}},
+    {"SPV_KHR_vulkan_memory_model", {0, nullptr, &DeviceExtensions::vk_khr_vulkan_memory_model, ""}},
+    {"SPV_NVX_multiview_per_view_attributes", {0, nullptr, &DeviceExtensions::vk_nvx_multiview_per_view_attributes, ""}},
+    {"SPV_NV_compute_shader_derivatives", {0, nullptr, &DeviceExtensions::vk_nv_compute_shader_derivatives, ""}},
+    {"SPV_NV_cooperative_matrix", {0, nullptr, &DeviceExtensions::vk_nv_cooperative_matrix, ""}},
+    {"SPV_NV_fragment_shader_barycentric", {0, nullptr, &DeviceExtensions::vk_nv_fragment_shader_barycentric, ""}},
+    {"SPV_NV_geometry_shader_passthrough", {0, nullptr, &DeviceExtensions::vk_nv_geometry_shader_passthrough, ""}},
+    {"SPV_NV_mesh_shader", {0, nullptr, &DeviceExtensions::vk_nv_mesh_shader, ""}},
+    {"SPV_NV_ray_tracing", {0, nullptr, &DeviceExtensions::vk_nv_ray_tracing, ""}},
+    {"SPV_NV_sample_mask_override_coverage", {0, nullptr, &DeviceExtensions::vk_nv_sample_mask_override_coverage, ""}},
+    {"SPV_NV_shader_image_footprint", {0, nullptr, &DeviceExtensions::vk_nv_shader_image_footprint, ""}},
+    {"SPV_NV_shader_sm_builtins", {0, nullptr, &DeviceExtensions::vk_nv_shader_sm_builtins, ""}},
+    {"SPV_NV_shader_subgroup_partitioned", {0, nullptr, &DeviceExtensions::vk_nv_shader_subgroup_partitioned, ""}},
+    {"SPV_NV_shading_rate", {0, nullptr, &DeviceExtensions::vk_nv_shading_rate_image, ""}},
+    {"SPV_NV_viewport_array2", {0, nullptr, &DeviceExtensions::vk_nv_viewport_array2, ""}},
+};
+// clang-format on
+
+static inline const char* string_SpvCapability(uint32_t input_value) {
+    switch ((spv::Capability)input_value) {
+         case spv::CapabilityAtomicFloat32AddEXT:
+            return "AtomicFloat32AddEXT";
+         case spv::CapabilityAtomicFloat64AddEXT:
+            return "AtomicFloat64AddEXT";
+         case spv::CapabilityClipDistance:
+            return "ClipDistance";
+         case spv::CapabilityComputeDerivativeGroupLinearNV:
+            return "ComputeDerivativeGroupLinearNV";
+         case spv::CapabilityComputeDerivativeGroupQuadsNV:
+            return "ComputeDerivativeGroupQuadsNV";
+         case spv::CapabilityCooperativeMatrixNV:
+            return "CooperativeMatrixNV";
+         case spv::CapabilityCullDistance:
+            return "CullDistance";
+         case spv::CapabilityDemoteToHelperInvocationEXT:
+            return "DemoteToHelperInvocationEXT";
+         case spv::CapabilityDenormFlushToZero:
+            return "DenormFlushToZero";
+         case spv::CapabilityDenormPreserve:
+            return "DenormPreserve";
+         case spv::CapabilityDerivativeControl:
+            return "DerivativeControl";
+         case spv::CapabilityDeviceGroup:
+            return "DeviceGroup";
+         case spv::CapabilityDrawParameters:
+            return "DrawParameters";
+         case spv::CapabilityFloat16:
+            return "Float16";
+         case spv::CapabilityFloat64:
+            return "Float64";
+         case spv::CapabilityFragmentBarycentricNV:
+            return "FragmentBarycentricNV";
+         case spv::CapabilityFragmentDensityEXT:
+            return "FragmentDensityEXT";
+         case spv::CapabilityFragmentMaskAMD:
+            return "FragmentMaskAMD";
+         case spv::CapabilityFragmentShaderPixelInterlockEXT:
+            return "FragmentShaderPixelInterlockEXT";
+         case spv::CapabilityFragmentShaderSampleInterlockEXT:
+            return "FragmentShaderSampleInterlockEXT";
+         case spv::CapabilityFragmentShaderShadingRateInterlockEXT:
+            return "FragmentShaderShadingRateInterlockEXT";
+         case spv::CapabilityFragmentShadingRateKHR:
+            return "FragmentShadingRateKHR";
+         case spv::CapabilityGeometry:
+            return "Geometry";
+         case spv::CapabilityGeometryPointSize:
+            return "GeometryPointSize";
+         case spv::CapabilityGeometryShaderPassthroughNV:
+            return "GeometryShaderPassthroughNV";
+         case spv::CapabilityGeometryStreams:
+            return "GeometryStreams";
+         case spv::CapabilityGroupNonUniform:
+            return "GroupNonUniform";
+         case spv::CapabilityGroupNonUniformArithmetic:
+            return "GroupNonUniformArithmetic";
+         case spv::CapabilityGroupNonUniformBallot:
+            return "GroupNonUniformBallot";
+         case spv::CapabilityGroupNonUniformClustered:
+            return "GroupNonUniformClustered";
+         case spv::CapabilityGroupNonUniformPartitionedNV:
+            return "GroupNonUniformPartitionedNV";
+         case spv::CapabilityGroupNonUniformQuad:
+            return "GroupNonUniformQuad";
+         case spv::CapabilityGroupNonUniformShuffle:
+            return "GroupNonUniformShuffle";
+         case spv::CapabilityGroupNonUniformShuffleRelative:
+            return "GroupNonUniformShuffleRelative";
+         case spv::CapabilityGroupNonUniformVote:
+            return "GroupNonUniformVote";
+         case spv::CapabilityImage1D:
+            return "Image1D";
+         case spv::CapabilityImageBuffer:
+            return "ImageBuffer";
+         case spv::CapabilityImageCubeArray:
+            return "ImageCubeArray";
+         case spv::CapabilityImageFootprintNV:
+            return "ImageFootprintNV";
+         case spv::CapabilityImageGatherBiasLodAMD:
+            return "ImageGatherBiasLodAMD";
+         case spv::CapabilityImageGatherExtended:
+            return "ImageGatherExtended";
+         case spv::CapabilityImageMSArray:
+            return "ImageMSArray";
+         case spv::CapabilityImageQuery:
+            return "ImageQuery";
+         case spv::CapabilityImageReadWriteLodAMD:
+            return "ImageReadWriteLodAMD";
+         case spv::CapabilityInputAttachment:
+            return "InputAttachment";
+         case spv::CapabilityInputAttachmentArrayDynamicIndexing:
+            return "InputAttachmentArrayDynamicIndexing";
+         case spv::CapabilityInputAttachmentArrayNonUniformIndexing:
+            return "InputAttachmentArrayNonUniformIndexing";
+         case spv::CapabilityInt16:
+            return "Int16";
+         case spv::CapabilityInt64:
+            return "Int64";
+         case spv::CapabilityInt64Atomics:
+            return "Int64Atomics";
+         case spv::CapabilityInt64ImageEXT:
+            return "Int64ImageEXT";
+         case spv::CapabilityInt8:
+            return "Int8";
+         case spv::CapabilityIntegerFunctions2INTEL:
+            return "IntegerFunctions2INTEL";
+         case spv::CapabilityInterpolationFunction:
+            return "InterpolationFunction";
+         case spv::CapabilityMatrix:
+            return "Matrix";
+         case spv::CapabilityMeshShadingNV:
+            return "MeshShadingNV";
+         case spv::CapabilityMinLod:
+            return "MinLod";
+         case spv::CapabilityMultiView:
+            return "MultiView";
+         case spv::CapabilityMultiViewport:
+            return "MultiViewport";
+         case spv::CapabilityPerViewAttributesNV:
+            return "PerViewAttributesNV";
+         case spv::CapabilityPhysicalStorageBufferAddresses:
+            return "PhysicalStorageBufferAddresses";
+         case spv::CapabilityRayQueryKHR:
+            return "RayQueryKHR";
+         case spv::CapabilityRayTracingKHR:
+            return "RayTracingKHR";
+         case spv::CapabilityRayTracingNV:
+            return "RayTracingNV";
+         case spv::CapabilityRayTraversalPrimitiveCullingKHR:
+            return "RayTraversalPrimitiveCullingKHR";
+         case spv::CapabilityRoundingModeRTE:
+            return "RoundingModeRTE";
+         case spv::CapabilityRoundingModeRTZ:
+            return "RoundingModeRTZ";
+         case spv::CapabilityRuntimeDescriptorArray:
+            return "RuntimeDescriptorArray";
+         case spv::CapabilitySampleMaskOverrideCoverageNV:
+            return "SampleMaskOverrideCoverageNV";
+         case spv::CapabilitySampleMaskPostDepthCoverage:
+            return "SampleMaskPostDepthCoverage";
+         case spv::CapabilitySampleRateShading:
+            return "SampleRateShading";
+         case spv::CapabilitySampled1D:
+            return "Sampled1D";
+         case spv::CapabilitySampledBuffer:
+            return "SampledBuffer";
+         case spv::CapabilitySampledCubeArray:
+            return "SampledCubeArray";
+         case spv::CapabilitySampledImageArrayDynamicIndexing:
+            return "SampledImageArrayDynamicIndexing";
+         case spv::CapabilitySampledImageArrayNonUniformIndexing:
+            return "SampledImageArrayNonUniformIndexing";
+         case spv::CapabilityShader:
+            return "Shader";
+         case spv::CapabilityShaderClockKHR:
+            return "ShaderClockKHR";
+         case spv::CapabilityShaderLayer:
+            return "ShaderLayer";
+         case spv::CapabilityShaderNonUniform:
+            return "ShaderNonUniform";
+         case spv::CapabilityShaderSMBuiltinsNV:
+            return "ShaderSMBuiltinsNV";
+         case spv::CapabilityShaderViewportIndex:
+            return "ShaderViewportIndex";
+         case spv::CapabilityShaderViewportIndexLayerEXT:
+            return "ShaderViewportIndexLayerEXT";
+         case spv::CapabilityShaderViewportMaskNV:
+            return "ShaderViewportMaskNV";
+         case spv::CapabilitySignedZeroInfNanPreserve:
+            return "SignedZeroInfNanPreserve";
+         case spv::CapabilitySparseResidency:
+            return "SparseResidency";
+         case spv::CapabilityStencilExportEXT:
+            return "StencilExportEXT";
+         case spv::CapabilityStorageBuffer16BitAccess:
+            return "StorageBuffer16BitAccess";
+         case spv::CapabilityStorageBuffer8BitAccess:
+            return "StorageBuffer8BitAccess";
+         case spv::CapabilityStorageBufferArrayDynamicIndexing:
+            return "StorageBufferArrayDynamicIndexing";
+         case spv::CapabilityStorageBufferArrayNonUniformIndexing:
+            return "StorageBufferArrayNonUniformIndexing";
+         case spv::CapabilityStorageImageArrayDynamicIndexing:
+            return "StorageImageArrayDynamicIndexing";
+         case spv::CapabilityStorageImageArrayNonUniformIndexing:
+            return "StorageImageArrayNonUniformIndexing";
+         case spv::CapabilityStorageImageExtendedFormats:
+            return "StorageImageExtendedFormats";
+         case spv::CapabilityStorageImageMultisample:
+            return "StorageImageMultisample";
+         case spv::CapabilityStorageImageReadWithoutFormat:
+            return "StorageImageReadWithoutFormat";
+         case spv::CapabilityStorageImageWriteWithoutFormat:
+            return "StorageImageWriteWithoutFormat";
+         case spv::CapabilityStorageInputOutput16:
+            return "StorageInputOutput16";
+         case spv::CapabilityStoragePushConstant16:
+            return "StoragePushConstant16";
+         case spv::CapabilityStoragePushConstant8:
+            return "StoragePushConstant8";
+         case spv::CapabilityStorageTexelBufferArrayDynamicIndexing:
+            return "StorageTexelBufferArrayDynamicIndexing";
+         case spv::CapabilityStorageTexelBufferArrayNonUniformIndexing:
+            return "StorageTexelBufferArrayNonUniformIndexing";
+         case spv::CapabilitySubgroupBallotKHR:
+            return "SubgroupBallotKHR";
+         case spv::CapabilitySubgroupVoteKHR:
+            return "SubgroupVoteKHR";
+         case spv::CapabilityTessellation:
+            return "Tessellation";
+         case spv::CapabilityTessellationPointSize:
+            return "TessellationPointSize";
+         case spv::CapabilityTransformFeedback:
+            return "TransformFeedback";
+         case spv::CapabilityUniformAndStorageBuffer16BitAccess:
+            return "UniformAndStorageBuffer16BitAccess";
+         case spv::CapabilityUniformAndStorageBuffer8BitAccess:
+            return "UniformAndStorageBuffer8BitAccess";
+         case spv::CapabilityUniformBufferArrayDynamicIndexing:
+            return "UniformBufferArrayDynamicIndexing";
+         case spv::CapabilityUniformBufferArrayNonUniformIndexing:
+            return "UniformBufferArrayNonUniformIndexing";
+         case spv::CapabilityUniformTexelBufferArrayDynamicIndexing:
+            return "UniformTexelBufferArrayDynamicIndexing";
+         case spv::CapabilityUniformTexelBufferArrayNonUniformIndexing:
+            return "UniformTexelBufferArrayNonUniformIndexing";
+         case spv::CapabilityVariablePointers:
+            return "VariablePointers";
+         case spv::CapabilityVariablePointersStorageBuffer:
+            return "VariablePointersStorageBuffer";
+         case spv::CapabilityVulkanMemoryModel:
+            return "VulkanMemoryModel";
+         case spv::CapabilityVulkanMemoryModelDeviceScope:
+            return "VulkanMemoryModelDeviceScope";
+        default:
+            return "Unhandled OpCapability";
+    };
+};
+
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const *src) const {
+    bool skip = false;
+
+    for (auto insn : *src) {
+        if (insn.opcode() == spv::OpCapability) {
+            // All capabilities are generated so if it is not in the list it is not supported by Vulkan
+            if (spirvCapabilities.count(insn.word(1)) == 0) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01090",
+                    "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.word(1)));
+                    continue;
+            }
+
+            // Each capability has one or more requirements to check
+            // Only one item has to be satisfied and an error only occurs
+            // when all are not satisfied
+            auto caps = spirvCapabilities.equal_range(insn.word(1));
+            bool has_support = false;
+            for (auto it = caps.first; (it != caps.second) && (has_support == false); ++it) {
+                if (it->second.version) {
+                    if (api_version >= it->second.version) {
+                        has_support = true;
+                    }
+                } else if (it->second.feature) {
+                    if (it->second.feature.IsEnabled(enabled_features)) {
+                        has_support = true;
+                    }
+                } else if (it->second.extension) {
+                    if (device_extensions.*(it->second.extension)) {
+                        has_support = true;
+                    }
+                } else if (it->second.property) {
+                    switch (insn.word(1)) {
+                        default:
+                            break;
+                        case spv::CapabilityDenormFlushToZero:
+                            has_support = ((phys_dev_props_core12.shaderDenormFlushToZeroFloat64 & VK_TRUE) != 0);
+                            break;
+                        case spv::CapabilityDenormPreserve:
+                            has_support = ((phys_dev_props_core12.shaderDenormPreserveFloat64 & VK_TRUE) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniform:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_BASIC_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformArithmetic:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformBallot:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_BALLOT_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformClustered:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_CLUSTERED_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformPartitionedNV:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformQuad:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_QUAD_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformShuffle:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformShuffleRelative:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT) != 0);
+                            break;
+                        case spv::CapabilityGroupNonUniformVote:
+                            has_support = ((phys_dev_props_core11.subgroupSupportedOperations & VK_SUBGROUP_FEATURE_VOTE_BIT) != 0);
+                            break;
+                        case spv::CapabilityRoundingModeRTE:
+                            has_support = ((phys_dev_props_core12.shaderRoundingModeRTEFloat64 & VK_TRUE) != 0);
+                            break;
+                        case spv::CapabilityRoundingModeRTZ:
+                            has_support = ((phys_dev_props_core12.shaderRoundingModeRTZFloat64 & VK_TRUE) != 0);
+                            break;
+                        case spv::CapabilitySignedZeroInfNanPreserve:
+                            has_support = ((phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat64 & VK_TRUE) != 0);
+                            break;
+                    }
+                }
+            }
+
+            if (has_support == false) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01091",
+                    "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.word(1)));
+                    continue;
+            }
+
+        } else if (insn.opcode() == spv::OpExtension) {
+            std::string extension_name = (char const *)&insn.word(1);
+
+            if (spirvExtensions.count(extension_name) == 0) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-04146",
+                    "vkCreateShaderModule(): A SPIR-V Extension (%s) was declared that is not supported by Vulkan.", extension_name.c_str());
+               continue;
+            }
+
+            // Each SPIR-V Extension has one or more requirements to check
+            // Only one item has to be satisfied and an error only occurs
+            // when all are not satisfied
+            auto ext = spirvExtensions.equal_range(extension_name);
+            bool has_support = false;
+            for (auto it = ext.first; (it != ext.second) && (has_support == false); ++it) {
+                if (it->second.version) {
+                    if (api_version >= it->second.version) {
+                        has_support = true;
+                    }
+                } else if (it->second.feature) {
+                    if (it->second.feature.IsEnabled(enabled_features)) {
+                        has_support = true;
+                    }
+                } else if (it->second.extension) {
+                    if (device_extensions.*(it->second.extension)) {
+                        has_support = true;
+                    }
+                } else if (it->second.property) {
+                    switch (insn.word(1)) {
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            if (has_support == false) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-04147",
+                    "vkCreateShaderModule(): The SPIR-V Extension (%s) was declared, but none of the requirements were met to use it.", extension_name.c_str());
+                    continue;
+            }
+        }
+    }
+    return skip;
+}

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1899,6 +1899,28 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         state_tracker->enabled_features.portability_subset_features = *portability_features;
     }
 
+    const auto *shader_integer_functions2_features =
+        lvl_find_in_chain<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>(pCreateInfo->pNext);
+    if (shader_integer_functions2_features) {
+        state_tracker->enabled_features.shader_integer_functions2_features = *shader_integer_functions2_features;
+    }
+
+    const auto *shader_sm_builtins_feature = lvl_find_in_chain<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>(pCreateInfo->pNext);
+    if (shader_sm_builtins_feature) {
+        state_tracker->enabled_features.shader_sm_builtins_feature = *shader_sm_builtins_feature;
+    }
+
+    const auto *shader_atomic_float_feature = lvl_find_in_chain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(pCreateInfo->pNext);
+    if (shader_atomic_float_feature) {
+        state_tracker->enabled_features.shader_atomic_float_feature = *shader_atomic_float_feature;
+    }
+
+    const auto *shader_image_atomic_int64_feature =
+        lvl_find_in_chain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(pCreateInfo->pNext);
+    if (shader_image_atomic_int64_feature) {
+        state_tracker->enabled_features.shader_image_atomic_int64_feature = *shader_image_atomic_int64_feature;
+    }
+
     // Store physical device properties and physical device mem limits into CoreChecks structs
     DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
     DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -41,6 +41,7 @@ class BestPracticesOutputGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -66,6 +67,7 @@ class BestPracticesOutputGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers
@@ -270,7 +272,7 @@ class BestPracticesOutputGenerator(OutputGenerator):
             pre_decl = pre_decl.replace(')', ',\n    void*                                       state_data)')
         pre_decl = pre_decl.replace(')', ') {\n')
         pre_decl = 'void BestPractices::PostCallRecord' + pre_decl[2:]
-        type = cdecl.split(' ')[1] 
+        type = cdecl.split(' ')[1]
         if type == 'VkResult':
             error_codes = cmdinfo.elem.attrib.get('errorcodes')
             success_codes = cmdinfo.elem.attrib.get('successcodes')

--- a/scripts/command_counter_generator.py
+++ b/scripts/command_counter_generator.py
@@ -42,6 +42,7 @@ class CommandCounterOutputGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -64,6 +65,7 @@ class CommandCounterOutputGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -41,6 +41,7 @@ class DispatchTableHelperOutputGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -62,6 +63,7 @@ class DispatchTableHelperOutputGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers
@@ -91,7 +93,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
     # Called once at the beginning of each run
     def beginFile(self, genOpts):
         OutputGenerator.beginFile(self, genOpts)
-        
+
         # Initialize members that require the tree
         self.handle_types = GetHandleTypes(self.registry.tree)
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -66,6 +66,7 @@ def main(argv):
                                               "vk_typemap_helper.h",
                                               "best_practices.h",
                                               "best_practices.cpp",
+                                              "spirv_validation_helper.cpp",
                                               "command_counter_helper.cpp",
                                               "command_counter_helper.h"]],
                 [common_codegen.repo_relative('scripts/vk_validation_stats.py'),

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -44,6 +44,7 @@ class HelperFileOutputGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -69,6 +70,7 @@ class HelperFileOutputGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText       = prefixText
         self.genFuncPointers  = genFuncPointers

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -73,6 +73,7 @@ class LayerChassisDispatchGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -98,6 +99,7 @@ class LayerChassisDispatchGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers
@@ -944,7 +946,7 @@ VkResult DispatchDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarker
             local_tag_info.object = it->second;
         }
     }
-    VkResult result = layer_data->device_dispatch_table.DebugMarkerSetObjectTagEXT(device, 
+    VkResult result = layer_data->device_dispatch_table.DebugMarkerSetObjectTagEXT(device,
                                                                                    reinterpret_cast<VkDebugMarkerObjectTagInfoEXT *>(&local_tag_info));
     return result;
 }
@@ -1969,7 +1971,7 @@ VkResult DispatchBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkComma
                 self.appendSection('source_file', "\n".join(str(api_decls).rstrip().split("\n")))
             if api_pre:
                 self.appendSection('source_file', "\n".join(str(api_pre).rstrip().split("\n")))
-            # Generate the wrapped dispatch call 
+            # Generate the wrapped dispatch call
             self.appendSection('source_file', '    ' + assignresult + api_func + '(' + wrapped_paramstext + ');')
 
             # And add the post-API-call codegen

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -74,6 +74,7 @@ class LayerChassisGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -100,6 +101,7 @@ class LayerChassisGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/layer_dispatch_table_generator.py
+++ b/scripts/layer_dispatch_table_generator.py
@@ -47,6 +47,7 @@ class LayerDispatchTableGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -72,6 +73,7 @@ class LayerDispatchTableGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.prefixText      = None

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -62,6 +62,9 @@ def makeGenOpts(args):
     # Features to include (list of features)
     features = args.feature
 
+    # Spirv elements to emit (list of extensions and capabilities)
+    emitSpirv = args.emitSpirv
+
     # Whether to disable inclusion protect in headers
     protect = args.protect
 
@@ -73,14 +76,15 @@ def makeGenOpts(args):
 
     # Descriptive names for various regexp patterns used to select
     # versions and extensions
-    allFeatures     = allExtensions = '.*'
-    noFeatures      = noExtensions = None
+    allFeatures     = allExtensions = allSpirv = '.*'
+    noFeatures      = noExtensions = noSpirv = None
 
     # Turn lists of names/patterns into matching regular expressions
     addExtensionsPat     = makeREstring(extensions, None)
     removeExtensionsPat  = makeREstring(removeExtensions, None)
     emitExtensionsPat    = makeREstring(emitExtensions, allExtensions)
     featuresPat          = makeREstring(features, allFeatures)
+    emitSpirvPat         = makeREstring(emitSpirv, allSpirv)
 
     # Copyright text prefixing all headers (list of strings).
     prefixStrings = [
@@ -134,6 +138,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -159,6 +164,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -184,6 +190,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -209,6 +216,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -234,6 +242,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -260,6 +269,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -286,6 +296,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -310,6 +321,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -335,6 +347,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -360,6 +373,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -384,6 +398,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -409,6 +424,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -434,6 +450,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -459,6 +476,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -484,6 +502,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -509,6 +528,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -536,6 +556,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -561,6 +582,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -586,6 +608,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -611,6 +634,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -636,6 +660,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -661,6 +686,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
@@ -686,6 +712,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -711,6 +738,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -737,6 +765,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitSpirv         = None,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFeature    = False,
             apicall           = 'VKAPI_ATTR ',
@@ -745,6 +774,32 @@ def makeGenOpts(args):
             alignFuncParam    = 48,
             expandEnumerants  = False,
             helper_file_type  = 'synchronization_helper_header')
+        ]
+
+    # Options for spirv_validation_helper code-generated header
+    genOpts['spirv_validation_helper.cpp'] = [
+          SpirvValidationHelperOutputGenerator,
+          SpirvValidationHelperOutputGeneratorOptions(
+            conventions       = conventions,
+            filename          = 'spirv_validation_helper.cpp',
+            directory         = directory,
+            genpath           = None,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat,
+            emitSpirv         = emitSpirvPat,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFeature    = False,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            expandEnumerants  = False)
         ]
 
 # Generate a target based on the options in the matching genOpts{} object.
@@ -774,6 +829,7 @@ def genTarget(args):
             write('* options.addExtensions     =', options.addExtensions, file=sys.stderr)
             write('* options.removeExtensions  =', options.removeExtensions, file=sys.stderr)
             write('* options.emitExtensions    =', options.emitExtensions, file=sys.stderr)
+            write('* options.emitSpirv         =', options.emitSpirv, file=sys.stderr)
 
         gen = createGenerator(errFile=errWarn,
                               warnFile=errWarn,
@@ -808,6 +864,9 @@ if __name__ == '__main__':
     parser.add_argument('-feature', action='append',
                         default=[],
                         help='Specify a core API feature name or names to add to targets')
+    parser.add_argument('-emitSpirv', action='append',
+                        default=[],
+                        help='Specify spirv extensions or capabilities to emit in targets')
     parser.add_argument('-debug', action='store_true',
                         help='Enable debugging')
     parser.add_argument('-dump', action='store_true',
@@ -871,6 +930,7 @@ if __name__ == '__main__':
     from lvt_file_generator import LvtFileOutputGenerator, LvtFileOutputGeneratorOptions
     from command_counter_generator import CommandCounterOutputGenerator, CommandCounterOutputGeneratorOptions
     from best_practices_generator import BestPracticesOutputGenerator, BestPracticesOutputGeneratorOptions
+    from spirv_validation_generator import SpirvValidationHelperOutputGenerator, SpirvValidationHelperOutputGeneratorOptions
 
     # Temporary workaround for vkconventions python2 compatibility
     import abc; abc.ABC = abc.ABCMeta('ABC', (object,), {})

--- a/scripts/lvt_file_generator.py
+++ b/scripts/lvt_file_generator.py
@@ -56,6 +56,7 @@ class LvtFileOutputGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -78,6 +79,7 @@ class LvtFileOutputGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -76,6 +76,7 @@ class ObjectTrackerGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -102,6 +103,7 @@ class ObjectTrackerGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -76,6 +76,7 @@ class ParameterValidationGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  apicall = '',
@@ -99,6 +100,7 @@ class ParameterValidationGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.apicall         = apicall

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -1,0 +1,465 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2020 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Spencer Fricke <s.fricke@samsung.com>
+
+import os,re,sys,string,json
+import xml.etree.ElementTree as etree
+from generator import *
+from collections import namedtuple
+from common_codegen import *
+
+# This is a workaround to use a Python 2.7 and 3.x compatible syntax
+from io import open
+
+class SpirvValidationHelperOutputGeneratorOptions(GeneratorOptions):
+    def __init__(self,
+                 conventions = None,
+                 filename = None,
+                 directory = '.',
+                 genpath = None,
+                 apiname = None,
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = None,
+                 addExtensions = None,
+                 removeExtensions = None,
+                 emitExtensions = None,
+                 emitSpirv = None,
+                 sortProcedure = regSortFeatures,
+                 prefixText = "",
+                 genFuncPointers = True,
+                 protectFile = True,
+                 protectFeature = True,
+                 apicall = '',
+                 apientry = '',
+                 apientryp = '',
+                 indentFuncProto = True,
+                 indentFuncPointer = False,
+                 alignFuncParam = 0,
+                 expandEnumerants = True):
+        GeneratorOptions.__init__(self,
+                conventions = conventions,
+                filename = filename,
+                directory = directory,
+                genpath = genpath,
+                apiname = apiname,
+                profile = profile,
+                versions = versions,
+                emitversions = emitversions,
+                defaultExtensions = defaultExtensions,
+                addExtensions = addExtensions,
+                removeExtensions = removeExtensions,
+                emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
+                sortProcedure = sortProcedure)
+        self.prefixText      = prefixText
+        self.genFuncPointers = genFuncPointers
+        self.protectFile     = protectFile
+        self.protectFeature  = protectFeature
+        self.apicall         = apicall
+        self.apientry        = apientry
+        self.apientryp       = apientryp
+        self.indentFuncProto = indentFuncProto
+        self.indentFuncPointer = indentFuncPointer
+        self.alignFuncParam  = alignFuncParam
+        self.expandEnumerants = expandEnumerants
+#
+# SpirvValidationHelperOutputGenerator - Generate SPIR-V validation
+# for SPIR-V extensions and capabilities
+class SpirvValidationHelperOutputGenerator(OutputGenerator):
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+        self.extensions = dict()
+        self.capabilities = dict()
+
+        # TODO - Remove these ExludeList array in future when script is been used in a few releases
+        #
+        # Sometimes the Vulkan-Headers XML will mention new SPIR-V capability or extensions
+        # That require an update of the SPIRV-Headers which might not be ready to pull in.
+        # These 2 arrays SHOULD be empty when possible and when the SPIR-V Headers are updated these
+        # should be attempted to be cleared
+        self.extensionExcludeList = []
+        self.capabilityExcludeList = []
+
+        # This is a list that maps the Vulkan struct a feature field is with the internal
+        # state tracker's enabled features value
+        #
+        # If a new SPIR-V Capability is added to uses a new feature struct, it will need to be
+        # added here with the name added in 'DeviceFeatures' struct
+        self.featureMap = [
+          # {'vulkan' : <Vulkan Spec Feature Struct Name>, 'layer' : <Name of variable in CoreChecks DeviceFeatures>},
+            {'vulkan' : 'VkPhysicalDeviceFeatures', 'layer' : 'core'},
+            {'vulkan' : 'VkPhysicalDeviceVulkan11Features', 'layer' : 'core11'},
+            {'vulkan' : 'VkPhysicalDeviceVulkan12Features', 'layer' : 'core12'},
+            {'vulkan' : 'VkPhysicalDeviceTransformFeedbackFeaturesEXT', 'layer' : 'transform_feedback_features'},
+            {'vulkan' : 'VkPhysicalDeviceCooperativeMatrixFeaturesNV', 'layer' : 'cooperative_matrix_features'},
+            {'vulkan' : 'VkPhysicalDeviceComputeShaderDerivativesFeaturesNV', 'layer' : 'compute_shader_derivatives_features'},
+            {'vulkan' : 'VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV', 'layer' : 'fragment_shader_barycentric_features'},
+            {'vulkan' : 'VkPhysicalDeviceShaderImageFootprintFeaturesNV', 'layer' : 'shader_image_footprint_features'},
+            {'vulkan' : 'VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT', 'layer' : 'fragment_shader_interlock_features'},
+            {'vulkan' : 'VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT', 'layer' : 'demote_to_helper_invocation_features'},
+            {'vulkan' : 'VkPhysicalDeviceRayQueryFeaturesKHR', 'layer' : 'ray_query_features'},
+            {'vulkan' : 'VkPhysicalDeviceRayTracingPipelineFeaturesKHR', 'layer' : 'ray_tracing_pipeline_features'},
+            {'vulkan' : 'VkPhysicalDeviceAccelerationStructureFeaturesKHR', 'layer' : 'ray_tracing_acceleration_structure_features'},
+            {'vulkan' : 'VkPhysicalDeviceFragmentDensityMapFeaturesEXT', 'layer' : 'fragment_density_map_features'},
+            {'vulkan' : 'VkPhysicalDeviceBufferDeviceAddressFeaturesEXT', 'layer' : 'buffer_device_address_ext'},
+            {'vulkan' : 'VkPhysicalDeviceFragmentShadingRateFeaturesKHR', 'layer' : 'fragment_shading_rate_features'},
+            {'vulkan' : 'VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL', 'layer' : 'shader_integer_functions2_features'},
+            {'vulkan' : 'VkPhysicalDeviceShaderSMBuiltinsFeaturesNV', 'layer' : 'shader_sm_builtins_feature'},
+            {'vulkan' : 'VkPhysicalDeviceShadingRateImageFeaturesNV', 'layer' : 'shading_rate_image'},
+            {'vulkan' : 'VkPhysicalDeviceShaderAtomicFloatFeaturesEXT', 'layer' : 'shader_atomic_float_feature'},
+            {'vulkan' : 'VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT', 'layer' : 'shader_image_atomic_int64_feature'},
+        ]
+
+        # Properties are harder to handle genearted without generating a template for every property struct type
+        # The simpler solution is create strings that will be printed out as static comparisons at compile time
+        # The Map is used to map Vulkan property structs with the state tracker variable name
+        self.propertyInfo = dict()
+        self.propertyMap = {
+            'VkPhysicalDeviceVulkan11Properties' : 'phys_dev_props_core11',
+            'VkPhysicalDeviceVulkan12Properties' : 'phys_dev_props_core12',
+        }
+
+    #
+    # Called at beginning of processing as file is opened
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+        # File Comment
+        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
+        file_comment += '// See spirv_validation_generator.py for modifications\n'
+        write(file_comment, file=self.outFile)
+        # Copyright Statement
+        copyright = ''
+        copyright += '\n'
+        copyright += '/***************************************************************************\n'
+        copyright += ' *\n'
+        copyright += ' * Copyright (c) 2020 The Khronos Group Inc.\n'
+        copyright += ' *\n'
+        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
+        copyright += ' * you may not use this file except in compliance with the License.\n'
+        copyright += ' * You may obtain a copy of the License at\n'
+        copyright += ' *\n'
+        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
+        copyright += ' *\n'
+        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
+        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
+        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
+        copyright += ' * See the License for the specific language governing permissions and\n'
+        copyright += ' * limitations under the License.\n'
+        copyright += ' *\n'
+        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
+        copyright += ' *\n'
+        copyright += ' ****************************************************************************/\n'
+        write(copyright, file=self.outFile)
+        write('#include <unordered_map>', file=self.outFile)
+        write('#include <string>', file=self.outFile)
+        write('#include <functional>', file=self.outFile)
+        write('#include <spirv/unified1/spirv.hpp>', file=self.outFile)
+        write('#include "vk_extension_helper.h"', file=self.outFile)
+        write('#include "core_validation_types.h"', file=self.outFile)
+        write('#include "core_validation.h"', file=self.outFile)
+        write(self.featurePointer(), file=self.outFile)
+        write(self.mapStructDeclarations(), file=self.outFile)
+    #
+    # Write generated file content to output file
+    def endFile(self):
+        write(self.capabilityStruct(), file=self.outFile)
+        write(self.extensionStruct(), file=self.outFile)
+        write(self.enumHelper(), file=self.outFile)
+        write(self.validateFunction(), file=self.outFile)
+        # Finish processing in superclass
+        OutputGenerator.endFile(self)
+    #
+    # Processing point at beginning of each extension definition
+    def beginFeature(self, interface, emit):
+        OutputGenerator.beginFeature(self, interface, emit)
+        self.featureExtraProtect = GetFeatureProtect(interface)
+    #
+    # Capture all SPIR-V elements from registry
+    def genSpirv(self, spirvinfo, spirvName, alias):
+        OutputGenerator.genSpirv(self, spirvinfo, spirvName, alias)
+        spirvElem = spirvinfo.elem
+        name = spirvElem.get('name')
+        enables = []
+        for elem in spirvElem:
+            if elem.tag != 'enable':
+                self.logMsg('error', 'should only be <enable> tags in ' + name)
+            # Each <enable> holds only one possible requirment
+            # This internal python dict is to represent the struct generated later
+            enable = {
+                'version' : None,
+                'feature' : None,
+                'extension' : None,
+                'property' : None,
+            }
+            if 'version' in elem.attrib:
+                enable['version'] = elem.attrib['version']
+            elif 'feature' in elem.attrib:
+                enable['feature'] = {
+                    'feature' : elem.attrib['feature'],
+                    'struct' : elem.attrib['struct']
+                }
+            elif 'extension' in elem.attrib:
+                enable['extension'] = elem.attrib['extension']
+            elif 'property' in elem.attrib:
+                enable['property'] =  {
+                    'property' : elem.attrib['property'],
+                    'member' : elem.attrib['member'],
+                    'value' : elem.attrib['value']
+                }
+            else:
+                self.logMsg('error', 'No known attributes in <enable> for ' + name)
+            enables.append(enable)
+        if spirvElem.tag == 'spirvcapability':
+            self.capabilities[name] = enables
+        elif spirvElem.tag == 'spirvextension':
+            self.extensions[name] = enables
+    #
+    # Creates the Enum string helpers for better error messages. Same idea of vk_enum_string_helper.h but for SPIR-V
+    def enumHelper(self):
+        # There are some enums that share the same value in the SPIR-V header.
+        # This array remove the duplicate to not print out, usually due to being the older value given
+        excludeList = ['ShaderViewportIndexLayerNV', 'ShadingRateNV']
+        output =  'static inline const char* string_SpvCapability(uint32_t input_value) {\n'
+        output += '    switch ((spv::Capability)input_value) {\n'
+        for name, enables in sorted(self.capabilities.items()):
+            if name not in excludeList:
+                output += '         case spv::Capability' + name + ':\n'
+                output += '            return \"' + name + '\";\n'
+        output += '        default:\n'
+        output += '            return \"Unhandled OpCapability\";\n'
+        output += '    };\n'
+        output += '};'
+        return output
+    #
+    # Creates the FeaturePointer struct to map features with those in the layers state tracker
+    def featurePointer(self):
+        output = '\n'
+        output += 'struct FeaturePointer {\n'
+        output += '    // Callable object to test if this feature is enabled in the given aggregate feature struct\n'
+        output += '    const std::function<VkBool32(const DeviceFeatures &)> IsEnabled;\n'
+        output += '\n'
+        output += '    // Test if feature pointer is populated\n'
+        output += '    explicit operator bool() const { return static_cast<bool>(IsEnabled); }\n'
+        output += '\n'
+        output += '    // Default and nullptr constructor to create an empty FeaturePointer\n'
+        output += '    FeaturePointer() : IsEnabled(nullptr) {}\n'
+        output += '    FeaturePointer(std::nullptr_t ptr) : IsEnabled(nullptr) {}\n'
+        output += '\n'
+        output += '    // Constructors to populate FeaturePointer based on given pointer to member\n'
+        for feature in self.featureMap:
+            output += '    FeaturePointer(VkBool32 ' + feature['vulkan'] + '::*ptr)\n'
+            output += '        : IsEnabled([=](const DeviceFeatures &features) { return features.' + feature['layer'] + '.*ptr; }) {}\n'
+        output += '};\n'
+        return output
+    #
+    # Declare the struct that contains requirement for the spirv info
+    def mapStructDeclarations(self):
+        output = '// Each instance of the struct will only have a singel field non-null\n'
+        output += 'struct RequiredSpirvInfo {\n'
+        output += '    uint32_t version;\n'
+        output += '    FeaturePointer feature;\n'
+        output += '    ExtEnabled DeviceExtensions::*extension;\n'
+        output += '    const char* property; // For human readability and make some capabilities unique\n'
+        output += '};\n'
+        return output
+    #
+    # Creates the value of the struct declared in mapStructDeclarations()
+    def createMapValue(self, name, enable, isExtension):
+        output = ''
+        if enable['version'] != None:
+            # Version should be VK_API_VERSION_x_x as defined in header
+            output = '{' + enable['version'] + ', nullptr, nullptr, ""}'
+        elif enable['feature'] != None:
+            output = '{0, &' + enable['feature']['struct'] + '::'  + enable['feature']['feature'] + ', nullptr, ""}'
+        elif enable['extension'] != None:
+            # All fields in DeviceExtensions should just be the extension name lowercase
+            output = '{0, nullptr, &DeviceExtensions::' + enable['extension'].lower() + ', ""}'
+        elif enable['property'] != None:
+            propertyStruct = enable['property']['property']
+            # Need to make sure to return a boolean value to prevent compiler warning for implicit conversions
+            propertyLogic = "(" + propertyStruct + '::' + enable['property']['member'] + ' & ' + enable['property']['value'] + ") != 0"
+            # Save info later to be printed out
+            self.propertyInfo[name] = {
+                "logic" : propertyLogic,
+                "struct" : propertyStruct,
+                "isExtension" : isExtension
+            }
+            # For properties, this string is just for human readableness
+            output = '{0, nullptr, nullptr, "' + propertyLogic + '"}'
+        else:
+            output = '{0, nullptr, nullptr, ""}'
+        return output
+    #
+    # Build the struct with all the requirments for the spirv capabilities
+    def capabilityStruct(self):
+        output = '// clang-format off\n'
+        output += 'static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirvCapabilities = {\n'
+
+        # Sort so the order is the same on Windows and Unix
+        for name, enables in sorted(self.capabilities.items()):
+            for enable in enables:
+                # Prepend with comment and comment out line if in exclude list as explained in declaration
+                if name in self.capabilityExcludeList:
+                    output += '    // Not found in current SPIR-V Headers\n    //'
+                output += '    {spv::Capability' + name + ', ' + self.createMapValue(name, enable, False) + '},\n'
+        output += '};\n'
+        output += '// clang-format on\n'
+        return output
+    #
+    # Build the struct with all the requirments for the spirv extensions
+    def extensionStruct(self):
+        output = '// clang-format off\n'
+        output += 'static const std::unordered_multimap<std::string, RequiredSpirvInfo> spirvExtensions = {\n'
+
+        # Sort so the order is the same on Windows and Unix
+        for name, enables in sorted(self.extensions.items()):
+            for enable in enables:
+                # Prepend with comment and comment out line if in exclude list as explained in declaration
+                if name in self.extensionExcludeList:
+                    output += '    // Not found in current SPIR-V Headers\n    //'
+                output += '    {\"' + name + '\", ' + self.createMapValue(name, enable, True) + '},\n'
+        output += '};\n'
+        output += '// clang-format on\n'
+        return output
+    #
+    # The main function to validate all the extensions and capabilities
+    def validateFunction(self):
+        output = '''
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const *src) const {
+    bool skip = false;
+
+    for (auto insn : *src) {
+        if (insn.opcode() == spv::OpCapability) {
+            // All capabilities are generated so if it is not in the list it is not supported by Vulkan
+            if (spirvCapabilities.count(insn.word(1)) == 0) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01090",
+                    "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.word(1)));
+                    continue;
+            }
+
+            // Each capability has one or more requirements to check
+            // Only one item has to be satisfied and an error only occurs
+            // when all are not satisfied
+            auto caps = spirvCapabilities.equal_range(insn.word(1));
+            bool has_support = false;
+            for (auto it = caps.first; (it != caps.second) && (has_support == false); ++it) {
+                if (it->second.version) {
+                    if (api_version >= it->second.version) {
+                        has_support = true;
+                    }
+                } else if (it->second.feature) {
+                    if (it->second.feature.IsEnabled(enabled_features)) {
+                        has_support = true;
+                    }
+                } else if (it->second.extension) {
+                    if (device_extensions.*(it->second.extension)) {
+                        has_support = true;
+                    }
+                } else if (it->second.property) {
+                    switch (insn.word(1)) {
+                        default:
+                            break;'''
+
+        for name, info in sorted(self.propertyInfo.items()):
+            # Only capabilities here
+            if info['isExtension'] == True:
+                continue
+            # Need to string replace property string to create valid C++ logic
+            logic = info['logic'].replace('::', '.')
+            logic = logic.replace(info['struct'], self.propertyMap[info['struct']])
+
+            output += '''
+                        case spv::Capability{}:
+                            has_support = ({});
+                            break;'''.format(name, logic)
+
+        output += '''
+                    }
+                }
+            }
+
+            if (has_support == false) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01091",
+                    "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.word(1)));
+                    continue;
+            }
+
+        } else if (insn.opcode() == spv::OpExtension) {
+            std::string extension_name = (char const *)&insn.word(1);
+
+            if (spirvExtensions.count(extension_name) == 0) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-04146",
+                    "vkCreateShaderModule(): A SPIR-V Extension (%s) was declared that is not supported by Vulkan.", extension_name.c_str());
+               continue;
+            }
+
+            // Each SPIR-V Extension has one or more requirements to check
+            // Only one item has to be satisfied and an error only occurs
+            // when all are not satisfied
+            auto ext = spirvExtensions.equal_range(extension_name);
+            bool has_support = false;
+            for (auto it = ext.first; (it != ext.second) && (has_support == false); ++it) {
+                if (it->second.version) {
+                    if (api_version >= it->second.version) {
+                        has_support = true;
+                    }
+                } else if (it->second.feature) {
+                    if (it->second.feature.IsEnabled(enabled_features)) {
+                        has_support = true;
+                    }
+                } else if (it->second.extension) {
+                    if (device_extensions.*(it->second.extension)) {
+                        has_support = true;
+                    }
+                } else if (it->second.property) {
+                    switch (insn.word(1)) {
+                        default:
+                            break;'''
+
+        for name, info in sorted(self.propertyInfo.items()):
+            # Only extensions here
+            if info['isExtension'] == False:
+                continue
+            # Need to string replace property string to create valid C++ logic
+            logic = info['logic'].replace('::', '.')
+            logic = logic.replace(info['struct'], self.propertyMap[info['struct']])
+
+            output += '''
+                        case spv::Capability{}:
+                            has_support = ({});
+                            break;'''.format(name, logic)
+
+        output += '''
+                    }
+                }
+            }
+
+            if (has_support == false) {
+                skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-04147",
+                    "vkCreateShaderModule(): The SPIR-V Extension (%s) was declared, but none of the requirements were met to use it.", extension_name.c_str());
+                    continue;
+            }
+        }
+    }
+    return skip;
+}'''
+        return output

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -72,6 +72,7 @@ class ThreadGeneratorOptions(GeneratorOptions):
                  addExtensions = None,
                  removeExtensions = None,
                  emitExtensions = None,
+                 emitSpirv = None,
                  sortProcedure = regSortFeatures,
                  prefixText = "",
                  genFuncPointers = True,
@@ -97,6 +98,7 @@ class ThreadGeneratorOptions(GeneratorOptions):
                 addExtensions = addExtensions,
                 removeExtensions = removeExtensions,
                 emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
                 sortProcedure = sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -61,6 +61,7 @@ layer_source_files = [common_codegen.repo_relative(path) for path in [
     'layers/stateless_validation.h',
     'layers/generated/parameter_validation.cpp',
     'layers/generated/object_tracker.cpp',
+    'layers/generated/spirv_validation_helper.cpp',
 ]]
 
 test_source_files = glob.glob(os.path.join(common_codegen.repo_relative('tests'), '*.cpp'))

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -1804,11 +1804,13 @@ TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension2of2) {
     TEST_DESCRIPTION("Create a shader in which uses a non-unique capability ID extension, 2 of 2");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME)) {
-        printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix, VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
+    // Need to use SPV_EXT_shader_viewport_index_layer
+    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+        printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix,
+               VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
+    m_device_extension_names.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // These tests require that the device support multiViewport


### PR DESCRIPTION
Closes #1022 

This uses the new SPIR-V tags in the XML starting in 1.2.159 which contain the information of all SPIR-V capabilities and extension and what they need (vulkan features, version, ext, etc) to be used

There is still some manual work needed in top of `spirv_validation_generator.py` do to nature of mapping to variable names and cases where the public SPIR-V Header isn't updated before the Vulkan Header are for a new extension

---

Adds 
- VUID-VkShaderModuleCreateInfo-pCode-01090
- VUID-VkShaderModuleCreateInfo-pCode-01091
- VUID-VkShaderModuleCreateInfo-pCode-04146
- VUID-VkShaderModuleCreateInfo-pCode-04147