### PR TITLE
layers: Use LvlInitStruct

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1943,9 +1943,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                     skip |= ValidateSampleLocationsInfo(&sample_location_info, "vkCreateGraphicsPipelines");
                     const VkExtent2D grid_size = sample_location_info.sampleLocationGridSize;
 
-                    VkMultisamplePropertiesEXT multisample_prop;
-                    multisample_prop.sType = VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT;
-                    multisample_prop.pNext = nullptr;
+                    auto multisample_prop = LvlInitStruct<VkMultisamplePropertiesEXT>();
                     DispatchGetPhysicalDeviceMultisamplePropertiesEXT(physical_device, multisample_state->rasterizationSamples,
                                                                       &multisample_prop);
                     const VkExtent2D max_grid_size = multisample_prop.maxSampleLocationGridSize;
@@ -3555,8 +3553,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         }
 
         // Collect external buffer info
-        VkPhysicalDeviceExternalBufferInfo pdebi = {};
-        pdebi.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO;
+        auto pdebi = LvlInitStruct<VkPhysicalDeviceExternalBufferInfo>();
         pdebi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
         if (AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE & ahb_desc.usage) {
             pdebi.usage |= ahb_usage_map_a2v[AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE];
@@ -3564,21 +3561,16 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         if (AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER & ahb_desc.usage) {
             pdebi.usage |= ahb_usage_map_a2v[AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER];
         }
-        VkExternalBufferProperties ext_buf_props = {};
-        ext_buf_props.sType = VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES;
-        ext_buf_props.pNext = nullptr;
+        auto ext_buf_props = LvlInitStruct<VkExternalBufferProperties>();
         DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &pdebi, &ext_buf_props);
 
         //  If buffer is not NULL, Android hardware buffers must be supported for import, as reported by
         //  VkExternalImageFormatProperties or VkExternalBufferProperties.
         if (0 == (ext_buf_props.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
             // Collect external format info
-            VkPhysicalDeviceExternalImageFormatInfo pdeifi = {};
-            pdeifi.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+            auto pdeifi = LvlInitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
             pdeifi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-            VkPhysicalDeviceImageFormatInfo2 pdifi2 = {};
-            pdifi2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
-            pdifi2.pNext = &pdeifi;
+            auto pdifi2 = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2>(&pdeifi);
             if (0 < ahb_format_map_a2v.count(ahb_desc.format)) pdifi2.format = ahb_format_map_a2v[ahb_desc.format];
             pdifi2.type = VK_IMAGE_TYPE_2D;           // Seems likely
             pdifi2.tiling = VK_IMAGE_TILING_OPTIMAL;  // Ditto
@@ -3595,11 +3587,8 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
                 pdifi2.flags |= ahb_create_map_a2v[AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT];
             }
 
-            VkExternalImageFormatProperties ext_img_fmt_props = {};
-            ext_img_fmt_props.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
-            VkImageFormatProperties2 ifp2 = {};
-            ifp2.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
-            ifp2.pNext = &ext_img_fmt_props;
+            auto ext_img_fmt_props = LvlInitStruct<VkExternalImageFormatProperties>();
+            auto ifp2 = LvlInitStruct<VkImageFormatProperties2>(&ext_img_fmt_props);
 
             VkResult fmt_lookup_result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &pdifi2, &ifp2);
 
@@ -3612,11 +3601,8 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         }
 
         // Retrieve buffer and format properties of the provided AHardwareBuffer
-        VkAndroidHardwareBufferFormatPropertiesANDROID ahb_format_props = {};
-        ahb_format_props.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID;
-        VkAndroidHardwareBufferPropertiesANDROID ahb_props = {};
-        ahb_props.sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID;
-        ahb_props.pNext = &ahb_format_props;
+        auto ahb_format_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+        auto ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_format_props);
         DispatchGetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &ahb_props);
 
         // allocationSize must be the size returned by vkGetAndroidHardwareBufferPropertiesANDROID for the Android hardware buffer
@@ -5160,9 +5146,7 @@ bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelin
                          "vkGetPipelineExecutableStatisticsKHR called when pipelineExecutableInfo feature is not enabled.");
     }
 
