### PR TITLE
Add missing device queue VUs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -993,6 +993,7 @@ class CoreChecks : public ValidationStateTracker {
                                         VkDeviceSize dataSize, const void* pData) const override;
     bool PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex,
                                        VkQueue* pQueue) const override;
+    bool PreCallValidateGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue) const override;
     bool PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator,
                                                      VkSamplerYcbcrConversion* pYcbcrConversion) const override;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -525,7 +525,6 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
 
     // Validate pCreateInfo->pQueueCreateInfos
     if (pCreateInfo->pQueueCreateInfos) {
-        layer_data::unordered_set<uint32_t> set;
 
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
@@ -537,13 +536,6 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
                              "].queueFamilyIndex is VK_QUEUE_FAMILY_IGNORED, but it is required to provide a valid queue family "
                              "index value.",
                              i);
-            } else if (set.count(requested_queue_family)) {
-                skip |= LogError(physicalDevice, "VUID-VkDeviceCreateInfo-queueFamilyIndex-00372",
-                                 "vkCreateDevice: pCreateInfo->pQueueCreateInfos[%" PRIu32 "].queueFamilyIndex (=%" PRIu32
-                                 ") is not unique within pCreateInfo->pQueueCreateInfos array.",
-                                 i, requested_queue_family);
-            } else {
-                set.insert(requested_queue_family);
             }
 
             if (queue_create_info.pQueuePriorities != nullptr) {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2182,8 +2182,9 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     if (pCreateInfo->pQueueCreateInfos != nullptr) {
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
-            state_tracker->queue_family_index_map.emplace(queue_create_info.queueFamilyIndex, queue_create_info.queueCount);
-            state_tracker->queue_family_create_flags_map.emplace( queue_create_info.queueFamilyIndex, queue_create_info.flags);
+            state_tracker->queue_family_index_set.insert(queue_create_info.queueFamilyIndex);
+            state_tracker->device_queue_info_list.push_back(
+                {i, queue_create_info.queueFamilyIndex, queue_create_info.flags, queue_create_info.queueCount});
         }
     }
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1472,9 +1472,16 @@ class ValidationStateTracker : public ValidationObject {
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;
 
-    // Map for queue family index to queue count
-    layer_data::unordered_map<uint32_t, uint32_t> queue_family_index_map;
-    layer_data::unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_create_flags_map;
+    // tracks which queue family index were used when creating the device for quick lookup
+    layer_data::unordered_set<uint32_t> queue_family_index_set;
+    // The queue count can different for the same queueFamilyIndex if the create flag are different
+    struct DeviceQueueInfo {
+        uint32_t index;  // from VkDeviceCreateInfo
+        uint32_t queue_family_index;
+        VkDeviceQueueCreateFlags flags;
+        uint32_t queue_count;
+    };
+    std::vector<DeviceQueueInfo> device_queue_info_list;
     bool performance_lock_acquired = false;
 
     template <typename ExtProp>

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -10707,6 +10707,111 @@ TEST_F(VkPositiveLayerTest, SwapchainExclusiveModeQueueFamilyPropertiesReference
     m_errorMonitor->VerifyNotFound();
 }
 
+TEST_F(VkPositiveLayerTest, ProtectedAndUnprotectedQueue) {
+    TEST_DESCRIPTION("Test creating 2 queues, 1 protected, and getting both with vkGetDeviceQueue2");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    m_errorMonitor->ExpectSuccess();
+
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("%s Did not find VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    // Needed for both protected memory and vkGetDeviceQueue2
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s test requires Vulkan 1.1 extensions, not available.  Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
+        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+
+    auto protected_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&protected_features);
+    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+
+    if (protected_features.protectedMemory == VK_FALSE) {
+        printf("%s test requires protectedMemory, not available.  Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    // Try to find a protected queue family type
+    bool protected_queue = false;
+    VkQueueFamilyProperties queue_properties;  // selected queue family used
+    uint32_t queue_family_index = 0;
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+
+    for (size_t i = 0; i < queue_families.size(); i++) {
+        // need to have at least 2 queues to use
+        if (((queue_families[i].queueFlags & VK_QUEUE_PROTECTED_BIT) != 0) && (queue_families[i].queueCount > 1)) {
+            protected_queue = true;
+            queue_family_index = i;
+            queue_properties = queue_families[i];
+            break;
+        }
+    }
+
+    if (protected_queue == false) {
+        printf("%s test requires queue family with VK_QUEUE_PROTECTED_BIT and 2 queues, not available.  Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    float queue_priority = 1.0;
+
+    VkDeviceQueueCreateInfo queue_create_info[2];
+    queue_create_info[0] = LvlInitStruct<VkDeviceQueueCreateInfo>();
+    queue_create_info[0].flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
+    queue_create_info[0].queueFamilyIndex = queue_family_index;
+    queue_create_info[0].queueCount = 1;
+    queue_create_info[0].pQueuePriorities = &queue_priority;
+
+    queue_create_info[1] = LvlInitStruct<VkDeviceQueueCreateInfo>();
+    queue_create_info[1].flags = 0;  // unprotected because the protected flag is not set
+    queue_create_info[1].queueFamilyIndex = queue_family_index;
+    queue_create_info[1].queueCount = 1;
+    queue_create_info[1].pQueuePriorities = &queue_priority;
+
+    VkDevice test_device = VK_NULL_HANDLE;
+    VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&protected_features);
+    device_create_info.flags = 0;
+    device_create_info.pQueueCreateInfos = queue_create_info;
+    device_create_info.queueCreateInfoCount = 2;
+    device_create_info.pEnabledFeatures = nullptr;
+    device_create_info.enabledLayerCount = 0;
+    device_create_info.enabledExtensionCount = 0;
+    ASSERT_VK_SUCCESS(vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device));
+
+    VkQueue test_queue_protected = VK_NULL_HANDLE;
+    VkQueue test_queue_unprotected = VK_NULL_HANDLE;
+
+    PFN_vkGetDeviceQueue2 vkGetDeviceQueue2 = (PFN_vkGetDeviceQueue2)vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2");
+    ASSERT_TRUE(vkGetDeviceQueue2 != nullptr);
+
+    VkDeviceQueueInfo2 queue_info_2 = LvlInitStruct<VkDeviceQueueInfo2>();
+
+    queue_info_2.flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
+    queue_info_2.queueFamilyIndex = queue_family_index;
+    queue_info_2.queueIndex = 0;
+    vkGetDeviceQueue2(test_device, &queue_info_2, &test_queue_protected);
+
+    queue_info_2.flags = 0;
+    queue_info_2.queueIndex = 0;
+    vkGetDeviceQueue2(test_device, &queue_info_2, &test_queue_unprotected);
+
+    vk::DestroyDevice(test_device, nullptr);
+
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkPositiveLayerTest, ShaderFloatControl) {
     TEST_DESCRIPTION("Test VK_KHR_float_controls");
     m_errorMonitor->ExpectSuccess();


### PR DESCRIPTION
So a bit to digest here but for resources see [internal issue](https://gitlab.khronos.org/vulkan/vulkan/-/issues/2645) and [Vulkan guide section on protected queues](https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/protected.md#protected-queues)

The main thing/issue with the current code is it assumes `queueFamilyIndex` is unqiue, but starting in 1.1 you can have cases for protected queues where it isn't unique (see guide link above).

The core changes are:
- at device creation if 1.1 it will track multiple `VkDeviceQueueCreateInfo` with same `queueFamilyIndex`
- remove duplicate `VkDeviceQueueCreateInfo` check from `StatelessValidation` and moved to `CoreCheck` since I need the Physical Device API version
- changed state tracking to just track the entire queue info (gives better error messaging tracking the index though!)
- change `vkGetDeviceQueue` check to use new state tracking
- added `vkGetDeviceQueue2` check

Note `UNASSIGNED-VkDeviceQueueInfo2` is purposed as a missing VU in the gitlab internal issue and will update when upstreamed

For tests, added tests for all the VUs and a positive test to creates a device with non-unqiue `queueFamilyIndex`

Tested on local 1.0 and 1.1 Android device as well
