### PR TITLE
layers: Add descriptor level change tracking for image layouts

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3110,14 +3110,10 @@ struct CommandBufferSubmitState {
                     // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
                     // This submit time not record time...
                     const bool record_time_validate = false;
-                    layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
-                    if (set_node->GetTotalDescriptorCount() > cvdescriptorset::PrefilterBindRequestMap::kManyDescriptors_) {
-                        checked_layouts.emplace();
-                    }
                     skip |= core->ValidateDescriptorSetBindingData(
                         cb_node, set_node, dynamic_offsets, binding_info, cmd_info.framebuffer, cmd_info.attachments.get(),
                         *cmd_info.subpasses.get(), record_time_validate, function.c_str(),
-                        core->GetDrawDispatchVuid(cmd_info.cmd_type), checked_layouts);
+                        core->GetDrawDispatchVuid(cmd_info.cmd_type));
                 }
             }
         }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -441,8 +441,7 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::pair<const uint32_t, DescriptorRequirement>& binding_info,
                                           VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE*>* attachments,
                                           const std::vector<SUBPASS_INFO>& subpasses, bool record_time_validate, const char* caller,
-                                          const DrawDispatchVuid& vuids,
-                                          layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+                                          const DrawDispatchVuid& vuids) const;
 
     bool ValidateGeneralBufferDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
                                          const cvdescriptorset::DescriptorSet* descriptor_set,
@@ -456,8 +455,7 @@ class CoreChecks : public ValidationStateTracker {
                                  const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,
                                  bool record_time_validate, const std::vector<IMAGE_VIEW_STATE*>* attachments,
                                  const std::vector<SUBPASS_INFO>& subpasses, VkFramebuffer framebuffer,
-                                 VkDescriptorType descriptor_type,
-                                 layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+                                 VkDescriptorType descriptor_type) const;
 
     bool ValidateTexelDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
                                  const cvdescriptorset::DescriptorSet* descriptor_set,
@@ -567,10 +565,10 @@ class CoreChecks : public ValidationStateTracker {
                                        const VkImageSubresourceRange& subresourceRange, const char* cmd_name,
                                        const char* param_name, const char* image_layer_count_var_name, const VkImage image,
                                        SubresourceRangeErrorCodes errorCodes) const;
-    void SetImageLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state,
+    void SetImageLayout(CMD_BUFFER_STATE* cb_node, IMAGE_STATE& image_state,
                         const VkImageSubresourceRange& image_subresource_range, VkImageLayout layout,
                         VkImageLayout expected_layout = kInvalidLayout);
-    void SetImageLayout(CMD_BUFFER_STATE* cb_node, const IMAGE_STATE& image_state,
+    void SetImageLayout(CMD_BUFFER_STATE* cb_node, IMAGE_STATE& image_state,
                         const VkImageSubresourceLayers& image_subresource_layers, VkImageLayout layout);
     bool ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPassCreateVersion rp_version, VkImageLayout layout,
                                                               VkImage image, VkImageView image_view, VkFramebuffer framebuffer,
@@ -692,7 +690,7 @@ class CoreChecks : public ValidationStateTracker {
     void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const ImgBarrier* barrier);
 
     template <typename ImgBarrier>
-    void RecordTransitionImageLayout(CMD_BUFFER_STATE* cb_state, const IMAGE_STATE* image_state, const ImgBarrier& img_barrier,
+    void RecordTransitionImageLayout(CMD_BUFFER_STATE* cb_state, IMAGE_STATE* image_state, const ImgBarrier& img_barrier,
                                      bool is_release_op);
     void RecordBarriers(Func func_name, CMD_BUFFER_STATE* cb_state, uint32_t bufferBarrierCount,
                         const VkBufferMemoryBarrier* pBufferMemBarriers, uint32_t imageMemBarrierCount,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -474,6 +474,7 @@ class IMAGE_STATE : public BINDABLE {
     VkDeviceSize swapchain_fake_address;  // Needed for swapchain syncval, since there is no VkDeviceMemory::fake_base_address
 
     std::vector<VkSparseImageMemoryRequirements> sparse_requirements;
+    uint64_t layout_change_count;  // The sequence number for changes to image layout (for cached validation)
     IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCreateInfo);
     IMAGE_STATE(IMAGE_STATE const &rh_obj) = delete;
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -394,10 +394,16 @@ class ImageDescriptor : public Descriptor {
     std::shared_ptr<IMAGE_VIEW_STATE> GetSharedImageViewState() const { return image_view_state_; }
     VkImageLayout GetImageLayout() const { return image_layout_; }
 
+    uint64_t GetLayoutChangeCount(const CMD_BUFFER_STATE *cb) const {
+        auto it = layout_change_counts_.find(cb);
+        return (it != layout_change_counts_.end()) ? it->second : 0;
+    }
+
   protected:
     ImageDescriptor(DescriptorClass class_);
     std::shared_ptr<IMAGE_VIEW_STATE> image_view_state_;
     VkImageLayout image_layout_;
+    layer_data::unordered_map<const CMD_BUFFER_STATE*, uint64_t> layout_change_counts_;
 };
 
 class ImageSamplerDescriptor : public ImageDescriptor {


### PR DESCRIPTION
Extend the set level change tracking to also track changes per image.
The set level tracking does catch (and skip) completely unchanged
DescriptorSets, but we can also get very large sets with only a few
changed descriptors. The new change count also catches cases of
the same image reused in multiple descriptors, so the checked_layouts
set optimization is removed.