### PR TITLE
Warn for an application's use of 'specialuse' extensions

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -36,6 +36,10 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_Deprecated
     "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_DeprecatedExtension =
     "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_API_Mismatch =
     "UNASSIGNED-BestPractices-vkCreateDevice-API-version-mismatch";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SharingModeExclusive =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -117,6 +117,38 @@ bool BestPractices::ValidateDeprecatedExtensions(const char* api_name, const cha
     return skip;
 }
 
+bool BestPractices::ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const char* vuid) const {
+    bool skip = false;
+    auto dep_info_it = special_use_extensions.find(extension_name);
+
+    if (dep_info_it != special_use_extensions.end()) {
+        auto special_uses = dep_info_it->second;
+        std::string message("is intended to support the following uses: ");
+        if (special_uses.find("cadsupport") != std::string::npos) {
+            message.append("specialized functionality used by CAD/CAM applications, ");
+        }
+        if (special_uses.find("d3demulation") != std::string::npos) {
+            message.append("D3D emulation layers, and applications ported from D3D, by adding functionality specific to D3D, ");
+        }
+        if (special_uses.find("devtools") != std::string::npos) {
+            message.append(" developer tools such as capture-replay libraries, ");
+        }
+        if (special_uses.find("debugging") != std::string::npos) {
+            message.append("use by applications when debugging, ");
+        }
+        if (special_uses.find("glemulation") != std::string::npos) {
+            message.append(
+                "OpenGL and/or OpenGL ES emulation layers, and applications ported from those APIs, by adding functionality "
+                "specific to those APIs, ");
+        }
+        message.append("and it is strongly recommended that they be otherwise avoided");
+
+        skip |= LogWarning(instance, vuid, "%s(): Attempting to enable extension %s, but this extension %s.", api_name,
+                           extension_name, message.c_str());
+    }
+    return skip;
+}
+
 bool BestPractices::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                                   VkInstance* pInstance) const {
     bool skip = false;

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -163,6 +163,8 @@ bool BestPractices::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pC
             (pCreateInfo->pApplicationInfo ? pCreateInfo->pApplicationInfo->apiVersion : VK_API_VERSION_1_0);
         skip |= ValidateDeprecatedExtensions("CreateInstance", pCreateInfo->ppEnabledExtensionNames[i], specified_version,
                                              kVUID_BestPractices_CreateInstance_DeprecatedExtension);
+        skip |= ValidateSpecialUseExtensions("CreateInstance", pCreateInfo->ppEnabledExtensionNames[i],
+                                             kVUID_BestPractices_CreateInstance_SpecialUseExtension);
     }
 
     return skip;
@@ -205,6 +207,8 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
         }
         skip |= ValidateDeprecatedExtensions("CreateDevice", pCreateInfo->ppEnabledExtensionNames[i], instance_api_version,
                                              kVUID_BestPractices_CreateDevice_DeprecatedExtension);
+        skip |= ValidateSpecialUseExtensions("CreateInstance", pCreateInfo->ppEnabledExtensionNames[i],
+                                             kVUID_BestPractices_CreateDevice_SpecialUseExtension);
     }
 
     const auto bp_pd_state = GetPhysicalDeviceStateBP(physicalDevice);

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -112,6 +112,8 @@ class BestPractices : public ValidationStateTracker {
 
     bool ValidateDeprecatedExtensions(const char* api_name, const char* extension_name, uint32_t version, const char* vuid) const;
 
+    bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const char* vuid) const;
+
     bool PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                     uint32_t stride) const;

--- a/layers/generated/best_practices.h
+++ b/layers/generated/best_practices.h
@@ -1708,3 +1708,21 @@ const std::unordered_map<std::string, DeprecationData>  deprecated_extensions = 
     {"VK_NV_win32_keyed_mutex", {kExtPromoted, "VK_KHR_win32_keyed_mutex"}},
 };
 
+const std::unordered_map<std::string, std::string> special_use_extensions = {
+    {"VK_AMD_buffer_marker", "devtools"},
+    {"VK_AMD_shader_info", "devtools"},
+    {"VK_EXT_debug_marker", "debugging"},
+    {"VK_EXT_debug_report", "debugging"},
+    {"VK_EXT_debug_utils", "debugging"},
+    {"VK_EXT_depth_clip_enable", "d3demulation"},
+    {"VK_EXT_device_memory_report", "devtools"},
+    {"VK_EXT_line_rasterization", "cadsupport"},
+    {"VK_EXT_pipeline_creation_feedback", "devtools"},
+    {"VK_EXT_transform_feedback", "glemulation, d3demulation, devtools"},
+    {"VK_EXT_validation_features", "debugging"},
+    {"VK_EXT_validation_flags", "debugging"},
+    {"VK_INTEL_performance_query", "devtools"},
+    {"VK_KHR_performance_query", "devtools"},
+    {"VK_KHR_pipeline_executable_properties", "devtools"},
+};
+

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -113,6 +113,7 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
 
     // Create a 1.1 vulkan instance and request an extension promoted to core in 1.1
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension");
     VkInstance dummy;
     auto features = features_;
     auto ici = GetInstanceCreateInfo();
@@ -184,6 +185,40 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+    vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
+    TEST_DESCRIPTION("Create a device with a 'specialuse' extension.");
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME)) {
+        m_device_extension_names.push_back(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
+    } else {
+        printf("%s %s Extension not supported, skipping test\n", kSkipPrefix, VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
+        return;
+    }
+
+    VkDevice local_device;
+    VkDeviceCreateInfo dev_info = {};
+    VkDeviceQueueCreateInfo queue_info = {};
+    queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_info.pNext = NULL;
+    queue_info.queueFamilyIndex = 0;
+    queue_info.queueCount = 1;
+    queue_info.pQueuePriorities = nullptr;
+    dev_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dev_info.pNext = nullptr;
+    dev_info.queueCreateInfoCount = 1;
+    dev_info.pQueueCreateInfos = &queue_info;
+    dev_info.enabledLayerCount = 0;
+    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.enabledExtensionCount = m_device_extension_names.size();
+    dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
+
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension");
     vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
XML tags half a dozen categories of special use extensions and layers should warn if one is used.