### PR TITLE
corechecks: Remove unique_ptr from image layout states vector

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ uint32_t ResolveRemainingLevels(const VkImageSubresourceRange *range, uint32_t m
 
 uint32_t ResolveRemainingLayers(const VkImageSubresourceRange *range, uint32_t layers);
 VkImageSubresourceRange NormalizeSubresourceRange(const IMAGE_STATE &image_state, const VkImageSubresourceRange &range);
-GlobalImageLayoutRangeMap *GetLayoutRangeMap(GlobalImageLayoutMap *map, const IMAGE_STATE &image_state);
+GlobalImageLayoutRangeMap *GetLayoutRangeMap(GlobalImageLayoutMap &map, const IMAGE_STATE &image_state);
 const GlobalImageLayoutRangeMap *GetLayoutRangeMap(const GlobalImageLayoutMap &map, VkImage image);
 
 #endif  // CORE_VALIDATION_BUFFER_VALIDATION_H_

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -150,7 +150,7 @@ ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(CMD_BUFFER_STATE *cb_sta
 }
 
 void AddInitialLayoutintoImageLayoutMap(const IMAGE_STATE &image_state, GlobalImageLayoutMap &image_layout_map) {
-    auto *range_map = GetLayoutRangeMap(&image_layout_map, image_state);
+    auto *range_map = GetLayoutRangeMap(image_layout_map, image_state);
     auto range_gen = subresource_adapter::RangeGenerator(image_state.subresource_encoder, image_state.full_range);
     for (; range_gen->non_empty(); ++range_gen) {
         range_map->insert(range_map->end(), std::make_pair(*range_gen, image_state.createInfo.initialLayout));
@@ -3115,7 +3115,7 @@ struct CommandBufferSubmitState {
         if (cb_node == nullptr) {
             return skip;
         }
-        skip |= core->ValidateCmdBufImageLayouts(cb_node, core->imageLayoutMap, &overlay_image_layout_map);
+        skip |= core->ValidateCmdBufImageLayouts(cb_node, core->imageLayoutMap, overlay_image_layout_map);
         current_cmds.push_back(cmd);
         skip |= core->ValidatePrimaryCommandBufferState(loc, cb_node,
                                                         static_cast<int>(std::count(current_cmds.begin(), current_cmds.end(), cmd)),

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -719,7 +719,7 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo) override;
 
     bool ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE* pCB, const GlobalImageLayoutMap& globalImageLayoutMap,
-                                    GlobalImageLayoutMap* overlayLayoutMap_arg) const;
+                                    GlobalImageLayoutMap& overlayLayoutMap) const;
 
     void UpdateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB);
 

--- a/layers/image_layout_map.h
+++ b/layers/image_layout_map.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2020 The Khronos Group Inc.
- * Copyright (c) 2019-2020 Valve Corporation
- * Copyright (c) 2019-2020 LunarG, Inc.
- * Copyright (C) 2019-2020 Google Inc.
+/* Copyright (c) 2019-2021 The Khronos Group Inc.
+ * Copyright (c) 2019-2021 Valve Corporation
+ * Copyright (c) 2019-2021 LunarG, Inc.
+ * Copyright (C) 2019-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ class ImageSubresourceLayoutMap {
     using ParallelIterator = sparse_container::parallel_iterator<MapA, MapB>;
     using LayoutMap = RangeMap;
     using InitialLayoutMap = RangeMap;
-    using InitialLayoutStates = std::vector<std::unique_ptr<InitialLayoutState>>;
+    using InitialLayoutStates = std::vector<InitialLayoutState>;
 
     class ConstIterator {
       public:
@@ -194,8 +194,8 @@ class ImageSubresourceLayoutMap {
         if (!initial_state) {
             // Allocate on demand...  initial_layout_states_ holds ownership as a unique_ptr, while
             // each subresource has a non-owning copy of the plain pointer.
-            initial_state = new InitialLayoutState(cb_state, view_state);
-            initial_layout_states_.emplace_back(initial_state);
+            initial_layout_states_.emplace_back(cb_state, view_state);
+            initial_state = &initial_layout_states_.back();
         }
         assert(initial_state);
         sparse_container::update_range_value(initial_layout_state_map_, range, initial_state, WritePolicy::prefer_dest);


### PR DESCRIPTION
The InitialLayoutStates vector appears to perform better if
it contains the InitialLayoutState struct directly. This change also
switches parameters in calls related to this vector to use references
when possible.