### PR TITLE
corechecks: Improve core_error::Location to VUID lookups

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5387,18 +5387,15 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const CMD_BUFFER_ST
     auto op_type =
         ComputeBarrierOperationsType(cb_state, bufferBarrierCount, pBufferMemBarriers, imageMemBarrierCount, pImageMemBarriers);
 
-    // NOTE: for vkCmdPipelineBarrier() and vkCmdWaitEvents() the access mask checks use the function name for {refpage}
     for (uint32_t i = 0; i < memBarrierCount; ++i) {
         const auto &mem_barrier = pMemBarriers[i];
-        Location loc(outer_loc.function, outer_loc.structure, Field::pMemoryBarriers, i);
+        auto loc = outer_loc.dot(Struct::VkMemoryBarrier, Field::pMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier, src_stage_mask, dst_stage_mask);
     }
     for (uint32_t i = 0; i < imageMemBarrierCount; ++i) {
         const auto &mem_barrier = pImageMemBarriers[i];
-        Location loc(outer_loc.function, outer_loc.structure, Field::pImageMemoryBarriers, i);
+        auto loc = outer_loc.dot(Struct::VkImageMemoryBarrier, Field::pImageMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier, src_stage_mask, dst_stage_mask);
-
-        loc.structure = Struct::VkImageMemoryBarrier;
         skip |= ValidateImageBarrier(objects, loc, cb_state, mem_barrier);
     }
     {
@@ -5407,10 +5404,8 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const CMD_BUFFER_ST
     }
     for (uint32_t i = 0; i < bufferBarrierCount; ++i) {
         const auto &mem_barrier = pBufferMemBarriers[i];
-        Location loc(outer_loc.function, outer_loc.structure, Field::pBufferMemoryBarriers, i);
+        auto loc = outer_loc.dot(Struct::VkBufferMemoryBarrier, Field::pMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier, src_stage_mask, dst_stage_mask);
-
-        loc.structure = Struct::VkBufferMemoryBarrier;
         skip |= ValidateBufferBarrier(objects, loc, cb_state, mem_barrier);
     }
     return skip;
@@ -5427,14 +5422,12 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Loca
     auto queue_flags = GetQueueFlags(*cb_state);
     for (uint32_t i = 0; i < dep_info->memoryBarrierCount; ++i) {
         const auto &mem_barrier = dep_info->pMemoryBarriers[i];
-        Location loc = outer_loc.dot(Field::pMemoryBarriers, i);
-        loc.structure = Struct::VkMemoryBarrier2KHR;
+        auto loc = outer_loc.dot(Struct::VkMemoryBarrier2KHR, Field::pMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier);
     }
     for (uint32_t i = 0; i < dep_info->imageMemoryBarrierCount; ++i) {
         const auto &mem_barrier = dep_info->pImageMemoryBarriers[i];
-        Location loc = outer_loc.dot(Field::pImageMemoryBarriers, i);
-        loc.structure = Struct::VkImageMemoryBarrier2KHR;
+        auto loc = outer_loc.dot(Struct::VkImageMemoryBarrier2KHR, Field::pImageMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier);
         skip |= ValidateImageBarrier(objects, loc, cb_state, mem_barrier);
     }
@@ -5445,8 +5438,7 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Loca
 
     for (uint32_t i = 0; i < dep_info->bufferMemoryBarrierCount; ++i) {
         const auto &mem_barrier = dep_info->pBufferMemoryBarriers[i];
-        Location loc = outer_loc.dot(Field::pBufferMemoryBarriers, i);
-        loc.structure = Struct::VkBufferMemoryBarrier2KHR;
+        auto loc = outer_loc.dot(Struct::VkBufferMemoryBarrier2KHR, Field::pBufferMemoryBarriers, i);
         skip |= ValidateMemoryBarrier(objects, loc, op_type, queue_flags, mem_barrier);
         skip |= ValidateBufferBarrier(objects, loc, cb_state, mem_barrier);
     }

--- a/layers/core_error_location.cpp
+++ b/layers/core_error_location.cpp
@@ -36,7 +36,7 @@ const std::string& String(Func func) {
         FUNC_ENTRY(vkCmdPipelineBarrier2KHR),
         FUNC_ENTRY(vkCmdWaitEvents),
         FUNC_ENTRY(vkCmdWaitEvents2KHR),
-        FUNC_ENTRY(vkCmdWriteTimestamp2),
+        FUNC_ENTRY(vkCmdWriteTimestamp),
         FUNC_ENTRY(vkCmdWriteTimestamp2KHR),
         FUNC_ENTRY(vkCreateRenderPass),
         FUNC_ENTRY(vkCreateRenderPass2),
@@ -62,16 +62,6 @@ const std::string& String(Struct structure) {
         STRUCT_ENTRY(VkSubmitInfo),
         STRUCT_ENTRY(VkSubmitInfo2KHR),
         STRUCT_ENTRY(VkCommandBufferSubmitInfoKHR),
-        STRUCT_ENTRY(vkCmdSetEvent),
-        STRUCT_ENTRY(vkCmdSetEvent2KHR),
-        STRUCT_ENTRY(vkCmdResetEvent),
-        STRUCT_ENTRY(vkCmdResetEvent2KHR),
-        STRUCT_ENTRY(vkCmdPipelineBarrier),
-        STRUCT_ENTRY(vkCmdPipelineBarrier2KHR),
-        STRUCT_ENTRY(vkCmdWaitEvents),
-        STRUCT_ENTRY(vkCmdWaitEvents2KHR),
-        STRUCT_ENTRY(vkCmdWriteTimestamp2),
-        STRUCT_ENTRY(vkCmdWriteTimestamp2KHR),
         STRUCT_ENTRY(VkSubpassDependency),
         STRUCT_ENTRY(VkSubpassDependency2),
         STRUCT_ENTRY(VkBindSparseInfo),
@@ -124,6 +114,7 @@ const std::string& String(Field field) {
         FIELD_ENTRY(dstQueueFamilyIndex),
         FIELD_ENTRY(queryPool),
         FIELD_ENTRY(pDependencies),
+        FIELD_ENTRY(pipelineStage),
     };
     const auto entry = table.find(field);
     assert(entry != table.end());
@@ -155,4 +146,36 @@ void Location::AppendFields(std::ostream& out) const {
         out << "[" << index << "]";
     }
 }
+
+bool operator==(const Key& key, const Location& loc) {
+    assert(key.function != Func::Empty || key.structure != Struct::Empty);
+    assert(loc.function != Func::Empty);
+    if (key.function != Func::Empty) {
+        if (key.function != loc.function) {
+            return false;
+        }
+    }
+    if (key.structure != Struct::Empty) {
+        if (key.structure != loc.structure) {
+            return false;
+        }
+    }
+    if (key.field == Field::Empty) {
+        return true;
+    }
+    if (key.field == loc.field) {
+        return true;
+    }
+    if (key.recurse_field) {
+        const Location *prev = loc.prev;
+        while (prev != nullptr) {
+            if (key.field == prev->field) {
+                return true;
+            }
+            prev = prev->prev;
+        }
+    }
+    return false;
+}
+
 }  // namespace core_error

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7225,7 +7225,7 @@ bool CoreChecks::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEve
                                       "VUID-vkCmdSetEvent-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_state, CMD_SETEVENT, "vkCmdSetEvent()");
     skip |= InsideRenderPass(cb_state, "vkCmdSetEvent()", "VUID-vkCmdSetEvent-renderpass");
-    Location loc(Func::vkCmdSetEvent, Struct::vkCmdSetEvent, Field::stageMask);
+    Location loc(Func::vkCmdSetEvent, Field::stageMask);
     LogObjectList objects(commandBuffer);
     skip |= ValidatePipelineStage(objects, loc, GetQueueFlags(*cb_state), stageMask);
     skip |= ValidateStageMaskHost(loc, stageMask);
