### PR TITLE
Fix: Null pointer dereference in state tracker in PreCallRecordCmdBindPipeline #2770

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -1331,8 +1331,8 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
 
     // For each draw command D recorded to this command buffer, let
     //  * g_D be the graphics pipeline used
-    //  * v_G be the viewportCount of g_D, if g_D disables VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT, 0 otherwise.
-    //  * s_G be the scissorCount  of g_D, if g_D disables VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT,  0 otherwise.
+    //  * v_G be the viewportCount of g_D (0 if g_D disables rasterization or enables VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT)
+    //  * s_G be the scissorCount  of g_D (0 if g_D disables rasterization or enables VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT)
     // Then this value is max(0, max(v_G for all D in cb), max(s_G for all D in cb))
     uint32_t usedViewportScissorCount;
     uint32_t pipelineStaticViewportCount; // v_G for currently-bound graphics pipeline.

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3810,6 +3810,7 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
 
     auto pipe_state = GetPipelineState(pipeline);
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == pipelineBindPoint) {
+        bool rasterization_enabled = VK_FALSE == pipe_state->graphicsPipelineCI.ptr()->pRasterizationState->rasterizerDiscardEnable;
         const auto* viewport_state = pipe_state->graphicsPipelineCI.ptr()->pViewportState;
         const auto* dynamic_state = pipe_state->graphicsPipelineCI.ptr()->pDynamicState;
         cb_state->status &= ~cb_state->static_status;
@@ -3818,28 +3819,29 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
         cb_state->dynamic_status = CBSTATUS_ALL_STATE_SET & (~cb_state->static_status);
 
         // Used to calculate CMD_BUFFER_STATE::usedViewportScissorCount upon draw command with this graphics pipeline.
+        // If rasterization disabled (no viewport/scissors used), or the actual number of viewports/scissors is dynamic (unknown at
+        // this time), then these are set to 0 to disable this checking.
         auto has_dynamic_viewport_count = cb_state->dynamic_status & CBSTATUS_VIEWPORT_WITH_COUNT_SET;
-        auto has_dynamic_scissor_count  = cb_state->dynamic_status & CBSTATUS_SCISSOR_WITH_COUNT_SET;
+        auto has_dynamic_scissor_count = cb_state->dynamic_status & CBSTATUS_SCISSOR_WITH_COUNT_SET;
         cb_state->pipelineStaticViewportCount =
-            has_dynamic_viewport_count ? 0 : pipe_state->graphicsPipelineCI.pViewportState->viewportCount;
+            has_dynamic_viewport_count || !rasterization_enabled ? 0 : viewport_state->viewportCount;
         cb_state->pipelineStaticScissorCount =
-            has_dynamic_scissor_count ? 0 : pipe_state->graphicsPipelineCI.pViewportState->scissorCount;
+            has_dynamic_scissor_count || !rasterization_enabled ? 0 : viewport_state->scissorCount;
 
-        // Trash dynamic viewport/scissor state if pipeline defines static state.
+        // Trash dynamic viewport/scissor state if pipeline defines static state and enabled rasterization.
         // akeley98 NOTE: There's a bit of an ambiguity in the spec, whether binding such a pipeline overwrites
         // the entire viewport (scissor) array, or only the subsection defined by the viewport (scissor) count.
         // I am taking the latter interpretation based on the implementation details of NVIDIA's Vulkan driver.
-        // ncesario-lunarg also points out viewport_state may be null if rasterization is disabled.
         if (!has_dynamic_viewport_count) {
             cb_state->trashedViewportCount = true;
-            if (cb_state->static_status & CBSTATUS_VIEWPORT_SET && viewport_state != nullptr) {
+            if (rasterization_enabled && (cb_state->static_status & CBSTATUS_VIEWPORT_SET)) {
                 cb_state->trashedViewportMask |= (uint32_t(1) << viewport_state->viewportCount) - 1u;
                 // should become = ~uint32_t(0) if the other interpretation is correct.
             }
         }
         if (!has_dynamic_scissor_count) {
             cb_state->trashedScissorCount = true;
-            if (cb_state->static_status & CBSTATUS_SCISSOR_SET && viewport_state != nullptr) {
+            if (rasterization_enabled && (cb_state->static_status & CBSTATUS_SCISSOR_SET)) {
                 cb_state->trashedScissorMask |= (uint32_t(1) << viewport_state->scissorCount) - 1u;
                 // should become = ~uint32_t(0) if the other interpretation is correct.
             }


### PR DESCRIPTION
Change ValidationStateTracker::PreCallRecordCmdBindPipeline so that it doesn't dereference pViewportState when rasterizerDiscardEnable is true.

[  PASSED  ] 900 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] VkLayerTest.DisplayPlaneSurface
[  FAILED  ] VkLayerTest.ValidateImportMemoryHandleType