### PR TITLE
layers: Fix drm_format_modifier tiling subresource querying

### DIFF
--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -283,7 +283,7 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
     linear_image = false;
 
     // WORKAROUND for dev_sim and mock_icd not containing valid VkSubresourceLayout yet. Treat it as optimal image.
-    if (image_->createInfo.tiling != VK_IMAGE_TILING_OPTIMAL) {
+    if (image_->createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
         subres = {static_cast<VkImageAspectFlags>(AspectBit(0)), 0, 0};
         DispatchGetImageSubresourceLayout(image_->store_device_as_workaround, image_->image, &subres, &layout);
         if (layout.size > 0) {


### PR DESCRIPTION
The current layer hits a driver assert (mesa, anv) when calling vkBindImageMemory2 on an image with `VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`. This happens because the layer queries subresource layouts with invalid aspect bits (only `VK_IMAGE_ASPECT_MEMORY_PLANE_*_BIT_EXT` would be allowed).
The issue can be reproduced with existing tests from positivelayertests.