### PR TITLE
layers: fix warnings when using GCC or Clang

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -292,10 +292,20 @@ struct BufferBinding {
     VkDeviceSize size;
     VkDeviceSize offset;
     VkDeviceSize stride;
+
+    BufferBinding() : buffer_state(), size(0), offset(0), stride(0) {}
+    virtual ~BufferBinding() {}
+
+    virtual void reset() { *this = BufferBinding(); }
 };
 
 struct IndexBufferBinding : BufferBinding {
     VkIndexType index_type;
+
+    IndexBufferBinding() : BufferBinding(), index_type(static_cast<VkIndexType>(0)) {}
+    virtual ~IndexBufferBinding() {}
+
+    virtual void reset() override { *this = IndexBufferBinding(); }
 };
 
 inline bool operator==(MEM_BINDING a, MEM_BINDING b) NOEXCEPT {

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2342,9 +2342,9 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t write_count, const VkWrit
                     const ACCELERATION_STRUCTURE_STATE_KHR *as_state =
                         GetAccelerationStructureStateKHR(pnext_struct->pAccelerationStructures[j]);
                     if (as_state && (as_state->create_infoKHR.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR &&
-                                     (as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR ||
-                                      as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) &&
-                                     as_state->build_info_khr.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR)) {
+                                     ((as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
+                                       as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) ||
+                                      as_state->build_info_khr.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR))) {
                         skip |=
                             LogError(dest_set, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03579",
                                      "%s: Each acceleration structure in pAccelerationStructures must have been created with "

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -3805,7 +3805,6 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
     const SHADER_MODULE_STATE *shaders[32];
     memset(shaders, 0, sizeof(shaders));
     spirv_inst_iter entrypoints[32];
-    memset(entrypoints, 0, sizeof(entrypoints));
     bool skip = false;
 
     uint32_t pointlist_stage_mask = DetermineFinalGeomStage(pipeline, pCreateInfo);

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1486,7 +1486,7 @@ void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
         }
         pCB->framebuffers.clear();
         pCB->activeFramebuffer = VK_NULL_HANDLE;
-        memset(&pCB->index_buffer_binding, 0, sizeof(pCB->index_buffer_binding));
+        pCB->index_buffer_binding.reset();
 
         pCB->qfo_transfer_image_barriers.Reset();
         pCB->qfo_transfer_buffer_barriers.Reset();


### PR DESCRIPTION
Several warnings were emitted when building the layers with recent
versions of GCC and Clang.

* One of the conditions to emit the
  VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03579
  validation error was wrong and was always true. This appears to be an
  actual implementation bug.

* Skip a memset() call to zero-initialize an array of spirv_inst_iter
  structures. They have a suitable default constructor so the memset()
  call is not needed and should not be used as the type is not trivial.

* Avoid resetting the command buffer index buffer binding state using
  memset(). It does not have a trivial copy-assignment operator and
  could leak memory from a shared pointer.