### PR TITLE
layers: Improve Image copy/create message

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -577,11 +577,6 @@ class CoreChecks : public ValidationStateTracker {
                         const char* function, const char* member, const char* vuid) const;
     VkExtent3D GetScaledItg(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* img) const;
 
-    template <typename RegionType>
-    bool CopyImageMultiplaneValidation(VkCommandBuffer command_buffer, const IMAGE_STATE* src_image_state,
-                                       const IMAGE_STATE* dst_image_state, const RegionType region,
-                                       CopyCommandVersion version) const;
-
     bool PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                            const VkClearColorValue* pColor, uint32_t rangeCount,
                                            const VkImageSubresourceRange* pRanges) const override;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -936,19 +936,21 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (FormatIsDepthOrStencil(image_format)) {
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
                     if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
-                        skip |=
-                            LogError(device, "VUID-VkImageCreateInfo-Format-02536",
-                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width exceeds device "
-                                     "maxFramebufferWidth");
+                        skip |= LogError(
+                            device, "VUID-VkImageCreateInfo-Format-02536",
+                            "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                            "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%u) exceeds device "
+                            "maxFramebufferWidth (%u)",
+                            pCreateInfo->extent.width, device_limits.maxFramebufferWidth);
                     }
 
                     if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
-                        skip |=
-                            LogError(device, "VUID-VkImageCreateInfo-format-02537",
-                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height exceeds device "
-                                     "maxFramebufferHeight");
+                        skip |= LogError(
+                            device, "VUID-VkImageCreateInfo-format-02537",
+                            "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                            "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%u) exceeds device "
+                            "maxFramebufferHeight (%u)",
+                            pCreateInfo->extent.height, device_limits.maxFramebufferHeight);
                     }
                 }
 


### PR DESCRIPTION
Someone internally found an error while looking at an image copy, I realized the message lacked giving the information needed (mainly which `pRegion` the copy error belonged too... went through and improved some other error messaging for image copies and creation to display values

Also instead of having to pass the `pRegion` index also into `CopyImageMultiplaneValidation`, it seemed worth just inlining as it fits well where it is now