-    VkPipelineInfoKHR pi = {};
-    pi.sType = VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR;
-    pi.pNext = nullptr;
+    auto pi = LvlInitStruct<VkPipelineInfoKHR>();
     pi.pipeline = pExecutableInfo->pipeline;
 
     // We could probably cache this instead of fetching it every time
@@ -12038,9 +12022,7 @@ bool CoreChecks::PreCallValidateBindImageMemory(VkDevice device, VkImage image, 
         }
     }
 
-    VkBindImageMemoryInfo bind_info = {};
-    bind_info.sType = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
-    bind_info.pNext = nullptr;
+    auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>();
     bind_info.image = image;
     bind_info.memory = mem;
     bind_info.memoryOffset = memoryOffset;
@@ -12354,9 +12336,7 @@ bool CoreChecks::PreCallValidateImportFenceFdKHR(VkDevice device, const VkImport
 }
 
 static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(VkSwapchainCreateInfoKHR const *pCreateInfo) {
-    VkImageCreateInfo result = {};
-    result.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    result.pNext = nullptr;
+    auto result = LvlInitStruct<VkImageCreateInfo>();
 
     if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) {
         result.flags |= VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -907,20 +907,19 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
         vmaUnmapMemory(vmaAllocator, output_block.allocation);
     }
 
-    VkWriteDescriptorSet desc_writes[1] = {};
+    auto desc_writes = LvlInitStruct<VkWriteDescriptorSet>();
     const uint32_t desc_count = 1;
 
     // Write the descriptor
     output_desc_buffer_info.buffer = output_block.buffer;
     output_desc_buffer_info.offset = 0;
 
-    desc_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    desc_writes[0].descriptorCount = 1;
-    desc_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    desc_writes[0].pBufferInfo = &output_desc_buffer_info;
-    desc_writes[0].dstSet = desc_sets[0];
-    desc_writes[0].dstBinding = 3;
-    DispatchUpdateDescriptorSets(device, desc_count, desc_writes, 0, NULL);
+    desc_writes.descriptorCount = 1;
+    desc_writes.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    desc_writes.pBufferInfo = &output_desc_buffer_info;
+    desc_writes.dstSet = desc_sets[0];
+    desc_writes.dstBinding = 3;
+    DispatchUpdateDescriptorSets(device, desc_count, &desc_writes, 0, NULL);
 
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const auto *pipeline_state = cb_node->lastBound[lv_bind_point].pipeline_state;

