### PR TITLE
Fix VK_EXT_image_drm_format_modifier validation

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5548,6 +5548,12 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const IMAGE_STATE *image_state,
         format_properties_2.pNext = (void *)&drm_properties_list;
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, view_format, &format_properties_2);
 
+        std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
+        drm_properties.resize(drm_properties_list.drmFormatModifierCount);
+        drm_properties_list.pDrmFormatModifierProperties = drm_properties.data();
+
+        DispatchGetPhysicalDeviceFormatProperties2(physical_device, view_format, &format_properties_2);
+
         for (uint32_t i = 0; i < drm_properties_list.drmFormatModifierCount; i++) {
             if ((drm_properties_list.pDrmFormatModifierProperties[i].drmFormatModifier & drm_format_properties.drmFormatModifier) !=
                 0) {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -639,6 +639,16 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
         VkDrmFormatModifierPropertiesListEXT drm_properties_list = {VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
                                                                     nullptr};
         format_properties_2.pNext = (void *)&drm_properties_list;
+
+        // First call is to get the number of modifiers compatible with the queried format
+        DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_view_format, &format_properties_2);
+
+        std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
+        drm_properties.resize(drm_properties_list.drmFormatModifierCount);
+        drm_properties_list.pDrmFormatModifierProperties = drm_properties.data();
+
+        // Second call, now with an allocated array in pDrmFormatModifierProperties, is to get the modifiers
+        // compatible with the queried format
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_view_format, &format_properties_2);
 
         for (uint32_t i = 0; i < drm_properties_list.drmFormatModifierCount; i++) {


### PR DESCRIPTION
In some places, GetPhysicalDeviceFormatProperties2 was not called twice as it is needed when checking supported modifier properties (the first call to retrieve the count, the second to retrieve the actual properties).
This lead to crashes inside the layer when using the extension.

The fix is pretty much just copied from other places inside the layer where it's done correctly.