### PR TITLE
layers: Portability - CreateGraphicsPipelines

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1984,6 +1984,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_sample_locations, &phys_dev_props->sample_locations_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_custom_border_color, &phys_dev_props->custom_border_color_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_multiview, &phys_dev_props->multiview_props);
+    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_portability_subset, &phys_dev_props->portability_props);
 
     if (!state_tracker->device_extensions.vk_feature_version_1_2 && dev_ext.vk_khr_timeline_semaphore) {
         VkPhysicalDeviceTimelineSemaphorePropertiesKHR timeline_semaphore_props;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1368,6 +1368,7 @@ class ValidationStateTracker : public ValidationObject {
         VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props;
         VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_border_color_props;
         VkPhysicalDeviceMultiviewProperties multiview_props;
+        VkPhysicalDevicePortabilitySubsetPropertiesKHR portability_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;


### PR DESCRIPTION
Adds validation for VUIDs
- VUID-VkPipelineInputAssemblyStateCreateInfo-triangleFans-04452
- VUID-VkVertexInputBindingDescription-stride-04456
- VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457
- VUID-VkPipelineRasterizationStateCreateInfo-pointPolygons-04458
- VUID-VkPipelineDepthStencilStateCreateInfo-separateStencilMaskRef-04453
- VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04454
- VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04455

Change-Id: I5af3dccf8065b51a8ac31c835366c5391bfd7ea6