### PR TITLE
syncval: Use correct raster order for depth/stencil resolve reads

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -392,7 +392,7 @@ void ResolveOperation(Action &action, const RENDER_PASS_STATE &rp_state, const V
 
         if (aspect_mask) {
             action(aspect_string, "resolve read", src_at, dst_at, attachment_views[src_at],
-                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, kDepthStencilAttachmentRasterOrder, offset, extent,
+                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, kAttachmentRasterOrder, offset, extent,
                    aspect_mask);
             action(aspect_string, "resolve write", src_at, dst_at, attachment_views[dst_at],
                    SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, kAttachmentRasterOrder, offset, extent, aspect_mask);


### PR DESCRIPTION
This fixes sync validation for the dEQP-VK.renderpass2.depth_stencil_resolve.*
CTS cases.

Change-Id: I4aa0cd9309d0b36707c18b7af645f321bb682605