### PR TITLE
build: Allow generating layers json file for cross-compiling

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -191,7 +191,20 @@ if (!is_android) {
       sources += [ "layers/json/$json_name.in" ]
       outputs += [ "$vulkan_data_dir/$json_name" ]
     }
+
+    if (is_linux) {
+      _platform = "Linux"
+    } else if (is_win) {
+      _platform = "Windows"
+    } else if (is_mac) {
+      _platform = "Darwin"
+    } else {
+      _platform = "Other"
+    }
+
     args = [
+             "--platform",
+             _platform,
              rebase_path("layers/json", root_build_dir),
              rebase_path(vulkan_data_dir, root_build_dir),
            ] + rebase_path(sources, root_build_dir)

--- a/build-gn/generate_vulkan_layers_json.py
+++ b/build-gn/generate_vulkan_layers_json.py
@@ -35,6 +35,9 @@ def glob_slash(dirname):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--icd', action='store_true')
+    parser.add_argument('--platform', type=str, default=platform.system(),
+        help='Target platform to build validation layers for: '
+             'Linux|Darwin|Windows|...')
     parser.add_argument('source_dir')
     parser.add_argument('target_dir')
     parser.add_argument('version_header', help='path to vulkan_core.h')
@@ -97,10 +100,10 @@ def main():
     # Set json file prefix and suffix for generating files, default to Linux.
     relative_path_prefix = '../lib'
     file_type_suffix = '.so'
-    if platform.system() == 'Windows':
+    if args.platform == 'Windows':
         relative_path_prefix = r'..\\'  # json-escaped, hence two backslashes.
         file_type_suffix = '.dll'
-    elif platform.system() == 'Darwin':
+    elif args.platform == 'Darwin':
         file_type_suffix = '.dylib'
 
     # For each *.json.in template files in source dir generate actual json file


### PR DESCRIPTION
This change adds an optional argument `--platform Linux|Darwin|Windows|...` to `generate_vulkan_layers_json.py`, so that it could
generate layers json file with correct library filename for specific target platforms. It is useful when making cross-platform builds.

Test: Run `generate_vulkan_layers_json.py`
1) without `--platform` argument, 2) with `--platform Windows`, 3) with "--platform Linux` and 4) `--platform Darwin`.