### PR TITLE
Add new BP VUID for common errors

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -93,6 +93,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreatePipelines_TooManyIn
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearAttachments_ClearAfterLoad =
     "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load";
 static const char DECORATE_UNUSED *kVUID_BestPractices_Error_Result = "UNASSIGNED-BestPractices-Error-Result";
+static const char DECORATE_UNUSED *kVUID_BestPractices_Failure_Result = "UNASSIGNED-BestPractices-Failure-Result";
 static const char DECORATE_UNUSED *kVUID_BestPractices_NonSuccess_Result = "UNASSIGNED-BestPractices-NonSuccess-Result";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SuboptimalSwapchain = "UNASSIGNED-BestPractices-SuboptimalSwapchain";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SuboptimalSwapchainImageCount =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -578,7 +578,15 @@ void BestPractices::ValidateReturnCodes(const char* api_name, VkResult result, c
                                         const std::vector<VkResult>& success_codes) const {
     auto error = std::find(error_codes.begin(), error_codes.end(), result);
     if (error != error_codes.end()) {
-        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", api_name, string_VkResult(result));
+        static const std::vector<VkResult> common_failure_codes = {VK_ERROR_OUT_OF_DATE_KHR,
+                                                                   VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT};
+
+        auto common_failure = std::find(common_failure_codes.begin(), common_failure_codes.end(), result);
+        if (common_failure != common_failure_codes.end()) {
+            LogInfo(instance, kVUID_BestPractices_Failure_Result, "%s(): Returned error %s.", api_name, string_VkResult(result));
+        } else {
+            LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", api_name, string_VkResult(result));
+        }
         return;
     }
     auto success = std::find(success_codes.begin(), success_codes.end(), result);


### PR DESCRIPTION
Some swapchain methods return 'error' VkResults as part of normal operation. For those specific errors, log at Info level and provide a different VUID for filtering.

See https://github.com/KhronosGroup/Vulkan-ValidationLayers/projects/1#card-49789238