@@ -7244,7 +7244,7 @@ bool CoreChecks::PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, V
                                       "VUID-vkCmdSetEvent2KHR-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_state, CMD_SETEVENT, func);
     skip |= InsideRenderPass(cb_state, func, "VUID-vkCmdSetEvent2KHR-renderpass");
-    Location loc(Func::vkCmdSetEvent2KHR, Struct::vkCmdSetEvent2KHR, Field::pDependencyInfo);
+    Location loc(Func::vkCmdSetEvent2KHR, Field::pDependencyInfo);
     if (pDependencyInfo->dependencyFlags != 0) {
         skip |= LogError(objects, "VUID-vkCmdSetEvent2KHR-dependencyFlags-03825", "%s (%s) must be 0",
                          loc.dot(Field::dependencyFlags).Message().c_str(),
@@ -7258,7 +7258,7 @@ bool CoreChecks::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkE
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     assert(cb_state);
     LogObjectList objects(commandBuffer);
-    Location loc(Func::vkCmdResetEvent, Struct::vkCmdResetEvent, Field::stageMask);
+    Location loc(Func::vkCmdResetEvent, Field::stageMask);
 
     bool skip = ValidateCmdQueueFlags(cb_state, "vkCmdResetEvent()", VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
                                       "VUID-vkCmdResetEvent-commandBuffer-cmdpool");
@@ -7275,7 +7275,7 @@ bool CoreChecks::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer,
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     assert(cb_state);
     LogObjectList objects(commandBuffer);
-    Location loc(Func::vkCmdResetEvent2KHR, Struct::vkCmdResetEvent2KHR, Field::stageMask);
+    Location loc(Func::vkCmdResetEvent2KHR, Field::stageMask);
 
     bool skip = ValidateCmdQueueFlags(cb_state, func, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
                                       "VUID-vkCmdResetEvent2KHR-commandBuffer-cmdpool");
@@ -7724,15 +7724,17 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
 
     auto queue_flags = GetQueueFlags(*cb_state);
     LogObjectList objects(commandBuffer);
-    Location loc(Func::vkCmdWaitEvents, Struct::vkCmdWaitEvents);
+    Location loc(Func::vkCmdWaitEvents);
+
     skip |= ValidatePipelineStage(objects, loc.dot(Field::srcStageMask), queue_flags, srcStageMask);
     skip |= ValidatePipelineStage(objects, loc.dot(Field::dstStageMask), queue_flags, dstStageMask);
 
     skip |= ValidateCmdQueueFlags(cb_state, "vkCmdWaitEvents()", VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
                                   "VUID-vkCmdWaitEvents-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_state, CMD_WAITEVENTS, "vkCmdWaitEvents()");
-    skip |= ValidateBarriers(loc, cb_state, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
-                             bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+    skip |=
+        ValidateBarriers(loc.dot(Field::pDependencyInfo), cb_state, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
+                         bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     return skip;
 }
 
@@ -7745,7 +7747,7 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer,
     for (uint32_t i = 0; (i < eventCount) && !skip; i++) {
         LogObjectList objects(commandBuffer);
         objects.add(pEvents[i]);
-        Location loc(Func::vkCmdWaitEvents2KHR, Struct::vkCmdWaitEvents2KHR, Field::pDependencyInfos, i);
+        Location loc(Func::vkCmdWaitEvents2KHR, Field::pDependencyInfos, i);
         if (pDependencyInfos[i].dependencyFlags != 0) {
             skip |= LogError(objects, "VUID-vkCmdWaitEvents2KHR-dependencyFlags-03844", "%s (%s) must be 0.",
                              loc.dot(Field::dependencyFlags).Message().c_str(),
@@ -7836,7 +7838,7 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer
     assert(cb_state);
     LogObjectList objects(commandBuffer);
     auto queue_flags = GetQueueFlags(*cb_state);
-    Location loc(Func::vkCmdPipelineBarrier, Struct::vkCmdPipelineBarrier);
+    Location loc(Func::vkCmdPipelineBarrier);
 
     auto op_type = ComputeBarrierOperationsType(cb_state, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount,
                                                 pImageMemoryBarriers);
@@ -7878,7 +7880,7 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBu
         ComputeBarrierOperationsType(cb_state, pDependencyInfo->bufferMemoryBarrierCount, pDependencyInfo->pBufferMemoryBarriers,
                                      pDependencyInfo->imageMemoryBarrierCount, pDependencyInfo->pImageMemoryBarriers);
 
-    Location loc(Func::vkCmdPipelineBarrier2KHR, Struct::vkCmdPipelineBarrier2KHR, Field::pDependencyInfo);
+    Location loc(Func::vkCmdPipelineBarrier2KHR, Field::pDependencyInfo);
     skip |= ValidateCmdQueueFlags(cb_state, "vkCmdPipelineBarrier2KHR()",
                                   VK_QUEUE_TRANSFER_BIT | VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
                                   "VUID-vkCmdPipelineBarrier-commandBuffer-cmdpool");
@@ -8482,7 +8484,7 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp2KHR(VkCommandBuffer commandBuf
                                       "VUID-vkCmdWriteTimestamp2KHR-commandBuffer-cmdpool");
     skip |= ValidateCmd(cb_state, CMD_WRITETIMESTAMP, "vkCmdWriteTimestamp2KHR()");
 
-    Location loc(Func::vkCmdWriteTimestamp2KHR, Struct::vkCmdWriteTimestamp2KHR, Field::stage);
+    Location loc(Func::vkCmdWriteTimestamp2KHR, Field::stage);
     if ((stage & (stage - 1)) != 0) {
         skip |= LogError(cb_state->commandBuffer, "VUID-vkCmdWriteTimestamp2KHR-stage-03859",
                          "%s (%s) must only set a single pipeline stage.", loc.Message().c_str(),

--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -30,6 +30,9 @@ namespace sync_vuid_maps {
 using core_error::Field;
 using core_error::Func;
 using core_error::Struct;
+using core_error::FindVUID;
+using core_error::Key;
+using core_error::Entry;
 
 const std::map<VkPipelineStageFlags2KHR, std::string> kFeatureNameMap{
     {VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR, "geometryShader"},
@@ -45,30 +48,6 @@ const std::map<VkPipelineStageFlags2KHR, std::string> kFeatureNameMap{
     {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracing"},
 };
 
-static std::string MakeKey(const std::string &refpage, const std::string &field_name) {
-    std::string key(refpage);
-    key += "-";
-    key += field_name;
-    return key;
-}
-
-template <typename Table>
-static const std::string &FindVUID(const std::string &refpage, const std::string &field_name, const Table &table) {
-    static const std::string empty;
-    auto key = MakeKey(refpage, field_name);
-    const auto pos =
-        std::find_if(table.begin(), table.end(), [&key](const std::string &entry) { return entry.find(key) != std::string::npos; });
-
-    return (pos != table.end()) ? *pos : empty;
-}
-
-template <typename Table>
-static const std::string &FindVUID(const Struct &structure, const Field &field, const Table &table) {
-    const auto &str_ref = core_error::String(structure);
-    const auto &str_field = core_error::String(field);
-    return FindVUID(str_ref, str_field, table);
-}
-
 // commonvalidity/pipeline_stage_common.txt
 // commonvalidity/stage_mask_2_common.txt
 // commonvalidity/stage_mask_common.txt
@@ -77,592 +56,657 @@ static const std::string &FindVUID(const Struct &structure, const Field &field, 
 // renderpass.txt VkSubpassDependency2-srcStageMask
 // renderpass.txt VkSubpassDependency-dstStageMask
 // renderpass.txt VkSubpassDependency-srcStageMask
-
-static const std::map<VkPipelineStageFlags2KHR, std::vector<std::string>> kStageMaskErrors{
+static const std::map<VkPipelineStageFlags2KHR, std::vector<Entry>> kStageMaskErrors{
     {VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03931",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03931",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04092",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04092",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03931",
-      "VUID-vkCmdResetEvent-stageMask-04092",
-      "VUID-vkCmdSetEvent-stageMask-04092",
-      "VUID-vkCmdWaitEvents-dstStageMask-04092",
-      "VUID-vkCmdWaitEvents-srcStageMask-04092",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03931",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04077",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03931",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03931",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03931",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03931",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03931",
-      "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-conditionalRendering",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-conditionalRendering",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-conditionalRendering",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-conditionalRendering",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-conditionalRendering"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03931"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03931"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04092"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04092"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03931"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04092"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04092"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04092"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04092"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03931"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04077"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03931"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03931"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03931"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03931"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03931"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-conditionalRendering"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-conditionalRendering"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-conditionalRendering"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-conditionalRendering"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-conditionalRendering"},
+     }},
     {VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03932",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03932",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04093",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04093",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03932",
-      "VUID-vkCmdResetEvent-stageMask-04093",
-      "VUID-vkCmdSetEvent-stageMask-04093",
-      "VUID-vkCmdWaitEvents-dstStageMask-04093",
-      "VUID-vkCmdWaitEvents-srcStageMask-04093",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03932",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04078",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03932",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03932",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03932",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03932",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03932",
-      "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-fragmentDensity",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-fragmentDensity",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-fragmentDensity",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-fragmentDensity",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-fragmentDensity"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03932"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03932"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04093"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04093"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03932"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04093"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04093"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04093"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04093"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03932"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04078"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03932"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03932"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03932"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03932"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03932"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-fragmentDensity"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-fragmentDensity"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-fragmentDensity"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-fragmentDensity"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-fragmentDensity"},
+     }},
     {VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03936",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03936",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04097",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04097",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03936",
-      "VUID-vkCmdResetEvent-stageMask-04097",
-      "VUID-vkCmdSetEvent-stageMask-04097",
-      "VUID-vkCmdWaitEvents-dstStageMask-04097",
-      "VUID-vkCmdWaitEvents-srcStageMask-04097",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03936",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04081",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03936",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03936",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03936",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03936",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03936",
-      "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-shadingRate",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-shadingRate",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-shadingRate",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-shadingRate",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-shadingRate"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03936"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03936"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04097"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04097"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03936"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04097"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04097"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04097"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04097"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03936"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04081"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03936"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03936"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03936"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03936"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03936"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-shadingRate"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-shadingRate"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-shadingRate"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-shadingRate"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-shadingRate"},
+     }},
     {VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03929",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03929",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04090",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04090",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03929",
-      "VUID-vkCmdResetEvent-stageMask-04090",
-      "VUID-vkCmdSetEvent-stageMask-04090",
-      "VUID-vkCmdWaitEvents-dstStageMask-04090",
-      "VUID-vkCmdWaitEvents-srcStageMask-04090",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03929",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04075",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03929",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03929",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03929",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03929",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03929",
-      "VUID-VkSubmitInfo-pWaitDstStageMask-00076",
-      "VUID-VkSubpassDependency-srcStageMask-00860",
-      "VUID-VkSubpassDependency-dstStageMask-00861",
-      "VUID-VkSubpassDependency2-srcStageMask-03080",
-      "VUID-VkSubpassDependency2-dstStageMask-03081"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03929"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03929"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04090"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04090"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03929"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04090"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04090"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04090"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04090"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03929"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04075"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03929"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03929"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03929"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03929"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03929"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-VkSubmitInfo-pWaitDstStageMask-00076"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-VkSubpassDependency-srcStageMask-00860"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-VkSubpassDependency-dstStageMask-00861"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-VkSubpassDependency2-srcStageMask-03080"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-VkSubpassDependency2-dstStageMask-03081"},
+     }},
     {VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03934",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03934",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04095",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04095",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03934",
-      "VUID-vkCmdResetEvent-stageMask-04095",
-      "VUID-vkCmdSetEvent-stageMask-04095",
-      "VUID-vkCmdWaitEvents-dstStageMask-04095",
-      "VUID-vkCmdWaitEvents-srcStageMask-04095",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03934",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04080",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03934",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03934",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03934",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03934",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03934",
-      "VUID-VkSubmitInfo-pWaitDstStageMask-02089",
-      "VUID-VkSubpassDependency-srcStageMask-02099",
-      "VUID-VkSubpassDependency-dstStageMask-02101",
-      "VUID-VkSubpassDependency2-srcStageMask-02103",
-      "VUID-VkSubpassDependency2-dstStageMask-02105"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03934"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03934"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04095"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04095"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03934"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04095"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04095"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04095"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04095"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03934"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04080"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03934"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03934"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03934"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03934"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03934"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-VkSubmitInfo-pWaitDstStageMask-02089"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-VkSubpassDependency-srcStageMask-02099"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-VkSubpassDependency-dstStageMask-02101"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-VkSubpassDependency2-srcStageMask-02103"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-VkSubpassDependency2-dstStageMask-02105"},
+     }},
     {VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03935",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03935",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04096",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04096",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03935",
-      "VUID-vkCmdResetEvent-stageMask-04096",
-      "VUID-vkCmdSetEvent-stageMask-04096",
-      "VUID-vkCmdWaitEvents-dstStageMask-04096",
-      "VUID-vkCmdWaitEvents-srcStageMask-04096",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03935",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04080",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03935",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03935",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03935",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03935",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03935",
-      "VUID-VkSubmitInfo-pWaitDstStageMask-02090",
-      "VUID-VkSubpassDependency-srcStageMask-02100",
-      "VUID-VkSubpassDependency-dstStageMask-02102",
-      "VUID-VkSubpassDependency2-srcStageMask-02104",
-      "VUID-VkSubpassDependency2-dstStageMask-02106"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03935"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03935"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04096"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04096"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03935"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04096"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04096"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04096"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04096"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03935"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04080"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03935"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03935"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03935"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03935"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03935"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-VkSubmitInfo-pWaitDstStageMask-02090"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-VkSubpassDependency-srcStageMask-02100"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-VkSubpassDependency-dstStageMask-02102"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-VkSubpassDependency2-srcStageMask-02104"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-VkSubpassDependency2-dstStageMask-02106"},
+     }},
     {VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04091",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04091",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03930",
-      "VUID-vkCmdResetEvent-stageMask-04091",
-      "VUID-vkCmdSetEvent-stageMask-04091",
-      "VUID-vkCmdWaitEvents-dstStageMask-04091",
-      "VUID-vkCmdWaitEvents-srcStageMask-04091",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03930",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04076",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03930",
-      "VUID-VkSubmitInfo-pWaitDstStageMask-00077",
-      "VUID-VkSubpassDependency-srcStageMask-00862",
-      "VUID-VkSubpassDependency-dstStageMask-00863",
-      "VUID-VkSubpassDependency2-srcStageMask-03082",
-      "VUID-VkSubpassDependency2-dstStageMask-03083"}},
-    {VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04091",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04091",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03930",
-      "VUID-vkCmdResetEvent-stageMask-04091",
-      "VUID-vkCmdSetEvent-stageMask-04091",
-      "VUID-vkCmdWaitEvents-dstStageMask-04091",
-      "VUID-vkCmdWaitEvents-srcStageMask-04091",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03930",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04076",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03930",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03930",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03930",
-      "VUID-VkSubmitInfo-pWaitDstStageMask-00077",
-      "VUID-VkSubpassDependency-srcStageMask-00862",
-      "VUID-VkSubpassDependency-dstStageMask-00863",
-      "VUID-VkSubpassDependency2-srcStageMask-03082",
-      "VUID-VkSubpassDependency2-dstStageMask-03083"}},
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03930"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03930"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04091"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04091"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03930"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04091"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04091"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04091"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04091"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03930"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04076"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03930"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03930"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03930"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03930"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03930"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-VkSubmitInfo-pWaitDstStageMask-00077"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-VkSubpassDependency-srcStageMask-00862"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-VkSubpassDependency-dstStageMask-00863"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-VkSubpassDependency2-srcStageMask-03082"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-VkSubpassDependency2-dstStageMask-03083"},
+     }},
+    {
+        VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR,
+        {
+            {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03930"},
+            {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03930"},
+            {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04091"},
+            {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04091"},
+            {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03930"},
+            {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04091"},
+            {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04091"},
+            {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04091"},
+            {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04091"},
+            {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03930"},
+            {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04076"},
+            {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03930"},
+            {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03930"},
+            {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03930"},
+            {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03930"},
+            {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03930"},
+            {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-VkSubmitInfo-pWaitDstStageMask-00077"},
+            {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-VkSubpassDependency-srcStageMask-00862"},
+            {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-VkSubpassDependency-dstStageMask-00863"},
+            {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-VkSubpassDependency2-srcStageMask-03082"},
+            {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-VkSubpassDependency2-dstStageMask-03083"},
+        },
+    },
     {VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT,
-     {"VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03933",
-      "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03933",
-      "VUID-vkCmdPipelineBarrier-dstStageMask-04094",
-      "VUID-vkCmdPipelineBarrier-srcStageMask-04094",
-      "VUID-vkCmdResetEvent2KHR-stageMask-03933",
-      "VUID-vkCmdResetEvent-stageMask-04094",
-      "VUID-vkCmdSetEvent-stageMask-04094",
-      "VUID-vkCmdWaitEvents-dstStageMask-04094",
-      "VUID-vkCmdWaitEvents-srcStageMask-04094",
-      "VUID-vkCmdWriteTimestamp2KHR-stage-03933",
-      "VUID-vkCmdWriteTimestamp-pipelineStage-04079",
-      "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03933",
-      "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03933",
-      "VUID-VkMemoryBarrier2KHR-dstStageMask-03933",
-      "VUID-VkMemoryBarrier2KHR-srcStageMask-03933",
-      "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03933",
-      "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-transformFeedback",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-transformFeedback",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-transformFeedback",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-transformFeedback",
-      "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-transformFeedback"}},
-    // special case for VK_PIPELINE_STAGE_NONE_KHR. This entry omits the synchronization2
+     {
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2KHR-dstStageMask-03933"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2KHR-srcStageMask-03933"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-04094"},
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-04094"},
+         {Key(Func::vkCmdResetEvent2KHR, Field::stageMask), "VUID-vkCmdResetEvent2KHR-stageMask-03933"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-04094"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-04094"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-04094"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-04094"},
+         {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03933"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04079"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkImageMemoryBarrier2KHR-dstStageMask-03933"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkImageMemoryBarrier2KHR-srcStageMask-03933"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstStageMask), "VUID-VkMemoryBarrier2KHR-dstStageMask-03933"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcStageMask), "VUID-VkMemoryBarrier2KHR-srcStageMask-03933"},
+         {Key(Struct::VkSemaphoreSubmitInfoKHR, Field::stageMask), "VUID-VkSemaphoreSubmitInfoKHR-stageMask-03933"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-transformFeedback"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-transformFeedback"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-transformFeedback"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-transformFeedback"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-transformFeedback"},
+     }},
+    // special case for the NONE stage. This entry omits the synchronization2
     // commands because they shouldn't be called unless synchronization2 is enabled.
-    {0,
-     {"VUID-vkCmdPipelineBarrier-srcStageMask-03937", "VUID-vkCmdPipelineBarrier-dstStageMask-03937",
-      "VUID-vkCmdResetEvent-stageMask-03937", "VUID-vkCmdSetEvent-stageMask-03937", "VUID-vkCmdWaitEvents-srcStageMask-03937",
-      "VUID-vkCmdWaitEvents-dstStageMask-03937"}},
+    {VK_PIPELINE_STAGE_2_NONE_KHR,
+     {
+         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-03937"},
+         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-03937"},
+         {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-03937"},
+         {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-03937"},
+         {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-03937"},
+         {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-03937"},
+         {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage),
+          "UNASSIGNED-CoreChecks-vkCmdWriteTimestamp-pipelineStage-noneStage"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "UNASSIGNED-CoreChecks-VkSubmitInfo-pWaitDstStageMask-noneStage"},
+         {Key(Struct::VkSubpassDependency, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-srcStageMask-noneStage"},
+         {Key(Struct::VkSubpassDependency, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency-dstStageMask-noneStage"},
+         {Key(Struct::VkSubpassDependency2, Field::srcStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask-noneStage"},
+         {Key(Struct::VkSubpassDependency2, Field::dstStageMask),
+          "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask-noneStage"},
+     }},
 };
 
 const std::string &GetBadFeatureVUID(const Location &loc, VkPipelineStageFlags2KHR bit) {
-    const auto entry = kStageMaskErrors.find(bit);
-    assert(entry != kStageMaskErrors.end());
-    const auto &result = FindVUID(loc.structure, loc.field, entry->second);
+    const auto &result = FindVUID(bit, loc, kStageMaskErrors);
     assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandle-pipeline-stage-feature");
+        return unhandled;
+    }
     return result;
 }
 
 // commonvalidity/access_mask_2_common.txt
-static const std::map<VkAccessFlags2KHR, std::array<std::string, 6>> kAccessMask2Common = {
+static const std::map<VkAccessFlags2KHR, std::array<Entry, 6>> kAccessMask2Common{
     {VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03900",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03900",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03900",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03900",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03900",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03900",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03900"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03900"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03900"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03900"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03900"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03900"},
+     }}},
     {VK_ACCESS_2_INDEX_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03901",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03901",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03901",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03901",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03901",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03901",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03901"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03901"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03901"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03901"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03901"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03901"},
+     }}},
     {VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03902",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03902",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03902",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03902",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03902",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03902",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03902"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03902"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03902"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03902"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03902"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03902"},
+     }}},
     {VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03903",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03903",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03903",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03903",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03903",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03903",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03903"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03903"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03903"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03903"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03903"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03903"},
+     }}},
     {VK_ACCESS_2_UNIFORM_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03904",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03904",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03904",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03904",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03904",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03904",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03904"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03904"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03904"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03904"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03904"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03904"},
+     }}},
     {VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03905",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03905",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03905",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03905",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03905",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03905",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03905"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03905"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03905"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03905"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03905"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03905"},
+     }}},
     {VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03906",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03906",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03906",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03906",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03906",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03906",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03906"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03906"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03906"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03906"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03906"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03906"},
+     }}},
     {VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03907",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03907",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03907",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03907",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03907",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03907",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03907"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03907"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03907"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03907"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03907"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03907"},
+     }}},
     {VK_ACCESS_2_SHADER_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03908",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03908",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03908",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03908",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03908",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03908",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03908"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03908"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03908"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03908"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03908"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03908"},
+     }}},
     {VK_ACCESS_2_SHADER_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03909",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03909",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03909",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03909",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03909",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03909",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03909"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03909"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03909"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03909"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03909"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03909"},
+     }}},
     {VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03910",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03910",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03910",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03910",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03910",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03910",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03910"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03910"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03910"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03910"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03910"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03910"},
+     }}},
     {VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03911",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03911",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03911",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03911",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03911",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03911",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03911"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03911"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03911"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03911"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03911"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03911"},
