### PR TITLE
corechecks: Correct VUID strings for synchronization APIS

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12849,7 +12849,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
         if (semaphore_state && !semaphore_state->signaled && !SemaphoreWasSignaled(pPresentInfo->pWaitSemaphores[i])) {
             LogObjectList objlist(queue);
             objlist.add(pPresentInfo->pWaitSemaphores[i]);
-            skip |= LogError(objlist, "VUID-vkQueuePresentKHR-pWaitSemaphores-03873",
+            skip |= LogError(objlist, "VUID-vkQueuePresentKHR-pWaitSemaphores-03268",
                              "vkQueuePresentKHR: Queue %s is waiting on pWaitSemaphores[%u] (%s) that has no way to be signaled.",
                              report_data->FormatHandle(queue).c_str(), i,
                              report_data->FormatHandle(pPresentInfo->pWaitSemaphores[i]).c_str());

--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -240,7 +240,7 @@ static const std::map<VkPipelineStageFlags2KHR, std::vector<std::string>> kStage
       "VUID-vkCmdSetEvent-stageMask-04091",
       "VUID-vkCmdWaitEvents-dstStageMask-04091",
       "VUID-vkCmdWaitEvents-srcStageMask-04091",
-      "VUID-vkCmdWriteTimestamp2KHR-pipelineStage-04076",
+      "VUID-vkCmdWriteTimestamp2KHR-pipelineStage-03930",
       "VUID-vkCmdWriteTimestamp-pipelineStage-04076",
       "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03930",
       "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03930",
@@ -585,7 +585,7 @@ const std::string &GetBadAccessFlagsVUID(const CoreErrorLocation &loc, VkAccessF
 }
 
 static const std::vector<std::string> kQueueCapErrors{
-    "VUID-VkSubmitInfo-pWaitDstStageMask-00066",
+    "VUID-vkQueueSubmit-pWaitDstStageMask-00066",
     "VUID-vkCmdBeginRenderPass-srcStageMask-00901",
     "VUID-vkCmdBeginRenderPass-dstStageMask-00901",
     "VUID-vkCmdSetEvent-stageMask-4098",

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -5317,7 +5317,7 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) co
                             (cmd_ == CMD_WAITEVENTS) ? "VUID-vkCmdResetEvent-event-03834" : "VUID-vkCmdResetEvent-event-03835";
                         if (ignore_reason == SyncEventState::Reset2WaitRace) {
                             vuid =
-                                (cmd_ == CMD_WAITEVENTS) ? "VUID-vkCmdResetEvent-event-03831" : "VUID-vkCmdResetEvent-event-03832";
+                                (cmd_ == CMD_WAITEVENTS) ? "VUID-vkCmdResetEvent2KHR-event-03831" : "VUID-vkCmdResetEvent2KHR-event-03832";
                         }
                         const char *const message =
                             "%s: %s %s operation following %s without intervening execution barrier, may cause race condition. %s";


### PR DESCRIPTION
Commit e60d417b5 garbled several VUIDs, fix them.

Change-Id: I5c611010c3c45a4a4c826d5d1d63eef5dbe65b86