### PR TITLE
Label VU for color and depthStencil attachments being the same

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9499,9 +9499,15 @@ bool CoreChecks::AddAttachmentUse(RenderPassCreateVersion rp_version, uint32_t s
                              string_VkImageLayout(new_layout));
         }
     } else if (uses & ~ATTACHMENT_INPUT || (uses && (new_use == ATTACHMENT_RESOLVE || new_use == ATTACHMENT_PRESERVE))) {
-        /* Note: input attachments are assumed to be done first. */
-        vuid = use_rp2 ? "VUID-VkSubpassDescription2-pPreserveAttachments-03074"
-                       : "VUID-VkSubpassDescription-pPreserveAttachments-00854";
+        if (new_use == ATTACHMENT_COLOR && (uses & ATTACHMENT_DEPTH)) {
+            // assumes depthStencil attachments are added prior to color
+            vuid = use_rp2 ? "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"
+                           : "VUID-VkSubpassDescription-pDepthStencilAttachment-04438";
+        } else {
+            // assumes input attachments are added prior to preserve
+            vuid = use_rp2 ? "VUID-VkSubpassDescription2-pPreserveAttachments-03074"
+                           : "VUID-VkSubpassDescription-pPreserveAttachments-00854";
+        }
         skip |= LogError(device, vuid, "%s: subpass %u uses attachment %u as both %s and %s attachment.", function_name, subpass,
                          attachment, StringAttachmentType(uses), StringAttachmentType(new_use));
     } else {


### PR DESCRIPTION
Both 
- VUID-VkSubpassDescription2-pDepthStencilAttachment-04440
- VUID-VkSubpassDescription-pDepthStencilAttachment-04438

were added recently to the spec, the code was already there to validate, just needed proper label (and test to verify)