### PR TITLE
build: Update build docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,10 +1,9 @@
 # Build Instructions
 
-Instructions for building this repository on Linux, Windows, Android, and
-MacOS.
-
 ## Index
 
+1. [Requirements](#requirements)
+1. [Building](#building)
 1. [Contributing](#contributing-to-the-repository)
 1. [Repository Content](#repository-content)
 1. [Repository Set-Up](#repository-set-up)
@@ -12,6 +11,43 @@ MacOS.
 1. [Linux Build](#building-on-linux)
 1. [Android Build](#building-on-android)
 1. [MacOS build](#building-on-macos)
+
+## Requirements
+
+1. Python >= 3.7 (3.6 may work, 3.5 and earlier is not supported)
+1. CMake >= 3.10.2
+1. C++ >= c++11 compiler. See platform-specific sections below for supported compiler versions.
+
+## Building
+
+**NOTE**: See [this](#google-test) first if you are also building the tests.
+
+```bash
+# One-time generation
+mkdir build # Arbitrary build directory
+cd build
+
+# Run './scripts/update_deps.py --help' for more information
+# NOTE: You can alternatively set -DUPDATE_DEPS=ON during cmake generation
+#       to have a cmake target automatically run this as needed.
+python3 ./scripts/update_deps.py --dir external --arch x64 --config debug
+
+# NOTE: If using -DUPDATE_DEPS=ON, CMAKE_BUILD_TYPE is used to determine the build type
+#       of external dependencies. For generators such as Visual Studio that usually ignore
+#       CMAKE_BUILD_TYPE, it's a good idea to still set CMAKE_BUILD_TYPE in this case to control
+#       the build type of dependencies. If you want a "mix" (e.g., Release dependencies, Debug VVL),
+#       you will want to use `update_deps.py` manually.
+cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Building
+cmake --build . --config Debug
+```
+
+Note the `-C ../external/helper.cmake` argument passed to cmake. This is necessary when
+calling the `update_deps.py` script manually. See below for more details.
+
+These are general instructions that should "just work" on Windows and Linux. For platform-specific
+build instructions, see the appropriate `<Platform> Build` section below.
 
 ## Contributing to the Repository
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,54 @@ add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-find_package(PythonInterp 3 QUIET)
+if (UPDATE_DEPS)
+    find_package(PythonInterp 3 REQUIRED)
+
+    if (CMAKE_GENERATOR_PLATFORM)
+        set(_target_arch ${CMAKE_GENERATOR_PLATFORM})
+    else()
+        message(WARNING "CMAKE_GENERATOR_PLATFORM not set. Using x64 as target architecture.")
+        set(_target_arch x64)
+    endif()
+
+    if (NOT CMAKE_BUILD_TYPE)
+        message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
+        set(_build_type Debug)
+    else()
+        set(_build_type ${CMAKE_BUILD_TYPE})
+    endif()
+
+    message("********************************************************************************")
+    message("* NOTE: Adding target vvl_update_deps to run as needed for updating            *")
+    message("*       dependencies.                                                          *")
+    message("********************************************************************************")
+
+    # Add a target so that update_deps.py will run when necessary
+    # NOTE: This is triggered off of the timestamps of known_good.json and helper.cmake
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake
+                       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}"
+                       DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json)
+
+    add_custom_target(vvl_update_deps DEPENDS ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+
+    # Check if update_deps.py needs to be run on first cmake run
+    if (${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json IS_NEWER_THAN ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            RESULT_VARIABLE _update_deps_result
+        )
+        if (NOT (${_update_deps_result} EQUAL 0))
+            message(FATAL_ERROR "Could not run update_deps.py which is necessary to download dependencies.")
+        endif()
+    endif()
+    include(${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+else()
+    message("********************************************************************************")
+    message("* NOTE: Not adding target to run update_deps.py automatically.                 *")
+    message("********************************************************************************")
+    find_package(PythonInterp 3 QUIET)
+endif()
 
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
@@ -297,6 +344,9 @@ add_library(VkLayer_utils
             layers/vk_format_utils.cpp)
 target_link_libraries(VkLayer_utils PUBLIC Vulkan::Headers)
 set_target_properties(VkLayer_utils PROPERTIES CXX_STANDARD ${VVL_CPP_STANDARD})
+if (UPDATE_DEPS)
+    add_dependencies(VkLayer_utils vvl_update_deps)
+endif()
 if(WIN32)
     target_compile_definitions(VkLayer_utils PUBLIC _CRT_SECURE_NO_WARNINGS NOMINMAX)
     if(MINGW)

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -76,10 +76,6 @@ def BuildVVL(args):
     cmake_ver_cmd = 'cmake --version'
     RunShellCmd(cmake_ver_cmd)
 
-    print("Run update_deps.py for VVL Repository")
-    update_cmd = f'python3 scripts/update_deps.py --dir {EXTERNAL_DIR_NAME} --config {args.configuration} --arch {args.arch}'
-    RunShellCmd(update_cmd)
-
     GTEST_DIR = RepoRelative("external/googletest")
     if not os.path.exists(GTEST_DIR):
         print("Clone Testing Framework Source Code")
@@ -92,7 +88,7 @@ def BuildVVL(args):
 
     utils.make_dirs(VVL_BUILD_DIR)
     print("Run CMake for Validation Layers")
-    cmake_cmd = f'cmake -C ../{EXTERNAL_DIR_NAME}/helper.cmake -DCMAKE_BUILD_TYPE={args.configuration.capitalize()} {args.cmake} ..'
+    cmake_cmd = f'cmake -DUPDATE_DEPS=ON -DCMAKE_BUILD_TYPE={args.configuration.capitalize()} {args.cmake} ..'
     if IsWindows(): cmake_cmd = cmake_cmd + f' -A {args.arch}'
     RunShellCmd(cmake_cmd, VVL_BUILD_DIR)
 


### PR DESCRIPTION
This moves calling `update_deps.py` inside CMakeLists.txt in an attempt to streamline the build a bit and make it look more like a "standard cmake project." i.e., "git clone ... -> cmake ... -> cmake --build ..."

The build type and generator will get passed to `update_deps.py` by default. I also updated the docs to put a sort of "TL;DR" up front; I may be missing something important there, though.

@lunarpapillo @johnzupin This change would break 32b internal CI. If this change looks like something we want, adding the cmake var `NO_UPDATE_DEPS=ON` would need to be added so that things function the same as before (I can make that change...maybe even without breaking all of CI). Or we can change the default behavior to prefer what is necessary for CI, but this seems backwards to me. OR, upgrading to cmake >= 3.15 might work as `CMAKE_GENERATOR_PLATFORM` (i.e., what's controlled by the `-A` argument) looks like it wasn't supported officially until 3.15.