### PR TITLE
layers: Initial VK_KHR_portability_subset support

### DIFF
--- a/docs/portability_validation.md
+++ b/docs/portability_validation.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD041 -->
+<!-- Copyright 2020 LunarG, Inc. -->
+[![Khronos Vulkan][1]][2]
+
+[1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
+[2]: https://www.khronos.org/vulkan/
+
+# VK_KHR_portability_subset Validation
+
+## Requirements
+
+Either
+- The [VK_LAYER_LUNARG_device_simulation](https://vulkan.lunarg.com/doc/sdk/1.2.154.1/windows/device_simulation_layer.html) layer with portability enabled _or_
+- A driver that supports `VK_KHR_portability_subset`.
+
+## Running the tests
+The following is an example setup for running the portability tests on Windows with devsim:
+```powershell
+# Replace ';' with ':' when running on *nix
+$env:VK_LAYER_PATH="/path/to/VulkanTools/build/layersvt/Debug;/path/to/Vulkan-ValidationLayers/build/layers/Debug"
+
+# Make sure the devsim layer is loaded.
+# Again be sure to replace ';' with ':' when running on *nix.
+$env:VK_INSTANCE_LAYERS="VK_LAYER_KHRONOS_validation;VK_LAYER_LUNARG_device_simulation"
+
+# This environment variable must be set to ensure portability is enabled as there is currently no programatic way to enable portability in the devsim layer
+$env:VK_DEVSIM_EMULATE_PORTABILITY_SUBSET_EXTENSION="1"
+
+/path/to/Vulkan-ValidationLayers/build/tests/Debug/vk_layer_validation_tests.exe --gtest_filter=VkPortability*
+```

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13727,6 +13727,18 @@ bool CoreChecks::PreCallValidateCmdSetStencilOpEXT(VkCommandBuffer commandBuffer
     return skip;
 }
 
+bool CoreChecks::PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,
+                                            const VkAllocationCallbacks *pAllocator, VkEvent *pEvent) const {
+    bool skip = false;
+    if (device_extensions.vk_khr_portability_subset != ExtEnabled::kNotEnabled) {
+        if (VK_FALSE == enabled_features.portability_subset_features.events) {
+            skip |= LogError(device, "VUID-vkCreateEvent-events-04468",
+                             "vkCreateEvent: events are not supported via VK_KHR_portability_subset");
+        }
+    }
+    return skip;
+}
+
 void PIPELINE_STATE::initGraphicsPipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                                           std::shared_ptr<const RENDER_PASS_STATE> &&rpstate) {
     reset();

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1362,6 +1362,9 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                            VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) const;
 
+    bool PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                    VkEvent* pEvent) const final;
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                   VkAndroidHardwareBufferPropertiesANDROID* pProperties) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1463,6 +1463,7 @@ struct DeviceFeatures {
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipeline_creation_cache_control_features;
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features;
     VkPhysicalDeviceMultiviewFeatures multiview_features;
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features;
 };
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1851,6 +1851,11 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         state_tracker->enabled_features.multiview_features = *multiview_features;
     }
 
+    const auto *portability_features = lvl_find_in_chain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(pCreateInfo->pNext);
+    if (portability_features) {
+        state_tracker->enabled_features.portability_subset_features = *portability_features;
+    }
+
     // Store physical device properties and physical device mem limits into CoreChecks structs
     DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
     DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ set(COMMON_CPP
     vklayertests_descriptor_renderpass_framebuffer.cpp
     vklayertests_command.cpp
     vklayertests_imageless_framebuffer.cpp
+    vklayertests_portability_subset.cpp
     vkpositivelayertests.cpp
     vkrenderframework.cpp
     vktestbinding.cpp
@@ -120,6 +121,11 @@ target_include_directories(vk_layer_validation_tests
                                   ${PROJECT_BINARY_DIR}/layers)
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils)
+
+option(PORTABILITY_TESTS_USE_DEVSIM "Automatically add the devsim layer for portability tests" OFF)
+if (PORTABILITY_TESTS_USE_DEVSIM)
+    target_compile_definitions(vk_layer_validation_tests PRIVATE PORTABILITY_TESTS_USE_DEVSIM=1)
+endif()
 
 # Specify target_link_libraries
 if(WIN32)

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 The Khronos Group Inc.
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Author: Nathaniel Cesario <nathaniel@lunarg.com>
+ */
+
+#include "cast_utils.h"
+#include "layer_validation_tests.h"
+
+class VkPortabilitySubsetTest : public VkLayerTest {
+  public:
+    void InitPortabilitySubsetFramework() {
+        // VK_KHR_portability_subset extension dependencies
+        instance_extensions_.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+
+        InitFramework(m_errorMonitor, nullptr);
+    }
+};
+
+TEST_F(VkPortabilitySubsetTest, ValidatePortabilityCreateDevice) {
+    TEST_DESCRIPTION("Portability: CreateDevice called and VK_KHR_portability_subset not enabled");
+
+    ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
+
+    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    if (!portability_supported) {
+        printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
+        return;
+    }
+
+    vk_testing::PhysicalDevice phys_device(gpu());
+
+    // request all queues
+    const std::vector<VkQueueFamilyProperties> queue_props = phys_device.queue_properties();
+    vk_testing::QueueCreateInfoArray queue_info(phys_device.queue_properties());
+
+    // Only request creation with queuefamilies that have at least one queue
+    std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
+    auto qci = queue_info.data();
+    for (uint32_t j = 0; j < queue_info.size(); ++j) {
+        if (qci[j].queueCount) {
+            create_queue_infos.push_back(qci[j]);
+        }
+    }
+
+    VkDeviceCreateInfo dev_info = {};
+    dev_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dev_info.pNext = nullptr;
+    dev_info.queueCreateInfoCount = create_queue_infos.size();
+    dev_info.pQueueCreateInfos = create_queue_infos.data();
+    dev_info.enabledLayerCount = 0;
+    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.enabledExtensionCount = 0;
+    dev_info.ppEnabledExtensionNames =
+        nullptr;  // VK_KHR_portability_subset not included in enabled extensions should trigger 04451
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pProperties-04451");
+    VkDevice device;
+    vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
+    TEST_DESCRIPTION("Portability: CreateEvent when not supported");
+
+    ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
+
+    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    if (!portability_supported) {
+        printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
+        return;
+    }
+    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+
+    auto portability_feature = lvl_init_struct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    portability_feature.events = VK_FALSE;  // Make sure events are disabled
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateEvent-events-04468");
+    VkEventCreateInfo eci = {VK_STRUCTURE_TYPE_EVENT_CREATE_INFO, nullptr, 0};
+    VkEvent event;
+    vk::CreateEvent(m_device->device(), &eci, nullptr, &event);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Add checks for the following VUIDs:
- VUID-VkDeviceCreateInfo-pProperties-04451.
- VUID-vkCreateEvent-events-04468.

Change-Id: I61743dc7ceddd2f4e627a7caeafacfcd0ff19d77