### PR TITLE
build: Fix clang warnings

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1510,13 +1510,14 @@ bool BestPractices::ValidateIndexBufferArm(VkCommandBuffer commandBuffer, uint32
         if (max_index < min_index || max_index == min_index) return skip;
 
         if (max_index - min_index >= indexCount) {
-            skip |= LogPerformanceWarning(
-                device, kVUID_BestPractices_CmdDrawIndexed_SparseIndexBuffer,
-                "%s The indices which were specified for the draw call only utilise approximately %.02f%% of "
-                "index buffer value range. Arm Mali architectures before G71 do not have IDVS (Index-Driven "
-                "Vertex Shading), meaning all vertices corresponding to indices between the minimum and "
-                "maximum would be loaded, and possibly shaded, whether or not they are used.",
-                VendorSpecificTag(kBPVendorArm), (static_cast<float>(indexCount) / (max_index - min_index)) * 100.0f);
+            skip |=
+                LogPerformanceWarning(device, kVUID_BestPractices_CmdDrawIndexed_SparseIndexBuffer,
+                                      "%s The indices which were specified for the draw call only utilise approximately %.02f%% of "
+                                      "index buffer value range. Arm Mali architectures before G71 do not have IDVS (Index-Driven "
+                                      "Vertex Shading), meaning all vertices corresponding to indices between the minimum and "
+                                      "maximum would be loaded, and possibly shaded, whether or not they are used.",
+                                      VendorSpecificTag(kBPVendorArm),
+                                      (static_cast<float>(indexCount) / static_cast<float>(max_index - min_index)) * 100.0f);
             return skip;
         }
 
@@ -1556,9 +1557,9 @@ bool BestPractices::ValidateIndexBufferArm(VkCommandBuffer commandBuffer, uint32
         }
 
         // low index buffer utilization implies that: of the vertices available to the draw call, not all are utilized
-        float utilization = static_cast<float>(vertex_reference_count) / (max_index - min_index + 1);
+        float utilization = static_cast<float>(vertex_reference_count) / static_cast<float>(max_index - min_index + 1);
         // low hit rate (high miss rate) implies the order of indices in the draw call may be possible to improve
-        float cache_hit_rate = static_cast<float>(vertex_reference_count) / vertex_shade_count;
+        float cache_hit_rate = static_cast<float>(vertex_reference_count) / static_cast<float>(vertex_shade_count);
 
         if (utilization < 0.5f) {
             skip |= LogPerformanceWarning(device, kVUID_BestPractices_CmdDrawIndexed_SparseIndexBuffer,

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1910,7 +1910,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         uint64_t texel_count = (uint64_t)pCreateInfo->extent.width * (uint64_t)pCreateInfo->extent.height *
                                (uint64_t)pCreateInfo->extent.depth * (uint64_t)pCreateInfo->arrayLayers *
                                (uint64_t)pCreateInfo->samples;
-        uint64_t total_size = (uint64_t)std::ceil(FormatTexelSize(pCreateInfo->format) * texel_count);
+        uint64_t total_size = (uint64_t)std::ceil(FormatTexelSize(pCreateInfo->format) * static_cast<double>(texel_count));
 
         // Round up to imageGranularity boundary
         VkDeviceSize imageGranularity = phys_dev_props.limits.bufferImageGranularity;

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -449,7 +449,7 @@ bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::str
         }
     }
     if (0 == line_index) return false;
-    *linenumber = std::stoul(tokens[line_index]);
+    *linenumber = static_cast<uint32_t>(std::stoul(tokens[line_index]));
     uint32_t filename_index = line_index + 1;
     // Remove enclosing double quotes around filename
     if (size > filename_index) filename = tokens[filename_index].substr(1, tokens[filename_index].size() - 2);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -212,9 +212,9 @@ void SetLocalDisableSetting(std::string list_of_disables, std::string delimiter,
 uint32_t TokenToUint(std::string &token) {
     uint32_t int_id = 0;
     if ((token.find("0x") == 0) || token.find("0X") == 0) {  // Handle hex format
-        int_id = std::strtoul(token.c_str(), nullptr, 16);
+        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 16));
     } else {
-        int_id = std::strtoul(token.c_str(), nullptr, 10);  // Decimal format
+        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 10));  // Decimal format
     }
     return int_id;
 }
