### PR TITLE
syncval: Implement Cmd*Event synchronization validation

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -844,22 +844,6 @@ void ValidationStateTracker::RemoveAliasingImages(const std::unordered_set<VkIma
     }
 }
 
-const EVENT_STATE *ValidationStateTracker::GetEventState(VkEvent event) const {
-    auto it = eventMap.find(event);
-    if (it == eventMap.end()) {
-        return nullptr;
-    }
-    return &it->second;
-}
-
-EVENT_STATE *ValidationStateTracker::GetEventState(VkEvent event) {
-    auto it = eventMap.find(event);
-    if (it == eventMap.end()) {
-        return nullptr;
-    }
-    return &it->second;
-}
-
 const QUEUE_STATE *ValidationStateTracker::GetQueueState(VkQueue queue) const {
     auto it = queueMap.find(queue);
     if (it == queueMap.cend()) {
@@ -2200,7 +2184,7 @@ void ValidationStateTracker::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq
             for (auto event : cb_node->writeEventsBeforeWait) {
                 auto event_node = eventMap.find(event);
                 if (event_node != eventMap.end()) {
-                    event_node->second.write_in_use--;
+                    event_node->second->write_in_use--;
                 }
             }
             QueryMap local_query_to_state_map;
@@ -2360,8 +2344,8 @@ void ValidationStateTracker::PostCallRecordQueueSubmit(VkQueue queue, uint32_t s
                     function(nullptr, /*do_validate*/ false, &local_event_to_stage_map);
                 }
 
-                for (auto event_stage_pair : local_event_to_stage_map) {
-                    eventMap[event_stage_pair.first].stageMask = event_stage_pair.second;
+                for (auto eventStagePair : local_event_to_stage_map) {
+                    eventMap[eventStagePair.first]->stageMask = eventStagePair.second;
                 }
             }
         }
@@ -2723,9 +2707,10 @@ void ValidationStateTracker::PreCallRecordDestroySemaphore(VkDevice device, VkSe
 
 void ValidationStateTracker::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) {
     if (!event) return;
-    EVENT_STATE *event_state = GetEventState(event);
+    EVENT_STATE *event_state = Get<EVENT_STATE>(event);
     const VulkanTypedHandle obj_struct(event, kVulkanObjectTypeEvent);
     InvalidateCommandBuffers(event_state->cb_bindings, obj_struct);
+    event_state->destroyed = true;
     eventMap.erase(event);
 }
 
@@ -5097,8 +5082,7 @@ void ValidationStateTracker::PostCallRecordGetFenceFdKHR(VkDevice device, const 
 void ValidationStateTracker::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkEvent *pEvent, VkResult result) {
     if (VK_SUCCESS != result) return;
-    eventMap[*pEvent].write_in_use = 0;
-    eventMap[*pEvent].stageMask = VkPipelineStageFlags(0);
+    eventMap[*pEvent] = std::make_shared<EVENT_STATE>();
 }
 
 void ValidationStateTracker::RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR *pCreateInfo,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -85,8 +85,8 @@ class SEMAPHORE_STATE : public BASE_NODE {
 
 class EVENT_STATE : public BASE_NODE {
   public:
-    int write_in_use;
-    VkPipelineStageFlags stageMask;
+    int write_in_use = 0;
+    VkPipelineStageFlags stageMask = VkPipelineStageFlags(0);
 };
 
 class QUEUE_STATE {
@@ -363,7 +363,6 @@ class ValidationStateTracker : public ValidationObject {
     //  TODO -- move to private
     //  TODO -- make consistent with traits approach below.
     std::unordered_map<VkQueue, QUEUE_STATE> queueMap;
-    std::unordered_map<VkEvent, EVENT_STATE> eventMap;
 
     std::unordered_set<VkQueue> queues;  // All queues under given device
     QueryMap queryToStateMap;
@@ -413,6 +412,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkFence, FENCE_STATE, fenceMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkQueryPool, QUERY_POOL_STATE, queryPoolMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkSemaphore, SEMAPHORE_STATE, semaphoreMap)
+    VALSTATETRACK_MAP_AND_TRAITS(VkEvent, EVENT_STATE, eventMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, SAMPLER_YCBCR_CONVERSION_STATE, samplerYcbcrConversionMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE, accelerationStructureMap)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR, accelerationStructureMap_khr)
@@ -622,8 +622,8 @@ class ValidationStateTracker : public ValidationObject {
                                                         const CMD_BUFFER_STATE* primary_cb = nullptr);
     const IMAGE_VIEW_STATE* GetActiveAttachmentImageViewState(const CMD_BUFFER_STATE* cb, uint32_t index,
                                                               const CMD_BUFFER_STATE* primary_cb = nullptr) const;
-    const EVENT_STATE* GetEventState(VkEvent event) const;
-    EVENT_STATE* GetEventState(VkEvent event);
+    const EVENT_STATE* GetEventState(VkEvent event) const { return Get<EVENT_STATE>(event); }
+    EVENT_STATE* GetEventState(VkEvent event) { return Get<EVENT_STATE>(event); }
     const QUEUE_STATE* GetQueueState(VkQueue queue) const;
     QUEUE_STATE* GetQueueState(VkQueue queue);
     const BINDABLE* GetObjectMemBinding(const VulkanTypedHandle& typed_handle) const;

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -359,11 +359,11 @@ class ImageRangeEncoder : public RangeEncoder {
 
 class ImageRangeGenerator {
   public:
-    ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_() {}
+    ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_(), base_address_() {}
     bool operator!=(const ImageRangeGenerator& rhs) { return (pos_ != rhs.pos_) || (&encoder_ != &rhs.encoder_); }
     ImageRangeGenerator(const ImageRangeEncoder& encoder);
     ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, const VkOffset3D& offset,
-                        const VkExtent3D& extent);
+                        const VkExtent3D& extent, VkDeviceSize base_address);
     inline const IndexRange& operator*() const { return pos_; }
     inline const IndexRange* operator->() const { return &pos_; }
     ImageRangeGenerator* operator++();
@@ -374,6 +374,7 @@ class ImageRangeGenerator {
     const VkImageSubresourceRange subres_range_;
     const VkOffset3D offset_;
     const VkExtent3D extent_;
+    VkDeviceSize base_address_;
     uint32_t range_arraylayer_base_;
     uint32_t range_layer_count_;
 

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -235,6 +235,8 @@ static inline ResourceAccessRange MakeRange(const BUFFER_VIEW_STATE &buf_view_st
 
 // Range generators for to allow event scope filtration to be limited to the top of the resource access traversal pipeline
 //
+// Note: there is no "begin/end" or reset facility.  These are each written as "one time through" generators.
+//
 // Usage:
 //  Constructor() -- initializes the generator to point to the begin of the space declared.
 //  *  -- the current range of the generator empty signfies end
@@ -301,8 +303,6 @@ using EventSimpleRangeGenerator = FilteredRangeGenerator<SyncEventState::ScopeMa
 // Templated to allow for different Range generators or map sources...
 
 // Generate the ranges that are the intersection of the RangeGen ranges and the entries in the FilterMap
-// Note that begin *cannot* reset RangeGen (image range generation currently doesn't support it), so you can only iterate over
-// this generator once.
 template <typename FilterMap, typename RangeGen, typename KeyType = typename FilterMap::key_type>
 class FilteredGeneratorGenerator {
   public:
@@ -353,7 +353,7 @@ class FilteredGeneratorGenerator {
     KeyType FastForwardFilter(const KeyType &range) {
         auto filter_range = FilterRange();
         int retry_count = 0;
-        const static int kRetryLimit = 2;  // TODO -- determine wheter this limit is optimal
+        const static int kRetryLimit = 2;  // TODO -- determine whether this limit is optimal
         while (!filter_range.empty() && (filter_range.end <= range.begin)) {
             if (retry_count < kRetryLimit) {
                 ++filter_pos_;

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -233,6 +233,172 @@ static inline ResourceAccessRange MakeRange(const BUFFER_VIEW_STATE &buf_view_st
     return MakeRange(*buf_view_state.buffer_state.get(), buf_view_state.create_info.offset, buf_view_state.create_info.range);
 }
 
+// Range generators for to allow event scope filtration to be limited to the top of the resource access traversal pipeline
+//
+// Usage:
+//  Constructor() -- initializes the generator to point to the begin of the space declared.
+//  *  -- the current range of the generator empty signfies end
+//  ++ -- advance to the next non-empty range (or end)
+
+// A wrapper for a single range with the same semantics as the actual generators below
+template <typename KeyType>
+class SingleRangeGenerator {
+  public:
+    SingleRangeGenerator(const KeyType &range) : current_(range) {}
+    KeyType &operator*() const { return *current_; }
+    KeyType *operator->() const { return &*current_; }
+    SingleRangeGenerator &operator++() {
+        current_ = KeyType();  // just one real range
+        return *this;
+    }
+
+    bool operator==(const SingleRangeGenerator &other) const { return current_ == other.current_; }
+
+  private:
+    SingleRangeGenerator() = default;
+    const KeyType range_;
+    KeyType current_;
+};
+
+// Generate the ranges that are the intersection of range and the entries in the FilterMap
+template <typename FilterMap, typename KeyType = typename FilterMap::key_type>
+class FilteredRangeGenerator {
+  public:
+    FilteredRangeGenerator(const FilterMap &filter, const KeyType &range)
+        : range_(range), filter_(&filter), filter_pos_(), current_() {
+        SeekBegin();
+    }
+    const KeyType &operator*() const { return current_; }
+    const KeyType *operator->() const { return &current_; }
+    FilteredRangeGenerator &operator++() {
+        ++filter_pos_;
+        UpdateCurrent();
+        return *this;
+    }
+
+    bool operator==(const FilteredRangeGenerator &other) const { return current_ == other.current_; }
+
+  private:
+    FilteredRangeGenerator() = default;
+    void UpdateCurrent() {
+        if (filter_pos_ != filter_->cend()) {
+            current_ = range_ & filter_pos_->first;
+        } else {
+            current_ = KeyType();
+        }
+    }
+    void SeekBegin() {
+        filter_pos_ = filter_->lower_bound(range_);
+        UpdateCurrent();
+    }
+    const KeyType range_;
+    const FilterMap *filter_;
+    typename FilterMap::const_iterator filter_pos_;
+    KeyType current_;
+};
+using EventSimpleRangeGenerator = FilteredRangeGenerator<SyncEventState::ScopeMap>;
+
+// Templated to allow for different Range generators or map sources...
+
+// Generate the ranges that are the intersection of the RangeGen ranges and the entries in the FilterMap
+// Note that begin *cannot* reset RangeGen (image range generation currently doesn't support it), so you can only iterate over
+// this generator once.
+template <typename FilterMap, typename RangeGen, typename KeyType = typename FilterMap::key_type>
+class FilteredGeneratorGenerator {
+  public:
+    FilteredGeneratorGenerator(const FilterMap &filter, RangeGen &gen) : filter_(&filter), gen_(&gen), filter_pos_(), current_() {
+        SeekBegin();
+    }
+    const KeyType &operator*() const { return current_; }
+    const KeyType *operator->() const { return &current_; }
+    FilteredGeneratorGenerator &operator++() {
+        KeyType gen_range = GenRange();
+        KeyType filter_range = FilterRange();
+        current_ = KeyType();
+        while (gen_range.non_empty() && filter_range.non_empty() && current_.empty()) {
+            if (gen_range.end > filter_range.end) {
+                // if the generated range is beyond the filter_range, advance the filter range
+                filter_range = AdvanceFilter();
+            } else {
+                gen_range = AdvanceGen();
+            }
+            current_ = gen_range & filter_range;
+        }
+        return *this;
+    }
+
+    bool operator==(const FilteredGeneratorGenerator &other) const { return current_ == other.current_; }
+
+  private:
+    KeyType AdvanceFilter() {
+        ++filter_pos_;
+        auto filter_range = FilterRange();
+        if (filter_range.valid()) {
+            FastForwardGen(filter_range);
+        }
+        return filter_range;
+    }
+    KeyType AdvanceGen() {
+        ++(*gen_);
+        auto gen_range = GenRange();
+        if (gen_range.valid()) {
+            FastForwardFilter(gen_range);
+        }
+        return gen_range;
+    }
+
+    KeyType FilterRange() const { return (filter_pos_ != filter_->cend()) ? filter_pos_->first : KeyType(); }
+    KeyType GenRange() const { return *(*gen_); }
+
+    KeyType FastForwardFilter(const KeyType &range) {
+        auto filter_range = FilterRange();
+        int retry_count = 0;
+        const static int kRetryLimit = 2;  // TODO -- determine wheter this limit is optimal
+        while (!filter_range.empty() && (filter_range.end <= range.begin)) {
+            if (retry_count < kRetryLimit) {
+                ++filter_pos_;
+                filter_range = FilterRange();
+                retry_count++;
+            } else {
+                // Okay we've tried walking, do a seek.
+                filter_pos_ = filter_->lower_bound(range);
+                break;
+            }
+        }
+        return FilterRange();
+    }
+
+    // TODO: Consider adding "seek" (or an absolute bound "get" to range generators to make this walk
+    // faster.
+    KeyType FastForwardGen(const KeyType &range) {
+        auto gen_range = GenRange();
+        while (!gen_range.empty() && (gen_range.end <= range.begin)) {
+            ++(*gen_);
+            gen_range = GenRange();
+        }
+        return gen_range;
+    }
+
+    void SeekBegin() {
+        auto gen_range = GenRange();
+        if (gen_range.empty()) {
+            current_ = KeyType();
+            filter_pos_ = filter_->cend();
+        } else {
+            filter_pos_ = filter_->lower_bound(gen_range);
+            current_ = gen_range & FilterRange();
+        }
+    }
+
+    FilteredGeneratorGenerator() = default;
+    const FilterMap *filter_;
+    RangeGen *const gen_;
+    typename FilterMap::const_iterator filter_pos_;
+    KeyType current_;
+};
+
+using EventImageRangeGenerator = FilteredGeneratorGenerator<SyncEventState::ScopeMap, subresource_adapter::ImageRangeGenerator>;
+
 // Expand the pipeline stage without regard to whether the are valid w.r.t. queue or extension
 VkPipelineStageFlags ExpandPipelineStages(VkQueueFlags queue_flags, VkPipelineStageFlags stage_mask) {
     VkPipelineStageFlags expanded = stage_mask;
@@ -511,6 +677,16 @@ HazardResult AccessContext::DetectPreviousHazard(AccessAddressType type, const D
     return hazard;
 }
 
+template <typename Action>
+void AccessContext::ForAll(Action &&action) {
+    for (const auto address_type : kAddressTypes) {
+        auto &accesses = GetAccessStateMap(address_type);
+        for (const auto &access : accesses) {
+            action(address_type, access);
+        }
+    }
+}
+
 // A recursive range walker for hazard detection, first for the current context and the (DetectHazardRecur) to walk
 // the DAG of the contexts (for example subpasses)
 template <typename Detector>
@@ -717,6 +893,14 @@ void AccessContext::ResolvePreviousAccess(AccessAddressType type, const Resource
             const ApplyTrackbackBarriersAction barrier_action(src_external_.barriers);
             src_external_.context->ResolveAccessRange(type, range, barrier_action, descent_map, infill_state);
         }
+    }
+}
+
+// Non-lazy import of all accesses, WaitEvents needs this.
+void AccessContext::ResolvePreviousAccesses() {
+    ResourceAccessState default_state;
+    for (const auto address_type : kAddressTypes) {
+        ResolvePreviousAccess(address_type, kFullRange, &GetAccessStateMap(address_type), &default_state);
     }
 }
 
@@ -1088,6 +1272,62 @@ class BarrierHazardDetector {
     SyncStageAccessFlags src_access_scope_;
 };
 
+class EventBarrierHazardDetector {
+  public:
+    EventBarrierHazardDetector(SyncStageAccessIndex usage_index, VkPipelineStageFlags src_exec_scope,
+                               SyncStageAccessFlags src_access_scope, const SyncEventState::ScopeMap &event_scope,
+                               const ResourceUsageTag &scope_tag)
+        : usage_index_(usage_index),
+          src_exec_scope_(src_exec_scope),
+          src_access_scope_(src_access_scope),
+          event_scope_(event_scope),
+          scope_pos_(event_scope.cbegin()),
+          scope_end_(event_scope.cend()),
+          scope_tag_(scope_tag) {}
+
+    HazardResult Detect(const ResourceAccessRangeMap::const_iterator &pos) const {
+        // TODO NOTE: This is almost the slowest way to do this... need to intelligently walk this...
+        // Need to find a more efficient sync, since we know pos->first is strictly increasing call to call
+        // NOTE: "cached_lower_bound_impl" with upgrades could do this.
+        if (scope_pos_ == scope_end_) return HazardResult();
+        if (!scope_pos_->first.intersects(pos->first)) {
+            event_scope_.lower_bound(pos->first);
+            if ((scope_pos_ == scope_end_) || !scope_pos_->first.intersects(pos->first)) return HazardResult();
+        }
+
+        // Some portion of this pos is in the event_scope, so check for a barrier hazard
+        return pos->second.DetectBarrierHazard(usage_index_, src_exec_scope_, src_access_scope_, scope_tag_);
+    }
+    HazardResult DetectAsync(const ResourceAccessRangeMap::const_iterator &pos, const ResourceUsageTag &start_tag) const {
+        // Async barrier hazard detection can use the same path as the usage index is not IsRead, but is IsWrite
+        return pos->second.DetectAsyncHazard(usage_index_, start_tag);
+    }
+
+  private:
+    SyncStageAccessIndex usage_index_;
+    VkPipelineStageFlags src_exec_scope_;
+    SyncStageAccessFlags src_access_scope_;
+    const SyncEventState::ScopeMap &event_scope_;
+    SyncEventState::ScopeMap::const_iterator scope_pos_;
+    SyncEventState::ScopeMap::const_iterator scope_end_;
+    const ResourceUsageTag &scope_tag_;
+};
+
+HazardResult AccessContext::DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags src_exec_scope,
+                                                     const SyncStageAccessFlags &src_access_scope,
+                                                     const VkImageSubresourceRange &subresource_range,
+                                                     const SyncEventState &sync_event, DetectOptions options) const {
+    // It's not particularly DRY to get the address type in this function as well as lower down, but we have to select the
+    // first access scope map to use, and there's no easy way to plumb it in below.
+    const auto address_type = ImageAddressType(image);
+    const auto &event_scope = sync_event.FirstScope(address_type);
+
+    EventBarrierHazardDetector detector(SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, src_exec_scope, src_access_scope,
+                                        event_scope, sync_event.first_scope_tag);
+    VkOffset3D zero_offset = {0, 0, 0};
+    return DetectHazard(detector, image, subresource_range, zero_offset, image.createInfo.extent, options);
+}
+
 HazardResult AccessContext::DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags src_exec_scope,
                                                      const SyncStageAccessFlags &src_access_scope,
                                                      const VkImageSubresourceRange &subresource_range,
@@ -1138,6 +1378,7 @@ template <typename Action>
 void UpdateMemoryAccessState(ResourceAccessRangeMap *accesses, const ResourceAccessRange &range, const Action &action) {
     // TODO: Optimization for operations that do a pure overwrite (i.e. WRITE usages which rewrite the state, vs READ usages
     //       that do incrementalupdates
+    assert(accesses);
     auto pos = accesses->lower_bound(range);
     if (pos == accesses->end() || !pos->first.intersects(range)) {
         // The range is empty, fill it with a default value.
@@ -1171,6 +1412,14 @@ void UpdateMemoryAccessState(ResourceAccessRangeMap *accesses, const ResourceAcc
         pos = next;
     }
 }
+template <typename Action, typename RangeGen>
+void UpdateMemoryAccessState(ResourceAccessRangeMap *accesses, const Action &action, RangeGen *range_gen_arg) {
+    assert(range_gen_arg);
+    auto &range_gen = *range_gen_arg;  // Non-const references must be * by style requirement but deref-ing * iterator is a pain
+    for (; range_gen->non_empty(); ++range_gen) {
+        UpdateMemoryAccessState(accesses, *range_gen, action);
+    }
+}
 
 struct UpdateMemoryAccessStateFunctor {
     using Iterator = ResourceAccessRangeMap::iterator;
@@ -1196,30 +1445,7 @@ struct UpdateMemoryAccessStateFunctor {
     const ResourceUsageTag &tag;
 };
 
-// This functor applies a single barrier, updating the "pending state" in each touched memory range, but does not
-// resolve the pendinging state. Suitable for processing Image and Buffer barriers from PipelineBarriers or Events
-class ApplyBarrierFunctor {
-  public:
-    using Iterator = ResourceAccessRangeMap::iterator;
-    inline Iterator Infill(ResourceAccessRangeMap *accesses, Iterator pos, ResourceAccessRange range) const { return pos; }
-
-    Iterator operator()(ResourceAccessRangeMap *accesses, Iterator pos) const {
-        auto &access_state = pos->second;
-        access_state.ApplyBarrier(barrier_, layout_transition_);
-        return pos;
-    }
-
-    ApplyBarrierFunctor(const SyncBarrier &barrier, bool layout_transition)
-        : barrier_(barrier), layout_transition_(layout_transition) {}
-
-  private:
-    const SyncBarrier barrier_;
-    const bool layout_transition_;
-};
-
-// This functor applies a collection of barriers, updating the "pending state" in each touched memory range, and optionally
-// resolves the pending state. Suitable for processing Global memory barriers, or Subpass Barriers when the "final" barrier
-// of a collection is known/present.
+// The barrier operation for pipeline and subpass dependencies`
 struct PipelineBarrierOp {
     SyncBarrier barrier;
     bool layout_transition;
@@ -1228,7 +1454,23 @@ struct PipelineBarrierOp {
     PipelineBarrierOp() = default;
     void operator()(ResourceAccessState *access_state) const { access_state->ApplyBarrier(barrier, layout_transition); }
 };
+// The barrier operation for wait events
+struct WaitEventBarrierOp {
+    const ResourceUsageTag *scope_tag;
+    SyncBarrier barrier;
+    bool layout_transition;
+    WaitEventBarrierOp(const ResourceUsageTag &scope_tag_, const SyncBarrier &barrier_, bool layout_transition_)
+        : scope_tag(&scope_tag_), barrier(barrier_), layout_transition(layout_transition_) {}
+    WaitEventBarrierOp() = default;
+    void operator()(ResourceAccessState *access_state) const {
+        assert(scope_tag);  // Not valid to have a non-scope op executed, default construct included for std::vector support
+        access_state->ApplyBarrier(*scope_tag, barrier, layout_transition);
+    }
+};
 
+// This functor applies a collection of barriers, updating the "pending state" in each touched memory range, and optionally
+// resolves the pending state. Suitable for processing Global memory barriers, or Subpass Barriers when the "final" barrier
+// of a collection is known/present.
 template <typename BarrierOp>
 class ApplyBarrierOpsFunctor {
   public:
@@ -1257,6 +1499,26 @@ class ApplyBarrierOpsFunctor {
     bool resolve_;
     const std::vector<BarrierOp> &barrier_ops_;
     const ResourceUsageTag &tag_;
+};
+
+// This functor applies a single barrier, updating the "pending state" in each touched memory range, but does not
+// resolve the pendinging state. Suitable for processing Image and Buffer barriers from PipelineBarriers or Events
+template <typename BarrierOp>
+class ApplyBarrierFunctor {
+  public:
+    using Iterator = ResourceAccessRangeMap::iterator;
+    inline Iterator Infill(ResourceAccessRangeMap *accesses, Iterator pos, ResourceAccessRange range) const { return pos; }
+
+    Iterator operator()(ResourceAccessRangeMap *accesses, Iterator pos) const {
+        auto &access_state = pos->second;
+        barrier_op_(&access_state);
+        return pos;
+    }
+
+    ApplyBarrierFunctor(const BarrierOp &barrier_op) : barrier_op_(barrier_op) {}
+
+  private:
+    const BarrierOp barrier_op_;
 };
 
 // This functor resolves the pendinging state.
@@ -1471,6 +1733,97 @@ void AccessContext::RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, u
     if (transitions.size()) {
         ResolvePendingBarrierFunctor apply_pending_action(tag);
         ApplyGlobalBarriers(apply_pending_action);
+    }
+}
+void CommandBufferAccessContext::ApplyBufferBarriers(const SyncEventState &sync_event, VkPipelineStageFlags dst_exec_scope,
+                                                     const SyncStageAccessFlags &dst_stage_accesses, uint32_t barrier_count,
+                                                     const VkBufferMemoryBarrier *barriers) {
+    const auto &scope_tag = sync_event.first_scope_tag;
+    auto *access_context = GetCurrentAccessContext();
+    const auto address_type = AccessAddressType::kLinear;
+    for (uint32_t index = 0; index < barrier_count; index++) {
+        auto barrier = barriers[index];  // barrier is a copy
+        const auto *buffer = sync_state_->Get<BUFFER_STATE>(barrier.buffer);
+        if (!buffer) continue;
+        const auto base_address = ResourceBaseAddress(*buffer);
+        barrier.size = GetBufferWholeSize(*buffer, barrier.offset, barrier.size);
+        const ResourceAccessRange range = MakeRange(barrier) + base_address;
+        const auto src_access_scope = SyncStageAccess::AccessScope(sync_event.stage_accesses, barrier.srcAccessMask);
+        const auto dst_access_scope = SyncStageAccess::AccessScope(dst_stage_accesses, barrier.dstAccessMask);
+        const SyncBarrier sync_barrier(sync_event.exec_scope, src_access_scope, dst_exec_scope, dst_access_scope);
+        const ApplyBarrierFunctor<WaitEventBarrierOp> barrier_action({scope_tag, sync_barrier, false /* layout_transition */});
+        EventSimpleRangeGenerator filtered_range_gen(sync_event.FirstScope(address_type), range);
+        UpdateMemoryAccessState(&(access_context->GetAccessStateMap(address_type)), barrier_action, &filtered_range_gen);
+    }
+}
+
+void CommandBufferAccessContext::ApplyGlobalBarriers(SyncEventState &sync_event, VkPipelineStageFlags dstStageMask,
+                                                     VkPipelineStageFlags dst_exec_scope,
+                                                     const SyncStageAccessFlags &dst_stage_accesses, uint32_t memory_barrier_count,
+                                                     const VkMemoryBarrier *pMemoryBarriers, const ResourceUsageTag &tag) {
+    std::vector<WaitEventBarrierOp> barrier_ops;
+    barrier_ops.reserve(std::min<uint32_t>(memory_barrier_count, 1));
+    const auto &scope_tag = sync_event.first_scope_tag;
+    auto *access_context = GetCurrentAccessContext();
+    for (uint32_t barrier_index = 0; barrier_index < memory_barrier_count; barrier_index++) {
+        const auto &barrier = pMemoryBarriers[barrier_index];
+        SyncBarrier sync_barrier(sync_event.exec_scope,
+                                 SyncStageAccess::AccessScope(sync_event.stage_accesses, barrier.srcAccessMask), dst_exec_scope,
+                                 SyncStageAccess::AccessScope(dst_stage_accesses, barrier.dstAccessMask));
+        barrier_ops.emplace_back(scope_tag, sync_barrier, false);
+    }
+    if (0 == memory_barrier_count) {
+        // If there are no global memory barriers, force an exec barrier
+        barrier_ops.emplace_back(scope_tag, SyncBarrier(sync_event.exec_scope, 0, dst_exec_scope, 0), false);
+    }
+    ApplyBarrierOpsFunctor<WaitEventBarrierOp> barriers_functor(false /* don't resolve */, barrier_ops, tag);
+    for (const auto address_type : kAddressTypes) {
+        EventSimpleRangeGenerator filtered_range_gen(sync_event.FirstScope(address_type), kFullRange);
+        UpdateMemoryAccessState(&(access_context->GetAccessStateMap(address_type)), barriers_functor, &filtered_range_gen);
+    }
+
+    // Apply the global barrier to the event itself (for race condition tracking)
+    // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
+    sync_event.barriers = dstStageMask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    sync_event.barriers |= dst_exec_scope;
+}
+
+void CommandBufferAccessContext::ApplyGlobalBarriersToEvents(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags src_exec_scope,
+                                                             VkPipelineStageFlags dstStageMask,
+                                                             VkPipelineStageFlags dst_exec_scope) {
+    const bool all_commands_bit = 0 != (srcStageMask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    for (auto &event_pair : event_state_) {
+        assert(event_pair.second);  // Shouldn't be storing empty
+        auto &sync_event = *event_pair.second;
+        // Events don't happen at a stage, so we need to check and store the unexpanded ALL_COMMANDS if set for inter-event-calls
+        if ((sync_event.barriers & src_exec_scope) || all_commands_bit) {
+            sync_event.barriers |= dst_exec_scope;
+            sync_event.barriers |= dstStageMask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        }
+    }
+}
+
+void CommandBufferAccessContext::ApplyImageBarriers(const SyncEventState &sync_event, VkPipelineStageFlags dst_exec_scope,
+                                                    const SyncStageAccessFlags &dst_stage_accesses, uint32_t barrier_count,
+                                                    const VkImageMemoryBarrier *barriers, const ResourceUsageTag &tag) {
+    const auto &scope_tag = sync_event.first_scope_tag;
+    auto *access_context = GetCurrentAccessContext();
+    for (uint32_t index = 0; index < barrier_count; index++) {
+        const auto &barrier = barriers[index];
+        const auto *image = sync_state_->Get<IMAGE_STATE>(barrier.image);
+        if (!image) continue;
+        auto subresource_range = NormalizeSubresourceRange(image->createInfo, barrier.subresourceRange);
+        bool layout_transition = barrier.oldLayout != barrier.newLayout;
+        const auto src_access_scope = SyncStageAccess::AccessScope(sync_event.stage_accesses, barrier.srcAccessMask);
+        const auto dst_access_scope = SyncStageAccess::AccessScope(dst_stage_accesses, barrier.dstAccessMask);
+        const SyncBarrier sync_barrier(sync_event.exec_scope, src_access_scope, dst_exec_scope, dst_access_scope);
+        const ApplyBarrierFunctor<WaitEventBarrierOp> barrier_action({scope_tag, sync_barrier, layout_transition});
+        const auto base_address = ResourceBaseAddress(*image);
+        subresource_adapter::ImageRangeGenerator range_gen(*image->fragment_encoder.get(), subresource_range, {0, 0, 0},
+                                                           image->createInfo.extent, base_address);
+        const auto address_type = AccessContext::ImageAddressType(*image);
+        EventImageRangeGenerator filtered_range_gen(sync_event.FirstScope(address_type), range_gen);
+        UpdateMemoryAccessState(&(access_context->GetAccessStateMap(address_type)), barrier_action, &filtered_range_gen);
     }
 }
 
@@ -1891,26 +2244,261 @@ void CommandBufferAccessContext::RecordEndRenderPass(const RENDER_PASS_STATE &re
 
 bool CommandBufferAccessContext::ValidateSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
                                                   VkPipelineStageFlags stageMask) const {
-    return false;
+    // I'll put this here just in case we need to pass this in for future extension support
+    const auto cmd = CMD_SETEVENT;
+    bool skip = false;
+    const auto *sync_event = GetEventState(event);
+    if (!sync_event) return false;  // Core, Lifetimes, or Param check needs to catch invalid events.
+
+    const char *const reset_set =
+        "%s: %s %s operation following %s without intervening execution barrier, is a race condition and may result in data "
+        "hazards.";
+    const char *const wait =
+        "%s: %s %s operation following %s without intervening vkCmdResetEvent, may result in data hazard and is ignored.";
+
+    const auto exec_scope = WithEarlierPipelineStages(ExpandPipelineStages(GetQueueFlags(), stageMask));
+    if (!sync_event->HasBarrier(stageMask, exec_scope)) {
+        const char *vuid = nullptr;
+        const char *message = nullptr;
+        switch (sync_event->last_command) {
+            case CMD_RESETEVENT:
+                // Needs a barrier between reset and set
+                vuid = "SYNC-vkCmdSetEvent-missingbarrier-reset";
+                message = reset_set;
+                break;
+            case CMD_SETEVENT:
+                // Needs a barrier between set and set
+                vuid = "SYNC-vkCmdSetEvent-missingbarrier-set";
+                message = reset_set;
+                break;
+            case CMD_WAITEVENTS:
+                // Needs a barrier or is in second execution scope
+                vuid = "SYNC-vkCmdSetEvent-missingbarrier-wait";
+                message = wait;
+                break;
+            default:
+                // The only other valid last command that wasn't one.
+                assert(sync_event->last_command == CMD_NONE);
+                break;
+        }
+        if (vuid) {
+            assert(nullptr != message);
+            const char *const cmd_name = CommandTypeString(cmd);
+            skip |= sync_state_->LogError(event, vuid, message, cmd_name, sync_state_->report_data->FormatHandle(event).c_str(),
+                                          cmd_name, CommandTypeString(sync_event->last_command));
+        }
+    }
+
+    return skip;
 }
 
-void CommandBufferAccessContext::RecordSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {}
+void CommandBufferAccessContext::RecordSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
+                                                const ResourceUsageTag &tag) {
+    auto *sync_event = GetEventState(event);
+    if (!sync_event) return;  // Core, Lifetimes, or Param check needs to catch invalid events.
+
+    // NOTE: We're going to simply record the sync scope here, as anything else would be implementation defined/undefined
+    //       and we're issuing errors re: missing barriers between event commands, which if the user fixes would fix
+    //       any issues caused by naive scope setting here.
+
+    // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
+    // Given:
+    //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
+    // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
+
+    const auto stage_mask = ExpandPipelineStages(GetQueueFlags(), stageMask);
+    const auto exec_scope = WithEarlierPipelineStages(stage_mask);
+
+    sync_event->stage_mask_param = stageMask;
+
+    if (!sync_event->HasBarrier(stageMask, exec_scope)) {
+        sync_event->unsynchronized_set = sync_event->last_command;
+        sync_event->ResetFirstScope();
+    } else if (sync_event->exec_scope == 0) {
+        // We only set the scope if there isn't one
+        sync_event->stage_mask = stage_mask;
+        sync_event->exec_scope = exec_scope;
+        sync_event->stage_accesses = SyncStageAccess::AccessScopeByStage(sync_event->stage_mask);
+
+        auto set_scope = [&sync_event](AccessAddressType address_type, const ResourceAccessRangeMap::value_type &access) {
+            auto &scope_map = sync_event->first_scope[static_cast<size_t>(address_type)];
+            if (access.second.InSourceScopeOrChain(sync_event->exec_scope, sync_event->stage_accesses)) {
+                scope_map.insert(scope_map.end(), std::make_pair(access.first, true));
+            }
+        };
+        GetCurrentAccessContext()->ForAll(set_scope);
+        sync_event->unsynchronized_set = CMD_NONE;
+        sync_event->first_scope_tag = tag;
+    }
+    sync_event->last_command = CMD_SETEVENT;
+    sync_event->barriers = 0U;
+}
 
 bool CommandBufferAccessContext::ValidateResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
                                                     VkPipelineStageFlags stageMask) const {
-    return false;
+    // I'll put this here just in case we need to pass this in for future extension support
+    const auto cmd = CMD_RESETEVENT;
+
+    bool skip = false;
+    // TODO: EVENTS:
+    // What is it we need to check... that we've had a reset since a set?  Set/Set seems ill formed...
+    const auto *sync_event = GetEventState(event);
+    if (!sync_event) return false;  // Core, Lifetimes, or Param check needs to catch invalid events.
+
+    const char *const set_wait =
+        "%s: %s %s operation following %s without intervening execution barrier, is a race condition and may result in data "
+        "hazards.";
+    const char *message = set_wait;  // Only one message this call.
+    const auto exec_scope = WithEarlierPipelineStages(ExpandPipelineStages(GetQueueFlags(), stageMask));
+    if (!sync_event->HasBarrier(stageMask, exec_scope)) {
+        const char *vuid = nullptr;
+        switch (sync_event->last_command) {
+            case CMD_SETEVENT:
+                // Needs a barrier between set and reset
+                vuid = "SYNC-vkCmdResetEvent-missingbarrier-set";
+                break;
+            case CMD_WAITEVENTS: {
+                // Needs to be in the barriers chain (either because of a barrier, or because of dstStageMask
+                vuid = "SYNC-vkCmdResetEvent-missingbarrier-wait";
+                break;
+            }
+            default:
+                // The only other valid last command that wasn't one.
+                assert((sync_event->last_command == CMD_NONE) || (sync_event->last_command == CMD_RESETEVENT));
+                break;
+        }
+        if (vuid) {
+            const char *const cmd_name = CommandTypeString(cmd);
+            skip |= sync_state_->LogError(event, vuid, message, cmd_name, sync_state_->report_data->FormatHandle(event).c_str(),
+                                          cmd_name, CommandTypeString(sync_event->last_command));
+        }
+    }
+    return skip;
 }
 
-void CommandBufferAccessContext::RecordResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {}
+void CommandBufferAccessContext::RecordResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
+    const auto cmd = CMD_RESETEVENT;
+    auto *sync_event = GetEventState(event);
+    if (!sync_event) return;
 
-bool CommandBufferAccessContext::ValidateWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                    VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                                    uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-                                                    uint32_t bufferMemoryBarrierCount,
+    // Clear out the first sync scope, any races vs. wait or set are reported, so we'll keep the bookkeeping simple assuming
+    // the safe case
+    for (const auto address_type : kAddressTypes) {
+        sync_event->first_scope[static_cast<size_t>(address_type)].clear();
+    }
+
+    // Update the event state
+    sync_event->last_command = cmd;
+    sync_event->unsynchronized_set = CMD_NONE;
+    sync_event->ResetFirstScope();
+    sync_event->barriers = 0U;
+}
+
+bool CommandBufferAccessContext::ValidateWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,
+                                                    VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
+                                                    const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
                                                     const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                     uint32_t imageMemoryBarrierCount,
                                                     const VkImageMemoryBarrier *pImageMemoryBarriers) const {
-    return false;
+    const auto cmd = CMD_WAITEVENTS;
+    const char *const ignored = "Wait operation is ignored for this event.";
+    bool skip = false;
+
+    if (srcStageMask & VK_PIPELINE_STAGE_HOST_BIT) {
+        const char *const cmd_name = CommandTypeString(cmd);
+        const char *const vuid = "SYNC-vkCmdWaitEvents-hostevent-unsupported";
+        skip = sync_state_->LogWarning(cb_state_->commandBuffer, vuid,
+                                       "%s, srcStageMask includes %s, unsupported by synchronization validaton.", cmd_name,
+                                       string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), ignored);
+    }
+
+    VkPipelineStageFlags event_stage_masks = 0U;
+    for (uint32_t event_index = 0; event_index < eventCount; event_index++) {
+        const auto event = pEvents[event_index];
+        const auto *sync_event = GetEventState(event);
+        if (!sync_event) continue;  // Core, Lifetimes, or Param check needs to catch invalid events.
+
+        event_stage_masks |= sync_event->stage_mask_param;
+        const auto ignore_reason = sync_event->IsIgnoredByWait(srcStageMask);
+        if (ignore_reason) {
+            switch (ignore_reason) {
+                case SyncEventState::ResetWaitRace: {
+                    const char *const cmd_name = CommandTypeString(cmd);
+                    const char *const vuid = "SYNC-vkCmdWaitEvents-missingbarrier-reset";
+                    const char *const message =
+                        "%s: %s %s operation following %s without intervening execution barrier, may cause race condition. %s";
+                    skip |=
+                        sync_state_->LogError(event, vuid, message, cmd_name, sync_state_->report_data->FormatHandle(event).c_str(),
+                                              cmd_name, CommandTypeString(sync_event->last_command), ignored);
+                    break;
+                }
+                case SyncEventState::SetRace: {
+                    // Issue error message that Wait is waiting on an signal subject to race condition, and is thus ignored for this
+                    // event
+                    const char *const cmd_name = CommandTypeString(cmd);
+                    const char *const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
+                    const char *const message =
+                        "%s: %s Unsychronized %s calls result in race conditions w.r.t. event signalling, % %s";
+                    const char *const reason = "First synchronization scope is undefined.";
+                    skip |=
+                        sync_state_->LogError(event, vuid, message, cmd_name, sync_state_->report_data->FormatHandle(event).c_str(),
+                                              CommandTypeString(sync_event->last_command), reason, ignored);
+                    break;
+                }
+                case SyncEventState::MissingStageBits: {
+                    const VkPipelineStageFlags missing_bits = sync_event->stage_mask_param & ~srcStageMask;
+                    // Issue error message that event waited for is not in wait events scope
+                    const char *const cmd_name = CommandTypeString(cmd);
+                    const char *const vuid = "VUID-vkCmdWaitEvents-srcStageMask-01158";
+                    const char *const message =
+                        "%s: %s stageMask 0x%" PRIx32 " includes bits not present in srcStageMask 0x%" PRIx32
+                        ". Bits missing from srcStageMask %s. %s";
+                    skip |= sync_state_->LogError(
+                        event, vuid, message, cmd_name, sync_state_->report_data->FormatHandle(event).c_str(),
+                        sync_event->stage_mask_param, srcStageMask, string_VkPipelineStageFlags(missing_bits).c_str(), ignored);
+                    break;
+                }
+                default:
+                    assert(ignore_reason == SyncEventState::NotIgnored);
+            }
+        } else if (imageMemoryBarrierCount) {
+            const auto *context = GetCurrentAccessContext();
+            assert(context);
+            for (uint32_t barrier_index = 0; barrier_index < imageMemoryBarrierCount; barrier_index++) {
+                const auto &barrier = pImageMemoryBarriers[barrier_index];
+                if (barrier.oldLayout == barrier.newLayout) continue;
+                const auto *image_state = sync_state_->Get<IMAGE_STATE>(barrier.image);
+                if (!image_state) continue;
+                auto subresource_range = NormalizeSubresourceRange(image_state->createInfo, barrier.subresourceRange);
+                const auto src_access_scope = SyncStageAccess::AccessScope(sync_event->stage_accesses, barrier.srcAccessMask);
+                const auto hazard =
+                    context->DetectImageBarrierHazard(*image_state, sync_event->exec_scope, src_access_scope, subresource_range,
+                                                      *sync_event, AccessContext::DetectOptions::kDetectAll);
+                if (hazard.hazard) {
+                    const char *const cmd_name = CommandTypeString(cmd);
+                    skip |= sync_state_->LogError(barrier.image, string_SyncHazardVUID(hazard.hazard),
+                                                  "%s: Hazard %s for image barrier %" PRIu32 " %s. Access info %s.", cmd_name,
+                                                  string_SyncHazard(hazard.hazard), barrier_index,
+                                                  sync_state_->report_data->FormatHandle(barrier.image).c_str(),
+                                                  string_UsageTag(hazard).c_str());
+                    break;
+                }
+            }
+        }
+    }
+
+    // Note that we can't check for HOST in pEvents as we don't track that set event type
+    const auto extra_stage_bits = (srcStageMask & ~VK_PIPELINE_STAGE_HOST_BIT) & ~event_stage_masks;
+    if (extra_stage_bits) {
+        // Issue error message that event waited for is not in wait events scope
+        const char *const cmd_name = CommandTypeString(cmd);
+        const char *const vuid = "VUID-vkCmdWaitEvents-srcStageMask-01158";
+        const char *const message =
+            "%s: srcStageMask 0x%" PRIx32 " contains stages not present in pEvents stageMask. Extra stages are %s.";
+        skip |= sync_state_->LogError(cb_state_->commandBuffer, vuid, message, cmd_name, srcStageMask,
+                                      string_VkPipelineStageFlags(extra_stage_bits).c_str());
+    }
+    return skip;
 }
 
 void CommandBufferAccessContext::RecordWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
@@ -1919,7 +2507,67 @@ void CommandBufferAccessContext::RecordWaitEvents(VkCommandBuffer commandBuffer,
                                                   uint32_t bufferMemoryBarrierCount,
                                                   const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                   uint32_t imageMemoryBarrierCount,
-                                                  const VkImageMemoryBarrier *pImageMemoryBarriers) const {}
+                                                  const VkImageMemoryBarrier *pImageMemoryBarriers, const ResourceUsageTag &tag) {
+    auto *access_context = GetCurrentAccessContext();
+    assert(access_context);
+    if (!access_context) return;
+
+    // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
+    // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
+    // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
+    // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here
+    access_context->ResolvePreviousAccesses();
+
+    const auto dst_stage_mask = ExpandPipelineStages(GetQueueFlags(), dstStageMask);
+    auto dst_stage_accesses = SyncStageAccess::AccessScopeByStage(dst_stage_mask);
+    const auto dst_exec_scope = WithLaterPipelineStages(dst_stage_mask);
+    for (uint32_t event_index = 0; event_index < eventCount; event_index++) {
+        const auto event = pEvents[event_index];
+        auto *sync_event = GetEventState(event);
+        if (!sync_event) continue;
+
+        sync_event->last_command = CMD_WAITEVENTS;
+
+        if (!sync_event->IsIgnoredByWait(srcStageMask)) {
+            // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
+            // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
+            // of the barriers is maintained.
+            ApplyBufferBarriers(*sync_event, dst_exec_scope, dst_stage_accesses, bufferMemoryBarrierCount, pBufferMemoryBarriers);
+            ApplyImageBarriers(*sync_event, dst_exec_scope, dst_stage_accesses, imageMemoryBarrierCount, pImageMemoryBarriers, tag);
+            ApplyGlobalBarriers(*sync_event, dstStageMask, dst_exec_scope, dst_stage_accesses, memoryBarrierCount, pMemoryBarriers,
+                                tag);
+        } else {
+            // We ignored this wait, so we don't have any effective synchronization barriers for it.
+            sync_event->barriers = 0U;
+        }
+    }
+
+    // Apply the pending barriers
+    ResolvePendingBarrierFunctor apply_pending_action(tag);
+    access_context->ApplyGlobalBarriers(apply_pending_action);
+}
+
+void CommandBufferAccessContext::RecordDestroyEvent(VkEvent event) {
+    // Erase is okay with the key not being
+    event_state_.erase(event);
+}
+
+SyncEventState *CommandBufferAccessContext::GetEventState(VkEvent event) {
+    auto &event_up = event_state_[event];
+    if (!event_up) {
+        auto event_atate = sync_state_->GetShared<EVENT_STATE>(event);
+        event_up.reset(new SyncEventState(event_atate));
+    }
+    return event_up.get();
+}
+
+const SyncEventState *CommandBufferAccessContext::GetEventState(VkEvent event) const {
+    auto event_it = event_state_.find(event);
+    if (event_it == event_state_.cend()) {
+        return nullptr;
+    }
+    return event_it->second.get();
+}
 
 bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const SyncValidator &sync_state, const CMD_BUFFER_STATE &cmd,
                                                             const VkRect2D &render_area, const char *func_name) const {
@@ -2417,21 +3065,56 @@ HazardResult ResourceAccessState::DetectBarrierHazard(SyncStageAccessIndex usage
         // Look at the reads if any
         for (uint32_t read_index = 0; read_index < last_read_count; read_index++) {
             const auto &read_access = last_reads[read_index];
-            // If the read stage is not in the src sync sync
-            // *AND* not execution chained with an existing sync barrier (that's the or)
-            // then the barrier access is unsafe (R/W after R)
-            if ((src_exec_scope & (read_access.stage | read_access.barriers)) == 0) {
+            if (read_access.IsReadBarrierHazard(src_exec_scope)) {
                 hazard.Set(this, usage_index, WRITE_AFTER_READ, read_access.access, read_access.tag);
                 break;
             }
         }
+    } else if (last_write.any() && IsWriteBarrierHazard(src_exec_scope, src_access_scope)) {
+        hazard.Set(this, usage_index, WRITE_AFTER_WRITE, last_write, write_tag);
+    }
+
+    return hazard;
+}
+
+HazardResult ResourceAccessState::DetectBarrierHazard(SyncStageAccessIndex usage_index, VkPipelineStageFlags src_exec_scope,
+                                                      const SyncStageAccessFlags &src_access_scope,
+                                                      const ResourceUsageTag &event_tag) const {
+    // Only supporting image layout transitions for now
+    assert(usage_index == SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
+    HazardResult hazard;
+    // only test for WAW if there no intervening read operations.
+    // See DetectHazard(SyncStagetAccessIndex) above for more details.
+
+    if (last_read_count) {
+        // Look at the reads if any... if reads exist, they are either the resaon the access is in the event
+        // first scope, or they are a hazard.
+        for (uint32_t read_index = 0; read_index < last_read_count; read_index++) {
+            const auto &read_access = last_reads[read_index];
+            if (read_access.tag.IsBefore(event_tag)) {
+                // The read is in the events first synchronization scope, so we use a barrier hazard check
+                // If the read stage is not in the src sync scope
+                // *AND* not execution chained with an existing sync barrier (that's the or)
+                // then the barrier access is unsafe (R/W after R)
+                if (read_access.IsReadBarrierHazard(src_exec_scope)) {
+                    hazard.Set(this, usage_index, WRITE_AFTER_READ, read_access.access, read_access.tag);
+                    break;
+                }
+            } else {
+                // The read not in the event first sync scope and so is a hazard vs. the layout transition
+                hazard.Set(this, usage_index, WRITE_AFTER_READ, read_access.access, read_access.tag);
+            }
+        }
     } else if (last_write.any()) {
-        // If the previous write is *not* in the 1st access scope
-        // *AND* the current barrier is not in the dependency chain
-        // *AND* the there is no prior memory barrier for the previous write in the dependency chain
-        // then the barrier access is unsafe (R/W after W)
-        if (((last_write & src_access_scope) == 0) && ((src_exec_scope & write_dependency_chain) == 0) && (write_barriers == 0)) {
-            // TODO: Do we need a difference hazard name for this?
+        // if there are no reads, the write is either the reason the access is in the event scope... they are a hazard
+        if (write_tag.IsBefore(event_tag)) {
+            // The write is in the first sync scope of the event (sync their aren't any reads to be the reason)
+            // So do a normal barrier hazard check
+            if (IsWriteBarrierHazard(src_exec_scope, src_access_scope)) {
+                hazard.Set(this, usage_index, WRITE_AFTER_WRITE, last_write, write_tag);
+            }
+        } else {
+            // The write isn't in scope, and is thus a hazard to the layout transistion for wait
             hazard.Set(this, usage_index, WRITE_AFTER_WRITE, last_write, write_tag);
         }
     }
@@ -2567,7 +3250,7 @@ void ResourceAccessState::ApplyBarrier(const SyncBarrier &barrier, bool layout_t
     //       transistion, under the theory of "most recent access".  If the read/write *isn't* safe
     //       vs. this layout transition DetectBarrierHazard should report it.  We treat the layout
     //       transistion *as* a write and in scope with the barrier (it's before visibility).
-    if (layout_transition || InSourceScopeOrChain(barrier.src_exec_scope, barrier.src_access_scope)) {
+    if (layout_transition || WriteInSourceScopeOrChain(barrier.src_exec_scope, barrier.src_access_scope)) {
         pending_write_barriers |= barrier.dst_access_scope;
         pending_write_dep_chain |= barrier.dst_exec_scope;
     }
@@ -2587,6 +3270,40 @@ void ResourceAccessState::ApplyBarrier(const SyncBarrier &barrier, bool layout_t
     }
 }
 
+// Apply the tag scoped memory barrier without updating the existing barriers.  The execution barrier
+// changes the "chaining" state, but to keep barriers independent. See discussion above.
+void ResourceAccessState::ApplyBarrier(const ResourceUsageTag &scope_tag, const SyncBarrier &barrier, bool layout_transition) {
+    // The scope logic for events is, if we're here, the resource usage was flagged as "in the first execution scope" at
+    // the time of the SetEvent, thus all we need check is whether the access is the same one (i.e. before the scope tag
+    // in order to know if it's in the excecution scope
+    // Notice that the layout transition sets the pending barriers *regardless*, as any lack of src_access_scope to
+    // guard against the layout transition should be reported in the detect barrier hazard phase, and we only report
+    // errors w.r.t. "most recent" accesses.
+    if (layout_transition || ((write_tag.IsBefore(scope_tag)) && (barrier.src_access_scope & last_write).any())) {
+        pending_write_barriers |= barrier.dst_access_scope;
+        pending_write_dep_chain |= barrier.dst_exec_scope;
+    }
+    // Track layout transistion as pending as we can't modify last_write until all barriers processed
+    pending_layout_transition |= layout_transition;
+
+    if (!pending_layout_transition) {
+        // Once we're dealing with a layout transition (which is modelled as a *write*) then the last reads/writes/chains
+        // don't need to be tracked as we're just going to zero them.
+        for (uint32_t read_index = 0; read_index < last_read_count; read_index++) {
+            ReadState &access = last_reads[read_index];
+            // If this read is the same one we included in the set event and in scope, then apply the execution barrier...
+            // NOTE: That's not really correct... this read stage might *not* have been included in the setevent, and the barriers
+            // representing the chain might have changed since then (that would be an odd usage), so as a first approximation
+            // we'll assume the barriers *haven't* been changed since (if the tag hasn't), and while this could be a false
+            // positive in the case of Set; SomeBarrier; Wait; we'll live with it until we can add more state to the first scope
+            // capture (the specific write and read stages that *were* in scope at the moment of SetEvents.
+            // TODO: eliminate the false positive by including write/read-stages "in scope" information in SetEvents first_scope
+            if (access.tag.IsBefore(scope_tag) && (barrier.src_exec_scope & (access.stage | access.barriers))) {
+                access.pending_dep_chain |= barrier.dst_exec_scope;
+            }
+        }
+    }
+}
 void ResourceAccessState::ApplyPendingBarriers(const ResourceUsageTag &tag) {
     if (pending_layout_transition) {
         // SetWrite clobbers the read count, and thus we don't have to clear the read_state out.
@@ -2709,7 +3426,7 @@ void SyncValidator::ApplyBufferBarriers(AccessContext *context, VkPipelineStageF
         const auto src_access_scope = AccessScope(src_stage_accesses, barrier.srcAccessMask);
         const auto dst_access_scope = AccessScope(dst_stage_accesses, barrier.dstAccessMask);
         const SyncBarrier sync_barrier(src_exec_scope, src_access_scope, dst_exec_scope, dst_access_scope);
-        const ApplyBarrierFunctor update_action(sync_barrier, false /* layout_transition */);
+        const ApplyBarrierFunctor<PipelineBarrierOp> update_action({sync_barrier, false /* layout_transition */});
         context->UpdateResourceAccess(*buffer, range, update_action);
     }
 }
@@ -2727,7 +3444,7 @@ void SyncValidator::ApplyImageBarriers(AccessContext *context, VkPipelineStageFl
         const auto src_access_scope = AccessScope(src_stage_accesses, barrier.srcAccessMask);
         const auto dst_access_scope = AccessScope(dst_stage_accesses, barrier.dstAccessMask);
         const SyncBarrier sync_barrier(src_exec_scope, src_access_scope, dst_exec_scope, dst_access_scope);
-        const ApplyBarrierFunctor barrier_action(sync_barrier, layout_transition);
+        const ApplyBarrierFunctor<PipelineBarrierOp> barrier_action({sync_barrier, layout_transition});
         context->UpdateResourceAccess(*image, subresource_range, barrier_action);
     }
 }
@@ -2750,7 +3467,6 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
             const ResourceAccessRange src_range = MakeRange(*src_buffer, copy_region.srcOffset, copy_region.size);
             auto hazard = context->DetectHazard(*src_buffer, SYNC_TRANSFER_TRANSFER_READ, src_range);
             if (hazard.hazard) {
-                // TODO -- add tag information to log msg when useful.
                 skip |= LogError(srcBuffer, string_SyncHazardVUID(hazard.hazard),
                                  "vkCmdCopyBuffer: Hazard %s for srcBuffer %s, region %" PRIu32 ". Access info %s.",
                                  string_SyncHazard(hazard.hazard), report_data->FormatHandle(srcBuffer).c_str(), region,
@@ -2792,6 +3508,13 @@ void SyncValidator::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, Vk
             const ResourceAccessRange dst_range = MakeRange(*dst_buffer, copy_region.dstOffset, copy_region.size);
             context->UpdateAccessState(*dst_buffer, SYNC_TRANSFER_TRANSFER_WRITE, dst_range, tag);
         }
+    }
+}
+
+void SyncValidator::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) {
+    // Clear out events from the command buffer contexts
+    for (auto &cb_context : cb_access_state) {
+        cb_context.second->RecordDestroyEvent(event);
     }
 }
 
@@ -3071,6 +3794,9 @@ void SyncValidator::PreCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffe
     // This is needed to guarantee order independence of the three lists.
     ApplyGlobalBarriers(access_context, src_exec_scope, dst_exec_scope, src_stage_accesses, dst_stage_accesses, memoryBarrierCount,
                         pMemoryBarriers, tag);
+
+    // Need to pass the unexpanded stage masks as the ALL_COMMANDS bit is removed during expansion.
+    cb_access_context->ApplyGlobalBarriersToEvents(srcStageMask, src_exec_scope, dstStageMask, dst_exec_scope);
 }
 
 void SyncValidator::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
@@ -4521,8 +5247,8 @@ void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkE
     auto *cb_context = GetAccessContext(commandBuffer);
     assert(cb_context);
     if (!cb_context) return;
-
-    cb_context->RecordSetEvent(commandBuffer, event, stageMask);
+    const auto tag = cb_context->NextCommandTag(CMD_SETEVENT);
+    cb_context->RecordSetEvent(commandBuffer, event, stageMask, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
@@ -4556,8 +5282,8 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
     assert(cb_context);
     if (!cb_context) return skip;
 
-    return cb_context->ValidateWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
-                                          pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount,
+    return cb_context->ValidateWaitEvents(eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
+                                          bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount,
                                           pImageMemoryBarriers);
 }
 
@@ -4576,7 +5302,39 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
     assert(cb_context);
     if (!cb_context) return;
 
+    const auto tag = cb_context->NextCommandTag(CMD_WAITEVENTS);
     cb_context->RecordWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
                                  pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount,
-                                 pImageMemoryBarriers);
+                                 pImageMemoryBarriers, tag);
+}
+
+void SyncEventState::ResetFirstScope() {
+    for (const auto address_type : kAddressTypes) {
+        first_scope[static_cast<size_t>(address_type)].clear();
+    }
+    stage_mask = 0U;
+    exec_scope = 0U;
+    stage_accesses.reset();
+}
+
+// Keep the "ignore this event" logic in same place for ValidateWait and RecordWait to use
+SyncEventState::IgnoreReason SyncEventState::IsIgnoredByWait(VkPipelineStageFlags srcStageMask) const {
+    IgnoreReason reason = NotIgnored;
+
+    if (last_command == CMD_RESETEVENT && !HasBarrier(0U, 0U)) {
+        reason = ResetWaitRace;
+    } else if (unsynchronized_set) {
+        reason = SetRace;
+    } else {
+        const VkPipelineStageFlags missing_bits = stage_mask_param & ~srcStageMask;
+        if (missing_bits) reason = MissingStageBits;
+    }
+
+    return reason;
+}
+
+bool SyncEventState::HasBarrier(VkPipelineStageFlags stageMask, VkPipelineStageFlags exec_scope_arg) const {
+    bool has_barrier = (last_command == CMD_NONE) || (stageMask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT) ||
+                       (barriers & exec_scope_arg) || (barriers & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    return has_barrier;
 }

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1220,22 +1220,25 @@ class ApplyBarrierFunctor {
 // This functor applies a collection of barriers, updating the "pending state" in each touched memory range, and optionally
 // resolves the pending state. Suitable for processing Global memory barriers, or Subpass Barriers when the "final" barrier
 // of a collection is known/present.
+struct PipelineBarrierOp {
+    SyncBarrier barrier;
+    bool layout_transition;
+    PipelineBarrierOp(const SyncBarrier &barrier_, bool layout_transition_)
+        : barrier(barrier_), layout_transition(layout_transition_) {}
+    PipelineBarrierOp() = default;
+    void operator()(ResourceAccessState *access_state) const { access_state->ApplyBarrier(barrier, layout_transition); }
+};
+
+template <typename BarrierOp>
 class ApplyBarrierOpsFunctor {
   public:
     using Iterator = ResourceAccessRangeMap::iterator;
     inline Iterator Infill(ResourceAccessRangeMap *accesses, Iterator pos, ResourceAccessRange range) const { return pos; }
 
-    struct BarrierOp {
-        SyncBarrier barrier;
-        bool layout_transition;
-        BarrierOp(const SyncBarrier &barrier_, bool layout_transition_)
-            : barrier(barrier_), layout_transition(layout_transition_) {}
-        BarrierOp() = default;
-    };
     Iterator operator()(ResourceAccessRangeMap *accesses, Iterator pos) const {
         auto &access_state = pos->second;
-        for (const auto op : barrier_ops_) {
-            access_state.ApplyBarrier(op.barrier, op.layout_transition);
+        for (const auto &op : barrier_ops_) {
+            op(&access_state);
         }
 
         if (resolve_) {
@@ -1246,36 +1249,31 @@ class ApplyBarrierOpsFunctor {
         return pos;
     }
 
-    // A valid tag is required IFF any of the barriers ops are a layout transition, as transitions are write ops
-    ApplyBarrierOpsFunctor(bool resolve, size_t size_hint, const ResourceUsageTag &tag)
-        : resolve_(resolve), barrier_ops_(), tag_(tag) {
-        if (size_hint) {
-            barrier_ops_.reserve(size_hint);
-        }
-    };
-
     // A valid tag is required IFF layout_transition is true, as transitions are write ops
-    ApplyBarrierOpsFunctor(bool resolve, const std::vector<SyncBarrier> &barriers, bool layout_transition,
-                           const ResourceUsageTag &tag)
-        : resolve_(resolve), barrier_ops_(), tag_(tag) {
-        barrier_ops_.reserve(barriers.size());
-        for (const auto &barrier : barriers) {
-            barrier_ops_.emplace_back(barrier, layout_transition);
-        }
-    }
-
-    void PushBack(const SyncBarrier &barrier, bool layout_transition) { barrier_ops_.emplace_back(barrier, layout_transition); }
-
-    void PushBack(const std::vector<SyncBarrier> &barriers, bool layout_transition) {
-        barrier_ops_.reserve(barrier_ops_.size() + barriers.size());
-        for (const auto &barrier : barriers) {
-            barrier_ops_.emplace_back(barrier, layout_transition);
-        }
-    }
+    ApplyBarrierOpsFunctor(bool resolve, const std::vector<BarrierOp> &barrier_ops, const ResourceUsageTag &tag)
+        : resolve_(resolve), barrier_ops_(barrier_ops), tag_(tag) {}
 
   private:
     bool resolve_;
-    std::vector<BarrierOp> barrier_ops_;
+    const std::vector<BarrierOp> &barrier_ops_;
+    const ResourceUsageTag &tag_;
+};
+
+// This functor resolves the pendinging state.
+class ResolvePendingBarrierFunctor {
+  public:
+    using Iterator = ResourceAccessRangeMap::iterator;
+    inline Iterator Infill(ResourceAccessRangeMap *accesses, Iterator pos, ResourceAccessRange range) const { return pos; }
+
+    Iterator operator()(ResourceAccessRangeMap *accesses, Iterator pos) const {
+        auto &access_state = pos->second;
+        access_state.ApplyPendingBarriers(tag_);
+        return pos;
+    }
+
+    ResolvePendingBarrierFunctor(const ResourceUsageTag &tag) : tag_(tag) {}
+
+  private:
     const ResourceUsageTag &tag_;
 };
 
@@ -1471,7 +1469,7 @@ void AccessContext::RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, u
 
     // If there were no transitions skip this global map walk
     if (transitions.size()) {
-        ApplyBarrierOpsFunctor apply_pending_action(true /* resolve */, 0, tag);
+        ResolvePendingBarrierFunctor apply_pending_action(tag);
         ApplyGlobalBarriers(apply_pending_action);
     }
 }
@@ -2253,8 +2251,13 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
         const auto &attachment = attachment_views_[transition.attachment];
         const auto &last_trackback = subpass_contexts_[transition.prev_pass].GetDstExternalTrackBack();
         assert(&subpass_contexts_[transition.prev_pass] == last_trackback.context);
-        ApplyBarrierOpsFunctor barrier_ops(true /* resolve */, last_trackback.barriers, true /* layout transition */, tag);
-        external_context->UpdateResourceAccess(*attachment->image_state, attachment->normalized_subresource_range, barrier_ops);
+        std::vector<PipelineBarrierOp> barrier_ops;
+        barrier_ops.reserve(last_trackback.barriers.size());
+        for (const auto &barrier : last_trackback.barriers) {
+            barrier_ops.emplace_back(barrier, true);
+        }
+        ApplyBarrierOpsFunctor<PipelineBarrierOp> barrier_action(true /* resolve */, barrier_ops, tag);
+        external_context->UpdateResourceAccess(*attachment->image_state, attachment->normalized_subresource_range, barrier_action);
     }
 }
 
@@ -2677,17 +2680,19 @@ void SyncValidator::ApplyGlobalBarriers(AccessContext *context, VkPipelineStageF
                                         VkPipelineStageFlags dst_exec_scope, SyncStageAccessFlags src_access_scope,
                                         SyncStageAccessFlags dst_access_scope, uint32_t memory_barrier_count,
                                         const VkMemoryBarrier *pMemoryBarriers, const ResourceUsageTag &tag) {
-    ApplyBarrierOpsFunctor barriers_functor(true /* resolve */, std::min<uint32_t>(1, memory_barrier_count), tag);
+    std::vector<PipelineBarrierOp> barrier_ops;
+    barrier_ops.reserve(std::min<uint32_t>(1, memory_barrier_count));
     for (uint32_t barrier_index = 0; barrier_index < memory_barrier_count; barrier_index++) {
         const auto &barrier = pMemoryBarriers[barrier_index];
         SyncBarrier sync_barrier(src_exec_scope, SyncStageAccess::AccessScope(src_access_scope, barrier.srcAccessMask),
                                  dst_exec_scope, SyncStageAccess::AccessScope(dst_access_scope, barrier.dstAccessMask));
-        barriers_functor.PushBack(sync_barrier, false);
+        barrier_ops.emplace_back(sync_barrier, false);
     }
     if (0 == memory_barrier_count) {
         // If there are no global memory barriers, force an exec barrier
-        barriers_functor.PushBack(SyncBarrier(src_exec_scope, 0, dst_exec_scope, 0), false);
+        barrier_ops.emplace_back(SyncBarrier(src_exec_scope, 0, dst_exec_scope, 0), false);
     }
+    ApplyBarrierOpsFunctor<PipelineBarrierOp> barriers_functor(true /* resolve */, barrier_ops, tag);
     context->ApplyGlobalBarriers(barriers_functor);
 }
 

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -414,7 +414,6 @@ class AccessContext {
     void SetStartTag(const ResourceUsageTag &tag) { start_tag_ = tag; }
 
   private:
-    HazardResult DetectHazard(AccessAddressType type, SyncStageAccessIndex usage_index, const ResourceAccessRange &range) const;
     template <typename Detector>
     HazardResult DetectHazard(AccessAddressType type, const Detector &detector, const ResourceAccessRange &range,
                               DetectOptions options) const;

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -514,6 +514,22 @@ class CommandBufferAccessContext {
     bool ValidateEndRenderpass(const char *func_name) const;
     void RecordNextSubpass(const RENDER_PASS_STATE &render_pass, const ResourceUsageTag &tag);
     void RecordEndRenderPass(const RENDER_PASS_STATE &render_pass, const ResourceUsageTag &tag);
+
+    bool ValidateSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
+    void RecordSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    bool ValidateResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
+    void RecordResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    bool ValidateWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+                            VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
+                            const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
+                            const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+                            const VkImageMemoryBarrier *pImageMemoryBarriers) const;
+    void RecordWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+                          VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
+                          const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
+                          const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+                          const VkImageMemoryBarrier *pImageMemoryBarriers) const;
+
     CMD_BUFFER_STATE *GetCommandBufferState() { return cb_state_.get(); }
     const CMD_BUFFER_STATE *GetCommandBufferState() const { return cb_state_.get(); }
     VkQueueFlags GetQueueFlags() const { return queue_flags_; }
@@ -865,4 +881,22 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                                 VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) const override;
     void PreCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                               VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) override;
+
+    bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const override;
+    void PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) override;
+
+    bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const override;
+    void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) override;
+
+    bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+                                      VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
+                                      uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
+                                      uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
+                                      uint32_t imageMemoryBarrierCount,
+                                      const VkImageMemoryBarrier *pImageMemoryBarriers) const override;
+    void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+                                     VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
+                                     uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
+                                     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
+                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) override;
 };

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -121,6 +121,36 @@ struct SyncBarrier {
 
 enum class AccessAddressType : uint32_t { kLinear = 0, kIdealized = 1, kMaxType = 1, kTypeCount = kMaxType + 1 };
 
+struct SyncEventState {
+    enum IgnoreReason { NotIgnored = 0, ResetWaitRace, SetRace, MissingStageBits };
+    using EventPointer = std::shared_ptr<EVENT_STATE>;
+    using ScopeMap = sparse_container::range_map<VkDeviceSize, bool>;
+    EventPointer event;
+    CMD_TYPE last_command;  // Only Event commands are valid here.
+    CMD_TYPE unsynchronized_set;
+    VkPipelineStageFlags barriers;
+    VkPipelineStageFlags stage_mask_param;
+    VkPipelineStageFlags stage_mask;
+    VkPipelineStageFlags exec_scope;
+    SyncStageAccessFlags stage_accesses;
+    ResourceUsageTag first_scope_tag;
+    std::array<ScopeMap, static_cast<size_t>(AccessAddressType::kTypeCount)> first_scope;
+    SyncEventState(const EventPointer &event_state)
+        : event(event_state),
+          last_command(CMD_NONE),
+          unsynchronized_set(CMD_NONE),
+          barriers(0U),
+          stage_mask_param(0U),
+          stage_mask(0U),
+          exec_scope(0U),
+          stage_accesses() {}
+    SyncEventState() : SyncEventState(EventPointer()) {}
+    void ResetFirstScope();
+    const ScopeMap &FirstScope(AccessAddressType address_type) const { return first_scope[static_cast<size_t>(address_type)]; }
+    IgnoreReason IsIgnoredByWait(VkPipelineStageFlags srcStageMask) const;
+    bool HasBarrier(VkPipelineStageFlags stageMask, VkPipelineStageFlags exec_scope) const;
+};
+
 // To represent ordering guarantees such as rasterization and store
 struct SyncOrderingBarrier {
     VkPipelineStageFlags exec_scope;
@@ -148,6 +178,13 @@ class ResourceAccessState : public SyncStageAccess {
             bool same = (stage == rhs.stage) && (access == rhs.access) && (barriers == rhs.barriers) && (tag == rhs.tag);
             return same;
         }
+        bool IsReadBarrierHazard(VkPipelineStageFlags src_exec_scope) const {
+            // If the read stage is not in the src sync scope
+            // *AND* not execution chained with an existing sync barrier (that's the or)
+            // then the barrier access is unsafe (R/W after R)
+            return (src_exec_scope & (stage | barriers)) == 0;
+        }
+
         bool operator!=(const ReadState &rhs) const { return !(*this == rhs); }
         inline void Set(VkPipelineStageFlagBits stage_, SyncStageAccessFlags access_, VkPipelineStageFlags barriers_,
                         const ResourceUsageTag &tag_) {
@@ -166,6 +203,8 @@ class ResourceAccessState : public SyncStageAccess {
     HazardResult DetectBarrierHazard(SyncStageAccessIndex usage_index, VkPipelineStageFlags source_exec_scope,
                                      const SyncStageAccessFlags &source_access_scope) const;
     HazardResult DetectAsyncHazard(SyncStageAccessIndex usage_index, const ResourceUsageTag &start_tag) const;
+    HazardResult DetectBarrierHazard(SyncStageAccessIndex usage_index, VkPipelineStageFlags source_exec_scope,
+                                     const SyncStageAccessFlags &source_access_scope, const ResourceUsageTag &event_tag) const;
 
     void Update(SyncStageAccessIndex usage_index, const ResourceUsageTag &tag);
     void SetWrite(const SyncStageAccessFlags &usage_bit, const ResourceUsageTag &tag);
@@ -173,6 +212,7 @@ class ResourceAccessState : public SyncStageAccess {
     void ApplyBarriers(const std::vector<SyncBarrier> &barriers, bool layout_transition);
     void ApplyBarriers(const std::vector<SyncBarrier> &barriers, const ResourceUsageTag &tag);
     void ApplyBarrier(const SyncBarrier &barrier, bool layout_transition);
+    void ApplyBarrier(const ResourceUsageTag &scope_tag, const SyncBarrier &barrier, bool layout_transition);
     void ApplyPendingBarriers(const ResourceUsageTag &tag);
 
     ResourceAccessState()
@@ -205,12 +245,25 @@ class ResourceAccessState : public SyncStageAccess {
     bool operator!=(const ResourceAccessState &rhs) const { return !(*this == rhs); }
     VkPipelineStageFlags GetReadBarriers(const SyncStageAccessFlags &usage) const;
     SyncStageAccessFlags GetWriteBarriers() const { return write_barriers; }
+    bool InSourceScopeOrChain(VkPipelineStageFlags src_exec_scope, SyncStageAccessFlags src_access_scope) const {
+        return ReadInSourceScopeOrChain(src_exec_scope) || WriteInSourceScopeOrChain(src_exec_scope, src_access_scope);
+    }
 
   private:
     static constexpr VkPipelineStageFlags kInvalidAttachmentStage = ~VkPipelineStageFlags(0);
     bool IsWriteHazard(SyncStageAccessFlags usage) const { return (usage & ~write_barriers).any(); }
     bool IsRAWHazard(VkPipelineStageFlagBits usage_stage, const SyncStageAccessFlags &usage) const;
-    bool InSourceScopeOrChain(VkPipelineStageFlags src_exec_scope, SyncStageAccessFlags src_access_scope) const {
+    bool IsWriteBarrierHazard(VkPipelineStageFlags src_exec_scope, const SyncStageAccessFlags &src_access_scope) const {
+        // If the previous write is *not* in the 1st access scope
+        // *AND* the current barrier is not in the dependency chain
+        // *AND* the there is no prior memory barrier for the previous write in the dependency chain
+        // then the barrier access is unsafe (R/W after W)
+        return ((last_write & src_access_scope) == 0) && ((src_exec_scope & write_dependency_chain) == 0) && (write_barriers == 0);
+    }
+    bool ReadInSourceScopeOrChain(VkPipelineStageFlags src_exec_scope) const {
+        return (0 != (src_exec_scope & (last_read_stages | read_execution_barriers)));
+    }
+    bool WriteInSourceScopeOrChain(VkPipelineStageFlags src_exec_scope, SyncStageAccessFlags src_access_scope) const {
         return (src_access_scope & last_write).any() || (write_dependency_chain & src_exec_scope);
     }
 
@@ -304,6 +357,10 @@ class AccessContext {
                               const VkOffset3D &offset, const VkExtent3D &extent, VkImageAspectFlags aspect_mask = 0U) const;
     HazardResult DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags src_exec_scope,
                                           const SyncStageAccessFlags &src_access_scope,
+                                          const VkImageSubresourceRange &subresource_range, const SyncEventState &sync_event,
+                                          DetectOptions options) const;
+    HazardResult DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags src_exec_scope,
+                                          const SyncStageAccessFlags &src_access_scope,
                                           const VkImageSubresourceRange &subresource_range, DetectOptions options) const;
     HazardResult DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags src_exec_scope,
                                           const SyncStageAccessFlags &src_stage_accesses,
@@ -332,6 +389,7 @@ class AccessContext {
     // Would need to add a "hint" overload to parallel_iterator::invalidate_[AB] call, if so.
     void ResolvePreviousAccess(AccessAddressType type, const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
                                const ResourceAccessState *infill_state) const;
+    void ResolvePreviousAccesses();
     template <typename BarrierAction>
     void ResolveAccessRange(const IMAGE_STATE &image_state, const VkImageSubresourceRange &subresource_range,
                             BarrierAction &barrier_action, AccessAddressType address_type, ResourceAccessRangeMap *descent_map,
@@ -367,7 +425,6 @@ class AccessContext {
 
     template <typename Action>
     void ApplyGlobalBarriers(const Action &barrier_action);
-
     static AccessAddressType ImageAddressType(const IMAGE_STATE &image);
 
     AccessContext(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyGraphNode> &dependencies,
@@ -412,6 +469,8 @@ class AccessContext {
                                    uint32_t subpass) const;
 
     void SetStartTag(const ResourceUsageTag &tag) { start_tag_ = tag; }
+    template <typename Action>
+    void ForAll(Action &&action);
 
   private:
     template <typename Detector>
@@ -491,11 +550,23 @@ class CommandBufferAccessContext {
         render_pass_contexts_.clear();
         current_context_ = &cb_access_context_;
         current_renderpass_context_ = nullptr;
+        event_state_.clear();
     }
 
     AccessContext *GetCurrentAccessContext() { return current_context_; }
     const AccessContext *GetCurrentAccessContext() const { return current_context_; }
     void RecordBeginRenderPass(const ResourceUsageTag &tag);
+    void ApplyBufferBarriers(const SyncEventState &sync_event, VkPipelineStageFlags dst_exec_scope,
+                             const SyncStageAccessFlags &dst_stage_accesses, uint32_t barrier_count,
+                             const VkBufferMemoryBarrier *barriers);
+    void ApplyGlobalBarriers(SyncEventState &sync_event, VkPipelineStageFlags dstStageMask, VkPipelineStageFlags dst_exec_scope,
+                             const SyncStageAccessFlags &dst_stage_accesses, uint32_t memory_barrier_count,
+                             const VkMemoryBarrier *pMemoryBarriers, const ResourceUsageTag &tag);
+    void ApplyGlobalBarriersToEvents(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags src_exec_scope,
+                                     VkPipelineStageFlags dstStageMask, VkPipelineStageFlags dst_exec_scope);
+    void ApplyImageBarriers(const SyncEventState &sync_event, VkPipelineStageFlags dst_exec_scope,
+                            const SyncStageAccessFlags &dst_stage_accesses, uint32_t barrier_count,
+                            const VkImageMemoryBarrier *barriers, const ResourceUsageTag &tag);
     bool ValidateBeginRenderPass(const RENDER_PASS_STATE &render_pass, const VkRenderPassBeginInfo *pRenderPassBegin,
                                  const VkSubpassBeginInfo *pSubpassBeginInfo, const char *func_name) const;
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const char *func_name) const;
@@ -512,19 +583,19 @@ class CommandBufferAccessContext {
     void RecordEndRenderPass(const RENDER_PASS_STATE &render_pass, const ResourceUsageTag &tag);
 
     bool ValidateSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
-    void RecordSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
+    void RecordSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask, const ResourceUsageTag &tag);
     bool ValidateResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) const;
     void RecordResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
-    bool ValidateWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                            VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
-                            const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
-                            const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                            const VkImageMemoryBarrier *pImageMemoryBarriers) const;
+    bool ValidateWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,
+                            VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
+                            uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
+                            uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) const;
     void RecordWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                           VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
                           const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
                           const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                          const VkImageMemoryBarrier *pImageMemoryBarriers) const;
+                          const VkImageMemoryBarrier *pImageMemoryBarriers, const ResourceUsageTag &tag);
+    void RecordDestroyEvent(VkEvent event);
 
     CMD_BUFFER_STATE *GetCommandBufferState() { return cb_state_.get(); }
     const CMD_BUFFER_STATE *GetCommandBufferState() const { return cb_state_.get(); }
@@ -541,6 +612,8 @@ class CommandBufferAccessContext {
     }
 
   private:
+    SyncEventState *GetEventState(VkEvent);
+    const SyncEventState *GetEventState(VkEvent) const;
     uint32_t command_number_;
     uint32_t reset_count_;
     std::vector<RenderPassAccessContext> render_pass_contexts_;
@@ -551,6 +624,7 @@ class CommandBufferAccessContext {
     SyncValidator *sync_state_;
 
     VkQueueFlags queue_flags_;
+    std::unordered_map<VkEvent, std::unique_ptr<SyncEventState>> event_state_;
 };
 
 class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
@@ -633,6 +707,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     void PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
                                     const VkBufferCopy *pRegions) override;
 
+    void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) override;
     bool PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfos) const override;
 
     void PreCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfos) override;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -338,6 +338,7 @@ class VkRenderFramework : public VkTestFramework {
 class VkDescriptorSetObj;
 class VkConstantBufferObj;
 class VkPipelineObj;
+typedef vk_testing::Event VkEventObj;
 typedef vk_testing::Fence VkFenceObj;
 typedef vk_testing::Buffer VkBufferObj;
 typedef vk_testing::AccelerationStructure VkAccelerationStructureObj;
@@ -382,6 +383,15 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
                                 uint32_t rangeCount, const VkImageSubresourceRange *pRanges);
     void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer);
     void BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer, VkBuffer instanceData);
