### PR TITLE
layers: Add an Android default log force option via setprop

### DIFF
--- a/docs/khronos_validation_layer.md
+++ b/docs/khronos_validation_layer.md
@@ -96,7 +96,7 @@ the following system property:
 adb shell setprop debug.vvl.forcelayerlog 1
 ```
 
-The debug.vvl namespace signifies validation layers, and setting this property will force the validation layer callback to always execute, even if the app registers
+The debug.vvl namespace signifies validation layers, and setting this property forces the validation layer callback to always execute, even if the app registers
 a messenger callback itself. This is especially useful for automation tasks, ensuring that errors can be read in a parseable format.
 
 Refer to [VK_EXT_debug_utils](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_debug_utils)

--- a/docs/khronos_validation_layer.md
+++ b/docs/khronos_validation_layer.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2020 LunarG, Inc. -->
+<!-- Copyright 2015-2021 LunarG, Inc. -->
 
 [![Khronos Vulkan][1]][2]
 

--- a/docs/khronos_validation_layer.md
+++ b/docs/khronos_validation_layer.md
@@ -87,6 +87,18 @@ annotated with valid usage identifiers.
 | Perf Warn | `VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT` | `VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT` |
 | Info | `VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT` | `VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT` or `VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT` |
 
+By default, if an app uses the VK_EXT_debug_utils extension and registers a messenger, the validation layer default messenger log callback will not
+execute, as it is considered to be handled by the app. However, using the validation layer callback can be very useful, as it provides a unified log
+that can be easily parsed. On Android, the validation layer default callback can be forced to always execute, and log its contents to logcat, using
+the following system property:
+
+```bash
+adb shell setprop debug.vvl.forcelayerlog 1
+```
+
+The debug.vvl namespace signifies validation layers, and setting this property will force the validation layer callback to always execute, even if the app registers
+a messenger callback itself. This is especially useful for automation tasks, ensuring that errors can be read in a parseable format.
+
 Refer to [VK_EXT_debug_utils](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VK_EXT_debug_utils)
 in the Vulkan Specification for details on this feature.
 

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -33,6 +33,8 @@
 #define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
 #endif
 
+std::string GetEnvironment(const char* variable);
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -33,7 +33,7 @@
 #define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
 #endif
 
-std::string GetEnvironment(const char* variable);
+std::string GetEnvironment(const char *variable);
 
 #ifdef __cplusplus
 extern "C" {

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -62,9 +62,8 @@
 
 #if defined __ANDROID__
 #include <android/log.h>
-#include <sys/system_properties.h>
 #define LOGCONSOLE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VALIDATION", __VA_ARGS__))
-static const char DECORATE_UNUSED *kForceDefaultCallbackKey = "debug.vulkan.debuglogforce";
+static const char DECORATE_UNUSED *kForceDefaultCallbackKey = "debug.vvl.forcelayerlog";
 #else
 #define LOGCONSOLE(...)      \
     {                        \
@@ -263,23 +262,6 @@ typedef struct _debug_report_data {
     }
 
 } debug_report_data;
-
-#if defined __ANDROID__
-template <typename T>
-static bool GetSystemProperty(const char *keyName, T *val) {
-    char value[PROP_VALUE_MAX];
-    if (__system_property_get(keyName, value) > 0) {
-        // Convert string to value with type T
-        std::stringstream ss;
-        ss << value;
-        T v = T();
-        ss >> v;
-        *val = v;
-        return true;
-    }
-    return false;
-}
-#endif
 
 template debug_report_data *GetLayerDataPtr<debug_report_data>(void *data_key,
                                                                std::unordered_map<void *, debug_report_data *> &data_map);
@@ -598,8 +580,9 @@ static inline void layer_create_callback(DebugCallbackStatusFlags callback_statu
 
 #if defined __ANDROID__
     // On Android, if the default callback system property is set, force the default callback to be printed
-    int forceDefaultCallback = 0;
-    if (GetSystemProperty(kForceDefaultCallbackKey, &forceDefaultCallback) && forceDefaultCallback == 1) {
+    std::string forceLayerLog = GetEnvironment(kForceDefaultCallbackKey);
+    int forceDefaultCallback = atoi(forceLayerLog.c_str());
+    if (forceDefaultCallback == 1) {
         debug_data->forceDefaultLogCallback = true;
     }
 #endif


### PR DESCRIPTION
It's useful for certain downstream tools/systems(like automation)
to parse the log output of validation layers. On Android via logcat,
the default validation layer callback only prints when the Vulkan app
explicitly doesn't subscribe to the VK_EXT_debug_utils callback via
vkCreateDebugUtilsMessengerEXT. When the app does subscribe, then only
the app's callback is executed. To allow such downstream tools to
parse logcat for validation layer errors, this PR adds a mechanism to
force the default log to always be printed, regardless of whether the
app subscribes via vkCreateDebugUtilsMessengerEXT. This PR is currently
limited to Android-only, and opt-in with an Android system property.
This allows downstream tools to set the property and parse the logcat
in a known form(accessing key info like VUID), and every other existing
app relying on validation layers will remain unaffected.