### PR TITLE
corechecks: Simplify Image Layout Transition maps

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4521,7 +4521,8 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE *pCB, const G
         }
 
         // Update all layout set operations (which will be a subset of the initial_layouts)
-        sparse_container::splice(overlay_map, subres_map->GetCurrentLayoutMap(), sparse_container::value_precedence::prefer_source);
+        sparse_container::splice(*overlay_map, subres_map->GetCurrentLayoutMap(),
+                                 sparse_container::value_precedence::prefer_source);
     }
 
     return skip;
@@ -4534,7 +4535,7 @@ void CoreChecks::UpdateCmdBufImageLayouts(CMD_BUFFER_STATE *pCB) {
         const auto *image_state = GetImageState(image);
         if (!image_state) continue;  // Can't set layouts of a dead image
         auto *global_map = GetLayoutRangeMap(imageLayoutMap, *image_state);
-        sparse_container::splice(global_map, subres_map->GetCurrentLayoutMap(), sparse_container::value_precedence::prefer_source);
+        sparse_container::splice(*global_map, subres_map->GetCurrentLayoutMap(), sparse_container::value_precedence::prefer_source);
     }
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3034,7 +3034,7 @@ struct CommandBufferSubmitState {
                     // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
                     // This submit time not record time...
                     const bool record_time_validate = false;
-                    Optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
+                    layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
                     if (set_node->GetTotalDescriptorCount() > cvdescriptorset::PrefilterBindRequestMap::kManyDescriptors_) {
                         checked_layouts.emplace();
                     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11261,11 +11261,11 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                 if (VK_IMAGE_LAYOUT_UNDEFINED == sub_layout) continue;  // secondary doesn't care about current or initial
 
                 // Look up the layout to compared to the intial layout of the sub command buffer (current else initial)
-                auto cb_layouts = cb_subres_map->GetSubresourceLayouts(subresource);
-                auto cb_layout = cb_layouts.current_layout;
+                const auto *cb_layouts = cb_subres_map->GetSubresourceLayouts(subresource);
+                auto cb_layout = cb_layouts ? cb_layouts->current_layout : kInvalidLayout;
                 const char *layout_type = "current";
-                if (cb_layouts.current_layout == kInvalidLayout) {
-                    cb_layout = cb_layouts.initial_layout;
+                if (cb_layout == kInvalidLayout) {
+                    cb_layout = cb_layouts ? cb_layouts->initial_layout : kInvalidLayout;
                     layout_type = "initial";
                 }
                 if ((cb_layout != kInvalidLayout) && (cb_layout != sub_layout)) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -443,7 +443,7 @@ class CoreChecks : public ValidationStateTracker {
                                           VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE*>* attachments,
                                           const std::vector<SUBPASS_INFO>& subpasses, bool record_time_validate, const char* caller,
                                           const DrawDispatchVuid& vuids,
-                                          Optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+                                          layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
 
     bool ValidateGeneralBufferDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
                                          const cvdescriptorset::DescriptorSet* descriptor_set,
@@ -458,7 +458,7 @@ class CoreChecks : public ValidationStateTracker {
                                  bool record_time_validate, const std::vector<IMAGE_VIEW_STATE*>* attachments,
                                  const std::vector<SUBPASS_INFO>& subpasses, VkFramebuffer framebuffer,
                                  VkDescriptorType descriptor_type,
-                                 Optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+                                 layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
 
     bool ValidateTexelDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
                                  const cvdescriptorset::DescriptorSet* descriptor_set,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1253,7 +1253,7 @@ struct QFOTransferCBScoreboards {
 
 typedef std::map<QueryObject, QueryState> QueryMap;
 typedef layer_data::unordered_map<VkEvent, VkPipelineStageFlags2KHR> EventToStageMap;
-typedef ImageSubresourceLayoutMap::LayoutMap GlobalImageLayoutRangeMap;
+typedef subresource_adapter::BothRangeMap<VkImageLayout, 16> GlobalImageLayoutRangeMap;
 typedef layer_data::unordered_map<VkImage, layer_data::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
 typedef layer_data::unordered_map<VkImage, layer_data::optional<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1254,9 +1254,9 @@ struct QFOTransferCBScoreboards {
 typedef std::map<QueryObject, QueryState> QueryMap;
 typedef layer_data::unordered_map<VkEvent, VkPipelineStageFlags2KHR> EventToStageMap;
 typedef ImageSubresourceLayoutMap::LayoutMap GlobalImageLayoutRangeMap;
-typedef layer_data::unordered_map<VkImage, Optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
+typedef layer_data::unordered_map<VkImage, layer_data::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
-typedef layer_data::unordered_map<VkImage, Optional<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
+typedef layer_data::unordered_map<VkImage, layer_data::optional<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
 
 enum LvlBindPoint {
     BindPoint_Graphics = VK_PIPELINE_BIND_POINT_GRAPHICS,

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -753,7 +753,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet *descriptor_set, const Bi
                                    const std::vector<uint32_t> &dynamic_offsets, const CMD_BUFFER_STATE *cb_node,
                                    const std::vector<IMAGE_VIEW_STATE *> *attachments, const std::vector<SUBPASS_INFO> &subpasses,
                                    const char *caller, const DrawDispatchVuid &vuids) const {
-    Optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
+    layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
     if (descriptor_set->GetTotalDescriptorCount() > cvdescriptorset::PrefilterBindRequestMap::kManyDescriptors_) {
         checked_layouts.emplace();
     }
@@ -791,7 +791,7 @@ bool CoreChecks::ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE *cb_nod
                                                   VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE *> *attachments,
                                                   const std::vector<SUBPASS_INFO> &subpasses, bool record_time_validate,
                                                   const char *caller, const DrawDispatchVuid &vuids,
-                                                  Optional<layer_data::unordered_map<VkImageView, VkImageLayout>> &checked_layouts) const {
+                                                  layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> &checked_layouts) const {
     using DescriptorClass = cvdescriptorset::DescriptorClass;
     using BufferDescriptor = cvdescriptorset::BufferDescriptor;
     using ImageDescriptor = cvdescriptorset::ImageDescriptor;
@@ -924,7 +924,7 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
                                          bool record_time_validate, const std::vector<IMAGE_VIEW_STATE *> *attachments,
                                          const std::vector<SUBPASS_INFO> &subpasses, VkFramebuffer framebuffer,
                                          VkDescriptorType descriptor_type,
-                                         Optional<layer_data::unordered_map<VkImageView, VkImageLayout>> &checked_layouts) const {
+                                         layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> &checked_layouts) const {
     std::vector<const SAMPLER_STATE *> sampler_states;
     VkImageView image_view = image_descriptor.GetImageView();
     const IMAGE_VIEW_STATE *image_view_state = image_descriptor.GetImageViewState();

--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -229,13 +229,13 @@ bool ImageSubresourceLayoutMap::UpdateFrom(const ImageSubresourceLayoutMap& othe
     if (CompatibilityKey() != other.CompatibilityKey()) return false;
 
     bool updated = false;
-    updated |= sparse_container::splice(&layouts_.initial, other.layouts_.initial, Arbiter::prefer_dest);
-    updated |= sparse_container::splice(&layouts_.current, other.layouts_.current, Arbiter::prefer_source);
+    updated |= sparse_container::splice(layouts_.initial, other.layouts_.initial, Arbiter::prefer_dest);
+    updated |= sparse_container::splice(layouts_.current, other.layouts_.current, Arbiter::prefer_source);
     // NOTE -- we are copying plain pointers from 'other' which owns them as unique_ptr.  This works because
     //         currently this function is only used to import from secondary command buffers, destruction of which
     //         invalidate the referencing primary command buffer, meaning that the dangling pointer will either be
     //         cleaned up in invalidation, on not referenced by validation code.
-    sparse_container::splice(&initial_layout_state_map_, other.initial_layout_state_map_, Arbiter::prefer_dest);
+    sparse_container::splice(initial_layout_state_map_, other.initial_layout_state_map_, Arbiter::prefer_dest);
 
     return updated;
 }

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -1691,15 +1691,16 @@ class parallel_iterator {
     const value_type *operator->() const { return &pos_; }
 };
 
-template <typename RangeMap, typename SourceIterator = typename RangeMap::const_iterator>
-bool splice(RangeMap *to, const RangeMap &from, value_precedence arbiter, SourceIterator begin, SourceIterator end) {
+template <typename DstRangeMap, typename SrcRangeMap, typename Updater,
+          typename SourceIterator = typename SrcRangeMap::const_iterator>
+bool splice(DstRangeMap &to, const SrcRangeMap &from, SourceIterator begin, SourceIterator end, const Updater &updater) {
     if (from.empty() || (begin == end) || (begin == from.cend())) return false;  // nothing to merge.
 
-    using ParallelIterator = parallel_iterator<RangeMap, const RangeMap>;
-    using Key = typename RangeMap::key_type;
-    using CachedLowerBound = cached_lower_bound_impl<RangeMap>;
-    using ConstCachedLowerBound = cached_lower_bound_impl<const RangeMap>;
-    ParallelIterator par_it(*to, from, begin->first.begin);
+    using ParallelIterator = parallel_iterator<DstRangeMap, const SrcRangeMap>;
+    using Key = typename SrcRangeMap::key_type;
+    using CachedLowerBound = cached_lower_bound_impl<DstRangeMap>;
+    using ConstCachedLowerBound = cached_lower_bound_impl<const SrcRangeMap>;
+    ParallelIterator par_it(to, from, begin->first.begin);
     bool updated = false;
     while (par_it->range.non_empty() && par_it->pos_B->lower_bound != end) {
         const Key &range = par_it->range;
@@ -1711,24 +1712,15 @@ bool splice(RangeMap *to, const RangeMap &from, value_precedence arbiter, Source
             // Because of how the parallel iterator walk, "to" is valid over the whole range or it isn't (ranges don't span
             // transitions between map entries or between valid and invalid ranges)
             if (to_lb->valid) {
-                // Only rewrite this range if source is preferred (and the value differs)
-                // TODO determine if equality checks are always wanted. (for example heavyweight values)
-                if (arbiter == value_precedence::prefer_source && (write_it->second != read_it->second)) {
-                    // Both ranges occupied and source is preferred and from differs from to
-                    if (write_it->first == range) {
-                        // we're writing the whole destination range, so just set the value
-                        write_it->second = read_it->second;
-                    } else {
-                        to->overwrite_range(write_it, std::make_pair(range, read_it->second));
-                        par_it.invalidate_A();  // we've changed map 'to' behind to_lb's back... let it know.
-                    }
-                    updated = true;
-                }
+                updated |= updater.update(write_it->second, read_it->second);
             } else {
                 // Insert into the gap.
-                to->insert(write_it, std::make_pair(range, read_it->second));
-                par_it.invalidate_A();  // we've changed map 'to' behind to_lb's back... let it know.
-                updated = true;
+                auto opt = updater.insert(read_it->second);
+                if (opt) {
+                    to.insert(write_it, std::make_pair(range, std::move(*opt)));
+                    updated = true;
+                    par_it.invalidate_A();  // we've changed map 'to' behind to_lb's back... let it know.
+                }
             }
         }
         ++par_it;  // next range over which both 'to' and 'from' stay constant
@@ -1736,8 +1728,43 @@ bool splice(RangeMap *to, const RangeMap &from, value_precedence arbiter, Source
     return updated;
 }
 // And short hand for "from begin to end"
+template <typename DstRangeMap, typename SrcRangeMap, typename Updater>
+bool splice(DstRangeMap &to, const SrcRangeMap &from, const Updater &updater) {
+    return splice(to, from, from.cbegin(), from.cend(), updater);
+}
+
+template <typename T>
+struct update_prefer_source {
+    bool update(T &dst, const T &src) const {
+        if (dst != src) {
+            dst = src;
+            return true;
+        }
+        return false;
+    }
+
+    layer_data::optional<T> insert(const T &src) const { return layer_data::optional<T>(layer_data::in_place, src); }
+};
+
+template <typename T>
+struct update_prefer_dest {
+    bool update(T &dst, const T &src) const { return false; }
+
+    layer_data::optional<T> insert(const T &src) const { return layer_data::optional<T>(layer_data::in_place, src); }
+};
+
+template <typename RangeMap, typename SourceIterator = typename RangeMap::const_iterator>
+bool splice(RangeMap &to, const RangeMap &from, value_precedence arbiter, SourceIterator begin, SourceIterator end) {
+    if (arbiter == value_precedence::prefer_source) {
+        return splice(to, from, from.cbegin(), from.cend(), update_prefer_source<typename RangeMap::mapped_type>());
+    } else {
+        return splice(to, from, from.cbegin(), from.cend(), update_prefer_dest<typename RangeMap::mapped_type>());
+    }
+}
+
+// And short hand for "from begin to end"
 template <typename RangeMap>
-bool splice(RangeMap *to, const RangeMap &from, value_precedence arbiter) {
+bool splice(RangeMap &to, const RangeMap &from, value_precedence arbiter) {
     return splice(to, from, arbiter, from.cbegin(), from.cend());
 }
 


### PR DESCRIPTION
Use a single range_map in ImageSubresourceLayoutMap instead of having 3 separate maps for each type of data tracked. This speeds up construction, lookups and iteration.

Make InitialLayoutStates be a small_vector
    
Many images appear to need only 1 or 2 InitialLayoutStates, so using a small vector prevents new calls in these cases. Performance appears to fall off if the small vector is size 4. In some cases we're getting over entries 255, so the small vector cannot use uint8_t for its size.
    
