### PR TITLE
Remove duplicate type declaration to fix compiler error CS2386

### DIFF
--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -141,9 +141,6 @@ class range_view {
     const Range &range_;
 };
 
-template <typename Container>
-using const_correct_iterator = decltype(std::declval<Container>().begin());
-
 // Type parameters for the range_map(s)
 struct insert_range_no_split_bounds {
     const static bool split_boundaries = false;


### PR DESCRIPTION
Definition one: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/layers/range_vector.h#L144
Definition two: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/layers/range_vector.h#L673

Causes the following [error](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2386?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(C2386)%26rd%3Dtrue&view=msvc-160).
