### PR TITLE
fix false positives for barrier queue ownership transfer detection

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1263,9 +1263,13 @@ void CoreChecks::RecordBarrierValidationInfo(const Location &loc, CMD_BUFFER_STA
         }
     }
 
+    // 7.7.4: If the values of srcQueueFamilyIndex and dstQueueFamilyIndex are equal, no ownership transfer is performed, and the
+    // barrier operates as if they were both set to VK_QUEUE_FAMILY_IGNORED.
     const uint32_t src_queue_family = barrier.srcQueueFamilyIndex;
     const uint32_t dst_queue_family = barrier.dstQueueFamilyIndex;
-    if (!QueueFamilyIsIgnored(src_queue_family) && !QueueFamilyIsIgnored(dst_queue_family)) {
+    const bool is_ownership_transfer = src_queue_family != dst_queue_family;
+
+    if (is_ownership_transfer) {
         // Only enqueue submit time check if it is needed. If more submit time checks are added, change the criteria
         // TODO create a better named list, or rename the submit time lists to something that matches the broader usage...
         auto handle_state = BarrierHandleState(*this, barrier);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -124,6 +124,8 @@ static inline bool QueueFamilyIsExternal(const uint32_t queue_family_index) {
     return (queue_family_index == VK_QUEUE_FAMILY_EXTERNAL) || (queue_family_index == VK_QUEUE_FAMILY_FOREIGN_EXT);
 }
 
+// Caution: Section 7.7.4 states that "If the values of srcQueueFamilyIndex and dstQueueFamilyIndex are equal, no ownership transfer
+// is performed, and the barrier operates as if they were both set to VK_QUEUE_FAMILY_IGNORED."; this does not handle that case.
 static inline bool QueueFamilyIsIgnored(uint32_t queue_family_index) { return queue_family_index == VK_QUEUE_FAMILY_IGNORED; }
 
 // Intentionally ignore VulkanTypedHandle::node, it is optional

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6505,9 +6505,12 @@ TEST_F(VkLayerTest, InvalidBarrierQueueFamily) {
         excl_test.Init(nullptr);
 
         // core_validation::barrier_queue_families::kSubmitQueueMustMatchSrcOrDst
-        excl_test("UNASSIGNED-CoreValidation-VkImageMemoryBarrier-sharing-mode-exclusive-same-family",
-                  "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier-sharing-mode-exclusive-same-family", other_family, other_family,
-                  false, submit_family);
+        // akeley98: this test is wrong and should pass validation. Two queue families aren't enough to test this; you need three:
+        // one for the queue to submit to, and two distinct different families for the barrier. Because the barrier families are
+        // equal here, no ownership transfer actually happens, and this barrier is valid by the spec.
+        // excl_test("UNASSIGNED-CoreValidation-VkImageMemoryBarrier-sharing-mode-exclusive-same-family",
+        //           "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier-sharing-mode-exclusive-same-family", other_family, other_family,
+        //           false, submit_family);
 
         // true -> positive test (testing both the index logic and the QFO transfer tracking.
         excl_test("POSITIVE_TEST", "POSITIVE_TEST", submit_family, other_family, true, submit_family);


### PR DESCRIPTION
According to Vulkan spec section 7.7.4: Queue Family Ownership Transfer,

If the values of `srcQueueFamilyIndex` and `dstQueueFamilyIndex` are equal, no ownership transfer is performed, and the barrier operates as if they were both set to `VK_QUEUE_FAMILY_IGNORED`.

However the validation layers actually detect ownership transfers by checking that both `srcQueueFamilyIndex` and `dstQueueFamilyIndex` are  `VK_QUEUE_FAMILY_IGNORED`; this leads to incorrect validation errors where the user orders no ownership transfer by setting both barrier queue families to an equal value, but that value does not match the family index of the queue that the barrier is submitted to. This happened to me when I left both queue family indices as the default 0 value but did not submit to queue family 0.

It's possible that I'm the only person too lazy to type out `VK_QUEUE_FAMILY_IGNORED` (and thus risk hitting driver bugs from drivers with the same error?) but nonetheless I think the validation layers should follow the spec in this case. The correct way to detect a queue ownership transfer is to check that the src/dst indices are not equal (note that checking for `VK_QUEUE_FAMILY_IGNORED` falls out of this implementation, as both indices should equal that value in that case).

This is more of a bug report with source code than a legitimate MR, as I don't have time to fix test coverage for this case. Unfortunately the changes to handle this case are substantial; you need 3 queue families to test for this, not just 2 (see my comment in `vklayertests_buffer_image_memory_sampler.cpp`). Feel free to reject and fix in your own way (or explain the mistake in my spec interpretation).