### PR TITLE
DrawDispatch 02693 VUID checks

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -69,6 +69,7 @@ struct DrawDispatchVuid {
     const char* protected_command_buffer = kVUIDUndefined;
     // TODO: Some instance values are in VkBuffer. The validation in those Cmds is skipped.
     const char* max_multiview_instance_index = kVUIDUndefined;
+    const char* img_filter_cubic = kVUIDUndefined;
     const char* filter_cubic = kVUIDUndefined;
     const char* filter_cubic_min_max = kVUIDUndefined;
     const char* viewport_count_primitive_shading_rate = kVUIDUndefined;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -731,8 +731,9 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const Bi
 bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_node, const DescriptorSet *descriptor_set,
                                                   const std::vector<uint32_t> &dynamic_offsets,
                                                   std::pair<const uint32_t, DescriptorRequirement> &binding_info,
-                                                  VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE*> *attachments,
-                                                  const std::vector<SUBPASS_INFO>& subpasses,const char *caller, const DrawDispatchVuid &vuids) const {
+                                                  VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE *> *attachments,
+                                                  const std::vector<SUBPASS_INFO> &subpasses, const char *caller,
+                                                  const DrawDispatchVuid &vuids) const {
     using DescriptorClass = cvdescriptorset::DescriptorClass;
     using BufferDescriptor = cvdescriptorset::BufferDescriptor;
     using ImageDescriptor = cvdescriptorset::ImageDescriptor;
@@ -3363,7 +3364,8 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet *dest_set, const 
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV: {
             const auto *accInfo = lvl_find_in_chain<VkWriteDescriptorSetAccelerationStructureNV>(update->pNext);
             for (uint32_t di = 0; di < update->descriptorCount; ++di) {
-                if (!ValidateAccelerationStructureUpdate(GetAccelerationStructureStateNV(accInfo->pAccelerationStructures[di]), func_name, error_code, error_msg)) {
+                if (!ValidateAccelerationStructureUpdate(GetAccelerationStructureStateNV(accInfo->pAccelerationStructures[di]),
+                                                         func_name, error_code, error_msg)) {
                     std::stringstream error_str;
                     error_str << "Attempted write update to acceleration structure descriptor failed due to: "
                               << error_msg->c_str();

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -75,6 +75,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         unprotected_command_buffer         = "VUID-vkCmdDraw-commandBuffer-02707";
         protected_command_buffer           = "VUID-vkCmdDraw-commandBuffer-02712";
         max_multiview_instance_index       = "VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDraw-None-02693";
         filter_cubic                       = "VUID-vkCmdDraw-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDraw-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDraw-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -113,6 +114,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         unprotected_command_buffer         = "VUID-vkCmdDrawIndexed-commandBuffer-02707";
         protected_command_buffer           = "VUID-vkCmdDrawIndexed-commandBuffer-02712";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndexed-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndexed-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndexed-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexed-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexed-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -153,6 +155,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawIndirect-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawIndirect-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndirect-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndirect-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndirect-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirect-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirect-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -193,6 +196,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawIndexedIndirect-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawIndexedIndirect-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndexedIndirect-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndexedIndirect-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndexedIndirect-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexedIndirect-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexedIndirect-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -217,6 +221,7 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDispatch-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDispatch-commandBuffer-02707";
         protected_command_buffer           = "VUID-vkCmdDispatch-commandBuffer-02712";
+        img_filter_cubic                   = "VUID-vkCmdDispatch-None-02693";
         filter_cubic                       = "VUID-vkCmdDispatch-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDispatch-filterCubicMinmax-02695";
     }
@@ -242,6 +247,7 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         sampler_bias_offset                = "VUID-vkCmdDispatchIndirect-None-02704";
         dynamic_state_setting_commands     = "VUID-vkCmdDispatchIndirect-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDispatchIndirect-commandBuffer-02707";
+        img_filter_cubic                   = "VUID-vkCmdDispatchIndirect-None-02693";
         filter_cubic                       = "VUID-vkCmdDispatchIndirect-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDispatchIndirect-filterCubicMinmax-02695";
     }
@@ -281,6 +287,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawIndirectCount-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawIndirectCount-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndirectCount-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndirectCount-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndirectCount-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirectCount-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirectCount-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -321,6 +328,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawIndexedIndirectCount-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndexedIndirectCount-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndexedIndirectCount-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndexedIndirectCount-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexedIndirectCount-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexedIndirectCount-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -346,6 +354,7 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdTraceRaysNV-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdTraceRaysNV-commandBuffer-02707";
         protected_command_buffer           = "VUID-vkCmdTraceRaysNV-commandBuffer-02712";
+        img_filter_cubic                   = "VUID-vkCmdTraceRaysNV-None-02693";
         filter_cubic                       = "VUID-vkCmdTraceRaysNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdTraceRaysNV-filterCubicMinmax-02695";
     }
@@ -370,6 +379,7 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdTraceRaysKHR-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdTraceRaysKHR-commandBuffer-02707";
         protected_command_buffer           = "VUID-vkCmdTraceRaysKHR-commandBuffer-02712";
+        img_filter_cubic                   = "VUID-vkCmdTraceRaysKHR-None-02693";
         filter_cubic                       = "VUID-vkCmdTraceRaysKHR-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdTraceRaysKHR-filterCubicMinmax-02695";
     }
@@ -396,6 +406,7 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         sampler_bias_offset                = "VUID-vkCmdTraceRaysIndirectKHR-None-02704";
         dynamic_state_setting_commands     = "VUID-vkCmdTraceRaysIndirectKHR-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-02707";
+        img_filter_cubic                   = "VUID-vkCmdTraceRaysIndirectKHR-None-02693";
         filter_cubic                       = "VUID-vkCmdTraceRaysIndirectKHR-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdTraceRaysIndirectKHR-filterCubicMinmax-02695";
     }
