### PR TITLE
GN: Suppress -Wunguarded-availability-new on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -53,8 +53,13 @@ config("vulkan_internal_config") {
     "API_NAME=\"Vulkan\"",
     "VK_ENABLE_BETA_EXTENSIONS",
   ]
+
+  cflags = []
   if (is_clang || !is_win) {
-    cflags = [ "-Wno-unused-function" ]
+    cflags += [ "-Wno-unused-function" ]
+  }
+  if (is_clang && is_mac) {
+    cflags += [ "-Wno-unguarded-availability-new" ]
   }
   if (is_linux) {
     defines += [


### PR DESCRIPTION
On macOS vk_mem_alloc.h defines aligned_alloc and then uses it, which is
valid. However since aligned_alloc was added in macOS 10.15, clang
complains that it is used without it being in the deployment target (if
deploying for a version <10.15). This commit suppresses the warning at
the GN level since vk_mem_alloc.h is a copied from VMA.