### PR TITLE
Fix mesh pipeline validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4888,7 +4888,7 @@ bool CoreChecks::ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPE
     const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;
 
     for (uint32_t i = 0; i < count; i++) {
-        auto pvids_ci = LvlFindInChain<VkPipelineVertexInputDivisorStateCreateInfoEXT>(pipe_cis[i].pVertexInputState->pNext);
+        auto pvids_ci = (pipe_cis[i].pVertexInputState) ? LvlFindInChain<VkPipelineVertexInputDivisorStateCreateInfoEXT>(pipe_cis[i].pVertexInputState->pNext) : nullptr;
         if (nullptr == pvids_ci) continue;
 
         const PIPELINE_STATE *pipe_state = pipe_state_vec[i].get();

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -3268,6 +3268,7 @@ void ProcessExecutionModes(SHADER_MODULE_STATE const *src, const spirv_inst_iter
                 case spv::ExecutionModeTriangles:
                 case spv::ExecutionModeQuads:
                 case spv::ExecutionModeOutputTriangleStrip:
+                case spv::ExecutionModeOutputTrianglesNV:
                     pipeline->topology_at_rasterizer = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
                     break;
             }


### PR DESCRIPTION
Fixes a null de-reference when validating a pipeline that contains a mesh shader, but not a vertex shader. Per the spec:

> pVertexInputState is a pointer to a VkPipelineVertexInputStateCreateInfo structure. **It is ignored
if the pipeline includes a mesh shader stage**.

This change also adds a test for when `pInputAssemblyState` is null, as that should also be ignored (this appears to work without any additional VVL changes):

> pInputAssemblyState is a pointer to a VkPipelineInputAssemblyStateCreateInfo structure which
determines input assembly behavior, as described in Drawing Commands. **It is ignored if the
pipeline includes a mesh shader stage.**

Closes #2696.