### PR TITLE
layers: Correct VUID to the image version

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7573,7 +7573,7 @@ bool CoreChecks::ValidateBarriers(const char *funcName, const CMD_BUFFER_STATE *
         }
 
         if (image_data) {
-            skip |= ValidateMemoryIsBoundToImage(image_data, funcName, "VUID-VkBufferMemoryBarrier-buffer-01931");
+            skip |= ValidateMemoryIsBoundToImage(image_data, funcName, "VUID-VkImageMemoryBarrier-image-01932");
 
             const auto aspect_mask = mem_barrier.subresourceRange.aspectMask;
             skip |= ValidateImageAspectMask(image_data->image, image_data->createInfo.format, aspect_mask, funcName);


### PR DESCRIPTION
Change the VUID to report to reflect the condition being tested.  Corrects issue of returning the "buffer must be bound" VUID instead of the "image must be bound" VUID

