### PR TITLE
layers: add settings to the layer manifest

### DIFF
--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -1,52 +1,502 @@
 {
-    "file_format_version" : "1.1.0",
-    "layer" : {
+    "file_format_version" : "1.2.0",
+    "layer": {
         "name": "VK_LAYER_KHRONOS_validation",
         "type": "GLOBAL",
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
         "implementation_version": "1",
         "description": "Khronos Validation Layer",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html",
         "instance_extensions": [
-             {
-                 "name": "VK_EXT_debug_report",
-                 "spec_version": "9"
-             },
-             {
-                 "name": "VK_EXT_debug_utils",
-                 "spec_version": "1"
-             },
-             {
-                 "name": "VK_EXT_validation_features",
-                 "spec_version": "2"
-             }
-         ],
+            {
+                "name": "VK_EXT_debug_report",
+                "spec_version": "9"
+            },
+            {
+                "name": "VK_EXT_debug_utils",
+                "spec_version": "1"
+            },
+            {
+                "name": "VK_EXT_validation_features",
+                "spec_version": "2"
+            }
+        ],
         "device_extensions": [
-             {
-                 "name": "VK_EXT_debug_marker",
-                 "spec_version": "4",
-                 "entrypoints": ["vkDebugMarkerSetObjectTagEXT",
-                        "vkDebugMarkerSetObjectNameEXT",
-                        "vkCmdDebugMarkerBeginEXT",
-                        "vkCmdDebugMarkerEndEXT",
-                        "vkCmdDebugMarkerInsertEXT"
-                       ]
-             },
-             {
-                 "name": "VK_EXT_validation_cache",
-                 "spec_version": "1",
-                 "entrypoints": ["vkCreateValidationCacheEXT",
-                         "vkDestroyValidationCacheEXT",
-                         "vkGetValidationCacheDataEXT",
-                         "vkMergeValidationCachesEXT"
+            {
+                "name": "VK_EXT_debug_marker",
+                "spec_version": "4",
+                "entrypoints": [
+                    "vkDebugMarkerSetObjectTagEXT",
+                    "vkDebugMarkerSetObjectNameEXT",
+                    "vkCmdDebugMarkerBeginEXT",
+                    "vkCmdDebugMarkerEndEXT",
+                    "vkCmdDebugMarkerInsertEXT"
+                ]
+            },
+            {
+                "name": "VK_EXT_validation_cache",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkCreateValidationCacheEXT",
+                    "vkDestroyValidationCacheEXT",
+                    "vkGetValidationCacheDataEXT",
+                    "vkMergeValidationCachesEXT"
+                ]
+            },
+            {
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
+            }
+        ],
+        "presets": [
+            {
+                "label": "Standard",
+                "description": "Good default validation setup that balance validation coverage and performance.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": []
+                    },
+                    {
+                        "key": "disables",
+                        "value": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]
+                    }
+                ]
+            },
+            {
+                "label": "Reduced-Overhead",
+                "description": "Disables some checks in the interest of better performance.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "editor_state": "01110111111111111111111001111111111110",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": [
                         ]
-             },
-             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
+                    },
+                    {
+                        "key": "disables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                            "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
+                            "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
+                            "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
+                            "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
+                            "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
+                            "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE"
                         ]
