### PR TITLE
layers: Avoid redundant image layout checks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3135,10 +3135,14 @@ struct CommandBufferSubmitState {
                     // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
                     // This submit time not record time...
                     const bool record_time_validate = false;
-                    skip |= core->ValidateDescriptorSetBindingData(cb_node, set_node, dynamic_offsets, binding_info,
-                                                                   cmd_info.framebuffer, cmd_info.attachments.get(),
-                                                                   *cmd_info.subpasses.get(), record_time_validate,
-                                                                   function.c_str(), core->GetDrawDispatchVuid(cmd_info.cmd_type));
+                    Optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
+                    if (set_node->GetTotalDescriptorCount() > cvdescriptorset::PrefilterBindRequestMap::kManyDescriptors_) {
+                        checked_layouts.emplace();
+                    }
+                    skip |= core->ValidateDescriptorSetBindingData(
+                        cb_node, set_node, dynamic_offsets, binding_info, cmd_info.framebuffer, cmd_info.attachments.get(),
+                        *cmd_info.subpasses.get(), record_time_validate, function.c_str(),
+                        core->GetDrawDispatchVuid(cmd_info.cmd_type), checked_layouts);
                 }
             }
         }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -437,7 +437,8 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::pair<const uint32_t, DescriptorRequirement>& binding_info,
                                           VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE*>* attachments,
                                           const std::vector<SUBPASS_INFO>& subpasses, bool record_time_validate, const char* caller,
-                                          const DrawDispatchVuid& vuids) const;
+                                          const DrawDispatchVuid& vuids,
+                                          Optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
 
     // Validate contents of a CopyUpdate
     using DescriptorSet = cvdescriptorset::DescriptorSet;


### PR DESCRIPTION
When there are a large number of image layouts, keep track of the ones
that have been validated and avoid rechecking the same layouts.

This provides some performance improvement for applications providing
repeated layouts without significant impact to others.