### PR TITLE
Fix PushConstants drawtime compatibility

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1133,8 +1133,8 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
         // If valid set is not bound throw an error
         if ((state.per_set.size() <= set_index) || (!state.per_set[set_index].bound_descriptor_set)) {
             result |= LogError(cb_node->commandBuffer, kVUID_Core_DrawState_DescriptorSetNotBound,
-                               "%s uses set #%u but that set is not bound.", report_data->FormatHandle(pipe->pipeline).c_str(),
-                               set_index);
+                               "%s(): %s uses set #%u but that set is not bound.", CommandTypeString(cmd_type),
+                               report_data->FormatHandle(pipe->pipeline).c_str(), set_index);
         } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[set_index].bound_descriptor_set, pipeline_layout,
                                                  set_index, error_string)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
@@ -1142,8 +1142,8 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
             LogObjectList objlist(set_handle);
             objlist.add(pipeline_layout->layout);
             result |= LogError(objlist, kVUID_Core_DrawState_PipelineLayoutsIncompatible,
-                               "%s bound as set #%u is not compatible with overlapping %s due to: %s",
-                               report_data->FormatHandle(set_handle).c_str(), set_index,
+                               "%s(): %s bound as set #%u is not compatible with overlapping %s due to: %s",
+                               CommandTypeString(cmd_type), report_data->FormatHandle(set_handle).c_str(), set_index,
                                report_data->FormatHandle(pipeline_layout->layout).c_str(), error_string.c_str());
         } else {  // Valid set is bound and layout compatible, validate that it's updated
             // Pull the set node
@@ -1203,42 +1203,55 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     }
 
     // Verify if push constants have been set
