### PR TITLE
Change validation for incorrect spec VU

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1393,6 +1393,12 @@ class CoreChecks : public ValidationStateTracker {
                                                                     VkQueryType queryType, VkQueryPool queryPool,
                                                                     uint32_t firstQuery) const override;
 
+    bool PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer,
+                                                                   uint32_t accelerationStructureCount,
+                                                                   const VkAccelerationStructureNV* pAccelerationStructures,
+                                                                   VkQueryType queryType, VkQueryPool queryPool,
+                                                                   uint32_t firstQuery) const override;
+
     // Calculates the total number of shader groups taking libraries into account.
     uint32_t CalcTotalShaderGroupCount(const PIPELINE_STATE* pipelineState) const;
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4632,12 +4632,10 @@ bool StatelessValidation::manual_PreCallValidateCmdWriteAccelerationStructuresPr
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureNV *pAccelerationStructures,
     VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) const {
     bool skip = false;
-    if (!(queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR ||
-          queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR)) {
+    if (queryType != VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV) {
         skip |= LogError(device, "VUID-vkCmdWriteAccelerationStructuresPropertiesNV-queryType-03432",
                          "vkCmdWriteAccelerationStructuresPropertiesNV: queryType must be "
-                         "VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR or "
-                         "VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR.");
+                         "VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV.");
     }
     return skip;
 }


### PR DESCRIPTION
Spec language for `VUID-vkCmdWriteAccelerationStructuresPropertiesNV-queryType-03432` was incorrect.  There is an [approved spec MR](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4310) in flight and this PR updates the validation to match the corrected VU language.

This change also implements 03431 and brings the `vkCmdWriteAccelerationStructuresPropertiesNV `validation up to par with the `vkCmdWriteAccelerationStructuresPropertiesKHR` checks.

Fixes #2448.

@pixeljetstream, @souravpNV, please feel free to have a look as well.  Thanks!