### PR TITLE
Fix descriptorCount bindings being checked

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1387,7 +1387,7 @@ void OneOffDescriptorSet::Clear() {
 }
 
 void OneOffDescriptorSet::WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range,
-                                                    VkDescriptorType descriptorType, uint32_t count) {
+                                                    VkDescriptorType descriptorType, uint32_t arrayElement, uint32_t count) {
     const auto index = buffer_infos.size();
 
     VkDescriptorBufferInfo buffer_info = {};
@@ -1404,6 +1404,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferInfo(int binding, VkBuffer buffer
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
     descriptor_write.dstBinding = binding;
+    descriptor_write.dstArrayElement = arrayElement;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pBufferInfo = &buffer_infos[index];
@@ -1414,7 +1415,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferInfo(int binding, VkBuffer buffer
 }
 
 void OneOffDescriptorSet::WriteDescriptorBufferView(int binding, VkBufferView &buffer_view, VkDescriptorType descriptorType,
-                                                    uint32_t count) {
+                                                    uint32_t arrayElement, uint32_t count) {
     const auto index = buffer_views.size();
 
     for (uint32_t i = 0; i < count; ++i) {
@@ -1426,6 +1427,7 @@ void OneOffDescriptorSet::WriteDescriptorBufferView(int binding, VkBufferView &b
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
     descriptor_write.dstBinding = binding;
+    descriptor_write.dstArrayElement = arrayElement;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pTexelBufferView = &buffer_views[index];
@@ -1436,7 +1438,8 @@ void OneOffDescriptorSet::WriteDescriptorBufferView(int binding, VkBufferView &b
 }
 
 void OneOffDescriptorSet::WriteDescriptorImageInfo(int binding, VkImageView image_view, VkSampler sampler,
-                                                   VkDescriptorType descriptorType, VkImageLayout imageLayout, uint32_t count) {
+                                                   VkDescriptorType descriptorType, VkImageLayout imageLayout,
+                                                   uint32_t arrayElement, uint32_t count) {
     const auto index = image_infos.size();
 
     VkDescriptorImageInfo image_info = {};
@@ -1453,6 +1456,7 @@ void OneOffDescriptorSet::WriteDescriptorImageInfo(int binding, VkImageView imag
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = set_;
     descriptor_write.dstBinding = binding;
+    descriptor_write.dstArrayElement = arrayElement;
     descriptor_write.descriptorCount = count;
     descriptor_write.descriptorType = descriptorType;
     descriptor_write.pImageInfo = &image_infos[index];

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -396,12 +396,15 @@ struct OneOffDescriptorSet {
     bool Initialized();
     void Clear();
     void WriteDescriptorBufferInfo(int binding, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range,
-                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uint32_t count = 1);
+                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uint32_t arrayElement = 0,
+                                   uint32_t count = 1);
     void WriteDescriptorBufferView(int binding, VkBufferView &buffer_view,
-                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, uint32_t count = 1);
+                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+                                   uint32_t arrayElement = 0, uint32_t count = 1);
     void WriteDescriptorImageInfo(int binding, VkImageView image_view, VkSampler sampler,
                                   VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                  VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, uint32_t count = 1);
+                                  VkImageLayout imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, uint32_t arrayElement = 0,
+                                  uint32_t count = 1);
     void UpdateDescriptorSets();
 };
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -13223,15 +13223,15 @@ TEST_F(VkLayerTest, VerityUnnormalizedCoordinatesSampler) {
     ASSERT_VK_SUCCESS(vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler));
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 1);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, view_pass, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(3, view_fail, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
+                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 2);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(4, view_fail, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(5, view_pass, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
+                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 2);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(6, view_pass, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
+                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 2);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
     m_commandBuffer->begin();

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7955,9 +7955,9 @@ TEST_F(VkLayerTest, InvailStorageAtomicOperation) {
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(3, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                      VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                     VK_IMAGE_LAYOUT_GENERAL, 2);
+                                                     VK_IMAGE_LAYOUT_GENERAL, 0, 2);
     g_pipe.descriptor_set_->WriteDescriptorBufferView(1, buffer_view);
-    g_pipe.descriptor_set_->WriteDescriptorBufferView(0, buffer_view, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 2);
+    g_pipe.descriptor_set_->WriteDescriptorBufferView(0, buffer_view, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 0, 2);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
     m_commandBuffer->begin();


### PR DESCRIPTION
Closes #2600 

From spec

> dynamicOffsetCount must equal the total number of dynamic **descriptors** in the sets being bound

I didn't even realize until now you could have a `VkDescriptorSetLayoutBinding` with a `dynamicOffsetCount` of zero (special case in spec) and now it will skip a binding with a dynamic descriptor type that doesn't actually have a descriptor to it.. this solves #2600

While adding this, I realize I wasn't handling the case where `descriptorCount` was greater then `1` so added that support. It consisted of removing the old descriptor dynamic index helper functions and added a new one that will just track which `cvdescriptorset::Descriptor` to grab by the offset.

I also added the `dstArrayElement` field to all the `VkWriteDescriptorSet` wrappers in the testing framework