### PR TITLE
corechecks: Make InitialLayoutStates be a small_vector

### DIFF
--- a/layers/image_layout_map.h
+++ b/layers/image_layout_map.h
@@ -96,7 +96,7 @@ class ImageSubresourceLayoutMap {
     using ParallelIterator = sparse_container::parallel_iterator<MapA, MapB>;
     using LayoutMap = RangeMap;
     using InitialLayoutMap = RangeMap;
-    using InitialLayoutStates = std::vector<InitialLayoutState>;
+    using InitialLayoutStates = small_vector<InitialLayoutState, 2, uint32_t>;
 
     class ConstIterator {
       public:


### PR DESCRIPTION
Many images appear to need only 1 or 2 InitialLayoutStates, so using
a small vector prevents new calls in these cases. Performance appears
to fall off if the small vector is size 4. In some cases we're getting
over entries 255, so the small vector cannot use uint8_t for its size.

Change-Id: I54867270c75934c3440986d18e5c9d7f51255780