+     }}},
     {VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03912",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03912",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03912",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03912",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03912",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03912",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03912"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03912"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03912"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03912"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03912"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03912"},
+     }}},
     {VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03913",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03913",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03913",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03913",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03913",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03913",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03913"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03913"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03913"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03913"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03913"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03913"},
+     }}},
     {VK_ACCESS_2_TRANSFER_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03914",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03914",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03914",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03914",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03914",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03914",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03914"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03914"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03914"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03914"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03914"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03914"},
+     }}},
     {VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03915",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03915",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03915",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03915",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03915",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03915",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03915"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03915"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03915"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03915"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03915"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03915"},
+     }}},
     {VK_ACCESS_2_HOST_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03916",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03916",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03916",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03916",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03916",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03916",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03916"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03916"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03916"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03916"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03916"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03916"},
+     }}},
     {VK_ACCESS_2_HOST_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03917",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03917",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03917",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03917",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03917",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03917",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03917"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03917"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03917"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03917"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03917"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03917"},
+     }}},
     {VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03918",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03918",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03918",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03918",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03918",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03918",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03918"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03918"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03918"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03918"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03918"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03918"},
+     }}},
     {VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03919",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03919",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03919",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03919",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03919",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03919",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03919"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03919"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03919"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03919"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03919"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03919"},
