### PR TITLE
 Fix winsock include on case-sensitive fs

### DIFF
--- a/layers/vk_loader_platform.h
+++ b/layers/vk_loader_platform.h
@@ -25,7 +25,7 @@
 
 #if defined(_WIN32)
 // WinSock2.h must be included *BEFORE* windows.h
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif  // _WIN32
 
 #include "vulkan/vk_platform.h"


### PR DESCRIPTION
On MinGW from Linux this fails because winsock2.h is lowercase. This will still work on win32.