### PR TITLE
layers: Fix BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -99,6 +99,7 @@ core_validation_sources = [
   "layers/generated/corechecks_optick_instrumentation.h",
   "layers/generated/spirv_validation_helper.cpp",
   "layers/generated/command_validation.cpp",
+  "layers/generated/command_validation.h",
   "layers/generated/synchronization_validation_types.cpp",
   "layers/generated/synchronization_validation_types.h",
   "layers/sync_utils.cpp",


### PR DESCRIPTION
command_validation.h was included by core_validation_types.h in #2728