### PR TITLE
Provoking vertex validation

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1545,6 +1545,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features;
     VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features;
     VkPhysicalDeviceInheritedViewportScissorFeaturesNV inherited_viewport_scissor_features;
+    VkPhysicalDeviceProvokingVertexFeaturesEXT provoking_vertex_features;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1467,6 +1467,7 @@ class ValidationStateTracker : public ValidationObject {
         VkPhysicalDeviceMultiviewProperties multiview_props;
         VkPhysicalDevicePortabilitySubsetPropertiesKHR portability_props;
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
+        VkPhysicalDeviceProvokingVertexPropertiesEXT provoking_vertex_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;


### PR DESCRIPTION
closes: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2755

Added two validations.
```
VUID-VkPipelineRasterizationProvokingVertexStateCreateInfoEXT-provokingVertexMode-04883
If provokingVertexMode is VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT, then the provokingVertexLast feature must be enabled
```
```
VUID-vkCmdBindPipeline-pipelineBindPoint-04881
If pipelineBindPoint is VK_PIPELINE_BIND_POINT_GRAPHICS and the provokingVertexModePerPipeline limit is VK_FALSE, then pipeline’s VkPipelineRasterizationProvokingVertexStateCreateInfoEXT::provokingVertexMode must be the same as that of any other pipelines previously bound to this bind point within the current renderpass instance, including any pipeline already bound when beginning the renderpass instance
```
 The extension `VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME` is new. The GPU driver doesn't support it, so the test only can run in mock_icd.
