### PR TITLE
Disable image layout check at queue submit time for update-after-bind

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3081,9 +3081,12 @@ bool CoreChecks::ValidateCommandBuffersForSubmit(VkQueue queue, const VkSubmitIn
                             std::string error;
                             std::vector<uint32_t> dynamic_offsets;
                             // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
-                            skip |= ValidateDescriptorSetBindingData(
-                                cb_node, set_node, dynamic_offsets, binding_info, cmd_info.framebuffer, cmd_info.attachments.get(),
-                                *cmd_info.subpasses.get(), function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
+                            // This submit time not record time...
+                            const bool record_time_validate = false;
+                            skip |= ValidateDescriptorSetBindingData(cb_node, set_node, dynamic_offsets, binding_info,
+                                                                     cmd_info.framebuffer, cmd_info.attachments.get(),
+                                                                     *cmd_info.subpasses.get(), record_time_validate,
+                                                                     function.c_str(), GetDrawDispatchVuid(cmd_info.cmd_type));
                         }
                     }
                 }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -403,7 +403,7 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::vector<uint32_t>& dynamic_offsets,
                                           std::pair<const uint32_t, DescriptorRequirement>& binding_info, VkFramebuffer framebuffer,
                                           const std::vector<IMAGE_VIEW_STATE*>* attachments,
-                                          const std::vector<SUBPASS_INFO>& subpasses, const char* caller,
+                                          const std::vector<SUBPASS_INFO>& subpasses, bool record_time_validate, const char* caller,
                                           const DrawDispatchVuid& vuids) const;
 
     // Validate contents of a CopyUpdate

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -728,8 +728,10 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const Bi
             // or the view could have been destroyed
             continue;
         }
+        // // This is a record time only path
+        const bool record_time_validate = true;
         result |= ValidateDescriptorSetBindingData(cb_node, descriptor_set, dynamic_offsets, binding_pair, framebuffer, attachments,
-                                                   subpasses, caller, vuids);
+                                                   subpasses, record_time_validate, caller, vuids);
     }
     return result;
 }
@@ -738,8 +740,8 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                                                   const std::vector<uint32_t> &dynamic_offsets,
                                                   std::pair<const uint32_t, DescriptorRequirement> &binding_info,
                                                   VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE *> *attachments,
-                                                  const std::vector<SUBPASS_INFO> &subpasses, const char *caller,
-                                                  const DrawDispatchVuid &vuids) const {
+                                                  const std::vector<SUBPASS_INFO> &subpasses, bool record_time_validate,
+                                                  const char *caller, const DrawDispatchVuid &vuids) const {
     using DescriptorClass = cvdescriptorset::DescriptorClass;
     using BufferDescriptor = cvdescriptorset::BufferDescriptor;
     using ImageDescriptor = cvdescriptorset::ImageDescriptor;
@@ -919,7 +921,9 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                             }
                         }
 
-                        if (!disabled[image_layout_validation]) {
+                        // NOTE: Submit time validation of UPDATE_AFTER_BIND image layout is not possible with the
+                        // image layout tracking as currently implemented, so only record_time_validation is done
+                        if (!disabled[image_layout_validation] && record_time_validate) {
                             auto image_node = image_view_state->image_state.get();
                             assert(image_node);
                             // Verify Image Layout


### PR DESCRIPTION
Disable queue submit time image layout validation for update-after-bind
bindings, as currently not enough information is tracked for correct
validation at that point.

All other queue submit time checks for update-after-bind are retained.

Fixes false positive from #1519