### PR TITLE
layers: Temp fix for multi-EntryPoint pc

### DIFF
--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -214,6 +214,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     };
     // entry point is not unqiue to single value so need multimap
     std::unordered_multimap<std::string, EntryPoint> entry_points;
+    bool multiple_entry_points{false};
     bool has_valid_spirv;
     bool has_specialization_constants{false};
     VkShaderModule vk_shader_module;


### PR DESCRIPTION
I have started working on a solution for the multi- `OpEntryPoint` fix for the layers, but it is a much bigger change to go tracking each function block that is used in an entry point, for now, purpose to just add this to stop the false errors seen in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2583 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450 for the short term

Note: the 2 `VkPositiveLayerTest` will fail without this patch, but are both fully valid and show the issue where flipping the entry points around was the main issue