### PR TITLE
cmake: Add BUILD_WERROR

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -247,6 +247,7 @@ on/off options currently supported by this repository:
 | BUILD_LAYER_SUPPORT_FILES | All | `OFF` | Controls whether or not layer support files are installed. |
 | BUILD_TESTS | All | `???` | Controls whether or not the validation layer tests are built. The default is `ON` when the Google Test repository is cloned into the `external` directory.  Otherwise, the default is `OFF`. |
 | INSTALL_TESTS | All | `OFF` | Controls whether or not the validation layer tests are installed. This option is only available when a copy of Google Test is available
+| BUILD_WERROR | Linux | `ON` | Controls whether or not to treat compiler warnings as errors. |
 | BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the components with XCB support. |
 | BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the components with Xlib support. |
 | BUILD_WSI_WAYLAND_SUPPORT | Linux | `ON` | Build the components with Wayland support. |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,14 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
                         -fvisibility=hidden)
 
     # Treat warnings as errors for versions of GCC and c++11-compliant Clang versions that are shipped on Ubuntu 18.04 or older.
-    if((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
-       (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND
-        (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0) AND
-        (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 7.0.0)))
-        add_compile_options(-Werror)
+    option(BUILD_WERROR "Build with -Werror" ON)
+    if(BUILD_WERROR)
+        if((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
+           (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND
+            (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0) AND
+            (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 7.0.0)))
+            add_compile_options(-Werror)
+        endif()
     endif()
 
     set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
The user's compiler may not be the same as the developer's compiler and its useful to allow disabling `-Werror` in such cases. By default it will be enabled to avoid changing the current behavior, but can be disabled by passing `-DBUILD_WERROR=OFF` as a cmake argument.

Also see the similar PR https://github.com/LunarG/gfxreconstruct/pull/459 for reference.