### PR TITLE
Implement Travis CI Checks using Github Actions

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Valve Corporation
+# Copyright (c) 2020 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+name: CI Build
+
+# Perform CI builds for pull requests targeting the master branch or any pushes to the repo.
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  code-format:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Source Code Format Testing",
+            os: ubuntu-latest,
+            cc: "gcc", cxx: "g++"
+          }
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v1
+    - name: Install build dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y python-pathlib
+    - name: Execute Source Code Format Checking Script
+      run: |
+        python3 scripts/check_code_format.py
+
+  linux:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Ubuntu GCC Debug",
+            os: ubuntu-latest,
+            type: "debug",
+            build_dir: "build",
+            cc: "gcc", cxx: "g++"
+          }
+        - {
+            name: "Ubuntu Clang Debug",
+            os: ubuntu-latest,
+            type: "debug",
+            build_dir: "build",
+            cc: "clang", cxx: "clang++"
+          }
+    steps:
+    - name: Select and Set Up CMake Version
+      uses: jwlawson/actions-setup-cmake@v1.4
+      with:
+        cmake-version: '3.10.2'
+    - name: Clone repository
+      uses: actions/checkout@v1
+    - name: Install build dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev \
+                              libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
+                              libxcb-randr0-dev python-pathlib
+    - name: Build and Test Vulkan-ValidationLayers 
+      run: |
+        python3 scripts/github_ci_win_linux.py --config ${{ matrix.config.type }}
+
+  gn:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Linux GN Debug Build ",
+            os: ubuntu-latest,
+            cc: "gcc", cxx: "g++"
+          }
+    steps:
+    - name: Select and Set Up CMake Version
+      uses: jwlawson/actions-setup-cmake@v1.4
+      with:
+        cmake-version: '3.10.2'
+    - name: Clone repository
+      uses: actions/checkout@v1
+    - name: Install build dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev \
+                              libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
+                              libxcb-randr0-dev python-pathlib
+    - name: Build Vulkan-ValidationLayers Using Ninja
+      run: |
+        python3 scripts/github_ci_gn.py
+
+  android:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Android armeabi-v8a",
+            os: ubuntu-latest,
+            abi: arm64-v8a,
+            ndk: r21d,
+          }
+        - {
+            name: "Android armeabi-v7a",
+            os: ubuntu-latest,
+            abi: armeabi-v7a,
+            ndk: r21d,
+          }
+    steps:
+    - name: Select and Set Up CMake Version
+      uses: jwlawson/actions-setup-cmake@v1.4
+      with:
+        cmake-version: '3.10.2'
+    - name: Clone repository
+      uses: actions/checkout@v1
+    - name: Build ValidationLayers
+      run: |
+        python3 scripts/github_ci_android.py --abi ${{ matrix.config.abi }}
+

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -18,27 +18,25 @@
 #
 # Author: Mark Lobodzinski <mark@lunarg.com>
 
-import os,re,sys,string
-import shutil
+import os
+import sys
 import subprocess
-import platform
-import xml.etree.ElementTree as etree
-from collections import namedtuple, OrderedDict
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], '..'))
+
+if sys.version_info[0] != 3:
+    print("This script requires Python 3. Run script with [-h] option for more details.")
+    sys_exit(0)
 
 # helper to define paths relative to the repo root
 def repo_relative(path):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', path))
 
 # Runs a command in a directory and returns its return code.
-#    Captures the standard error stream and prints it if error.
-def RunShellCmd(command, directory):
-    print("Command: ", command)
+# Directory is project root by default, or a relative path from project root
+def RunShellCmd(command, start_dir = PROJECT_ROOT):
+    if start_dir != PROJECT_ROOT:
+        start_dir = repo_relative(start_dir)
     cmd_list = command.split(" ")
