### PR TITLE
scripts: Handle XML spirvcapability using alias

### DIFF
--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -130,6 +130,32 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
             {'vulkan' : 'VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR', 'layer' : 'workgroup_memory_explicit_layout_features'},
         ]
 
+        # Promoted features structure in state_tracker.cpp are put in the VkPhysicalDeviceVulkan*Features structs
+        # but the XML can still list them. This list all promoted structs to ignore since they are aliased.
+        # Tried to generate these, but no reliable way from vk.xml
+        self.promotedFeatures = [
+            # 1.1
+            "VkPhysicalDevice16BitStorageFeatures",
+            "VkPhysicalDeviceMultiviewFeatures",
+            "VkPhysicalDeviceVariablePointersFeatures",
+            "VkPhysicalDeviceProtectedMemoryFeatures",
+            "VkPhysicalDeviceSamplerYcbcrConversionFeatures",
+            "VkPhysicalDeviceShaderDrawParametersFeatures",
+            # 1.2
+            "VkPhysicalDevice8BitStorageFeatures",
+            "VkPhysicalDeviceShaderFloat16Int8Features",
+            "VkPhysicalDeviceDescriptorIndexingFeatures",
+            "VkPhysicalDeviceScalarBlockLayoutFeatures",
+            "VkPhysicalDeviceImagelessFramebufferFeatures",
+            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures",
+            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures",
+            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures",
+            "VkPhysicalDeviceTimelineSemaphoreFeatures",
+            "VkPhysicalDeviceBufferDeviceAddressFeatures",
+            "VkPhysicalDeviceShaderAtomicInt64Features",
+            "VkPhysicalDeviceVulkanMemoryModelFeatures",
+        ]
+
         # Properties are harder to handle genearted without generating a template for every property struct type
         # The simpler solution is create strings that will be printed out as static comparisons at compile time
         # The Map is used to map Vulkan property structs with the state tracker variable name
@@ -214,6 +240,8 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
             if 'version' in elem.attrib:
                 enable['version'] = elem.attrib['version']
             elif 'feature' in elem.attrib:
+                if elem.attrib['struct'] in self.promotedFeatures:
+                    continue
                 enable['feature'] = {
                     'feature' : elem.attrib['feature'],
                     'struct' : elem.attrib['struct']


### PR DESCRIPTION
So this seems to do nothing, but because of https://github.com/KhronosGroup/Vulkan-Docs/issues/1437 there is a fix coming (internal Vulkan MR 4399) to fix the XML.

The new XML will break the build with a difference in `spirv_validation_helper.cpp` of

```patch
     {spv::CapabilityDrawParameters, {0, &VkPhysicalDeviceVulkan11Features::shaderDrawParameters, nullptr, ""}},
+    {spv::CapabilityDrawParameters, {0, &VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters, nullptr, ""}},
```

This change will prevent ` {spv::CapabilityDrawParameters, {0, &VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters, nullptr, ""}},` from being generated and breaking the build. This is valid because how state_tracker absorbs everything to the `core11` and `core12` structs