### PR TITLE
layers: Portability Shader Validation

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -258,6 +258,11 @@ static const char DECORATE_UNUSED *kVUID_Core_CreateInstance_Debug_Warning = "UN
 static const char DECORATE_UNUSED *kVUID_Core_ImageMemoryBarrier_SharingModeExclusiveSameFamily = "UNASSIGNED-CoreValidation-vkImageMemoryBarrier-sharing-mode-exclusive-same-family";
 static const char DECORATE_UNUSED *kVUID_Core_BufferMemoryBarrier_SharingModeExclusiveSameFamily = "UNASSIGNED-CoreValidation-vkBufferMemoryBarrier-sharing-mode-exclusive-same-family";
 
+// Portability contextual VUs
+static const char DECORATE_UNUSED *kVUID_Portability_Tessellation_Isolines = "UNASSIGNED-PortabilityValidation-Shader-isolines-not-supported";
+static const char DECORATE_UNUSED *kVUID_Portability_Tessellation_PointMode = "UNASSIGNED-PortabilityValidation-Shader-point-mode-not-supported";
+static const char DECORATE_UNUSED *kVUID_Portability_InterpolationFunction = "UNASSIGNED-PortabilityValidation-Shader-interpolation-function-supported";
+
 // clang-format on
 
 #undef DECORATE_UNUSED

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -633,6 +633,15 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE con
                     continue;
             }
 
+            // Portability checks
+            if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
+                if ((VK_FALSE == enabled_features.portability_subset_features.shaderSampleRateInterpolationFunctions) &&
+                    (spv::CapabilityInterpolationFunction == insn.word(1))) {
+                    skip |= LogError(device, kVUID_Portability_InterpolationFunction,
+                                     "Invalid shader capability (portability error): interpolation functions are not supported "
+                                     "by this platform");
+                }
+            }
         } else if (insn.opcode() == spv::OpExtension) {
             std::string extension_name = (char const *)&insn.word(1);
 

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -403,6 +403,15 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE con
                     continue;
             }
 
+            // Portability checks
+            if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
+                if ((VK_FALSE == enabled_features.portability_subset_features.shaderSampleRateInterpolationFunctions) &&
+                    (spv::CapabilityInterpolationFunction == insn.word(1))) {
+                    skip |= LogError(device, kVUID_Portability_InterpolationFunction,
+                                     "Invalid shader capability (portability error): interpolation functions are not supported "
+                                     "by this platform");
+                }
+            }
         } else if (insn.opcode() == spv::OpExtension) {
             std::string extension_name = (char const *)&insn.word(1);
 


### PR DESCRIPTION
Validates the following contextual VUs:
- If vkPhysicalDevicePortabilitySubsetFeaturesKHR::tessellationIsolines is VK_FALSE, then isoline tessellation is not supported by the implementation, and IsoLines must not be used in either tessellation shader stage.
- If VkPhysicalDevicePortabilitySubsetFeaturesKHR::tessellationPointMode is VK_FALSE, then point mode tessellation is not supported by the implementation, and PointMode must not be used in either tessellation shader stage.
- GLSL.std.450 fragment interpolation functions are not supported by the implementation and OpCapability must not be set to InterpolationFunction if VkPhysicalDevicePortabilitySubsetFeaturesKHR::shaderSampleRateInterpolationFunctions is VK_FALSE.

This to resolve the remaining VUs in #2208.

Initial commit is passing internal CI.