### PR TITLE
layers: Fix missing parenthesis in sync validation

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -193,7 +193,7 @@ std::string CommandBufferAccessContext::FormatUsage(const HazardResult &hazard) 
     }
 
     // PHASE2 TODO -- add comand buffer and reset from secondary if applicable
-    out << ", " << string_UsageTag(tag) << ", reset_no: " << reset_count_;
+    out << ", " << string_UsageTag(tag) << ", reset_no: " << reset_count_ << ")";
     return out.str();
 }
 


### PR DESCRIPTION
Added a missing parenthesis in synchronization_validation.cpp.