### PR TITLE
Fix input-attachment checks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9679,13 +9679,14 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
     // Track when we're observing the first use of an attachment
     std::vector<bool> attach_first_use(pCreateInfo->attachmentCount, true);
-    // Track if attachments are used as input as well as another type
-    layer_data::unordered_set<uint32_t> input_attachments;
 
     for (uint32_t i = 0; i < pCreateInfo->subpassCount; ++i) {
         const VkSubpassDescription2 &subpass = pCreateInfo->pSubpasses[i];
         std::vector<uint8_t> attachment_uses(pCreateInfo->attachmentCount);
         std::vector<VkImageLayout> attachment_layouts(pCreateInfo->attachmentCount);
+
+        // Track if attachments are used as input as well as another type
+        layer_data::unordered_set<uint32_t> input_attachments;
 
         if (subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_GRAPHICS) {
             vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-03062"


### PR DESCRIPTION
It appears the layers will incorrectly flag the following situation:
- Subpass N renders to an attachment (OPTIMAL layout)
- Subpass N+1 reads the attachment as an input attachment (READ_ONLY_OPTIMAL layout)
  * So far so good; no errors. Most use-cases stop here.
- Subpass N+2 renders to the attachment again (OPTIMAL layout)
  * Now a warning is emitted saying the attachment is used as _both_ and input-attachment _and_ a color-attachment, but is not GENERAL layout (as is needed when this is the case). This error is incorrect; the attachment is _not_ used as both input- and color-attachment in this sub-pass, so OPTIMAL layout should be OK.

An example of an incorrect error is:
`04-29 13:47:59.294 21585 21625 I VALIDATION: VUID-VkSubpassDescription2-None-04439(ERROR / SPEC): msgNum: 1708087736 - Validation Error: [ VUID-VkSubpassDescription2-None-04439 ] Object 0: handle = 0x76c7fad8d0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x65cf59b8 | vkCreateRenderPass2KHR(): pSubpasses[2].pColorAttachments[0] is also an input attachment so the layout (VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) must not be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL or VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL_KHR. The Vulkan spec states: Attachments must follow the image layout requirements based on the type of attachment it is being used as (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkSubpassDescription2-None-04439)`

In this case the color attachment is not '_also an input attachment_' (in this sub-pass), and so the error is incorrect. Debugging, it seems the code is tracking input attachment use in _any_ previous subpass -- not just use in the *current* subpass -- hence the use as an attachment in subpass N+2 gets flagged as the attachment was used as an input-attachment in subpass N+1. By moving the `input_attachment` set inside the per-subpass for-loop we avoid this.

The assumption I'm making here is that the layout requirements only apply to an attachment being used in multiple ways inside a particular sub-pass. I'm fairly sure this is the correct reading. If not the one would imagine the use in subpass N+1 should also be flagged -- making most example code using (non-self-depdendency) input attachments wrong -- unless there's something 'special' about input-attachment use which impacts use in later sub-passes. As far as I know this is not the case.