-    p = subprocess.Popen(cmd_list, cwd=directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (stdout, stderr) = p.communicate()  # Forces a wait
-    if p.returncode != 0:
-        print('Error -- stderr contents:\n', stderr.decode())
-    else:
-        print(stdout.decode())
-    return p.returncode
+    subprocess.check_call(cmd_list, cwd=start_dir)
 

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2015-2017, 2019-2020 The Khronos Group Inc.
+# Copyright (c) 2015-2017, 2019-2020 Valve Corporation
+# Copyright (c) 2015-2017, 2019-2020 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+import os,re,sys,string
+import shutil
+import subprocess
+import platform
+import xml.etree.ElementTree as etree
+from collections import namedtuple, OrderedDict
+
+# helper to define paths relative to the repo root
+def repo_relative(path):
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', path))
+
+# Runs a command in a directory and returns its return code.
+#    Captures the standard error stream and prints it if error.
+def RunShellCmd(command, directory):
+    print("Command: ", command)
+    cmd_list = command.split(" ")
+    p = subprocess.Popen(cmd_list, cwd=directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (stdout, stderr) = p.communicate()  # Forces a wait
+    if p.returncode != 0:
+        print('Error -- stderr contents:\n', stderr.decode())
+    else:
+        print(stdout.decode())
+    return p.returncode
+

--- a/scripts/github_ci_android.py
+++ b/scripts/github_ci_android.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Valve Corporation
+# Copyright (c) 2020 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+import os
+import argparse
+import shutil
+import subprocess
+import sys
+import platform
+
+import common_ci
+from argparse import RawDescriptionHelpFormatter
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], '..'))
+SUPPORTED_ABIS = [ 'arm64-v8a', 'armeabi-v7a']
+DEFAULT_ABI = SUPPORTED_ABIS[0]
+
+#
+# Fetch Android components, build Android VVL
+def BuildAndroid(target_abi):
+    print("Fetching NDK\n")
+    wget_cmd = 'wget http://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip'
+    ret_code = common_ci.RunShellCmd(wget_cmd, PROJECT_ROOT)
+
+    if ret_code == 0:
+        print("Extracting NDK components\n")
+        unzip_cmd = 'unzip -u -q android-ndk-r21d-linux-x86_64.zip'
+        ret_code = common_ci.RunShellCmd(unzip_cmd, PROJECT_ROOT)
+        # Add NDK to path
+        os.environ['ANDROID_NDK_HOME'] = common_ci.repo_relative('android-ndk-r21d')
+        os.environ['PATH'] = os.environ.get('ANDROID_NDK_HOME') + ':' + os.environ.get('PATH')
+
+    if ret_code == 0:
+        print("Preparing Android Dependencies\n")
+        update_sources_cmd = './update_external_sources_android.sh --abi %s --no-build' % target_abi
+        ret_code = common_ci.RunShellCmd(update_sources_cmd, common_ci.repo_relative("build-android"))
+
+    if ret_code == 0:
+        print("Building Android Layers and Tests\n")
+        ndk_build_cmd = 'ndk-build APP_ABI=%s -j%s' % (target_abi, os.cpu_count())
+        ret_code = common_ci.RunShellCmd(ndk_build_cmd, common_ci.repo_relative("build-android"))
+
+    return ret_code
+
+#
+# Module Entrypoint
+def main():
+    parser = argparse.ArgumentParser(description='''Usage: python3 ./scripts/github_ci_android.py
+    - Reqires python3
+    - Run script in repo root
+    ''', formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument(
+        '-a', '--abi', dest='target_abi',
+        metavar='ABI', action='store',
+        choices=SUPPORTED_ABIS, default=DEFAULT_ABI,
+        help='Build target ABI. Can be one of: {0}'.format(
+            ', '.join(SUPPORTED_ABIS)))
+    args = parser.parse_args()
+
+    if sys.version_info[0] != 3:
+        print("This script requires Python 3. Run script with [-h] option for more details.")
+        exit()
+
+    ret_code = BuildAndroid(args.target_abi)
+    if ret_code != 0:
+        sys.exit(ret_code)
+    else:
+        sys.exit(0)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/github_ci_gn.py
+++ b/scripts/github_ci_gn.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Valve Corporation
+# Copyright (c) 2020 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+import os
+import argparse
+import shutil
+import subprocess
+import sys
+import platform
+import common_ci
+from argparse import RawDescriptionHelpFormatter
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], '..'))
+
+#
+# Build VVL repo using gn and Ninja
+def BuildGn():
+    print("Cloning Ninja depot_tools\n")
+    clone_cmd = 'git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools'
+    ret_code = common_ci.RunShellCmd(clone_cmd, PROJECT_ROOT)
+    os.environ['PATH'] = os.environ.get('PATH') + ":" + common_ci.repo_relative("depot_tools")
+
+    if ret_code == 0:
+        print("Updating Ninja build dependencies\n")
+        update_cmd = './build-gn/update_deps.sh'
+        ret_code = common_ci.RunShellCmd(update_cmd, PROJECT_ROOT)
+
+    if ret_code == 0:
+        print("Generating Ninja Files\n", )
+        # TODO: Enable ccache for Ninja builds : --args="cc_wrapper=\"ccache\""
+        #       There are issues passing this on the command line.
+        #       Possible solution is to write/append this line to the out/Debug/args.gn file
+        gn_gen_cmd = 'gn gen out/Debug'
+        ret_code = common_ci.RunShellCmd(gn_gen_cmd, PROJECT_ROOT)
+
+    if ret_code == 0:
+        print("Running Ninja Build\n", )
+        ninja_build_cmd = 'ninja -C out/Debug'
+        ret_code = common_ci.RunShellCmd(ninja_build_cmd, PROJECT_ROOT)
+
+    return ret_code
+
+#
+# Module Entrypoint
+def main():
+    parser = argparse.ArgumentParser(description='''Usage: python3 ./scripts/github_ci_gn.py
+    - Reqires python3
+    - Run script in repo root
+    ''', formatter_class=RawDescriptionHelpFormatter)
+
+    if sys.version_info[0] != 3:
+        print("This script requires Python 3. Run script with [-h] option for more details.")
+        sys.exit(0)
+
+    ret_code = BuildGn()
+    if ret_code:
+        sys.exit(ret_code)
+    else:
+        sys.exit(0)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/github_ci_win_linux.py
+++ b/scripts/github_ci_win_linux.py
@@ -26,9 +26,9 @@ import platform
 import common_ci
 from argparse import RawDescriptionHelpFormatter
 