-             }
-         ]
+                    }
+                ]
+            },
+            {
+                "label": "Best Practices",
+                "description": "Provides warnings about potential API misuse but valid usages of the API.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT"
+                        ]
+                    },
+                    {
+                        "key": "disables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                        ]
+                    }
+                ]
+            },
+            {
+                "label": "Synchronization",
+                "description": "Identify resource access conflicts due to missing or incorrect synchronization operations between actions reading or writing the same regions of memory.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT"
+                        ]
+                    },
+                    {
+                        "key": "disables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                        ]
+                    }
+                ]
+            },
+            {
+                "label": "GPU-Assisted",
+                "description": "Check for API usage errors at shader execution time.",
+                "platforms": [ "WINDOWS", "LINUX" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
+                            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"
+                        ]
+                    },
+                    {
+                        "key": "disables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                        ]
+                    }
+                ]
+            },
+            {
+                "label": "Shader Printf",
+                "description": "Debug shader code by \"printing\" any values of interest to the debug callback or stdout.",
+                "platforms": [ "WINDOWS", "LINUX" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "enables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT"
+                        ]
+                    },
+                    {
+                        "key": "disables",
+                        "value": [
+                            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "settings": [
+            {
+                "key": "debug_action",
+                "label": "Debug Action",
+                "description": "This indicates what action is to be taken when a layer wants to report information",
+                "type": "FLAGS",
+                "flags": [
+                    {
+                        "key": "VK_DBG_LAYER_ACTION_LOG_MSG",
+                        "label": "Log Message",
+                        "description": "Log a txt message to stdout or to a log filename.",
+                        "settings": [
+                            {
+                                "key": "log_filename",
+                                "label": "Log Filename",
+                                "description": "Specifies the output filename",
+                                "type": "SAVE_FILE",
+                                "default": "stdout",
+                                "dependence": {
+                                    "mode": "ALL",
+                                    "settings": [
+                                        {
+                                            "key": "debug_action",
+                                            "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "key": "VK_DBG_LAYER_ACTION_CALLBACK",
+                        "label": "Callback",
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
+                    },
+                    {
+                        "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
+                        "label": "Debug Output",
+                        "description": "Log a txt message using the Windows OutputDebugString function."
+                    },
+                    {
+                        "key": "VK_DBG_LAYER_ACTION_BREAK",
+                        "label": "Break",
+                        "description": "Trigger a breakpoint if a debugger is in use."
+                    }
+                ],
+                "default": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ]
+            },
+            {
+                "key": "report_flags",
+                "label": "Message Severity",
+                "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
+                "type": "FLAGS",
+                "flags": [
+                    {
+                        "key": "info",
+                        "label": "Info",
+                        "description": "Report informational messages."
+                    },
+                    {
+                        "key": "warn",
+                        "label": "Warning",
+                        "description": "Report warnings from using the API in a manner which may lead to undefined behavior or to warn the user of common trouble spots. A warning does NOT necessarily signify illegal application behavior."
+                    },
+                    {
+                        "key": "perf",
+                        "label": "performance",
+                        "description": "Report using the API in a way that may cause suboptimal performance."
+                    },
+                    {
+                        "key": "error",
+                        "label": "Error",
+                        "description": "Report errors in API usage."
+                    },
+                    {
+                        "key": "debug",
+                        "label": "Debug",
+                        "description": "For layer development. Report messages for debugging layer behavior."
+                    }
+                ],
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
+            },
+            {
+                "key": "duplicate_message_limit",
+                "label": "Duplicated Messages Limit",
+                "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
+                "type": "INT",
+                "default": 10,
+                "range": {
+                    "min": 0
+                }
+            },
+            {
+                "key": "message_id_filter",
+                "label": "Mute Message VUIDs",
+                "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
+                "type": "LIST",
+                "default": []
+            },
+            {
+                "key": "disables",
+                "label": "Disables",
+                "description": "Setting an option here will disable areas of validation",
+                "type": "FLAGS",
+                "flags": [
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                        "label": "Thread Safety",
+                        "description": "Thread checks. It may help with performance to run with thread-checking disabled most of the time, enabling it occasionally for a quick sanity check, or when debugging difficult application behaviors."
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                        "label": "Stateless Parameter",
+                        "description": "Stateless parameter checks. This may not always be necessary late in a development cycle."
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                        "label": "Object Lifetime",
+                        "description": "Object tracking checks. This may not always be necessary late in a development cycle."
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",
+                        "label": "Core",
+                        "description": "The main, heavy-duty validation checks. This may be valuable early in the development cycle to reduce validation output while correcting parameter/object usage errors."
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                        "label": "Handle Wrapping",
+                        "description": "Handle wrapping checks. Disable this feature if you are running into crashes when authoring new extensions or developing new Vulkan objects/structures"
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
+                        "label": "Disable Shaders",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
+                        "label": "Command Buffer State",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
+                        "label": "Image Layout",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
+                        "label": "Query",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
+                        "label": "Push Constant Range",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
+                        "label": "Object in Use",
+                        "description": "",
+                        "view": "ADVANCED"
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
+                        "label": "Idle Descritor Set",
+                        "description": "",
+                        "view": "ADVANCED"
+                    }
+                ],
+                "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]
+            },
+            {
+                "key": "enables",
+                "label": "Enables",
+                "description": "Setting an option here will enable specialized areas of validation",
+                "type": "FLAGS",
+                "flags": [
+                    {
+                        "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",
+                        "label": "Synchronization",
+                        "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
+                        "url": "${LUNARG_SDK}/synchronization_usage.html",
+                        "status": "STABLE",
+                        "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
+                        "label": "Debug Printf",
+                        "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
+                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "status": "STABLE",
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "printf_to_stdout",
+                                "label": "Printf to stdout",
+                                "description": "To redirect Debug Printf messages from the debug callback to stdout",
+                                "type": "BOOL",
+                                "default": true,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_verbose",
+                                "label": "Verbose",
+                                "description": "Verbosity of debug printf messages",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_buffer_size",
+                                "label": "Printf buffer size",
+                                "description": "The size in bytes of the buffer used by debug printf",
+                                "type": "INT",
+                                "default": 1024,
+                                "range": {
+                                    "min": 128,
+                                    "max": 1048576
+                                },
+                                "unit": "bytes",
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
+                        "label": "GPU-Assisted",
+                        "description": "Check for API usage errors at shader execution time",
+                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "gpuav_buffer_oob",
+                                "label": "Check Out of Bounds ",
+                                "description": "Enable buffer out of bounds checking",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
+                        "label": "Reserve Descriptor Set Binding Slot",
+                        "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
+                        "platforms": [ "WINDOWS", "LINUX" ]
+                    },
+                    {
+                        "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
+                        "label": "Best Practices",
+                        "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
+                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                    },
+                    {
+                        "key": "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM",
+                        "label": "ARM-specific best practices",
+                        "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
+                        "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                    }
+                ],
+                "default": []
+            }
+        ]
     }
 }

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -462,7 +462,7 @@
                                 "label": "Check Out of Bounds ",
                                 "description": "Enable buffer out of bounds checking",
                                 "type": "BOOL",
-                                "default": false,
+                                "default": true,
                                 "dependence": {
                                     "mode": "ANY",
                                     "settings": [


### PR DESCRIPTION
Surrender validation layer settings to validation layers developers.

Vulkan Configurator will use these settings when loading the validation layer.

The settings are data-driven except for the "validation areas". If you want to add a new setting in this section, you still need to contact me. The rest you are fully in control.

![validation](https://user-images.githubusercontent.com/62888873/114589498-03e8b600-9c88-11eb-98e4-468cd51b5138.gif)
