### PR TITLE
layers: Fix winsock include on case-sensitive fs

### DIFF
--- a/layers/vk_loader_platform.h
+++ b/layers/vk_loader_platform.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vk_loader_platform.h
+++ b/layers/vk_loader_platform.h
@@ -25,7 +25,7 @@
 
 #if defined(_WIN32)
 // WinSock2.h must be included *BEFORE* windows.h
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif  // _WIN32
 
 #include "vulkan/vk_platform.h"


### PR DESCRIPTION
On MinGW from Linux this fails because winsock2.h is lowercase.