-EXTERNAL_DIR_NAME = "external_linux"
+# TODO: Pass this in as arg, may be useful for running locally
+EXTERNAL_DIR_NAME = "external"
 BUILD_DIR_NAME = "build"
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], '..'))
 EXTERNAL_DIR = common_ci.repo_relative(EXTERNAL_DIR_NAME)
 VVL_BUILD_DIR = common_ci.repo_relative(BUILD_DIR_NAME)
 CONFIGURATIONS = ['release', 'debug']
@@ -50,8 +50,7 @@ def CreateBuildDirectory(dir_path):
 def CheckVVLCodegenConsistency():
     print("Check Generated Source Code Consistency")
     gen_check_cmd = 'python3 scripts/generate_source.py --verify %s/Vulkan-Headers/registry' % EXTERNAL_DIR
-    ret_code = common_ci.RunShellCmd(gen_check_cmd, PROJECT_ROOT)
-    return ret_code
+    return subprocess.call(gen_check_cmd.split(" "), cwd=common_ci.PROJECT_ROOT)
 
 #
 # Prepare the Validation Layers for testing
@@ -59,147 +58,121 @@ def BuildVVL(args):
 
     print("Log CMake version")
     cmake_ver_cmd = 'cmake --version'
-    common_ci.RunShellCmd(cmake_ver_cmd, PROJECT_ROOT)
+    common_ci.RunShellCmd(cmake_ver_cmd)
 
     print("Run update_deps.py for VVL Repository")
     update_cmd = 'python3 scripts/update_deps.py --dir %s --config %s --arch x64' % (EXTERNAL_DIR_NAME, args.configuration)
-    ret_code = common_ci.RunShellCmd(update_cmd, PROJECT_ROOT)
+    common_ci.RunShellCmd(update_cmd)
 
-    if ret_code == 0:
-        GTEST_DIR = common_ci.repo_relative("external/googletest")
-        if not os.path.exists(GTEST_DIR):
-            print("Clone Testing Framework Source Code")
-            clone_gtest_cmd = 'git clone https://github.com/google/googletest.git %s' % GTEST_DIR
-            ret_code = common_ci.RunShellCmd(clone_gtest_cmd, PROJECT_ROOT)
-            
-            if ret_code == 0:
-                print("Get Specified Testing Source")
-                gtest_checkout_cmd = 'git checkout tags/release-1.8.1'
-                common_ci.RunShellCmd(gtest_checkout_cmd, GTEST_DIR)
+    GTEST_DIR = common_ci.repo_relative("external/googletest")
+    if not os.path.exists(GTEST_DIR):
+        print("Clone Testing Framework Source Code")
+        clone_gtest_cmd = 'git clone https://github.com/google/googletest.git %s' % GTEST_DIR
+        common_ci.RunShellCmd(clone_gtest_cmd)
 
-    if ret_code == 0:
-        CreateBuildDirectory(VVL_BUILD_DIR)
-        print("Run CMake for Validation Layers")
-        cmake_cmd = 'cmake -C ../%s/helper.cmake -DCMAKE_BUILD_TYPE=%s -DUSE_CCACHE=ON ..' \
-            % (EXTERNAL_DIR_NAME, args.configuration.capitalize())
-        ret_code = common_ci.RunShellCmd(cmake_cmd, VVL_BUILD_DIR)
+        print("Get Specified Testing Source")
+        gtest_checkout_cmd = 'git checkout tags/release-1.8.1'
+        common_ci.RunShellCmd(gtest_checkout_cmd, GTEST_DIR)
 
-    if ret_code == 0:
-        print("Build Validation Layers and Tests")
-        os.chdir(VVL_BUILD_DIR)
-        build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
-        ret_code = common_ci.RunShellCmd(build_cmd, VVL_BUILD_DIR)
+    CreateBuildDirectory(VVL_BUILD_DIR)
+    print("Run CMake for Validation Layers")
+    cmake_cmd = 'cmake -C ../%s/helper.cmake -DCMAKE_BUILD_TYPE=%s -DUSE_CCACHE=ON ..' \
+        % (EXTERNAL_DIR_NAME, args.configuration.capitalize())
+    common_ci.RunShellCmd(cmake_cmd, VVL_BUILD_DIR)
 
