### PR TITLE
Fixed bug for protected command buffer

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1102,7 +1102,9 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                         std::string image_desc = "Image is ";
                         image_desc.append(string_VkImageUsageFlagBits(subpass.usage));
                         // Because inputAttachment is read only, it doesn't need to care protected command buffer case.
-                        if (subpass.usage != VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
+                        // Some CMD_TYPE could not be protected. See VUID-02711.
+                        if (subpass.usage != VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT &&
+                            vuid.protected_command_buffer != kVUIDUndefined) {
                             result |= ValidateUnprotectedImage(cb_node, view_state->image_state.get(), function,
                                                                 vuid.protected_command_buffer, image_desc.c_str());
                         }

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7536,7 +7536,8 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
 
     // Use unprotected resources in protected command buffer
     g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 1024);
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[1], sampler);
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[1], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
     protectedCommandBuffer.begin();


### PR DESCRIPTION
1) Some command buffer of cmd_type couldn't be protected. They should keep this validation.
See
> VUID-vkCmdDrawIndirect-commandBuffer-02711
> commandBuffer must not be a protected command buffer

2) Using  a wrong descriptor type to cause Galaxy S10 crash.