### PR TITLE
Add check destroying presentable image

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2306,6 +2306,13 @@ bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, con
     const VulkanTypedHandle obj_struct(image, kVulkanObjectTypeImage);
     bool skip = false;
     if (image_state) {
+        if (image_state->is_swapchain_image) {
+            // TODO - Add VUID when headers are upstreamed
+            skip |= LogError(device, "UNASSIGNED-vkDestroyImage-image",
+                             "vkDestroyImage(): %s is a presentable image and it is controlled by the implementation and is "
+                             "destroyed with vkDestroySwapchainKHR.",
+                             report_data->FormatHandle(image_state->image).c_str());
+        }
         skip |= ValidateObjectNotInUse(image_state, obj_struct, "vkDestroyImage", "VUID-vkDestroyImage-image-01000");
     }
     return skip;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2399,6 +2399,28 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     DestroySwapchain();
 }
 
+TEST_F(VkLayerTest, GetSwapchainImageAndTryDestroy) {
+    TEST_DESCRIPTION("Try destroying a swapchain presentable image with vkDestroyImage");
+
+    if (!AddSurfaceInstanceExtension()) return;
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AddSwapchainDeviceExtension()) return;
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_TRUE(InitSwapchain());
+    uint32_t image_count;
+    std::vector<VkImage> images;
+    ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));
+    images.resize(image_count, VK_NULL_HANDLE);
+    ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, images.data()));
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkDestroyImage-image");
+    vk::DestroyImage(device(), images.at(0), nullptr);
+    m_errorMonitor->VerifyFound();
+
+    DestroySwapchain();
+}
+
 TEST_F(VkLayerTest, NotCheckingForSurfaceSupport) {
     TEST_DESCRIPTION("Test not calling GetPhysicalDeviceSurfaceSupportKHR");
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2718

Was a simple fix so just created this PR quick

Will update VUID when internal MR 4505 is brought into a future header