+     }}},
     {VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03920",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03920",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03920",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03920"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03920"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03920"},
+     }}},
     {VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-04747",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-04747",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-04747",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-04747",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-04747",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-04747",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-04747"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-04747"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-04747"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-04747"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-04747"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-04747"},
+     }}},
     {VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03920",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03920",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03920",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03920",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03920"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03920"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03920"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03920"},
+     }}},
     {VK_ACCESS_2_SHADING_RATE_IMAGE_READ_BIT_NV,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03922",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03922",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03922",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03922",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03922",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03922",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03922"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03922"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03922"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03922"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03922"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03922"},
+     }}},
     {VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03923",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03923",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03923",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03923",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03923",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03923",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03923"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03923"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03923"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03923"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03923"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03923"},
+     }}},
     {VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03924",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03924",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03924",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03924",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03924",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03924",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03924"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03924"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03924"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03924"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03924"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03924"},
+     }}},
     {VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03925",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03925",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03925",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03925",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03925",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03925",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03925"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03925"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03925"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03925"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03925"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03925"},
+     }}},
     {VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03926",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03926",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03926",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03926",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03926",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03926",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03926"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03926"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03926"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03926"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03926"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03926"},
+     }}},
     {VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03927",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03927",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03927",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03927",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03927",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03927",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03927"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03927"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03927"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03927"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03927"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03927"},
