### PR TITLE
layers: Portability validation for CreateImage

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1954,6 +1954,21 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
     skip |= ValidateImageFormatFeatures(pCreateInfo);
 
+    // Check compatibility with VK_KHR_portability_subset
+    if (ExtEnabled::kNotEnabled != device_extensions.vk_khr_portability_subset) {
+        if (VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT & pCreateInfo->flags &&
+            VK_FALSE == enabled_features.portability_subset_features.imageView2DOn3DImage) {
+            skip |= LogError(device, "VUID-VkImageCreateInfo-imageView2DOn3DImage-04459",
+                             "vkCreateImage (portability error): VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT is not supported.");
+        }
+        if ((VK_SAMPLE_COUNT_1_BIT != pCreateInfo->samples) && (1 != pCreateInfo->arrayLayers) &&
+            (VK_FALSE == enabled_features.portability_subset_features.multisampleArrayImage)) {
+            skip |=
+                LogError(device, "VUID-VkImageCreateInfo-multisampleArrayImage-04460",
+                         "vkCreateImage (portability error): Cannot create an image with samples/texel > 1 && arrayLayers != 1");
+        }
+    }
+
     return skip;
 }
 

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -93,3 +93,51 @@ TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
     vk::CreateEvent(m_device->device(), &eci, nullptr, &event);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(VkPortabilitySubsetTest, CreateImage) {
+    TEST_DESCRIPTION("Portability: CreateImage - VUIDs 04459, 04460");
+
+    ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
+
+    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    if (!portability_supported) {
+        printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
+        return;
+    }
+    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+
+    auto portability_feature = lvl_init_struct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    // Make sure image features are disabled via portability extension
+    portability_feature.imageView2DOn3DImage = VK_FALSE;
+    portability_feature.multisampleArrayImage = VK_FALSE;
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    VkImageCreateInfo ci;
+    ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    ci.pNext = NULL;
+    ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
+    ci.imageType = VK_IMAGE_TYPE_3D;
+    ci.format = VK_FORMAT_R8G8B8A8_UNORM;
+    ci.extent.width = 512;
+    ci.extent.height = 64;
+    ci.extent.depth = 1;
+    ci.mipLevels = 1;
+    ci.arrayLayers = 1;
+    ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    ci.queueFamilyIndexCount = 0;
+    ci.pQueueFamilyIndices = nullptr;
+    ci.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-imageView2DOn3DImage-04459");
+
+    ci.imageType = VK_IMAGE_TYPE_2D;
+    ci.flags = 0;
+    ci.samples = VK_SAMPLE_COUNT_2_BIT;
+    ci.arrayLayers = 2;
+    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-multisampleArrayImage-04460");
+}


### PR DESCRIPTION
Add support for VUIDs
- VUID-VkImageCreateInfo-imageView2DOn3DImage-04459
> If the VK_KHR_portability_subset extension is enabled, and VkPhysicalDevicePortabilitySubsetFeaturesKHR::imageView2DOn3DImage is VK_FALSE, flags must not contain VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT.
- VUID-VkImageCreateInfo-multisampleArrayImage-04460
> If the VK_KHR_portability_subset extension is enabled, and VkPhysicalDevicePortabilitySubsetFeaturesKHR::multisampleArrayImage is VK_FALSE, and samples is not VK_SAMPLE_COUNT_1_BIT, then arrayLayers must be 1.

Change-Id: I2335876f079e661983a69b757fd9e0c9979e42cb