### PR TITLE
Move pDynamicOffset to bind time

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6755,26 +6755,6 @@ bool CoreChecks::PreCallValidateCmdSetStencilReference(VkCommandBuffer commandBu
     return skip;
 }
 
-bool CoreChecks::ValidateDynamicOffsetAlignment(VkCommandBuffer command_buffer, const VkDescriptorSetLayoutBinding *binding,
-                                                VkDescriptorType test_type, VkDeviceSize alignment, const uint32_t *pDynamicOffsets,
-                                                const char *err_msg, const char *limit_name, uint32_t *offset_idx) const {
-    bool skip = false;
-    if (binding->descriptorType == test_type) {
-        const auto end_idx = *offset_idx + binding->descriptorCount;
-        for (uint32_t current_idx = *offset_idx; current_idx < end_idx; current_idx++) {
-            if (SafeModulo(pDynamicOffsets[current_idx], alignment) != 0) {
-                skip |= LogError(
-                    command_buffer, err_msg,
-                    "vkCmdBindDescriptorSets(): pDynamicOffsets[%d] is %d but must be a multiple of device limit %s 0x%" PRIxLEAST64
-                    ".",
-                    current_idx, pDynamicOffsets[current_idx], limit_name, alignment);
-            }
-        }
-        *offset_idx = end_idx;
-    }
-    return skip;
-}
-
 bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                       VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
                                                       const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,
@@ -6824,14 +6804,65 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                     const auto &limits = phys_dev_props.limits;
                     for (uint32_t binding_idx = 0; binding_idx < binding_count; binding_idx++) {
                         const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
-                        skip |= ValidateDynamicOffsetAlignment(commandBuffer, binding, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
-                                                               limits.minUniformBufferOffsetAlignment, pDynamicOffsets,
-                                                               "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971",
-                                                               "minUniformBufferOffsetAlignment", &cur_dyn_offset);
-                        skip |= ValidateDynamicOffsetAlignment(commandBuffer, binding, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC,
-                                                               limits.minStorageBufferOffsetAlignment, pDynamicOffsets,
-                                                               "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972",
-                                                               "minStorageBufferOffsetAlignment", &cur_dyn_offset);
+                        const uint32_t offset = pDynamicOffsets[cur_dyn_offset];
+                        // skip checking binding if not needed
+                        if (cvdescriptorset::IsDyanmicDescriptor(binding->descriptorType) == false) {
+                            continue;
+                        } else if (offset == 0) {
+                            // offset of zero is equivalent of not having the dynamic offset
+                            cur_dyn_offset++;
+                            continue;
+                        }
+
+                        // Validate alignment with limit
+                        if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) &&
+                            (SafeModulo(offset, limits.minUniformBufferOffsetAlignment) != 0)) {
+                            skip |= LogError(commandBuffer, "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971",
+                                             "vkCmdBindDescriptorSets(): pDynamicOffsets[%u] is %u, but must be a multiple of "
+                                             "device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                             cur_dyn_offset, offset, limits.minUniformBufferOffsetAlignment);
+                        }
+                        if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) &&
+                            (SafeModulo(offset, limits.minStorageBufferOffsetAlignment) != 0)) {
+                            skip |= LogError(commandBuffer, "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972",
+                                             "vkCmdBindDescriptorSets(): pDynamicOffsets[%u] is %u, but must be a multiple of "
+                                             "device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                             cur_dyn_offset, offset, limits.minStorageBufferOffsetAlignment);
+                        }
+
+                        auto *descriptor = descriptor_set->GetDescriptorFromBinding(binding_idx);
+                        // Currently only GeneralBuffer are dynamic and need to be checked
+                        if (descriptor->GetClass() == cvdescriptorset::DescriptorClass::GeneralBuffer) {
+                            const auto *buffer_descriptor = static_cast<const cvdescriptorset::BufferDescriptor *>(descriptor);
+                            const VkDeviceSize bound_range = buffer_descriptor->GetRange();
+                            const VkDeviceSize bound_offset = buffer_descriptor->GetOffset();
+                            const BUFFER_STATE *buffer_state = buffer_descriptor->GetBufferState();
+                            assert(buffer_state != nullptr);
+                            // Validate offset didn't go over buffer
+                            if ((bound_range == VK_WHOLE_SIZE) && (offset > 0)) {
+                                LogObjectList objlist(commandBuffer);
+                                objlist.add(pDescriptorSets[set_idx]);
+                                objlist.add(buffer_state->buffer);
+                                skip |= LogError(objlist, "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979",
+                                                 "vkCmdBindDescriptorSets(): pDynamicOffsets[%u] is 0x%x, but must be zero since "
+                                                 "the buffer descriptor's range is VK_WHOLE_SIZE in descriptorSet #%u binding #%u.",
+                                                 cur_dyn_offset, offset, set_idx, binding_idx);
+
+                            } else if ((bound_range != VK_WHOLE_SIZE) &&
+                                       ((offset + bound_range + bound_offset) > buffer_state->createInfo.size)) {
+                                LogObjectList objlist(commandBuffer);
+                                objlist.add(pDescriptorSets[set_idx]);
+                                objlist.add(buffer_state->buffer);
+                                skip |= LogError(objlist, "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979",
+                                                 "vkCmdBindDescriptorSets(): pDynamicOffsets[%u] is 0x%x which when added to the "
+                                                 "buffer descriptor's range (0x%" PRIxLEAST64
+                                                 ") is greater then the size of the buffer (0x%" PRIxLEAST64
+                                                 ") in descriptorSet #%u binding #%u.",
+                                                 cur_dyn_offset, offset, bound_range, buffer_state->createInfo.size, set_idx,
+                                                 binding_idx);
+                            }
+                        }
+                        cur_dyn_offset++;
                     }
                     // Keep running total of dynamic descriptor count to verify at the end
                     total_dynamic_descriptors += set_dynamic_descriptor_count;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -314,9 +314,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT* pSampleLocationsInfo, const char* apiName) const;
     bool InsideRenderPass(const CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode) const;
     bool OutsideRenderPass(const CMD_BUFFER_STATE* pCB, const char* apiName, const char* msgCode) const;
