### PR TITLE
SyncVal ImageRange traversal optimizations

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1564,4 +1564,7 @@ ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(CMD_BUFFER_STATE *cb_sta
 const ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(const CMD_BUFFER_STATE *cb_state, VkImage image);
 void AddInitialLayoutintoImageLayoutMap(const IMAGE_STATE &image_state, GlobalImageLayoutMap &image_layout_map);
 
+uint32_t GetSubpassDepthStencilAttachmentIndex(const safe_VkPipelineDepthStencilStateCreateInfo *pipe_ds_ci,
+                                               const safe_VkAttachmentReference2 *depth_stencil_ref);
+
 #endif  // CORE_VALIDATION_TYPES_H_

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -1401,11 +1401,12 @@ class cached_lower_bound_impl {
 
     inline iterator lower_bound(const index_type &index) { return map_->lower_bound(key_type(index, index + 1)); }
     inline bool at_end(const iterator &it) const { return it == end_; }
-    inline bool at_end() const { return at_end(lower_bound_); }
 
     bool is_lower_than(const index_type &index, const iterator &it) { return at_end(it) || (index < it->first.end); }
 
   public:
+    // The cached lower bound knows the parent map, and thus can tell us this...
+    inline bool at_end() const { return at_end(lower_bound_); }
     // includes(index) is a convenience function to test if the index would be in the currently cached lower bound
     bool includes(const index_type &index) const { return !at_end() && lower_bound_->first.includes(index); }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -42,6 +42,15 @@ const char *CommandTypeString(CMD_TYPE type) {
     return kGeneratedCommandNameList[type];
 }
 
+uint32_t GetSubpassDepthStencilAttachmentIndex(const safe_VkPipelineDepthStencilStateCreateInfo *pipe_ds_ci,
+                                               const safe_VkAttachmentReference2 *depth_stencil_ref) {
+    uint32_t depth_stencil_attachment = VK_ATTACHMENT_UNUSED;
+    if (pipe_ds_ci && depth_stencil_ref) {
+        depth_stencil_attachment = depth_stencil_ref->attachment;
+    }
+    return depth_stencil_attachment;
+}
+
 VkDynamicState ConvertToDynamicState(CBStatusFlagBits flag) {
     switch (flag) {
         case CBSTATUS_LINE_WIDTH_SET:

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -325,7 +325,71 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
         }
     }
 }
+#ifdef IMAGE_RANGE_GEN_DIAG
+ImageRangeGenerator::Diag ImageRangeGenerator::diag_;
+ImageRangeGenerator::~ImageRangeGenerator() {
+    if (!encoder_) return;
+    // Post-process the coverage map
+    IndexType sum = 0;
+    for (const auto& span : diag_coverage_map_) {
+        sum += span.first.distance();
+    }
+    diag_.RecordCoverage(diag_increment_count_, sum, encoder_->TotalSize());
+}
 
+void ImageRangeGenerator::DiagPlusPlus() {
+    ++diag_increment_count_;
+    auto insert_it = diag_coverage_map_.insert(std::make_pair(pos_, true));
+    if (!insert_it.second) {
+        diag_.RecordDuplicate(pos_, insert_it.first->first);
+    }
+    if (pos_.end > base_address_ + encoder_->TotalSize()) {
+        diag_.RecordOOB(pos_, 1);
+    }
+    if (pos_.begin < base_address_) {
+        diag_.RecordOOB(pos_, 2);
+    }
+    if (!pos_.distance()) {
+        diag_.ErrorAction();
+    }
+}
+
+void ImageRangeGenerator::Diag::RecordDuplicate(const IndexRange& pos, const IndexRange& extant) {
+    std::lock_guard<std::mutex> lock(diag_mutex);
+    std::cout << "Insert failure: " << pos.begin << ", " << pos.end << std::endl;
+    std::cout << "Extant: " << extant.begin << ", " << extant.end << std::endl;
+    dupcount++;
+    ErrorAction();
+}
+void ImageRangeGenerator::Diag::RecordOOB(IndexRange& pos, int type) {
+    assert(type);  // Don't call this if there isn't an error
+    std::lock_guard<std::mutex> lock(diag_mutex);
+    std::cout << "OOB failure: [" << pos.begin << ", " << pos.end << "), type " << type << std::endl;
+    if (type == 1) oob_high++;
+    if (type == 2) oob_low++;
+    ErrorAction();
+}
+
+void ImageRangeGenerator::Diag::RecordCoverage(uint64_t count, IndexType covered, IndexType total) {
+    std::lock_guard<std::mutex> lock(diag_mutex);
+    increment_calls += count;
+    coverage_covered += covered;
+    coverage_total += total;
+    coverage_counter++;
+    if (0 == (coverage_counter % coverage_limit)) {
+        Report();
+    }
+}
+
+void ImageRangeGenerator::Diag::Report() {
+    static volatile double coverage = double(coverage_covered) / double(coverage_total);
+    static volatile double average_range = double(coverage_covered) / double(increment_calls);
+    std::cout << "Count: " << increment_calls << " Covered: " << coverage_covered << " Total: " << coverage_total
+              << " ++sum: " << coverage_covered;
+    std::cout << " Coverage:" << coverage << " Avg Range: " << average_range << std::endl;
+}
+
+#endif
 IndexType ImageRangeEncoder::Encode(const VkImageSubresource& subres, uint32_t layer, VkOffset3D offset) const {
     const auto& subres_layout = SubresourceLayout(subres);
     return static_cast<IndexType>(floor(static_cast<double>(layer * subres_layout.arrayPitch + offset.z * subres_layout.depthPitch +
@@ -450,6 +514,9 @@ void ImageRangeGenerator::SetPos() {
 }
 
 ImageRangeGenerator* ImageRangeGenerator::operator++() {
+#ifdef IMAGE_RANGE_GEN_DIAG
+    DiagPlusPlus();
+#endif
     offset_y_index_++;
 
     if (offset_y_index_ < offset_y_count_) {

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -396,6 +396,7 @@ class ImageRangeGenerator {
     void DiagPlusPlus();
 #endif
 
+    ImageRangeGenerator(const ImageRangeGenerator&) = default;
     ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_(), base_address_(), pos_() {}
     bool operator!=(const ImageRangeGenerator& rhs) { return (pos_ != rhs.pos_) || (&encoder_ != &rhs.encoder_); }
     ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, const VkOffset3D& offset,
@@ -407,9 +408,9 @@ class ImageRangeGenerator {
 
   private:
     const ImageRangeEncoder* encoder_;
-    const VkImageSubresourceRange subres_range_;
-    const VkOffset3D offset_;
-    const VkExtent3D extent_;
+    VkImageSubresourceRange subres_range_;
+    VkOffset3D offset_;
+    VkExtent3D extent_;
     VkDeviceSize base_address_;
     uint32_t range_arraylayer_base_;
     uint32_t range_layer_count_;

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -23,14 +23,8 @@
 #ifndef SUBRESOURCE_ADAPTER_H_
 #define SUBRESOURCE_ADAPTER_H_
 
-// Do not commit enabled
-// #define IMAGE_RANGE_GEN_DIAG
-
 #include <algorithm>
 #include <array>
-#ifdef IMAGE_RANGE_GEN_DIAG
-#include <mutex>
-#endif
 #include <vector>
 #include "range_vector.h"
 #include "vk_layer_data.h"
@@ -394,35 +388,6 @@ class ImageRangeEncoder : public RangeEncoder {
 
 class ImageRangeGenerator {
   public:
-#ifdef IMAGE_RANGE_GEN_DIAG
-    // WIP ZZZ
-    ~ImageRangeGenerator();
-    struct Diag {
-        uint64_t dupcount = 0;
-        const uint64_t coverage_limit = ~uint64_t(0);
-        uint64_t increment_calls = 0;
-        uint64_t coverage_counter = 0;
-        uint64_t coverage_total = 0;
-        uint64_t coverage_covered = 0;
-        uint64_t oob_high = 0;
-        uint64_t oob_low = 0;
-        std::mutex diag_mutex;
-        void RecordDuplicate(const IndexRange& pos, const IndexRange& extant);
-        void RecordOOB(IndexRange& pos, int type);
-        void RecordCoverage(uint64_t count, IndexType covered, IndexType total);
-#if defined(_WIN32)
-        void ErrorAction() { __debugbreak(); }
-#else
-        void ErrorAction(){};
-#endif
-        void Report();
-    };
-    static Diag diag_;
-    uint64_t diag_increment_count_ = 0;
-    sparse_container::range_map<VkDeviceSize, bool> diag_coverage_map_;
-    void DiagPlusPlus();
-#endif
-
     ImageRangeGenerator(const ImageRangeGenerator&) = default;
     ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_(), base_address_(), pos_() {}
     bool operator!=(const ImageRangeGenerator& rhs) { return (pos_ != rhs.pos_) || (&encoder_ != &rhs.encoder_); }

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -26,6 +26,39 @@
 #include "synchronization_validation.h"
 #include "sync_utils.h"
 
+#ifdef SYNCVAL_DIAGNOSTICS
+struct SyncDiagnostics {
+    void DebugAction() const {
+#if defined(_WIN32)
+        __debugbreak();
+#endif
+    }
+    void Detect(const ResourceAccessRange &range) {
+        std::lock_guard<std::mutex> lock(diag_mutex);
+        if (range.distance() == kConditionValue) {
+            ++condition;
+            DebugAction();
+        }
+        detect_histogram[range.distance()] += 1;
+    }
+    void InstanceDump(VkInstance instance) {
+        std::cout << "# instance handle\n" << instance << "\n";
+        std::cout << "# condition count\n" << condition << "\n";
+        std::cout << "# Detection Size Histogram\n";
+        for (const auto &entry : detect_histogram) {
+            std::cout << "{ " << entry.first << ", " << entry.second << "}\n";
+        }
+        std::cout << std::endl;
+        detect_histogram.clear();
+    }
+    std::map<ResourceAccessRange::index_type, size_t> detect_histogram;
+    uint64_t condition;
+    std::mutex diag_mutex;
+    static const ResourceAccessRangeIndex kConditionValue = ~ResourceAccessRangeIndex(0);
+};
+static SyncDiagnostics sync_diagnostics;
+#endif
+
 static bool SimpleBinding(const BINDABLE &bindable) { return !bindable.sparse && bindable.binding.mem_state; }
 
 static bool SimpleBinding(const IMAGE_STATE &image_state) {
@@ -1203,6 +1236,9 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const IMAGE_STATE &
                                                        base_address);
     const auto address_type = ImageAddressType(image);
     for (; range_gen->non_empty(); ++range_gen) {
+#ifdef SYNCVAL_DIAGNOSTICS
+        sync_diagnostics.Detect(*range_gen);
+#endif
         HazardResult hazard = DetectHazard(address_type, detector, *range_gen, options);
         if (hazard.hazard) return hazard;
     }
@@ -5860,3 +5896,11 @@ void SyncValidator::PreCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer comman
         context->UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, SyncOrdering::kNonAttachment, range, tag);
     }
 }
+
+#ifdef SYNCVAL_DIAGNOSTICS
+bool SyncValidator::PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) const {
+    sync_diagnostics.InstanceDump(instance);
+    ImageRangeGen::diag_.Report();
+    return StateTracker::PreCallValidateDestroyInstance(instance, pAllocator);
+}
+#endif

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -28,6 +28,9 @@
 #include "synchronization_validation_types.h"
 #include "state_tracker.h"
 
+// Do not commit enabled
+// #define SYNCVAL_DIAGNOSTICS
+
 class AccessContext;
 class CommandBufferAccessContext;
 using CommandBufferAccessContextShared = std::shared_ptr<CommandBufferAccessContext>;
@@ -1317,4 +1320,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                                  VkDeviceSize dstOffset, uint32_t marker) const override;
     void PreCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage, VkBuffer dstBuffer,
                                                VkDeviceSize dstOffset, uint32_t marker) override;
+#ifdef SYNCVAL_DIAGNOSTICS
+    bool PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) const override;
+#endif
 };

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -28,9 +28,6 @@
 #include "synchronization_validation_types.h"
 #include "state_tracker.h"
 
-// Do not commit enabled
-// #define SYNCVAL_DIAGNOSTICS
-
 class AccessContext;
 class CommandBufferAccessContext;
 using CommandBufferAccessContextShared = std::shared_ptr<CommandBufferAccessContext>;
@@ -1356,7 +1353,4 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                                  VkDeviceSize dstOffset, uint32_t marker) const override;
     void PreCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage, VkBuffer dstBuffer,
                                                VkDeviceSize dstOffset, uint32_t marker) override;
-#ifdef SYNCVAL_DIAGNOSTICS
-    bool PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) const override;
-#endif
 };


### PR DESCRIPTION
Implement several range traversal optimizations:

1. Reduce recursion and unneeded map copies when traversing ranges in to AccessContext hierarchies
2. Store range generators for attachments, generated at begin renderpass time to minimize construction time
3. Refactor ImageRangeGenerator and ImageRangeEncoder to reduce generator construction time
4. Replace "upper_bound" based range termination checks with direct range value inspection

Useful diagnostic code exists for range generation and traversal temporarily in commit list, but is removed... but obviously can be found again if needed.