--- a/layers/generated/vk_typemap_helper.h
+++ b/layers/generated/vk_typemap_helper.h
@@ -4557,6 +4557,7 @@ template <typename T> T LvlInitStruct(void *p_next) {
 template <typename T> T LvlInitStruct() {
     T out = {};
     out.sType = LvlTypeMap<T>::kSType;
+    out.pNext = nullptr;
     return out;
 }
 
@@ -4588,6 +4589,7 @@ template <typename T> T lvl_init_struct(void *p_next) {
 template <typename T> T lvl_init_struct() {
     T out = {};
     out.sType = LvlTypeMap<T>::kSType;
+    out.pNext = nullptr;
     return out;
 }
 

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -102,9 +102,7 @@ VkResult UtilDescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescripto
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
             pool_count * numBindingsInSet,
         };
-        VkDescriptorPoolCreateInfo desc_pool_info = {};
-        desc_pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        desc_pool_info.pNext = NULL;
+        auto desc_pool_info = LvlInitStruct<VkDescriptorPoolCreateInfo>();
         desc_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
         desc_pool_info.maxSets = pool_count;
         desc_pool_info.poolSizeCount = 1;

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -236,9 +236,8 @@ void UtilPreCallRecordPipelineCreations(uint32_t count, const CreateInfo *pCreat
                 const SHADER_MODULE_STATE *shader =
                     object_ptr->GetShaderModuleState(Accessor::GetShaderModule(pCreateInfos[pipeline], stage));
 
-                VkShaderModuleCreateInfo create_info = {};
                 VkShaderModule shader_module;
-                create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+                auto create_info = LvlInitStruct<VkShaderModuleCreateInfo>();
                 create_info.pCode = shader->words.data();
                 create_info.codeSize = shader->words.size() * sizeof(uint32_t);
                 VkResult result = DispatchCreateShaderModule(object_ptr->device, &create_info, pAllocator, &shader_module);
@@ -400,8 +399,7 @@ void UtilSubmitBarrier(VkQueue queue, ObjectType *object_ptr) {
 
         VkResult result = VK_SUCCESS;
 
-        VkCommandPoolCreateInfo pool_create_info = {};
-        pool_create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        auto pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
         pool_create_info.queueFamilyIndex = queue_family_index;
         result = DispatchCreateCommandPool(object_ptr->device, &pool_create_info, nullptr,
                                            &queue_barrier_command_info.barrier_command_pool);
@@ -411,8 +409,7 @@ void UtilSubmitBarrier(VkQueue queue, ObjectType *object_ptr) {
             return;
         }
 
-        VkCommandBufferAllocateInfo buffer_alloc_info = {};
-        buffer_alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        auto buffer_alloc_info = LvlInitStruct<VkCommandBufferAllocateInfo>();
         buffer_alloc_info.commandPool = queue_barrier_command_info.barrier_command_pool;
         buffer_alloc_info.commandBufferCount = 1;
         buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -430,12 +427,10 @@ void UtilSubmitBarrier(VkQueue queue, ObjectType *object_ptr) {
         object_ptr->vkSetDeviceLoaderData(object_ptr->device, queue_barrier_command_info.barrier_command_buffer);
 
         // Record a global memory barrier to force availability of device memory operations to the host domain.
-        VkCommandBufferBeginInfo command_buffer_begin_info = {};
-        command_buffer_begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        auto command_buffer_begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
         result = DispatchBeginCommandBuffer(queue_barrier_command_info.barrier_command_buffer, &command_buffer_begin_info);
         if (result == VK_SUCCESS) {
-            VkMemoryBarrier memory_barrier = {};
-            memory_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            auto memory_barrier = LvlInitStruct<VkMemoryBarrier>();
             memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
             memory_barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
 
@@ -447,8 +442,7 @@ void UtilSubmitBarrier(VkQueue queue, ObjectType *object_ptr) {
 
     UtilQueueBarrierCommandInfo &queue_barrier_command_info = queue_barrier_command_info_it.first->second;
     if (queue_barrier_command_info.barrier_command_buffer != VK_NULL_HANDLE) {
-        VkSubmitInfo submit_info = {};
-        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        auto submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &queue_barrier_command_info.barrier_command_buffer;
         DispatchQueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -363,8 +363,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     VkBuffer vbo = VK_NULL_HANDLE;
     VmaAllocation vbo_allocation = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        VkBufferCreateInfo vbo_ci = {};
-        vbo_ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        auto vbo_ci = LvlInitStruct<VkBufferCreateInfo>();
         vbo_ci.size = sizeof(float) * 9;
         vbo_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
 
@@ -393,8 +392,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     VkBuffer ibo = VK_NULL_HANDLE;
     VmaAllocation ibo_allocation = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        VkBufferCreateInfo ibo_ci = {};
-        ibo_ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        auto ibo_ci = LvlInitStruct<VkBufferCreateInfo>();
         ibo_ci.size = sizeof(uint32_t) * 3;
         ibo_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
 
@@ -420,10 +418,9 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
         }
     }
 
-    VkGeometryNV geometry = {};
-    geometry.sType = VK_STRUCTURE_TYPE_GEOMETRY_NV;
+    auto geometry = LvlInitStruct<VkGeometryNV>();
     geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_NV;
-    geometry.geometry.triangles.sType = VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV;
+    geometry.geometry.triangles = LvlInitStruct<VkGeometryTrianglesNV>();
     geometry.geometry.triangles.vertexData = vbo;
     geometry.geometry.triangles.vertexOffset = 0;
     geometry.geometry.triangles.vertexCount = 3;
@@ -435,13 +432,10 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     geometry.geometry.triangles.indexType = VK_INDEX_TYPE_UINT32;
     geometry.geometry.triangles.transformData = VK_NULL_HANDLE;
     geometry.geometry.triangles.transformOffset = 0;
-    geometry.geometry.aabbs = {};
-    geometry.geometry.aabbs.sType = VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV;
+    geometry.geometry.aabbs = LvlInitStruct<VkGeometryAABBNV>();
 
-    VkAccelerationStructureCreateInfoNV as_ci = {};
-    as_ci.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV;
-    as_ci.info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
-    as_ci.info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;
+    auto as_ci = LvlInitStruct<VkAccelerationStructureCreateInfoNV>();
+    as_ci.info = LvlInitStruct<VkAccelerationStructureInfoNV>();
     as_ci.info.instanceCount = 0;
     as_ci.info.geometryCount = 1;
     as_ci.info.pGeometries = &geometry;
@@ -455,8 +449,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
 
     VkMemoryRequirements2 as_mem_requirements = {};
     if (result == VK_SUCCESS) {
-        VkAccelerationStructureMemoryRequirementsInfoNV as_mem_requirements_info = {};
-        as_mem_requirements_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV;
+        auto as_mem_requirements_info = LvlInitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
         as_mem_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
         as_mem_requirements_info.accelerationStructure = as_validation_state.replacement_as;
 
@@ -477,8 +470,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     }
 
     if (result == VK_SUCCESS) {
-        VkBindAccelerationStructureMemoryInfoNV as_bind_info = {};
-        as_bind_info.sType = VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_NV;
+        auto as_bind_info = LvlInitStruct<VkBindAccelerationStructureMemoryInfoNV>();
         as_bind_info.accelerationStructure = as_validation_state.replacement_as;
         as_bind_info.memory = as_memory_ai.deviceMemory;
         as_bind_info.memoryOffset = as_memory_ai.offset;
@@ -501,8 +493,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
 
     VkMemoryRequirements2 scratch_mem_requirements = {};
     if (result == VK_SUCCESS) {
-        VkAccelerationStructureMemoryRequirementsInfoNV scratch_mem_requirements_info = {};
-        scratch_mem_requirements_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV;
+        auto scratch_mem_requirements_info = LvlInitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
         scratch_mem_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
         scratch_mem_requirements_info.accelerationStructure = as_validation_state.replacement_as;
 
@@ -513,8 +504,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     VkBuffer scratch = VK_NULL_HANDLE;
     VmaAllocation scratch_allocation = {};
     if (result == VK_SUCCESS) {
-        VkBufferCreateInfo scratch_ci = {};
-        scratch_ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        auto scratch_ci = LvlInitStruct<VkBufferCreateInfo>();
         scratch_ci.size = scratch_mem_requirements.memoryRequirements.size;
         scratch_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
         VmaAllocationCreateInfo scratch_aci = {};
@@ -529,8 +519,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
 
     VkCommandPool command_pool = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        VkCommandPoolCreateInfo command_pool_ci = {};
-        command_pool_ci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        auto command_pool_ci = LvlInitStruct<VkCommandPoolCreateInfo>();
         command_pool_ci.queueFamilyIndex = 0;
 
         result = DispatchCreateCommandPool(device_gpuav->device, &command_pool_ci, nullptr, &command_pool);
@@ -542,8 +531,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
 
     if (result == VK_SUCCESS) {
-        VkCommandBufferAllocateInfo command_buffer_ai = {};
-        command_buffer_ai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        auto command_buffer_ai = LvlInitStruct<VkCommandBufferAllocateInfo>();
         command_buffer_ai.commandPool = command_pool;
         command_buffer_ai.commandBufferCount = 1;
         command_buffer_ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -559,8 +547,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     }
 
     if (result == VK_SUCCESS) {
-        VkCommandBufferBeginInfo command_buffer_bi = {};
-        command_buffer_bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        auto command_buffer_bi = LvlInitStruct<VkCommandBufferBeginInfo>();
 
         result = DispatchBeginCommandBuffer(command_buffer, &command_buffer_bi);
         if (result != VK_SUCCESS) {
@@ -581,8 +568,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
         // Hook up queue dispatch
         device_gpuav->vkSetDeviceLoaderData(device_gpuav->device, queue);
 
-        VkSubmitInfo submit_info = {};
-        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        auto submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &command_buffer;
         result = DispatchQueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -619,8 +605,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     }
 
     if (result == VK_SUCCESS) {
-        VkPipelineLayoutCreateInfo pipeline_layout_ci = {};
-        pipeline_layout_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        auto pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
         pipeline_layout_ci.setLayoutCount = 1;
         pipeline_layout_ci.pSetLayouts = &device_gpuav->debug_desc_layout;
         result = DispatchCreatePipelineLayout(device_gpuav->device, &pipeline_layout_ci, 0, &as_validation_state.pipeline_layout);
@@ -632,8 +617,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
 
     VkShaderModule shader_module = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        VkShaderModuleCreateInfo shader_module_ci = {};
-        shader_module_ci.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        auto shader_module_ci = LvlInitStruct<VkShaderModuleCreateInfo>();
         shader_module_ci.codeSize = sizeof(kComputeShaderSpirv);
         shader_module_ci.pCode = (uint32_t *)kComputeShaderSpirv;
 
@@ -645,14 +629,12 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(GpuAssisted *d
     }
 
     if (result == VK_SUCCESS) {
-        VkPipelineShaderStageCreateInfo pipeline_stage_ci = {};
-        pipeline_stage_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        auto pipeline_stage_ci = LvlInitStruct<VkPipelineShaderStageCreateInfo>();
         pipeline_stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
         pipeline_stage_ci.module = shader_module;
         pipeline_stage_ci.pName = "main";
 
-        VkComputePipelineCreateInfo pipeline_ci = {};
-        pipeline_ci.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        auto pipeline_ci = LvlInitStruct<VkComputePipelineCreateInfo>();
         pipeline_ci.stage = pipeline_stage_ci;
         pipeline_ci.layout = as_validation_state.pipeline_layout;
 
@@ -807,8 +789,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
         // Two uint for each current valid handle
         (8 * current_valid_handles.size());
 
-    VkBufferCreateInfo validation_buffer_create_info = {};
-    validation_buffer_create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    auto validation_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     validation_buffer_create_info.size = validation_buffer_size;
     validation_buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -874,14 +855,15 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
     descriptor_buffer_infos[1].offset = 0;
     descriptor_buffer_infos[1].range = validation_buffer_size;
 
-    VkWriteDescriptorSet descriptor_set_writes[2] = {};
-    descriptor_set_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    VkWriteDescriptorSet descriptor_set_writes[2] = {
+        LvlInitStruct<VkWriteDescriptorSet>(),
+        LvlInitStruct<VkWriteDescriptorSet>(),
+    };
     descriptor_set_writes[0].dstSet = as_validation_buffer_info.descriptor_set;
     descriptor_set_writes[0].dstBinding = 0;
     descriptor_set_writes[0].descriptorCount = 1;
     descriptor_set_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     descriptor_set_writes[0].pBufferInfo = &descriptor_buffer_infos[0];
-    descriptor_set_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_set_writes[1].dstSet = as_validation_buffer_info.descriptor_set;
     descriptor_set_writes[1].dstBinding = 1;
     descriptor_set_writes[1].descriptorCount = 1;
@@ -891,8 +873,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
     DispatchUpdateDescriptorSets(device, 2, descriptor_set_writes, 0, nullptr);
 
     // Issue a memory barrier to make sure anything writing to the instance buffer has finished.
-    VkMemoryBarrier memory_barrier = {};
-    memory_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    auto memory_barrier = LvlInitStruct<VkMemoryBarrier>();
     memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
     DispatchCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1,
@@ -910,8 +891,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
 
     // Issue a buffer memory barrier to make sure that any invalid bottom level acceleration structure handles
     // have been replaced by the validation compute shader before any builds take place.
-    VkBufferMemoryBarrier instance_buffer_barrier = {};
-    instance_buffer_barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+    auto instance_buffer_barrier = LvlInitStruct<VkBufferMemoryBarrier>();
     instance_buffer_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
     instance_buffer_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_NV;
     instance_buffer_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1951,7 +1931,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
             di_input_desc_buffer_info.buffer = di_input_block.buffer;
             di_input_desc_buffer_info.offset = 0;
 
-            desc_writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            desc_writes[1] = LvlInitStruct<VkWriteDescriptorSet>();
             desc_writes[1].dstBinding = 1;
             desc_writes[1].descriptorCount = 1;
             desc_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -2007,7 +1987,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
         bda_input_desc_buffer_info.buffer = bda_input_block.buffer;
         bda_input_desc_buffer_info.offset = 0;
 
-        desc_writes[desc_count].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        desc_writes[desc_count] = LvlInitStruct<VkWriteDescriptorSet>();
         desc_writes[desc_count].dstBinding = 2;
         desc_writes[desc_count].descriptorCount = 1;
         desc_writes[desc_count].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -2020,7 +2000,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     output_desc_buffer_info.buffer = output_block.buffer;
     output_desc_buffer_info.offset = 0;
 
-    desc_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    desc_writes[0] = LvlInitStruct<VkWriteDescriptorSet>();
     desc_writes[0].descriptorCount = 1;
     desc_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     desc_writes[0].pBufferInfo = &output_desc_buffer_info;

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -366,8 +366,7 @@ static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags ms
     std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_info;
     object_name_info.resize(objects.object_list.size());
     for (uint32_t i = 0; i < objects.object_list.size(); i++) {
-        object_name_info[i].sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-        object_name_info[i].pNext = NULL;
+        object_name_info[i] = LvlInitStruct<VkDebugUtilsObjectNameInfoEXT>();
         object_name_info[i].objectType = ConvertVulkanObjectToCoreObject(objects.object_list[i].type);
         object_name_info[i].objectHandle = objects.object_list[i].handle;
         object_name_info[i].pObjectName = NULL;
@@ -408,9 +407,7 @@ static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags ms
         location = XXH32(text_vuid, strlen(text_vuid), 8);
     }
 
-    VkDebugUtilsMessengerCallbackDataEXT callback_data;
-    callback_data.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
-    callback_data.pNext = NULL;
+    auto callback_data = LvlInitStruct<VkDebugUtilsMessengerCallbackDataEXT>();
     callback_data.flags = 0;
     callback_data.pMessageIdName = text_vuid;
     callback_data.messageIdNumber = static_cast<int32_t>(location);

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -106,9 +106,7 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
     LogMessageTypeFlags report_flags = GetLayerOptionFlags(report_flags_key, log_msg_type_option_definitions, 0);
     VkLayerDbgActionFlags debug_action = GetLayerOptionFlags(debug_action_key, debug_actions_option_definitions, 0);
     // Flag as default if these settings are not from a vk_layer_settings.txt file
-    VkDebugUtilsMessengerCreateInfoEXT dbg_create_info;
-    memset(&dbg_create_info, 0, sizeof(dbg_create_info));
-    dbg_create_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+    auto dbg_create_info = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
     dbg_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     if (report_flags & kErrorBit) {
         dbg_create_info.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
@@ -174,9 +172,7 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
     if (debug_action & VK_DBG_LAYER_ACTION_LOG_MSG) {
         const char *log_filename = getLayerOption(log_filename_key.c_str());
         FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
-        VkDebugReportCallbackCreateInfoEXT dbg_create_info;
-        memset(&dbg_create_info, 0, sizeof(dbg_create_info));
-        dbg_create_info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
+        auto dbg_create_info = LvlInitStruct<VkDebugReportCallbackCreateInfoEXT>();
         dbg_create_info.flags = report_flags;
         dbg_create_info.pfnCallback = report_log_callback;
         dbg_create_info.pUserData = (void *)log_output;
@@ -186,9 +182,7 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
     callback = VK_NULL_HANDLE;
 
     if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
-        VkDebugReportCallbackCreateInfoEXT dbg_create_info;
-        memset(&dbg_create_info, 0, sizeof(dbg_create_info));
-        dbg_create_info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
+        auto dbg_create_info = LvlInitStruct<VkDebugReportCallbackCreateInfoEXT>();
         dbg_create_info.flags = report_flags;
         dbg_create_info.pfnCallback = report_win32_debug_output_msg;
         dbg_create_info.pUserData = NULL;
@@ -198,9 +192,7 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
     callback = VK_NULL_HANDLE;
 
     if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {
-        VkDebugReportCallbackCreateInfoEXT dbg_create_info;
-        memset(&dbg_create_info, 0, sizeof(dbg_create_info));
-        dbg_create_info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
+        auto dbg_create_info = LvlInitStruct<VkDebugReportCallbackCreateInfoEXT>();
         dbg_create_info.flags = report_flags;
         dbg_create_info.pfnCallback = DebugBreakCallback;
         dbg_create_info.pUserData = NULL;

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -1848,6 +1848,7 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
             'template <typename T> T {init_func}() {{',
             '    T out = {{}};',
             '    out.sType = {type_map}<T>::kSType;',
+            '    out.pNext = nullptr;',
             '    return out;',
             '}}',
 


### PR DESCRIPTION
Use LvlInitStruct to initialize "sType" structures to ensure pNext is
initialized as null.

Closes #2628.