### PR TITLE
cmake: Install the header files into the vulkan directory

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -72,7 +72,7 @@ if(BUILD_LAYER_SUPPORT_FILES)
         generated/vk_object_types.h
         generated/vk_extension_helper.h
         generated/vk_typemap_helper.h)
-    install(FILES ${LAYER_UTIL_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(FILES ${LAYER_UTIL_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan)
 endif()
 
 set(TARGET_NAMES


### PR DESCRIPTION
When building with `BUILD_LAYER_SUPPORT_FILES` enabled which is required when building `VulkanTools` (https://github.com/LunarG/VulkanTools) it will install all of the files into `/usr/include` by default. However at least one file, `xxhash.h`, will conflict with `xxHash` package. I think its better to instead install to `/usr/include/vulkan` which is used by the `Vulkan-Headers` already and entirely avoid any conflicts. If you have any better ideas where to install it I can change that.

I have a patch for `VulkanTools` already for if and when this is merged, I am not sure if there are any other projects that would need to be changed?