### PR TITLE
layers: Fix typedef and spelling

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -379,13 +379,13 @@ class CoreChecks : public ValidationStateTracker {
                                                 void* pData);
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(VkPipelineBindPoint bind_point, const cvdescriptorset::DescriptorSet* descriptor_set,
-                           const std::map<uint32_t, DescriptorReqirement>& bindings, const std::vector<uint32_t>& dynamic_offsets,
+                           const BindingReqMap& bindings, const std::vector<uint32_t>& dynamic_offsets,
                            const CMD_BUFFER_STATE* cb_node, const std::vector<VkImageView>& attachment_views, const char* caller,
                            const DrawDispatchVuid& vuids) const;
     bool ValidateDescriptorSetBindingData(VkPipelineBindPoint bind_point, const CMD_BUFFER_STATE* cb_node,
                                           const cvdescriptorset::DescriptorSet* descriptor_set,
                                           const std::vector<uint32_t>& dynamic_offsets,
-                                          std::pair<const uint32_t, DescriptorReqirement>& binding_info, VkFramebuffer framebuffer,
+                                          std::pair<const uint32_t, DescriptorRequirement>& binding_info, VkFramebuffer framebuffer,
                                           const std::vector<VkImageView>& attachment_views, const char* caller,
                                           const DrawDispatchVuid& vuids) const;
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -178,19 +178,19 @@ struct less<SamplerUsedByImage> {
 };
 }  // namespace std
 
-struct DescriptorReqirement {
+struct DescriptorRequirement {
     descriptor_req reqs;
     std::vector<std::map<SamplerUsedByImage, std::map<VkDescriptorSet, const cvdescriptorset::Descriptor *>>>
         samplers_used_by_image;  // Copy from StageState.interface_var. BUT it combines from plural shader stages.
                                  // The index of array is index of image.
-    DescriptorReqirement() : reqs(descriptor_req(0)) {}
+    DescriptorRequirement() : reqs(descriptor_req(0)) {}
 };
 
-inline bool operator==(const DescriptorReqirement &a, const DescriptorReqirement &b) NOEXCEPT { return a.reqs == b.reqs; }
+inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) NOEXCEPT { return a.reqs == b.reqs; }
 
-inline bool operator<(const DescriptorReqirement &a, const DescriptorReqirement &b) NOEXCEPT { return a.reqs < b.reqs; }
+inline bool operator<(const DescriptorRequirement &a, const DescriptorRequirement &b) NOEXCEPT { return a.reqs < b.reqs; }
 
-typedef std::map<uint32_t, DescriptorReqirement> BindingReqMap;
+typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 
 struct DESCRIPTOR_POOL_STATE : BASE_NODE {
     VkDescriptorPool pool;
@@ -1242,7 +1242,7 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
         VkPipelineBindPoint bind_point;
         CMD_TYPE cmd_type;
         std::string function;
-        std::vector<std::pair<const uint32_t, DescriptorReqirement>> binding_infos;
+        std::vector<std::pair<const uint32_t, DescriptorRequirement>> binding_infos;
         VkFramebuffer framebuffer;
         std::vector<VkImageView> attachment_views;  // vector index is attachment index. If the value is VK_NULL_HANDLE(0),
                                                     // it means the attachment isn't used in this command.

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -629,7 +629,7 @@ class DescriptorSet : public BASE_NODE {
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *, CMD_TYPE cmd_type, const PIPELINE_STATE *,
-                         const std::map<uint32_t, DescriptorReqirement> &, const char *function);
+                         const BindingReqMap &, const char *function);
 
     // Track work that has been bound or validated to avoid duplicate work, important when large descriptor arrays
     // are present


### PR DESCRIPTION
- Apply the BindingReqMap typedef to where it should have been used.
  This will make it easier to modify the typedef in the future.
- Fix spelling of DescriptorRequirement.

Change-Id: If199357cbedb7249245ab62d0785957206ecb6c6