+    void SetEvent(VkEventObj &event, VkPipelineStageFlags stageMask) { event.cmd_set(*this, stageMask); }
+    void ResetEvent(VkEventObj &event, VkPipelineStageFlags stageMask) { event.cmd_reset(*this, stageMask); }
+    void WaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,
+                    VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
+                    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
+                    uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) {
+        vk::CmdWaitEvents(handle(), eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
+                          bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+    }
 
   protected:
     VkDeviceObj *m_device;

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2943,7 +2943,7 @@ TEST_F(VkSyncValTest, SyncEventsCopyImageHazards) {
         image_a.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     };
 
-    // Scope chcek.  One access in, one access not
+    // Scope check.  One access in, one access not
     m_commandBuffer->begin();
     set_layouts();
     m_errorMonitor->ExpectSuccess();

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -482,6 +482,14 @@ void Event::init(const Device &dev, const VkEventCreateInfo &info) { NON_DISPATC
 
 void Event::set() { EXPECT(vk::SetEvent(device(), handle()) == VK_SUCCESS); }
 
+void Event::cmd_set(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask) {
+    vk::CmdSetEvent(cmd.handle(), handle(), stage_mask);
+}
+
+void Event::cmd_reset(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask) {
+    vk::CmdResetEvent(cmd.handle(), handle(), stage_mask);
+}
+
 void Event::reset() { EXPECT(vk::ResetEvent(device(), handle()) == VK_SUCCESS); }
 
 NON_DISPATCHABLE_HANDLE_DTOR(QueryPool, vk::DestroyQueryPool)

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -358,6 +358,8 @@ class Event : public internal::NonDispHandle<VkEvent> {
     // vkResetEvent()
     VkResult status() const { return vk::GetEventStatus(device(), handle()); }
     void set();
+    void cmd_set(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask);
+    void cmd_reset(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask);
     void reset();
 
     static VkEventCreateInfo create_info(VkFlags flags);


### PR DESCRIPTION
Implements #2308 .

SetEvent -- creates map of accesses in first sync scope
WaitEvent -- applies barriers within first sync scope (and not newer than SetEvent)
ResetEvent -- resets.

All: State machine checks for inter-event-call race conditions.