### PR TITLE
Add VK_KHR_shader_clock support

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -482,6 +482,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const* producer, spirv_inst_iter producer_entrypoint,
                                         shader_stage_attributes const* producer_stage, SHADER_MODULE_STATE const* consumer,
                                         spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
+    bool ValidatePropertiesAndFeatures(SHADER_MODULE_STATE const* module) const;
 
     // Buffer Validation Functions
     // Remove the pending QFO release records from the global set

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1497,6 +1497,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceShaderSMBuiltinsFeaturesNV shader_sm_builtins_feature;
     VkPhysicalDeviceShaderAtomicFloatFeaturesEXT shader_atomic_float_feature;
     VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT shader_image_atomic_int64_feature;
+    VkPhysicalDeviceShaderClockFeaturesKHR shader_clock_feature;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1912,6 +1912,11 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         LvlFindInChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(pCreateInfo->pNext);
     if (shader_image_atomic_int64_feature) {
         state_tracker->enabled_features.shader_image_atomic_int64_feature = *shader_image_atomic_int64_feature;
+    }
+
+    const auto *shader_clock_feature = LvlFindInChain<VkPhysicalDeviceShaderClockFeaturesKHR>(pCreateInfo->pNext);
+    if (shader_clock_feature) {
+        state_tracker->enabled_features.shader_clock_feature = *shader_clock_feature;
     }
 
     // Store physical device properties and physical device mem limits into CoreChecks structs


### PR DESCRIPTION
Spec has (for now unassigned) VUs

> if shaderSubgroupClock is not enabled, the Subgroup scope must not be used for OpReadClockKHR.

and 

> if shaderDeviceClock is not enabled, the Device scope must not be used for OpReadClockKHR.

so added coverage for them