-    bool ValidateDynamicOffsetAlignment(const VkCommandBuffer command_buffer, const VkDescriptorSetLayoutBinding* binding,
-                                        VkDescriptorType test_type, VkDeviceSize alignment, const uint32_t* pDynamicOffsets,
-                                        const char* err_msg, const char* limit_name, uint32_t* offset_idx) const;
 
     bool ValidateImageSampleCount(const IMAGE_STATE* image_state, VkSampleCountFlagBits sample_count, const char* location,
                                   const std::string& msgCode) const;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -100,8 +100,7 @@ cvdescriptorset::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescript
             non_empty_bindings_.insert(binding_num);
         }
 
-        if (binding_info.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
-            binding_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
+        if (IsDyanmicDescriptor(binding_info.descriptorType)) {
             binding_to_dyn_count[binding_num] = binding_info.descriptorCount;
             dynamic_descriptor_count_ += binding_info.descriptorCount;
             binding_type_stats_.dynamic_buffer_count++;
@@ -545,8 +544,7 @@ bool cvdescriptorset::ValidateDescriptorSetLayoutCreateInfo(
                             "VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-descriptorBindingVariableDescriptorCount-03014",
                             "Invalid flags for VkDescriptorSetLayoutBinding entry %" PRIu32, i);
                     }
-                    if ((binding_info.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
-                         binding_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+                    if (IsDyanmicDescriptor(binding_info.descriptorType)) {
                         skip |= val_obj->LogError(val_obj->device,
                                                   "VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-pBindingFlags-03015",
                                                   "Invalid flags for VkDescriptorSetLayoutBinding entry %" PRIu32, i);
@@ -804,39 +802,6 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                                                     report_data->FormatHandle(set).c_str(), caller, binding, index,
                                                     report_data->FormatHandle(buffer).c_str(),
                                                     report_data->FormatHandle(mem_binding->mem).c_str());
-                                }
-                            }
-                        }
-                        if (descriptor->IsDynamic()) {
-                            // Validate that dynamic offsets are within the buffer
-                            auto buffer_size = buffer_node->createInfo.size;
-                            auto range = static_cast<const BufferDescriptor *>(descriptor)->GetRange();
-                            auto desc_offset = static_cast<const BufferDescriptor *>(descriptor)->GetOffset();
-                            auto dyn_offset = dynamic_offsets[binding_it.GetDynamicOffsetIndex() + array_idx];
-                            if (VK_WHOLE_SIZE == range) {
-                                if ((dyn_offset + desc_offset) > buffer_size) {
-                                    auto set = descriptor_set->GetSet();
-                                    return LogError(set, vuids.descriptor_valid,
-                                                    "%s encountered the following validation error at %s time: Descriptor in "
-                                                    "binding #%" PRIu32 " index %" PRIu32
-                                                    " is using buffer %s with update range of VK_WHOLE_SIZE has dynamic offset "
-                                                    "%" PRIu32 " combined with offset %" PRIu64
-                                                    " that oversteps the buffer size of %" PRIu64 ".",
-                                                    report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                                    report_data->FormatHandle(buffer).c_str(), dyn_offset, desc_offset,
-                                                    buffer_size);
-                                }
-                            } else {
-                                if ((dyn_offset + desc_offset + range) > buffer_size) {
-                                    auto set = descriptor_set->GetSet();
-                                    return LogError(
-                                        set, vuids.descriptor_valid,
-                                        "%s encountered the following validation error at %s time: "
-                                        "Descriptor in binding #%" PRIu32 " index %" PRIu32
-                                        " is uses buffer %s with dynamic offset %" PRIu32 " combined with offset %" PRIu64
-                                        " and range %" PRIu64 " that oversteps the buffer size of %" PRIu64 ".",
-                                        report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                        report_data->FormatHandle(buffer).c_str(), dyn_offset, desc_offset, range, buffer_size);
                                 }
                             }
                         }
