### PR TITLE
Fix various tests failing on Android

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -668,6 +668,7 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
     err = vk::MapMemory(m_device->device(), mem, 0, mem_reqs.size, 0, (void **)&pData);
     ASSERT_VK_SUCCESS(err);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkMapMemory-memory-00678");
+    m_errorMonitor->SetUnexpectedError("VUID-vkMapMemory-size-00681");
     err = vk::MapMemory(m_device->device(), mem, 0, mem_reqs.size, 0, (void **)&pData);
     m_errorMonitor->VerifyFound();
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -8322,7 +8322,9 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) 
         return;
     }
     VkDepthStencilObj ds_image(m_device);
-    ds_image.Init(m_device, 64, 64, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    ds_image.Init(m_device, 64, 64, ds_format,
+                  VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                  VK_IMAGE_ASPECT_DEPTH_BIT);
     ASSERT_TRUE(ds_image.initialized());
     VkImageView ds_view = *ds_image.BindInfo();
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -2131,7 +2131,8 @@ VkImageView *VkDepthStencilObj::BindInfo() { return &m_attachmentBindInfo; }
 
 VkFormat VkDepthStencilObj::Format() const { return this->m_depth_stencil_fmt; }
 
-void VkDepthStencilObj::Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format, VkImageUsageFlags usage) {
+void VkDepthStencilObj::Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format, VkImageUsageFlags usage,
+                             VkImageAspectFlags aspect) {
     VkImageViewCreateInfo view_info = {};
 
     m_device = device;
@@ -2141,12 +2142,14 @@ void VkDepthStencilObj::Init(VkDeviceObj *device, int32_t width, int32_t height,
     /* create image */
     VkImageObj::Init(width, height, 1, m_depth_stencil_fmt, usage, VK_IMAGE_TILING_OPTIMAL);
 
-    VkImageAspectFlags aspect = VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    if (FormatIsDepthOnly(format))
-        aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
-    else if (FormatIsStencilOnly(format))
-        aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
-
+    // allows for overriding by caller
+    if (aspect == 0) {
+        aspect = VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
+        if (FormatIsDepthOnly(format))
+            aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+        else if (FormatIsStencilOnly(format))
+            aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
     SetLayout(aspect, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
     view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -512,7 +512,7 @@ class VkDepthStencilObj : public VkImageObj {
   public:
     VkDepthStencilObj(VkDeviceObj *device);
     void Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format,
-              VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+              VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VkImageAspectFlags aspect = 0);
     bool Initialized();
     VkImageView *BindInfo();
 


### PR DESCRIPTION
**InvalidMemoryMapping**
Simple missing VUID might be hit

**DrawWithPipelineIncompatibleWithRenderPassMultiview**
This one was missing the check if the device supports Multiview but not Renderpass2 which caused some issues on one device

**ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets**
Was crashing on updating the descriptor, realized the test was doing an invalid update and hitting `UNASSIGNED-CoreValidation-DrawState-InvalidImageView`, added simple fix to choose AspectMask manually for image