### PR TITLE
    corechecks: Fix sync2 queue caps vs pipeline stage checks

### DIFF
--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -610,7 +610,12 @@ static const std::vector<std::string> kQueueCapErrors{
 
 const std::string &GetStageQueueCapVUID(const CoreErrorLocation &loc, VkPipelineStageFlags2KHR bit) {
     // no per-bit lookups needed
-    return FindVUID(loc.refpage, loc.field_name, kQueueCapErrors);
+    const auto& result = FindVUID(loc.refpage, loc.field_name, kQueueCapErrors);
+    if (!result.empty()) {
+        return result;
+    }
+    const auto& result2 = FindVUID(loc.StringFuncName(), loc.StringField(), kQueueCapErrors);
+    return result2;
 }
 
 static const std::map<QueueError, std::vector<std::string>> kBarrierQueueErrors{


### PR DESCRIPTION
   The matching for the sync2 functions in
    sync_vuid_maps::GetStageQueueCapVUID() was insufficiently fuzzy.
    This is a short term fix until there's a chance to redo the
    location to be a) not string based and b) much more robust.
    
Fixes #2590
