### PR TITLE
Mark querypool slots as ENDED in vkCmdWriteAccelerationStructuresPropertiesKHR

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1167,6 +1167,11 @@ class CoreChecks : public ValidationStateTracker {
                                           VkQueryPool queryPool, uint32_t slot) const override;
     void PreCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkQueryPool queryPool,
                                         uint32_t slot) override;
+    void PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
+                                                                  uint32_t accelerationStructureCount,
+                                                                  const VkAccelerationStructureKHR* pAccelerationStructures,
+                                                                  VkQueryType queryType, VkQueryPool queryPool,
+                                                                  uint32_t firstQuery) override;
     bool PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer) const override;
     bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4475,6 +4475,23 @@ void ValidationStateTracker::PostCallRecordCmdWriteTimestamp(VkCommandBuffer com
     });
 }
 
+void ValidationStateTracker::PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
+    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
+    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {
+    if (disabled[query_validation]) return;
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    auto pool_state = GetQueryPoolState(queryPool);
+    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(queryPool, kVulkanObjectTypeQueryPool, pool_state),
+                            cb_state);
+    cb_state->queryUpdates.emplace_back(
+        [queryPool, firstQuery, accelerationStructureCount](const ValidationStateTracker *device_data, bool do_validate,
+                                                            VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
+                                                            QueryMap *localQueryToStateMap) {
+            return SetQueryStateMulti(queryPool, firstQuery, accelerationStructureCount, perfQueryPass, QUERYSTATE_ENDED,
+                                      localQueryToStateMap);
+        });
+}
+
 void ValidationStateTracker::PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
                                                              const VkAllocationCallbacks *pAllocator, VkFramebuffer *pFramebuffer,
                                                              VkResult result) {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1199,6 +1199,11 @@ class ValidationStateTracker : public ValidationObject {
                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers) override;
     void PostCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                          VkQueryPool queryPool, uint32_t slot) override;
+    void PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
+                                                                   uint32_t accelerationStructureCount,
+                                                                   const VkAccelerationStructureKHR* pAccelerationStructures,
+                                                                   VkQueryType queryType, VkQueryPool queryPool,
+                                                                   uint32_t firstQuery) override;
     void PreCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                                const VkViewportWScalingNV* pViewportWScalings) override;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR


### PR DESCRIPTION
`vkCmdWriteAccelerationStructuresPropertiesKHR` did not have the affected querypool slots marked as `QUERYSTATE_ENDED`, resulting in the following validation layer error when copying results out:

    Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidQuery ] Object 0: handle = 0x7f54ecc529b8, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x46ab3a6e | vkCmdCopyQueryPoolResults(): Requesting a copy from query to buffer on VkQueryPool 0xff00000000ff[] query 0: waiting on a query that has been reset and not issued yet

This is simply fixed by marking the slots as containing valid data (`QUERYSTATE_ENDED`) in the `PostCall` handler.

Similarly it does not check whether every affected slot is in reset state like `vkCmdWriteTimestamp`, which has been added in `PreCall`.

EDIT: Are there any conventions regarding function sorting/ordering in cpp files and headers?

---

This issue was not previously noticed in our framework because we were not resetting the querypool prior to querying acceleration structure properties. Playing around with these calls uncovered a second issue: copying results from an uninitialized and un-reset (I think this is `QUERYSTATE_UNKNOWN`) querypool does not trigger validation layer errors. On NVidia that blocks indefinitely in the driver; afaik there should at least be a warning for that. After all the validation layer seems to check if this querypool slot can be made available by any command buffer submitted thus far, if I read the code correctly.