### PR TITLE
Add imageFormatMaybeLinear/imageCreateDrmFormatModifiers calculation to 02257, add 02259 check

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -8279,6 +8279,28 @@ TEST_F(VkLayerTest, CreateImageMiscErrors) {
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.mipLevels = 2;
         CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+
+        image_ci = safe_image_ci;
+        image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+        image_ci.mipLevels = 1;
+        image_ci.tiling = VK_IMAGE_TILING_LINEAR;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+
+        image_ci = safe_image_ci;
+        image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+        image_ci.mipLevels = 2;
+        image_ci.flags = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-02259");
+
+        image_ci = safe_image_ci;
+        image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+        image_ci.mipLevels = 1;
+        image_ci.flags = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
+        image_ci.tiling = VK_IMAGE_TILING_LINEAR;
+        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-02259");
     }
 
     {


### PR DESCRIPTION
Spec defines these two state 'consolidations' but they were not properly accounted for in `VUID-VkImageCreateInfo-samples-02257`.  They were also used in the `VUID-VkImageCreateInfo-flags-02259` check, so that was added as well, along with some tests for both.

Fixes #1670.

> • Let uint64_t imageCreateDrmFormatModifiers[] be the set of Linux DRM format modifiers that the resultant image may have.
>      ◦ If tiling is not VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, then imageCreateDrmFormatModifiers is empty.
>      ◦ If VkImageCreateInfo::pNext contains VkImageDrmFormatModifierExplicitCreateInfoEXT, then imageCreateDrmFormatModifiers contains exactly one modifier, VkImageDrmFormatModifierExplicitCreateInfoEXT::drmFormatModifier.
>      ◦ If VkImageCreateInfo::pNext contains VkImageDrmFormatModifierListCreateInfoEXT, then 
imageCreateDrmFormatModifiers contains the entire array VkImageDrmFormatModifierListCreateInfoEXT::pDrmFormatModifiers.


> • Let VkBool32 imageCreateMaybeLinear indicate if the resultant image may be linear.
>      ◦ If tiling is VK_IMAGE_TILING_LINEAR, then imageCreateMaybeLinear is true.
>      ◦ If tiling is VK_IMAGE_TILING_OPTIMAL, then imageCreateMaybeLinear is false.
>      ◦ If tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, then imageCreateMaybeLinear_ is true if and only if imageCreateDrmFormatModifiers contains DRM_FORMAT_MOD_LINEAR.