### PR TITLE
Fix VK_KHR_timeline_semaphore feature bug

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4086,16 +4086,16 @@ bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemapho
     bool skip = false;
     auto *sem_type_create_info = LvlFindInChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext);
 
-    if (sem_type_create_info && sem_type_create_info->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE &&
-        !enabled_features.core12.timelineSemaphore && !device_extensions.vk_khr_timeline_semaphore) {
-        skip |= LogError(device, "VUID-VkSemaphoreTypeCreateInfo-timelineSemaphore-03252",
-                         "VkCreateSemaphore: timelineSemaphore feature is not enabled, can not create timeline semaphores");
-    }
+    if (sem_type_create_info) {
+        if (sem_type_create_info->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE && !enabled_features.core12.timelineSemaphore) {
+            skip |= LogError(device, "VUID-VkSemaphoreTypeCreateInfo-timelineSemaphore-03252",
+                             "VkCreateSemaphore: timelineSemaphore feature is not enabled, can not create timeline semaphores");
+        }
 
-    if (sem_type_create_info && sem_type_create_info->semaphoreType == VK_SEMAPHORE_TYPE_BINARY &&
-        sem_type_create_info->initialValue != 0) {
-        skip |= LogError(device, "VUID-VkSemaphoreTypeCreateInfo-semaphoreType-03279",
-                         "vkCreateSemaphore: if semaphoreType is VK_SEMAPHORE_TYPE_BINARY, initialValue must be zero");
+        if (sem_type_create_info->semaphoreType == VK_SEMAPHORE_TYPE_BINARY && sem_type_create_info->initialValue != 0) {
+            skip |= LogError(device, "VUID-VkSemaphoreTypeCreateInfo-semaphoreType-03279",
+                             "vkCreateSemaphore: if semaphoreType is VK_SEMAPHORE_TYPE_BINARY, initialValue must be zero");
+        }
     }
 
     return skip;


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2659

Even if someone is using Vulkan 1.0/1.1 and enables the `VK_KHR_timeline_semaphore` extension, they still need to enable `VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore` to use (which we map to `enabled_features.core12.timelineSemaphore` in state tracking)

The issue was these 2 VUs didn't have a test, so added 2 tests to check with both extensions and 1.2 core path