@@ -1823,8 +1788,7 @@ void cvdescriptorset::DescriptorSet::FilterBindingReqs(const CMD_BUFFER_STATE &c
         }
         // Caching criteria differs per type.
         // If image_layout have changed , the image descriptors need to be validated against them.
-        if ((layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
-            (layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+        if (IsDyanmicDescriptor(layout_binding->descriptorType)) {
             FilterOneBindingReq(binding_req_pair, out_req, dynamic_buffers, stats.dynamic_buffer_count);
         } else if ((layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
                    (layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)) {
@@ -1861,8 +1825,7 @@ void cvdescriptorset::DescriptorSet::UpdateValidationCache(const CMD_BUFFER_STAT
             continue;
         }
         // Caching criteria differs per type.
-        if ((layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
-            (layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+        if (IsDyanmicDescriptor(layout_binding->descriptorType)) {
             dynamic_buffers.emplace(binding);
         } else if ((layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
                    (layout_binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)) {
@@ -2238,14 +2201,8 @@ cvdescriptorset::BufferDescriptor::BufferDescriptor(const VkDescriptorType type)
     : storage_(false), dynamic_(false), offset_(0), range_(0) {
     updated = false;
     descriptor_class = GeneralBuffer;
-    if (VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC == type) {
-        dynamic_ = true;
-    } else if (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER == type) {
-        storage_ = true;
-    } else if (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC == type) {
-        dynamic_ = true;
-        storage_ = true;
-    }
+    dynamic_ = IsDyanmicDescriptor(type);
+    storage_ = ((VK_DESCRIPTOR_TYPE_STORAGE_BUFFER == type) || (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC == type));
 }
 void cvdescriptorset::BufferDescriptor::WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *update,
                                                     const uint32_t index) {

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -382,6 +382,10 @@ bool ValidateDescriptorSetLayoutCreateInfo(const ValidationObject *val_obj, cons
                                            const VkPhysicalDeviceInlineUniformBlockPropertiesEXT *inline_uniform_block_props,
                                            const DeviceExtensions *device_extensions);
 
+inline bool IsDyanmicDescriptor(VkDescriptorType type) {
+    return ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC));
+}
+
 class SamplerDescriptor : public Descriptor {
   public:
     SamplerDescriptor(const ValidationStateTracker *dev_data, const VkSampler *);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1347,13 +1347,13 @@ void OneOffDescriptorSet::Clear() {
     descriptor_writes.clear();
 }
 
-void OneOffDescriptorSet::WriteDescriptorBufferInfo(int blinding, VkBuffer buffer, VkDeviceSize size,
+void OneOffDescriptorSet::WriteDescriptorBufferInfo(int blinding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                                     VkDescriptorType descriptorType, uint32_t count) {
     const auto index = buffer_infos.size();
 
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = buffer;
-    buffer_info.offset = 0;
+    buffer_info.offset = offset;
     buffer_info.range = size;
 
     for (uint32_t i = 0; i < count; ++i) {

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -392,7 +392,7 @@ struct OneOffDescriptorSet {
     ~OneOffDescriptorSet();
     bool Initialized();
     void Clear();
-    void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize size,
+    void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                    VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uint32_t count = 1);
     void WriteDescriptorBufferView(int binding, VkBufferView &buffer_view,
                                    VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, uint32_t count = 1);

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7601,7 +7601,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     ASSERT_VK_SUCCESS(err);
 
     // Use protected resources in unprotected command buffer
-    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_protected, 1024);
+    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_protected, 0, 1024);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[0], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
@@ -7695,7 +7695,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     m_commandBuffer->end();
 
     // Use unprotected resources in protected command buffer
-    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 1024);
+    g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 0, 1024);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[1], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4714,8 +4714,7 @@ TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
     // 1. No dynamicOffset supplied
     // 2. Too many dynamicOffsets supplied
     // 3. Dynamic offset oversteps buffer being updated
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
-                                         " requires 1 dynamicOffsets, but only 0 dynamicOffsets are left in pDynamicOffsets ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359");
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -4749,15 +4748,15 @@ TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, NULL);
     m_errorMonitor->VerifyFound();
-    uint32_t pDynOff[2] = {512, 756};
+    uint32_t pDynOff[2] = {0, 756};
     // Now cause error b/c too many dynOffsets in array for # of dyn descriptors
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Attempting to bind 1 descriptorSets with 1 dynamic descriptors, but ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 2, pDynOff);
     m_errorMonitor->VerifyFound();
+    pDynOff[0] = 512;
     // Finally cause error due to dynamicOffset being too big
-    m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, " dynamic offset 512 combined with offset 0 and range 1024 that oversteps the buffer size of 1024");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979");
     // Create PSO to be used for draw-time errors below
     VkShaderObj vs(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this);
     VkShaderObj fs(m_device, bindStateFragUniformShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);
@@ -4777,7 +4776,6 @@ TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
     // /w range 1024 & size 1024
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 1, pDynOff);
-    m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->EndRenderPass();

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020 The Khronos Group Inc.
- * Copyright (c) 2020 Valve Corporation
- * Copyright (c) 2020 LunarG, Inc.
- * Copyright (c) 2020 Google, Inc.
+ * Copyright (c) 2020-2021 The Khronos Group Inc.
+ * Copyright (c) 2020-2021 Valve Corporation
+ * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2021 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -598,9 +598,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
                                                   {4, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
-    descriptor_set.WriteDescriptorBufferInfo(0, offset_buffer.handle(), 4);
-    descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    descriptor_set.WriteDescriptorBufferInfo(2, VK_NULL_HANDLE, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.WriteDescriptorBufferInfo(0, offset_buffer.handle(), 0, 4);
+    descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 0, 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.WriteDescriptorBufferInfo(2, VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.WriteDescriptorBufferView(3, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     descriptor_set.WriteDescriptorBufferView(4, storage_buffer_view, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     descriptor_set.UpdateDescriptorSets();
@@ -1588,10 +1588,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationRestoresSt
     ASSERT_VK_SUCCESS(
         vk::CreateComputePipelines(m_device->device(), VK_NULL_HANDLE, 1, &compute_pipeline_ci, nullptr, &compute_pipeline));
 
-    normal_descriptor_set.WriteDescriptorBufferInfo(0, normal_descriptor_buffer.handle(), 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    normal_descriptor_set.WriteDescriptorBufferInfo(0, normal_descriptor_buffer.handle(), 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     normal_descriptor_set.UpdateDescriptorSets();
 
-    output_descriptor_set.WriteDescriptorBufferInfo(0, output_descriptor_buffer.handle(), output_descriptor_buffer_size,
+    output_descriptor_set.WriteDescriptorBufferInfo(0, output_descriptor_buffer.handle(), 0, output_descriptor_buffer_size,
                                                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     output_descriptor_set.UpdateDescriptorSets();
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3565,7 +3565,7 @@ TEST_F(VkLayerTest, InUseDestroyedSignaled) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_test.GetBuffer(), 1024, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_test.GetBuffer(), 0, 1024, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
     VkEvent event;

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -2760,7 +2760,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     VkConstantBufferObj buffer(m_device, sizeof(bo_data), (const void *)&bo_data, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     // Update descriptor set
-    descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), sizeof(bo_data));
+    descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), 0, sizeof(bo_data));
     descriptor_set.UpdateDescriptorSets();
 
     PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (c) 2015-2020 Google, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2021 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1015,7 +1015,7 @@ TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
                                            {3, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                        });
 
-    descriptor_set.WriteDescriptorBufferInfo(0, buffer_a.handle(), 2048);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer_a.handle(), 0, 2048);
     descriptor_set.WriteDescriptorImageInfo(1, imageview_c, sampler_c, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                             VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.WriteDescriptorImageInfo(2, imageview_s, sampler_s, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);


### PR DESCRIPTION
So to break this down

1. Currently `VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979` was being down at draw time, but I see no reason why not to just do it at bind time
2. To make life easier with the looping of the `pDynamicOffset` I needed to move `ValidateDynamicOffsetAlignment` inlined to the function for the 2 cases
3. Added a `IsDyanmicDescriptor` to future proof the case where a new descriptor type is also used to check the various spots in the code
4. For the the tests, I needed to access the `offset` in the `OneOffDescriptorSet::WriteDescriptorBufferInfo`

@locke-lunarg for if there is a reason I am missing this was done at draw time?