### PR TITLE
VK_KHR_image_format_list for swapchain

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12672,51 +12672,6 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
         }
     }
 
-    if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) {
-        if (!device_extensions.vk_khr_swapchain_mutable_format) {
-            if (LogError(device, kVUID_Core_DrawState_ExtensionNotEnabled,
-                         "%s: pCreateInfo->flags contains VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR which requires the "
-                         "VK_KHR_swapchain_mutable_format extension, which has not been enabled.",
-                         func_name)) {
-                return true;
-            }
-        } else {
-            const auto *image_format_list = LvlFindInChain<VkImageFormatListCreateInfo>(pCreateInfo->pNext);
-            if (image_format_list == nullptr) {
-                if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-flags-03168",
-                             "%s: pCreateInfo->flags contains VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the pNext chain of "
-                             "pCreateInfo does not contain an instance of VkImageFormatListCreateInfo.",
-                             func_name)) {
-                    return true;
-                }
-            } else if (image_format_list->viewFormatCount == 0) {
-                if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-flags-03168",
-                             "%s: pCreateInfo->flags contains VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the viewFormatCount "
-                             "member of VkImageFormatListCreateInfo in the pNext chain is zero.",
-                             func_name)) {
-                    return true;
-                }
-            } else {
-                bool found_base_format = false;
-                for (uint32_t i = 0; i < image_format_list->viewFormatCount; ++i) {
-                    if (image_format_list->pViewFormats[i] == pCreateInfo->imageFormat) {
-                        found_base_format = true;
-                        break;
-                    }
-                }
-                if (!found_base_format) {
-                    if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-flags-03168",
-                                 "%s: pCreateInfo->flags contains VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but none of the "
-                                 "elements of the pViewFormats member of VkImageFormatListCreateInfo match "
-                                 "pCreateInfo->imageFormat.",
-                                 func_name)) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-
     if ((pCreateInfo->imageSharingMode == VK_SHARING_MODE_CONCURRENT) && pCreateInfo->pQueueFamilyIndices) {
         bool skip1 = ValidatePhysicalDeviceQueueFamilies(pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices,
                                                          "vkCreateBuffer", "pCreateInfo->pQueueFamilyIndices",

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -7771,6 +7771,7 @@ bool StatelessValidation::PreCallValidateCreateSharedSwapchainsKHR(
         }
     }
     skip |= validate_array("vkCreateSharedSwapchainsKHR", "swapchainCount", "pSwapchains", swapchainCount, &pSwapchains, true, true, "VUID-vkCreateSharedSwapchainsKHR-swapchainCount-arraylength", "VUID-vkCreateSharedSwapchainsKHR-pSwapchains-parameter");
+    if (!skip) skip |= manual_PreCallValidateCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
     return skip;
 }
 

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1335,6 +1335,8 @@ class StatelessValidation : public ValidationObject {
     bool ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkDeviceSize offset, VkDeviceSize countBufferOffset,
                                              bool khr) const;
 
+    bool ValidateSwapchainCreateInfo(const char *func_name, VkSwapchainCreateInfoKHR const *pCreateInfo) const;
+
     bool OutputExtensionError(const std::string &api_name, const std::string &extension_name) const;
 
     void PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) override;
@@ -1457,6 +1459,10 @@ class StatelessValidation : public ValidationObject {
 
     bool manual_PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) const;
+    bool manual_PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
+                                                         const VkSwapchainCreateInfoKHR *pCreateInfos,
+                                                         const VkAllocationCallbacks *pAllocator,
+                                                         VkSwapchainKHR *pSwapchains) const;
     bool manual_PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) const;
     bool manual_PreCallValidateCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                     const VkDisplayModeCreateInfoKHR *pCreateInfo,

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -176,6 +176,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdUpdateBuffer',
             'vkCmdFillBuffer',
             'vkCreateSwapchainKHR',
+            'vkCreateSharedSwapchainsKHR',
             'vkQueuePresentKHR',
             'vkCreateDescriptorPool',
             'vkCmdDispatch',


### PR DESCRIPTION
The first commit is to fix the fact the swapchain tests were not calling `vkGetPhysicalDeviceSurfaceSupportKHR` and tripping `VUID-VkSwapchainCreateInfoKHR-surface-01270` (just happened to still work in drivers I guess)

Then moved `VUID-VkSwapchainCreateInfoKHR-flags-03168` from `core_validation` to `parameter_validation_utils` (also wrote missing test for it). Also `vkCreateSharedSwapchainsKHR` was missing from having its create info checked in parameter utils

Lastly this adds support for `VUID-VkSwapchainCreateInfoKHR-pNext-04099` and `VUID-VkSwapchainCreateInfoKHR-flags-04100`