-    return ret_code
+    print("Build Validation Layers and Tests")
+    os.chdir(VVL_BUILD_DIR)
+    build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
+    common_ci.RunShellCmd(build_cmd, VVL_BUILD_DIR)
 
 #
 # Prepare Loader for executing Layer Validation Tests
 def BuildLoader(args):
     LOADER_DIR = common_ci.repo_relative("%s/Vulkan-Loader" % EXTERNAL_DIR_NAME)
-    ret_code = 0
     # Clone Loader repo
     if not os.path.exists(LOADER_DIR):
         print("Clone Loader Source Code")
         clone_loader_cmd = 'git clone https://github.com/KhronosGroup/Vulkan-Loader.git'
-        ret_code = common_ci.RunShellCmd(clone_loader_cmd, EXTERNAL_DIR)
+        common_ci.RunShellCmd(clone_loader_cmd, EXTERNAL_DIR)
 
-    if ret_code == 0:
-        print("Run update_deps.py for Loader Repository")
-        update_cmd = 'python3 scripts/update_deps.py --dir external'
-        ret_code = common_ci.RunShellCmd(update_cmd, LOADER_DIR)
-       
-    if ret_code == 0:
-        print("Run CMake for Loader")
-        LOADER_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Loader/%s" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
-        CreateBuildDirectory(LOADER_BUILD_DIR)
-        cmake_cmd = 'cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=%s ..' % args.configuration.capitalize()
-        ret_code = common_ci.RunShellCmd(cmake_cmd, LOADER_BUILD_DIR)
-       
-    if ret_code == 0:
-        print("Build Loader")
-        build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
-        ret_code = common_ci.RunShellCmd(build_cmd, LOADER_BUILD_DIR)
+    print("Run update_deps.py for Loader Repository")
+    update_cmd = 'python3 scripts/update_deps.py --dir external'
+    common_ci.RunShellCmd(update_cmd, LOADER_DIR)
 
-    return ret_code
+    print("Run CMake for Loader")
+    LOADER_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Loader/%s" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
+    CreateBuildDirectory(LOADER_BUILD_DIR)
+    cmake_cmd = 'cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=%s ..' % args.configuration.capitalize()
+    common_ci.RunShellCmd(cmake_cmd, LOADER_BUILD_DIR)
+
+    print("Build Loader")
+    build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
+    common_ci.RunShellCmd(build_cmd, LOADER_BUILD_DIR)
 
 #
 # Prepare Mock ICD for use with Layer Validation Tests
 def BuildMockICD(args):
-    ret_code = 0
     if not os.path.exists(common_ci.repo_relative("%s/Vulkan-Tools" % EXTERNAL_DIR_NAME)):
         print("Clone Vulkan-Tools Repository")
         clone_tools_cmd = 'git clone https://github.com/KhronosGroup/Vulkan-Tools.git'
-        ret_code = common_ci.RunShellCmd(clone_tools_cmd, EXTERNAL_DIR)
+        common_ci.RunShellCmd(clone_tools_cmd, EXTERNAL_DIR)
 
-    if ret_code == 0:
-        print("Run CMake for ICD")
-        ICD_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Tools/%s" % (EXTERNAL_DIR_NAME,BUILD_DIR_NAME))
-        CreateBuildDirectory(ICD_BUILD_DIR)
-        cmake_args = ['cmake',
-                     '-DCMAKE_BUILD_TYPE=%s' % args.configuration.capitalize(),
-                      '-DBUILD_CUBE=NO',
-                      '-DBUILD_VULKANINFO=NO',
-                      '-DINSTALL_ICD=OFF',
-                      '-DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install' % (EXTERNAL_DIR, BUILD_DIR_NAME),
-                      '..']
-        cmake_cmd = \
-            'cmake -DCMAKE_BUILD_TYPE=%s -DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -DINSTALL_ICD=OFF -DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install ..' \
-            % (args.configuration.capitalize(), EXTERNAL_DIR, BUILD_DIR_NAME)
-        ret_code = common_ci.RunShellCmd(cmake_cmd, ICD_BUILD_DIR)
+    print("Run CMake for ICD")
+    ICD_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Tools/%s" % (EXTERNAL_DIR_NAME,BUILD_DIR_NAME))
+    CreateBuildDirectory(ICD_BUILD_DIR)
+    cmake_args = ['cmake',
+                 '-DCMAKE_BUILD_TYPE=%s' % args.configuration.capitalize(),
+                  '-DBUILD_CUBE=NO',
+                  '-DBUILD_VULKANINFO=NO',
+                  '-DINSTALL_ICD=OFF',
+                  '-DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install' % (EXTERNAL_DIR, BUILD_DIR_NAME),
+                  '..']
+    cmake_cmd = \
+        'cmake -DCMAKE_BUILD_TYPE=%s -DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -DINSTALL_ICD=OFF -DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install ..' \
+        % (args.configuration.capitalize(), EXTERNAL_DIR, BUILD_DIR_NAME)
+    common_ci.RunShellCmd(cmake_cmd, ICD_BUILD_DIR)
 
