### PR TITLE
cmake: Test CMake minimum requirement

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -78,6 +78,10 @@ jobs:
     - name: Build and Test Vulkan-ValidationLayers 
       run: |
         python3 scripts/github_ci_win_linux.py --config ${{ matrix.config.type }}
+    - name: Test CMake minimum version requirements
+      run: |
+        python3 scripts/cmake_test_min.py
+      if: matrix.config.os == 'ubuntu-latest' && matrix.config.cc == 'gcc'
 
   gn:
     name: ${{ matrix.config.name }}

--- a/scripts/cmake_test_min.py
+++ b/scripts/cmake_test_min.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Nathaniel Cesario <nathaniel@lunarg.com>
+
+# Test to make sure cmake is compliant with minimum version
+# NOTE: this assumes VVL has already been "setup" (update_deps.py has been run, etc.)
+
+import os, platform, subprocess
+from urllib.parse import urlparse
+import utils.utils as utils
+
+curr_platform = platform.system().lower()
+cmake_version = '3.10.2'
+cmake_urls = {
+    'linux': { 'url': f'https://github.com/Kitware/CMake/releases/download/v{cmake_version}/cmake-{cmake_version}-Linux-x86_64.tar.gz', 'dirname': f'cmake-{cmake_version}-Linux-x86_64' },
+    'windows': { 'url': f'https://github.com/Kitware/CMake/releases/download/v{cmake_version}/cmake-{cmake_version}-win64-x64.zip', 'dirname': f'cmake-{cmake_version}-win64-x64' }
+}
+
+#
+# Check if the system is Windows
+def get_cmake_url():
+    try: return cmake_urls[curr_platform]
+    except: raise Exception(f'Unsupported platform: {curr_platform}')
+
+def get_cmake_exe_path(url_info):
+    path = os.path.join(os.getcwd(), url_info['dirname'], 'bin', 'cmake')
+    if curr_platform == 'windows': path = path + '.exe'
+    return path
+
+def get_cmake_args(path):
+    args = [path, '-C', '../external/helper.cmake', '..']
+    if curr_platform == 'windows': args.extend(['-Ax64'])
+    return args
+
+def main():
+    url_info = get_cmake_url()
+    cmake_exe_path = get_cmake_exe_path(url_info)
+
+    if not os.path.exists(cmake_exe_path):
+        url = urlparse(url_info['url'])
+        print(f'cmake minimum version does not exist locally; downloading from {url_info["url"]}')
+        cmake_archive = os.path.basename(url.path)
+        with utils.URLRequest(url) as res:
+            with open(cmake_archive, 'wb') as fd: fd.write(res.read())
+        utils.expand_archive(cmake_archive)
+
+    cmake_build_dir = 'build-cmake-test'
+    utils.make_or_exist_dirs(cmake_build_dir, True)
+    currDir = os.getcwd()
+    cmake_args = get_cmake_args(cmake_exe_path)
+    subprocess.check_call(cmake_args, cwd=cmake_build_dir)
+
+if __name__ == '__main__': main()

--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Nathaniel Cesario <nathaniel@lunarg.com>
+
+# Various utility functions/classes
+
+import os, shutil
+import urllib.parse
+from urllib.parse import urlparse
+import http.client as http
+
+def make_or_exist_dirs(path, clean=False):
+    "Wrapper for os.makedirs that tolerates the directory already existing"
+    # Could use os.makedirs(path, exist_ok=True) if we drop python2
+    if not os.path.isdir(path):
+        os.makedirs(path)
+    elif clean:
+        shutil.rmtree(path)
+        os.makedirs(path)
+
+# Utility for making simple GET requests
+# Usage: with URLRequest('https://example.com/path/to/file.txt') as res: print(res.read().decode('utf-8'))
+# NOTE: May make more sense to just use the requests package (https://pypi.org/project/requests/)
+class URLRequest:
+    def __init__(self, url):
+        self.url = None
+        if type(url) == str: self.url = urlparse(url.strip())
+        elif type(url) == urllib.parse.ParseResult: self.url = url
+        else: raise Exception(f'Unknown URL type: {type(url)}')
+
+        self.conn_ = None
+        self.connect()
+
+        res = self.conn_.getresponse()
+        while res.status == 302:
+            # redirect
+            url = None
+            for h in res.getheaders():
+                if h[0] == 'Location': url = h[1]
+            if url is None: raise Exception('Encountered redirect during request, but did not find redirect location')
+
+            self.conn_.close()
+            self.url = urlparse(url)
+            self.connect()
+            res = self.conn_.getresponse()
+        self.res = res
+
+    def __enter__(self): return self.res
+    def __exit__(self, type, value, tb):
+        self.conn_.close()
+        return False
+
+    def connect(self):
+        if self.url.scheme == 'http': self.conn_ = http.HTTPConnection(self.url.netloc)
+        elif self.url.scheme == 'https': self.conn_ = http.HTTPSConnection(self.url.netloc)
+        else: raise Exception(f'Unknown scheme {self.url.scheme}')
+        self.conn_.request('GET', f'{self.url.path}?{self.url.query}')
+
+    def close(self): self.conn_.close()
+
+# Currently only gzip tar and zip files are supported
+def expand_archive(path):
+    if path.endswith('tar.gz') or path.endswith('tgz'):
+        import tarfile
+        with tarfile.open(path, 'r:gz') as tar: tar.extractall()
+    elif path.endswith('.zip'):
+        import zipfile
+        with zipfile.ZipFile(path, 'r') as archive: archive.extractall('.')
+    else:
+        raise Exception(f'Could not expand archive at {path}')


### PR DESCRIPTION
Add a build step to generate VVL using the minimum required CMake
version. This is to ensure that newer cmake features do not get
introduced, which would break running cmake on the minimum required
version.

Change-Id: I73aff1e141710405744833eda05da234455778ed