### PR TITLE
Account for quoted layer settings file strings

### DIFF
--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -161,6 +161,14 @@ std::string GetNextToken(std::string *token_list, const std::string &delimiter, 
         token = *token_list;
     }
     token_list->erase(0, *pos + delimiter.length());
+
+    // Remove quotes from quoted strings
+    if ((token.length() > 0) && (token[0] == '\"')) {
+        token.erase(token.begin());
+        if ((token.length() > 0) && (token[token.length() - 1] == '\"')) {
+            token.erase(--token.end());
+        }
+    }
     return token;
 }
 


### PR DESCRIPTION
The `vk_layer_settings.txt` file was not intended to support settings options that are quoted, but it is documented that way.  If a layer settings token has quotation marks at the beginning or ending, remove them.

[Passes CI.](http://erusea:4040/#/c/7980/)

Fixes #2378.