### PR TITLE
Remove warning if swapchain present mode is FIFO_KHR [WIP]

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -301,7 +301,8 @@ bool BestPractices::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkS
                                "vkGetPhysicalDeviceSurfaceCapabilitiesKHR().");
         }
 
-        if (bp_pd_state->vkGetPhysicalDeviceSurfacePresentModesKHRState != QUERY_DETAILS) {
+        if ((pCreateInfo->presentMode != VK_PRESENT_MODE_FIFO_KHR) &&
+            (bp_pd_state->vkGetPhysicalDeviceSurfacePresentModesKHRState != QUERY_DETAILS)) {
             skip |= LogWarning(device, kVUID_BestPractices_Swapchain_GetSurfaceNotCalled,
                                "vkCreateSwapchainKHR() called before getting surface present mode(s) from "
                                "vkGetPhysicalDeviceSurfacePresentModesKHR().");


### PR DESCRIPTION
A present mode of `VK_PRESENT_MODE_FIFO_KHR` is required to be
supported, so this is now checked and no longer issues a warning
about `vkCreateSwapchainKHR()` being called before first getting surface
present mode(s) from `vkGetPhysicalDeviceSurfacePresentModesKHR()`

Test added for three checks using
`UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved`
which make sure `GetPhysicalDeviceSurfaceCapabilitiesKHR()`,
`GetPhysicalDeviceSurfaceFormatsKHR()`, and
`GetPhysicalDeviceSurfacePresentModesKHR()` are all queried before
swapchain creation--except for when `presentMode` ia
`VK_PRESENT_MODE_FIFO_KHR` which is guaranteed to be supported.