### PR TITLE
BUILD.md: Restore XCode SPIRV-Tools config line

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -865,6 +865,7 @@ To create and open an Xcode project:
     cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
           -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
           -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
+          -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
           -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
           -GXcode ..
     open VULKAN.xcodeproj


### PR DESCRIPTION
Restore a line that was accidentally removed by #2618.
The line gives the option to specify the SPIRV-Tools install location,
in the case of building via XCode.