### PR TITLE
build: Revert robin-hood-hashing for GN

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -77,7 +77,6 @@ config("vulkan_layer_config") {
   include_dirs = [
     "layers",
     "layers/generated",
-    "${robin_hood_headers_dir}",
   ]
 }
 
@@ -167,7 +166,6 @@ command_counter_sources = [
 chassis_sources = [
   "$vulkan_headers_dir/include/vulkan/vk_layer.h",
   "$vulkan_headers_dir/include/vulkan/vulkan.h",
-  "$robin_hood_headers_dir/robin_hood.h",
   "layers/generated/chassis.cpp",
   "layers/generated/chassis.h",
   "layers/generated/chassis_dispatch_helper.h",
@@ -234,13 +232,11 @@ source_set("vulkan_layer_utils") {
   include_dirs = [
     "layers",
     "layers/generated",
-    "${robin_hood_headers_dir}",
   ]
   sources = [
     "$vulkan_headers_dir/include/vulkan/vk_layer.h",
     "$vulkan_headers_dir/include/vulkan/vk_sdk_platform.h",
     "$vulkan_headers_dir/include/vulkan/vulkan.h",
-    "$robin_hood_headers_dir/robin_hood.h",
     "layers/android_ndk_types.h",
     "layers/cast_utils.h",
     "layers/generated/vk_enum_string_helper.h",
@@ -277,7 +273,6 @@ source_set("vulkan_layer_utils") {
 config("vulkan_core_validation_config") {
   include_dirs = [
     "$vvl_glslang_dir",
-    "${robin_hood_headers_dir}",
   ]
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ endif()
 option(INSTALL_TESTS "Install tests" OFF)
 option(BUILD_LAYERS "Build layers" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Generate layer files" OFF) # For generating files when not building layers
+option(USE_ROBIN_HOOD_HASHING "Use robin-hood-hashing" ON)
 
 if(BUILD_TESTS OR BUILD_LAYERS)
 
@@ -184,10 +185,12 @@ if(BUILD_TESTS OR BUILD_LAYERS)
     if(NOT SPIRV_TOOLS_INSTALL_DIR)
         set(SPIRV_TOOLS_INSTALL_DIR $ENV{SPIRV_TOOLS_INSTALL_DIR})
     endif()
-    if(NOT ROBIN_HOOD_HASHING_INSTALL_DIR)
-        set(ROBIN_HOOD_HASHING_INSTALL_DIR $ENV{ROBIN_HOOD_HASHING_INSTALL_DIR})
+    if (USE_ROBIN_HOOD_HASHING)
+        if(NOT ROBIN_HOOD_HASHING_INSTALL_DIR)
+            set(ROBIN_HOOD_HASHING_INSTALL_DIR $ENV{ROBIN_HOOD_HASHING_INSTALL_DIR})
+        endif()
+        set(ROBIN_HOOD_HASHING_INCLUDE_DIR "${ROBIN_HOOD_HASHING_INSTALL_DIR}/src/include" PATH "Path to robin-hood-hashing/include")
     endif()
-    set(ROBIN_HOOD_HASHING_INCLUDE_DIR "${ROBIN_HOOD_HASHING_INSTALL_DIR}/src/include" PATH "Path to robin-hood-hashing/include")
 
     if (NOT TARGET glslang)
         if(NOT SPIRV_HEADERS_INSTALL_DIR)
@@ -308,8 +311,12 @@ target_include_directories(VkLayer_utils
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}/layers
                                   ${PROJECT_BINARY_DIR}
-                                  ${VulkanHeaders_INCLUDE_DIR}
-                                  ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+                                  ${VulkanHeaders_INCLUDE_DIR})
+
+if (USE_ROBIN_HOOD_HASHING)
+    target_include_directories(VkLayer_utils PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+    target_compile_definitions(VkLayer_utils PUBLIC USE_ROBIN_HOOD_HASHING)
+endif()
 
 # uninstall target ---------------------------------------------------------------------------------------------------------------
 if(NOT TARGET uninstall)

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -31,7 +31,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -DUSE_ROBIN_HOOD_HASHING -fvisibility=hidden
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -75,7 +75,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 LOCAL_STATIC_LIBRARIES += layer_utils glslang SPIRV-Tools SPIRV-Tools-opt
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -frtti
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -DUSE_ROBIN_HOOD_HASHING -fvisibility=hidden
 LOCAL_LDLIBS    := -llog -landroid
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -110,7 +110,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -DUSE_ROBIN_HOOD_HASHING -fvisibility=hidden
 LOCAL_LDLIBS := -llog -landroid -ldl
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -146,7 +146,7 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
-LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden -DVALIDATION_APK
+LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DNV_EXTENSIONS -DAMD_EXTENSIONS -fvisibility=hidden -DVALIDATION_APK -DUSE_ROBIN_HOOD_HASHING
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS := -llog -landroid -ldl
 LOCAL_LDFLAGS := -u ANativeActivity_onCreate

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -260,8 +260,10 @@ if(BUILD_LAYERS)
     # Note that CMake reduces inlining optimization levels for RelWithDebInfo builds.
     if(MSVC)
         target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<CONFIG:Release>:/Zi>")
-        # This warning produces what look like false positives in robin_hood.h with Visual Studio 2015
-        target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.1>>:/wd4996>")
+        if (USE_ROBIN_HOOD_HASHING)
+            # This warning produces what look like false positives in robin_hood.h with Visual Studio 2015
+            target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.1>>:/wd4996>")
+        endif()
         # Need to use this instead of target_link_options() for older versions of CMake.
         target_link_libraries(VkLayer_khronos_validation PRIVATE "$<$<CONFIG:Release>:-DEBUG:FULL>")
     endif()
@@ -273,7 +275,9 @@ if(BUILD_LAYERS)
     if(INSTRUMENT_OPTICK)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${OPTICK_SOURCE_DIR})
     endif()
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+    if (USE_ROBIN_HOOD_HASHING)
+        target_include_directories(VkLayer_khronos_validation PRIVATE ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+    endif()
     target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
 
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -32,56 +32,73 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
+
+#ifdef USE_ROBIN_HOOD_HASHING
 #include "robin_hood.h"
+#else
+#include <unordered_set>
+#endif
 
 // namespace aliases to allow map and set implementations to easily be swapped out
 namespace layer_data {
+
+#ifdef USE_ROBIN_HOOD_HASHING
 template <typename T>
 using hash = robin_hood::hash<T>;
 
-template <typename Key, typename Hash = robin_hood::hash<Key>, typename KeyEqual = std::equal_to<Key> >
+template <typename Key, typename Hash = robin_hood::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 using unordered_set = robin_hood::unordered_set<Key, Hash, KeyEqual>;
 
-template <typename Key, typename T, typename Hash = robin_hood::hash<Key>, typename KeyEqual = std::equal_to<Key> >
+template <typename Key, typename T, typename Hash = robin_hood::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 using unordered_map = robin_hood::unordered_map<Key, T, Hash, KeyEqual>;
-
 
 // robin_hood-compatible insert_iterator (std:: uses the wrong insert method)
 template <typename T>
-class insert_iterator : public std::iterator<std::output_iterator_tag, void,void,void,void > {
- public:
-  typedef typename T::value_type value_type;
-  typedef typename T::iterator iterator;
-  insert_iterator(T& t, iterator i)
-      : container(&t), iter(i) {}
+class insert_iterator : public std::iterator<std::output_iterator_tag, void, void, void, void> {
+  public:
+    typedef typename T::value_type value_type;
+    typedef typename T::iterator iterator;
+    insert_iterator(T &t, iterator i) : container(&t), iter(i) {}
 
-  insert_iterator& operator=(const value_type& value)
-  {
-      auto result = container->insert(value);
-      iter = result.first;
-      ++iter;
-      return *this;
-  }
+    insert_iterator &operator=(const value_type &value) {
+        auto result = container->insert(value);
+        iter = result.first;
+        ++iter;
+        return *this;
+    }
 
-  insert_iterator& operator=(value_type&& value)
-  {
-      auto result = container->insert(std::move(value));
-      iter = result.first;
-      ++iter;
-      return *this;
-  }
+    insert_iterator &operator=(value_type &&value) {
+        auto result = container->insert(std::move(value));
+        iter = result.first;
+        ++iter;
+        return *this;
+    }
 
-  insert_iterator& operator*() { return *this; }
+    insert_iterator &operator*() { return *this; }
 
-  insert_iterator& operator++() { return *this; }
+    insert_iterator &operator++() { return *this; }
 
-  insert_iterator& operator++(int) { return *this; }
- private:
-  T* container;
-  typename T::iterator iter;
+    insert_iterator &operator++(int) { return *this; }
+
+  private:
+    T *container;
+    typename T::iterator iter;
 };
+#else
+template <typename T>
+using hash = std::hash<T>;
 
-};
+template <typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
+using unordered_set = std::unordered_set<Key, Hash, KeyEqual>;
+
+template <typename Key, typename T, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
+using unordered_map = std::unordered_map<Key, T, Hash, KeyEqual>;
+
+template <typename T>
+using insert_iterator = std::insert_iterator<T>;
+#endif
+
+}  // namespace layer_data
 
 // A vector class with "small string optimization" -- meaning that the class contains a fixed working store for N elements.
 // Useful in in situations where the needed size is unknown, but the typical size is known  If size increases beyond the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,12 +115,14 @@ target_include_directories(vk_layer_validation_tests
                                   ${GLSLANG_SPIRV_INCLUDE_DIR}
                                   ${SPIRV_TOOLS_INCLUDE_DIR}
                                   ${SPIRV_HEADERS_INCLUDE_DIR}
-                                  ${ROBIN_HOOD_HASHING_INCLUDE_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_BINARY_DIR}
                                   ${PROJECT_BINARY_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
+if (USE_ROBIN_HOOD_HASHING)
+    target_include_directories(vk_layer_validation_tests PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+endif()
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils)
 


### PR DESCRIPTION
Add some infrastructure to make robin-hood-hashing optional. This change
1. Removes the use of robin-hood-hashing from the GN build
2. Makes the use of robin-hood-hashing optional for cmake builds via the
   USE_ROBIN_HOOD_HASHING cmake variable
3. Leaves robin-hood-hashing as the default for Android with no
   "configuration" option (i.e., additional changes to Android.mk must
   be made to _not_ use robin-hood-hashing on Android).