+     }}},
     {VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR,
-     {
-         "VUID-VkMemoryBarrier2KHR-srcAccessMask-03928",
-         "VUID-VkMemoryBarrier2KHR-dstAccessMask-03928",
-         "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03928",
-         "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03928",
-         "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03928",
-         "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03928",
-     }},
+     {{
+         {Key(Struct::VkMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkMemoryBarrier2KHR-srcAccessMask-03928"},
+         {Key(Struct::VkMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkMemoryBarrier2KHR-dstAccessMask-03928"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2KHR-srcAccessMask-03928"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2KHR-dstAccessMask-03928"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2KHR-srcAccessMask-03928"},
+         {Key(Struct::VkImageMemoryBarrier2KHR, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2KHR-dstAccessMask-03928"},
+     }}},
 };
 
 // commonvalidity/fine_sync_commands_common.txt
-static const std::vector<std::string> kFineSyncCommon = {
-    "VUID-vkCmdPipelineBarrier-srcAccessMask-02815", "VUID-vkCmdPipelineBarrier-dstAccessMask-02816",
-    "VUID-vkCmdWaitEvents-srcAccessMask-02815",      "VUID-vkCmdWaitEvents-dstAccessMask-02816",
-    "VUID-VkSubpassDependency-srcAccessMask-00868",  "VUID-VkSubpassDependency-dstAccessMask-00869",
-    "VUID-VkSubpassDependency2-srcAccessMask-03088", "VUID-VkSubpassDependency2-dstAccessMask-03089",
+static const std::vector<Entry> kFineSyncCommon = {
+    {Key(Func::vkCmdPipelineBarrier, Field::srcAccessMask), "VUID-vkCmdPipelineBarrier-srcAccessMask-02815"},
+    {Key(Func::vkCmdPipelineBarrier, Field::dstAccessMask), "VUID-vkCmdPipelineBarrier-dstAccessMask-02816"},
+    {Key(Func::vkCmdWaitEvents, Field::srcAccessMask), "VUID-vkCmdWaitEvents-srcAccessMask-02815"},
+    {Key(Func::vkCmdWaitEvents, Field::dstAccessMask), "VUID-vkCmdWaitEvents-dstAccessMask-02816"},
+    {Key(Struct::VkSubpassDependency, Field::srcAccessMask), "VUID-VkSubpassDependency-srcAccessMask-00868"},
+    {Key(Struct::VkSubpassDependency, Field::dstAccessMask), "VUID-VkSubpassDependency-dstAccessMask-00869"},
+    {Key(Struct::VkSubpassDependency2, Field::srcAccessMask), "VUID-VkSubpassDependency2-srcAccessMask-03088"},
+    {Key(Struct::VkSubpassDependency2, Field::dstAccessMask), "VUID-VkSubpassDependency2-dstAccessMask-03089"},
 };
 const std::string &GetBadAccessFlagsVUID(const Location &loc, VkAccessFlags2KHR bit) {
-    const auto entry = kAccessMask2Common.find(bit);
-    if (entry != kAccessMask2Common.end()) {
-        const auto &result = FindVUID(loc.structure, loc.field, entry->second);
-        if (!result.empty()) {
-            return result;
-        }
+    const auto &result = FindVUID(bit, loc, kAccessMask2Common);
+    if (!result.empty()) {
+        return result;
     }
-    const auto &result2 = FindVUID(loc.structure, loc.field, kFineSyncCommon);
+    const auto &result2 = FindVUID(loc, kFineSyncCommon);
     assert(!result2.empty());
+    if (result2.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-bad-access-flags");
+        return unhandled;
+    }
     return result2;
 }
 
-static const std::vector<std::string> kQueueCapErrors{
-    "VUID-vkQueueSubmit-pWaitDstStageMask-00066",
-    "VUID-vkCmdBeginRenderPass-srcStageMask-00901",
-    "VUID-vkCmdBeginRenderPass-dstStageMask-00901",
-    "VUID-vkCmdSetEvent-stageMask-4098",
-    "VUID-vkCmdResetEvent-stageMask-4098",
-    "VUID-vkCmdWaitEvents-srcStageMask-4098",
-    "VUID-vkCmdWaitEvents-dstStageMask-4098",
-    "VUID-vkCmdPipelineBarrier-srcStageMask-4098",
-    "VUID-vkCmdPipelineBarrier-dstStageMask-4098",
-    "VUID-vkCmdWriteTimestamp-pipelineStage-04074",
-    "VUID-vkCmdBeginRenderPass2-srcStageMask-03101",
-    "VUID-vkCmdBeginRenderPass2-dstStageMask-03101",
-    "VUID-vkCmdSetEvent2KHR-srcStageMask-03827",
-    "VUID-vkCmdSetEvent2KHR-dstStageMask-03828",
-    "VUID-vkCmdPipelineBarrier2KHR-srcStageMask-03849",
-    "VUID-vkCmdPipelineBarrier2KHR-dstStageMask-03850",
-    "VUID-vkCmdWaitEvents2KHR-srcStageMask-03842",
-    "VUID-vkCmdWaitEvents2KHR-dstStageMask-03843",
-    "VUID-vkCmdWriteTimestamp2KHR-stage-03860",
-    "VUID-vkQueueSubmit2KHR-stageMask-03869",  // TODO: src
-    "VUID-vkQueueSubmit2KHR-stageMask-03870",  // TODO: dst
+static const std::vector<Entry> kQueueCapErrors{
+    {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-vkQueueSubmit-pWaitDstStageMask-00066"},
+    // src and dst use the same VUID string for 00901
+    {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-vkCmdBeginRenderPass-srcStageMask-00901"},
+    {Key(Struct::VkSubpassDependency, Field::dstStageMask), "VUID-vkCmdBeginRenderPass-srcStageMask-00901"},
+    {Key(Func::vkCmdSetEvent, Field::stageMask), "VUID-vkCmdSetEvent-stageMask-4098"},
+    {Key(Func::vkCmdResetEvent, Field::stageMask), "VUID-vkCmdResetEvent-stageMask-4098"},
+    {Key(Func::vkCmdWaitEvents, Field::srcStageMask), "VUID-vkCmdWaitEvents-srcStageMask-4098"},
+    {Key(Func::vkCmdWaitEvents, Field::dstStageMask), "VUID-vkCmdWaitEvents-dstStageMask-4098"},
+    {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-4098"},
+    {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-4098"},
+    {Key(Func::vkCmdWriteTimestamp, Field::pipelineStage), "VUID-vkCmdWriteTimestamp-pipelineStage-04074"},
+    // src and dst use the same VUID string for 03101
+    {Key(Struct::VkSubpassDependency2, Field::srcStageMask), "VUID-vkCmdBeginRenderPass2-srcStageMask-03101"},
+    {Key(Struct::VkSubpassDependency2, Field::dstStageMask), "VUID-vkCmdBeginRenderPass2-srcStageMask-03101"},
+    {Key(Func::vkCmdSetEvent, Field::srcStageMask), "VUID-vkCmdSetEvent2KHR-srcStageMask-03827"},
+    {Key(Func::vkCmdSetEvent, Field::dstStageMask), "VUID-vkCmdSetEvent2KHR-dstStageMask-03828"},
+    {Key(Func::vkCmdPipelineBarrier2KHR, Field::srcStageMask), "VUID-vkCmdPipelineBarrier2KHR-srcStageMask-03849"},
+    {Key(Func::vkCmdPipelineBarrier2KHR, Field::dstStageMask), "VUID-vkCmdPipelineBarrier2KHR-dstStageMask-03850"},
+    {Key(Func::vkCmdWaitEvents2KHR, Field::srcStageMask), "VUID-vkCmdWaitEvents2KHR-srcStageMask-03842"},
+    {Key(Func::vkCmdWaitEvents2KHR, Field::dstStageMask), "VUID-vkCmdWaitEvents2KHR-dstStageMask-03843"},
+    {Key(Func::vkCmdWriteTimestamp2KHR, Field::stage), "VUID-vkCmdWriteTimestamp2KHR-stage-03860"},
+    {Key(Func::vkQueueSubmit2KHR, Field::pSignalSemaphoreInfos, true), "VUID-vkQueueSubmit2KHR-stageMask-03869"},
+    {Key(Func::vkQueueSubmit2KHR, Field::pWaitSemaphoreInfos, true), "VUID-vkQueueSubmit2KHR-stageMask-03870"},
 };
 
 const std::string &GetStageQueueCapVUID(const Location &loc, VkPipelineStageFlags2KHR bit) {
     // no per-bit lookups needed
-    const auto &result = FindVUID(loc.structure, loc.field, kQueueCapErrors);
-    if (!result.empty()) {
-        return result;
+    const auto &result = FindVUID(loc, kQueueCapErrors);
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-queue-capabilities");
+        return unhandled;
     }
-    const auto &result2 = FindVUID(loc.StringFunc(), loc.StringField(), kQueueCapErrors);
-    return result2;
+    return result;
 }
 
-static const std::map<QueueError, std::vector<std::string>> kBarrierQueueErrors{
+static const std::map<QueueError, std::vector<Entry>> kBarrierQueueErrors{
     {QueueError::kSrcOrDstMustBeIgnore,
      {
          // this isn't an error for synchronization2, so we don't need the 2KHR versions
-         "VUID-VkBufferMemoryBarrier-synchronization2-03853",
-         "VUID-VkImageMemoryBarrier-synchronization2-03857",
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-synchronization2-03853"},
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-synchronization2-03857"},
      }},
 
     {QueueError::kSpecialOrIgnoreOnly,
      {
-         "VUID-VkBufferMemoryBarrier2KHR-buffer-04088",
-         "VUID-VkBufferMemoryBarrier-buffer-04088",
-         "VUID-VkImageMemoryBarrier2KHR-image-04071",
-         "VUID-VkImageMemoryBarrier-image-04071",
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-buffer-04088"},
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-buffer-04088"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-04071"},
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-04071"},
      }},
     {QueueError::kSrcAndDstValidOrSpecial,
      {
-         "VUID-VkBufferMemoryBarrier2KHR-buffer-04089",
-         "VUID-VkBufferMemoryBarrier-buffer-04089",
-         "VUID-VkImageMemoryBarrier2KHR-image-04072",
-         "VUID-VkImageMemoryBarrier-image-04072",
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-buffer-04089"},
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-buffer-04089"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-04072"},
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-04072"},
      }},
 
     {QueueError::kSrcAndDestMustBeIgnore,
      {
          // this isn't an error for synchronization2, so we don't need the 2KHR versions
-         "VUID-VkBufferMemoryBarrier-synchronization2-03852",
-         "VUID-VkImageMemoryBarrier-synchronization2-03856",
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-synchronization2-03852"},
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-synchronization2-03856"},
      }},
     {QueueError::kSrcAndDstBothValid,
      {
-         "VUID-VkBufferMemoryBarrier2KHR-buffer-04086",
-         "VUID-VkBufferMemoryBarrier-buffer-04086",
-         "VUID-VkImageMemoryBarrier2KHR-image-04069",
-         "VUID-VkImageMemoryBarrier-image-04069",
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-buffer-04086"},
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-buffer-04086"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-04069"},
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-04069"},
      }},
     {QueueError::kSubmitQueueMustMatchSrcOrDst,
      {
-         "UNASSIGNED-CoreValidation-VkImageMemoryBarrier-sharing-mode-exclusive-same-family",
-         "UNASSIGNED-CoreValidation-VkImageMemoryBarrier2KHR-sharing-mode-exclusive-same-family",
-         "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier-sharing-mode-exclusive-same-family",
-         "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier2KHR-sharing-mode-exclusive-same-family",
+         {Key(Struct::VkImageMemoryBarrier), "UNASSIGNED-CoreValidation-VkImageMemoryBarrier-sharing-mode-exclusive-same-family"},
+         {Key(Struct::VkImageMemoryBarrier2KHR),
+          "UNASSIGNED-CoreValidation-VkImageMemoryBarrier2KHR-sharing-mode-exclusive-same-family"},
+         {Key(Struct::VkBufferMemoryBarrier), "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier-sharing-mode-exclusive-same-family"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR),
+          "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier2KHR-sharing-mode-exclusive-same-family"},
      }},
 };
 
@@ -677,93 +721,177 @@ const std::map<QueueError, std::string> kQueueErrorSummary{
 };
 
 const std::string &GetBarrierQueueVUID(const Location &loc, QueueError error) {
-    const auto entry = kBarrierQueueErrors.find(error);
-    assert(entry != kBarrierQueueErrors.end());
-
-    // NOTE we ignore field_name here because of inconsistencies in the VUIDs.
-    const auto &result = FindVUID(loc.structure, Field::Empty, entry->second);
+    const auto &result = FindVUID(error, loc, kBarrierQueueErrors);
     assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-queue-error");
+        return unhandled;
+    }
     return result;
 }
 
-static const std::map<VkImageLayout, std::array<std::string, 2>> kImageLayoutErrors{
+static const std::map<VkImageLayout, std::array<Entry, 2>> kImageLayoutErrors{
     {VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01208", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01208"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01208"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01208"},
+     }}},
     {VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01209", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01209"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01209"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01209"},
+     }}},
     {VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01210", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01210"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01210"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01210"},
+     }}},
     {VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01211", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01211"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01211"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01211"},