-    if ret_code == 0:
-        VVL_REG_DIR = "%s/Vulkan-Headers/registry" % EXTERNAL_DIR
-        VT_SCRIPTS_DIR = "%s/Vulkan-Tools/scripts" % EXTERNAL_DIR
+    VVL_REG_DIR = "%s/Vulkan-Headers/registry" % EXTERNAL_DIR
+    VT_SCRIPTS_DIR = "%s/Vulkan-Tools/scripts" % EXTERNAL_DIR
 
-        print ("Geneating ICD Source Code")
-        VT_ICD_DIR = "%s/Vulkan-Tools/icd/generated" % EXTERNAL_DIR
-        LVL_GEN_SCRIPT = common_ci.repo_relative("scripts/lvl_genvk.py")
-        typemap_cmd = 'python3 %s -registry %s/vk.xml vk_typemap_helper.h' % (LVL_GEN_SCRIPT, VVL_REG_DIR)
-        typemap_ret_code = common_ci.RunShellCmd(typemap_cmd, VT_ICD_DIR)
+    print ("Geneating ICD Source Code")
+    VT_ICD_DIR = "%s/Vulkan-Tools/icd/generated" % EXTERNAL_DIR
+    LVL_GEN_SCRIPT = common_ci.repo_relative("scripts/lvl_genvk.py")
+    typemap_cmd = 'python3 %s -registry %s/vk.xml vk_typemap_helper.h' % (LVL_GEN_SCRIPT, VVL_REG_DIR)
+    common_ci.RunShellCmd(typemap_cmd, VT_ICD_DIR)
 
-        KVT_GEN_SCRIPT = "%s/Vulkan-Tools/scripts/kvt_genvk.py" % EXTERNAL_DIR
-        icd_cpp_cmd = 'python3 %s -registry %s/vk.xml mock_icd.cpp' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
-        icd_cpp_ret_code = common_ci.RunShellCmd(icd_cpp_cmd, VT_ICD_DIR)
+    KVT_GEN_SCRIPT = "%s/Vulkan-Tools/scripts/kvt_genvk.py" % EXTERNAL_DIR
+    icd_cpp_cmd = 'python3 %s -registry %s/vk.xml mock_icd.cpp' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
+    common_ci.RunShellCmd(icd_cpp_cmd, VT_ICD_DIR)
 
-        icd_h_cmd = 'python3 %s -registry %s/vk.xml mock_icd.h' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
-        icd_h_ret_code = common_ci.RunShellCmd(icd_h_cmd, VT_ICD_DIR)
+    icd_h_cmd = 'python3 %s -registry %s/vk.xml mock_icd.h' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
+    common_ci.RunShellCmd(icd_h_cmd, VT_ICD_DIR)
 
-        if typemap_ret_code != 0  or icd_cpp_ret_code != 0 or icd_h_ret_code != 0:
-            ret_code = 1
+    print("Build Mock ICD")
+    build_cmd = 'cmake --build . --target VkICD_mock_icd -- -j%s' % os.cpu_count()
+    common_ci.RunShellCmd(build_cmd, ICD_BUILD_DIR)
 
