### PR TITLE
layers: Ensure drawIndirectCount device extension is tracked correctly

### DIFF
--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -806,7 +806,8 @@ bool CoreChecks::ValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkB
                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                               uint32_t stride, const char *apiName) const {
     bool skip = false;
-    if ((api_version >= VK_API_VERSION_1_2) && (enabled_features.core12.drawIndirectCount == VK_FALSE)) {
+    if ((api_version >= VK_API_VERSION_1_2) && (enabled_features.core12.drawIndirectCount == VK_FALSE) &&
+        (!device_extensions.vk_khr_draw_indirect_count)) {
         skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndirectCount-None-04445",
                          "%s(): Starting in Vulkan 1.2 the VkPhysicalDeviceVulkan12Features::drawIndirectCount must be enabled to "
                          "call this command.",
@@ -849,7 +850,8 @@ bool CoreChecks::ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuff
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                      uint32_t stride, const char *apiName) const {
     bool skip = false;
-    if ((api_version >= VK_API_VERSION_1_2) && (enabled_features.core12.drawIndirectCount == VK_FALSE)) {
+    if ((api_version >= VK_API_VERSION_1_2) && (enabled_features.core12.drawIndirectCount == VK_FALSE) &&
+        (!device_extensions.vk_khr_draw_indirect_count)) {
         skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-None-04445",
                          "%s(): Starting in Vulkan 1.2 the VkPhysicalDeviceVulkan12Features::drawIndirectCount must be enabled to "
                          "call this command.",


### PR DESCRIPTION
drawIndirectCount when added as an extension to the device does not
have a corresponding feature extension that can be enabled. This
means state_tracker can incorrectly report drawIndirectCount as
being used without first being enabled in the device.

Change-Id: I279347ba9a6718f5f9494af8aea2342c0158dd5f