### PR TITLE
build: Generate PDB file for Release builds

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -255,6 +255,14 @@ if(BUILD_LAYERS)
     target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
 
+    # Force generation of the PDB file for Release builds.
+    # Note that CMake reduces optimization levels for RelWithDebInfo builds.
+    if(MSVC)
+        target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<CONFIG:Release>:/Zi>")
+        # Need to use this instead of target_link_options for older versions of CMake.
+        target_link_libraries(VkLayer_khronos_validation PRIVATE "$<$<CONFIG:Release>:-DEBUG:FULL>")
+    endif()
+
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
     # because the json format uses backslash escapes
     file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)


### PR DESCRIPTION
CMake's RelWithDebInfo build type reduces the optimization level of the
code generation.  This change allows us to make a fully-optimized
Release build and still get a PDB file.

Change-Id: I84dfc8fbed9fcd593ab065fc53c2836a87548ff9