-    if ret_code == 0:
-        print("Build Mock ICD")
-        build_cmd = 'cmake --build . --target VkICD_mock_icd -- -j%s' % os.cpu_count()
-        ret_code = common_ci.RunShellCmd(build_cmd, ICD_BUILD_DIR)
-
-        # Copy json file into dir with ICD executable
-        src_filename = common_ci.repo_relative("%s/Vulkan-Tools/icd/linux/VkICD_mock_icd.json" % EXTERNAL_DIR_NAME)
-        dst_filename = common_ci.repo_relative("%s/Vulkan-Tools/%s/icd/VkICD_mock_icd.json" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
-        shutil.copyfile(src_filename, dst_filename)
-
-    return ret_code
+    # Copy json file into dir with ICD executable
+    src_filename = common_ci.repo_relative("%s/Vulkan-Tools/icd/linux/VkICD_mock_icd.json" % EXTERNAL_DIR_NAME)
+    dst_filename = common_ci.repo_relative("%s/Vulkan-Tools/%s/icd/VkICD_mock_icd.json" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
+    shutil.copyfile(src_filename, dst_filename)
 
 #
 # Run the Layer Validation Tests
 def RunVVLTests(args):
     print("Run Vulkan-ValidationLayer Tests using Mock ICD")
-    os.chdir(PROJECT_ROOT)
+    os.chdir(common_ci.PROJECT_ROOT)
     lvt_cmd = '%s/tests/vk_layer_validation_tests' % BUILD_DIR_NAME
     lvt_env = dict(os.environ)
     lvt_env['LD_LIBRARY_PATH'] = '%s/Vulkan-Loader/%s/loader' % (EXTERNAL_DIR, BUILD_DIR_NAME)
-    lvt_env['VK_LAYER_PATH'] = '%s/%s/layers' % (PROJECT_ROOT, BUILD_DIR_NAME)
+    lvt_env['VK_LAYER_PATH'] = '%s/%s/layers' % (common_ci.PROJECT_ROOT, BUILD_DIR_NAME)
     lvt_env['VK_ICD_FILENAMES'] = '%s/Vulkan-Tools/%s/icd/VkICD_mock_icd.json' % (EXTERNAL_DIR, BUILD_DIR_NAME)
-    ret_code = subprocess.call(lvt_cmd.split(" "), env=lvt_env)
-
-    return ret_code
+    subprocess.call(lvt_cmd.split(" "), env=lvt_env)
 
 #
 # Module Entrypoint
 def main():
-    parser = argparse.ArgumentParser(description='''Usage: python3 ./scripts/github_ci_win_linux.py
-    - Reqires python3
-    - Run script in repo root
-    ''', formatter_class=RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         '-c', '--config', dest='configuration',
         metavar='CONFIG', action='store',
@@ -208,28 +181,22 @@ def main():
             ', '.join(CONFIGURATIONS)))
     args = parser.parse_args()
 
-    if sys.version_info[0] != 3:
-        print("This script requires Python 3. Run script with [-h] option for more details.")
-        sys_exit(0)
+    ret_code = 0
+    try:
+        BuildVVL(args)
+        ret_code = CheckVVLCodegenConsistency()
+        BuildLoader(args)
+        BuildMockICD(args)
+        RunVVLTests(args)
 
-    ret_code = BuildVVL(args)
-    if ret_code == 0:
-        ret_code = BuildLoader(args)
-    if ret_code == 0:
-        ret_code = BuildMockICD(args)
-    if ret_code == 0:
-        ret_code = RunVVLTests(args)
+    except subprocess.CalledProcessError as proc_error:
+        print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
+        sys.exit(proc_error.returncode)
+    except Exception as unknown_error:
+        print('An unkown error occured: %s', unknown_error)
+        sys.exit(1)
 
-    # Run codgen checks regardless of previous failures
-    inconsistent_source = CheckVVLCodegenConsistency()
-
-    if ret_code != 0 or inconsistent_source != 0:
-        if ret_code != 0:
-            sys.exit(ret_code)
-        else:
-            sys.exit(inconsistent_source)
-    else:
-        exit(0)
+    sys.exit(ret_code)
 
 if __name__ == '__main__':
   main()

--- a/scripts/github_ci_win_linux.py
+++ b/scripts/github_ci_win_linux.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Valve Corporation
+# Copyright (c) 2020 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+import os
+import argparse
+import shutil
+import subprocess
+import sys
+import platform
+
+import common_ci
+from argparse import RawDescriptionHelpFormatter
+
+EXTERNAL_DIR_NAME = "external_linux"
+BUILD_DIR_NAME = "build"
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], '..'))
+EXTERNAL_DIR = common_ci.repo_relative(EXTERNAL_DIR_NAME)
+VVL_BUILD_DIR = common_ci.repo_relative(BUILD_DIR_NAME)
+CONFIGURATIONS = ['release', 'debug']
+DEFAULT_CONFIGURATION = CONFIGURATIONS[0]
+
+#
+# Check if the system is Windows
+def is_windows():
+    return 'windows' == platform.system().lower()
+
+#
+# Create build directory if it does not already exist
+def CreateBuildDirectory(dir_path):
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+
+#
+# Verify consistency of generated source code
+def CheckVVLCodegenConsistency():
+    print("Check Generated Source Code Consistency")
+    gen_check_cmd = 'python3 scripts/generate_source.py --verify %s/Vulkan-Headers/registry' % EXTERNAL_DIR
+    ret_code = common_ci.RunShellCmd(gen_check_cmd, PROJECT_ROOT)
+    return ret_code
+
+#
+# Prepare the Validation Layers for testing
+def BuildVVL(args):
+
+    print("Log CMake version")
+    cmake_ver_cmd = 'cmake --version'
+    common_ci.RunShellCmd(cmake_ver_cmd, PROJECT_ROOT)
+
+    print("Run update_deps.py for VVL Repository")
+    update_cmd = 'python3 scripts/update_deps.py --dir %s --config %s --arch x64' % (EXTERNAL_DIR_NAME, args.configuration)
+    ret_code = common_ci.RunShellCmd(update_cmd, PROJECT_ROOT)
+
+    if ret_code == 0:
+        GTEST_DIR = common_ci.repo_relative("external/googletest")
+        if not os.path.exists(GTEST_DIR):
+            print("Clone Testing Framework Source Code")
+            clone_gtest_cmd = 'git clone https://github.com/google/googletest.git %s' % GTEST_DIR
+            ret_code = common_ci.RunShellCmd(clone_gtest_cmd, PROJECT_ROOT)
+            
+            if ret_code == 0:
+                print("Get Specified Testing Source")
+                gtest_checkout_cmd = 'git checkout tags/release-1.8.1'
+                common_ci.RunShellCmd(gtest_checkout_cmd, GTEST_DIR)
+
+    if ret_code == 0:
+        CreateBuildDirectory(VVL_BUILD_DIR)
+        print("Run CMake for Validation Layers")
+        cmake_cmd = 'cmake -C ../%s/helper.cmake -DCMAKE_BUILD_TYPE=%s -DUSE_CCACHE=ON ..' \
+            % (EXTERNAL_DIR_NAME, args.configuration.capitalize())
+        ret_code = common_ci.RunShellCmd(cmake_cmd, VVL_BUILD_DIR)
+
+    if ret_code == 0:
+        print("Build Validation Layers and Tests")
+        os.chdir(VVL_BUILD_DIR)
+        build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
+        ret_code = common_ci.RunShellCmd(build_cmd, VVL_BUILD_DIR)
+
+    return ret_code
+
+#
+# Prepare Loader for executing Layer Validation Tests
+def BuildLoader(args):
+    LOADER_DIR = common_ci.repo_relative("%s/Vulkan-Loader" % EXTERNAL_DIR_NAME)
+    ret_code = 0
+    # Clone Loader repo
+    if not os.path.exists(LOADER_DIR):
+        print("Clone Loader Source Code")
+        clone_loader_cmd = 'git clone https://github.com/KhronosGroup/Vulkan-Loader.git'
+        ret_code = common_ci.RunShellCmd(clone_loader_cmd, EXTERNAL_DIR)
+
+    if ret_code == 0:
+        print("Run update_deps.py for Loader Repository")
+        update_cmd = 'python3 scripts/update_deps.py --dir external'
+        ret_code = common_ci.RunShellCmd(update_cmd, LOADER_DIR)
+       
+    if ret_code == 0:
+        print("Run CMake for Loader")
+        LOADER_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Loader/%s" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
+        CreateBuildDirectory(LOADER_BUILD_DIR)
+        cmake_cmd = 'cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=%s ..' % args.configuration.capitalize()
+        ret_code = common_ci.RunShellCmd(cmake_cmd, LOADER_BUILD_DIR)
+       
+    if ret_code == 0:
+        print("Build Loader")
+        build_cmd = 'cmake --build . -- -j%s' % os.cpu_count()
+        ret_code = common_ci.RunShellCmd(build_cmd, LOADER_BUILD_DIR)
+
+    return ret_code
+
+#
+# Prepare Mock ICD for use with Layer Validation Tests
+def BuildMockICD(args):
+    ret_code = 0
+    if not os.path.exists(common_ci.repo_relative("%s/Vulkan-Tools" % EXTERNAL_DIR_NAME)):
+        print("Clone Vulkan-Tools Repository")
+        clone_tools_cmd = 'git clone https://github.com/KhronosGroup/Vulkan-Tools.git'
+        ret_code = common_ci.RunShellCmd(clone_tools_cmd, EXTERNAL_DIR)
+
+    if ret_code == 0:
+        print("Run CMake for ICD")
+        ICD_BUILD_DIR = common_ci.repo_relative("%s/Vulkan-Tools/%s" % (EXTERNAL_DIR_NAME,BUILD_DIR_NAME))
+        CreateBuildDirectory(ICD_BUILD_DIR)
+        cmake_args = ['cmake',
+                     '-DCMAKE_BUILD_TYPE=%s' % args.configuration.capitalize(),
+                      '-DBUILD_CUBE=NO',
+                      '-DBUILD_VULKANINFO=NO',
+                      '-DINSTALL_ICD=OFF',
+                      '-DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install' % (EXTERNAL_DIR, BUILD_DIR_NAME),
+                      '..']
+        cmake_cmd = \
+            'cmake -DCMAKE_BUILD_TYPE=%s -DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -DINSTALL_ICD=OFF -DVULKAN_HEADERS_INSTALL_DIR=%s/Vulkan-Headers/%s/install ..' \
+            % (args.configuration.capitalize(), EXTERNAL_DIR, BUILD_DIR_NAME)
+        ret_code = common_ci.RunShellCmd(cmake_cmd, ICD_BUILD_DIR)
+
+    if ret_code == 0:
+        VVL_REG_DIR = "%s/Vulkan-Headers/registry" % EXTERNAL_DIR
+        VT_SCRIPTS_DIR = "%s/Vulkan-Tools/scripts" % EXTERNAL_DIR
+
+        print ("Geneating ICD Source Code")
+        VT_ICD_DIR = "%s/Vulkan-Tools/icd/generated" % EXTERNAL_DIR
+        LVL_GEN_SCRIPT = common_ci.repo_relative("scripts/lvl_genvk.py")
+        typemap_cmd = 'python3 %s -registry %s/vk.xml vk_typemap_helper.h' % (LVL_GEN_SCRIPT, VVL_REG_DIR)
+        typemap_ret_code = common_ci.RunShellCmd(typemap_cmd, VT_ICD_DIR)
+
+        KVT_GEN_SCRIPT = "%s/Vulkan-Tools/scripts/kvt_genvk.py" % EXTERNAL_DIR
+        icd_cpp_cmd = 'python3 %s -registry %s/vk.xml mock_icd.cpp' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
+        icd_cpp_ret_code = common_ci.RunShellCmd(icd_cpp_cmd, VT_ICD_DIR)
+
+        icd_h_cmd = 'python3 %s -registry %s/vk.xml mock_icd.h' % (KVT_GEN_SCRIPT, VVL_REG_DIR)
+        icd_h_ret_code = common_ci.RunShellCmd(icd_h_cmd, VT_ICD_DIR)
+
+        if typemap_ret_code != 0  or icd_cpp_ret_code != 0 or icd_h_ret_code != 0:
+            ret_code = 1
+
+    if ret_code == 0:
+        print("Build Mock ICD")
+        build_cmd = 'cmake --build . --target VkICD_mock_icd -- -j%s' % os.cpu_count()
+        ret_code = common_ci.RunShellCmd(build_cmd, ICD_BUILD_DIR)
+
+        # Copy json file into dir with ICD executable
+        src_filename = common_ci.repo_relative("%s/Vulkan-Tools/icd/linux/VkICD_mock_icd.json" % EXTERNAL_DIR_NAME)
+        dst_filename = common_ci.repo_relative("%s/Vulkan-Tools/%s/icd/VkICD_mock_icd.json" % (EXTERNAL_DIR_NAME, BUILD_DIR_NAME))
+        shutil.copyfile(src_filename, dst_filename)
+
+    return ret_code
+
+#
+# Run the Layer Validation Tests
+def RunVVLTests(args):
+    print("Run Vulkan-ValidationLayer Tests using Mock ICD")
+    os.chdir(PROJECT_ROOT)
+    lvt_cmd = '%s/tests/vk_layer_validation_tests' % BUILD_DIR_NAME
+    lvt_env = dict(os.environ)
+    lvt_env['LD_LIBRARY_PATH'] = '%s/Vulkan-Loader/%s/loader' % (EXTERNAL_DIR, BUILD_DIR_NAME)
+    lvt_env['VK_LAYER_PATH'] = '%s/%s/layers' % (PROJECT_ROOT, BUILD_DIR_NAME)
+    lvt_env['VK_ICD_FILENAMES'] = '%s/Vulkan-Tools/%s/icd/VkICD_mock_icd.json' % (EXTERNAL_DIR, BUILD_DIR_NAME)
+    ret_code = subprocess.call(lvt_cmd.split(" "), env=lvt_env)
+
+    return ret_code
+
+#
+# Module Entrypoint
+def main():
+    parser = argparse.ArgumentParser(description='''Usage: python3 ./scripts/github_ci_win_linux.py
+    - Reqires python3
+    - Run script in repo root
+    ''', formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument(
+        '-c', '--config', dest='configuration',
+        metavar='CONFIG', action='store',
+        choices=CONFIGURATIONS, default=DEFAULT_CONFIGURATION,
+        help='Build target configuration. Can be one of: {0}'.format(
+            ', '.join(CONFIGURATIONS)))
+    args = parser.parse_args()
+
+    if sys.version_info[0] != 3:
+        print("This script requires Python 3. Run script with [-h] option for more details.")
+        sys_exit(0)
+
+    ret_code = BuildVVL(args)
+    if ret_code == 0:
+        ret_code = BuildLoader(args)
+    if ret_code == 0:
+        ret_code = BuildMockICD(args)
+    if ret_code == 0:
+        ret_code = RunVVLTests(args)
+
+    # Run codgen checks regardless of previous failures
+    inconsistent_source = CheckVVLCodegenConsistency()
+
+    if ret_code != 0 or inconsistent_source != 0:
+        if ret_code != 0:
+            sys.exit(ret_code)
+        else:
+            sys.exit(inconsistent_source)
+    else:
+        exit(0)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Added Github actions workflow file for non-Windows CI checks. Actions are controlled by a yml file in the /.github/workflows directory.  The yml script relies on python scripts for checks that cover the CI steps listed below.  Note that these scripts can be run directly, for instance to check your Android or GN builds locally.

Travis checks are still enabled, they'll run in parallel during the initial testing phase, and will then be disabled.  The functionality covered by AppVeyor will also be integrated in the near-term [just realized that Actions will only support 2017 for a limited time, or 2019, but not 2015].

Also! Note the times.  The Actions steps all finished in about 15 minutes -- right now it's been 25 minutes, neither of the travis steps are done, and one has not yet started.

- Linux gnu compiler build and test
- Linux clang compiler build and test
- Android 32-bit build
- Android 64-bit build
- GN build
- Code format checks