-    if (cb_node->push_constant_data_ranges) {
-        if (pipeline_layout->push_constant_ranges != cb_node->push_constant_data_ranges) {
-            LogObjectList objlist(cb_node->commandBuffer);
-            objlist.add(cb_node->push_constant_pipeline_layout_set);
-            objlist.add(pipeline_layout->layout);
-            objlist.add(pipe->pipeline);
-            result |= LogError(
-                objlist, vuid.push_constants_set, "The active push constants of %s isn't compatible with %s of active %s.",
-                report_data->FormatHandle(cb_node->push_constant_pipeline_layout_set).c_str(),
-                report_data->FormatHandle(pipeline_layout->layout).c_str(), report_data->FormatHandle(pipe->pipeline).c_str());
-        } else {
-            for (const auto &stage : pipe->stage_state) {
-                const auto *entrypoint =
-                    FindEntrypointStruct(stage.shader_state.get(), stage.entry_point_name.c_str(), stage.stage_flag);
-                if (!entrypoint || !entrypoint->push_constant_used_in_shader.IsUsed()) {
-                    continue;
-                }
-                const auto it = cb_node->push_constant_data_update.find(stage.stage_flag);
-                if (it == cb_node->push_constant_data_update.end()) {
-                    // This error has been printed in ValidatePushConstantUsage.
-                    break;
-                }
+    if (cb_node->push_constant_data_ranges && (pipeline_layout->push_constant_ranges != cb_node->push_constant_data_ranges)) {
+        LogObjectList objlist(cb_node->commandBuffer);
+        objlist.add(cb_node->push_constant_pipeline_layout_set);
+        objlist.add(pipeline_layout->layout);
+        objlist.add(pipe->pipeline);
+        result |= LogError(
+            objlist, vuid.push_constants_set, "%s(): The active push constants of %s isn't compatible with %s of active %s.",
+            CommandTypeString(cmd_type), report_data->FormatHandle(cb_node->push_constant_pipeline_layout_set).c_str(),
+            report_data->FormatHandle(pipeline_layout->layout).c_str(), report_data->FormatHandle(pipe->pipeline).c_str());
+    } else {
+        for (const auto &stage : pipe->stage_state) {
+            const auto *entrypoint =
+                FindEntrypointStruct(stage.shader_state.get(), stage.entry_point_name.c_str(), stage.stage_flag);
+            if (!entrypoint || !entrypoint->push_constant_used_in_shader.IsUsed()) {
+                continue;
+            }
 
-                uint32_t issue_index = 0;
-                const auto ret = ValidatePushConstantSetUpdate(it->second, entrypoint->push_constant_used_in_shader, issue_index);
+            // Edge case where if the shader is using push constants statically and there never was a vkCmdPushConstants
+            if (!cb_node->push_constant_data_ranges) {
+                LogObjectList objlist(cb_node->commandBuffer);
+                objlist.add(pipeline_layout->layout);
+                objlist.add(pipe->pipeline);
+                result |= LogError(objlist, vuid.push_constants_set,
+                                   "%s(): Shader in %s uses push-constant statically but vkCmdPushConstants was not called yet for "
+                                   "pipeline layout %s.",
+                                   CommandTypeString(cmd_type), string_VkShaderStageFlags(stage.stage_flag).c_str(),
+                                   report_data->FormatHandle(pipeline_layout->layout).c_str());
+            }
 
-                // "not set" error has been printed in ValidatePushConstantUsage.
-                if (ret == PC_Byte_Not_Updated) {
-                    const auto loc_descr = entrypoint->push_constant_used_in_shader.GetLocationDesc(issue_index);
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(pipeline_layout->layout);
-                    result |= LogError(objlist, vuid.push_constants_set, "Push-constant buffer:%s in %s of %s is not updated.",
-                                       loc_descr.c_str(), string_VkShaderStageFlags(stage.stage_flag).c_str(),
-                                       report_data->FormatHandle(pipeline_layout->layout).c_str());
-                    break;
-                }
+            const auto it = cb_node->push_constant_data_update.find(stage.stage_flag);
+            if (it == cb_node->push_constant_data_update.end()) {
+                // This error has been printed in ValidatePushConstantUsage.
+                break;
+            }
+
+            uint32_t issue_index = 0;
+            const auto ret = ValidatePushConstantSetUpdate(it->second, entrypoint->push_constant_used_in_shader, issue_index);
+
+            // "not set" error has been printed in ValidatePushConstantUsage.
+            if (ret == PC_Byte_Not_Updated) {
+                const auto loc_descr = entrypoint->push_constant_used_in_shader.GetLocationDesc(issue_index);
+                LogObjectList objlist(cb_node->commandBuffer);
+                objlist.add(pipeline_layout->layout);
+                objlist.add(pipe->pipeline);
+                result |=
+                    LogError(objlist, vuid.push_constants_set, "%s(): Push-constant buffer:%s in %s of %s is not updated.",
+                             CommandTypeString(cmd_type), loc_descr.c_str(), string_VkShaderStageFlags(stage.stage_flag).c_str(),
+                             report_data->FormatHandle(pipeline_layout->layout).c_str());
+                break;
             }
         }
     }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3744,7 +3744,6 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
         cb_state->status |= cb_state->static_status;
         cb_state->dynamic_status = CBSTATUS_ALL_STATE_SET & (~cb_state->static_status);
     }
-    ResetCommandBufferPushConstantDataIfIncompatible(cb_state, pipe_state->pipeline_layout->layout);
     const auto lv_bind_point = ConvertToLvlBindPoint(pipelineBindPoint);
     cb_state->lastBound[lv_bind_point].pipeline_state = pipe_state;
     SetPipelineState(pipe_state);
@@ -4175,7 +4174,6 @@ void ValidationStateTracker::PreCallRecordCmdBindDescriptorSets(VkCommandBuffer 
     UpdateLastBoundDescriptorSets(cb_state, pipelineBindPoint, pipeline_layout, firstSet, setCount, pDescriptorSets, nullptr,
                                   dynamicOffsetCount, pDynamicOffsets);
     cb_state->lastBound[lv_bind_point].pipeline_layout = layout;
-    ResetCommandBufferPushConstantDataIfIncompatible(cb_state, layout);
     UpdateSamplerDescriptorsUsedByImage(cb_state->lastBound[lv_bind_point]);
 }
 
@@ -6178,6 +6176,13 @@ void ValidationStateTracker::RecordPipelineShaderStage(VkPipelineShaderStageCrea
     }
 }
 
+// Discussed in details in https://github.com/KhronosGroup/Vulkan-Docs/issues/1081
+// Internal discussion and CTS were written to prove that this is not called after an incompatible vkCmdBindPipeline
+// "Binding a pipeline with a layout that is not compatible with the push constant layout does not disturb the push constant values"
+//
+// vkCmdBindDescriptorSet has nothing to do with push constants and don't need to call this after neither
+//
+// Part of this assumes apps at draw/dispath/traceRays/etc time will have it properly compatabile or else other VU will be triggered
 void ValidationStateTracker::ResetCommandBufferPushConstantDataIfIncompatible(CMD_BUFFER_STATE *cb_state, VkPipelineLayout layout) {
     if (cb_state == nullptr) {
         return;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2654

- Use of when `ResetCommandBufferPushConstantDataIfIncompatible` was called was wrong (as noted in comment)
  - `// case 6` is example of `dEQP-VK.pipeline.push_constant.lifetime.push_range0_bind_layout1_overlapping_range_bind_layout0` from CTS that was failing previously
- `PushConstantsStaticallyUnused` tests used to make sure validation doesn't assume a range in the layout means the shader in the pipeline will use them