### PR TITLE
tests: Add test for devsim/loader crash

### DIFF
--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -110,7 +110,7 @@ struct InstanceExtensions {
     };
 
     typedef layer_data::unordered_map<std::string,InstanceInfo> InstanceInfoMap;
-    static const InstanceInfo &get_info(const char *name) {
+    static const InstanceInfoMap &get_info_map() {
         static const InstanceInfoMap info_map = {
             {"VK_VERSION_1_1", InstanceInfo(&InstanceExtensions::vk_feature_version_1_1, {})},
             {"VK_VERSION_1_2", InstanceInfo(&InstanceExtensions::vk_feature_version_1_2, {})},
@@ -203,9 +203,14 @@ struct InstanceExtensions {
 #endif
         };
 
+        return info_map;
+    }
+
+    static const InstanceInfo &get_info(const char *name) {
         static const InstanceInfo empty_info {nullptr, InstanceReqVec()};
-        InstanceInfoMap::const_iterator info = info_map.find(name);
-        if ( info != info_map.cend()) {
+        const auto &ext_map = InstanceExtensions::get_info_map();
+        const auto info = ext_map.find(name);
+        if ( info != ext_map.cend()) {
             return info->second;
         }
         return empty_info;
@@ -553,7 +558,7 @@ struct DeviceExtensions : public InstanceExtensions {
     };
 
     typedef layer_data::unordered_map<std::string,DeviceInfo> DeviceInfoMap;
-    static const DeviceInfo &get_info(const char *name) {
+    static const DeviceInfoMap &get_info_map() {
         static const DeviceInfoMap info_map = {
             {"VK_VERSION_1_1", DeviceInfo(&DeviceExtensions::vk_feature_version_1_1, {})},
             {"VK_VERSION_1_2", DeviceInfo(&DeviceExtensions::vk_feature_version_1_2, {})},
@@ -985,9 +990,14 @@ struct DeviceExtensions : public InstanceExtensions {
                            {&DeviceExtensions::vk_khr_maintenance3, VK_KHR_MAINTENANCE3_EXTENSION_NAME}}})},
         };
 
+        return info_map;
+    }
+
+    static const DeviceInfo &get_info(const char *name) {
         static const DeviceInfo empty_info {nullptr, DeviceReqVec()};
-        DeviceInfoMap::const_iterator info = info_map.find(name);
-        if ( info != info_map.cend()) {
+        const auto &ext_map = DeviceExtensions::get_info_map();
+        const auto info = ext_map.find(name);
+        if ( info != ext_map.cend()) {
             return info->second;
         }
         return empty_info;

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -902,7 +902,7 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
                 '    };',
                 '',
                 '    typedef layer_data::unordered_map<std::string,%s> %s;' % (info_type, info_map_type),
-                '    static const %s &get_info(const char *name) {' %info_type,
+                '    static const %s &get_info_map() {' %info_map_type,
                 '        static const %s info_map = {' % info_map_type ])
             struct.extend([
                 '            {"VK_VERSION_1_1", %sInfo(&%sExtensions::vk_feature_version_1_1, {})},' % (type, type)])
@@ -922,9 +922,14 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
             struct.extend([
                 '        };',
                 '',
+                '        return info_map;',
+                '    }',
+                '',
+                '    static const %s &get_info(const char *name) {' % info_type,
                 '        static const %s empty_info {nullptr, %s()};' % (info_type, req_vec_type),
-                '        %s::const_iterator info = info_map.find(name);' % info_map_type,
-                '        if ( info != info_map.cend()) {',
+                '        const auto &ext_map = %s::get_info_map();' % struct_type,
+                '        const auto info = ext_map.find(name);',
+                '        if ( info != ext_map.cend()) {',
                 '            return info->second;',
                 '        }',
                 '        return empty_info;',

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -155,6 +155,11 @@ TEST_F(VkPortabilitySubsetTest, CreateImageView) {
     }
     m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
+    const bool test_bits_per_comp = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    if (test_bits_per_comp) {
+        m_device_extension_names.push_back(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    }
+
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
     vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
@@ -211,8 +216,10 @@ TEST_F(VkPortabilitySubsetTest, CreateImageView) {
     ci.format = VK_FORMAT_R5G6B5_UNORM_PACK16;  // Wrong number of components
     CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
 
-    ci.format = VK_FORMAT_R12X4G12X4_UNORM_2PACK16;  // Wrong number of bits per component
-    CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
+    if (test_bits_per_comp) {
+        ci.format = VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR;  // Wrong number of bits per component
+        CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
+    }
 }
 
 TEST_F(VkPortabilitySubsetTest, CreateSampler) {

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "layer_validation_tests.h"
+#include "vk_extension_helper.h"
 
 #include <algorithm>
 #include <array>
@@ -12684,4 +12685,25 @@ TEST_F(VkPositiveLayerTest, ImageDescriptorSubresourceLayout) {
         }
     };
     do_test(&image, &view, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
+TEST_F(VkPositiveLayerTest, DevsimLoaderCrash) {
+    TEST_DESCRIPTION("Test to see if instance extensions are called during CreateInstance.");
+
+    // See https://github.com/KhronosGroup/Vulkan-Loader/issues/537 for more details.
+    // This is specifically meant to ensure a crash encountered in devsim does not occur, but also to
+    // attempt to ensure that no extension calls have been added to CreateInstance hooks.
+    // NOTE: it is certainly possible that a layer will call an extension during the Createinstance hook
+    //       and the loader will _not_ crash (e.g., nvidia, android seem to not crash in this case, but AMD does).
+    //       So, this test will only catch an erroneous extension _if_ run on HW/a driver that crashes in this use
+    //       case.
+
+    for (const auto &ext : InstanceExtensions::get_info_map()) {
+        // Add all "real" instance extensions
+        if (InstanceExtensionSupported(ext.first.c_str())) {
+            m_instance_extension_names.emplace_back(ext.first.c_str());
+        }
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 }


### PR DESCRIPTION
Attempt to test if extensions are being called inside the CreateInstance
hook of any layers.

See Github issues #2468 for motivation and link to more details.

If someone has other ideas as to how to test this, please let me know!