@@ -429,6 +440,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawMeshTasksNV-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawMeshTasksNV-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawMeshTasksNV-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawMeshTasksNV-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -466,6 +478,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawMeshTasksIndirectNV-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawMeshTasksIndirectNV-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksIndirectNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -503,6 +516,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksIndirectCountNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -543,6 +557,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         dynamic_state_setting_commands     = "VUID-vkCmdDrawIndirectByteCountEXT-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-02707";
         max_multiview_instance_index       = "VUID-vkCmdDrawIndirectByteCountEXT-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawIndirectByteCountEXT-None-02693";
         filter_cubic                       = "VUID-vkCmdDrawIndirectByteCountEXT-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirectByteCountEXT-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirectByteCountEXT-primitiveFragmentShadingRateWithMultipleViewports-04552";
@@ -566,6 +581,7 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         sampler_bias_offset                = "VUID-vkCmdDispatchBase-None-02704";
         dynamic_state_setting_commands     = "VUID-vkCmdDispatchBase-None-02859";
         unprotected_command_buffer         = "VUID-vkCmdDispatchBase-commandBuffer-02707";
+        img_filter_cubic                   = "VUID-vkCmdDispatchBase-None-02693";
         filter_cubic                       = "VUID-vkCmdDispatchBase-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDispatchBase-filterCubicMinmax-02695";
     }

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -8099,6 +8099,63 @@ TEST_F(VkLayerTest, VerifyFilterCubicSamplerInCmdDraw) {
     m_commandBuffer->end();
 }
 
+TEST_F(VkLayerTest, VerifyImgFilterCubicSamplerInCmdDraw) {
+    TEST_DESCRIPTION(
+        "Verify if sampler is filter cubic with the VK_IMG_filter cubic extension that it's a valid ImageViewType.");
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_IMG_FILTER_CUBIC_EXTENSION_NAME)) {
+        m_device_extension_names.push_back(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
+    } else {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
+    VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_2D;
+
+    VkImageObj image(m_device);
+    image.Init(image_ci);
+    VkImageView imageView = image.targetView(format, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
+                                             VK_REMAINING_ARRAY_LAYERS, imageViewType);
+
+    auto sampler_ci = lvl_init_struct<VkSamplerCreateInfo>();
+    sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
+    sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
+    VkSampler sampler;
+    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+
+    VkShaderObj fs(m_device, bindStateFragSamplerShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    CreatePipelineHelper g_pipe(*this);
+    g_pipe.InitInfo();
+    g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+    g_pipe.InitState();
+    ASSERT_VK_SUCCESS(g_pipe.CreateGraphicsPipeline());
+
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler);
+    g_pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
+                              &g_pipe.descriptor_set_->set_, 0, nullptr);
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-vkCmdDraw-None-02693");
+    m_commandBuffer->Draw(1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}
+
 TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
     TEST_DESCRIPTION("Verify if instance index in CmdDraw is greater than maxMultiviewInstanceIndex.");
     uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_1);


### PR DESCRIPTION
Similar to the 02694 and 02695 VUIDs, this is a set of simpler checks related to the `VK_IMG_filter_cubic` extension.  Added checks and tests.

Passes internal CI.