### PR TITLE
Fix Handle <-> uint64 logic

### DIFF
--- a/layers/generated/vk_object_types.h
+++ b/layers/generated/vk_object_types.h
@@ -841,7 +841,7 @@ struct VulkanTypedHandle {
         return CastFromUint64<Handle>(handle);
     }
     VulkanTypedHandle() :
-        handle(VK_NULL_HANDLE),
+        handle(CastToUint64(VK_NULL_HANDLE)),
         type(kVulkanObjectTypeUnknown),
         node(nullptr) {}
 };

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
- * Copyright (C) 2015-2020 Google Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,17 +69,17 @@ bool ObjectLifetimes::ValidateDeviceObject(const VulkanTypedHandle &device_typed
     return LogError(instance, invalid_handle_code, "Invalid %s.", report_data->FormatHandle(device_typed).c_str());
 }
 
-bool ObjectLifetimes::ValidateAnonymousObject(uint64_t object_handle, VkObjectType core_object_type, bool null_allowed,
+bool ObjectLifetimes::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, bool null_allowed,
                                               const char *invalid_handle_code, const char *wrong_device_code) const {
-    if (null_allowed && (object_handle == VK_NULL_HANDLE)) return false;
+    if (null_allowed && (object == HandleToUint64(VK_NULL_HANDLE))) return false;
     auto object_type = ConvertCoreObjectToVulkanObject(core_object_type);
 
     if (object_type == kVulkanObjectTypeDevice) {
-        return ValidateDeviceObject(VulkanTypedHandle(reinterpret_cast<VkDevice>(object_handle), object_type), invalid_handle_code,
+        return ValidateDeviceObject(VulkanTypedHandle(reinterpret_cast<VkDevice>(object), object_type), invalid_handle_code,
                                     wrong_device_code);
     }
 
-    return CheckObjectValidity(object_handle, object_type, null_allowed, invalid_handle_code, wrong_device_code);
+    return CheckObjectValidity(object, object_type, null_allowed, invalid_handle_code, wrong_device_code);
 }
 
 void ObjectLifetimes::AllocateCommandBuffer(const VkCommandPool command_pool, const VkCommandBuffer command_buffer,

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -1204,7 +1204,7 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
                     return CastFromUint64<Handle>(handle);
                 }
                 VulkanTypedHandle() :
-                    handle(VK_NULL_HANDLE),
+                    handle(CastToUint64(VK_NULL_HANDLE)),
                     type(kVulkanObjectTypeUnknown),
                     node(nullptr) {}
             }; ''')  +'\n'


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-Headers/commit/e01b00657664ac34389d51b04c58dff3eb19a026 fixed some broken logic around `VK_DEFINE_NON_DISPATCHABLE_HANDLE`  that was causing `VK_NULL_HANDLE` to always be defined as `0`.
`VK_NULL_HANDLE` is now correctly defined as `nullptr`, `((void*)0)`, `0ULL` or `0`.

This has exposed some type mismatches in the VVL, which this change fixes.