### PR TITLE
corechecks: Descriptor::GetClass() shouldn't be virtual

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -805,8 +805,9 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
         for (uint32_t i = index_range.start; i < index_range.end; ++i, ++array_idx) {
             uint32_t index = i - index_range.start;
             const auto *descriptor = descriptor_set->GetDescriptorFromGlobalIndex(i);
+            const auto descriptor_class = descriptor->GetClass();
 
-            if (descriptor->GetClass() == DescriptorClass::InlineUniform) {
+            if (descriptor_class == DescriptorClass::InlineUniform) {
                 // Can't validate the descriptor because it may not have been updated.
                 continue;
             } else if (!descriptor->updated) {
@@ -818,7 +819,6 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                     " is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
                     report_data->FormatHandle(set).c_str(), caller, binding, index);
             } else {
-                auto descriptor_class = descriptor->GetClass();
                 if (descriptor_class == DescriptorClass::GeneralBuffer) {
                     // Verify that buffers are valid
                     auto buffer = static_cast<const BufferDescriptor *>(descriptor)->GetBuffer();

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -337,7 +337,7 @@ class Descriptor {
     virtual void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) = 0;
     // Create binding between resources of this descriptor and given cb_node
     virtual void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) = 0;
-    virtual DescriptorClass GetClass() const { return descriptor_class; };
+    DescriptorClass GetClass() const { return descriptor_class; };
     // Special fast-path check for SamplerDescriptors that are immutable
     virtual bool IsImmutableSampler() const { return false; };
     bool updated;  // Has descriptor been updated?


### PR DESCRIPTION
This method ends up being a performance hotspot in applications
that use many descriptors. It doesn't look like it needs to be
virtual.

Change-Id: I4193b1da3ba76159dbb9c4d6814073773f261752