### PR TITLE
Lazier map creation to improve image layout validation performance

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4401,23 +4401,17 @@ void CoreChecks::PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, co
 GlobalImageLayoutRangeMap *GetLayoutRangeMap(GlobalImageLayoutMap *map, const IMAGE_STATE &image_state) {
     assert(map);
     // This approach allows for a single hash lookup or/create new
-    auto inserted = map->emplace(std::make_pair(image_state.image, nullptr));
-    if (inserted.second) {
-        assert(nullptr == inserted.first->second.get());
-        GlobalImageLayoutRangeMap *layout_map = new GlobalImageLayoutRangeMap(image_state.subresource_encoder.SubresourceCount());
-        inserted.first->second.reset(layout_map);
-        return layout_map;
-    } else {
-        assert(nullptr != inserted.first->second.get());
-        return inserted.first->second.get();
+    auto &layout_map = (*map)[image_state.image];
+    if (!layout_map) {
+        layout_map.emplace(image_state.subresource_encoder.SubresourceCount());
     }
-    return nullptr;
+    return &layout_map;
 }
 
 const GlobalImageLayoutRangeMap *GetLayoutRangeMap(const GlobalImageLayoutMap &map, VkImage image) {
     auto it = map.find(image);
     if (it != map.end()) {
-        return it->second.get();
+        return &it->second;
     }
     return nullptr;
 }

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1244,8 +1244,9 @@ struct QFOTransferCBScoreboards {
 typedef std::map<QueryObject, QueryState> QueryMap;
 typedef std::unordered_map<VkEvent, VkPipelineStageFlags2KHR> EventToStageMap;
 typedef ImageSubresourceLayoutMap::LayoutMap GlobalImageLayoutRangeMap;
-typedef std::unordered_map<VkImage, std::unique_ptr<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
-typedef std::unordered_map<VkImage, std::unique_ptr<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
+typedef std::unordered_map<VkImage, Optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
+
+typedef std::unordered_map<VkImage, Optional<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
 
 enum LvlBindPoint {
     BindPoint_Graphics = VK_PIPELINE_BIND_POINT_GRAPHICS,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5020,7 +5020,7 @@ void ValidationStateTracker::PreCallRecordCmdExecuteCommands(VkCommandBuffer com
             if (!image_state) continue;  // Can't set layouts of a dead image
 
             auto *cb_subres_map = GetImageSubresourceLayoutMap(cb_state, *image_state);
-            const auto *sub_cb_subres_map = sub_layout_map_entry.second.get();
+            const auto *sub_cb_subres_map = &sub_layout_map_entry.second;
             assert(cb_subres_map && sub_cb_subres_map);  // Non const get and map traversal should never be null
             cb_subres_map->UpdateFrom(*sub_cb_subres_map);
         }


### PR DESCRIPTION
Reduce map lookups and memory allocation by only constructing needed maps, and allowing efficient `[]` lookups for new entries without unneeded constructions.

struct Optional approximates std::optional which is not support on C++11.