### PR TITLE
tests: Choose device based on type

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2194,9 +2194,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
-        return;
     }
 
     if (!AddSurfaceInstanceExtension()) {
@@ -2205,6 +2202,11 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
+        return;
+    }
 
     if (extension_dependency_satisfied && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
@@ -2302,9 +2304,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
-        return;
     }
 
     if (!AddSurfaceInstanceExtension()) {
@@ -2313,6 +2312,11 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
+        return;
+    }
 
     if (extension_dependency_satisfied && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
@@ -2459,9 +2463,6 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     if (InstanceExtensionSupported(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
         extension_dependency_satisfied = true;
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
-        return;
     }
 
     if (!AddSurfaceInstanceExtension()) return;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -290,7 +290,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> instance_extensions_;
     std::vector<const char *> &m_instance_extension_names = instance_extensions_;  // compatibility alias name
     VkInstance instance_;
-    VkPhysicalDevice gpu_;
+    VkPhysicalDevice gpu_ = VK_NULL_HANDLE;
     VkPhysicalDeviceProperties physDevProps_;
 
     VkDeviceObj *m_device;

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,6 +132,7 @@ bool VkTestFramework::m_do_everything_spv = false;
 bool VkTestFramework::m_devsim_layer = false;
 int VkTestFramework::m_width = 0;
 int VkTestFramework::m_height = 0;
+int VkTestFramework::m_phys_device_index = -1;
 
 bool VkTestFramework::optionMatch(const char *option, char *optionLine) {
     if (strncmp(option, optionLine, strlen(option)) == 0)
@@ -150,7 +151,9 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_canonicalize_spv = true;
         else if (optionMatch("--devsim", argv[i]))
             m_devsim_layer = true;
-        else if (optionMatch("--help", argv[i]) || optionMatch("-h", argv[i])) {
+        else if (optionMatch("--device-index", argv[i]) && ((i + 1) < *argc)) {
+            m_phys_device_index = std::atoi(argv[++i]);
+        } else if (optionMatch("--help", argv[i]) || optionMatch("-h", argv[i])) {
             printf("\nOther options:\n");
             printf(
                 "\t--show-images\n"
@@ -176,6 +179,11 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             printf(
                 "\t--canonicalize-SPV\n"
                 "\t\tRemap SPIR-V ids before submission to aid compression.\n");
+            printf(
+                "\t--device-index <physical device index>\n"
+                "\t\tIndex into VkPhysicalDevice array returned from vkEnumeratePhysicalDevices.\n"
+                "\t\tThe default behavior is to automatically choose \"the most reasonable device.\"\n"
+                "\t\tAn invalid index (i.e., outside the range [0, *pPhysicalDeviceCount)) will result in the default behavior\n");
             exit(0);
         } else {
             printf("\nUnrecognized option: %s\n", argv[i]);

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2019 The Khronos Group Inc.
- * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ class VkTestFramework : public ::testing::Test {
     static bool m_strip_spv;
     static bool m_do_everything_spv;
     static bool m_devsim_layer;
+    static int m_phys_device_index;
 
     char **ReadFileData(const char *fileName);
     void FreeFileData(char **data);

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2019 The Khronos Group Inc.
-//  Copyright (c) 2015-2019 Valve Corporation
-//  Copyright (c) 2015-2019 LunarG, Inc.
-//  Copyright (c) 2015-2019 Google, Inc.
+//  Copyright (c) 2015-2021 The Khronos Group Inc.
+//  Copyright (c) 2015-2021 Valve Corporation
+//  Copyright (c) 2015-2021 LunarG, Inc.
+//  Copyright (c) 2015-2021 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ VkTestFramework::~VkTestFramework() {}
 
 // Define static elements
 bool VkTestFramework::m_devsim_layer = false;
+int VkTestFramework::m_phys_device_index = -1;
 ANativeWindow *VkTestFramework::window = nullptr;
 
 VkFormat VkTestFramework::GetFormat(VkInstance instance, vk_testing::Device *device) {

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2019 The Khronos Group Inc.
-//  Copyright (c) 2015-2019 Valve Corporation
-//  Copyright (c) 2015-2019 LunarG, Inc.
-//  Copyright (c) 2015-2019 Google, Inc.
+//  Copyright (c) 2015-2021 The Khronos Group Inc.
+//  Copyright (c) 2015-2021 Valve Corporation
+//  Copyright (c) 2015-2021 LunarG, Inc.
+//  Copyright (c) 2015-2021 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class VkTestFramework : public ::testing::Test {
                    std::vector<unsigned int> &spv, bool debug = false, uint32_t spirv_minor_version = 0);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
     static bool m_devsim_layer;
+    static int m_phys_device_index;
     static ANativeWindow *window;
 };
 


### PR DESCRIPTION
Choose the VkPhysicalDevice for testing based on device type rather than
the first device returned from vkEnumeratePhysicalDevices.

This change also adds a `--device-index` command line argument to manually choose the device index.