### PR TITLE
layers: Reduce looping for builtins

### DIFF
--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -129,6 +129,13 @@ struct function_set {
     function_set() : id(0), offset(0), length(0) {}
 };
 
+struct builtin_set {
+    uint32_t offset;  // offset to instruction (OpDecorate or OpMemberDecorate)
+    spv::BuiltIn builtin;
+
+    builtin_set(uint32_t offset, spv::BuiltIn builtin) : offset(offset), builtin(builtin) {}
+};
+
 struct shader_struct_member {
     uint32_t offset;
     uint32_t size;                                 // A scalar size or a struct size. Not consider array
@@ -194,9 +201,12 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Find all decoration instructions to prevent relooping module later - many checks need this info
     std::vector<spirv_inst_iter> decoration_inst;
     std::vector<spirv_inst_iter> member_decoration_inst;
-    // Execution are not tied to a entry point and are their own mapping tied to entry point function
-    // <OpEntryPoint function <id> operand> : <Execution Mode Instruction list>
+    // Execution are not tied to an entry point and are their own mapping tied to entry point function
+    // [OpEntryPoint function <id> operand] : [Execution Mode Instruction list]
     std::unordered_map<uint32_t, std::vector<spirv_inst_iter>> execution_mode_inst;
+    // both OpDecorate and OpMemberDecorate builtin instructions
+    std::vector<builtin_set> builtin_decoration_list;
+
     struct EntryPoint {
         uint32_t offset;  // into module to get OpEntryPoint instruction
         VkShaderStageFlagBits stage;


### PR DESCRIPTION
Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/projects/4#card-50486050.

Few spots were looping the first part of the shader just to find the built-in information. Moved that to the initial pass since we are already collecting the decorations there for other reasons

----

(note: this will totally merge conflict in the head file with !2596 and I will fix the later, in case you want to save yourself a internal CI run on this until the other PR is in)