+     }}},
     {VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01212", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01212"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01212"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01212"},
+     }}},
     {VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01213", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01213"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01213"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01213"},
+     }}},
     {VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV,
-     {"VUID-VkImageMemoryBarrier-oldLayout-02088", "VUID-VkImageMemoryBarrier2KHR-oldLayout-02088"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-02088"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-02088"},
+     }}},
     {VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01658", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01658"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01658"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01658"},
+     }}},
     {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01659", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01659"}},
+     {{
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01659"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01659"},
+     }}},
 };
 
 const std::string &GetBadImageLayoutVUID(const Location &loc, VkImageLayout layout) {
-    const auto entry = kImageLayoutErrors.find(layout);
-    assert(entry != kImageLayoutErrors.end());
-
-    // NOTE we ignore field_name here these VUIDs always use oldLayout
-    const auto &result = FindVUID(loc.structure, Field::Empty, entry->second);
+    const auto &result = FindVUID(layout, loc, kImageLayoutErrors);
     assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-bad-image-layout");
+        return unhandled;
+    }
     return result;
 }
 
-static const std::map<BufferError, std::array<std::string, 2>> kBufferErrors{
-    {BufferError::kNoMemory, {"VUID-VkBufferMemoryBarrier2KHR-buffer-01931", "VUID-VkBufferMemoryBarrier-buffer-01931"}},
-    {BufferError::kOffsetTooBig, {"VUID-VkBufferMemoryBarrier-offset-01187", "VUID-VkBufferMemoryBarrier2KHR-offset-01187"}},
-    {BufferError::kSizeOutOfRange, {"VUID-VkBufferMemoryBarrier-size-01189", "VUID-VkBufferMemoryBarrier2KHR-size-01189"}},
-    {BufferError::kSizeZero, {"VUID-VkBufferMemoryBarrier-size-01188", "VUID-VkBufferMemoryBarrier2KHR-size-01188"}},
+static const std::map<BufferError, std::array<Entry, 2>> kBufferErrors{
+    {BufferError::kNoMemory,
+     {{
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-buffer-01931"},
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-buffer-01931"},
+     }}},
+    {BufferError::kOffsetTooBig,
+     {{
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-offset-01187"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-offset-01187"},
+     }}},
+    {BufferError::kSizeOutOfRange,
+     {{
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-size-01189"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-size-01189"},
+     }}},
+    {BufferError::kSizeZero,
+     {{
+         {Key(Struct::VkBufferMemoryBarrier), "VUID-VkBufferMemoryBarrier-size-01188"},
+         {Key(Struct::VkBufferMemoryBarrier2KHR), "VUID-VkBufferMemoryBarrier2KHR-size-01188"},
+     }}},
 };
 
 const std::string &GetBufferBarrierVUID(const Location &loc, BufferError error) {
-    const auto entry = kBufferErrors.find(error);
-    assert(entry != kBufferErrors.end());
-
-    const auto &result = FindVUID(loc.structure, Field::Empty, entry->second);
+    const auto &result = FindVUID(error, loc, kBufferErrors);
     assert(!result.empty());
+    if (result.empty()) {
+         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-buffer-barrier-error");
+         return unhandled;
+    }
     return result;
 }
 
