### PR TITLE
layers: Fixed a typo on VUID 03066/00848 error message

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10137,7 +10137,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                         vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03066"
                                        : "VUID-VkSubpassDescription-pResolveAttachments-00848";
                         skip |= LogError(device, vuid,
-                                         "%s:  ubpass %u requests multisample resolve from attachment %u which has "
+                                         "%s: Subpass %u requests multisample resolve from attachment %u which has "
                                          "VK_SAMPLE_COUNT_1_BIT.",
                                          function_name, i, attachment_index);
                     }


### PR DESCRIPTION
Incorrect text on Subpass with multisample resolve of VK_SAMPLE_COUNT_1_BIT error message:
 ubpass -> Subpass