@@ -265,7 +265,7 @@ uint32_t SetMessageDuplicateLimit(std::string &config_message_limit, std::string
     auto GetNum = [](std::string &source_string) {
         uint32_t limit = 0;
         int radix = ((source_string.find("0x") == 0) ? 16 : 10);
-        limit = std::strtoul(source_string.c_str(), nullptr, radix);
+        limit = static_cast<uint32_t>(std::strtoul(source_string.c_str(), nullptr, radix));
         return limit;
     };
     // ENV var takes precedence over settings file

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -325,9 +325,10 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
 
 IndexType ImageRangeEncoder::Encode(const VkImageSubresource& subres, uint32_t layer, VkOffset3D offset) const {
     const auto& subres_layout = SubresourceLayout(subres);
-    return static_cast<IndexType>(floor(layer * subres_layout.arrayPitch + offset.z * subres_layout.depthPitch +
-                                        offset.y * subres_layout.rowPitch +
-                                        offset.x * texel_sizes_[LowerBoundFromMask(subres.aspectMask)] + subres_layout.offset));
+    return static_cast<IndexType>(floor(static_cast<double>(layer * subres_layout.arrayPitch + offset.z * subres_layout.depthPitch +
+                                                            offset.y * subres_layout.rowPitch) +
+                                        offset.x * texel_sizes_[LowerBoundFromMask(subres.aspectMask)] +
+                                        static_cast<double>(subres_layout.offset)));
 }
 
 void ImageRangeEncoder::Decode(const VkImageSubresource& subres, const IndexType& encode, uint32_t& out_layer,
@@ -340,7 +341,7 @@ void ImageRangeEncoder::Decode(const VkImageSubresource& subres, const IndexType
     decode -= (out_offset.z * subres_layout.depthPitch);
     out_offset.y = static_cast<int32_t>(decode / subres_layout.rowPitch);
     decode -= (out_offset.y * subres_layout.rowPitch);
-    out_offset.x = static_cast<int32_t>(decode / texel_sizes_[LowerBoundFromMask(subres.aspectMask)]);
+    out_offset.x = static_cast<int32_t>(static_cast<double>(decode) / texel_sizes_[LowerBoundFromMask(subres.aspectMask)]);
 }
 
 const VkSubresourceLayout& ImageRangeEncoder::SubresourceLayout(const VkImageSubresource& subres) const {

--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -31,6 +31,7 @@
 //    6/05/19 - Make changes to suppress warnings from clang 3.8.0
 //    6/05/19 - Make changes to suppress more warnings from GCC
 //    8/09/19 - Make changes to suppress dead code warnings (from upstream master branch)
+//   11/18/20 - Make changes to suppress warnings from clang
 //
 
 #ifndef AMD_VULKAN_MEMORY_ALLOCATOR_H
@@ -3129,7 +3130,7 @@ std::pair, std::vector, std::list, std::unordered_map.
 Set it to 0 or undefined to make the library using its own implementation of
 the containers.
 */
-#if VMA_USE_STL_CONTAINERS
+#if defined(VMA_USE_STL_CONTAINERS) && VMA_USE_STL_CONTAINERS
    #define VMA_USE_STL_VECTOR 1
    #define VMA_USE_STL_UNORDERED_MAP 1
    #define VMA_USE_STL_LIST 1
@@ -3142,15 +3143,15 @@ the containers.
     #endif
 #endif
 
-#if VMA_USE_STL_VECTOR
+#if defined(VMA_USE_STL_VECTOR) && VMA_USE_STL_VECTOR
    #include <vector>
 #endif
 
-#if VMA_USE_STL_UNORDERED_MAP
+#if defined(VMA_USE_STL_UNORDERED_MAP) && VMA_USE_STL_UNORDERED_MAP
    #include <unordered_map>
 #endif
 
-#if VMA_USE_STL_LIST
+#if defined(VMA_USE_STL_LIST) && VMA_USE_STL_LIST
    #include <list>
 #endif
 
@@ -3306,7 +3307,7 @@ void *aligned_alloc(size_t alignment, size_t size)
 
 // Read-write mutex, where "read" is shared access, "write" is exclusive access.
 #ifndef VMA_RW_MUTEX
-    #if VMA_USE_STL_SHARED_MUTEX
+    #if defined(VMA_USE_STL_SHARED_MUTEX) && VMA_USE_STL_SHARED_MUTEX
         // Use std::shared_mutex from C++17.
         #include <shared_mutex>
         class VmaRWMutex
@@ -3926,7 +3927,7 @@ public:
     VmaStlAllocator& operator=(const VmaStlAllocator& x) = delete;
 };
 
-#if VMA_USE_STL_VECTOR
+#if defined(VMA_USE_STL_VECTOR) && VMA_USE_STL_VECTOR
 
 #define VmaVector std::vector
 
@@ -4334,7 +4335,7 @@ typename VmaPoolAllocator<T>::ItemBlock& VmaPoolAllocator<T>::CreateNewBlock()
 ////////////////////////////////////////////////////////////////////////////////
 // class VmaRawList, VmaList
 
-#if VMA_USE_STL_LIST
+#if defined(VMA_USE_STL_LIST) && VMA_USE_STL_LIST
 
 #define VmaList std::list
 


### PR DESCRIPTION
Latest clang generated multiple build warnings.  This should resovle
the issues encountered.