### PR TITLE
layers: silent clang warning

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -5425,7 +5425,7 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(CMD_TYPE cmd, const SyncValidator &
             // TODO: Revisit this when all attachment validation is through SyncOps to see if we can discard the plain pointer copy
             // Note that this a safe to presist as long as shared_attachments is not cleared
             attachments_.reserve(shared_attachments_.size());
-            for (const auto attachment : shared_attachments_) {
+            for (const auto &attachment : shared_attachments_) {
                 attachments_.emplace_back(attachment.get());
             }
         }


### PR DESCRIPTION
So not sure with the `todo` above this what the goal was but I am unable to build ToT with my clang/ubuntu.20.4 setup due to the following

```
synchronization_validation.cpp:5428:29: error: loop variable 'attachment' of type 'const std::shared_ptr<const IMAGE_VIEW_STATE>' creates a copy from type 'const std::shared_ptr<const IMAGE_VIEW_STATE>' [-Werror,-Wrange-loop-construct]
            for (const auto attachment : shared_attachments_) {
 ```
 
 It seem to have been added here
 https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/64ffe55c3bf6ca2063a249f642601f661ae7e2ec#diff-4db5972bac4fb44578a6e0b54f24064bda9106222ea62ed20e34814a90326110
 
 cc @jzulauf-lunarg 
 