### PR TITLE
Add buffer out of bounds checking to GPU Assisted Validation

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -958,6 +958,19 @@ vkCmdBuildAccelerationStructureNV(...)  // build top level using modified instan
 
 vkEndCommandBuffer(...)
 ```
+
+## GPU-Assisted Buffer Access Validation
+
+When GPU-Assisted Validation is active, either the descriptor indexing input buffer
+(if descriptor indexing is enabled) or an input buffer of the same format without array
+sizes is used to inform instrumented shaders of the size of each of the buffers the shader
+may access.  If the shader accesses a buffer beyond the declared length of the buffer, the
+instrumentation will return an error to the validation layer.  This checking applies to to
+all uniform and storage buffers, but not to texel buffers. If a buffer access is found to be
+out of bounds, it will not be performed.  Instead, writes will be skipped, and reads will return 0.
+Note that this validation can be disabled by setting "khronos_validation.gpuav_buffer_oob = false" 
+in a vk_layer_settings.txt file.
+
 ## GPU-Assisted Validation Testing
 
 Validation Layer Tests (VLTs) exist for GPU-Assisted Validation.

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -279,8 +279,11 @@ bool DebugPrintf::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, 
     // If descriptor indexing is enabled, enable length checks and updated descriptor checks
     using namespace spvtools;
     spv_target_env target_env = PickSpirvEnv(api_version, (device_extensions.vk_khr_spirv_1_4 != kNotEnabled));
-    spvtools::ValidatorOptions options;
-    AdjustValidatorOptions(device_extensions, enabled_features, options);
+    spvtools::ValidatorOptions val_options;
+    AdjustValidatorOptions(device_extensions, enabled_features, val_options);
+    spvtools::OptimizerOptions opt_options;
+    opt_options.set_run_validator(true);
+    opt_options.set_validator_options(val_options);
     Optimizer optimizer(target_env);
     const spvtools::MessageConsumer DebugPrintfConsoleMessageConsumer =
         [this](spv_message_level_t level, const char *, const spv_position_t &position, const char *message) -> void {
@@ -297,7 +300,7 @@ bool DebugPrintf::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, 
     };
     optimizer.SetMessageConsumer(DebugPrintfConsoleMessageConsumer);
     optimizer.RegisterPass(CreateInstDebugPrintfPass(desc_set_bind_index, unique_shader_module_id));
-    bool pass = optimizer.Run(new_pgm.data(), new_pgm.size(), &new_pgm, options, false);
+    bool pass = optimizer.Run(new_pgm.data(), new_pgm.size(), &new_pgm, opt_options);
     if (!pass) {
         ReportSetupProblem(device, "Failure to instrument shader.  Proceeding with non-instrumented shader.");
     }

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -696,6 +696,15 @@ void DebugPrintf::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer comma
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
+void DebugPrintf::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
+                                                           uint32_t firstInstance, VkBuffer counterBuffer,
+                                                           VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                           uint32_t vertexStride) {
+    ValidationStateTracker::PreCallRecordCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
+                                                                     counterBufferOffset, counterOffset, vertexStride);
+    AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
+}
+
 void DebugPrintf::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -179,6 +179,9 @@ class DebugPrintf : public ValidationStateTracker {
     void PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                   uint32_t stride);
+    void PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount, uint32_t firstInstance,
+                                                  VkBuffer counterBuffer, VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                  uint32_t vertexStride);
     void PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask);
     void PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                  uint32_t drawCount, uint32_t stride);

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2869,7 +2869,6 @@ typedef enum ValidationCheckEnables {
 } ValidationCheckEnables;
 
 typedef enum VkValidationFeatureEnable {
-    VK_VALIDATION_FEATURE_ENABLE_SHADER_DEBUG_PRINTF,
     VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
 } VkValidationFeatureEnable;
 

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1473,6 +1473,15 @@ void GpuAssisted::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffe
     AllocateValidationResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
+void GpuAssisted::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
+                                                           uint32_t firstInstance, VkBuffer counterBuffer,
+                                                           VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                           uint32_t vertexStride) {
+    ValidationStateTracker::PreCallRecordCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
+                                                                     counterBufferOffset, counterOffset, vertexStride);
+    AllocateValidationResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
+}
+
 void GpuAssisted::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride) {

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -89,6 +89,7 @@ class GpuAssisted : public ValidationStateTracker {
     uint32_t unique_shader_module_id = 0;
     std::unordered_map<VkCommandBuffer, std::vector<GpuAssistedBufferInfo>> command_buffer_map;  // gpu_buffer_list;
     uint32_t output_buffer_size;
+    bool buffer_oob_enabled;
     std::map<VkDeviceAddress, VkDeviceSize> buffer_map;
     GpuAssistedAccelerationStructureBuildValidationState acceleration_structure_validation_state;
 
@@ -199,6 +200,7 @@ class GpuAssisted : public ValidationStateTracker {
                                          void* csm_state_data);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, VkPipelineBindPoint pipeline_bind_point,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer);
+    void SetDescriptorInitialized(uint32_t* pData, uint32_t index, const cvdescriptorset::Descriptor* descriptor);
     void UpdateInstrumentationBuffer(CMD_BUFFER_STATE* cb_node);
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
     void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -219,6 +219,9 @@ class GpuAssisted : public ValidationStateTracker {
     void PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                            VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                            uint32_t stride);
+    void PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount, uint32_t firstInstance,
+                                                  VkBuffer counterBuffer, VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                  uint32_t vertexStride);
     void PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                      uint32_t stride);

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -140,11 +140,19 @@ khronos_validation.log_filename = stdout
 
 # Example entry showing how to Enable GPU-Assisted Validation
 #khronos_validation.enables = VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT
+# Example entry showing how to disable buffer out of bounds checking
+#khronos_validation.gpuav_buffer_oob = false
 
 # Example entry showing how to Enable Best Practices Validation
 #khronos_validation.enables = VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT
 
 # Example entry showing how to enable Debug Printf messages
 #khronos_validation.enables = VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT
+# Example showing how to set the size in bytes of the buffer used by debug printf (default 1024 bytes)
+#khronos_validation.printf_buffer_size = 1024
+# Example of how to set the verbosity of debug printf messages (default not verbose)
+#khronos_validation.printf_verbose = false
+# Example of how to redirect debug printf messages from the debug callback to stdout
+#khronos_validation.printf_to_stdout = true
 
 ################################################################################

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -311,7 +311,6 @@ typedef enum ValidationCheckEnables {
 } ValidationCheckEnables;
 
 typedef enum VkValidationFeatureEnable {
-    VK_VALIDATION_FEATURE_ENABLE_SHADER_DEBUG_PRINTF,
     VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
 } VkValidationFeatureEnable;
 

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -293,6 +293,8 @@ class VkWsiEnabledLayerTest : public VkLayerTest {
 class VkGpuAssistedLayerTest : public VkLayerTest {
   public:
     bool InitGpuAssistedFramework(bool request_descriptor_indexing);
+    void ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSize binding_offset, VkDeviceSize binding_range,
+                              VkDescriptorType descriptor_type, const char *fragment_shader, const char *expected_error);
 
   protected:
 };

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -570,7 +570,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     VkBufferCreateInfo bci = {};
     bci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    bci.size = 8;
+    bci.size = 12;  // 64 bit pointer + int
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
     VkBufferObj buffer0;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -408,6 +408,11 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
             init_no_mem(dev,
                         create_info(size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, queue_families));
     }
+    void init_as_storage(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,
+        const std::vector<uint32_t> *queue_families = nullptr) {
+        init(dev, create_info(size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, queue_families), reqs);
+    }
+
     void init_no_mem(const Device &dev, const VkBufferCreateInfo &info);
 
     // get the internal memory


### PR DESCRIPTION
Also cleans up some GPU-AV warts.  This does not validate texel buffers, that validation will be coming in a follow on PR once VVL glslang is updated.