### PR TITLE
corechecks: Refactor ValidateDescriptorSetBindingData

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -445,6 +445,36 @@ class CoreChecks : public ValidationStateTracker {
                                           const DrawDispatchVuid& vuids,
                                           Optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
 
+    bool ValidateGeneralBufferDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
+                                         const cvdescriptorset::DescriptorSet* descriptor_set,
+                                         const cvdescriptorset::BufferDescriptor& descriptor,
+                                         const std::pair<const uint32_t, DescriptorRequirement>& binding_info,
+                                         uint32_t index) const;
+
+    bool ValidateImageDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
+                                 const cvdescriptorset::DescriptorSet* descriptor_set,
+                                 const cvdescriptorset::ImageDescriptor& image_descriptor,
+                                 const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,
+                                 bool record_time_validate, const std::vector<IMAGE_VIEW_STATE*>* attachments,
+                                 const std::vector<SUBPASS_INFO>& subpasses, VkFramebuffer framebuffer,
+                                 VkDescriptorType descriptor_type,
+                                 Optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+
+    bool ValidateTexelDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
+                                 const cvdescriptorset::DescriptorSet* descriptor_set,
+                                 const cvdescriptorset::TexelDescriptor& texel_descriptor,
+                                 const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index) const;
+
+    bool ValidateAccelerationDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
+                                        const cvdescriptorset::DescriptorSet* descriptor_set,
+                                        const cvdescriptorset::AccelerationStructureDescriptor& descriptor,
+                                        const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index) const;
+
+    bool ValidateSamplerDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
+                                   const cvdescriptorset::DescriptorSet* descriptor_set,
+                                   const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,
+                                   VkSampler sampler, bool is_immutable, const SAMPLER_STATE* sampler_state) const;
+
     // Validate contents of a CopyUpdate
     using DescriptorSet = cvdescriptorset::DescriptorSet;
     bool ValidateCopyUpdate(const VkCopyDescriptorSet* update, const DescriptorSet* dst_set, const DescriptorSet* src_set,

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -473,7 +473,7 @@ class AccelerationStructureDescriptor : public Descriptor {
     ACCELERATION_STRUCTURE_STATE *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
-    bool is_khr() { return is_khr_; }
+    bool is_khr() const { return is_khr_; }
 
   private:
     bool is_khr_;


### PR DESCRIPTION
Split this giant method into separate methods for each type of descriptor.

NOTE: viewing this change with 'ignore whitespace' on will show that no logic is changed in this refactor.