### PR TITLE
Fix queue retirement propagation via timeline semaphores

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1345,6 +1345,7 @@ static inline QFOTransferBarrierSets<VkBufferMemoryBarrier> &GetQFOBarrierSets(
 
 struct SEMAPHORE_WAIT {
     VkSemaphore semaphore;
+    VkSemaphoreTypeKHR type;
     VkQueue queue;
     uint64_t payload;
     uint64_t seq;


### PR DESCRIPTION
I encountered false-positive validation errors doing this:
1. Submit work CB1 to queue Q1 that signals timeline semaphore S with value V.
2. Submit work CB2 to queue Q2 that wait on S with value V and signals fence F.
3. Wait for F.
4. Destroy resources used only in CB1.

This PR fixes propagation of queue work retirement through timeline semaphores across queues.