-static const std::map<ImageError, std::vector<std::string>> kImageErrors{
-    {ImageError::kNoMemory, {"VUID-VkImageMemoryBarrier-image-01932", "VUID-VkImageMemoryBarrier2KHR-image-01932"}},
+static const std::map<ImageError, std::vector<Entry>> kImageErrors{
+    {ImageError::kNoMemory,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-01932"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-01932"},
+     }},
     {ImageError::kConflictingLayout,
-     {"VUID-VkImageMemoryBarrier-oldLayout-01197", "VUID-VkImageMemoryBarrier2KHR-oldLayout-01197"}},
-    {ImageError::kBadLayout, {"VUID-VkImageMemoryBarrier-newLayout-01198", "VUID-VkImageMemoryBarrier2KHR-newLayout-01198"}},
-    {ImageError::kNotColorAspect, {"VUID-VkImageMemoryBarrier-image-01671", "VUID-VkImageMemoryBarrier2KHR-image-01671"}},
-    {ImageError::kNotColorAspectYcbcr, {"VUID-VkImageMemoryBarrier-image-02902", "VUID-VkImageMemoryBarrier2KHR-image-02902"}},
-    {ImageError::kBadMultiplanarAspect, {"VUID-VkImageMemoryBarrier-image-01672", "VUID-VkImageMemoryBarrier2KHR-image-01672"}},
-    {ImageError::kBadPlaneCount, {"VUID-VkImageMemoryBarrier-image-01673", "VUID-VkImageMemoryBarrier2KHR-image-01673"}},
-    {ImageError::kNotDepthOrStencilAspect, {"VUID-VkImageMemoryBarrier-image-03319", "VUID-VkImageMemoryBarrier2KHR-image-03319"}},
-    {ImageError::kNotDepthAndStencilAspect, {"VUID-VkImageMemoryBarrier-image-01207", "VUID-VkImageMemoryBarrier2KHR-image-01207"}},
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-oldLayout-01197"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-oldLayout-01197"},
+     }},
+    {ImageError::kBadLayout,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-newLayout-01198"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-newLayout-01198"},
+     }},
+    {ImageError::kNotColorAspect,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-01671"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-01671"},
+     }},
+    {ImageError::kNotColorAspectYcbcr,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-02902"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-02902"},
+     }},
+    {ImageError::kBadMultiplanarAspect,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-01672"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-01672"},
+     }},
+    {ImageError::kBadPlaneCount,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-01673"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-01673"},
+     }},
+    {ImageError::kNotDepthOrStencilAspect,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-03319"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-03319"},
+     }},
+    {ImageError::kNotDepthAndStencilAspect,
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-01207"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-01207"},
+     }},
     {ImageError::kNotSeparateDepthAndStencilAspect,
-     {"VUID-VkImageMemoryBarrier-image-03320", "VUID-VkImageMemoryBarrier2KHR-image-03320"}},
-    {ImageError::kRenderPassMismatch, {"VUID-vkCmdPipelineBarrier-image-04073", "VUID-vkCmdPipelineBarrier2KHR-image-04073"}},
+     {
+         {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-image-03320"},
+         {Key(Struct::VkImageMemoryBarrier2KHR), "VUID-VkImageMemoryBarrier2KHR-image-03320"},
+     }},
+    {ImageError::kRenderPassMismatch,
+     {
+         {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-image-04073"},
+         {Key(Func::vkCmdPipelineBarrier2KHR), "VUID-vkCmdPipelineBarrier2KHR-image-04073"},
+     }},
     {ImageError::kRenderPassLayoutChange,
-     {"VUID-vkCmdPipelineBarrier-oldLayout-01181", "VUID-vkCmdPipelineBarrier2KHR-oldLayout-01181"}},
+     {
+         {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-oldLayout-01181"},
+         {Key(Func::vkCmdPipelineBarrier2KHR), "VUID-vkCmdPipelineBarrier2KHR-oldLayout-01181"},
+     }},
 };
 
 const std::string &GetImageBarrierVUID(const Location &loc, ImageError error) {
-    const auto entry = kImageErrors.find(error);
-    assert(entry != kImageErrors.end());
-
-    const auto &result = FindVUID(loc.structure, Field::Empty, entry->second);
-    if (!result.empty()) {
-        return result;
+    const auto &result = FindVUID(error, loc, kImageErrors);
+    assert(!result.empty());
+    if (result.empty()) {
+         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-image-barrier-error");
+         return unhandled;
     }
-    // hack to handle structure vs. function mismatches in these VUIDS
-    const auto &str_func = loc.StringFunc();
-    const auto &result2 = FindVUID(str_func, "", entry->second);
-    assert(!result2.empty());
-    return result2;
+    return result;
 }
 
 const SubresourceRangeErrorCodes &GetSubResourceVUIDs(const Location &loc) {
@@ -782,100 +910,97 @@ const SubresourceRangeErrorCodes &GetSubResourceVUIDs(const Location &loc) {
     return (loc.structure == Struct::VkImageMemoryBarrier2KHR) ? v2 : v1;
 }
 
-static const std::map<SubmitError, std::vector<std::string>> kSubmitErrors{
+static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
     {SubmitError::kTimelineSemSmallValue,
      {
-         "VUID-VkSemaphoreSignalInfo-value-03258",
-         "VUID-VkBindSparseInfo-pSignalSemaphores-03249",
-         "VUID-VkSubmitInfo-pSignalSemaphores-03242",
-         "VUID-VkSubmitInfo2KHR-semaphore-03881",
-         "VUID-VkSubmitInfo2KHR-semaphore-03882",
+         {Key(Struct::VkSemaphoreSignalInfo), "VUID-VkSemaphoreSignalInfo-value-03258"},
+         {Key(Struct::VkBindSparseInfo), "VUID-VkBindSparseInfo-pSignalSemaphores-03249"},
+         {Key(Struct::VkSubmitInfo), "VUID-VkSubmitInfo-pSignalSemaphores-03242"},
+         {Key(Struct::VkSubmitInfo2KHR), "VUID-VkSubmitInfo2KHR-semaphore-03881"},
+         {Key(Struct::VkSubmitInfo2KHR), "VUID-VkSubmitInfo2KHR-semaphore-03882"},
      }},
     {SubmitError::kSemAlreadySignalled,
      {
-         "VUID-vkQueueSubmit-pSignalSemaphores-00067",
-         "VUID-vkQueueBindSparse-pSignalSemaphores-01115",
-         "VUID-vkQueueSubmit2KHR-semaphore-03868",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pSignalSemaphores-00067"},
+         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pSignalSemaphores-01115"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-semaphore-03868"},
      }},
     {SubmitError::kBinaryCannotBeSignalled,
      {
-         "VUID-vkQueueSubmit-pWaitSemaphores-00069",
-         "VUID-vkQueueSubmit2KHR-semaphore-03872",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-00069"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-semaphore-03872"},
      }},
     {SubmitError::kTimelineCannotBeSignalled,
      {
-         "VUID-vkQueueSubmit-pWaitSemaphores-03238",
-         "VUID-vkQueueSubmit2KHR-semaphore-03873",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-03238"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-semaphore-03873"},
      }},
     {SubmitError::kTimelineSemMaxDiff,
      {
-         "VUID-VkBindSparseInfo-pWaitSemaphores-03250",
-         "VUID-VkBindSparseInfo-pSignalSemaphores-03251",
-         "VUID-VkSubmitInfo-pWaitSemaphores-03243",
-         "VUID-VkSubmitInfo-pSignalSemaphores-03244",
-         "VUID-VkSemaphoreSignalInfo-value-03260",
-         "VUID-VkSubmitInfo2KHR-semaphore-03883",
-         "VUID-VkSubmitInfo2KHR-semaphore-03884",
+         {Key(Struct::VkBindSparseInfo, Field::pWaitSemaphores), "VUID-VkBindSparseInfo-pWaitSemaphores-03250"},
+         {Key(Struct::VkBindSparseInfo, Field::pSignalSemaphores), "VUID-VkBindSparseInfo-pSignalSemaphores-03251"},
+         {Key(Struct::VkSubmitInfo, Field::pWaitSemaphores), "VUID-VkSubmitInfo-pWaitSemaphores-03243"},
+         {Key(Struct::VkSubmitInfo, Field::pSignalSemaphores), "VUID-VkSubmitInfo-pSignalSemaphores-03244"},
+         {Key(Struct::VkSemaphoreSignalInfo), "VUID-VkSemaphoreSignalInfo-value-03260"},
+         {Key(Struct::VkSubmitInfo2KHR, Field::pWaitSemaphoreInfos, true), "VUID-VkSubmitInfo2KHR-semaphore-03883"},
+         {Key(Struct::VkSubmitInfo2KHR, Field::pSignalSemaphoreInfos, true), "VUID-VkSubmitInfo2KHR-semaphore-03884"},
      }},
     {SubmitError::kProtectedFeatureDisabled,
      {
-         "VUID-VkProtectedSubmitInfo-protectedSubmit-01816",
-         "VUID-VkSubmitInfo2KHR-flags-03885",
+         {Key(Struct::VkProtectedSubmitInfo), "VUID-VkProtectedSubmitInfo-protectedSubmit-01816"},
+         {Key(Struct::VkSubmitInfo2KHR), "VUID-VkSubmitInfo2KHR-flags-03885"},
      }},
     {SubmitError::kBadUnprotectedSubmit,
      {
-         "VUID-VkSubmitInfo-pNext-04148",
-         "VUID-VkSubmitInfo2KHR-flags-03886",
+         {Key(Struct::VkSubmitInfo), "VUID-VkSubmitInfo-pNext-04148"},
+         {Key(Struct::VkSubmitInfo2KHR), "VUID-VkSubmitInfo2KHR-flags-03886"},
      }},
     {SubmitError::kBadProtectedSubmit,
      {
-         "VUID-VkSubmitInfo-pNext-04120",
-         "VUID-VkSubmitInfo2KHR-flags-03887",
+         {Key(Struct::VkSubmitInfo), "VUID-VkSubmitInfo-pNext-04120"},
+         {Key(Struct::VkSubmitInfo2KHR), "VUID-VkSubmitInfo2KHR-flags-03887"},
      }},
     {SubmitError::kCmdNotSimultaneous,
      {
-         "VUID-vkQueueSubmit-pCommandBuffers-00071",
-         "VUID-vkQueueSubmit2KHR-commandBuffer-03875",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pCommandBuffers-00071"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-commandBuffer-03875"},
      }},
     {SubmitError::kReusedOneTimeCmd,
      {
-         "VUID-vkQueueSubmit-pCommandBuffers-00072",
-         "VUID-vkQueueSubmit2KHR-commandBuffer-03876",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pCommandBuffers-00072"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-commandBuffer-03876"},
      }},
     {SubmitError::kSecondaryCmdNotSimultaneous,
      {
-         "VUID-vkQueueSubmit-pCommandBuffers-00073",
-         "VUID-vkQueueSubmit2KHR-commandBuffer-03877",
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit-pCommandBuffers-00073"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-commandBuffer-03877"},
      }},
     {SubmitError::kCmdWrongQueueFamily,
      {
-         "VUID-vkQueueSubmit-pCommandBuffers-00074",
-         "VUID-vkQueueSubmit2KHR-commandBuffer-03878",
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pCommandBuffers-00074"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-vkQueueSubmit2KHR-commandBuffer-03878"},
      }},
     {SubmitError::kSecondaryCmdInSubmit,
      {
-         "VUID-VkSubmitInfo-pCommandBuffers-00075",
-         "VUID-VkCommandBufferSubmitInfoKHR-commandBuffer-03890",
+         {Key(Func::vkQueueSubmit), "VUID-VkSubmitInfo-pCommandBuffers-00075"},
+         {Key(Func::vkQueueSubmit2KHR), "VUID-VkCommandBufferSubmitInfoKHR-commandBuffer-03890"},
      }},
     {SubmitError::kHostStageMask,
      {
-         "VUID-VkSubmitInfo-pWaitDstStageMask-00078",
-         "VUID-vkCmdSetEvent-stageMask-01149",
-         "VUID-vkCmdResetEvent-stageMask-01153",
-         "VUID-vkCmdResetEvent2KHR-stageMask-03830",
+         {Key(Struct::VkSubmitInfo), "VUID-VkSubmitInfo-pWaitDstStageMask-00078"},
+         {Key(Func::vkCmdSetEvent), "VUID-vkCmdSetEvent-stageMask-01149"},
+         {Key(Func::vkCmdResetEvent), "VUID-vkCmdResetEvent-stageMask-01153"},
+         {Key(Func::vkCmdResetEvent2KHR), "VUID-vkCmdResetEvent2KHR-stageMask-03830"},
      }},
 };
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
-    const auto entry = kSubmitErrors.find(error);
-    assert(entry != kSubmitErrors.end());
-
-    const auto &ref_result = FindVUID(loc.structure, loc.field, entry->second);
-    if (!ref_result.empty()) {
-        return ref_result;
-    }
-    const auto &result = FindVUID(loc.StringFunc(), loc.StringField(), entry->second);
+    const auto &result = FindVUID(error, loc, kSubmitErrors);
     assert(!result.empty());
+    if (result.empty()) {
+         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-submit-error");
+         return unhandled;
+    }
     return result;
 }
 


### PR DESCRIPTION
    Make the fuzzy matching of location to VUID be based on
    enums rather than strings. Also try to assert() if there's
    a problem with the lookup (in debug builds).
    
