### PR TITLE
layers: Remove unnecessary descriptor_sets functions

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6946,7 +6946,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                     for (uint32_t i = 0; i < binding_count; i++) {
                         const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(i);
                         // skip checking binding if not needed
-                        if (cvdescriptorset::IsDynamicDescriptorType(binding->descriptorType) == false) {
+                        if (cvdescriptorset::IsDynamicDescriptor(binding->descriptorType) == false) {
                             continue;
                         }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6946,7 +6946,8 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                     for (uint32_t i = 0; i < binding_count; i++) {
                         const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(i);
                         // skip checking binding if not needed
-                        if (cvdescriptorset::IsDyanmicDescriptor(binding->descriptorType) == false) {
+                        if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) &&
+                            (binding->descriptorType != VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
                             continue;
                         }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6946,8 +6946,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                     for (uint32_t i = 0; i < binding_count; i++) {
                         const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(i);
                         // skip checking binding if not needed
-                        if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) &&
-                            (binding->descriptorType != VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+                        if (cvdescriptorset::IsDynamicDescriptorType(binding->descriptorType) == false) {
                             continue;
                         }
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -144,7 +144,6 @@ class DescriptorSetLayoutDef {
     struct BindingTypeStats {
         uint32_t dynamic_buffer_count;
         uint32_t non_dynamic_buffer_count;
-        uint32_t image_sampler_count;
     };
     const BindingTypeStats &GetBindingTypeStats() const { return binding_type_stats_; }
 
@@ -356,6 +355,11 @@ bool ValidateDescriptorSetLayoutCreateInfo(const ValidationObject *val_obj, cons
                                            const VkPhysicalDeviceInlineUniformBlockFeaturesEXT *inline_uniform_block_features,
                                            const VkPhysicalDeviceInlineUniformBlockPropertiesEXT *inline_uniform_block_props,
                                            const DeviceExtensions *device_extensions);
+
+// All Dynamic descriptor types
+inline bool IsDynamicDescriptorType(VkDescriptorType type) {
+    return ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC));
+}
 
 class SamplerDescriptor : public Descriptor {
   public:

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -357,8 +357,13 @@ bool ValidateDescriptorSetLayoutCreateInfo(const ValidationObject *val_obj, cons
                                            const DeviceExtensions *device_extensions);
 
 // All Dynamic descriptor types
-inline bool IsDynamicDescriptorType(VkDescriptorType type) {
+inline bool IsDynamicDescriptor(VkDescriptorType type) {
     return ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC));
+}
+
+inline bool IsBufferDescriptor(VkDescriptorType type) {
+    return ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) ||
+            (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER));
 }
 
 class SamplerDescriptor : public Descriptor {


### PR DESCRIPTION
So after diving more into the code

- If the a new descriptor type is ever added, finding all the spots being used to add it is just as error prone as someone using `IsDyanmicDescriptor` incorrectly as descriptor types are used for various checks of different scopes anyways
- The `Descriptor` class had a virtual function for this already, but no one is using it anyway as it is easier to check the enum you want instead of hoping some abstracted function is doing it correctly. Plus there isn't any fancy logic picking which to use
- The functions ruins the places where switch statements make more scene