### PR TITLE
Update FormatIsUNorm()  list with missing formats

### DIFF
--- a/layers/vk_format_utils.cpp
+++ b/layers/vk_format_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -667,6 +667,16 @@ VK_LAYER_EXPORT bool FormatIsUNorm(VkFormat format) {
         case VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM:
         case VK_FORMAT_G16_B16R16_2PLANE_422_UNORM:
         case VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM:
+        case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
+        case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+        case VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG:
+        case VK_FORMAT_R10X6_UNORM_PACK16:
+        case VK_FORMAT_R10X6G10X6_UNORM_2PACK16:
+        case VK_FORMAT_R12X4_UNORM_PACK16:
+        case VK_FORMAT_R12X4G12X4_UNORM_2PACK16:
             is_unorm = true;
             break;
         default:


### PR DESCRIPTION
These guys were missing:
 
 - VK_FORMAT_B5G5R5A1_UNORM_PACK16
 - VK_FORMAT_BC1_RGBA_UNORM_BLOCK
 - ~~VK_FORMAT_D16_UNORM~~
 - ~~VK_FORMAT_D16_UNORM_S8_UINT~~
 - ~~VK_FORMAT_D24_UNORM_S8_UINT~~
 - VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG
 - VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG
 - VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG
 - VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG
 - VK_FORMAT_R10X6_UNORM_PACK16
 - VK_FORMAT_R10X6G10X6_UNORM_2PACK16
 - VK_FORMAT_R12X4_UNORM_PACK16
 - VK_FORMAT_R12X4G12X4_UNORM_2PACK16
 - ~~VK_FORMAT_X8_D24_UNORM_PACK32~~

Fixes #2449.