### PR TITLE
Add VU for CmdBindVertexBuffers2EXT pStrides values

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -14636,6 +14636,19 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers2EXT(VkCommandBuffer command
         }
     }
 
+    const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    const auto *pipe = cb_state->lastBound[lv_bind_point].pipeline_state;
+    auto vibs = IsDynamic(pipe, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
+    if (vibs && (pStrides == nullptr)) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03361",
+                         "vkCmdBindVertexBuffers2EXT(): pStrides is NULL but the bound pipeline was created with "
+                         "VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT dynamic state enabled.");
+    } else if (!vibs && (pStrides != nullptr)) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03361",
+                         "vkCmdBindVertexBuffers2EXT(): pStrides is non-NULL, but the bound pipeline was not created with "
+                         "VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT dynamic state enabled.");
+    }
+
     return skip;
 }
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -10771,6 +10771,11 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
                                offsets.data(), 0, 0);
     m_errorMonitor->VerifyFound();
 
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03361");
+    VkDeviceSize nstrides[1] = {0};
+    vkCmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 1, buffers.data(), offsets.data(), 0, nstrides);
+    m_errorMonitor->VerifyFound();
+
     {
         VkBufferObj bufferWrongUsage;
         bufferWrongUsage.init(*m_device, 16, 0, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
@@ -10793,7 +10798,6 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
 
         buffers2[0] = buffers[0];
         VkDeviceSize sizes[1] = {16};
-        // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2EXT-pBuffers-04112");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2EXT-pOffsets-03357");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2EXT-pSizes-03358");
         vkCmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 1, buffers2, offsets2, sizes, 0);
@@ -10855,6 +10859,10 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
     vkCmdSetViewportWithCountEXT(commandBuffer.handle(), 1, &viewport);
     strides[0] = 4;
     vkCmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 1, buffers.data(), offsets.data(), 0, strides);
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03361");
+    vkCmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 1, buffers.data(), offsets.data(), 0, 0);
+    m_errorMonitor->VerifyFound();
 
     vkCmdSetPrimitiveTopologyEXT(commandBuffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-primitiveTopology-03420");


### PR DESCRIPTION
**VUID-vkCmdBindVertexBuffers2EXT-pStrides-03361**
If the bound pipeline state object was created with the `VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT `dynamic state enabled then `pStrides `must not be NULL, otherwise `pStrides `must be NULL

And the appropriate tests.

[Passes internal CI](http://erusea:4040/#/c/8039/).

Fixes #2376