### PR TITLE
Fix binding index bug for dynamic offsets

### DIFF
--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -292,11 +292,6 @@ class DescriptorSetLayout : public BASE_NODE {
         uint32_t GetIndex() const { return index_; }
         bool AtEnd() const { return index_ == layout_->GetBindingCount(); }
 
-        // Return index into dynamic offset array for given binding
-        int32_t GetDynamicOffsetIndex() const {
-            return layout_->GetDynamicOffsetIndexFromBinding(Binding());  //  There is only binding mapped access in layout_
-        }
-
         bool operator==(const ConstBindingIterator &rhs) { return (index_ = rhs.index_) && (layout_ == rhs.layout_); }
 
         ConstBindingIterator &operator++() {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1386,14 +1386,14 @@ void OneOffDescriptorSet::Clear() {
     descriptor_writes.clear();
 }
 
-void OneOffDescriptorSet::WriteDescriptorBufferInfo(int blinding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
+void OneOffDescriptorSet::WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range,
                                                     VkDescriptorType descriptorType, uint32_t count) {
     const auto index = buffer_infos.size();
 
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = buffer;
     buffer_info.offset = offset;
-    buffer_info.range = size;
+    buffer_info.range = range;
 
     for (uint32_t i = 0; i < count; ++i) {
         buffer_infos.emplace_back(buffer_info);
@@ -1403,7 +1403,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferInfo(int blinding, VkBuffer buffe
     memset(&descriptor_write, 0, sizeof(descriptor_write));
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
-    descriptor_write.dstBinding = blinding;
+    descriptor_write.dstBinding = binding;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pBufferInfo = &buffer_infos[index];
@@ -1413,7 +1413,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferInfo(int blinding, VkBuffer buffe
     descriptor_writes.emplace_back(descriptor_write);
 }
 
-void OneOffDescriptorSet::WriteDescriptorBufferView(int blinding, VkBufferView &buffer_view, VkDescriptorType descriptorType,
+void OneOffDescriptorSet::WriteDescriptorBufferView(int binding, VkBufferView &buffer_view, VkDescriptorType descriptorType,
                                                     uint32_t count) {
     const auto index = buffer_views.size();
 
@@ -1425,7 +1425,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferView(int blinding, VkBufferView &
     memset(&descriptor_write, 0, sizeof(descriptor_write));
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
-    descriptor_write.dstBinding = blinding;
+    descriptor_write.dstBinding = binding;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pTexelBufferView = &buffer_views[index];
@@ -1435,7 +1435,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferView(int blinding, VkBufferView &
     descriptor_writes.emplace_back(descriptor_write);
 }
 
-void OneOffDescriptorSet::WriteDescriptorImageInfo(int blinding, VkImageView image_view, VkSampler sampler,
+void OneOffDescriptorSet::WriteDescriptorImageInfo(int binding, VkImageView image_view, VkSampler sampler,
                                                    VkDescriptorType descriptorType, VkImageLayout imageLayout, uint32_t count) {
     const auto index = image_infos.size();
 
@@ -1452,7 +1452,7 @@ void OneOffDescriptorSet::WriteDescriptorImageInfo(int blinding, VkImageView ima
     memset(&descriptor_write, 0, sizeof(descriptor_write));
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
-    descriptor_write.dstBinding = blinding;
+    descriptor_write.dstBinding = binding;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pImageInfo = &image_infos[index];

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -395,7 +395,7 @@ struct OneOffDescriptorSet {
     ~OneOffDescriptorSet();
     bool Initialized();
     void Clear();
-    void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
+    void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range,
                                    VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uint32_t count = 1);
     void WriteDescriptorBufferView(int binding, VkBufferView &buffer_view,
                                    VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, uint32_t count = 1);


### PR DESCRIPTION
closes #2600 

So the CTS test had a descriptor layout with bindings `0` and `2` and the loop of the bindings when it was `1` 

```c++
// binding_idx == 1

// Returned binding index of 2
VkDescriptorSetLayoutBinding *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);

// Was looking for binding index of 1
Descriptor *descriptor = descriptor_set->GetDescriptorFromBinding(binding_idx);
```

So the simple fix was fixing some naming so that the `binding_index` is the actual binding index value and not the loop of the **number** of bindings

----

Second commit is various tests and small tweaks that are general improvements and replicated the same error the CTS tests had
