### PR TITLE
Fix protected swapchain images

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -6279,6 +6279,7 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
             image_state->bind_swapchain = swapchain;
             image_state->bind_swapchain_imageIndex = i;
             image_state->is_swapchain_image = true;
+            image_state->unprotected = ((image_ci.flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0);
 
             // Since swapchains can't be linear, we can create an encoder here, and SyncValNeeds a fake_base_address
             image_state->fragment_encoder = std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(


### PR DESCRIPTION
Currently the `VkImage`s from a Swapchain with `VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR` were not being marked as protected and throwing a false error for `VUID-vkCmdDraw-commandBuffer-02712`

Simple 1 line fix and added a test to show a case it was failing prior
