### PR TITLE
Add swapchain image hazard detection

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -473,11 +473,8 @@ uint32_t FullMipChainLevels(VkExtent3D extent) { return FullMipChainLevels(exten
 
 uint32_t FullMipChainLevels(VkExtent2D extent) { return FullMipChainLevels(extent.height, extent.width); }
 
-bool CoreChecks::FindLayouts(VkImage image, std::vector<VkImageLayout> &layouts) const {
-    auto image_state = GetImageState(image);
-    if (!image_state) return false;
-
-    const auto *layout_range_map = GetLayoutRangeMap(imageLayoutMap, image);
+bool CoreChecks::FindLayouts(const IMAGE_STATE &image_state, std::vector<VkImageLayout> &layouts) const {
+    const auto *layout_range_map = GetLayoutRangeMap(imageLayoutMap, image_state.image);
     if (!layout_range_map) return false;
     // TODO: FindLayouts function should mutate into a ValidatePresentableLayout with the loop wrapping the LogError
     //       from the caller. You can then use decode to add the subresource of the range::begin to the error message.
@@ -485,7 +482,7 @@ bool CoreChecks::FindLayouts(VkImage image, std::vector<VkImageLayout> &layouts)
     // TODO: what is this test and what is it supposed to do?! -- the logic doesn't match the comment below?!
 
     // TODO: Make this robust for >1 aspect mask. Now it will just say ignore potential errors in this case.
-    if (layout_range_map->size() >= (image_state->createInfo.arrayLayers * image_state->createInfo.mipLevels + 1)) {
+    if (layout_range_map->size() >= (image_state.createInfo.arrayLayers * image_state.createInfo.mipLevels + 1)) {
         return false;
     }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -243,6 +243,7 @@ IMAGE_STATE::IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCr
       subresource_encoder(full_range),
       fragment_encoder(nullptr),
       store_device_as_workaround(dev),  // TODO REMOVE WHEN encoder can be const
+      swapchain_fake_address(0U),
       sparse_requirements{} {
     if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
         uint32_t *queue_family_indices = new uint32_t[createInfo.queueFamilyIndexCount];

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12825,7 +12825,7 @@ void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKH
         auto swapchain_data = GetSwapchainState(swapchain);
         if (swapchain_data) {
             for (const auto &swapchain_image : swapchain_data->images) {
-                if (!swapchain_image.image_state.get()) continue;
+                if (!swapchain_image.image_state) continue;
                 imageLayoutMap.erase(swapchain_image.image_state->image);
                 qfo_release_image_barrier_map.erase(swapchain_image.image_state->image);
             }
@@ -12866,7 +12866,7 @@ void CoreChecks::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchai
 
         for (; new_swapchain_image_index < *pSwapchainImageCount; ++new_swapchain_image_index) {
             if ((new_swapchain_image_index >= image_vector_size) ||
-                !swapchain_state->images[new_swapchain_image_index].image_state.get()) {
+                !swapchain_state->images[new_swapchain_image_index].image_state) {
                 break;
             };
         }
@@ -12917,7 +12917,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                     "vkQueuePresentKHR: pSwapchains[%u] image index is too large (%u). There are only %u images in this swapchain.",
                     i, pPresentInfo->pImageIndices[i], static_cast<uint32_t>(swapchain_data->images.size()));
             } else {
-                const auto *image_state = swapchain_data->images[pPresentInfo->pImageIndices[i]].image_state.get();
+                const auto *image_state = swapchain_data->images[pPresentInfo->pImageIndices[i]].image_state;
                 assert(image_state);
 
                 if (!image_state->acquired) {
@@ -13061,9 +13061,9 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const CommandVersion 
         auto physical_device_state = GetPhysicalDeviceState();
         // TODO: this is technically wrong on many levels, but requires massive cleanup
         if (physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called) {
-            const uint32_t acquired_images = static_cast<uint32_t>(std::count_if(
-                swapchain_data->images.begin(), swapchain_data->images.end(),
-                [](const SWAPCHAIN_IMAGE &image) { return (image.image_state.get() && image.image_state->acquired); }));
+            const uint32_t acquired_images = static_cast<uint32_t>(
+                std::count_if(swapchain_data->images.begin(), swapchain_data->images.end(),
+                              [](const SWAPCHAIN_IMAGE &image) { return (image.image_state && image.image_state->acquired); }));
 
             const uint32_t swapchain_image_count = static_cast<uint32_t>(swapchain_data->images.size());
             const auto min_image_count = physical_device_state->surfaceCapabilities.minImageCount;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12825,8 +12825,9 @@ void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKH
         auto swapchain_data = GetSwapchainState(swapchain);
         if (swapchain_data) {
             for (const auto &swapchain_image : swapchain_data->images) {
-                imageLayoutMap.erase(swapchain_image.image);
-                qfo_release_image_barrier_map.erase(swapchain_image.image);
+                if (!swapchain_image.image_state.get()) continue;
+                imageLayoutMap.erase(swapchain_image.image_state->image);
+                qfo_release_image_barrier_map.erase(swapchain_image.image_state->image);
             }
         }
     }
@@ -12865,7 +12866,7 @@ void CoreChecks::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchai
 
         for (; new_swapchain_image_index < *pSwapchainImageCount; ++new_swapchain_image_index) {
             if ((new_swapchain_image_index >= image_vector_size) ||
-                (swapchain_state->images[new_swapchain_image_index].image == VK_NULL_HANDLE)) {
+                !swapchain_state->images[new_swapchain_image_index].image_state.get()) {
                 break;
             };
         }
@@ -12916,8 +12917,8 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                     "vkQueuePresentKHR: pSwapchains[%u] image index is too large (%u). There are only %u images in this swapchain.",
                     i, pPresentInfo->pImageIndices[i], static_cast<uint32_t>(swapchain_data->images.size()));
             } else {
-                auto image = swapchain_data->images[pPresentInfo->pImageIndices[i]].image;
-                const auto image_state = GetImageState(image);
+                const auto *image_state = swapchain_data->images[pPresentInfo->pImageIndices[i]].image_state.get();
+                assert(image_state);
 
                 if (!image_state->acquired) {
                     skip |= LogError(pPresentInfo->pSwapchains[i], validation_error,
@@ -12926,7 +12927,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                 }
 
                 vector<VkImageLayout> layouts;
-                if (FindLayouts(image, layouts)) {
+                if (FindLayouts(*image_state, layouts)) {
                     for (auto layout : layouts) {
                         if ((layout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) && (!device_extensions.vk_khr_shared_presentable_image ||
                                                                             (layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR))) {
@@ -13060,11 +13061,9 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const CommandVersion 
         auto physical_device_state = GetPhysicalDeviceState();
         // TODO: this is technically wrong on many levels, but requires massive cleanup
         if (physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHR_called) {
-            const uint32_t acquired_images = static_cast<uint32_t>(
-                std::count_if(swapchain_data->images.begin(), swapchain_data->images.end(), [this](SWAPCHAIN_IMAGE image) {
-                    auto const state = GetImageState(image.image);
-                    return (state && state->acquired);
-                }));
+            const uint32_t acquired_images = static_cast<uint32_t>(std::count_if(
+                swapchain_data->images.begin(), swapchain_data->images.end(),
+                [](const SWAPCHAIN_IMAGE &image) { return (image.image_state.get() && image.image_state->acquired); }));
 
             const uint32_t swapchain_image_count = static_cast<uint32_t>(swapchain_data->images.size());
             const auto min_image_count = physical_device_state->surfaceCapabilities.minImageCount;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -617,7 +617,7 @@ class CoreChecks : public ValidationStateTracker {
                                                 const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                 const VkImageSubresourceRange* pRanges) override;
 
-    bool FindLayouts(VkImage image, std::vector<VkImageLayout>& layouts) const;
+    bool FindLayouts(const IMAGE_STATE& image_state, std::vector<VkImageLayout>& layouts) const;
 
     void SetImageViewLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE& view_state, VkImageLayout layout,
                             VkImageLayout layoutStencil);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -593,7 +593,7 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
 };
 
 struct SWAPCHAIN_IMAGE {
-    VkImage image;
+    std::shared_ptr<IMAGE_STATE> image_state;
     std::unordered_set<VkImage> bound_images;
 };
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -465,6 +465,7 @@ class IMAGE_STATE : public BINDABLE {
     const image_layout_map::Encoder subresource_encoder;                             // Subresource resolution encoder
     std::unique_ptr<const subresource_adapter::ImageRangeEncoder> fragment_encoder;  // Fragment resolution encoder
     const VkDevice store_device_as_workaround;                                       // TODO REMOVE WHEN encoder can be const
+    VkDeviceSize swapchain_fake_address;  // Needed for swapchain syncval, since there is no VkDeviceMemory::fake_base_address
 
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
     IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCreateInfo);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -245,10 +245,8 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
     VkExternalMemoryHandleTypeFlags export_handle_type_flags;
     VkExternalMemoryHandleTypeFlags import_handle_type_flags;
     std::unordered_set<VulkanTypedHandle> obj_bindings;  // objects bound to this memory
-    // Convenience vectors of handles to speed up iterating over objects independently
-    std::unordered_set<VkImage> bound_images;
-    std::unordered_set<VkBuffer> bound_buffers;
-    std::unordered_set<VkAccelerationStructureNV> bound_acceleration_structures;
+    // Images for alias search
+    std::unordered_set<IMAGE_STATE *> bound_images;
 
     MemRange mapped_range;
     void *shadow_copy_base;          // Base of layer's allocation for guard band, data, and alignment space
@@ -472,8 +470,8 @@ class IMAGE_STATE : public BINDABLE {
     IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCreateInfo);
     IMAGE_STATE(IMAGE_STATE const &rh_obj) = delete;
 
-    std::unordered_set<VkImage> aliasing_images;
-    bool IsCompatibleAliasing(IMAGE_STATE *other_image_state);
+    std::unordered_set<IMAGE_STATE *> aliasing_images;
+    bool IsCompatibleAliasing(IMAGE_STATE *other_image_state) const;
 
     bool IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const;
     bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_createInfo) const;
@@ -594,7 +592,7 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
 
 struct SWAPCHAIN_IMAGE {
     std::shared_ptr<IMAGE_STATE> image_state;
-    std::unordered_set<VkImage> bound_images;
+    std::unordered_set<IMAGE_STATE *> bound_images;
 };
 
 class SWAPCHAIN_NODE : public BASE_NODE {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -592,7 +592,7 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
 };
 
 struct SWAPCHAIN_IMAGE {
-    std::shared_ptr<IMAGE_STATE> image_state;
+    IMAGE_STATE *image_state = nullptr;
     std::unordered_set<IMAGE_STATE *> bound_images;
 };
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -423,9 +423,9 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map)
 
-    void AddAliasingImage(IMAGE_STATE* image_state);
+    void AddAliasingImage(IMAGE_STATE* image_state, std::unordered_set<IMAGE_STATE*>* bound_images);
     void RemoveAliasingImage(IMAGE_STATE* image_state);
-    void RemoveAliasingImages(const std::unordered_set<VkImage>& bound_images);
+    static void RemoveAliasingImages(const std::unordered_set<IMAGE_STATE*>& bound_images);
 
   public:
     template <typename State>
@@ -1304,11 +1304,7 @@ class ValidationStateTracker : public ValidationObject {
     VkFormatFeatureFlags GetPotentialFormatFeatures(VkFormat format) const;
     void IncrementBoundObjects(CMD_BUFFER_STATE const* cb_node);
     void IncrementResources(CMD_BUFFER_STATE* cb_node);
-    void InsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, DEVICE_MEMORY_STATE* mem_info,
-                                                VkDeviceSize mem_offset);
-    void InsertBufferMemoryRange(VkBuffer buffer, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset);
-    void InsertImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset);
-    void InsertMemoryRange(const VulkanTypedHandle& typed_handle, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize memoryOffset);
+    void InsertImageMemoryRange(IMAGE_STATE* image_state, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset);
     void InvalidateCommandBuffers(small_unordered_map<CMD_BUFFER_STATE*, int, 8>& cb_nodes, const VulkanTypedHandle& obj,
                                   bool unlink = true);
     void InvalidateLinkedCommandBuffers(std::unordered_set<CMD_BUFFER_STATE*>& cb_nodes, const VulkanTypedHandle& obj);
@@ -1366,8 +1362,7 @@ class ValidationStateTracker : public ValidationObject {
                              RENDER_PASS_STATE* render_pass);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
     void RemoveCommandBufferBinding(const VulkanTypedHandle& object, CMD_BUFFER_STATE* cb_node);
-    void RemoveBufferMemoryRange(VkBuffer buffer, DEVICE_MEMORY_STATE* mem_info);
-    void RemoveImageMemoryRange(VkImage image, DEVICE_MEMORY_STATE* mem_info);
+    void RemoveImageMemoryRange(IMAGE_STATE* image, DEVICE_MEMORY_STATE* mem_info);
     void ResetCommandBufferState(const VkCommandBuffer cb);
     void RetireFence(VkFence fence);
     void RetireTimelineSemaphore(VkSemaphore semaphore, uint64_t until_payload);

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -273,7 +273,7 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image)
     : ImageRangeEncoder(image, AspectParameters::Get(image.full_range.aspectMask)) {}
 
 ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParameters* param)
-    : RangeEncoder(image.full_range, param), image_(&image) {
+    : RangeEncoder(image.full_range, param), image_(&image), total_size_(0U) {
     if (image_->createInfo.extent.depth > 1) {
         limits_.arrayLayer = image_->createInfo.extent.depth;
     }
@@ -321,6 +321,7 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
                 }
                 subres_layouts_.push_back(layout);
             }
+            total_size_ += layout.size;
         }
     }
 }

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -348,6 +348,7 @@ class ImageRangeEncoder : public RangeEncoder {
     }
     inline const double& TexelSize(int aspect_index) const { return texel_sizes_[aspect_index]; }
     inline bool IsLinearImage() const { return linear_image; }
+    inline VkDeviceSize TotalSize() const { return total_size_; }
 
   private:
     bool linear_image;
@@ -355,6 +356,7 @@ class ImageRangeEncoder : public RangeEncoder {
     std::vector<double> texel_sizes_;
     std::vector<VkExtent3D> subres_extents_;
     std::vector<VkSubresourceLayout> subres_layouts_;
+    VkDeviceSize total_size_;
 };
 
 class ImageRangeGenerator {


### PR DESCRIPTION
Add support for swapchain images (from GetSwapchainImage and VkBindImageMemorySwapchainInfoKHR) in hazard detection and update paths.
    
Store image state pointers in the swapchain state data instead of continually looking it up.

Fixes #2603
