### PR TITLE
layers: Optimize command buffer state tracking

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -90,6 +90,7 @@ core_validation_sources = [
   "layers/core_validation.h",
   "layers/core_validation_error_enums.h",
   "layers/core_validation_types.h",
+  "layers/base_node.h",
   "layers/core_error_location.cpp",
   "layers/core_error_location.h",
   "layers/descriptor_sets.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -156,6 +156,7 @@ set(CORE_VALIDATION_LIBRARY_FILES
     core_error_location.h
     core_error_location.cpp
     core_validation_types.h
+    base_node.h
     drawdispatch.cpp
     convert_to_renderpass2.cpp
     descriptor_sets.cpp

--- a/layers/base_node.h
+++ b/layers/base_node.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
+ * Author: Tobin Ehlis <tobine@google.com>
+ * Author: Chris Forbes <chrisf@ijw.co.nz>
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
+ * Author: Tobias Hector <tobias.hector@amd.com>
+ * Author: Jeremy Gebben <jeremyg@lunarg.com>
+ */
+#pragma once
+
+#include "vk_object_types.h"
+#include "vk_layer_data.h"
+
+#include <atomic>
+
+class BASE_NODE {
+  public:
+    using BindingsType = layer_data::unordered_map<CMD_BUFFER_STATE *, int>;
+    // Track when object is being used by an in-flight command buffer
+    std::atomic_int in_use;
+    // Track command buffers that this object is bound to
+    //  binding initialized when cmd referencing object is bound to command buffer
+    //  binding removed when command buffer is reset or destroyed
+    // When an object is destroyed, any bound cbs are set to INVALID.
+    // "int" value is an index into object_bindings where the corresponding
+    // backpointer to this node is stored.
+    BindingsType cb_bindings;
+    // Set to true when the API-level object is destroyed, but this object may
+    // hang around until its shared_ptr refcount goes to zero.
+    bool destroyed;
+
+    BASE_NODE() {
+        in_use.store(0);
+        destroyed = false;
+    };
+};
+

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -608,9 +608,9 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
     for (auto& obj : mem_info->obj_bindings) {
         LogObjectList objlist(device);
         objlist.add(obj);
-        objlist.add(mem_info->mem);
+        objlist.add(mem_info->mem());
         skip |= LogWarning(objlist, layer_name.c_str(), "VK Object %s still has a reference to mem obj %s.",
-                           report_data->FormatHandle(obj).c_str(), report_data->FormatHandle(mem_info->mem).c_str());
+                           report_data->FormatHandle(obj).c_str(), report_data->FormatHandle(mem_info->mem()).c_str());
     }
 
     return skip;
@@ -1431,10 +1431,10 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* 
         // Verify vertex binding
         if (pipeline_state->vertex_binding_descriptions_.size() <= 0) {
             if ((!current_vtx_bfr_binding_info.empty()) && (!cb_state->vertex_buffer_used)) {
-                skip |= LogPerformanceWarning(cb_state->commandBuffer, kVUID_BestPractices_DrawState_VtxIndexOutOfBounds,
+                skip |= LogPerformanceWarning(cb_state->commandBuffer(), kVUID_BestPractices_DrawState_VtxIndexOutOfBounds,
                                               "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
-                                              report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                                              report_data->FormatHandle(pipeline_state->pipeline).c_str());
+                                              report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
+                                              report_data->FormatHandle(pipeline_state->pipeline()).c_str());
             }
         }
     }
@@ -1982,18 +1982,18 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    skip |= LogWarning(image_state->image, kVUID_Core_MemTrack_InvalidState,
+                    skip |= LogWarning(image_state->image(), kVUID_Core_MemTrack_InvalidState,
                                        "vkQueueBindSparse(): Binding sparse memory to %s without first calling "
                                        "vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
-                                       report_data->FormatHandle(image_state->image).c_str());
+                                       report_data->FormatHandle(image_state->image()).c_str());
                 }
             }
             if (!image_state->memory_requirements_checked) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                skip |= LogWarning(image_state->image, kVUID_Core_MemTrack_InvalidState,
+                skip |= LogWarning(image_state->image(), kVUID_Core_MemTrack_InvalidState,
                                    "vkQueueBindSparse(): Binding sparse memory to %s without first calling "
                                    "vkGetImageMemoryRequirements() to retrieve requirements.",
-                                   report_data->FormatHandle(image_state->image).c_str());
+                                   report_data->FormatHandle(image_state->image()).c_str());
             }
         }
         for (uint32_t i = 0; i < bind_info.imageOpaqueBindCount; ++i) {
@@ -2006,18 +2006,18 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    skip |= LogWarning(image_state->image, kVUID_Core_MemTrack_InvalidState,
+                    skip |= LogWarning(image_state->image(), kVUID_Core_MemTrack_InvalidState,
                                        "vkQueueBindSparse(): Binding opaque sparse memory to %s without first calling "
                                        "vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
-                                       report_data->FormatHandle(image_state->image).c_str());
+                                       report_data->FormatHandle(image_state->image()).c_str());
                 }
             }
             if (!image_state->memory_requirements_checked) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                skip |= LogWarning(image_state->image, kVUID_Core_MemTrack_InvalidState,
+                skip |= LogWarning(image_state->image(), kVUID_Core_MemTrack_InvalidState,
                                    "vkQueueBindSparse(): Binding opaque sparse memory to %s without first calling "
                                    "vkGetImageMemoryRequirements() to retrieve requirements.",
-                                   report_data->FormatHandle(image_state->image).c_str());
+                                   report_data->FormatHandle(image_state->image()).c_str());
             }
             for (uint32_t j = 0; j < image_opaque_bind.bindCount; ++j) {
                 if (image_opaque_bind.pBinds[j].flags & VK_SPARSE_MEMORY_BIND_METADATA_BIT) {
@@ -2029,10 +2029,10 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (sparse_image_state->sparse_metadata_required && !sparse_image_state->sparse_metadata_bound &&
                 sparse_images_with_metadata.find(sparse_image_state) == sparse_images_with_metadata.end()) {
                 // Warn if sparse image binding metadata required for image with sparse binding, but metadata not bound
-                skip |= LogWarning(sparse_image_state->image, kVUID_Core_MemTrack_InvalidState,
+                skip |= LogWarning(sparse_image_state->image(), kVUID_Core_MemTrack_InvalidState,
                                    "vkQueueBindSparse(): Binding sparse memory to %s which requires a metadata aspect but no "
                                    "binding with VK_SPARSE_MEMORY_BIND_METADATA_BIT set was made.",
-                                   report_data->FormatHandle(sparse_image_state->image).c_str());
+                                   report_data->FormatHandle(sparse_image_state->image()).c_str());
             }
         }
     }

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -605,7 +605,8 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
 
     const DEVICE_MEMORY_STATE* mem_info = ValidationStateTracker::GetDevMemState(memory);
 
-    for (auto& obj : mem_info->obj_bindings) {
+    for (const auto& node: mem_info->ObjectBindings()) {
+        const auto& obj = node->Handle();
         LogObjectList objlist(device);
         objlist.add(obj);
         objlist.add(mem_info->mem());

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1514,7 +1514,7 @@ bool BestPractices::ValidateIndexBufferArm(VkCommandBuffer commandBuffer, uint32
     if (cmd_state == nullptr) return skip;
 
     const auto* ib_state = cmd_state->index_buffer_binding.buffer_state.get();
-    if (ib_state == nullptr || cmd_state->index_buffer_binding.buffer_state->destroyed) return skip;
+    if (ib_state == nullptr || cmd_state->index_buffer_binding.buffer_state->Destroyed()) return skip;
 
     const VkIndexType ib_type = cmd_state->index_buffer_binding.index_type;
     const auto& ib_mem_state = *ib_state->binding.mem_state;

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -335,6 +335,7 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkIma
         } else {
             descriptor_format_bits = DescriptorRequirementsBitsFromFormat(create_info.format);
         }
+        image_state->AddParent(this);
     }
 }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -219,7 +219,6 @@ static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &creat
 
 IMAGE_STATE::IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCreateInfo)
     : BINDABLE(img, kVulkanObjectTypeImage),
-      image(img),
       safe_create_info(pCreateInfo),
       createInfo(*safe_create_info.ptr()),
       valid(false),
@@ -311,7 +310,6 @@ bool IMAGE_STATE::IsCompatibleAliasing(IMAGE_STATE *other_image_state) const {
 
 IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkImageView iv, const VkImageViewCreateInfo *ci)
     : BASE_NODE(iv, kVulkanObjectTypeImageView),
-      image_view(iv),
       create_info(*ci),
       normalized_subresource_range(NormalizeSubresourceRange(*im, ci->subresourceRange)),
       range_generator(im->subresource_encoder, normalized_subresource_range),
@@ -429,10 +427,10 @@ struct LayoutUseCheckAndMessage {
 };
 
 bool IMAGE_VIEW_STATE::OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) const {
-    if (image_view == compare_view.image_view) {
+    if (image_view() == compare_view.image_view()) {
         return true;
     }
-    if (image_state->image != compare_view.image_state->image) {
+    if (image_state->image() != compare_view.image_state->image()) {
         return false;
     }
     if (normalized_subresource_range.aspectMask != compare_view.normalized_subresource_range.aspectMask) {
@@ -477,7 +475,7 @@ uint32_t FullMipChainLevels(VkExtent3D extent) { return FullMipChainLevels(exten
 uint32_t FullMipChainLevels(VkExtent2D extent) { return FullMipChainLevels(extent.height, extent.width); }
 
 bool CoreChecks::FindLayouts(const IMAGE_STATE &image_state, std::vector<VkImageLayout> &layouts) const {
-    const auto *layout_range_map = GetLayoutRangeMap(imageLayoutMap, image_state.image);
+    const auto *layout_range_map = GetLayoutRangeMap(imageLayoutMap, image_state.image());
     if (!layout_range_map) return false;
     // TODO: FindLayouts function should mutate into a ValidatePresentableLayout with the loop wrapping the LogError
     //       from the caller. You can then use decode to add the subresource of the range::begin to the error message.
@@ -716,11 +714,11 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
     auto const &framebuffer_info = framebuffer_state->createInfo;
     const VkImageView *attachments = framebuffer_info.pAttachments;
 
-    auto render_pass = GetRenderPassState(pRenderPassBegin->renderPass)->renderPass;
-    auto framebuffer = framebuffer_state->framebuffer;
+    auto render_pass = GetRenderPassState(pRenderPassBegin->renderPass)->renderPass();
+    auto framebuffer = framebuffer_state->framebuffer();
 
     if (render_pass_info->attachmentCount != framebuffer_info.attachmentCount) {
-        skip |= LogError(pCB->commandBuffer, kVUID_Core_DrawState_InvalidRenderpass,
+        skip |= LogError(pCB->commandBuffer(), kVUID_Core_DrawState_InvalidRenderpass,
                          "You cannot start a render pass using a framebuffer with a different number of attachments.");
     }
 
@@ -737,11 +735,11 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
 
             if (!view_state) {
                 LogObjectList objlist(pRenderPassBegin->renderPass);
-                objlist.add(framebuffer_state->framebuffer);
+                objlist.add(framebuffer_state->framebuffer());
                 objlist.add(image_view);
                 skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
                                  "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
-                                 report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
+                                 report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
                                  report_data->FormatHandle(image_view).c_str());
                 continue;
             }
@@ -751,12 +749,12 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
 
             if (!image_state) {
                 LogObjectList objlist(pRenderPassBegin->renderPass);
-                objlist.add(framebuffer_state->framebuffer);
+                objlist.add(framebuffer_state->framebuffer());
                 objlist.add(image_view);
                 objlist.add(image);
                 skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
                                  "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
-                                 report_data->FormatHandle(framebuffer_state->framebuffer).c_str(), i,
+                                 report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
                                  report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
                 continue;
             }
@@ -1045,7 +1043,7 @@ bool CoreChecks::ValidateBarriersToImages(const Location &outer_loc, const CMD_B
                         const VkImageSubresourceRange &range = img_barrier.subresourceRange;
                         const auto &vuid = GetImageBarrierVUID(loc, ImageError::kConflictingLayout);
                         skip = LogError(
-                            cb_state->commandBuffer, vuid,
+                            cb_state->commandBuffer(), vuid,
                             "%s conflicts with earlier entry pImageMemoryBarrier[%u]. %s"
                             " subresourceRange: aspectMask=%u baseMipLevel=%u levelCount=%u, baseArrayLayer=%u, layerCount=%u; "
                             "conflicting barrier transitions image layout from %s when earlier barrier transitioned to layout %s.",
@@ -1129,7 +1127,7 @@ bool CoreChecks::ValidateBarriersToImages(const Location &outer_loc, const CMD_B
                         NormalizeSynchronization2Layout(img_barrier.subresourceRange.aspectMask, img_barrier.oldLayout);
                     if (!layout_check.Check(value.subresource, old_layout, value.current_layout, value.initial_layout)) {
                         const auto &vuid = GetImageBarrierVUID(loc, ImageError::kConflictingLayout);
-                        subres_skip = LogError(cb_state->commandBuffer, vuid,
+                        subres_skip = LogError(cb_state->commandBuffer(), vuid,
                                                "%s %s cannot transition the layout of aspect=%d level=%d layer=%d from %s when the "
                                                "%s layout is %s.",
                                                loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
@@ -1210,7 +1208,7 @@ bool CoreChecks::ValidateQFOTransferBarrierUniqueness(const Location &loc, const
     }
     if (barrier_record != nullptr) {
         skip |=
-            LogWarning(cb_state->commandBuffer, TransferBarrier::ErrMsgDuplicateQFOInCB(),
+            LogWarning(cb_state->commandBuffer(), TransferBarrier::ErrMsgDuplicateQFOInCB(),
                        "%s %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32 " to dstQueueFamilyIndex %" PRIu32
                        " duplicates existing barrier recorded in this command buffer.",
                        loc.Message().c_str(), transfer_type, handle_name, report_data->FormatHandle(barrier_record->handle).c_str(),
@@ -1401,14 +1399,14 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &loc, CMD_BUFFER_
     } else {  // !image_match
         auto img_loc = loc.dot(Field::image);
         const auto &vuid = GetImageBarrierVUID(img_loc, ImageError::kRenderPassMismatch);
-        skip |= LogError(fb_state->framebuffer, vuid, "%s Barrier for %s does not match an image from the current %s.",
+        skip |= LogError(fb_state->framebuffer(), vuid, "%s Barrier for %s does not match an image from the current %s.",
                          img_loc.Message().c_str(), report_data->FormatHandle(img_bar_image).c_str(),
-                         report_data->FormatHandle(fb_state->framebuffer).c_str());
+                         report_data->FormatHandle(fb_state->framebuffer()).c_str());
     }
     if (img_barrier.oldLayout != img_barrier.newLayout) {
         auto layout_loc = loc.dot(Field::oldLayout);
         const auto &vuid = GetImageBarrierVUID(layout_loc, ImageError::kRenderPassLayoutChange);
-        skip |= LogError(cb_state->commandBuffer, vuid,
+        skip |= LogError(cb_state->commandBuffer(), vuid,
                          "%s As the Image Barrier for %s is being executed within a render pass instance, oldLayout must "
                          "equal newLayout yet they are %s and %s.",
                          layout_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
@@ -1453,7 +1451,7 @@ void CoreChecks::EnqueueSubmitTimeValidateImageBarrierAttachment(const Location 
         // Secondary CB case w/o FB specified delay validation
         auto *this_ptr = this;  // Required for older compilers with c++20 compatibility
         core_error::LocationCapture loc_capture(loc);
-        const auto render_pass = rp_state->renderPass;
+        const auto render_pass = rp_state->renderPass();
         cb_state->cmd_execute_commands_functions.emplace_back(
             [this_ptr, loc_capture, cb_state, active_subpass, sub_desc, render_pass, barrier](const CMD_BUFFER_STATE *primary_cb,
                                                                                               const FRAMEBUFFER_STATE *fb) {
@@ -1500,15 +1498,15 @@ bool CoreChecks::ValidateAndUpdateQFOScoreboard(const debug_report_data *report_
     auto inserted = scoreboard->emplace(barrier, cb_state);
     if (!inserted.second && inserted.first->second != cb_state) {
         // This is a duplication (but don't report duplicates from the same CB, as we do that at record time
-        LogObjectList objlist(cb_state->commandBuffer);
+        LogObjectList objlist(cb_state->commandBuffer());
         objlist.add(barrier.handle);
-        objlist.add(inserted.first->second->commandBuffer);
+        objlist.add(inserted.first->second->commandBuffer());
         skip = LogWarning(objlist, TransferBarrier::ErrMsgDuplicateQFOInSubmit(),
                           "%s: %s %s queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
                           " to dstQueueFamilyIndex %" PRIu32 " duplicates existing barrier submitted in this batch from %s.",
                           "vkQueueSubmit()", TransferBarrier::BarrierName(), operation, TransferBarrier::HandleName(),
                           report_data->FormatHandle(barrier.handle).c_str(), barrier.srcQueueFamilyIndex,
-                          barrier.dstQueueFamilyIndex, report_data->FormatHandle(inserted.first->second->commandBuffer).c_str());
+                          barrier.dstQueueFamilyIndex, report_data->FormatHandle(inserted.first->second->commandBuffer()).c_str());
     }
     return skip;
 }
@@ -1529,7 +1527,7 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(
             const QFOTransferBarrierSet<TransferBarrier> &set_for_handle = set_it->second;
             const auto found = set_for_handle.find(release);
             if (found != set_for_handle.cend()) {
-                skip |= LogWarning(cb_state->commandBuffer, TransferBarrier::ErrMsgDuplicateQFOSubmitted(),
+                skip |= LogWarning(cb_state->commandBuffer(), TransferBarrier::ErrMsgDuplicateQFOSubmitted(),
                                    "%s: %s releasing queue ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
                                    " to dstQueueFamilyIndex %" PRIu32
                                    " duplicates existing barrier queued for execution, without intervening acquire operation.",
@@ -1548,7 +1546,7 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(
             matching_release_found = set_for_handle.find(acquire) != set_for_handle.cend();
         }
         if (!matching_release_found) {
-            skip |= LogError(cb_state->commandBuffer, TransferBarrier::ErrMsgMissingQFOReleaseInSubmit(),
+            skip |= LogError(cb_state->commandBuffer(), TransferBarrier::ErrMsgMissingQFOReleaseInSubmit(),
                              "%s: in submitted command buffer %s acquiring ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
                              " to dstQueueFamilyIndex %" PRIu32 " has no matching release barrier queued for execution.",
                              "vkQueueSubmit()", barrier_name, handle_name, report_data->FormatHandle(acquire.handle).c_str(),
@@ -1669,7 +1667,7 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
     if (disabled[image_layout_validation]) return false;
     assert(cb_node);
     assert(image_state);
-    const auto image = image_state->image;
+    const auto image = image_state->image();
     bool skip = false;
 
     const auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, image);
@@ -1681,7 +1679,7 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
         for (auto pos = subresource_map->Find(range); !(pos.AtEnd()) && !subres_skip; pos.IncrementInterval()) {
             if (!layout_check.Check(pos->subresource, explicit_layout, pos->current_layout, pos->initial_layout)) {
                 *error = true;
-                subres_skip |= LogError(cb_node->commandBuffer, layout_mismatch_msg_code,
+                subres_skip |= LogError(cb_node->commandBuffer(), layout_mismatch_msg_code,
                                         "%s: Cannot use %s (layer=%u mip=%u) with specific layout %s that doesn't match the "
                                         "%s layout %s.",
                                         caller, report_data->FormatHandle(image).c_str(), pos->subresource.arrayLayer,
@@ -1697,7 +1695,7 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
         if (VK_IMAGE_LAYOUT_GENERAL == explicit_layout) {
             if (image_state->createInfo.tiling != VK_IMAGE_TILING_LINEAR) {
                 // LAYOUT_GENERAL is allowed, but may not be performance optimal, flag as perf warning.
-                skip |= LogPerformanceWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidImageLayout,
+                skip |= LogPerformanceWarning(cb_node->commandBuffer(), kVUID_Core_DrawState_InvalidImageLayout,
                                               "%s: For optimal performance %s layout should be %s instead of GENERAL.", caller,
                                               report_data->FormatHandle(image).c_str(), string_VkImageLayout(optimal_layout));
             }
@@ -1712,7 +1710,7 @@ bool CoreChecks::VerifyImageLayout(const CMD_BUFFER_STATE *cb_node, const IMAGE_
             }
         } else {
             *error = true;
-            skip |= LogError(cb_node->commandBuffer, layout_invalid_msg_code,
+            skip |= LogError(cb_node->commandBuffer(), layout_invalid_msg_code,
                              "%s: Layout for %s is %s but can only be %s or VK_IMAGE_LAYOUT_GENERAL.", caller,
                              report_data->FormatHandle(image).c_str(), string_VkImageLayout(explicit_layout),
                              string_VkImageLayout(optimal_layout));
@@ -2315,7 +2313,7 @@ bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, con
             skip |= LogError(device, "UNASSIGNED-vkDestroyImage-image",
                              "vkDestroyImage(): %s is a presentable image and it is controlled by the implementation and is "
                              "destroyed with vkDestroySwapchainKHR.",
-                             report_data->FormatHandle(image_state->image).c_str());
+                             report_data->FormatHandle(image_state->image()).c_str());
         }
         skip |= ValidateObjectNotInUse(image_state, "vkDestroyImage", "VUID-vkDestroyImage-image-01000");
     }
@@ -2335,7 +2333,7 @@ void CoreChecks::PreCallRecordDestroyImage(VkDevice device, VkImage image, const
 bool CoreChecks::ValidateImageAttributes(const IMAGE_STATE *image_state, const VkImageSubresourceRange &range,
                                          const char *param_name) const {
     bool skip = false;
-    const VkImage image = image_state->image;
+    const VkImage image = image_state->image();
     const VkFormat format = image_state->createInfo.format;
 
     if (range.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) {
@@ -2368,7 +2366,7 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
     bool skip = false;
     if (strcmp(func_name, "vkCmdClearDepthStencilImage()") == 0) {
         if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
-            skip |= LogError(image_state->image, "VUID-vkCmdClearDepthStencilImage-imageLayout-00012",
+            skip |= LogError(image_state->image(), "VUID-vkCmdClearDepthStencilImage-imageLayout-00012",
                              "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
                              string_VkImageLayout(dest_image_layout));
         }
@@ -2377,7 +2375,7 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
         assert(strcmp(func_name, "vkCmdClearColorImage()") == 0);
         if (!device_extensions.vk_khr_shared_presentable_image) {
             if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
-                skip |= LogError(image_state->image, "VUID-vkCmdClearColorImage-imageLayout-00005",
+                skip |= LogError(image_state->image(), "VUID-vkCmdClearColorImage-imageLayout-00005",
                                  "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.", func_name,
                                  string_VkImageLayout(dest_image_layout));
             }
@@ -2385,7 +2383,7 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
             if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL) &&
                 (dest_image_layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)) {
                 skip |= LogError(
-                    image_state->image, "VUID-vkCmdClearColorImage-imageLayout-01394",
+                    image_state->image(), "VUID-vkCmdClearColorImage-imageLayout-01394",
                     "%s: Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL, SHARED_PRESENT_KHR, or GENERAL.",
                     func_name, string_VkImageLayout(dest_image_layout));
             }
@@ -2393,7 +2391,7 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
     }
 
     // Cast to const to prevent creation at validate time.
-    const auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, image_state->image);
+    const auto *subresource_map = GetImageSubresourceLayoutMap(cb_node, image_state->image());
     if (subresource_map) {
         bool subres_skip = false;
         LayoutUseCheckAndMessage layout_check(subresource_map);
@@ -2408,7 +2406,7 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE *cb_node, const I
                 } else {
                     assert(strcmp(func_name, "vkCmdClearColorImage()") == 0);
                 }
-                subres_skip |= LogError(cb_node->commandBuffer, error_code,
+                subres_skip |= LogError(cb_node->commandBuffer(), error_code,
                                         "%s: Cannot clear an image whose layout is %s and doesn't match the %s layout %s.",
                                         func_name, string_VkImageLayout(dest_image_layout), layout_check.message,
                                         string_VkImageLayout(layout_check.layout));
@@ -2716,7 +2714,7 @@ bool CoreChecks::CheckItgOffset(const CMD_BUFFER_STATE *cb_node, const VkOffset3
     if (IsExtentAllZeroes(granularity)) {
         // If the queue family image transfer granularity is (0, 0, 0), then the offset must always be (0, 0, 0)
         if (IsExtentAllZeroes(&offset_extent) == false) {
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) must be (x=0, y=0, z=0) when the command buffer's queue family "
                              "image transfer granularity is (w=0, h=0, d=0).",
                              function, i, member, offset->x, offset->y, offset->z);
@@ -2725,7 +2723,7 @@ bool CoreChecks::CheckItgOffset(const CMD_BUFFER_STATE *cb_node, const VkOffset3
         // If the queue family image transfer granularity is not (0, 0, 0), then the offset dimensions must always be even
         // integer multiples of the image transfer granularity.
         if (IsExtentAligned(&offset_extent, granularity) == false) {
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) dimensions must be even integer multiples of this command "
                              "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d).",
                              function, i, member, offset->x, offset->y, offset->z, granularity->width, granularity->height,
@@ -2744,7 +2742,7 @@ bool CoreChecks::CheckItgExtent(const CMD_BUFFER_STATE *cb_node, const VkExtent3
         // If the queue family image transfer granularity is (0, 0, 0), then the extent must always match the image
         // subresource extent.
         if (IsExtentEqual(extent, subresource_extent) == false) {
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d) "
                              "when the command buffer's queue family image transfer granularity is (w=0, h=0, d=0).",
                              function, i, member, extent->width, extent->height, extent->depth, subresource_extent->width,
@@ -2780,7 +2778,7 @@ bool CoreChecks::CheckItgExtent(const CMD_BUFFER_STATE *cb_node, const VkExtent3
         }
         if (!(x_ok && y_ok && z_ok)) {
             skip |=
-                LogError(cb_node->commandBuffer, vuid,
+                LogError(cb_node->commandBuffer(), vuid,
                          "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) dimensions must be even integer multiples of this command "
                          "buffer's queue family image transfer granularity (w=%d, h=%d, d=%d) or offset (x=%d, y=%d, z=%d) + "
                          "extent (w=%d, h=%d, d=%d) must match the image subresource extents (w=%d, h=%d, d=%d).",
@@ -2796,8 +2794,8 @@ bool CoreChecks::ValidateImageMipLevel(const CMD_BUFFER_STATE *cb_node, const IM
                                        const uint32_t i, const char *function, const char *member, const char *vuid) const {
     bool skip = false;
     if (mip_level >= img->createInfo.mipLevels) {
-        skip |= LogError(cb_node->commandBuffer, vuid, "In %s, pRegions[%u].%s.mipLevel is %u, but provided %s has %u mip levels.",
-                         function, i, member, mip_level, report_data->FormatHandle(img->image).c_str(), img->createInfo.mipLevels);
+        skip |= LogError(cb_node->commandBuffer(), vuid, "In %s, pRegions[%u].%s.mipLevel is %u, but provided %s has %u mip levels.",
+                         function, i, member, mip_level, report_data->FormatHandle(img->image()).c_str(), img->createInfo.mipLevels);
     }
     return skip;
 }
@@ -2808,10 +2806,10 @@ bool CoreChecks::ValidateImageArrayLayerRange(const CMD_BUFFER_STATE *cb_node, c
     bool skip = false;
     if (base_layer >= img->createInfo.arrayLayers || layer_count > img->createInfo.arrayLayers ||
         (base_layer + layer_count) > img->createInfo.arrayLayers) {
-        skip |= LogError(cb_node->commandBuffer, vuid,
+        skip |= LogError(cb_node->commandBuffer(), vuid,
                          "In %s, pRegions[%u].%s.baseArrayLayer is %u and .layerCount is "
                          "%u, but provided %s has %u array layers.",
-                         function, i, member, base_layer, layer_count, report_data->FormatHandle(img->image).c_str(),
+                         function, i, member, base_layer, layer_count, report_data->FormatHandle(img->image()).c_str(),
                          img->createInfo.arrayLayers);
     }
     return skip;
@@ -2900,7 +2898,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
         if (src_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.srcOffset.y) || (1 != src_copy_extent.height)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-00146" : "VUID-vkCmdCopyImage-srcImage-00146";
-                skip |= LogError(src_state->image, vuid,
+                skip |= LogError(src_state->image(), vuid,
                                  "%s: pRegion[%d] srcOffset.y is %d and extent.height is %d. For 1D images these must "
                                  "be 0 and 1, respectively.",
                                  func_name, i, region.srcOffset.y, src_copy_extent.height);
@@ -2909,7 +2907,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
 
         if ((src_state->createInfo.imageType == VK_IMAGE_TYPE_1D) && ((0 != region.srcOffset.z) || (1 != src_copy_extent.depth))) {
             vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01785" : "VUID-vkCmdCopyImage-srcImage-01785";
-            skip |= LogError(src_state->image, vuid,
+            skip |= LogError(src_state->image(), vuid,
                              "%s: pRegion[%d] srcOffset.z is %d and extent.depth is %d. For 1D images "
                              "these must be 0 and 1, respectively.",
                              func_name, i, region.srcOffset.z, src_copy_extent.depth);
@@ -2917,7 +2915,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
 
         if ((src_state->createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.srcOffset.z)) {
             vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01787" : "VUID-vkCmdCopyImage-srcImage-01787";
-            skip |= LogError(src_state->image, vuid, "%s: pRegion[%d] srcOffset.z is %d. For 2D images the z-offset must be 0.",
+            skip |= LogError(src_state->image(), vuid, "%s: pRegion[%d] srcOffset.z is %d. For 2D images the z-offset must be 0.",
                              func_name, i, region.srcOffset.z);
         }
 
@@ -2931,7 +2929,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
                 (SafeModulo(region.srcOffset.y, block_size.height) != 0) ||
                 (SafeModulo(region.srcOffset.z, block_size.depth) != 0)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01727" : "VUID-vkCmdCopyImage-srcImage-01727";
-                skip |= LogError(src_state->image, vuid,
+                skip |= LogError(src_state->image(), vuid,
                                  "%s: pRegion[%d] srcOffset (%d, %d) must be multiples of the compressed image's "
                                  "texel width & height (%d, %d).",
                                  func_name, i, region.srcOffset.x, region.srcOffset.y, block_size.width, block_size.height);
@@ -2941,7 +2939,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if ((SafeModulo(src_copy_extent.width, block_size.width) != 0) &&
                 (src_copy_extent.width + region.srcOffset.x != mip_extent.width)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01728" : "VUID-vkCmdCopyImage-srcImage-01728";
-                skip |= LogError(src_state->image, vuid,
+                skip |= LogError(src_state->image(), vuid,
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
                                  "width (%d), or when added to srcOffset.x (%d) must equal the image subresource width (%d).",
                                  func_name, i, src_copy_extent.width, block_size.width, region.srcOffset.x, mip_extent.width);
@@ -2951,7 +2949,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if ((SafeModulo(src_copy_extent.height, block_size.height) != 0) &&
                 (src_copy_extent.height + region.srcOffset.y != mip_extent.height)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01729" : "VUID-vkCmdCopyImage-srcImage-01729";
-                skip |= LogError(src_state->image, vuid,
+                skip |= LogError(src_state->image(), vuid,
                                  "%s: pRegion[%d] extent height (%d) must be a multiple of the compressed texture block "
                                  "height (%d), or when added to srcOffset.y (%d) must equal the image subresource height (%d).",
                                  func_name, i, src_copy_extent.height, block_size.height, region.srcOffset.y, mip_extent.height);
@@ -2961,7 +2959,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             uint32_t copy_depth = (slice_override ? depth_slices : src_copy_extent.depth);
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.srcOffset.z != mip_extent.depth)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-01730" : "VUID-vkCmdCopyImage-srcImage-01730";
-                skip |= LogError(src_state->image, vuid,
+                skip |= LogError(src_state->image(), vuid,
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block "
                                  "depth (%d), or when added to srcOffset.z (%d) must equal the image subresource depth (%d).",
                                  func_name, i, src_copy_extent.depth, block_size.depth, region.srcOffset.z, mip_extent.depth);
@@ -2972,7 +2970,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
         if (dst_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.dstOffset.y) || (1 != dst_copy_extent.height)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-00152" : "VUID-vkCmdCopyImage-dstImage-00152";
-                skip |= LogError(dst_state->image, vuid,
+                skip |= LogError(dst_state->image(), vuid,
                                  "%s: pRegion[%d] dstOffset.y is %d and dst_copy_extent.height is %d. For 1D images "
                                  "these must be 0 and 1, respectively.",
                                  func_name, i, region.dstOffset.y, dst_copy_extent.height);
@@ -2981,7 +2979,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
 
         if ((dst_state->createInfo.imageType == VK_IMAGE_TYPE_1D) && ((0 != region.dstOffset.z) || (1 != dst_copy_extent.depth))) {
             vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01786" : "VUID-vkCmdCopyImage-dstImage-01786";
-            skip |= LogError(dst_state->image, vuid,
+            skip |= LogError(dst_state->image(), vuid,
                              "%s: pRegion[%d] dstOffset.z is %d and extent.depth is %d. For 1D images these must be 0 "
                              "and 1, respectively.",
                              func_name, i, region.dstOffset.z, dst_copy_extent.depth);
@@ -2989,7 +2987,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
 
         if ((dst_state->createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.dstOffset.z)) {
             vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01788" : "VUID-vkCmdCopyImage-dstImage-01788";
-            skip |= LogError(dst_state->image, vuid, "%s: pRegion[%d] dstOffset.z is %d. For 2D images the z-offset must be 0.",
+            skip |= LogError(dst_state->image(), vuid, "%s: pRegion[%d] dstOffset.z is %d. For 2D images the z-offset must be 0.",
                              func_name, i, region.dstOffset.z);
         }
 
@@ -2998,7 +2996,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if (src_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-04443" : "VUID-vkCmdCopyImage-srcImage-04443";
-                    skip |= LogError(src_state->image, vuid,
+                    skip |= LogError(src_state->image(), vuid,
                                      "%s: pRegion[%d] srcSubresource.baseArrayLayer is %d and srcSubresource.layerCount "
                                      "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
                                      func_name, i, region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
@@ -3007,7 +3005,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if (dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
                     vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-04444" : "VUID-vkCmdCopyImage-dstImage-04444";
-                    skip |= LogError(dst_state->image, vuid,
+                    skip |= LogError(dst_state->image(), vuid,
                                      "%s: pRegion[%d] dstSubresource.baseArrayLayer is %d and dstSubresource.layerCount "
                                      "is %d. For VK_IMAGE_TYPE_3D images these must be 0 and 1, respectively.",
                                      func_name, i, region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
@@ -3017,7 +3015,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if (src_state->createInfo.imageType == VK_IMAGE_TYPE_3D || dst_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-00139" : "VUID-vkCmdCopyImage-srcImage-00139";
-                    skip |= LogError(src_state->image, vuid,
+                    skip |= LogError(src_state->image(), vuid,
                                      "%s: pRegion[%d] srcSubresource.baseArrayLayer is %d and "
                                      "srcSubresource.layerCount is %d. For copies with either source or dest of type "
                                      "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
@@ -3025,7 +3023,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
                 }
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
                     vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-srcImage-00139" : "VUID-vkCmdCopyImage-srcImage-00139";
-                    skip |= LogError(dst_state->image, vuid,
+                    skip |= LogError(dst_state->image(), vuid,
                                      "%s: pRegion[%d] dstSubresource.baseArrayLayer is %d and "
                                      "dstSubresource.layerCount is %d. For copies with either source or dest of type "
                                      "VK_IMAGE_TYPE_3D, these must be 0 and 1, respectively.",
@@ -3044,7 +3042,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
                 (SafeModulo(region.dstOffset.y, block_size.height) != 0) ||
                 (SafeModulo(region.dstOffset.z, block_size.depth) != 0)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01731" : "VUID-vkCmdCopyImage-dstImage-01731";
-                skip |= LogError(dst_state->image, vuid,
+                skip |= LogError(dst_state->image(), vuid,
                                  "%s: pRegion[%d] dstOffset (%d, %d) must be multiples of the compressed image's "
                                  "texel width & height (%d, %d).",
                                  func_name, i, region.dstOffset.x, region.dstOffset.y, block_size.width, block_size.height);
@@ -3054,7 +3052,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if ((SafeModulo(dst_copy_extent.width, block_size.width) != 0) &&
                 (dst_copy_extent.width + region.dstOffset.x != mip_extent.width)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01732" : "VUID-vkCmdCopyImage-dstImage-01732";
-                skip |= LogError(dst_state->image, vuid,
+                skip |= LogError(dst_state->image(), vuid,
                                  "%s: pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
                                  "block width (%d), or when added to dstOffset.x (%d) must equal the image subresource width (%d).",
                                  func_name, i, dst_copy_extent.width, block_size.width, region.dstOffset.x, mip_extent.width);
@@ -3064,7 +3062,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             if ((SafeModulo(dst_copy_extent.height, block_size.height) != 0) &&
                 (dst_copy_extent.height + region.dstOffset.y != mip_extent.height)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01733" : "VUID-vkCmdCopyImage-dstImage-01733";
-                skip |= LogError(dst_state->image, vuid,
+                skip |= LogError(dst_state->image(), vuid,
                                  "%s: pRegion[%d] dst_copy_extent height (%d) must be a multiple of the compressed "
                                  "texture block height (%d), or when added to dstOffset.y (%d) must equal the image subresource "
                                  "height (%d).",
@@ -3075,7 +3073,7 @@ bool CoreChecks::ValidateImageCopyData(const uint32_t regionCount, const ImageCo
             uint32_t copy_depth = (slice_override ? depth_slices : dst_copy_extent.depth);
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.dstOffset.z != mip_extent.depth)) {
                 vuid = is_2khr ? "VUID-VkCopyImageInfo2KHR-dstImage-01734" : "VUID-vkCmdCopyImage-dstImage-01734";
-                skip |= LogError(dst_state->image, vuid,
+                skip |= LogError(dst_state->image(), vuid,
                                  "%s: pRegion[%d] dst_copy_extent width (%d) must be a multiple of the compressed texture "
                                  "block depth (%d), or when added to dstOffset.z (%d) must equal the image subresource depth (%d).",
                                  func_name, i, dst_copy_extent.depth, block_size.depth, region.dstOffset.z, mip_extent.depth);
@@ -3103,7 +3101,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
 
     skip = ValidateImageCopyData(regionCount, pRegions, src_image_state, dst_image_state, version);
 
-    VkCommandBuffer command_buffer = cb_node->commandBuffer;
+    VkCommandBuffer command_buffer = cb_node->commandBuffer();
 
     for (uint32_t i = 0; i < regionCount; i++) {
         const RegionType region = pRegions[i];
@@ -3320,7 +3318,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
 
         // The union of all source regions, and the union of all destination regions, specified by the elements of regions,
         // must not overlap in memory
-        if (src_image_state->image == dst_image_state->image) {
+        if (src_image_state->image() == dst_image_state->image()) {
             for (uint32_t j = 0; j < regionCount; j++) {
                 if (RegionIntersects(&region, &pRegions[j], src_image_state->createInfo.imageType,
                                      FormatIsMultiplane(src_format))) {
@@ -3637,7 +3635,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                             "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u is not VK_ATTACHMENT_UNUSED "
                             "and not a valid attachment for %s attachmentCount=%u. Subpass %u pColorAttachment[%u]=%u.",
                             attachment_index, clear_desc->colorAttachment,
-                            report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(), cb_node->activeSubpass,
+                            report_data->FormatHandle(cb_node->activeRenderPass->renderPass()).c_str(), cb_node->activeSubpass,
                             clear_desc->colorAttachment, color_attachment, renderpass_attachment_count);
 
                         color_attachment = VK_ATTACHMENT_UNUSED;  // Defensive, prevent lookup past end of renderpass attachment
@@ -3647,7 +3645,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                                      "vkCmdClearAttachments() pAttachments[%u].colorAttachment=%u out of range for %s"
                                      " subpass %u. colorAttachmentCount=%u",
                                      attachment_index, clear_desc->colorAttachment,
-                                     report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
+                                     report_data->FormatHandle(cb_node->activeRenderPass->renderPass()).c_str(),
                                      cb_node->activeSubpass, subpass_desc->colorAttachmentCount);
                 }
                 fb_attachment = color_attachment;
@@ -3786,14 +3784,14 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         // Validation for VK_EXT_fragment_density_map
         if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: srcImage must not have been created with flags containing "
                              "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                              func_name);
         }
         if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: dstImage must not have been created with flags containing "
                              "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                              func_name);
@@ -3843,14 +3841,14 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
             if (src_subresource.layerCount != dst_subresource.layerCount) {
                 vuid = is_2khr ? "VUID-VkImageResolve2KHR-layerCount-00267" : "VUID-VkImageResolve-layerCount-00267";
                 skip |=
-                    LogError(cb_node->commandBuffer, vuid,
+                    LogError(cb_node->commandBuffer(), vuid,
                              "%s: layerCount in source and destination subresource of pRegions[%u] does not match.", func_name, i);
             }
             // For each region, src and dest image aspect must be color only
             if ((src_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) ||
                 (dst_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)) {
                 vuid = is_2khr ? "VUID-VkImageResolve2KHR-aspectMask-00266" : "VUID-VkImageResolve-aspectMask-00266";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: src and dest aspectMasks for pRegions[%u] must specify only VK_IMAGE_ASPECT_COLOR_BIT.",
                                  func_name, i);
             }
@@ -3860,9 +3858,9 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
 
             if ((VK_IMAGE_TYPE_3D == src_image_type) || (VK_IMAGE_TYPE_3D == dst_image_type)) {
                 if ((0 != src_subresource.baseArrayLayer) || (1 != src_subresource.layerCount)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-04446" : "VUID-vkCmdResolveImage-srcImage-04446";
                     skip |= LogError(objlist, vuid,
                                      "%s: pRegions[%u] baseArrayLayer must be 0 and layerCount must be 1 for all "
@@ -3870,9 +3868,9 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                                      func_name, i);
                 }
                 if ((0 != dst_subresource.baseArrayLayer) || (1 != dst_subresource.layerCount)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-04447" : "VUID-vkCmdResolveImage-srcImage-04447";
                     skip |= LogError(objlist, vuid,
                                      "%s: pRegions[%u] baseArrayLayer must be 0 and layerCount must be 1 for all "
@@ -3883,50 +3881,50 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
 
             if (VK_IMAGE_TYPE_1D == src_image_type) {
                 if ((pRegions[i].srcOffset.y != 0) || (pRegions[i].extent.height != 1)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-00271" : "VUID-vkCmdResolveImage-srcImage-00271";
                     skip |= LogError(objlist, vuid,
                                      "%s: srcImage (%s) is 1D but pRegions[%u] srcOffset.y (%d) is not 0 or "
                                      "extent.height (%u) is not 1.",
-                                     func_name, report_data->FormatHandle(src_image_state->image).c_str(), i,
+                                     func_name, report_data->FormatHandle(src_image_state->image()).c_str(), i,
                                      pRegions[i].srcOffset.y, pRegions[i].extent.height);
                 }
             }
             if ((VK_IMAGE_TYPE_1D == src_image_type) || (VK_IMAGE_TYPE_2D == src_image_type)) {
                 if ((pRegions[i].srcOffset.z != 0) || (pRegions[i].extent.depth != 1)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-00273" : "VUID-vkCmdResolveImage-srcImage-00273";
                     skip |= LogError(objlist, vuid,
                                      "%s: srcImage (%s) is 2D but pRegions[%u] srcOffset.z (%d) is not 0 or "
                                      "extent.depth (%u) is not 1.",
-                                     func_name, report_data->FormatHandle(src_image_state->image).c_str(), i,
+                                     func_name, report_data->FormatHandle(src_image_state->image()).c_str(), i,
                                      pRegions[i].srcOffset.z, pRegions[i].extent.depth);
                 }
             }
 
             if (VK_IMAGE_TYPE_1D == dst_image_type) {
                 if ((pRegions[i].dstOffset.y != 0) || (pRegions[i].extent.height != 1)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstImage-00276" : "VUID-vkCmdResolveImage-dstImage-00276";
                     skip |= LogError(objlist, vuid,
                                      "%s: dstImage (%s) is 1D but pRegions[%u] dstOffset.y (%d) is not 0 or "
                                      "extent.height (%u) is not 1.",
-                                     func_name, report_data->FormatHandle(dst_image_state->image).c_str(), i,
+                                     func_name, report_data->FormatHandle(dst_image_state->image()).c_str(), i,
                                      pRegions[i].dstOffset.y, pRegions[i].extent.height);
                 }
             }
             if ((VK_IMAGE_TYPE_1D == dst_image_type) || (VK_IMAGE_TYPE_2D == dst_image_type)) {
                 if ((pRegions[i].dstOffset.z != 0) || (pRegions[i].extent.depth != 1)) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstImage-00278" : "VUID-vkCmdResolveImage-dstImage-00278";
                     skip |= LogError(objlist, vuid,
                                      "%s: dstImage (%s) is 2D but pRegions[%u] dstOffset.z (%d) is not 0 or "
                                      "extent.depth (%u) is not 1.",
-                                     func_name, report_data->FormatHandle(dst_image_state->image).c_str(), i,
+                                     func_name, report_data->FormatHandle(dst_image_state->image()).c_str(), i,
                                      pRegions[i].dstOffset.z, pRegions[i].extent.depth);
                 }
             }
@@ -3938,35 +3936,35 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
             if (src_subresource.mipLevel < src_image_state->createInfo.mipLevels) {
                 uint32_t extent_check = ExceedsBounds(&(region.srcOffset), &(region.extent), &subresource_extent);
                 if ((extent_check & kXBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcOffset-00269" : "VUID-vkCmdResolveImage-srcOffset-00269";
                     skip |= LogError(objlist, vuid,
                                      "%s: srcImage (%s) pRegions[%u] x-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource width [%u].",
-                                     func_name, report_data->FormatHandle(src_image_state->image).c_str(), i, region.srcOffset.x,
+                                     func_name, report_data->FormatHandle(src_image_state->image()).c_str(), i, region.srcOffset.x,
                                      region.extent.width, subresource_extent.width);
                 }
 
                 if ((extent_check & kYBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcOffset-00270" : "VUID-vkCmdResolveImage-srcOffset-00270";
                     skip |= LogError(objlist, vuid,
                                      "%s: srcImage (%s) pRegions[%u] y-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource height [%u].",
-                                     func_name, report_data->FormatHandle(src_image_state->image).c_str(), i, region.srcOffset.y,
+                                     func_name, report_data->FormatHandle(src_image_state->image()).c_str(), i, region.srcOffset.y,
                                      region.extent.height, subresource_extent.height);
                 }
 
                 if ((extent_check & kZBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(src_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(src_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcOffset-00272" : "VUID-vkCmdResolveImage-srcOffset-00272";
                     skip |= LogError(objlist, vuid,
                                      "%s: srcImage (%s) pRegions[%u] z-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource depth [%u].",
-                                     func_name, report_data->FormatHandle(src_image_state->image).c_str(), i, region.srcOffset.z,
+                                     func_name, report_data->FormatHandle(src_image_state->image()).c_str(), i, region.srcOffset.z,
                                      region.extent.depth, subresource_extent.depth);
                 }
             }
@@ -3978,35 +3976,35 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
             if (dst_subresource.mipLevel < dst_image_state->createInfo.mipLevels) {
                 uint32_t extent_check = ExceedsBounds(&(region.dstOffset), &(region.extent), &subresource_extent);
                 if ((extent_check & kXBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstOffset-00274" : "VUID-vkCmdResolveImage-dstOffset-00274";
                     skip |= LogError(objlist, vuid,
                                      "%s: dstImage (%s) pRegions[%u] x-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource width [%u].",
-                                     func_name, report_data->FormatHandle(dst_image_state->image).c_str(), i, region.srcOffset.x,
+                                     func_name, report_data->FormatHandle(dst_image_state->image()).c_str(), i, region.srcOffset.x,
                                      region.extent.width, subresource_extent.width);
                 }
 
                 if ((extent_check & kYBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstOffset-00275" : "VUID-vkCmdResolveImage-dstOffset-00275";
                     skip |= LogError(objlist, vuid,
                                      "%s: dstImage (%s) pRegions[%u] y-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource height [%u].",
-                                     func_name, report_data->FormatHandle(dst_image_state->image).c_str(), i, region.srcOffset.y,
+                                     func_name, report_data->FormatHandle(dst_image_state->image()).c_str(), i, region.srcOffset.y,
                                      region.extent.height, subresource_extent.height);
                 }
 
                 if ((extent_check & kZBit) != 0) {
-                    LogObjectList objlist(cb_node->commandBuffer);
-                    objlist.add(dst_image_state->image);
+                    LogObjectList objlist(cb_node->commandBuffer());
+                    objlist.add(dst_image_state->image());
                     vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstOffset-00277" : "VUID-vkCmdResolveImage-dstOffset-00277";
                     skip |= LogError(objlist, vuid,
                                      "%s: dstImage (%s) pRegions[%u] z-dimension offset [%1d] + extent [%u] "
                                      "exceeds subResource depth [%u].",
-                                     func_name, report_data->FormatHandle(dst_image_state->image).c_str(), i, region.srcOffset.z,
+                                     func_name, report_data->FormatHandle(dst_image_state->image()).c_str(), i, region.srcOffset.z,
                                      region.extent.depth, subresource_extent.depth);
                 }
             }
@@ -4014,23 +4012,23 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
 
         if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
             vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-01386" : "VUID-vkCmdResolveImage-srcImage-01386";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s: srcImage format (%s) and dstImage format (%s) are not the same.",
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s: srcImage format (%s) and dstImage format (%s) are not the same.",
                              func_name, string_VkFormat(src_image_state->createInfo.format),
                              string_VkFormat(dst_image_state->createInfo.format));
         }
         if (src_image_state->createInfo.imageType != dst_image_state->createInfo.imageType) {
-            skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_MismatchedImageType,
+            skip |= LogWarning(cb_node->commandBuffer(), kVUID_Core_DrawState_MismatchedImageType,
                                "%s: srcImage type (%s) and dstImage type (%s) are not the same.", func_name,
                                string_VkImageType(src_image_state->createInfo.imageType),
                                string_VkImageType(dst_image_state->createInfo.imageType));
         }
         if (src_image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT) {
             vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-srcImage-00257" : "VUID-vkCmdResolveImage-srcImage-00257";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s: srcImage sample count is VK_SAMPLE_COUNT_1_BIT.", func_name);
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s: srcImage sample count is VK_SAMPLE_COUNT_1_BIT.", func_name);
         }
         if (dst_image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
             vuid = is_2khr ? "VUID-VkResolveImageInfo2KHR-dstImage-00259" : "VUID-vkCmdResolveImage-dstImage-00259";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s: dstImage sample count (%s) is not VK_SAMPLE_COUNT_1_BIT.",
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s: dstImage sample count (%s) is not VK_SAMPLE_COUNT_1_BIT.",
                              func_name, string_VkSampleCountFlagBits(dst_image_state->createInfo.samples));
         }
     } else {
@@ -4103,13 +4101,13 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
         // Validation for VK_EXT_fragment_density_map
         if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: srcImage must not have been created with flags containing VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                              func_name);
         }
         if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: dstImage must not have been created with flags containing VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                              func_name);
         }
@@ -4149,7 +4147,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
 
         if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_3D != src_type)) {
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-filter-00237" : "VUID-vkCmdBlitImage-filter-00237";
-            skip |= LogError(cb_node->commandBuffer, vuid,
+            skip |= LogError(cb_node->commandBuffer(), vuid,
                              "%s: source image type must be VK_IMAGE_TYPE_3D when cubic filtering is specified.", func_name);
         }
 
@@ -4160,7 +4158,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                << "the other one must also have unsigned integer format.  "
                << "Source format is " << string_VkFormat(src_format) << " Destination format is " << string_VkFormat(dst_format);
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00230" : "VUID-vkCmdBlitImage-srcImage-00230";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s.", ss.str().c_str());
         }
 
         // Validate consistency for signed formats
@@ -4170,7 +4168,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                << "the other one must also have signed integer format.  "
                << "Source format is " << string_VkFormat(src_format) << " Destination format is " << string_VkFormat(dst_format);
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00229" : "VUID-vkCmdBlitImage-srcImage-00229";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s.", ss.str().c_str());
         }
 
         // Validate filter for Depth/Stencil formats
@@ -4179,7 +4177,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
             ss << func_name << ": If the format of srcImage is a depth, stencil, or depth stencil "
                << "then filter must be VK_FILTER_NEAREST.";
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00232" : "VUID-vkCmdBlitImage-srcImage-00232";
-            skip |= LogError(cb_node->commandBuffer, vuid, "%s.", ss.str().c_str());
+            skip |= LogError(cb_node->commandBuffer(), vuid, "%s.", ss.str().c_str());
         }
 
         // Validate aspect bits and formats for depth/stencil images
@@ -4191,7 +4189,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                    << "Source format is " << string_VkFormat(src_format) << " Destination format is "
                    << string_VkFormat(dst_format);
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00231" : "VUID-vkCmdBlitImage-srcImage-00231";
-                skip |= LogError(cb_node->commandBuffer, vuid, "%s.", ss.str().c_str());
+                skip |= LogError(cb_node->commandBuffer(), vuid, "%s.", ss.str().c_str());
             }
         }  // Depth or Stencil
 
@@ -4238,32 +4236,32 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.srcOffsets[0].z == rgn.srcOffsets[1].z)) {
                 std::stringstream ss;
                 ss << func_name << ": pRegions[" << i << "].srcOffsets specify a zero-volume area.";
-                skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
+                skip |= LogWarning(cb_node->commandBuffer(), kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
             }
             if ((rgn.dstOffsets[0].x == rgn.dstOffsets[1].x) || (rgn.dstOffsets[0].y == rgn.dstOffsets[1].y) ||
                 (rgn.dstOffsets[0].z == rgn.dstOffsets[1].z)) {
                 std::stringstream ss;
                 ss << func_name << ": pRegions[" << i << "].dstOffsets specify a zero-volume area.";
-                skip |= LogWarning(cb_node->commandBuffer, kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
+                skip |= LogWarning(cb_node->commandBuffer(), kVUID_Core_DrawState_InvalidExtents, "%s", ss.str().c_str());
             }
 
             // Check that src/dst layercounts match
             if (rgn.srcSubresource.layerCount != rgn.dstSubresource.layerCount) {
                 vuid = is_2khr ? "VUID-VkImageBlit2KHR-layerCount-00239" : "VUID-VkImageBlit-layerCount-00239";
                 skip |=
-                    LogError(cb_node->commandBuffer, vuid,
+                    LogError(cb_node->commandBuffer(), vuid,
                              "%s: layerCount in source and destination subresource of pRegions[%d] does not match.", func_name, i);
             }
 
             if (rgn.srcSubresource.aspectMask != rgn.dstSubresource.aspectMask) {
                 vuid = is_2khr ? "VUID-VkImageBlit2KHR-aspectMask-00238" : "VUID-VkImageBlit-aspectMask-00238";
                 skip |=
-                    LogError(cb_node->commandBuffer, vuid, "%s: aspectMask members for pRegion[%d] do not match.", func_name, i);
+                    LogError(cb_node->commandBuffer(), vuid, "%s: aspectMask members for pRegion[%d] do not match.", func_name, i);
             }
 
             if (!VerifyAspectsPresent(rgn.srcSubresource.aspectMask, src_format)) {
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-aspectMask-00241" : "VUID-vkCmdBlitImage-aspectMask-00241";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] source aspectMask (0x%x) specifies aspects not present in source "
                                  "image format %s.",
                                  func_name, i, rgn.srcSubresource.aspectMask, string_VkFormat(src_format));
@@ -4271,7 +4269,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
 
             if (!VerifyAspectsPresent(rgn.dstSubresource.aspectMask, dst_format)) {
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-aspectMask-00242" : "VUID-vkCmdBlitImage-aspectMask-00242";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] dest aspectMask (0x%x) specifies aspects not present in dest image format %s.",
                                  func_name, i, rgn.dstSubresource.aspectMask, string_VkFormat(dst_format));
             }
@@ -4281,7 +4279,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
             if (VK_IMAGE_TYPE_1D == src_type) {
                 if ((0 != rgn.srcOffsets[0].y) || (1 != rgn.srcOffsets[1].y)) {
                     vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00245" : "VUID-vkCmdBlitImage-srcImage-00245";
-                    skip |= LogError(cb_node->commandBuffer, vuid,
+                    skip |= LogError(cb_node->commandBuffer(), vuid,
                                      "%s: region [%d], source image of type VK_IMAGE_TYPE_1D with srcOffset[].y values "
                                      "of (%1d, %1d). These must be (0, 1).",
                                      func_name, i, rgn.srcOffsets[0].y, rgn.srcOffsets[1].y);
@@ -4291,7 +4289,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
             if ((VK_IMAGE_TYPE_1D == src_type) || (VK_IMAGE_TYPE_2D == src_type)) {
                 if ((0 != rgn.srcOffsets[0].z) || (1 != rgn.srcOffsets[1].z)) {
                     vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00247" : "VUID-vkCmdBlitImage-srcImage-00247";
-                    skip |= LogError(cb_node->commandBuffer, vuid,
+                    skip |= LogError(cb_node->commandBuffer(), vuid,
                                      "%s: region [%d], source image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
                                      "srcOffset[].z values of (%1d, %1d). These must be (0, 1).",
                                      func_name, i, rgn.srcOffsets[0].z, rgn.srcOffsets[1].z);
@@ -4303,7 +4301,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.srcOffsets[1].x < 0) || (rgn.srcOffsets[1].x > static_cast<int32_t>(src_extent.width))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcOffset-00243" : "VUID-vkCmdBlitImage-srcOffset-00243";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] srcOffset[].x values (%1d, %1d) exceed srcSubresource width extent (%1d).",
                                  func_name, i, rgn.srcOffsets[0].x, rgn.srcOffsets[1].x, src_extent.width);
             }
@@ -4311,7 +4309,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.srcOffsets[1].y < 0) || (rgn.srcOffsets[1].y > static_cast<int32_t>(src_extent.height))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcOffset-00244" : "VUID-vkCmdBlitImage-srcOffset-00244";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] srcOffset[].y values (%1d, %1d) exceed srcSubresource height extent (%1d).",
                                  func_name, i, rgn.srcOffsets[0].y, rgn.srcOffsets[1].y, src_extent.height);
             }
@@ -4319,13 +4317,13 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.srcOffsets[1].z < 0) || (rgn.srcOffsets[1].z > static_cast<int32_t>(src_extent.depth))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcOffset-00246" : "VUID-vkCmdBlitImage-srcOffset-00246";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] srcOffset[].z values (%1d, %1d) exceed srcSubresource depth extent (%1d).",
                                  func_name, i, rgn.srcOffsets[0].z, rgn.srcOffsets[1].z, src_extent.depth);
             }
             if (oob) {
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-pRegions-00215" : "VUID-vkCmdBlitImage-pRegions-00215";
-                skip |= LogError(cb_node->commandBuffer, vuid, "%s: region [%d] source image blit region exceeds image dimensions.",
+                skip |= LogError(cb_node->commandBuffer(), vuid, "%s: region [%d] source image blit region exceeds image dimensions.",
                                  func_name, i);
             }
 
@@ -4334,7 +4332,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
             if (VK_IMAGE_TYPE_1D == dst_type) {
                 if ((0 != rgn.dstOffsets[0].y) || (1 != rgn.dstOffsets[1].y)) {
                     vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstImage-00250" : "VUID-vkCmdBlitImage-dstImage-00250";
-                    skip |= LogError(cb_node->commandBuffer, vuid,
+                    skip |= LogError(cb_node->commandBuffer(), vuid,
                                      "%s: region [%d], dest image of type VK_IMAGE_TYPE_1D with dstOffset[].y values of "
                                      "(%1d, %1d). These must be (0, 1).",
                                      func_name, i, rgn.dstOffsets[0].y, rgn.dstOffsets[1].y);
@@ -4344,7 +4342,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
             if ((VK_IMAGE_TYPE_1D == dst_type) || (VK_IMAGE_TYPE_2D == dst_type)) {
                 if ((0 != rgn.dstOffsets[0].z) || (1 != rgn.dstOffsets[1].z)) {
                     vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstImage-00252" : "VUID-vkCmdBlitImage-dstImage-00252";
-                    skip |= LogError(cb_node->commandBuffer, vuid,
+                    skip |= LogError(cb_node->commandBuffer(), vuid,
                                      "%s: region [%d], dest image of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D with "
                                      "dstOffset[].z values of (%1d, %1d). These must be (0, 1).",
                                      func_name, i, rgn.dstOffsets[0].z, rgn.dstOffsets[1].z);
@@ -4356,7 +4354,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.dstOffsets[1].x < 0) || (rgn.dstOffsets[1].x > static_cast<int32_t>(dst_extent.width))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstOffset-00248" : "VUID-vkCmdBlitImage-dstOffset-00248";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] dstOffset[].x values (%1d, %1d) exceed dstSubresource width extent (%1d).",
                                  func_name, i, rgn.dstOffsets[0].x, rgn.dstOffsets[1].x, dst_extent.width);
             }
@@ -4364,7 +4362,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.dstOffsets[1].y < 0) || (rgn.dstOffsets[1].y > static_cast<int32_t>(dst_extent.height))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstOffset-00249" : "VUID-vkCmdBlitImage-dstOffset-00249";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] dstOffset[].y values (%1d, %1d) exceed dstSubresource height extent (%1d).",
                                  func_name, i, rgn.dstOffsets[0].y, rgn.dstOffsets[1].y, dst_extent.height);
             }
@@ -4372,13 +4370,13 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 (rgn.dstOffsets[1].z < 0) || (rgn.dstOffsets[1].z > static_cast<int32_t>(dst_extent.depth))) {
                 oob = true;
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-dstOffset-00251" : "VUID-vkCmdBlitImage-dstOffset-00251";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] dstOffset[].z values (%1d, %1d) exceed dstSubresource depth extent (%1d).",
                                  func_name, i, rgn.dstOffsets[0].z, rgn.dstOffsets[1].z, dst_extent.depth);
             }
             if (oob) {
                 vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-pRegions-00216" : "VUID-vkCmdBlitImage-pRegions-00216";
-                skip |= LogError(cb_node->commandBuffer, vuid,
+                skip |= LogError(cb_node->commandBuffer(), vuid,
                                  "%s: region [%d] destination image blit region exceeds image dimensions.", func_name, i);
             }
 
@@ -4386,7 +4384,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                 if ((0 != rgn.srcSubresource.baseArrayLayer) || (1 != rgn.srcSubresource.layerCount) ||
                     (0 != rgn.dstSubresource.baseArrayLayer) || (1 != rgn.dstSubresource.layerCount)) {
                     vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-srcImage-00240" : "VUID-vkCmdBlitImage-srcImage-00240";
-                    skip |= LogError(cb_node->commandBuffer, vuid,
+                    skip |= LogError(cb_node->commandBuffer(), vuid,
                                      "%s: region [%d] blit to/from a 3D image type with a non-zero baseArrayLayer, or a "
                                      "layerCount other than 1.",
                                      func_name, i);
@@ -4444,7 +4442,7 @@ void CoreChecks::PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, co
 
 GlobalImageLayoutRangeMap *GetLayoutRangeMap(GlobalImageLayoutMap &map, const IMAGE_STATE &image_state) {
     // This approach allows for a single hash lookup or/create new
-    auto &layout_map = map[image_state.image];
+    auto &layout_map = map[image_state.image()];
     if (!layout_map) {
         layout_map.emplace(image_state.subresource_encoder.SubresourceCount());
     }
@@ -4535,7 +4533,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE *pCB, const G
                     for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->subresource_encoder.Decode(index);
                         skip |= LogError(
-                            pCB->commandBuffer, kVUID_Core_DrawState_InvalidImageLayout,
+                            pCB->commandBuffer(), kVUID_Core_DrawState_InvalidImageLayout,
                             "Submitted command buffer expects %s (subresource: aspectMask 0x%X array layer %u, mip level %u) "
                             "to be in layout %s--instead, current layout is %s.",
                             report_data->FormatHandle(image).c_str(), subresource.aspectMask, subresource.arrayLayer,
@@ -4655,7 +4653,7 @@ bool CoreChecks::ValidateUsageFlags(VkFlags actual, VkFlags desired, VkBool32 st
 // where an error will be flagged if usage is not correct
 bool CoreChecks::ValidateImageUsageFlags(IMAGE_STATE const *image_state, VkFlags desired, bool strict, const char *msgCode,
                                          char const *func_name, char const *usage_string) const {
-    return ValidateUsageFlags(image_state->createInfo.usage, desired, strict, image_state->image,
+    return ValidateUsageFlags(image_state->createInfo.usage, desired, strict, image_state->image(),
                               image_state->Handle(), msgCode, func_name, usage_string);
 }
 
@@ -4666,17 +4664,17 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(IMAGE_STATE const *image_state,
     if ((image_format_features & desired) != desired) {
         // Same error, but more details if it was an AHB external format
         if (image_state->has_ahb_format == true) {
-            skip |= LogError(image_state->image, vuid,
+            skip |= LogError(image_state->image(), vuid,
                              "In %s, VkFormatFeatureFlags (0x%08X) does not support required feature %s for the external format "
                              "found in VkAndroidHardwareBufferFormatPropertiesANDROID::formatFeatures used by %s.",
                              func_name, image_format_features, string_VkFormatFeatureFlags(desired).c_str(),
-                             report_data->FormatHandle(image_state->image).c_str());
+                             report_data->FormatHandle(image_state->image()).c_str());
         } else {
-            skip |= LogError(image_state->image, vuid,
+            skip |= LogError(image_state->image(), vuid,
                              "In %s, VkFormatFeatureFlags (0x%08X) does not support required feature %s for format %u used by %s "
                              "with tiling %s.",
                              func_name, image_format_features, string_VkFormatFeatureFlags(desired).c_str(),
-                             image_state->createInfo.format, report_data->FormatHandle(image_state->image).c_str(),
+                             image_state->createInfo.format, report_data->FormatHandle(image_state->image()).c_str(),
                              string_VkImageTiling(image_state->createInfo.tiling));
         }
     }
@@ -4689,17 +4687,17 @@ bool CoreChecks::ValidateImageSubresourceLayers(const CMD_BUFFER_STATE *cb_node,
     const VkImageAspectFlags apsect_mask = subresource_layers->aspectMask;
     // layerCount must not be zero
     if (subresource_layers->layerCount == 0) {
-        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-layerCount-01700",
+        skip |= LogError(cb_node->commandBuffer(), "VUID-VkImageSubresourceLayers-layerCount-01700",
                          "In %s, pRegions[%u].%s.layerCount must not be zero.", func_name, i, member);
     }
     // aspectMask must not contain VK_IMAGE_ASPECT_METADATA_BIT
     if (apsect_mask & VK_IMAGE_ASPECT_METADATA_BIT) {
-        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-aspectMask-00168",
+        skip |= LogError(cb_node->commandBuffer(), "VUID-VkImageSubresourceLayers-aspectMask-00168",
                          "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_METADATA_BIT set.", func_name, i, member);
     }
     // if aspectMask contains COLOR, it must not contain either DEPTH or STENCIL
     if ((apsect_mask & VK_IMAGE_ASPECT_COLOR_BIT) && (apsect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-aspectMask-00167",
+        skip |= LogError(cb_node->commandBuffer(), "VUID-VkImageSubresourceLayers-aspectMask-00167",
                          "In %s, pRegions[%u].%s.aspectMask has VK_IMAGE_ASPECT_COLOR_BIT and either VK_IMAGE_ASPECT_DEPTH_BIT or "
                          "VK_IMAGE_ASPECT_STENCIL_BIT set.",
                          func_name, i, member);
@@ -4707,7 +4705,7 @@ bool CoreChecks::ValidateImageSubresourceLayers(const CMD_BUFFER_STATE *cb_node,
     // aspectMask must not contain VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT
     if (apsect_mask & (VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT |
                        VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
-        skip |= LogError(cb_node->commandBuffer, "VUID-VkImageSubresourceLayers-aspectMask-02247",
+        skip |= LogError(cb_node->commandBuffer(), "VUID-VkImageSubresourceLayers-aspectMask-02247",
                          "In %s, pRegions[%u].%s.aspectMask has a VK_IMAGE_ASPECT_MEMORY_PLANE_*_BIT_EXT bit set.", func_name, i,
                          member);
     }
@@ -4718,7 +4716,7 @@ bool CoreChecks::ValidateImageSubresourceLayers(const CMD_BUFFER_STATE *cb_node,
 // where an error will be flagged if usage is not correct
 bool CoreChecks::ValidateBufferUsageFlags(BUFFER_STATE const *buffer_state, VkFlags desired, bool strict, const char *msgCode,
                                           char const *func_name, char const *usage_string) const {
-    return ValidateUsageFlags(buffer_state->createInfo.usage, desired, strict, buffer_state->buffer,
+    return ValidateUsageFlags(buffer_state->createInfo.usage, desired, strict, buffer_state->buffer(),
                               buffer_state->Handle(), msgCode, func_name, usage_string);
 }
 
@@ -4730,7 +4728,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
     if (range != VK_WHOLE_SIZE) {
         // Range must be greater than 0
         if (range <= 0) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00928",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-range-00928",
                              "vkCreateBufferView(): If VkBufferViewCreateInfo range (%" PRIuLEAST64
                              ") does not equal VK_WHOLE_SIZE, range must be greater than 0.",
                              range);
@@ -4738,7 +4736,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
         // Range must be a multiple of the element size of format
         const uint32_t format_size = FormatElementSize(pCreateInfo->format);
         if (SafeModulo(range, format_size) != 0) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00929",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-range-00929",
                              "vkCreateBufferView(): If VkBufferViewCreateInfo range (%" PRIuLEAST64
                              ") does not equal VK_WHOLE_SIZE, range must be a multiple of the element size of the format "
                              "(%" PRIu32 ").",
@@ -4746,7 +4744,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
         }
         // Range divided by the element size of format must be less than or equal to VkPhysicalDeviceLimits::maxTexelBufferElements
         if (SafeDivision(range, format_size) > device_limits->maxTexelBufferElements) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-00930",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-range-00930",
                              "vkCreateBufferView(): If VkBufferViewCreateInfo range (%" PRIuLEAST64
                              ") does not equal VK_WHOLE_SIZE, range divided by the element size of the format (%" PRIu32
                              ") must be less than or equal to VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
@@ -4754,7 +4752,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
         }
         // The sum of range and offset must be less than or equal to the size of buffer
         if (range + pCreateInfo->offset > buffer_state->createInfo.size) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-offset-00931",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-offset-00931",
                              "vkCreateBufferView(): If VkBufferViewCreateInfo range (%" PRIuLEAST64
                              ") does not equal VK_WHOLE_SIZE, the sum of offset (%" PRIuLEAST64
                              ") and range must be less than or equal to the size of the buffer (%" PRIuLEAST64 ").",
@@ -4767,7 +4765,7 @@ bool CoreChecks::ValidateBufferViewRange(const BUFFER_STATE *buffer_state, const
         // VkPhysicalDeviceLimits::maxTexelBufferElements
         if (SafeDivision(buffer_state->createInfo.size - pCreateInfo->offset, format_size) >
             device_limits->maxTexelBufferElements) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-range-04059",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-range-04059",
                              "vkCreateBufferView(): If VkBufferViewCreateInfo range (%" PRIuLEAST64
                              ") equals VK_WHOLE_SIZE, the buffer's size (%" PRIuLEAST64 ") minus the offset (%" PRIuLEAST64
                              "), divided by the element size of the format (%" PRIu32
@@ -4784,7 +4782,7 @@ bool CoreChecks::ValidateBufferViewBuffer(const BUFFER_STATE *buffer_state, cons
     const VkFormatProperties format_properties = GetPDFormatProperties(pCreateInfo->format);
     if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
-        skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-00933",
+        skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-buffer-00933",
                          "vkCreateBufferView(): If buffer was created with `usage` containing "
                          "VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, format (%s) must "
                          "be supported for uniform texel buffers",
@@ -4792,7 +4790,7 @@ bool CoreChecks::ValidateBufferViewBuffer(const BUFFER_STATE *buffer_state, cons
     }
     if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
-        skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-00934",
+        skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-buffer-00934",
                          "vkCreateBufferView(): If buffer was created with `usage` containing "
                          "VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, format (%s) must "
                          "be supported for storage texel buffers",
@@ -4877,7 +4875,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
 
         // Buffer view offset must be less than the size of buffer
         if (pCreateInfo->offset >= buffer_state->createInfo.size) {
-            skip |= LogError(buffer_state->buffer, "VUID-VkBufferViewCreateInfo-offset-00925",
+            skip |= LogError(buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-offset-00925",
                              "vkCreateBufferView(): VkBufferViewCreateInfo offset (%" PRIuLEAST64
                              ") must be less than the size of the buffer (%" PRIuLEAST64 ").",
                              pCreateInfo->offset, buffer_state->createInfo.size);
@@ -4889,7 +4887,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
             !enabled_features.texel_buffer_alignment_features.texelBufferAlignment) {
             const char *vuid = device_extensions.vk_ext_texel_buffer_alignment ? "VUID-VkBufferViewCreateInfo-offset-02749"
                                                                                : "VUID-VkBufferViewCreateInfo-offset-00926";
-            skip |= LogError(buffer_state->buffer, vuid,
+            skip |= LogError(buffer_state->buffer(), vuid,
                              "vkCreateBufferView(): VkBufferViewCreateInfo offset (%" PRIuLEAST64
                              ") must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment (%" PRIuLEAST64 ").",
                              pCreateInfo->offset, device_limits->minTexelBufferOffsetAlignment);
@@ -4908,7 +4906,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                 }
                 if (SafeModulo(pCreateInfo->offset, alignment_requirement) != 0) {
                     skip |= LogError(
-                        buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-02750",
+                        buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-buffer-02750",
                         "vkCreateBufferView(): If buffer was created with usage containing "
                         "VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, "
                         "VkBufferViewCreateInfo offset (%" PRIuLEAST64
@@ -4931,7 +4929,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                 }
                 if (SafeModulo(pCreateInfo->offset, alignment_requirement) != 0) {
                     skip |= LogError(
-                        buffer_state->buffer, "VUID-VkBufferViewCreateInfo-buffer-02751",
+                        buffer_state->buffer(), "VUID-VkBufferViewCreateInfo-buffer-02751",
                         "vkCreateBufferView(): If buffer was created with usage containing "
                         "VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, "
                         "VkBufferViewCreateInfo offset (%" PRIuLEAST64
@@ -5118,7 +5116,7 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const IMAGE_STATE *imag
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_layer_count, subresourceRange,
                                          "vkCreateImageView", "pCreateInfo->subresourceRange", image_layer_count_var_name,
-                                         image_state->image, subresource_range_error_codes);
+                                         image_state->image(), subresource_range_error_codes);
 }
 
 bool CoreChecks::ValidateCmdClearColorSubresourceRange(const IMAGE_STATE *image_state,
@@ -5131,7 +5129,7 @@ bool CoreChecks::ValidateCmdClearColorSubresourceRange(const IMAGE_STATE *image_
     subresource_range_error_codes.layer_count_err = "VUID-vkCmdClearColorImage-pRanges-01693";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         "vkCmdClearColorImage", param_name, "arrayLayers", image_state->image,
+                                         "vkCmdClearColorImage", param_name, "arrayLayers", image_state->image(),
                                          subresource_range_error_codes);
 }
 
@@ -5145,14 +5143,14 @@ bool CoreChecks::ValidateCmdClearDepthSubresourceRange(const IMAGE_STATE *image_
     subresource_range_error_codes.layer_count_err = "VUID-vkCmdClearDepthStencilImage-pRanges-01695";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         "vkCmdClearDepthStencilImage", param_name, "arrayLayers", image_state->image,
+                                         "vkCmdClearDepthStencilImage", param_name, "arrayLayers", image_state->image(),
                                          subresource_range_error_codes);
 }
 
 bool CoreChecks::ValidateImageBarrierSubresourceRange(const Location &loc, const IMAGE_STATE *image_state,
                                                       const VkImageSubresourceRange &subresourceRange) const {
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers, subresourceRange,
-                                         loc.StringFunc().c_str(), loc.StringField().c_str(), "arrayLayers", image_state->image,
+                                         loc.StringFunc().c_str(), loc.StringField().c_str(), "arrayLayers", image_state->image(),
                                          sync_vuid_maps::GetSubResourceVUIDs(loc));
 }
 
@@ -5313,7 +5311,7 @@ bool CoreChecks::ValidateConcurrentBarrierAtSubmit(const Location &loc, const Va
                                                    const VulkanTypedHandle &typed_handle, uint32_t src_queue_family,
                                                    uint32_t dst_queue_family) {
     using barrier_queue_families::ValidatorState;
-    ValidatorState val(state_data, LogObjectList(cb_state->commandBuffer), loc, typed_handle, VK_SHARING_MODE_CONCURRENT);
+    ValidatorState val(state_data, LogObjectList(cb_state->commandBuffer()), loc, typed_handle, VK_SHARING_MODE_CONCURRENT);
     return ValidatorState::ValidateAtQueueSubmit(queue_state, state_data, src_queue_family, dst_queue_family, val);
 }
 
@@ -5327,7 +5325,7 @@ bool CoreChecks::ValidateBarrierQueueFamilies(const Location &loc, const CMD_BUF
     }
 
     // Create the validator state from the image state
-    barrier_queue_families::ValidatorState val(this, LogObjectList(cb_state->commandBuffer), loc,
+    barrier_queue_families::ValidatorState val(this, LogObjectList(cb_state->commandBuffer()), loc,
                                                state_data->Handle(), state_data->createInfo.sharingMode);
     const uint32_t src_queue_family = barrier.srcQueueFamilyIndex;
     const uint32_t dst_queue_family = barrier.dstQueueFamilyIndex;
@@ -5344,7 +5342,7 @@ bool CoreChecks::ValidateBarrierQueueFamilies(const Location &loc, const CMD_BUF
     }
 
     // Create the validator state from the buffer state
-    barrier_queue_families::ValidatorState val(this, LogObjectList(cb_state->commandBuffer), loc,
+    barrier_queue_families::ValidatorState val(this, LogObjectList(cb_state->commandBuffer()), loc,
                                                state_data->Handle(), state_data->createInfo.sharingMode);
     const uint32_t src_queue_family = barrier.srcQueueFamilyIndex;
     const uint32_t dst_queue_family = barrier.dstQueueFamilyIndex;
@@ -5414,7 +5412,7 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
             auto layout_loc = loc.dot(Field::newLayout);
             const auto &vuid = sync_vuid_maps::GetImageBarrierVUID(loc, sync_vuid_maps::ImageError::kBadLayout);
             skip |=
-                LogError(cb_state->commandBuffer, vuid, "%s Image Layout cannot be transitioned to UNDEFINED or PREINITIALIZED.",
+                LogError(cb_state->commandBuffer(), vuid, "%s Image Layout cannot be transitioned to UNDEFINED or PREINITIALIZED.",
                          layout_loc.Message().c_str());
         }
     }
@@ -5427,7 +5425,7 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
 
         skip |= ValidateBarrierQueueFamilies(image_loc, cb_state, mem_barrier, image_data);
 
-        skip |= ValidateImageAspectMask(image_data->image, image_data->createInfo.format, mem_barrier.subresourceRange.aspectMask,
+        skip |= ValidateImageAspectMask(image_data->image(), image_data->createInfo.format, mem_barrier.subresourceRange.aspectMask,
                                         loc.StringFunc().c_str());
 
         skip |= ValidateImageBarrierSubresourceRange(loc.dot(Field::subresourceRange), image_data, mem_barrier.subresourceRange);
@@ -5442,7 +5440,7 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const CMD_BUFFER_ST
                                   const VkImageMemoryBarrier *pImageMemBarriers) const {
     bool skip = false;
     auto queue_flags = GetQueueFlags(*cb_state);
-    LogObjectList objects(cb_state->commandBuffer);
+    LogObjectList objects(cb_state->commandBuffer());
     auto op_type =
         ComputeBarrierOperationsType(cb_state, bufferBarrierCount, pBufferMemBarriers, imageMemBarrierCount, pImageMemBarriers);
 
@@ -5591,7 +5589,7 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const IMAGE_STATE *image_state,
         assert(device_extensions.vk_ext_image_drm_format_modifier);
         VkImageDrmFormatModifierPropertiesEXT drm_format_properties = {VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT,
                                                                        nullptr};
-        DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state->image, &drm_format_properties);
+        DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state->image(), &drm_format_properties);
 
         VkFormatProperties2 format_properties_2 = {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr};
         VkDrmFormatModifierPropertiesListEXT drm_properties_list = {VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
@@ -5618,41 +5616,41 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const IMAGE_STATE *image_state,
     }
 
     if (tiling_features == 0) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-None-02273",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-None-02273",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s has no supported format features on this "
                          "physical device.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_SAMPLED_BIT) && !(tiling_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-02274",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-02274",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                          "VK_IMAGE_USAGE_SAMPLED_BIT.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_STORAGE_BIT) && !(tiling_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-02275",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-02275",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                          "VK_IMAGE_USAGE_STORAGE_BIT.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) && !(tiling_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-02276",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-02276",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                          "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
                !(tiling_features & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-02277",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-02277",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                          "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) &&
                !(tiling_features & (VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT))) {
-        skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-02652",
+        skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-02652",
                          "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                          "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                          string_VkFormat(view_format), string_VkImageTiling(image_tiling));
     } else if ((image_usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) &&
                !(tiling_features & VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         if (enabled_features.fragment_shading_rate_features.attachmentFragmentShadingRate) {
-            skip |= LogError(image_state->image, "VUID-VkImageViewCreateInfo-usage-04550",
+            skip |= LogError(image_state->image(), "VUID-VkImageViewCreateInfo-usage-04550",
                              "vkCreateImageView(): pCreateInfo->format %s with tiling %s does not support usage that includes "
                              "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR.",
                              string_VkFormat(view_format), string_VkImageTiling(image_tiling));
@@ -5814,7 +5812,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         }
 
         // Validate correct image aspect bits for desired formats and format consistency
-        skip |= ValidateImageAspectMask(image_state->image, image_format, aspect_mask, "vkCreateImageView()");
+        skip |= ValidateImageAspectMask(image_state->image(), image_format, aspect_mask, "vkCreateImageView()");
 
         switch (image_type) {
             case VK_IMAGE_TYPE_1D:
@@ -6044,7 +6042,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
         // The srcOffset member of each element of pRegions must be less than the size of srcBuffer
         if (pRegions[i].srcOffset >= src_buffer_size) {
             vuid = is_2khr ? "VUID-VkCopyBufferInfo2KHR-srcOffset-00113" : "VUID-vkCmdCopyBuffer-srcOffset-00113";
-            skip |= LogError(src_buffer_state->buffer, vuid,
+            skip |= LogError(src_buffer_state->buffer(), vuid,
                              "%s: pRegions[%d].srcOffset (%" PRIuLEAST64 ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
                              func_name, i, pRegions[i].srcOffset, i, pRegions[i].size);
         }
@@ -6052,7 +6050,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
         // The dstOffset member of each element of pRegions must be less than the size of dstBuffer
         if (pRegions[i].dstOffset >= dst_buffer_size) {
             vuid = is_2khr ? "VUID-VkCopyBufferInfo2KHR-dstOffset-00114" : "VUID-vkCmdCopyBuffer-dstOffset-00114";
-            skip |= LogError(dst_buffer_state->buffer, vuid,
+            skip |= LogError(dst_buffer_state->buffer(), vuid,
                              "%s: pRegions[%d].dstOffset (%" PRIuLEAST64 ") is greater than pRegions[%d].size (%" PRIuLEAST64 ").",
                              func_name, i, pRegions[i].dstOffset, i, pRegions[i].size);
         }
@@ -6060,7 +6058,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
         // The size member of each element of pRegions must be less than or equal to the size of srcBuffer minus srcOffset
         if (pRegions[i].size > (src_buffer_size - pRegions[i].srcOffset)) {
             vuid = is_2khr ? "VUID-VkCopyBufferInfo2KHR-size-00115" : "VUID-vkCmdCopyBuffer-size-00115";
-            skip |= LogError(src_buffer_state->buffer, vuid,
+            skip |= LogError(src_buffer_state->buffer(), vuid,
                              "%s: pRegions[%d].size (%" PRIuLEAST64 ") is greater than the source buffer size (%" PRIuLEAST64
                              ") minus pRegions[%d].srcOffset (%" PRIuLEAST64 ").",
                              func_name, i, pRegions[i].size, src_buffer_size, i, pRegions[i].srcOffset);
@@ -6069,7 +6067,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
         // The size member of each element of pRegions must be less than or equal to the size of dstBuffer minus dstOffset
         if (pRegions[i].size > (dst_buffer_size - pRegions[i].dstOffset)) {
             vuid = is_2khr ? "VUID-VkCopyBufferInfo2KHR-size-00116" : "VUID-vkCmdCopyBuffer-size-00116";
-            skip |= LogError(dst_buffer_state->buffer, vuid,
+            skip |= LogError(dst_buffer_state->buffer(), vuid,
                              "%s: pRegions[%d].size (%" PRIuLEAST64 ") is greater than the destination buffer size (%" PRIuLEAST64
                              ") minus pRegions[%d].dstOffset (%" PRIuLEAST64 ").",
                              func_name, i, pRegions[i].size, dst_buffer_size, i, pRegions[i].dstOffset);
@@ -6077,10 +6075,10 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
     }
 
     // The union of the source regions, and the union of the destination regions, must not overlap in memory
-    if (src_buffer_state->buffer == dst_buffer_state->buffer) {
+    if (src_buffer_state->buffer() == dst_buffer_state->buffer()) {
         if (((src_min > dst_min) && (src_min < dst_max)) || ((src_max > dst_min) && (src_max < dst_max))) {
             vuid = is_2khr ? "VUID-VkCopyBufferInfo2KHR-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
-            skip |= LogError(src_buffer_state->buffer, vuid, "%s: Detected overlap between source and dest regions in memory.",
+            skip |= LogError(src_buffer_state->buffer(), vuid, "%s: Detected overlap between source and dest regions in memory.",
                              func_name);
         }
     }
@@ -6231,7 +6229,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         const VkImageAspectFlags region_aspect_mask = pRegions[i].imageSubresource.aspectMask;
         if (image_state->createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((pRegions[i].imageOffset.y != 0) || (pRegions[i].imageExtent.height != 1)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00199", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00199", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] imageOffset.y is %d and imageExtent.height is %d. For 1D images these must be 0 "
                                  "and 1, respectively.",
                                  function, i, pRegions[i].imageOffset.y, pRegions[i].imageExtent.height);
@@ -6240,7 +6238,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
 
         if ((image_state->createInfo.imageType == VK_IMAGE_TYPE_1D) || (image_state->createInfo.imageType == VK_IMAGE_TYPE_2D)) {
             if ((pRegions[i].imageOffset.z != 0) || (pRegions[i].imageExtent.depth != 1)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00201", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00201", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] imageOffset.z is %d and imageExtent.depth is %d. For 1D and 2D images these "
                                  "must be 0 and 1, respectively.",
                                  function, i, pRegions[i].imageOffset.z, pRegions[i].imageExtent.depth);
@@ -6249,7 +6247,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
 
         if (image_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
             if ((0 != pRegions[i].imageSubresource.baseArrayLayer) || (1 != pRegions[i].imageSubresource.layerCount)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00213", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00213", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] imageSubresource.baseArrayLayer is %d and imageSubresource.layerCount is %d. "
                                  "For 3D images these must be 0 and 1, respectively.",
                                  function, i, pRegions[i].imageSubresource.baseArrayLayer, pRegions[i].imageSubresource.layerCount);
@@ -6263,7 +6261,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
 
         if (FormatIsDepthOrStencil(image_format)) {
             if (SafeModulo(bufferOffset, 4) != 0) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("04053", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("04053", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] bufferOffset 0x%" PRIxLEAST64
                                  " must be a multiple 4 if using a depth/stencil format (%s).",
                                  function, i, bufferOffset, string_VkFormat(image_format));
@@ -6274,7 +6272,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
                 vuid = (device_extensions.vk_khr_sampler_ycbcr_conversion)
                            ? GetBufferImageCopyCommandVUID("01558", image_to_buffer, is_2khr)
                            : GetBufferImageCopyCommandVUID("00193", image_to_buffer, is_2khr);
-                skip |= LogError(image_state->image, vuid,
+                skip |= LogError(image_state->image(), vuid,
                                  "%s: pRegion[%d] bufferOffset 0x%" PRIxLEAST64
                                  " must be a multiple of this format's texel size (%" PRIu32 ").",
                                  function, i, bufferOffset, element_size);
@@ -6285,7 +6283,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         if ((pRegions[i].bufferRowLength != 0) && (pRegions[i].bufferRowLength < pRegions[i].imageExtent.width)) {
             vuid = (is_2khr) ? "VUID-VkBufferImageCopy2KHR-bufferRowLength-00195" : "VUID-VkBufferImageCopy-bufferRowLength-00195";
             skip |=
-                LogError(image_state->image, vuid,
+                LogError(image_state->image(), vuid,
                          "%s: pRegion[%d] bufferRowLength (%d) must be zero or greater-than-or-equal-to imageExtent.width (%d).",
                          function, i, pRegions[i].bufferRowLength, pRegions[i].imageExtent.width);
         }
@@ -6295,7 +6293,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             vuid =
                 (is_2khr) ? "VUID-VkBufferImageCopy2KHR-bufferImageHeight-00196" : "VUID-VkBufferImageCopy-bufferImageHeight-00196";
             skip |=
-                LogError(image_state->image, vuid,
+                LogError(image_state->image(), vuid,
                          "%s: pRegion[%d] bufferImageHeight (%d) must be zero or greater-than-or-equal-to imageExtent.height (%d).",
                          function, i, pRegions[i].bufferImageHeight, pRegions[i].imageExtent.height);
         }
@@ -6306,7 +6304,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         if ((pRegions[i].imageOffset.x < 0) || (pRegions[i].imageOffset.x > static_cast<int32_t>(adjusted_image_extent.width)) ||
             ((pRegions[i].imageOffset.x + static_cast<int32_t>(pRegions[i].imageExtent.width)) >
              static_cast<int32_t>(adjusted_image_extent.width))) {
-            skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00197", image_to_buffer, is_2khr),
+            skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00197", image_to_buffer, is_2khr),
                              "%s: Both pRegion[%d] imageoffset.x (%d) and (imageExtent.width + imageOffset.x) (%d) must be >= "
                              "zero or <= image subresource width (%d).",
                              function, i, pRegions[i].imageOffset.x, (pRegions[i].imageOffset.x + pRegions[i].imageExtent.width),
@@ -6317,7 +6315,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         if ((pRegions[i].imageOffset.y < 0) || (pRegions[i].imageOffset.y > static_cast<int32_t>(adjusted_image_extent.height)) ||
             ((pRegions[i].imageOffset.y + static_cast<int32_t>(pRegions[i].imageExtent.height)) >
              static_cast<int32_t>(adjusted_image_extent.height))) {
-            skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00198", image_to_buffer, is_2khr),
+            skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00198", image_to_buffer, is_2khr),
                              "%s: Both pRegion[%d] imageoffset.y (%d) and (imageExtent.height + imageOffset.y) (%d) must be >= "
                              "zero or <= image subresource height (%d).",
                              function, i, pRegions[i].imageOffset.y, (pRegions[i].imageOffset.y + pRegions[i].imageExtent.height),
@@ -6328,7 +6326,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         if ((pRegions[i].imageOffset.z < 0) || (pRegions[i].imageOffset.z > static_cast<int32_t>(adjusted_image_extent.depth)) ||
             ((pRegions[i].imageOffset.z + static_cast<int32_t>(pRegions[i].imageExtent.depth)) >
              static_cast<int32_t>(adjusted_image_extent.depth))) {
-            skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00200", image_to_buffer, is_2khr),
+            skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00200", image_to_buffer, is_2khr),
                              "%s: Both pRegion[%d] imageoffset.z (%d) and (imageExtent.depth + imageOffset.z) (%d) must be >= "
                              "zero or <= image subresource depth (%d).",
                              function, i, pRegions[i].imageOffset.z, (pRegions[i].imageOffset.z + pRegions[i].imageExtent.depth),
@@ -6340,14 +6338,14 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         std::bitset<num_bits> aspect_mask_bits(region_aspect_mask);
         if (aspect_mask_bits.count() != 1) {
             vuid = (is_2khr) ? "VUID-VkBufferImageCopy2KHR-aspectMask-00212" : "VUID-VkBufferImageCopy-aspectMask-00212";
-            skip |= LogError(image_state->image, vuid,
+            skip |= LogError(image_state->image(), vuid,
                              "%s: aspectMasks for imageSubresource in pRegion[%d] must have only a single bit set.", function, i);
         }
 
         // image subresource aspect bit must match format
         if (!VerifyAspectsPresent(region_aspect_mask, image_format)) {
             skip |=
-                LogError(image_state->image, GetBufferImageCopyCommandVUID("00211", image_to_buffer, is_2khr),
+                LogError(image_state->image(), GetBufferImageCopyCommandVUID("00211", image_to_buffer, is_2khr),
                          "%s: pRegion[%d] subresource aspectMask 0x%x specifies aspects that are not present in image format 0x%x.",
                          function, i, region_aspect_mask, image_format);
         }
@@ -6359,7 +6357,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             //  BufferRowLength must be a multiple of block width
             if (SafeModulo(pRegions[i].bufferRowLength, block_size.width) != 0) {
                 skip |=
-                    LogError(image_state->image, GetBufferImageCopyCommandVUID("00203", image_to_buffer, is_2khr),
+                    LogError(image_state->image(), GetBufferImageCopyCommandVUID("00203", image_to_buffer, is_2khr),
                              "%s: pRegion[%d] bufferRowLength (%d) must be a multiple of the compressed image's texel width (%d)..",
                              function, i, pRegions[i].bufferRowLength, block_size.width);
             }
@@ -6367,7 +6365,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             //  BufferRowHeight must be a multiple of block height
             if (SafeModulo(pRegions[i].bufferImageHeight, block_size.height) != 0) {
                 skip |= LogError(
-                    image_state->image, GetBufferImageCopyCommandVUID("00204", image_to_buffer, is_2khr),
+                    image_state->image(), GetBufferImageCopyCommandVUID("00204", image_to_buffer, is_2khr),
                     "%s: pRegion[%d] bufferImageHeight (%d) must be a multiple of the compressed image's texel height (%d)..",
                     function, i, pRegions[i].bufferImageHeight, block_size.height);
             }
@@ -6376,7 +6374,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             if ((SafeModulo(pRegions[i].imageOffset.x, block_size.width) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.y, block_size.height) != 0) ||
                 (SafeModulo(pRegions[i].imageOffset.z, block_size.depth) != 0)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00205", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00205", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] imageOffset(x,y) (%d, %d) must be multiples of the compressed image's texel "
                                  "width & height (%d, %d)..",
                                  function, i, pRegions[i].imageOffset.x, pRegions[i].imageOffset.y, block_size.width,
@@ -6386,7 +6384,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // bufferOffset must be a multiple of block size (linear bytes)
             uint32_t block_size_in_bytes = FormatElementSize(image_format);
             if (SafeModulo(bufferOffset, block_size_in_bytes) != 0) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00206", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00206", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] bufferOffset (0x%" PRIxLEAST64
                                  ") must be a multiple of the compressed image's texel block size (%" PRIu32 ")..",
                                  function, i, bufferOffset, block_size_in_bytes);
@@ -6396,7 +6394,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             VkExtent3D mip_extent = GetImageSubresourceExtent(image_state, &(pRegions[i].imageSubresource));
             if ((SafeModulo(pRegions[i].imageExtent.width, block_size.width) != 0) &&
                 (pRegions[i].imageExtent.width + pRegions[i].imageOffset.x != mip_extent.width)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00207", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00207", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block width "
                                  "(%d), or when added to offset.x (%d) must equal the image subresource width (%d)..",
                                  function, i, pRegions[i].imageExtent.width, block_size.width, pRegions[i].imageOffset.x,
@@ -6406,7 +6404,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // imageExtent height must be a multiple of block height, or extent+offset height must equal subresource height
             if ((SafeModulo(pRegions[i].imageExtent.height, block_size.height) != 0) &&
                 (pRegions[i].imageExtent.height + pRegions[i].imageOffset.y != mip_extent.height)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00208", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00208", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] extent height (%d) must be a multiple of the compressed texture block height "
                                  "(%d), or when added to offset.y (%d) must equal the image subresource height (%d)..",
                                  function, i, pRegions[i].imageExtent.height, block_size.height, pRegions[i].imageOffset.y,
@@ -6416,7 +6414,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // imageExtent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
             if ((SafeModulo(pRegions[i].imageExtent.depth, block_size.depth) != 0) &&
                 (pRegions[i].imageExtent.depth + pRegions[i].imageOffset.z != mip_extent.depth)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("00209", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("00209", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] extent width (%d) must be a multiple of the compressed texture block depth "
                                  "(%d), or when added to offset.z (%d) must equal the image subresource depth (%d)..",
                                  function, i, pRegions[i].imageExtent.depth, block_size.depth, pRegions[i].imageOffset.z,
@@ -6428,7 +6426,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         if (FormatIsMultiplane(image_format)) {
             // VK_IMAGE_ASPECT_PLANE_2_BIT valid only for image formats with three planes
             if ((FormatPlaneCount(image_format) < 3) && (region_aspect_mask == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("01560", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("01560", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] subresource aspectMask cannot be VK_IMAGE_ASPECT_PLANE_2_BIT unless image "
                                  "format has three planes.",
                                  function, i);
@@ -6437,7 +6435,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
             // image subresource aspectMask must be VK_IMAGE_ASPECT_PLANE_*_BIT
             if (0 ==
                 (region_aspect_mask & (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT))) {
-                skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("01560", image_to_buffer, is_2khr),
+                skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("01560", image_to_buffer, is_2khr),
                                  "%s: pRegion[%d] subresource aspectMask for multi-plane image formats must have a "
                                  "VK_IMAGE_ASPECT_PLANE_*_BIT when copying to or from.",
                                  function, i);
@@ -6447,7 +6445,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
                 const uint32_t compatible_size = FormatElementSize(compatible_format);
                 if (SafeModulo(bufferOffset, compatible_size) != 0) {
                     skip |= LogError(
-                        image_state->image, GetBufferImageCopyCommandVUID("01559", image_to_buffer, is_2khr),
+                        image_state->image(), GetBufferImageCopyCommandVUID("01559", image_to_buffer, is_2khr),
                         "%s: pRegion[%d]->bufferOffset is 0x%" PRIxLEAST64
                         " but must be a multiple of the multi-plane compatible format's texel size (%u) for plane %u (%s).",
                         function, i, bufferOffset, element_size, GetPlaneIndex(region_aspect_mask),
@@ -6462,15 +6460,15 @@ bool CoreChecks::ValidateBufferImageCopyData(const CMD_BUFFER_STATE *cb_node, ui
         const uint32_t queue_family_index = command_pool->queueFamilyIndex;
         const VkQueueFlags queue_flags = GetPhysicalDeviceState()->queue_family_properties[queue_family_index].queueFlags;
         if (((queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)) == 0) && (SafeModulo(bufferOffset, 4) != 0)) {
-            LogObjectList objlist(cb_node->commandBuffer);
-            objlist.add(command_pool->commandPool);
-            skip |= LogError(image_state->image, GetBufferImageCopyCommandVUID("04052", image_to_buffer, is_2khr),
+            LogObjectList objlist(cb_node->commandBuffer());
+            objlist.add(command_pool->commandPool());
+            skip |= LogError(image_state->image(), GetBufferImageCopyCommandVUID("04052", image_to_buffer, is_2khr),
                              "%s: pRegion[%d] bufferOffset 0x%" PRIxLEAST64
                              " must be a multiple 4 because the command buffer %s was allocated from the command pool %s "
                              "which was created with queueFamilyIndex %u, which doesn't contain the VK_QUEUE_GRAPHICS_BIT or "
                              "VK_QUEUE_COMPUTE_BIT flag.",
-                             function, i, bufferOffset, report_data->FormatHandle(cb_node->commandBuffer).c_str(),
-                             report_data->FormatHandle(command_pool->commandPool).c_str(), queue_family_index);
+                             function, i, bufferOffset, report_data->FormatHandle(cb_node->commandBuffer()).c_str(),
+                             report_data->FormatHandle(command_pool->commandPool()).c_str(), queue_family_index);
         }
     }
 
@@ -6489,7 +6487,7 @@ bool CoreChecks::ValidateImageBounds(const IMAGE_STATE *image_state, const uint3
 
         if (IsExtentSizeZero(&extent))  // Warn on zero area subresource
         {
-            skip |= LogWarning(image_state->image, kVUID_Core_Image_ZeroAreaSubregion,
+            skip |= LogWarning(image_state->image(), kVUID_Core_Image_ZeroAreaSubregion,
                                "%s: pRegion[%d] imageExtent of {%1d, %1d, %1d} has zero area", func_name, i, extent.width,
                                extent.height, extent.depth);
         }
@@ -6511,7 +6509,7 @@ bool CoreChecks::ValidateImageBounds(const IMAGE_STATE *image_state, const uint3
         }
 
         if (0 != ExceedsBounds(&offset, &extent, &image_extent)) {
-            skip |= LogError(image_state->image, msg_code, "%s: pRegion[%d] exceeds image bounds..", func_name, i);
+            skip |= LogError(image_state->image(), msg_code, "%s: pRegion[%d] exceeds image bounds..", func_name, i);
         }
     }
 
@@ -6600,7 +6598,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
     // Validation for VK_EXT_fragment_density_map
     if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2khr ? "VUID-VkCopyImageToBufferInfo2KHR-srcImage-02544" : "VUID-vkCmdCopyImageToBuffer-srcImage-02544";
-        skip |= LogError(cb_node->commandBuffer, vuid,
+        skip |= LogError(cb_node->commandBuffer(), vuid,
                          "%s: srcImage must not have been created with flags containing "
                          "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                          func_name);
@@ -6723,7 +6721,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
     // Validation for VK_EXT_fragment_density_map
     if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2khr ? "VUID-VkCopyBufferToImageInfo2KHR-dstImage-02543" : "VUID-vkCmdCopyBufferToImage-dstImage-02543";
-        skip |= LogError(cb_node->commandBuffer, vuid,
+        skip |= LogError(cb_node->commandBuffer(), vuid,
                          "%s: dstImage must not have been created with flags containing "
                          "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT",
                          func_name);
@@ -6766,16 +6764,16 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
         const VkImageAspectFlags region_aspect_mask = pRegions[i].imageSubresource.aspectMask;
         if (((queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) &&
             ((region_aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) != 0)) {
-            LogObjectList objlist(cb_node->commandBuffer);
-            objlist.add(command_pool->commandPool);
+            LogObjectList objlist(cb_node->commandBuffer());
+            objlist.add(command_pool->commandPool());
             vuid = is_2khr ? "VUID-VkCopyBufferToImageInfo2KHR-commandBuffer-04477"
                            : "VUID-vkCmdCopyBufferToImage-commandBuffer-04477";
-            skip |= LogError(dst_image_state->image, vuid,
+            skip |= LogError(dst_image_state->image(), vuid,
                              "%s(): pRegion[%d] subresource aspectMask 0x%x specifies VK_IMAGE_ASPECT_DEPTH_BIT or "
                              "VK_IMAGE_ASPECT_STENCIL_BIT but the command buffer %s was allocated from the command pool %s "
                              "which was created with queueFamilyIndex %u, which doesn't contain the VK_QUEUE_GRAPHICS_BIT flag.",
-                             func_name, i, region_aspect_mask, report_data->FormatHandle(cb_node->commandBuffer).c_str(),
-                             report_data->FormatHandle(command_pool->commandPool).c_str(), queue_family_index);
+                             func_name, i, region_aspect_mask, report_data->FormatHandle(cb_node->commandBuffer()).c_str(),
+                             report_data->FormatHandle(command_pool->commandPool()).c_str(), queue_family_index);
         }
     }
     return skip;
@@ -6915,11 +6913,11 @@ bool CoreChecks::ValidateProtectedImage(const CMD_BUFFER_STATE *cb_state, const 
                                         const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == true) && (image_state->unprotected == false)) {
-        LogObjectList objlist(cb_state->commandBuffer);
-        objlist.add(image_state->image);
+        LogObjectList objlist(cb_state->commandBuffer());
+        objlist.add(image_state->image());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while image %s is a protected image.%s", cmd_name,
-                         report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(image_state->image).c_str(), more_message);
+                         report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
+                         report_data->FormatHandle(image_state->image()).c_str(), more_message);
     }
     return skip;
 }
@@ -6929,11 +6927,11 @@ bool CoreChecks::ValidateUnprotectedImage(const CMD_BUFFER_STATE *cb_state, cons
                                           const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == false) && (image_state->unprotected == true)) {
-        LogObjectList objlist(cb_state->commandBuffer);
-        objlist.add(image_state->image);
+        LogObjectList objlist(cb_state->commandBuffer());
+        objlist.add(image_state->image());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while image %s is an unprotected image.%s", cmd_name,
-                         report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(image_state->image).c_str(), more_message);
+                         report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
+                         report_data->FormatHandle(image_state->image()).c_str(), more_message);
     }
     return skip;
 }
@@ -6943,11 +6941,11 @@ bool CoreChecks::ValidateProtectedBuffer(const CMD_BUFFER_STATE *cb_state, const
                                          const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == true) && (buffer_state->unprotected == false)) {
-        LogObjectList objlist(cb_state->commandBuffer);
-        objlist.add(buffer_state->buffer);
+        LogObjectList objlist(cb_state->commandBuffer());
+        objlist.add(buffer_state->buffer());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while buffer %s is a protected buffer.%s", cmd_name,
-                         report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(buffer_state->buffer).c_str(), more_message);
+                         report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
+                         report_data->FormatHandle(buffer_state->buffer()).c_str(), more_message);
     }
     return skip;
 }
@@ -6957,11 +6955,11 @@ bool CoreChecks::ValidateUnprotectedBuffer(const CMD_BUFFER_STATE *cb_state, con
                                            const char *vuid, const char *more_message) const {
     bool skip = false;
     if ((cb_state->unprotected == false) && (buffer_state->unprotected == true)) {
-        LogObjectList objlist(cb_state->commandBuffer);
-        objlist.add(buffer_state->buffer);
+        LogObjectList objlist(cb_state->commandBuffer());
+        objlist.add(buffer_state->buffer());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while buffer %s is an unprotected buffer.%s", cmd_name,
-                         report_data->FormatHandle(cb_state->commandBuffer).c_str(),
-                         report_data->FormatHandle(buffer_state->buffer).c_str(), more_message);
+                         report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
+                         report_data->FormatHandle(buffer_state->buffer()).c_str(), more_message);
     }
     return skip;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2236,14 +2236,15 @@ static char const *GetCauseStr(VulkanTypedHandle obj) {
 
 bool CoreChecks::ReportInvalidCommandBuffer(const CMD_BUFFER_STATE *cb_state, const char *call_source) const {
     bool skip = false;
-    for (const auto &obj : cb_state->broken_bindings) {
+    for (const auto& entry: cb_state->broken_bindings) {
+        const auto& obj = entry.first;
         const char *cause_str = GetCauseStr(obj);
         string vuid;
         std::ostringstream str;
         str << kVUID_Core_DrawState_InvalidCommandBuffer << "-" << object_string[obj.type];
         vuid = str.str();
-        LogObjectList objlist(cb_state->commandBuffer());
-        objlist.add(obj);
+        auto objlist = entry.second; //intentional copy
+        objlist.add(cb_state->commandBuffer());
         skip |=
             LogError(objlist, vuid, "You are adding %s to %s that is invalid because bound %s was %s.", call_source,
                      report_data->FormatHandle(cb_state->commandBuffer()).c_str(), report_data->FormatHandle(obj).c_str(), cause_str);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -194,7 +194,7 @@ bool CoreChecks::VerifyBoundMemoryIsValid(const DEVICE_MEMORY_STATE *mem_state, 
         result |= LogError(object, location.Vuid(),
                            "%s: %s used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
                            location.FuncName(), report_data->FormatHandle(typed_handle).c_str(), type_name + 2);
-    } else if (mem_state->destroyed) {
+    } else if (mem_state->Destroyed()) {
         result |= LogError(object, location.Vuid(),
                            "%s: %s used with no memory bound and previously bound memory was freed. Memory must not be freed "
                            "prior to this operation.",
@@ -243,7 +243,7 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, co
         // TODO look into how to properly check for a valid bound memory for an external AHB
     } else if (0 == (static_cast<uint32_t>(image_state->createInfo.flags) & VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
         result |= VerifyBoundMemoryIsValid(image_state->binding.mem_state.get(), image_state->image,
-                                           VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage), location);
+                                           image_state->Handle(), location);
     }
     return result;
 }
@@ -254,7 +254,7 @@ bool CoreChecks::ValidateMemoryIsBoundToBuffer(const BUFFER_STATE *buffer_state,
     bool result = false;
     if (0 == (static_cast<uint32_t>(buffer_state->createInfo.flags) & VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
         result |= VerifyBoundMemoryIsValid(buffer_state->binding.mem_state.get(), buffer_state->buffer,
-                                           VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer), api_name, error_code);
+                                           buffer_state->Handle(), api_name, error_code);
     }
     return result;
 }
@@ -263,16 +263,14 @@ bool CoreChecks::ValidateMemoryIsBoundToBuffer(const BUFFER_STATE *buffer_state,
 bool CoreChecks::ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE *as_state, const char *api_name,
                                                               const char *error_code) const {
     return VerifyBoundMemoryIsValid(as_state->binding.mem_state.get(), as_state->acceleration_structure,
-                                    VulkanTypedHandle(as_state->acceleration_structure, kVulkanObjectTypeAccelerationStructureNV),
-                                    api_name, error_code);
+                                    as_state->Handle(), api_name, error_code);
 }
 
 // Check to see if memory was bound to this acceleration structure
 bool CoreChecks::ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE_KHR *as_state,
                                                               const char *api_name, const char *error_code) const {
     return VerifyBoundMemoryIsValid(as_state->binding.mem_state.get(), as_state->acceleration_structure,
-                                    VulkanTypedHandle(as_state->acceleration_structure, kVulkanObjectTypeAccelerationStructureKHR),
-                                    api_name, error_code);
+                                    as_state->Handle(), api_name, error_code);
 }
 
 // Valid usage checks for a call to SetMemBinding().
@@ -322,7 +320,7 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory mem, const VulkanTypedHand
         if (mem_info) {
             const DEVICE_MEMORY_STATE *prev_binding = mem_binding->binding.mem_state.get();
             if (prev_binding) {
-                if (!prev_binding->destroyed) {
+                if (!prev_binding->Destroyed()) {
                     const char *error_code = nullptr;
                     if (typed_handle.type == kVulkanObjectTypeBuffer) {
                         if (strcmp(apiName, "vkBindBufferMemory()") == 0) {
@@ -726,12 +724,12 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     // Because vertex & index buffer is read only, it doesn't need to care protected command buffer case.
     if (enabled_features.core11.protectedMemory == VK_TRUE) {
         for (const auto &buffer_binding : current_vtx_bfr_binding_info) {
-            if (buffer_binding.buffer_state && !buffer_binding.buffer_state->destroyed) {
+            if (buffer_binding.buffer_state && !buffer_binding.buffer_state->Destroyed()) {
                 skip |= ValidateProtectedBuffer(pCB, buffer_binding.buffer_state.get(), caller, vuid.unprotected_command_buffer,
                                                 "Buffer is vertex buffer");
             }
         }
-        if (pCB->index_buffer_binding.buffer_state && !pCB->index_buffer_binding.buffer_state->destroyed) {
+        if (pCB->index_buffer_binding.buffer_state && !pCB->index_buffer_binding.buffer_state->Destroyed()) {
             skip |= ValidateProtectedBuffer(pCB, pCB->index_buffer_binding.buffer_state.get(), caller,
                                             vuid.unprotected_command_buffer, "Buffer is index buffer");
         }
@@ -977,7 +975,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
             if ((ds_attachment != nullptr) && (fb_state != nullptr)) {
                 const uint32_t attachment = ds_attachment->attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
-                    const auto *imageview_state = GetActiveAttachmentImageViewState(pCB, attachment);
+                    const auto *imageview_state = pCB->GetActiveAttachmentImageViewState(attachment);
                     if (imageview_state != nullptr) {
                         const IMAGE_STATE *image_state = GetImageState(imageview_state->create_info.image);
                         if (image_state != nullptr) {
@@ -1125,7 +1123,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                 uint32_t i = 0;
                 for (const auto &view_state : *cb_node->active_attachments.get()) {
                     const auto &subpass = cb_node->active_subpasses->at(i);
-                    if (subpass.used && view_state && !view_state->destroyed) {
+                    if (subpass.used && view_state && !view_state->Destroyed()) {
                         std::string image_desc = "Image is ";
                         image_desc.append(string_VkImageUsageFlagBits(subpass.usage));
                         // Because inputAttachment is read only, it doesn't need to care protected command buffer case.
@@ -2155,7 +2153,7 @@ bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const char *func
     auto set_node = setMap.find(set);
     if (set_node != setMap.end()) {
         // TODO : This covers various error cases so should pass error enum into this function and use passed in enum here
-        if (set_node->second->in_use.load()) {
+        if (set_node->second->InUse()) {
             skip |= LogError(set, "VUID-vkFreeDescriptorSets-pDescriptorSets-00309",
                              "Cannot call %s() on %s that is in use by a command buffer.", func_str,
                              report_data->FormatHandle(set).c_str());
@@ -2616,7 +2614,7 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location &loc, const
     using sync_vuid_maps::SubmitError;
 
     bool skip = false;
-    if ((pCB->in_use.load() || current_submit_count > 1) &&
+    if ((pCB->InUse() || current_submit_count > 1) &&
         !(pCB->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
         const auto &vuid = sync_vuid_maps::GetQueueSubmitVUID(loc, SubmitError::kCmdNotSimultaneous);
 
@@ -3941,11 +3939,11 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
 }
 
 // For given obj node, if it is use, flag a validation error and return callback result, else return false
-bool CoreChecks::ValidateObjectNotInUse(const BASE_NODE *obj_node, const VulkanTypedHandle &obj_struct, const char *caller_name,
-                                        const char *error_code) const {
+bool CoreChecks::ValidateObjectNotInUse(const BASE_NODE *obj_node, const char *caller_name, const char *error_code) const {
     if (disabled[object_in_use]) return false;
+    auto obj_struct = obj_node->Handle();
     bool skip = false;
-    if (obj_node->in_use.load()) {
+    if (obj_node->InUse()) {
         skip |= LogError(device, error_code, "Cannot call %s on %s that is currently in use by a command buffer.", caller_name,
                          report_data->FormatHandle(obj_struct).c_str());
     }
@@ -3954,10 +3952,9 @@ bool CoreChecks::ValidateObjectNotInUse(const BASE_NODE *obj_node, const VulkanT
 
 bool CoreChecks::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks *pAllocator) const {
     const DEVICE_MEMORY_STATE *mem_info = GetDevMemState(mem);
-    const VulkanTypedHandle obj_struct(mem, kVulkanObjectTypeDeviceMemory);
     bool skip = false;
     if (mem_info) {
-        skip |= ValidateObjectNotInUse(mem_info, obj_struct, "vkFreeMemory", "VUID-vkFreeMemory-memory-00677");
+        skip |= ValidateObjectNotInUse(mem_info, "vkFreeMemory", "VUID-vkFreeMemory-memory-00677");
     }
     return skip;
 }
@@ -4163,20 +4160,18 @@ bool CoreChecks::PreCallValidateDestroyFence(VkDevice device, VkFence fence, con
 bool CoreChecks::PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore semaphore,
                                                  const VkAllocationCallbacks *pAllocator) const {
     const SEMAPHORE_STATE *sema_node = GetSemaphoreState(semaphore);
-    const VulkanTypedHandle obj_struct(semaphore, kVulkanObjectTypeSemaphore);
     bool skip = false;
     if (sema_node) {
-        skip |= ValidateObjectNotInUse(sema_node, obj_struct, "vkDestroySemaphore", "VUID-vkDestroySemaphore-semaphore-01137");
+        skip |= ValidateObjectNotInUse(sema_node, "vkDestroySemaphore", "VUID-vkDestroySemaphore-semaphore-01137");
     }
     return skip;
 }
 
 bool CoreChecks::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) const {
     const EVENT_STATE *event_state = GetEventState(event);
-    const VulkanTypedHandle obj_struct(event, kVulkanObjectTypeEvent);
     bool skip = false;
     if (event_state) {
-        skip |= ValidateObjectNotInUse(event_state, obj_struct, "vkDestroyEvent", "VUID-vkDestroyEvent-event-01145");
+        skip |= ValidateObjectNotInUse(event_state, "vkDestroyEvent", "VUID-vkDestroyEvent-event-01145");
     }
     return skip;
 }
@@ -4185,10 +4180,9 @@ bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool qu
                                                  const VkAllocationCallbacks *pAllocator) const {
     if (disabled[query_validation]) return false;
     const QUERY_POOL_STATE *qp_state = GetQueryPoolState(queryPool);
-    const VulkanTypedHandle obj_struct(queryPool, kVulkanObjectTypeQueryPool);
     bool skip = false;
     if (qp_state) {
-        skip |= ValidateObjectNotInUse(qp_state, obj_struct, "vkDestroyQueryPool", "VUID-vkDestroyQueryPool-queryPool-00793");
+        skip |= ValidateObjectNotInUse(qp_state, "vkDestroyQueryPool", "VUID-vkDestroyQueryPool-queryPool-00793");
     }
     return skip;
 }
@@ -4422,8 +4416,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, V
     bool skip = false;
     if (buffer_state) {
         // Track objects tied to memory
-        const VulkanTypedHandle obj_struct(buffer, kVulkanObjectTypeBuffer);
-        skip = ValidateSetMemBinding(mem, obj_struct, api_name);
+        skip = ValidateSetMemBinding(mem, buffer_state->Handle(), api_name);
 
         const auto mem_info = GetDevMemState(mem);
 
@@ -4692,20 +4685,18 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(VkPhy
 bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipeline,
                                                 const VkAllocationCallbacks *pAllocator) const {
     const PIPELINE_STATE *pipeline_state = GetPipelineState(pipeline);
-    const VulkanTypedHandle obj_struct(pipeline, kVulkanObjectTypePipeline);
     bool skip = false;
     if (pipeline_state) {
-        skip |= ValidateObjectNotInUse(pipeline_state, obj_struct, "vkDestroyPipeline", "VUID-vkDestroyPipeline-pipeline-00765");
+        skip |= ValidateObjectNotInUse(pipeline_state, "vkDestroyPipeline", "VUID-vkDestroyPipeline-pipeline-00765");
     }
     return skip;
 }
 
 bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks *pAllocator) const {
     const SAMPLER_STATE *sampler_state = GetSamplerState(sampler);
-    const VulkanTypedHandle obj_struct(sampler, kVulkanObjectTypeSampler);
     bool skip = false;
     if (sampler_state) {
-        skip |= ValidateObjectNotInUse(sampler_state, obj_struct, "vkDestroySampler", "VUID-vkDestroySampler-sampler-01082");
+        skip |= ValidateObjectNotInUse(sampler_state, "vkDestroySampler", "VUID-vkDestroySampler-sampler-01082");
     }
     return skip;
 }
@@ -4713,10 +4704,9 @@ bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sample
 bool CoreChecks::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                       const VkAllocationCallbacks *pAllocator) const {
     const DESCRIPTOR_POOL_STATE *desc_pool_state = GetDescriptorPoolState(descriptorPool);
-    const VulkanTypedHandle obj_struct(descriptorPool, kVulkanObjectTypeDescriptorPool);
     bool skip = false;
     if (desc_pool_state) {
-        skip |= ValidateObjectNotInUse(desc_pool_state, obj_struct, "vkDestroyDescriptorPool",
+        skip |= ValidateObjectNotInUse(desc_pool_state, "vkDestroyDescriptorPool",
                                        "VUID-vkDestroyDescriptorPool-descriptorPool-00303");
     }
     return skip;
@@ -4728,7 +4718,7 @@ bool CoreChecks::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescrip
 // This function is only valid at a point when cmdBuffer is being reset or freed
 bool CoreChecks::CheckCommandBufferInFlight(const CMD_BUFFER_STATE *cb_node, const char *action, const char *error_code) const {
     bool skip = false;
-    if (cb_node->in_use.load()) {
+    if (cb_node->InUse()) {
         skip |= LogError(cb_node->commandBuffer, error_code, "Attempt to %s %s which is in use.", action,
                          report_data->FormatHandle(cb_node->commandBuffer).c_str());
     }
@@ -4851,10 +4841,9 @@ bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount
 bool CoreChecks::PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                    const VkAllocationCallbacks *pAllocator) const {
     const FRAMEBUFFER_STATE *framebuffer_state = GetFramebufferState(framebuffer);
-    const VulkanTypedHandle obj_struct(framebuffer, kVulkanObjectTypeFramebuffer);
     bool skip = false;
     if (framebuffer_state) {
-        skip |= ValidateObjectNotInUse(framebuffer_state, obj_struct, "vkDestroyFramebuffer",
+        skip |= ValidateObjectNotInUse(framebuffer_state, "vkDestroyFramebuffer",
                                        "VUID-vkDestroyFramebuffer-framebuffer-00892");
     }
     return skip;
@@ -4863,10 +4852,9 @@ bool CoreChecks::PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffe
 bool CoreChecks::PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass,
                                                   const VkAllocationCallbacks *pAllocator) const {
     const RENDER_PASS_STATE *rp_state = GetRenderPassState(renderPass);
-    const VulkanTypedHandle obj_struct(renderPass, kVulkanObjectTypeRenderPass);
     bool skip = false;
     if (rp_state) {
-        skip |= ValidateObjectNotInUse(rp_state, obj_struct, "vkDestroyRenderPass", "VUID-vkDestroyRenderPass-renderPass-00873");
+        skip |= ValidateObjectNotInUse(rp_state, "vkDestroyRenderPass", "VUID-vkDestroyRenderPass-renderPass-00873");
     }
     return skip;
 }
@@ -5754,7 +5742,7 @@ bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescripto
     const DESCRIPTOR_POOL_STATE *pool = GetDescriptorPoolState(descriptorPool);
     if (pool != nullptr) {
         for (auto *ds : pool->sets) {
-            if (ds && ds->in_use.load()) {
+            if (ds && ds->InUse()) {
                 skip |= LogError(descriptorPool, "VUID-vkResetDescriptorPool-descriptorPool-00313",
                                  "It is invalid to call vkResetDescriptorPool() with descriptor sets in use by a command buffer.");
                 if (skip) break;
@@ -5816,7 +5804,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     if (!cb_state) return false;
     bool skip = false;
-    if (cb_state->in_use.load()) {
+    if (cb_state->InUse()) {
         skip |= LogError(commandBuffer, "VUID-vkBeginCommandBuffer-commandBuffer-00049",
                          "Calling vkBeginCommandBuffer() on active %s before it has completed. You must check "
                          "command buffer fence before this call.",
@@ -5993,7 +5981,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE *cb_st
             const auto attachment = subpass_desc->pColorAttachments[i].attachment;
             if (attachment == VK_ATTACHMENT_UNUSED) continue;
 
-            const auto *imageview_state = GetActiveAttachmentImageViewState(cb_state, attachment);
+            const auto *imageview_state = cb_state->GetActiveAttachmentImageViewState(attachment);
             if (!imageview_state) continue;
 
             const IMAGE_STATE *image_state = GetImageState(imageview_state->create_info.image);
@@ -6731,10 +6719,9 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureNV(VkCommandBuffer c
 bool CoreChecks::PreCallValidateDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                const VkAllocationCallbacks *pAllocator) const {
     const ACCELERATION_STRUCTURE_STATE *as_state = GetAccelerationStructureStateNV(accelerationStructure);
-    const VulkanTypedHandle obj_struct(accelerationStructure, kVulkanObjectTypeAccelerationStructureNV);
     bool skip = false;
     if (as_state) {
-        skip |= ValidateObjectNotInUse(as_state, obj_struct, "vkDestroyAccelerationStructureNV",
+        skip |= ValidateObjectNotInUse(as_state, "vkDestroyAccelerationStructureNV",
                                        "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442");
     }
     return skip;
@@ -6743,10 +6730,9 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureNV(VkDevice device, 
 bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
                                                                 const VkAllocationCallbacks *pAllocator) const {
     const ACCELERATION_STRUCTURE_STATE_KHR *as_state = GetAccelerationStructureStateKHR(accelerationStructure);
-    const VulkanTypedHandle obj_struct(accelerationStructure, kVulkanObjectTypeAccelerationStructureKHR);
     bool skip = false;
     if (as_state) {
-        skip |= ValidateObjectNotInUse(as_state, obj_struct, "vkDestroyAccelerationStructureKHR",
+        skip |= ValidateObjectNotInUse(as_state, "vkDestroyAccelerationStructureKHR",
                                        "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442");
     }
     if (pAllocator && !as_state->allocator) {
@@ -11535,7 +11521,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         skip |= ValidateCommandBufferState(sub_cb_state, "vkCmdExecuteCommands()", 0,
                                            "VUID-vkCmdExecuteCommands-pCommandBuffers-00089");
         if (!(sub_cb_state->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
-            if (sub_cb_state->in_use.load()) {
+            if (sub_cb_state->InUse()) {
                 skip |= LogError(
                     cb_state->commandBuffer, "VUID-vkCmdExecuteCommands-pCommandBuffers-00091",
                     "vkCmdExecuteCommands(): Cannot execute pending %s without VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT set.",
@@ -11816,7 +11802,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
         if (image_state) {
             // Track objects tied to memory
             skip |=
-                ValidateSetMemBinding(bind_info.memory, VulkanTypedHandle(bind_info.image, kVulkanObjectTypeImage), error_prefix);
+                ValidateSetMemBinding(bind_info.memory, image_state->Handle(), error_prefix);
 
             const auto plane_info = LvlFindInChain<VkBindImagePlaneMemoryInfo>(bind_info.pNext);
             const auto mem_info = GetDevMemState(bind_info.memory);
@@ -12470,8 +12456,7 @@ bool CoreChecks::ValidateImportSemaphore(VkSemaphore semaphore, const char *call
     bool skip = false;
     const SEMAPHORE_STATE *sema_node = GetSemaphoreState(semaphore);
     if (sema_node) {
-        const VulkanTypedHandle obj_struct(semaphore, kVulkanObjectTypeSemaphore);
-        skip |= ValidateObjectNotInUse(sema_node, obj_struct, caller_name, kVUIDUndefined);
+        skip |= ValidateObjectNotInUse(sema_node, caller_name, kVUIDUndefined);
     }
     return skip;
 }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -353,8 +353,7 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE*, const char*, const char*) const;
     bool ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE_KHR*, const char*, const char*) const;
-    bool ValidateObjectNotInUse(const BASE_NODE* obj_node, const VulkanTypedHandle& obj_struct, const char* caller_name,
-                                const char* error_code) const;
+    bool ValidateObjectNotInUse(const BASE_NODE* obj_node, const char* caller_name, const char* error_code) const;
     bool ValidateCmdQueueFlags(const CMD_BUFFER_STATE* cb_node, const char* caller_name, VkQueueFlags flags,
                                const char* error_code) const;
     bool ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT* pSampleLocationsInfo, const char* apiName) const;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -40,9 +40,9 @@
 #include "layer_chassis_dispatch.h"
 #include "image_layout_map.h"
 #include "command_validation.h"
+#include "base_node.h"
 
 #include <array>
-#include <atomic>
 #include <functional>
 #include <list>
 #include <map>
@@ -71,28 +71,6 @@ using ImageSubresourceLayoutMap = image_layout_map::ImageSubresourceLayoutMap;
 struct CMD_BUFFER_STATE;
 class CoreChecks;
 class ValidationStateTracker;
-
-class BASE_NODE {
-  public:
-    using BindingsType = layer_data::unordered_map<CMD_BUFFER_STATE *, int>;
-    // Track when object is being used by an in-flight command buffer
-    std::atomic_int in_use;
-    // Track command buffers that this object is bound to
-    //  binding initialized when cmd referencing object is bound to command buffer
-    //  binding removed when command buffer is reset or destroyed
-    // When an object is destroyed, any bound cbs are set to INVALID.
-    // "int" value is an index into object_bindings where the corresponding
-    // backpointer to this node is stored.
-    BindingsType cb_bindings;
-    // Set to true when the API-level object is destroyed, but this object may
-    // hang around until its shared_ptr refcount goes to zero.
-    bool destroyed;
-
-    BASE_NODE() {
-        in_use.store(0);
-        destroyed = false;
-    };
-};
 
 // Track command pools and their command buffers
 struct COMMAND_POOL_STATE : public BASE_NODE {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -80,6 +80,13 @@ struct COMMAND_POOL_STATE : public BASE_NODE {
     bool unprotected;  // can't be used for protected memory
     // Cmd buffers allocated from this pool
     layer_data::unordered_set<VkCommandBuffer> commandBuffers;
+
+    COMMAND_POOL_STATE(VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo)
+        : BASE_NODE(cp, kVulkanObjectTypeCommandPool),
+          commandPool(cp),
+          createFlags(pCreateInfo->flags),
+          queueFamilyIndex(pCreateInfo->queueFamilyIndex),
+          unprotected((pCreateInfo->flags & VK_COMMAND_POOL_CREATE_PROTECTED_BIT) == 0) {}
 };
 
 // Utilities for barriers and the commmand pool
@@ -192,7 +199,8 @@ struct DESCRIPTOR_POOL_STATE : BASE_NODE {
     std::map<uint32_t, uint32_t> availableDescriptorTypeCount;  // Available # of descriptors of each type in this pool
 
     DESCRIPTOR_POOL_STATE(const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo *pCreateInfo)
-        : pool(pool),
+        : BASE_NODE(pool, kVulkanObjectTypeDescriptorPool),
+          pool(pool),
           maxSets(pCreateInfo->maxSets),
           availableSets(pCreateInfo->maxSets),
           createInfo(pCreateInfo),
@@ -242,7 +250,8 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
 
     DEVICE_MEMORY_STATE(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info,
                         uint64_t fake_address)
-        : object(disp_object),
+        : BASE_NODE(in_mem, kVulkanObjectTypeDeviceMemory),
+          object(disp_object),
           mem(in_mem),
           alloc_info(p_alloc_info),
           is_dedicated(false),
@@ -330,8 +339,10 @@ class BINDABLE : public BASE_NODE {
 
     BoundMemorySet bound_memory_set_;
 
-    BINDABLE()
-        : sparse(false),
+    template <typename Handle>
+    BINDABLE(Handle h, VulkanObjectType t)
+        : BASE_NODE(h, t),
+          sparse(false),
           binding{},
           requirements{},
           memory_requirements_checked(false),
@@ -340,6 +351,10 @@ class BINDABLE : public BASE_NODE {
           external_ahb(false),
           unprotected(true),
           bound_memory_set_{} {};
+
+    virtual ~BINDABLE() { Destroy(); }
+
+    void Destroy() override;
 
     // Update the cached set of memory bindings.
     // Code that changes binding.mem or sparse_bindings must call UpdateBoundMemorySet()
@@ -353,10 +368,16 @@ class BINDABLE : public BASE_NODE {
             }
         }
     }
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
 
     // Return unordered set of memory objects that are bound
     // Instead of creating a set from scratch each query, return the cached one
     const BoundMemorySet &GetBoundMemory() const { return bound_memory_set_; }
+
+    void SetMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, VkDeviceSize memory_offset);
+    void SetSparseMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize mem_offset, const VkDeviceSize mem_size);
+
+    void ClearMemoryObjectBindings();
 };
 
 class BUFFER_STATE : public BINDABLE {
@@ -364,7 +385,8 @@ class BUFFER_STATE : public BINDABLE {
     VkBuffer buffer;
     VkBufferCreateInfo createInfo;
     VkDeviceAddress deviceAddress;
-    BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo) : buffer(buff), createInfo(*pCreateInfo) {
+    BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo)
+        : BINDABLE(buff, kVulkanObjectTypeBuffer), buffer(buff), createInfo(*pCreateInfo) {
         if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
             uint32_t *pQueueFamilyIndices = new uint32_t[createInfo.queueFamilyIndexCount];
             for (uint32_t i = 0; i < createInfo.queueFamilyIndexCount; i++) {
@@ -400,8 +422,10 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
     std::shared_ptr<BUFFER_STATE> buffer_state;
     VkFormatFeatureFlags format_features;
     BUFFER_VIEW_STATE(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci)
-        : buffer_view(bv), create_info(*ci), buffer_state(bf){};
+        : BASE_NODE(bv, kVulkanObjectTypeBufferView), buffer_view(bv), create_info(*ci), buffer_state(bf){};
     BUFFER_VIEW_STATE(const BUFFER_VIEW_STATE &rh_obj) = delete;
+
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
 };
 
 struct SAMPLER_STATE : public BASE_NODE {
@@ -410,7 +434,8 @@ struct SAMPLER_STATE : public BASE_NODE {
     VkSamplerYcbcrConversion samplerConversion = VK_NULL_HANDLE;
     VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo = {};
 
-    SAMPLER_STATE(const VkSampler *ps, const VkSamplerCreateInfo *pci) : sampler(*ps), createInfo(*pci) {
+    SAMPLER_STATE(const VkSampler *ps, const VkSamplerCreateInfo *pci)
+        : BASE_NODE(*ps, kVulkanObjectTypeSampler), sampler(*ps), createInfo(*pci) {
         auto *conversionInfo = LvlFindInChain<VkSamplerYcbcrConversionInfo>(pci->pNext);
         if (conversionInfo) samplerConversion = conversionInfo->conversion;
         auto cbci = LvlFindInChain<VkSamplerCustomBorderColorCreateInfoEXT>(pci->pNext);
@@ -500,11 +525,14 @@ class IMAGE_STATE : public BINDABLE {
                        createInfo.queueFamilyIndexCount * sizeof(createInfo.pQueueFamilyIndices[0])) == 0);
     }
 
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
+
     ~IMAGE_STATE() {
         if ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) && (createInfo.queueFamilyIndexCount > 0)) {
             delete[] createInfo.pQueueFamilyIndices;
             createInfo.pQueueFamilyIndices = nullptr;
         }
+        Destroy();
     };
 };
 
@@ -524,6 +552,8 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci);
     IMAGE_VIEW_STATE(const IMAGE_VIEW_STATE &rh_obj) = delete;
 
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
+
     bool OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) const;
 };
 
@@ -542,7 +572,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
     uint64_t opaque_handle = 0;
     const VkAllocationCallbacks *allocator = NULL;
     ACCELERATION_STRUCTURE_STATE(VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci)
-        : acceleration_structure(as),
+        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureNV),
+          acceleration_structure(as),
           create_infoNV(ci),
           memory_requirements{},
           build_scratch_memory_requirements_checked{},
@@ -567,7 +598,8 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
     uint64_t opaque_handle = 0;
     const VkAllocationCallbacks *allocator = NULL;
     ACCELERATION_STRUCTURE_STATE_KHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci)
-        : acceleration_structure(as),
+        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureKHR),
+          acceleration_structure(as),
           create_infoKHR(ci),
           memory_requirements{},
           build_scratch_memory_requirements_checked{},
@@ -591,7 +623,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     bool shared_presentable = false;
     uint32_t get_swapchain_image_count = 0;
     SWAPCHAIN_NODE(const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain)
-        : createInfo(pCreateInfo), swapchain(swapchain) {}
+        : BASE_NODE(swapchain, kVulkanObjectTypeSwapchainKHR), swapchain(swapchain), createInfo(pCreateInfo) {}
 };
 
 // Store the DAG.
@@ -641,8 +673,10 @@ struct RENDER_PASS_STATE : public BASE_NODE {
     std::vector<SubpassDependencyGraphNode> subpass_dependencies;
     std::vector<std::vector<AttachmentTransition>> subpass_transitions;
 
-    RENDER_PASS_STATE(VkRenderPassCreateInfo2 const *pCreateInfo) : createInfo(pCreateInfo) {}
-    RENDER_PASS_STATE(VkRenderPassCreateInfo const *pCreateInfo) {
+    RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo)
+        : BASE_NODE(rp, kVulkanObjectTypeRenderPass), renderPass(rp), createInfo(pCreateInfo) {}
+    RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo)
+        : BASE_NODE(rp, kVulkanObjectTypeRenderPass), renderPass(rp)  {
         ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo, &createInfo);
     }
 };
@@ -834,9 +868,11 @@ struct PIPELINE_LAYOUT_STATE : public BASE_NODE {
     PushConstantRangesId push_constant_ranges;
     std::vector<PipelineLayoutCompatId> compat_for_set;
 
-    PIPELINE_LAYOUT_STATE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{}, compat_for_set{} {}
+    PIPELINE_LAYOUT_STATE(VkPipelineLayout l)
+        : BASE_NODE(l, kVulkanObjectTypePipelineLayout), layout(l), set_layouts{}, push_constant_ranges{}, compat_for_set{} {}
 
     void reset() {
+        handle_.handle = 0;
         layout = VK_NULL_HANDLE;
         set_layouts.clear();
         push_constant_ranges.reset();
@@ -969,10 +1005,10 @@ class PIPELINE_STATE : public BASE_NODE {
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> pipeline_layout;
     VkPrimitiveTopology topology_at_rasterizer;
     VkBool32 sample_location_enabled;
-
     // Default constructor
     PIPELINE_STATE()
-        : pipeline{},
+        : BASE_NODE(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
+          pipeline{},
           graphicsPipelineCI{},
           computePipelineCI{},
           raytracingPipelineCI{},
@@ -989,6 +1025,11 @@ class PIPELINE_STATE : public BASE_NODE {
           pipeline_layout(),
           topology_at_rasterizer{},
           sample_location_enabled(VK_FALSE) {}
+
+    void SetHandle(VkPipeline p) {
+        handle_.handle = CastToUint64(p);
+        pipeline = p;
+    }
 
     void reset() {
         VkGraphicsPipelineCreateInfo emptyGraphicsCI = {};
@@ -1406,6 +1447,25 @@ struct CMD_BUFFER_STATE : public BASE_NODE {
     uint32_t small_indexed_draw_call_count;
 
     bool transform_feedback_active{false};
+
+    CMD_BUFFER_STATE(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo)
+        : BASE_NODE(cb, kVulkanObjectTypeCommandBuffer), commandBuffer(cb), createInfo(*pCreateInfo) {}
+
+    ~CMD_BUFFER_STATE() { Destroy(); }
+
+    int AddReverseBinding(const VulkanTypedHandle &obj);
+    void InvalidateLinkedCommandBuffers(const VulkanTypedHandle &obj);
+
+    IMAGE_VIEW_STATE* GetActiveAttachmentImageViewState(uint32_t index);
+    const IMAGE_VIEW_STATE* GetActiveAttachmentImageViewState(uint32_t index) const;
+
+    void AddChild(BASE_NODE *child_node);
+
+    void RemoveChild(BASE_NODE *child_node);
+
+    void Reset();
+
+    void Destroy() override;
 };
 
 static inline const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const CMD_BUFFER_STATE *cb,
@@ -1471,7 +1531,9 @@ class FRAMEBUFFER_STATE : public BASE_NODE {
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_state;
     FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate)
-        : framebuffer(fb), createInfo(pCreateInfo), rp_state(rpstate){};
+        : BASE_NODE(fb, kVulkanObjectTypeFramebuffer), framebuffer(fb), createInfo(pCreateInfo), rp_state(rpstate){};
+
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
 };
 
 struct SHADER_MODULE_STATE;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -634,11 +634,11 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
 bool DebugPrintf::CommandBufferNeedsProcessing(VkCommandBuffer command_buffer) {
     bool buffers_present = false;
     auto cb_node = GetCBState(command_buffer);
-    if (GetBufferInfo(cb_node->commandBuffer).size()) {
+    if (GetBufferInfo(cb_node->commandBuffer()).size()) {
         buffers_present = true;
     }
     for (const auto *secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
-        if (GetBufferInfo(secondaryCmdBuffer->commandBuffer).size()) {
+        if (GetBufferInfo(secondaryCmdBuffer->commandBuffer()).size()) {
             buffers_present = true;
         }
     }
@@ -938,7 +938,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     const auto *pipeline_state = cb_node->lastBound[lv_bind_point].pipeline_state;
     if (pipeline_state) {
         if (pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index) {
-            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout, desc_set_bind_index, 1,
+            DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout(), desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }
         // Record buffer and memory info in CB state tracking

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -178,6 +178,8 @@ class DescriptorSetLayout : public BASE_NODE {
   public:
     // Constructors and destructor
     DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info, const VkDescriptorSetLayout layout);
+    virtual ~DescriptorSetLayout() { Destroy(); }
+
     bool HasBinding(const uint32_t binding) const { return layout_id_->HasBinding(binding); }
     // Return true if this layout is compatible with passed in layout from a pipelineLayout,
     //   else return false and update error_msg with description of incompatibility
@@ -326,17 +328,21 @@ class DescriptorSetLayout : public BASE_NODE {
 // Slightly broader than type, each c++ "class" will has a corresponding "DescriptorClass"
 enum DescriptorClass { PlainSampler, ImageSampler, Image, TexelBuffer, GeneralBuffer, InlineUniform, AccelerationStructure, Mutable, NoDescriptorClass };
 
+class DescriptorSet;
+
 class Descriptor {
   public:
     Descriptor(DescriptorClass class_) : updated(false), descriptor_class(class_) {}
     virtual ~Descriptor(){};
-    virtual void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) = 0;
-    virtual void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) = 0;
+    virtual void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) = 0;
+    virtual void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) = 0;
     // Create binding between resources of this descriptor and given cb_node
-    virtual void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) = 0;
     DescriptorClass GetClass() const { return descriptor_class; };
     // Special fast-path check for SamplerDescriptors that are immutable
     virtual bool IsImmutableSampler() const { return false; };
+    virtual bool AddParent(BASE_NODE *base_node) { return false; }
+    virtual void RemoveParent(BASE_NODE *base_node) {}
+
     bool updated;  // Has descriptor been updated?
     DescriptorClass descriptor_class;
 };
@@ -366,15 +372,26 @@ inline bool IsBufferDescriptor(VkDescriptorType type) {
 class SamplerDescriptor : public Descriptor {
   public:
     SamplerDescriptor(const ValidationStateTracker *dev_data, const VkSampler *);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
     const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
     SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
     std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = false;
+        if (sampler_state_) {
+            result = sampler_state_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        if (sampler_state_) {
+            sampler_state_->RemoveParent(base_node);
+        }
+    }
   private:
     bool immutable_;
     std::shared_ptr<SAMPLER_STATE> sampler_state_;
@@ -383,15 +400,28 @@ class SamplerDescriptor : public Descriptor {
 class ImageDescriptor : public Descriptor {
   public:
     ImageDescriptor(const VkDescriptorType);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *,
+                     const uint32_t) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
+    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *);
     VkImageView GetImageView() const { return image_view_state_ ? image_view_state_->image_view() : VK_NULL_HANDLE; }
     const IMAGE_VIEW_STATE *GetImageViewState() const { return image_view_state_.get(); }
     IMAGE_VIEW_STATE *GetImageViewState() { return image_view_state_.get(); }
     std::shared_ptr<IMAGE_VIEW_STATE> GetSharedImageViewState() const { return image_view_state_; }
     VkImageLayout GetImageLayout() const { return image_layout_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = false;
+        if (image_view_state_) {
+            result = image_view_state_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        if (image_view_state_) {
+            image_view_state_->RemoveParent(base_node);
+        }
+    }
   protected:
     ImageDescriptor(DescriptorClass class_);
     std::shared_ptr<IMAGE_VIEW_STATE> image_view_state_;
@@ -401,15 +431,27 @@ class ImageDescriptor : public Descriptor {
 class ImageSamplerDescriptor : public ImageDescriptor {
   public:
     ImageSamplerDescriptor(const ValidationStateTracker *dev_data, const VkSampler *);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
     const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
     SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
     std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = ImageDescriptor::AddParent(base_node);
+        if (sampler_state_) {
+            result |= sampler_state_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        ImageDescriptor::RemoveParent(base_node);
+        if (sampler_state_) {
+            sampler_state_->RemoveParent(base_node);
+        }
+    }
   private:
     std::shared_ptr<SAMPLER_STATE> sampler_state_;
     bool immutable_;
@@ -418,14 +460,26 @@ class ImageSamplerDescriptor : public ImageDescriptor {
 class TexelDescriptor : public Descriptor {
   public:
     TexelDescriptor(const VkDescriptorType);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *,
+                     const uint32_t) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
     VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->buffer_view() : VK_NULL_HANDLE; }
     const BUFFER_VIEW_STATE *GetBufferViewState() const { return buffer_view_state_.get(); }
     BUFFER_VIEW_STATE *GetBufferViewState() { return buffer_view_state_.get(); }
     std::shared_ptr<BUFFER_VIEW_STATE> GetSharedBufferViewState() const { return buffer_view_state_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = false;
+        if (buffer_view_state_) {
+            result = buffer_view_state_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        if (buffer_view_state_) {
+            buffer_view_state_->RemoveParent(base_node);
+        }
+    }
   private:
     std::shared_ptr<BUFFER_VIEW_STATE> buffer_view_state_;
 };
@@ -433,9 +487,9 @@ class TexelDescriptor : public Descriptor {
 class BufferDescriptor : public Descriptor {
   public:
     BufferDescriptor(const VkDescriptorType);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *,
+                     const uint32_t) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
     VkBuffer GetBuffer() const { return buffer_state_ ? buffer_state_->buffer() : VK_NULL_HANDLE; }
     const BUFFER_STATE *GetBufferState() const { return buffer_state_.get(); }
     BUFFER_STATE *GetBufferState() { return buffer_state_.get(); }
@@ -443,6 +497,18 @@ class BufferDescriptor : public Descriptor {
     VkDeviceSize GetOffset() const { return offset_; }
     VkDeviceSize GetRange() const { return range_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = false;
+        if (buffer_state_) {
+            result = buffer_state_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        if (buffer_state_) {
+            buffer_state_->RemoveParent(base_node);
+        }
+    }
   private:
     VkDeviceSize offset_;
     VkDeviceSize range_;
@@ -452,27 +518,43 @@ class BufferDescriptor : public Descriptor {
 class InlineUniformDescriptor : public Descriptor {
   public:
     InlineUniformDescriptor(const VkDescriptorType) : Descriptor(InlineUniform) {}
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override {
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override {
         updated = true;
     }
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override {}
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override { updated = true; }
 };
 
 class AccelerationStructureDescriptor : public Descriptor {
   public:
     AccelerationStructureDescriptor(const VkDescriptorType);
-    void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+    void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
     VkAccelerationStructureKHR GetAccelerationStructure() const { return acc_; }
     const ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
     ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
     VkAccelerationStructureNV GetAccelerationStructureNV() const { return acc_nv_; }
     const ACCELERATION_STRUCTURE_STATE *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
     ACCELERATION_STRUCTURE_STATE *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
-    void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-    void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+    void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
     bool is_khr() const { return is_khr_; }
 
+    bool AddParent(BASE_NODE *base_node) override {
+        bool result = false;
+        if (acc_state_) {
+            result |= acc_state_->AddParent(base_node);
+        }
+        if (acc_state_nv_) {
+            result |= acc_state_nv_->AddParent(base_node);
+        }
+        return result;
+    }
+    void RemoveParent(BASE_NODE *base_node) override {
+        if (acc_state_) {
+            acc_state_->RemoveParent(base_node);
+        }
+        if (acc_state_nv_) {
+            acc_state_nv_->RemoveParent(base_node);
+        }
+    }
   private:
     bool is_khr_;
     VkAccelerationStructureKHR acc_;
@@ -484,9 +566,8 @@ class AccelerationStructureDescriptor : public Descriptor {
 class MutableDescriptor : public Descriptor {
   public:
       MutableDescriptor();
-      void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
-      void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
-      void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
+      void WriteUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
+      void CopyUpdate(DescriptorSet *set_state, const ValidationStateTracker *dev_data, const Descriptor *) override;
 
   private:
       DescriptorClass active_descriptor_class_;
@@ -579,7 +660,8 @@ class DescriptorSet : public BASE_NODE {
     using StateTracker = ValidationStateTracker;
     DescriptorSet(const VkDescriptorSet, DESCRIPTOR_POOL_STATE *, const std::shared_ptr<DescriptorSetLayout const> &,
                   uint32_t variable_count, const StateTracker *state_data_const);
-    ~DescriptorSet();
+    ~DescriptorSet() { Destroy(); }
+
     // A number of common Get* functions that return data based on layout from which this set was created
     uint32_t GetTotalDescriptorCount() const { return layout_->GetTotalDescriptorCount(); };
     uint32_t GetDynamicDescriptorCount() const { return layout_->GetDynamicDescriptorCount(); };
@@ -665,8 +747,12 @@ class DescriptorSet : public BASE_NODE {
     struct DescriptorDeleter {
         void operator()(Descriptor *desc) { desc->~Descriptor(); }
     };
+ 
+    void Destroy() override;
 
-    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
+    void Reset() {
+        parent_nodes_.clear();
+    }
   private:
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -668,6 +668,7 @@ class DescriptorSet : public BASE_NODE {
         void operator()(Descriptor *desc) { desc->~Descriptor(); }
     };
 
+    bool AddParent(CMD_BUFFER_STATE *cb_node) override;
   private:
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -184,7 +184,7 @@ class DescriptorSetLayout : public BASE_NODE {
     // Return true if this layout is compatible with passed in layout
     bool IsCompatible(DescriptorSetLayout const *rh_ds_layout) const;
     // Straightforward Get functions
-    VkDescriptorSetLayout GetDescriptorSetLayout() const { return layout_; };
+    VkDescriptorSetLayout GetDescriptorSetLayout() const { return handle_.Cast<VkDescriptorSetLayout>(); };
     const DescriptorSetLayoutDef *GetLayoutDef() const { return layout_id_.get(); }
     DescriptorSetLayoutId GetLayoutId() const { return layout_id_; }
     uint32_t GetTotalDescriptorCount() const { return layout_id_->GetTotalDescriptorCount(); };
@@ -312,9 +312,7 @@ class DescriptorSetLayout : public BASE_NODE {
         uint32_t index_;
     };
     ConstBindingIterator end() const { return ConstBindingIterator(this, GetBindingCount()); }
-
   private:
-    VkDescriptorSetLayout layout_;
     DescriptorSetLayoutId layout_id_;
 };
 
@@ -372,7 +370,7 @@ class SamplerDescriptor : public Descriptor {
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
-    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler : VK_NULL_HANDLE; }
+    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
     const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
     SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
     std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
@@ -388,7 +386,7 @@ class ImageDescriptor : public Descriptor {
     void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
-    VkImageView GetImageView() const { return image_view_state_ ? image_view_state_->image_view : VK_NULL_HANDLE; }
+    VkImageView GetImageView() const { return image_view_state_ ? image_view_state_->image_view() : VK_NULL_HANDLE; }
     const IMAGE_VIEW_STATE *GetImageViewState() const { return image_view_state_.get(); }
     IMAGE_VIEW_STATE *GetImageViewState() { return image_view_state_.get(); }
     std::shared_ptr<IMAGE_VIEW_STATE> GetSharedImageViewState() const { return image_view_state_; }
@@ -407,7 +405,7 @@ class ImageSamplerDescriptor : public ImageDescriptor {
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
-    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler : VK_NULL_HANDLE; }
+    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
     const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
     SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
     std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
@@ -423,7 +421,7 @@ class TexelDescriptor : public Descriptor {
     void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
-    VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->buffer_view : VK_NULL_HANDLE; }
+    VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->buffer_view() : VK_NULL_HANDLE; }
     const BUFFER_VIEW_STATE *GetBufferViewState() const { return buffer_view_state_.get(); }
     BUFFER_VIEW_STATE *GetBufferViewState() { return buffer_view_state_.get(); }
     std::shared_ptr<BUFFER_VIEW_STATE> GetSharedBufferViewState() const { return buffer_view_state_; }
@@ -438,7 +436,7 @@ class BufferDescriptor : public Descriptor {
     void WriteUpdate(const ValidationStateTracker *dev_data, const VkWriteDescriptorSet *, const uint32_t) override;
     void CopyUpdate(const ValidationStateTracker *dev_data, const Descriptor *) override;
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *) override;
-    VkBuffer GetBuffer() const { return buffer_state_ ? buffer_state_->buffer : VK_NULL_HANDLE; }
+    VkBuffer GetBuffer() const { return buffer_state_ ? buffer_state_->buffer() : VK_NULL_HANDLE; }
     const BUFFER_STATE *GetBufferState() const { return buffer_state_.get(); }
     BUFFER_STATE *GetBufferState() { return buffer_state_.get(); }
     std::shared_ptr<BUFFER_STATE> GetSharedBufferState() const { return buffer_state_; }
@@ -606,7 +604,7 @@ class DescriptorSet : public BASE_NODE {
 
     const std::shared_ptr<DescriptorSetLayout const> &GetLayout() const { return layout_; };
     VkDescriptorSetLayout GetDescriptorSetLayout() const { return layout_->GetDescriptorSetLayout(); }
-    VkDescriptorSet GetSet() const { return set_; };
+    VkDescriptorSet GetSet() const { return handle_.Cast<VkDescriptorSet>(); };
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *, CMD_TYPE cmd_type, const PIPELINE_STATE *,
@@ -673,7 +671,6 @@ class DescriptorSet : public BASE_NODE {
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);
     bool some_update_;  // has any part of the set ever been updated?
-    VkDescriptorSet set_;
     DESCRIPTOR_POOL_STATE *pool_state_;
     const std::shared_ptr<DescriptorSetLayout const> layout_;
     // NOTE: the the backing store for the descriptors must be declared *before* it so it will be destructed *after* it

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -670,14 +670,14 @@ bool CoreChecks::ValidateCmdDrawInstance(VkCommandBuffer commandBuffer, uint32_t
     if (!cb_node) return skip;
 
     // Verify maxMultiviewInstanceIndex
-    if (cb_node->activeRenderPass && cb_node->activeRenderPass->renderPass && enabled_features.multiview_features.multiview &&
+    if (cb_node->activeRenderPass && cb_node->activeRenderPass->renderPass() && enabled_features.multiview_features.multiview &&
         ((instanceCount + firstInstance) > phys_dev_ext_props.multiview_props.maxMultiviewInstanceIndex)) {
         LogObjectList objlist(commandBuffer);
-        objlist.add(cb_node->activeRenderPass->renderPass);
+        objlist.add(cb_node->activeRenderPass->renderPass());
         skip |= LogError(objlist, vuid.max_multiview_instance_index,
                          "%s: renderpass %s multiview is enabled, and maxMultiviewInstanceIndex: %" PRIu32 ", but instanceCount: %" PRIu32
                          "and firstInstance: %" PRIu32 ".",
-                         caller, report_data->FormatHandle(cb_node->activeRenderPass->renderPass).c_str(),
+                         caller, report_data->FormatHandle(cb_node->activeRenderPass->renderPass()).c_str(),
                          phys_dev_ext_props.multiview_props.maxMultiviewInstanceIndex, instanceCount, firstInstance);
     }
     return skip;
@@ -710,7 +710,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
         VkDeviceSize end_offset = (index_size * (static_cast<VkDeviceSize>(firstIndex) + indexCount)) + index_buffer_binding.offset;
         if (end_offset > index_buffer_binding.size) {
             skip |=
-                LogError(index_buffer_binding.buffer_state->buffer, "VUID-vkCmdDrawIndexed-indexSize-00463",
+                LogError(index_buffer_binding.buffer_state->buffer(), "VUID-vkCmdDrawIndexed-indexSize-00463",
                          "vkCmdDrawIndexed() index size (%d) * (firstIndex (%d) + indexCount (%d)) "
                          "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
                          " bytes, which is greater than the index buffer size (%" PRIuLEAST64 ").",
@@ -967,7 +967,7 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
 
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_RAY_TRACING_NV);
     const PIPELINE_STATE *pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
-    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline)) {
+    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline())) {
         skip |= LogError(device, "VUID-vkCmdTraceRaysNV-None-02700",
                          "vkCmdTraceRaysKHR: A valid pipeline must be bound to the pipeline bind point used by this command.");
     }
@@ -997,7 +997,7 @@ bool CoreChecks::PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
     const PIPELINE_STATE *pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
-    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline)) {
+    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline())) {
         skip |= LogError(device, "VUID-vkCmdTraceRaysKHR-None-02700",
                          "vkCmdTraceRaysKHR: A valid pipeline must be bound to the pipeline bind point used by this command.");
     } else {  // bound to valid RT pipeline
@@ -1066,7 +1066,7 @@ bool CoreChecks::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer commandB
     const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
     const PIPELINE_STATE *pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
-    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline)) {
+    if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline())) {
         skip |=
             LogError(device, "VUID-vkCmdTraceRaysIndirectKHR-None-02700",
                      "vkCmdTraceRaysIndirectKHR: A valid pipeline must be bound to the pipeline bind point used by this command.");

--- a/layers/generated/command_validation.cpp
+++ b/layers/generated/command_validation.cpp
@@ -632,7 +632,7 @@ bool CoreChecks::ValidateCmd(const CMD_BUFFER_STATE *cb_state, const CMD_TYPE cm
         default:
             assert(cmd != CMD_NONE);
             const auto error = kGeneratedMustBeRecordingList[cmd];
-            skip |= LogError(cb_state->commandBuffer, error, "You must call vkBeginCommandBuffer() before this call to %s.",
+            skip |= LogError(cb_state->commandBuffer(), error, "You must call vkBeginCommandBuffer() before this call to %s.",
                             caller_name);
     }
 

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -307,7 +307,7 @@ void UtilPostCallRecordPipelineCreations(const uint32_t count, const CreateInfo 
             // the pipeline is used, so we have to keep another copy.
             if (shader_state && shader_state->has_valid_spirv) code = shader_state->words;
 
-            object_ptr->shader_map[shader_state->gpu_validation_shader_id].pipeline = pipeline_state->pipeline;
+            object_ptr->shader_map[shader_state->gpu_validation_shader_id].pipeline = pipeline_state->pipeline();
             // Be careful to use the originally bound (instrumented) shader here, even if PreCallRecord had to back it
             // out with a non-instrumented shader.  The non-instrumented shader (found in pCreateInfo) was destroyed above.
             VkShaderModule shader_module = VK_NULL_HANDLE;
@@ -344,7 +344,7 @@ template <typename ObjectType>
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
 void UtilProcessInstrumentationBuffer(VkQueue queue, CMD_BUFFER_STATE *cb_node, ObjectType *object_ptr) {
     if (cb_node && (cb_node->hasDrawCmd || cb_node->hasTraceRaysCmd || cb_node->hasDispatchCmd)) {
-        auto gpu_buffer_list = object_ptr->GetBufferInfo(cb_node->commandBuffer);
+        auto gpu_buffer_list = object_ptr->GetBufferInfo(cb_node->commandBuffer());
         uint32_t draw_index = 0;
         uint32_t compute_index = 0;
         uint32_t ray_trace_index = 0;
@@ -365,7 +365,7 @@ void UtilProcessInstrumentationBuffer(VkQueue queue, CMD_BUFFER_STATE *cb_node, 
 
             VkResult result = vmaMapMemory(object_ptr->vmaAllocator, buffer_info.output_mem_block.allocation, (void **)&pData);
             if (result == VK_SUCCESS) {
-                object_ptr->AnalyzeAndGenerateMessages(cb_node->commandBuffer, queue, buffer_info,
+                object_ptr->AnalyzeAndGenerateMessages(cb_node->commandBuffer(), queue, buffer_info,
                                                        operation_index, (uint32_t *)pData);
                 vmaUnmapMemory(object_ptr->vmaAllocator, buffer_info.output_mem_block.allocation);
             }

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -2313,11 +2313,11 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     const auto *pipeline_state = state.pipeline_state;
     if (pipeline_state) {
         if ((pipeline_state->pipeline_layout->set_layouts.size() <= desc_set_bind_index) &&
-            !pipeline_state->pipeline_layout->destroyed) {
+            !pipeline_state->pipeline_layout->Destroyed()) {
             DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_state->pipeline_layout->layout, desc_set_bind_index, 1,
                                           desc_sets.data(), 0, nullptr);
         }
-        if (pipeline_state->pipeline_layout->destroyed) {
+        if (pipeline_state->pipeline_layout->Destroyed()) {
             ReportSetupProblem(device, "Pipeline layout has been destroyed, aborting GPU-AV");
             aborted = true;
         } else {

--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -83,7 +83,7 @@ static bool UpdateLayoutStateImpl(LayoutsMap& layouts, InitialLayoutStates& init
 InitialLayoutState::InitialLayoutState(const CMD_BUFFER_STATE& cb_state_, const IMAGE_VIEW_STATE* view_state_)
     : image_view(VK_NULL_HANDLE), aspect_mask(0), label(cb_state_.debug_label) {
     if (view_state_) {
-        image_view = view_state_->image_view;
+        image_view = view_state_->image_view();
         aspect_mask = view_state_->create_info.subresourceRange.aspectMask;
     }
 }

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -188,7 +188,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     bool multiple_entry_points{false};
     bool has_valid_spirv;
     bool has_specialization_constants{false};
-    VkShaderModule vk_shader_module;
     uint32_t gpu_validation_shader_id;
 
     SHADER_MODULE_STATE(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env,
@@ -197,7 +196,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
           words(),
           def_index(),
           has_valid_spirv(true),
-          vk_shader_module(shaderModule),
           gpu_validation_shader_id(unique_shader_id) {
         words = PreprocessShaderBinary((uint32_t *)pCreateInfo->pCode, pCreateInfo->codeSize, env);
         BuildDefIndex();
@@ -206,8 +204,9 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     SHADER_MODULE_STATE()
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
           has_valid_spirv(false),
-          vk_shader_module(VK_NULL_HANDLE),
           gpu_validation_shader_id(UINT32_MAX) {}
+
+    VkShaderModule vk_shader_module() const { return handle_.Cast<VkShaderModule>(); }
 
     decoration_set get_decorations(unsigned id) const {
         // return the actual decorations for this id, or a default set.

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -193,12 +193,21 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     SHADER_MODULE_STATE(VkShaderModuleCreateInfo const *pCreateInfo, VkShaderModule shaderModule, spv_target_env env,
                         uint32_t unique_shader_id)
-        : words(), def_index(), has_valid_spirv(true), vk_shader_module(shaderModule), gpu_validation_shader_id(unique_shader_id) {
+        : BASE_NODE(shaderModule, kVulkanObjectTypeShaderModule),
+          words(),
+          def_index(),
+          has_valid_spirv(true),
+          vk_shader_module(shaderModule),
+          gpu_validation_shader_id(unique_shader_id) {
         words = PreprocessShaderBinary((uint32_t *)pCreateInfo->pCode, pCreateInfo->codeSize, env);
         BuildDefIndex();
     }
 
-    SHADER_MODULE_STATE() : has_valid_spirv(false), vk_shader_module(VK_NULL_HANDLE), gpu_validation_shader_id(UINT32_MAX) {}
+    SHADER_MODULE_STATE()
+        : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
+          has_valid_spirv(false),
+          vk_shader_module(VK_NULL_HANDLE),
+          gpu_validation_shader_id(UINT32_MAX) {}
 
     decoration_set get_decorations(unsigned id) const {
         // return the actual decorations for this id, or a default set.

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -216,10 +216,10 @@ bool CoreChecks::ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo 
         const auto input = location_it.second.input;
 
         if (attrib && !input) {
-            skip |= LogPerformanceWarning(vs->vk_shader_module, kVUID_Core_Shader_OutputNotConsumed,
+            skip |= LogPerformanceWarning(vs->vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed,
                                           "Vertex attribute at location %" PRIu32 " not consumed by vertex shader", location);
         } else if (!attrib && input) {
-            skip |= LogError(vs->vk_shader_module, kVUID_Core_Shader_InputNotProduced,
+            skip |= LogError(vs->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
                              "Vertex shader consumes input at location %" PRIu32 " but not provided", location);
         } else if (attrib && input) {
             const auto attrib_type = GetFormatType(attrib->format);
@@ -227,7 +227,7 @@ bool CoreChecks::ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo 
 
             // Type checking
             if (!(attrib_type & input_type)) {
-                skip |= LogError(vs->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(vs->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Attribute type of `%s` at location %" PRIu32 " does not match vertex shader input type of `%s`",
                                  string_VkFormat(attrib->format), location, vs->DescribeType(input->type_id).c_str());
             }
@@ -284,14 +284,14 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *f
         const auto output = location_it.second.output;
         if (attachment && !output) {
             if (pipeline->attachments[location].colorWriteMask != 0) {
-                skip |= LogWarning(fs->vk_shader_module, kVUID_Core_Shader_InputNotProduced,
+                skip |= LogWarning(fs->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
                                    "Attachment %" PRIu32
                                    " not written by fragment shader; undefined values will be written to attachment",
                                    location);
             }
         } else if (!attachment && output) {
             if (!(alpha_to_coverage_enabled && location == 0)) {
-                skip |= LogWarning(fs->vk_shader_module, kVUID_Core_Shader_OutputNotConsumed,
+                skip |= LogWarning(fs->vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed,
                                    "fragment shader writes to output location %" PRIu32 " with no matching attachment", location);
             }
         } else if (attachment && output) {
@@ -301,7 +301,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *f
             // Type checking
             if (!(output_type & attachment_type)) {
                 skip |=
-                    LogWarning(fs->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                    LogWarning(fs->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                "Attachment %" PRIu32
                                " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
                                location, string_VkFormat(attachment->format), fs->DescribeType(output->type_id).c_str());
@@ -315,7 +315,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const *f
     bool location_zero_has_alpha = output_zero && fs->get_def(output_zero->type_id) != fs->end() &&
                                    fs->GetComponentsConsumedByType(output_zero->type_id, false) == 4;
     if (alpha_to_coverage_enabled && !location_zero_has_alpha) {
-        skip |= LogError(fs->vk_shader_module, kVUID_Core_Shader_NoAlphaAtLocation0WithAlphaToCoverage,
+        skip |= LogError(fs->vk_shader_module(), kVUID_Core_Shader_NoAlphaAtLocation0WithAlphaToCoverage,
                          "fragment shader doesn't declare alpha output at location 0 even though alpha to coverage is enabled.");
     }
 
@@ -391,22 +391,22 @@ bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, SHADE
 
             if (ret == PC_Byte_Not_Set) {
                 const auto loc_descr = entrypoint->push_constant_used_in_shader.GetLocationDesc(issue_index);
-                LogObjectList objlist(src->vk_shader_module);
-                objlist.add(pipeline.pipeline_layout->layout);
+                LogObjectList objlist(src->vk_shader_module());
+                objlist.add(pipeline.pipeline_layout->layout());
                 skip |= LogError(objlist, vuid, "Push constant buffer:%s in %s is out of range in %s.", loc_descr.c_str(),
                                  string_VkShaderStageFlags(pStage->stage).c_str(),
-                                 report_data->FormatHandle(pipeline.pipeline_layout->layout).c_str());
+                                 report_data->FormatHandle(pipeline.pipeline_layout->layout()).c_str());
                 break;
             }
         }
     }
 
     if (!found_stage) {
-        LogObjectList objlist(src->vk_shader_module);
-        objlist.add(pipeline.pipeline_layout->layout);
+        LogObjectList objlist(src->vk_shader_module());
+        objlist.add(pipeline.pipeline_layout->layout());
         skip |= LogError(objlist, vuid, "Push constant is used in %s of %s. But %s doesn't set %s.",
-                         string_VkShaderStageFlags(pStage->stage).c_str(), report_data->FormatHandle(src->vk_shader_module).c_str(),
-                         report_data->FormatHandle(pipeline.pipeline_layout->layout).c_str(),
+                         string_VkShaderStageFlags(pStage->stage).c_str(), report_data->FormatHandle(src->vk_shader_module()).c_str(),
+                         report_data->FormatHandle(pipeline.pipeline_layout->layout()).c_str(),
                          string_VkShaderStageFlags(pStage->stage).c_str());
     }
     return skip;
@@ -442,7 +442,7 @@ bool CoreChecks::ValidateBuiltinLimits(SHADER_MODULE_STATE const *src, const lay
                                              "vkCreateGraphicsPipelines(): The BuiltIns SampleMask array sizes is %u which exceeds "
                                              "maxSampleMaskWords of %u in %s.",
                                              length, phys_dev_props.limits.maxSampleMaskWords,
-                                             report_data->FormatHandle(src->vk_shader_module).c_str());
+                                             report_data->FormatHandle(src->vk_shader_module()).c_str());
                         }
                         break;
                 }
@@ -848,14 +848,14 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
     switch (pStage->stage) {
         case VK_SHADER_STAGE_VERTEX_BIT:
             if (num_comp_out > limits.maxVertexOutputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Vertex shader exceeds "
                                  "VkPhysicalDeviceLimits::maxVertexOutputComponents of %u "
                                  "components by %u components",
                                  limits.maxVertexOutputComponents, num_comp_out - limits.maxVertexOutputComponents);
             }
             if (max_comp_out > static_cast<int>(limits.maxVertexOutputComponents)) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Vertex shader output variable uses location that "
                                  "exceeds component limit VkPhysicalDeviceLimits::maxVertexOutputComponents (%u)",
                                  limits.maxVertexOutputComponents);
@@ -864,7 +864,7 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 
         case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
             if (num_comp_in > limits.maxTessellationControlPerVertexInputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Tessellation control shader exceeds "
                                  "VkPhysicalDeviceLimits::maxTessellationControlPerVertexInputComponents of %u "
                                  "components by %u components",
@@ -873,13 +873,13 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
             }
             if (max_comp_in > static_cast<int>(limits.maxTessellationControlPerVertexInputComponents)) {
                 skip |=
-                    LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                    LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                              "Invalid Pipeline CreateInfo State: Tessellation control shader input variable uses location that "
                              "exceeds component limit VkPhysicalDeviceLimits::maxTessellationControlPerVertexInputComponents (%u)",
                              limits.maxTessellationControlPerVertexInputComponents);
             }
             if (num_comp_out > limits.maxTessellationControlPerVertexOutputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Tessellation control shader exceeds "
                                  "VkPhysicalDeviceLimits::maxTessellationControlPerVertexOutputComponents of %u "
                                  "components by %u components",
@@ -888,7 +888,7 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
             }
             if (max_comp_out > static_cast<int>(limits.maxTessellationControlPerVertexOutputComponents)) {
                 skip |=
-                    LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                    LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                              "Invalid Pipeline CreateInfo State: Tessellation control shader output variable uses location that "
                              "exceeds component limit VkPhysicalDeviceLimits::maxTessellationControlPerVertexOutputComponents (%u)",
                              limits.maxTessellationControlPerVertexOutputComponents);
@@ -897,7 +897,7 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 
         case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
             if (num_comp_in > limits.maxTessellationEvaluationInputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Tessellation evaluation shader exceeds "
                                  "VkPhysicalDeviceLimits::maxTessellationEvaluationInputComponents of %u "
                                  "components by %u components",
@@ -906,13 +906,13 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
             }
             if (max_comp_in > static_cast<int>(limits.maxTessellationEvaluationInputComponents)) {
                 skip |=
-                    LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                    LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                              "Invalid Pipeline CreateInfo State: Tessellation evaluation shader input variable uses location that "
                              "exceeds component limit VkPhysicalDeviceLimits::maxTessellationEvaluationInputComponents (%u)",
                              limits.maxTessellationEvaluationInputComponents);
             }
             if (num_comp_out > limits.maxTessellationEvaluationOutputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Tessellation evaluation shader exceeds "
                                  "VkPhysicalDeviceLimits::maxTessellationEvaluationOutputComponents of %u "
                                  "components by %u components",
@@ -921,7 +921,7 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
             }
             if (max_comp_out > static_cast<int>(limits.maxTessellationEvaluationOutputComponents)) {
                 skip |=
-                    LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                    LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                              "Invalid Pipeline CreateInfo State: Tessellation evaluation shader output variable uses location that "
                              "exceeds component limit VkPhysicalDeviceLimits::maxTessellationEvaluationOutputComponents (%u)",
                              limits.maxTessellationEvaluationOutputComponents);
@@ -929,12 +929,12 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
             // Portability validation
             if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
                 if (is_iso_lines && (VK_FALSE == enabled_features.portability_subset_features.tessellationIsolines)) {
-                    skip |= LogError(pipeline->pipeline, kVUID_Portability_Tessellation_Isolines,
+                    skip |= LogError(pipeline->pipeline(), kVUID_Portability_Tessellation_Isolines,
                                      "Invalid Pipeline CreateInfo state (portability error): Tessellation evaluation shader"
                                      " is using abstract patch type IsoLines, but this is not supported on this platform");
                 }
                 if (is_point_mode && (VK_FALSE == enabled_features.portability_subset_features.tessellationPointMode)) {
-                    skip |= LogError(pipeline->pipeline, kVUID_Portability_Tessellation_PointMode,
+                    skip |= LogError(pipeline->pipeline(), kVUID_Portability_Tessellation_PointMode,
                                      "Invalid Pipeline CreateInfo state (portability error): Tessellation evaluation shader"
                                      " is using abstract patch type PointMode, but this is not supported on this platform");
                 }
@@ -943,33 +943,33 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 
         case VK_SHADER_STAGE_GEOMETRY_BIT:
             if (num_comp_in > limits.maxGeometryInputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
                                  "VkPhysicalDeviceLimits::maxGeometryInputComponents of %u "
                                  "components by %u components",
                                  limits.maxGeometryInputComponents, num_comp_in - limits.maxGeometryInputComponents);
             }
             if (max_comp_in > static_cast<int>(limits.maxGeometryInputComponents)) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Geometry shader input variable uses location that "
                                  "exceeds component limit VkPhysicalDeviceLimits::maxGeometryInputComponents (%u)",
                                  limits.maxGeometryInputComponents);
             }
             if (num_comp_out > limits.maxGeometryOutputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
                                  "VkPhysicalDeviceLimits::maxGeometryOutputComponents of %u "
                                  "components by %u components",
                                  limits.maxGeometryOutputComponents, num_comp_out - limits.maxGeometryOutputComponents);
             }
             if (max_comp_out > static_cast<int>(limits.maxGeometryOutputComponents)) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Geometry shader output variable uses location that "
                                  "exceeds component limit VkPhysicalDeviceLimits::maxGeometryOutputComponents (%u)",
                                  limits.maxGeometryOutputComponents);
             }
             if (num_comp_out * num_vertices > limits.maxGeometryTotalOutputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Geometry shader exceeds "
                                  "VkPhysicalDeviceLimits::maxGeometryTotalOutputComponents of %u "
                                  "components by %u components",
@@ -980,14 +980,14 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 
         case VK_SHADER_STAGE_FRAGMENT_BIT:
             if (num_comp_in > limits.maxFragmentInputComponents) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Fragment shader exceeds "
                                  "VkPhysicalDeviceLimits::maxFragmentInputComponents of %u "
                                  "components by %u components",
                                  limits.maxFragmentInputComponents, num_comp_in - limits.maxFragmentInputComponents);
             }
             if (max_comp_in > static_cast<int>(limits.maxFragmentInputComponents)) {
-                skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_ExceedDeviceLimit,
+                skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_ExceedDeviceLimit,
                                  "Invalid Pipeline CreateInfo State: Fragment shader input variable uses location that "
                                  "exceeds component limit VkPhysicalDeviceLimits::maxFragmentInputComponents (%u)",
                                  limits.maxFragmentInputComponents);
@@ -1060,7 +1060,7 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
     if (total_resources > phys_dev_props.limits.maxPerStageResources) {
         const char *vuid = (stage == VK_SHADER_STAGE_COMPUTE_BIT) ? "VUID-VkComputePipelineCreateInfo-layout-01687"
                                                                   : "VUID-VkGraphicsPipelineCreateInfo-layout-01688";
-        skip |= LogError(pipeline->pipeline, vuid,
+        skip |= LogError(pipeline->pipeline(), vuid,
                          "Invalid Pipeline CreateInfo State: Shader Stage %s exceeds component limit "
                          "VkPhysicalDeviceLimits::maxPerStageResources (%u)",
                          string_VkShaderStageFlagBits(stage), phys_dev_props.limits.maxPerStageResources);
@@ -1224,7 +1224,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *src, VkPip
 
                     if (!(pStage->stage & phys_dev_ext_props.cooperative_matrix_props.cooperativeMatrixSupportedStages)) {
                         skip |= LogError(
-                            pipeline->pipeline, kVUID_Core_Shader_CooperativeMatrixSupportedStages,
+                            pipeline->pipeline(), kVUID_Core_Shader_CooperativeMatrixSupportedStages,
                             "OpTypeCooperativeMatrixNV used in shader stage not in cooperativeMatrixSupportedStages (= %u)",
                             phys_dev_ext_props.cooperative_matrix_props.cooperativeMatrixSupportedStages);
                     }
@@ -1272,7 +1272,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *src, VkPip
                         }
                     }
                     if (!valid) {
-                        skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_CooperativeMatrixType,
+                        skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_CooperativeMatrixType,
                                          "OpTypeCooperativeMatrixNV (result id = %u) operands don't match a supported matrix type",
                                          insn.word(1));
                     }
@@ -1319,7 +1319,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *src, VkPip
                         }
                     }
                     if (!valid) {
-                        skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_CooperativeMatrixMulAdd,
+                        skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_CooperativeMatrixMulAdd,
                                          "OpCooperativeMatrixMulAddNV (result id = %u) operands don't match a supported matrix "
                                          "VkCooperativeMatrixPropertiesNV",
                                          insn.word(2));
@@ -1609,13 +1609,13 @@ bool CoreChecks::ValidatePointListShaderState(const PIPELINE_STATE *pipeline, SH
     if ((stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT || stage == VK_SHADER_STAGE_GEOMETRY_BIT) &&
         !enabled_features.core.shaderTessellationAndGeometryPointSize) {
         if (pointsize_written) {
-            skip |= LogError(pipeline->pipeline, kVUID_Core_Shader_PointSizeBuiltInOverSpecified,
+            skip |= LogError(pipeline->pipeline(), kVUID_Core_Shader_PointSizeBuiltInOverSpecified,
                              "Pipeline topology is set to POINT_LIST and geometry or tessellation shaders write PointSize which "
                              "is prohibited when the shaderTessellationAndGeometryPointSize feature is not enabled.");
         }
     } else if (!pointsize_written) {
         skip |=
-            LogError(pipeline->pipeline, kVUID_Core_Shader_MissingPointSizeBuiltIn,
+            LogError(pipeline->pipeline(), kVUID_Core_Shader_MissingPointSizeBuiltIn,
                      "Pipeline topology is set to POINT_LIST, but PointSize is not written to in the shader corresponding to %s.",
                      string_VkShaderStageFlagBits(stage));
     }
@@ -1648,7 +1648,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const PIPELINE_STATE *pipeline
         pipeline->graphicsPipelineCI.pViewportState) {
         if (!IsDynamic(pipeline, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT) &&
             pipeline->graphicsPipelineCI.pViewportState->viewportCount > 1 && primitiverate_written) {
-            skip |= LogError(pipeline->pipeline,
+            skip |= LogError(pipeline->pipeline(),
                              "VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04503",
                              "vkCreateGraphicsPipelines: %s shader statically writes to PrimitiveShadingRateKHR built-in, but "
                              "multiple viewports "
@@ -1657,7 +1657,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const PIPELINE_STATE *pipeline
         }
 
         if (primitiverate_written && viewportindex_written) {
-            skip |= LogError(pipeline->pipeline,
+            skip |= LogError(pipeline->pipeline(),
                              "VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04504",
                              "vkCreateGraphicsPipelines: %s shader statically writes to both PrimitiveShadingRateKHR and "
                              "ViewportIndex built-ins,"
@@ -1666,7 +1666,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const PIPELINE_STATE *pipeline
         }
 
         if (primitiverate_written && viewportmask_written) {
-            skip |= LogError(pipeline->pipeline,
+            skip |= LogError(pipeline->pipeline(),
                              "VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04505",
                              "vkCreateGraphicsPipelines: %s shader statically writes to both PrimitiveShadingRateKHR and "
                              "ViewportMaskNV built-ins,"
@@ -1689,11 +1689,11 @@ bool CoreChecks::ValidatePropertiesAndFeatures(SHADER_MODULE_STATE const *module
             if ((scope_type == spv::ScopeSubgroup) && (enabled_features.shader_clock_feature.shaderSubgroupClock == VK_FALSE)) {
                 skip |= LogError(device, "UNASSIGNED-spirv-shaderClock-shaderSubgroupClock",
                                  "%s: OpReadClockKHR is used with a Subgroup scope but shaderSubgroupClock was not enabled.",
-                                 report_data->FormatHandle(module->vk_shader_module).c_str());
+                                 report_data->FormatHandle(module->vk_shader_module()).c_str());
             } else if ((scope_type == spv::ScopeDevice) && (enabled_features.shader_clock_feature.shaderDeviceClock == VK_FALSE)) {
                 skip |= LogError(device, "UNASSIGNED-spirv-shaderClock-shaderDeviceClock",
                                  "%s: OpReadClockKHR is used with a Device scope but shaderDeviceClock was not enabled.",
-                                 report_data->FormatHandle(module->vk_shader_module).c_str());
+                                 report_data->FormatHandle(module->vk_shader_module()).c_str());
             }
             break;
         }
@@ -1710,7 +1710,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
     if (!module->has_valid_spirv) {
         skip |= LogError(device, "VUID-VkPipelineShaderStageCreateInfo-module-parameter",
                          "%s does not contain valid spirv for stage %s.",
-                         report_data->FormatHandle(module->vk_shader_module).c_str(), string_VkShaderStageFlagBits(pStage->stage));
+                         report_data->FormatHandle(module->vk_shader_module()).c_str(), string_VkShaderStageFlagBits(pStage->stage));
     }
 
     // If specialization-constant values are given and specialization-constant instructions are present in the shader, the
@@ -1740,7 +1740,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
                                                                              const spv_position_t &position, const char *message) {
             skip |= LogError(
                 device, "VUID-VkPipelineShaderStageCreateInfo-module-parameter", "%s does not contain valid spirv for stage %s. %s",
-                report_data->FormatHandle(module->vk_shader_module).c_str(), string_VkShaderStageFlagBits(pStage->stage), message);
+                report_data->FormatHandle(module->vk_shader_module()).c_str(), string_VkShaderStageFlagBits(pStage->stage), message);
         };
         optimizer.SetMessageConsumer(consumer);
         optimizer.RegisterPass(spvtools::CreateSetSpecConstantDefaultValuePass(id_value_map));
@@ -1760,7 +1760,7 @@ bool CoreChecks::ValidatePipelineShaderStage(VkPipelineShaderStageCreateInfo con
             if (spv_valid != SPV_SUCCESS) {
                 skip |= LogError(device, "VUID-VkPipelineShaderStageCreateInfo-module-04145",
                                  "After specialization was applied, %s does not contain valid spirv for stage %s.",
-                                 report_data->FormatHandle(module->vk_shader_module).c_str(),
+                                 report_data->FormatHandle(module->vk_shader_module()).c_str(),
                                  string_VkShaderStageFlagBits(pStage->stage));
             }
 
@@ -1906,12 +1906,12 @@ bool CoreChecks::ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const *produ
         auto b_first = b_at_end ? std::make_pair(0u, 0u) : b_it->first;
 
         if (b_at_end || ((!a_at_end) && (a_first < b_first))) {
-            skip |= LogPerformanceWarning(producer->vk_shader_module, kVUID_Core_Shader_OutputNotConsumed,
+            skip |= LogPerformanceWarning(producer->vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed,
                                           "%s writes to output location %u.%u which is not consumed by %s", producer_stage->name,
                                           a_first.first, a_first.second, consumer_stage->name);
             a_it++;
         } else if (a_at_end || a_first > b_first) {
-            skip |= LogError(consumer->vk_shader_module, kVUID_Core_Shader_InputNotProduced,
+            skip |= LogError(consumer->vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
                              "%s consumes input location %u.%u which is not written by %s", consumer_stage->name, b_first.first,
                              b_first.second, producer_stage->name);
             b_it++;
@@ -1923,19 +1923,19 @@ bool CoreChecks::ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const *produ
             if (!TypesMatch(producer, consumer, a_it->second.type_id, b_it->second.type_id,
                             producer_stage->arrayed_output && !a_it->second.is_patch && !a_it->second.is_block_member,
                             consumer_stage->arrayed_input && !b_it->second.is_patch && !b_it->second.is_block_member, true)) {
-                skip |= LogError(producer->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(producer->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Type mismatch on location %u.%u: '%s' vs '%s'", a_first.first, a_first.second,
                                  producer->DescribeType(a_it->second.type_id).c_str(),
                                  consumer->DescribeType(b_it->second.type_id).c_str());
             }
             if (a_it->second.is_patch != b_it->second.is_patch) {
-                skip |= LogError(producer->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(producer->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Decoration mismatch on location %u.%u: is per-%s in %s stage but per-%s in %s stage",
                                  a_first.first, a_first.second, a_it->second.is_patch ? "patch" : "vertex", producer_stage->name,
                                  b_it->second.is_patch ? "patch" : "vertex", consumer_stage->name);
             }
             if (a_it->second.is_relaxed_precision != b_it->second.is_relaxed_precision) {
-                skip |= LogError(producer->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(producer->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Decoration mismatch on location %u.%u: %s and %s stages differ in precision", a_first.first,
                                  a_first.second, producer_stage->name, consumer_stage->name);
             }
@@ -1950,7 +1950,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const *produ
 
         if (!builtins_producer.empty() && !builtins_consumer.empty()) {
             if (builtins_producer.size() != builtins_consumer.size()) {
-                skip |= LogError(producer->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(producer->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Number of elements inside builtin block differ between stages (%s %d vs %s %d).",
                                  producer_stage->name, static_cast<int>(builtins_producer.size()), consumer_stage->name,
                                  static_cast<int>(builtins_consumer.size()));
@@ -1959,7 +1959,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const *produ
                 auto it_consumer = builtins_consumer.begin();
                 while (it_producer != builtins_producer.end() && it_consumer != builtins_consumer.end()) {
                     if (*it_producer != *it_consumer) {
-                        skip |= LogError(producer->vk_shader_module, kVUID_Core_Shader_InterfaceTypeMismatch,
+                        skip |= LogError(producer->vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                          "Builtin variable inside block doesn't match between %s and %s.", producer_stage->name,
                                          consumer_stage->name);
                         break;
@@ -2110,7 +2110,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE
                 IsDynamic(pipeline, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT) && pCB->viewportWithCountCount != 1) {
                 if (pipeline->wrote_primitive_shading_rate.find(stage->stage) != pipeline->wrote_primitive_shading_rate.end()) {
                     skip |=
-                        LogError(pipeline->pipeline, vuid.viewport_count_primitive_shading_rate,
+                        LogError(pipeline->pipeline(), vuid.viewport_count_primitive_shading_rate,
                                  "%s: %s shader of currently bound pipeline statically writes to PrimitiveShadingRateKHR built-in"
                                  "but multiple viewports are set by the last call to vkCmdSetViewportWithCountEXT,"
                                  "and the primitiveFragmentShadingRateWithMultipleViewports limit is not supported.",
@@ -2360,21 +2360,21 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE *shader
     uint32_t local_size_z = 0;
     if (shader->FindLocalSize(entrypoint, local_size_x, local_size_y, local_size_z)) {
         if (local_size_x > phys_dev_props.limits.maxComputeWorkGroupSize[0]) {
-            skip |= LogError(shader->vk_shader_module, "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
+            skip |= LogError(shader->vk_shader_module(), "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
                              "%s local_size_x (%" PRIu32 ") exceeds device limit maxComputeWorkGroupSize[0] (%" PRIu32 ").",
-                             report_data->FormatHandle(shader->vk_shader_module).c_str(), local_size_x,
+                             report_data->FormatHandle(shader->vk_shader_module()).c_str(), local_size_x,
                              phys_dev_props.limits.maxComputeWorkGroupSize[0]);
         }
         if (local_size_y > phys_dev_props.limits.maxComputeWorkGroupSize[1]) {
-            skip |= LogError(shader->vk_shader_module, "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
+            skip |= LogError(shader->vk_shader_module(), "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
                              "%s local_size_y (%" PRIu32 ") exceeds device limit maxComputeWorkGroupSize[1] (%" PRIu32 ").",
-                             report_data->FormatHandle(shader->vk_shader_module).c_str(), local_size_x,
+                             report_data->FormatHandle(shader->vk_shader_module()).c_str(), local_size_x,
                              phys_dev_props.limits.maxComputeWorkGroupSize[1]);
         }
         if (local_size_z > phys_dev_props.limits.maxComputeWorkGroupSize[2]) {
-            skip |= LogError(shader->vk_shader_module, "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
+            skip |= LogError(shader->vk_shader_module(), "UNASSIGNED-features-limits-maxComputeWorkGroupSize",
                              "%s local_size_z (%" PRIu32 ") exceeds device limit maxComputeWorkGroupSize[2] (%" PRIu32 ").",
-                             report_data->FormatHandle(shader->vk_shader_module).c_str(), local_size_x,
+                             report_data->FormatHandle(shader->vk_shader_module()).c_str(), local_size_x,
                              phys_dev_props.limits.maxComputeWorkGroupSize[2]);
         }
 
@@ -2392,10 +2392,10 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE *shader
             }
         }
         if (fail) {
-            skip |= LogError(shader->vk_shader_module, "UNASSIGNED-features-limits-maxComputeWorkGroupInvocations",
+            skip |= LogError(shader->vk_shader_module(), "UNASSIGNED-features-limits-maxComputeWorkGroupInvocations",
                              "%s local_size (%" PRIu32 ", %" PRIu32 ", %" PRIu32
                              ") exceeds device limit maxComputeWorkGroupInvocations (%" PRIu32 ").",
-                             report_data->FormatHandle(shader->vk_shader_module).c_str(), local_size_x, local_size_y, local_size_z,
+                             report_data->FormatHandle(shader->vk_shader_module()).c_str(), local_size_x, local_size_y, local_size_z,
                              limit);
         }
     }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -419,7 +419,7 @@ void AddImageStateProps(IMAGE_STATE &image_state, const VkDevice device, const V
         if (image_tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
             VkImageDrmFormatModifierPropertiesEXT drm_format_properties = {
                 VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT, nullptr};
-            DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state.image, &drm_format_properties);
+            DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state.image(), &drm_format_properties);
 
             VkFormatProperties2 format_properties_2 = {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr};
             VkDrmFormatModifierPropertiesListEXT drm_properties_list = {VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
@@ -674,7 +674,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
         assert(device_extensions.vk_ext_image_drm_format_modifier);
         VkImageDrmFormatModifierPropertiesEXT drm_format_properties = {VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT,
                                                                        nullptr};
-        DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state->image, &drm_format_properties);
+        DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state->image(), &drm_format_properties);
 
         VkFormatProperties2 format_properties_2 = {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr};
         VkDrmFormatModifierPropertiesListEXT drm_properties_list = {VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
@@ -769,7 +769,7 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
     auto buffer_state = GetBufferState(buffer);
 
     buffer_state->Destroy();
-    bufferMap.erase(buffer_state->buffer);
+    bufferMap.erase(buffer_state->buffer());
 }
 
 void ValidationStateTracker::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView,
@@ -1418,12 +1418,12 @@ void CMD_BUFFER_STATE::Reset() {
     primaryCommandBuffer = VK_NULL_HANDLE;
     // If secondary, invalidate any primary command buffer that may call us.
     if (createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
-        InvalidateLinkedCommandBuffers(VulkanTypedHandle(commandBuffer, kVulkanObjectTypeCommandBuffer));
+        InvalidateLinkedCommandBuffers(Handle());
     }
 
     // Remove reverse command buffer links.
     for (auto *sub_cb : linkedCommandBuffers) {
-        linkedCommandBuffers.erase(this);
+        sub_cb->linkedCommandBuffers.erase(this);
     }
     linkedCommandBuffers.clear();
     queue_submit_functions.clear();
@@ -1464,7 +1464,7 @@ void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
     if (cb_state) {
         cb_state->Reset();
         // Clean up the label data
-        ResetCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
+        ResetCmdDebugUtilsLabel(report_data, cb_state->commandBuffer());
     }
 
     if (command_buffer_reset_callback) {
@@ -2295,7 +2295,7 @@ void ValidationStateTracker::RecordSubmitCommandBuffer(CB_SUBMISSION &submission
     if (cb_node) {
         submission.cbs.push_back(command_buffer);
         for (auto *secondary_cmd_buffer : cb_node->linkedCommandBuffers) {
-            submission.cbs.push_back(secondary_cmd_buffer->commandBuffer);
+            submission.cbs.push_back(secondary_cmd_buffer->commandBuffer());
             IncrementResources(secondary_cmd_buffer);
         }
         IncrementResources(cb_node);
@@ -3012,10 +3012,10 @@ void ValidationStateTracker::FreeCommandBufferStates(COMMAND_POOL_STATE *pool_st
             // Remove the cb_state's references from COMMAND_POOL_STATEs
             pool_state->commandBuffers.erase(command_buffers[i]);
             // Remove the cb debug labels
-            EraseCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
+            EraseCmdDebugUtilsLabel(report_data, cb_state->commandBuffer());
             // Remove CBState from CB map
             cb_state->Destroy();
-            commandBufferMap.erase(cb_state->commandBuffer);
+            commandBufferMap.erase(cb_state->commandBuffer());
         }
     }
 }
@@ -3830,18 +3830,18 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevic
     // Query the requirements in case the application doesn't (to avoid bind/validation time query)
     auto as_memory_requirements_info = LvlInitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
     as_memory_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
-    as_memory_requirements_info.accelerationStructure = as_state->acceleration_structure;
+    as_memory_requirements_info.accelerationStructure = as_state->acceleration_structure();
     DispatchGetAccelerationStructureMemoryRequirementsNV(device, &as_memory_requirements_info, &as_state->memory_requirements);
 
     auto scratch_memory_req_info = LvlInitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
     scratch_memory_req_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
-    scratch_memory_req_info.accelerationStructure = as_state->acceleration_structure;
+    scratch_memory_req_info.accelerationStructure = as_state->acceleration_structure();
     DispatchGetAccelerationStructureMemoryRequirementsNV(device, &scratch_memory_req_info,
                                                          &as_state->build_scratch_memory_requirements);
 
     auto update_memory_req_info = LvlInitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
     update_memory_req_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV;
-    update_memory_req_info.accelerationStructure = as_state->acceleration_structure;
+    update_memory_req_info.accelerationStructure = as_state->acceleration_structure();
     DispatchGetAccelerationStructureMemoryRequirementsNV(device, &update_memory_req_info,
                                                          &as_state->update_scratch_memory_requirements);
     as_state->allocator = pAllocator;
@@ -4676,7 +4676,6 @@ static VkSubpassDependency2 ImplicitDependencyToExternal(uint32_t subpass) {
 void ValidationStateTracker::RecordCreateRenderPassState(RenderPassCreateVersion rp_version,
                                                          std::shared_ptr<RENDER_PASS_STATE> &render_pass,
                                                          VkRenderPass *pRenderPass) {
-    render_pass->renderPass = *pRenderPass;
     auto create_info = render_pass->createInfo.ptr();
 
     RecordRenderPassDAG(RENDER_PASS_VERSION_1, create_info, render_pass.get());
@@ -4997,7 +4996,7 @@ void ValidationStateTracker::PreCallRecordCmdExecuteCommands(VkCommandBuffer com
             cb_subres_map->UpdateFrom(*sub_cb_subres_map);
         }
 
-        sub_cb_state->primaryCommandBuffer = cb_state->commandBuffer;
+        sub_cb_state->primaryCommandBuffer = cb_state->commandBuffer();
         cb_state->linkedCommandBuffers.insert(sub_cb_state);
         sub_cb_state->linkedCommandBuffers.insert(cb_state);
         for (auto &function : sub_cb_state->queryUpdates) {
@@ -5243,7 +5242,7 @@ void ValidationStateTracker::PreCallRecordDestroySwapchainKHR(VkDevice device, V
 
             if (swapchain_image.image_state) {
                 swapchain_image.image_state->Destroy();
-                imageMap.erase(swapchain_image.image_state->image);
+                imageMap.erase(swapchain_image.image_state->image());
                 swapchain_image.image_state = nullptr;
             }
         }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -501,8 +501,6 @@ void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const Vk
 void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
     if (!image) return;
     IMAGE_STATE *image_state = GetImageState(image);
-    const VulkanTypedHandle obj_struct(image, kVulkanObjectTypeImage);
-    InvalidateCommandBuffers(image_state->cb_bindings, obj_struct);
     // Clean up memory mapping, bindings and range references for image
     for (auto *mem_binding : image_state->GetBoundMemory()) {
         RemoveImageMemoryRange(image_state, mem_binding);
@@ -514,8 +512,7 @@ void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage 
         }
     }
     RemoveAliasingImage(image_state);
-    ClearMemoryObjectBindings(obj_struct);
-    image_state->destroyed = true;
+    image_state->Destroy();
     // Remove image from imageMap
     imageMap.erase(image);
 }
@@ -523,10 +520,13 @@ void ValidationStateTracker::PreCallRecordDestroyImage(VkDevice device, VkImage 
 void ValidationStateTracker::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image,
                                                              VkImageLayout imageLayout, const VkClearColorValue *pColor,
                                                              uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
+
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
-        AddCommandBufferBindingImage(cb_node, image_state);
+        cb_node->AddChild(image_state);
     }
 }
 
@@ -534,81 +534,94 @@ void ValidationStateTracker::PreCallRecordCmdClearDepthStencilImage(VkCommandBuf
                                                                     VkImageLayout imageLayout,
                                                                     const VkClearDepthStencilValue *pDepthStencil,
                                                                     uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto image_state = GetImageState(image);
     if (cb_node && image_state) {
-        AddCommandBufferBindingImage(cb_node, image_state);
+        cb_node->AddChild(image_state);
     }
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                        VkImageLayout srcImageLayout, VkImage dstImage, VkImageLayout dstImageLayout,
                                                        uint32_t regionCount, const VkImageCopy *pRegions) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
     // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer,
                                                            const VkCopyImageInfo2KHR *pCopyImageInfo) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(pCopyImageInfo->srcImage);
     auto dst_image_state = GetImageState(pCopyImageInfo->dstImage);
 
-    // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                           VkImageLayout srcImageLayout, VkImage dstImage,
                                                           VkImageLayout dstImageLayout, uint32_t regionCount,
                                                           const VkImageResolve *pRegions) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
     // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
                                                               const VkResolveImageInfo2KHR *pResolveImageInfo) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(pResolveImageInfo->srcImage);
     auto dst_image_state = GetImageState(pResolveImageInfo->dstImage);
 
     // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                        VkImageLayout srcImageLayout, VkImage dstImage, VkImageLayout dstImageLayout,
                                                        uint32_t regionCount, const VkImageBlit *pRegions, VkFilter filter) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_image_state = GetImageState(dstImage);
 
     // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer,
                                                            const VkBlitImageInfo2KHR *pBlitImageInfo) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(pBlitImageInfo->srcImage);
     auto dst_image_state = GetImageState(pBlitImageInfo->dstImage);
 
     // Update bindings between images and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
@@ -717,46 +730,45 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
 
 void ValidationStateTracker::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                                         uint32_t regionCount, const VkBufferCopy *pRegions) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
     // Update bindings between buffers and cmd buffer
-    AddCommandBufferBindingBuffer(cb_node, src_buffer_state);
-    AddCommandBufferBindingBuffer(cb_node, dst_buffer_state);
+    cb_node->AddChild(src_buffer_state);
+    cb_node->AddChild(dst_buffer_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer,
                                                             const VkCopyBufferInfo2KHR *pCopyBufferInfos) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(pCopyBufferInfos->srcBuffer);
     auto dst_buffer_state = GetBufferState(pCopyBufferInfos->dstBuffer);
 
     // Update bindings between buffers and cmd buffer
-    AddCommandBufferBindingBuffer(cb_node, src_buffer_state);
-    AddCommandBufferBindingBuffer(cb_node, dst_buffer_state);
+    cb_node->AddChild(src_buffer_state);
+    cb_node->AddChild(dst_buffer_state);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyImageView(VkDevice device, VkImageView imageView,
                                                            const VkAllocationCallbacks *pAllocator) {
     IMAGE_VIEW_STATE *image_view_state = GetImageViewState(imageView);
     if (!image_view_state) return;
-    const VulkanTypedHandle obj_struct(imageView, kVulkanObjectTypeImageView);
 
     // Any bound cmd buffers are now invalid
-    InvalidateCommandBuffers(image_view_state->cb_bindings, obj_struct);
-    image_view_state->destroyed = true;
+    image_view_state->Destroy();
     imageViewMap.erase(imageView);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
     if (!buffer) return;
     auto buffer_state = GetBufferState(buffer);
-    const VulkanTypedHandle obj_struct(buffer, kVulkanObjectTypeBuffer);
 
-    InvalidateCommandBuffers(buffer_state->cb_bindings, obj_struct);
-    ClearMemoryObjectBindings(obj_struct);
-    buffer_state->destroyed = true;
+    buffer_state->Destroy();
     bufferMap.erase(buffer_state->buffer);
 }
 
@@ -764,86 +776,85 @@ void ValidationStateTracker::PreCallRecordDestroyBufferView(VkDevice device, VkB
                                                             const VkAllocationCallbacks *pAllocator) {
     if (!bufferView) return;
     auto buffer_view_state = GetBufferViewState(bufferView);
-    const VulkanTypedHandle obj_struct(bufferView, kVulkanObjectTypeBufferView);
 
     // Any bound cmd buffers are now invalid
-    InvalidateCommandBuffers(buffer_view_state->cb_bindings, obj_struct);
-    buffer_view_state->destroyed = true;
+    buffer_view_state->Destroy();
     bufferViewMap.erase(bufferView);
 }
 
 void ValidationStateTracker::PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                         VkDeviceSize size, uint32_t data) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto buffer_state = GetBufferState(dstBuffer);
     // Update bindings between buffer and cmd buffer
-    AddCommandBufferBindingBuffer(cb_node, buffer_state);
+    cb_node->AddChild(buffer_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                                VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                uint32_t regionCount, const VkBufferImageCopy *pRegions) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(srcImage);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
     // Update bindings between buffer/image and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingBuffer(cb_node, dst_buffer_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_buffer_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
                                                                    const VkCopyImageToBufferInfo2KHR *pCopyImageToBufferInfo) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_image_state = GetImageState(pCopyImageToBufferInfo->srcImage);
     auto dst_buffer_state = GetBufferState(pCopyImageToBufferInfo->dstBuffer);
 
     // Update bindings between buffer/image and cmd buffer
-    AddCommandBufferBindingImage(cb_node, src_image_state);
-    AddCommandBufferBindingBuffer(cb_node, dst_buffer_state);
+    cb_node->AddChild(src_image_state);
+    cb_node->AddChild(dst_buffer_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                                VkImageLayout dstImageLayout, uint32_t regionCount,
                                                                const VkBufferImageCopy *pRegions) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(srcBuffer);
     auto dst_image_state = GetImageState(dstImage);
 
-    AddCommandBufferBindingBuffer(cb_node, src_buffer_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_buffer_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
                                                                    const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo) {
+
+    if (disabled[command_buffer_state]) return;
+
     auto cb_node = GetCBState(commandBuffer);
     auto src_buffer_state = GetBufferState(pCopyBufferToImageInfo->srcBuffer);
     auto dst_image_state = GetImageState(pCopyBufferToImageInfo->dstImage);
 
-    AddCommandBufferBindingBuffer(cb_node, src_buffer_state);
-    AddCommandBufferBindingImage(cb_node, dst_image_state);
+    cb_node->AddChild(src_buffer_state);
+    cb_node->AddChild(dst_image_state);
 }
 
 // Get the image viewstate for a given framebuffer attachment
-IMAGE_VIEW_STATE *ValidationStateTracker::GetActiveAttachmentImageViewState(const CMD_BUFFER_STATE *cb, uint32_t index,
-                                                                            const CMD_BUFFER_STATE *primary_cb) {
-    if (primary_cb) {
-        assert(primary_cb->active_attachments && index != VK_ATTACHMENT_UNUSED && (index < primary_cb->active_attachments->size()));
-        return primary_cb->active_attachments->at(index);
-    }
-    assert(cb->active_attachments && index != VK_ATTACHMENT_UNUSED && (index < cb->active_attachments->size()));
-    return cb->active_attachments->at(index);
+IMAGE_VIEW_STATE *CMD_BUFFER_STATE::GetActiveAttachmentImageViewState(uint32_t index) {
+    assert(active_attachments && index != VK_ATTACHMENT_UNUSED && (index < active_attachments->size()));
+    return active_attachments->at(index);
 }
 
 // Get the image viewstate for a given framebuffer attachment
-const IMAGE_VIEW_STATE *ValidationStateTracker::GetActiveAttachmentImageViewState(const CMD_BUFFER_STATE *cb, uint32_t index,
-                                                                                  const CMD_BUFFER_STATE *primary_cb) const {
-    if (primary_cb) {
-        assert(primary_cb->active_attachments && index != VK_ATTACHMENT_UNUSED && (index < primary_cb->active_attachments->size()));
-        return primary_cb->active_attachments->at(index);
-    }
-    assert(cb->active_attachments && index != VK_ATTACHMENT_UNUSED && (index < cb->active_attachments->size()));
-    return cb->active_attachments->at(index);
+const IMAGE_VIEW_STATE *CMD_BUFFER_STATE::GetActiveAttachmentImageViewState(uint32_t index) const {
+    assert(active_attachments && index != VK_ATTACHMENT_UNUSED && (index < active_attachments->size()));
+    return active_attachments->at(index);
 }
 
 void ValidationStateTracker::AddAliasingImage(IMAGE_STATE *image_state, layer_data::unordered_set<IMAGE_STATE *> *bound_images) {
@@ -1000,171 +1011,81 @@ void ValidationStateTracker::AddMemObjInfo(void *object, const VkDeviceMemory me
     mem_info->unprotected = ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) == 0);
 }
 
-// Create binding link between given sampler and command buffer node
-void ValidationStateTracker::AddCommandBufferBindingSampler(CMD_BUFFER_STATE *cb_node, SAMPLER_STATE *sampler_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
-    AddCommandBufferBinding(sampler_state->cb_bindings,
-                            VulkanTypedHandle(sampler_state->sampler, kVulkanObjectTypeSampler, sampler_state), cb_node);
-}
-
 // Create binding link between given image node and command buffer node
-void ValidationStateTracker::AddCommandBufferBindingImage(CMD_BUFFER_STATE *cb_node, IMAGE_STATE *image_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
+bool IMAGE_STATE::AddParent(CMD_BUFFER_STATE *cb_node) {
     // Skip validation if this image was created through WSI
-    if (image_state->create_from_swapchain == VK_NULL_HANDLE) {
+    if (create_from_swapchain == VK_NULL_HANDLE) {
         // First update cb binding for image
-        if (AddCommandBufferBinding(image_state->cb_bindings,
-                                    VulkanTypedHandle(image_state->image, kVulkanObjectTypeImage, image_state), cb_node)) {
-            // Now update CB binding in MemObj mini CB list
-            for (auto *mem_binding : image_state->GetBoundMemory()) {
-                // Now update CBInfo's Mem reference list
-                AddCommandBufferBinding(mem_binding->cb_bindings,
-                                        VulkanTypedHandle(mem_binding->mem, kVulkanObjectTypeDeviceMemory, mem_binding), cb_node);
-            }
-        }
+        return BINDABLE::AddParent(cb_node);
     }
+    return false;
 }
 
 // Create binding link between given image view node and its image with command buffer node
-void ValidationStateTracker::AddCommandBufferBindingImageView(CMD_BUFFER_STATE *cb_node, IMAGE_VIEW_STATE *view_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
+bool IMAGE_VIEW_STATE::AddParent(CMD_BUFFER_STATE *cb_node) {
     // First add bindings for imageView
-    if (AddCommandBufferBinding(view_state->cb_bindings,
-                                VulkanTypedHandle(view_state->image_view, kVulkanObjectTypeImageView, view_state), cb_node)) {
+    if (BASE_NODE::AddParent(cb_node)) {
         // Only need to continue if this is a new item
-        auto image_state = view_state->image_state.get();
         // Add bindings for image within imageView
         if (image_state) {
-            AddCommandBufferBindingImage(cb_node, image_state);
+            image_state->AddParent(cb_node);
         }
+        return true;
     }
-}
-
-// Create binding link between given buffer node and command buffer node
-void ValidationStateTracker::AddCommandBufferBindingBuffer(CMD_BUFFER_STATE *cb_node, BUFFER_STATE *buffer_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
-    // First update cb binding for buffer
-    if (AddCommandBufferBinding(buffer_state->cb_bindings,
-                                VulkanTypedHandle(buffer_state->buffer, kVulkanObjectTypeBuffer, buffer_state), cb_node)) {
-        // Now update CB binding in MemObj mini CB list
-        for (auto *mem_binding : buffer_state->GetBoundMemory()) {
-            // Now update CBInfo's Mem reference list
-            AddCommandBufferBinding(mem_binding->cb_bindings,
-                                    VulkanTypedHandle(mem_binding->mem, kVulkanObjectTypeDeviceMemory, mem_binding), cb_node);
-        }
-    }
+    return false;
 }
 
 // Create binding link between given buffer view node and its buffer with command buffer node
-void ValidationStateTracker::AddCommandBufferBindingBufferView(CMD_BUFFER_STATE *cb_node, BUFFER_VIEW_STATE *view_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
+bool BUFFER_VIEW_STATE::AddParent(CMD_BUFFER_STATE *cb_node) {
     // First add bindings for bufferView
-    if (AddCommandBufferBinding(view_state->cb_bindings,
-                                VulkanTypedHandle(view_state->buffer_view, kVulkanObjectTypeBufferView, view_state), cb_node)) {
-        auto buffer_state = view_state->buffer_state.get();
+    if (BASE_NODE::AddParent(cb_node)) {
         // Add bindings for buffer within bufferView
         if (buffer_state) {
-            AddCommandBufferBindingBuffer(cb_node, buffer_state);
+            buffer_state->AddParent(cb_node);
         }
+        return true;
     }
+    return false;
 }
 
-// Create binding link between given acceleration structure and command buffer node
-void ValidationStateTracker::AddCommandBufferBindingAccelerationStructure(CMD_BUFFER_STATE *cb_node,
-                                                                          ACCELERATION_STRUCTURE_STATE *as_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
-    if (AddCommandBufferBinding(
-            as_state->cb_bindings,
-            VulkanTypedHandle(as_state->acceleration_structure, kVulkanObjectTypeAccelerationStructureNV, as_state), cb_node)) {
+bool BINDABLE::AddParent(CMD_BUFFER_STATE *cb_node) {
+    if (BASE_NODE::AddParent(cb_node)) {
         // Now update CB binding in MemObj mini CB list
-        for (auto *mem_binding : as_state->GetBoundMemory()) {
+        for (auto *mem_binding : GetBoundMemory()) {
             // Now update CBInfo's Mem reference list
-            AddCommandBufferBinding(mem_binding->cb_bindings,
-                                    VulkanTypedHandle(mem_binding->mem, kVulkanObjectTypeDeviceMemory, mem_binding), cb_node);
+            mem_binding->AddParent(cb_node);
         }
+        return true;
     }
+    return false;
 }
 
-// Create binding link between given acceleration structure and command buffer node
-void ValidationStateTracker::AddCommandBufferBindingAccelerationStructure(CMD_BUFFER_STATE *cb_node,
-                                                                          ACCELERATION_STRUCTURE_STATE_KHR *as_state) {
-    if (disabled[command_buffer_state]) {
-        return;
-    }
-    if (AddCommandBufferBinding(
-            as_state->cb_bindings,
-            VulkanTypedHandle(as_state->acceleration_structure, kVulkanObjectTypeAccelerationStructureKHR, as_state), cb_node)) {
-        // Now update CB binding in MemObj mini CB list
-        for (auto *mem_binding : as_state->GetBoundMemory()) {
-            // Now update CBInfo's Mem reference list
-            AddCommandBufferBinding(mem_binding->cb_bindings,
-                                    VulkanTypedHandle(mem_binding->mem, kVulkanObjectTypeDeviceMemory, mem_binding), cb_node);
+void BINDABLE::Destroy() {
+    if (!sparse) {
+        if (binding.mem_state) {
+            binding.mem_state->obj_bindings.erase(handle_);
         }
-    }
-}
-
-// Clear a single object binding from given memory object
-void ValidationStateTracker::ClearMemoryObjectBinding(const VulkanTypedHandle &typed_handle, DEVICE_MEMORY_STATE *mem_info) {
-    // This obj is bound to a memory object. Remove the reference to this object in that memory object's list
-    if (mem_info) {
-        mem_info->obj_bindings.erase(typed_handle);
-    }
-}
-
-// ClearMemoryObjectBindings clears the binding of objects to memory
-//  For the given object it pulls the memory bindings and makes sure that the bindings
-//  no longer refer to the object being cleared. This occurs when objects are destroyed.
-void ValidationStateTracker::ClearMemoryObjectBindings(const VulkanTypedHandle &typed_handle) {
-    BINDABLE *mem_binding = GetObjectMemBinding(typed_handle);
-    if (mem_binding) {
-        if (!mem_binding->sparse) {
-            ClearMemoryObjectBinding(typed_handle, mem_binding->binding.mem_state.get());
-        } else {  // Sparse, clear all bindings
-            for (auto &sparse_mem_binding : mem_binding->sparse_bindings) {
-                ClearMemoryObjectBinding(typed_handle, sparse_mem_binding.mem_state.get());
+    } else {  // Sparse, clear all bindings
+        for (auto &sparse_mem_binding : sparse_bindings) {
+            if (sparse_mem_binding.mem_state) {
+                sparse_mem_binding.mem_state->obj_bindings.erase(handle_);
             }
         }
     }
+    BASE_NODE::Destroy();
 }
 
 // SetMemBinding is used to establish immutable, non-sparse binding between a single image/buffer object and memory object.
 // Corresponding valid usage checks are in ValidateSetMemBinding().
-void ValidationStateTracker::SetMemBinding(VkDeviceMemory mem, BINDABLE *mem_binding, VkDeviceSize memory_offset,
-                                           const VulkanTypedHandle &typed_handle) {
-    assert(mem_binding);
-
-    if (mem != VK_NULL_HANDLE) {
-        mem_binding->binding.mem_state = GetShared<DEVICE_MEMORY_STATE>(mem);
-        if (mem_binding->binding.mem_state) {
-            mem_binding->binding.offset = memory_offset;
-            mem_binding->binding.size = mem_binding->requirements.size;
-            mem_binding->binding.mem_state->obj_bindings.insert(typed_handle);
-            // For image objects, make sure default memory state is correctly set
-            // TODO : What's the best/correct way to handle this?
-            if (kVulkanObjectTypeImage == typed_handle.type) {
-                auto const image_state = reinterpret_cast<const IMAGE_STATE *>(mem_binding);
-                if (image_state) {
-                    VkImageCreateInfo ici = image_state->createInfo;
-                    if (ici.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-                        // TODO::  More memory state transition stuff.
-                    }
-                }
-            }
-            mem_binding->UpdateBoundMemorySet();  // force recreation of cached set
-        }
+void BINDABLE::SetMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, VkDeviceSize memory_offset) {
+    if (!mem) {
+        return;
     }
+    binding.mem_state = mem;
+    binding.offset = memory_offset;
+    binding.size = requirements.size;
+    binding.mem_state->obj_bindings.insert(handle_);
+    UpdateBoundMemorySet();  // force recreation of cached set
 }
 
 // For NULL mem case, clear any previous binding Else...
@@ -1173,27 +1094,16 @@ void ValidationStateTracker::SetMemBinding(VkDeviceMemory mem, BINDABLE *mem_bin
 //  Add reference from objectInfo to memoryInfo
 //  Add reference off of object's binding info
 // Return VK_TRUE if addition is successful, VK_FALSE otherwise
-bool ValidationStateTracker::SetSparseMemBinding(const VkDeviceMemory mem, const VkDeviceSize mem_offset,
-                                                 const VkDeviceSize mem_size, const VulkanTypedHandle &typed_handle) {
-    bool skip = VK_FALSE;
-    // Handle NULL case separately, just clear previous binding & decrement reference
-    if (mem == VK_NULL_HANDLE) {
-        // TODO : This should cause the range of the resource to be unbound according to spec
-    } else {
-        BINDABLE *mem_binding = GetObjectMemBinding(typed_handle);
-        assert(mem_binding);
-        if (mem_binding) {  // Invalid handles are reported by object tracker, but Get returns NULL for them, so avoid SEGV here
-            assert(mem_binding->sparse);
-            MEM_BINDING binding = {GetShared<DEVICE_MEMORY_STATE>(mem), mem_offset, mem_size};
-            if (binding.mem_state) {
-                binding.mem_state->obj_bindings.insert(typed_handle);
-                // Need to set mem binding for this object
-                mem_binding->sparse_bindings.insert(binding);
-                mem_binding->UpdateBoundMemorySet();
-            }
-        }
+void BINDABLE::SetSparseMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize mem_offset, const VkDeviceSize mem_size) {
+    if (!mem) {
+        return;
     }
-    return skip;
+    assert(sparse);
+    MEM_BINDING sparse_binding = {mem, mem_offset, mem_size};
+    sparse_binding.mem_state->obj_bindings.insert(handle_);
+    // Need to set mem binding for this object
+    sparse_bindings.insert(sparse_binding);
+    UpdateBoundMemorySet();
 }
 
 void ValidationStateTracker::UpdateDrawState(CMD_BUFFER_STATE *cb_state, CMD_TYPE cmd_type, const VkPipelineBindPoint bind_point,
@@ -1270,10 +1180,8 @@ void ValidationStateTracker::UpdateDrawState(CMD_BUFFER_STATE *cb_state, CMD_TYP
 
 // Remove set from setMap and delete the set
 void ValidationStateTracker::FreeDescriptorSet(cvdescriptorset::DescriptorSet *descriptor_set) {
-    descriptor_set->destroyed = true;
-    const VulkanTypedHandle obj_struct(descriptor_set->GetSet(), kVulkanObjectTypeDescriptorSet);
     // Any bound cmd buffers are now invalid
-    InvalidateCommandBuffers(descriptor_set->cb_bindings, obj_struct);
+    descriptor_set->Destroy();
 
     setMap.erase(descriptor_set->GetSet());
 }
@@ -1420,26 +1328,133 @@ VkFormatFeatureFlags ValidationStateTracker::GetPotentialFormatFeatures(VkFormat
 // Tie the VulkanTypedHandle to the cmd buffer which includes:
 //  Add object_binding to cmd buffer
 //  Add cb_binding to object
-bool ValidationStateTracker::AddCommandBufferBinding(BASE_NODE::BindingsType &cb_bindings,
-                                                     const VulkanTypedHandle &obj, CMD_BUFFER_STATE *cb_node) {
-    if (disabled[command_buffer_state]) {
-        return false;
-    }
+bool BASE_NODE::AddParent(CMD_BUFFER_STATE *cb_node) {
     // Insert the cb_binding with a default 'index' of -1. Then push the obj into the object_bindings
     // vector, and update cb_bindings[cb_node] with the index of that element of the vector.
-    auto inserted = cb_bindings.emplace(cb_node, -1);
+    auto inserted = cb_bindings_.emplace(cb_node, -1);
     if (inserted.second) {
-        cb_node->object_bindings.push_back(obj);
-        inserted.first->second = static_cast<int>(cb_node->object_bindings.size()) - 1;
+        inserted.first->second = cb_node->AddReverseBinding(handle_);
         return true;
     }
     return false;
 }
 
-// For a given object, if cb_node is in that objects cb_bindings, remove cb_node
-void ValidationStateTracker::RemoveCommandBufferBinding(VulkanTypedHandle const &object, CMD_BUFFER_STATE *cb_node) {
-    BASE_NODE *base_obj = GetStateStructPtrFromObject(object);
-    if (base_obj) base_obj->cb_bindings.erase(cb_node);
+void BASE_NODE::RemoveParent(CMD_BUFFER_STATE *cb_node) {
+    auto it = cb_bindings_.find(cb_node);
+    if (it != cb_bindings_.end()) {
+        auto index = it->second;
+        assert(cb_node->object_bindings[index] == handle_);
+        cb_node->object_bindings[index] = VulkanTypedHandle();
+        cb_bindings_.erase(it);
+    }
+}
+
+int CMD_BUFFER_STATE::AddReverseBinding(const VulkanTypedHandle &obj) {
+     object_bindings.push_back(obj);
+     return static_cast<int>(object_bindings.size()) - 1;
+}
+
+void CMD_BUFFER_STATE::AddChild(BASE_NODE *child_node) {
+    child_node->AddParent(this);
+}
+
+void CMD_BUFFER_STATE::RemoveChild(BASE_NODE *child_node) {
+    child_node->RemoveParent(this);
+}
+
+void CMD_BUFFER_STATE::Reset() {
+    ResetUse();
+    // Reset CB state (note that createInfo is not cleared)
+    memset(&beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
+    memset(&inheritanceInfo, 0, sizeof(VkCommandBufferInheritanceInfo));
+    hasDrawCmd = false;
+    hasTraceRaysCmd = false;
+    hasBuildAccelerationStructureCmd = false;
+    hasDispatchCmd = false;
+    state = CB_NEW;
+    commandCount = 0;
+    submitCount = 0;
+    image_layout_change_count = 1;  // Start at 1. 0 is insert value for validation cache versions, s.t. new == dirty
+    status = 0;
+    static_status = 0;
+    inheritedViewportDepths.clear();
+    usedViewportScissorCount = 0;
+    pipelineStaticViewportCount = 0;
+    pipelineStaticScissorCount = 0;
+    viewportMask = 0;
+    viewportWithCountMask = 0;
+    viewportWithCountCount = 0;
+    scissorMask = 0;
+    scissorWithCountMask = 0;
+    scissorWithCountCount = 0;
+    trashedViewportMask = 0;
+    trashedScissorMask = 0;
+    trashedViewportCount = false;
+    trashedScissorCount = false;
+    usedDynamicViewportCount = false;
+    usedDynamicScissorCount = false;
+    primitiveTopology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
+
+    for (auto &item : lastBound) {
+        item.reset();
+    }
+
+    activeRenderPassBeginInfo = safe_VkRenderPassBeginInfo();
+    activeRenderPass = nullptr;
+    active_attachments = nullptr;
+    active_subpasses = nullptr;
+    attachments_view_states.clear();
+    activeSubpassContents = VK_SUBPASS_CONTENTS_INLINE;
+    activeSubpass = 0;
+    broken_bindings.clear();
+    waitedEvents.clear();
+    events.clear();
+    writeEventsBeforeWait.clear();
+    activeQueries.clear();
+    startedQueries.clear();
+    image_layout_map.clear();
+    current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
+    vertex_buffer_used = false;
+    primaryCommandBuffer = VK_NULL_HANDLE;
+    // If secondary, invalidate any primary command buffer that may call us.
+    if (createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+        InvalidateLinkedCommandBuffers(VulkanTypedHandle(commandBuffer, kVulkanObjectTypeCommandBuffer));
+    }
+
+    // Remove reverse command buffer links.
+    for (auto *sub_cb : linkedCommandBuffers) {
+        linkedCommandBuffers.erase(this);
+    }
+    linkedCommandBuffers.clear();
+    queue_submit_functions.clear();
+    cmd_execute_commands_functions.clear();
+    eventUpdates.clear();
+    queryUpdates.clear();
+
+    // Remove this cmdBuffer's reference from each FrameBuffer's CB ref list
+    for (auto &framebuffer : framebuffers) {
+        framebuffer->RemoveParent(this);
+    }
+    framebuffers.clear();
+    activeFramebuffer = VK_NULL_HANDLE;
+    index_buffer_binding.reset();
+
+    qfo_transfer_image_barriers.Reset();
+    qfo_transfer_buffer_barriers.Reset();
+    debug_label.Reset();
+    validate_descriptorsets_in_queuesubmit.clear();
+
+    // Best practices info
+    small_indexed_draw_call_count = 0;
+
+    transform_feedback_active = false;
+
+    // Remove object bindings
+    for (const auto &obj : object_bindings) {
+        BASE_NODE *base_obj = obj.node;
+        if (base_obj) RemoveChild(base_obj);
+    }
+    object_bindings.clear();
 }
 
 // Reset the command buffer state
@@ -1447,101 +1462,11 @@ void ValidationStateTracker::RemoveCommandBufferBinding(VulkanTypedHandle const 
 void ValidationStateTracker::ResetCommandBufferState(const VkCommandBuffer cb) {
     CMD_BUFFER_STATE *cb_state = GetCBState(cb);
     if (cb_state) {
-        cb_state->in_use.store(0);
-        // Reset CB state (note that createInfo is not cleared)
-        cb_state->commandBuffer = cb;
-        memset(&cb_state->beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
-        memset(&cb_state->inheritanceInfo, 0, sizeof(VkCommandBufferInheritanceInfo));
-        cb_state->hasDrawCmd = false;
-        cb_state->hasTraceRaysCmd = false;
-        cb_state->hasBuildAccelerationStructureCmd = false;
-        cb_state->hasDispatchCmd = false;
-        cb_state->state = CB_NEW;
-        cb_state->commandCount = 0;
-        cb_state->submitCount = 0;
-        cb_state->image_layout_change_count = 1;  // Start at 1. 0 is insert value for validation cache versions, s.t. new == dirty
-        cb_state->status = 0;
-        cb_state->static_status = 0;
-        cb_state->inheritedViewportDepths.clear();
-        cb_state->usedViewportScissorCount = 0;
-        cb_state->pipelineStaticViewportCount = 0;
-        cb_state->pipelineStaticScissorCount = 0;
-        cb_state->viewportMask = 0;
-        cb_state->viewportWithCountMask = 0;
-        cb_state->viewportWithCountCount = 0;
-        cb_state->scissorMask = 0;
-        cb_state->scissorWithCountMask = 0;
-        cb_state->scissorWithCountCount = 0;
-        cb_state->trashedViewportMask = 0;
-        cb_state->trashedScissorMask = 0;
-        cb_state->trashedViewportCount = false;
-        cb_state->trashedScissorCount = false;
-        cb_state->usedDynamicViewportCount = false;
-        cb_state->usedDynamicScissorCount = false;
-        cb_state->primitiveTopology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
-
-        for (auto &item : cb_state->lastBound) {
-            item.reset();
-        }
-
-        cb_state->activeRenderPassBeginInfo = safe_VkRenderPassBeginInfo();
-        cb_state->activeRenderPass = nullptr;
-        cb_state->active_attachments = nullptr;
-        cb_state->active_subpasses = nullptr;
-        cb_state->attachments_view_states.clear();
-        cb_state->activeSubpassContents = VK_SUBPASS_CONTENTS_INLINE;
-        cb_state->activeSubpass = 0;
-        cb_state->broken_bindings.clear();
-        cb_state->waitedEvents.clear();
-        cb_state->events.clear();
-        cb_state->writeEventsBeforeWait.clear();
-        cb_state->activeQueries.clear();
-        cb_state->startedQueries.clear();
-        cb_state->image_layout_map.clear();
-        cb_state->current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
-        cb_state->vertex_buffer_used = false;
-        cb_state->primaryCommandBuffer = VK_NULL_HANDLE;
-        // If secondary, invalidate any primary command buffer that may call us.
-        if (cb_state->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
-            InvalidateLinkedCommandBuffers(cb_state->linkedCommandBuffers, VulkanTypedHandle(cb, kVulkanObjectTypeCommandBuffer));
-        }
-
-        // Remove reverse command buffer links.
-        for (auto *sub_cb : cb_state->linkedCommandBuffers) {
-            sub_cb->linkedCommandBuffers.erase(cb_state);
-        }
-        cb_state->linkedCommandBuffers.clear();
-        cb_state->queue_submit_functions.clear();
-        cb_state->cmd_execute_commands_functions.clear();
-        cb_state->eventUpdates.clear();
-        cb_state->queryUpdates.clear();
-
-        // Remove object bindings
-        for (const auto &obj : cb_state->object_bindings) {
-            RemoveCommandBufferBinding(obj, cb_state);
-        }
-        cb_state->object_bindings.clear();
-        // Remove this cmdBuffer's reference from each FrameBuffer's CB ref list
-        for (auto &framebuffer : cb_state->framebuffers) {
-            framebuffer->cb_bindings.erase(cb_state);
-        }
-        cb_state->framebuffers.clear();
-        cb_state->activeFramebuffer = VK_NULL_HANDLE;
-        cb_state->index_buffer_binding.reset();
-
-        cb_state->qfo_transfer_image_barriers.Reset();
-        cb_state->qfo_transfer_buffer_barriers.Reset();
-
+        cb_state->Reset();
         // Clean up the label data
         ResetCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
-        cb_state->debug_label.Reset();
-        cb_state->validate_descriptorsets_in_queuesubmit.clear();
-
-        // Best practices info
-        cb_state->small_indexed_draw_call_count = 0;
-
-        cb_state->transform_feedback_active = false;
     }
+
     if (command_buffer_reset_callback) {
         (*command_buffer_reset_callback)(cb);
     }
@@ -2218,7 +2143,7 @@ void ValidationStateTracker::IncrementBoundObjects(CMD_BUFFER_STATE const *cb_no
     for (const auto &obj : cb_node->object_bindings) {
         auto base_obj = GetStateStructPtrFromObject(obj);
         if (base_obj) {
-            base_obj->in_use.fetch_add(1);
+            base_obj->BeginUse();
         }
     }
 }
@@ -2226,7 +2151,7 @@ void ValidationStateTracker::IncrementBoundObjects(CMD_BUFFER_STATE const *cb_no
 // Track which resources are in-flight by atomically incrementing their "in_use" count
 void ValidationStateTracker::IncrementResources(CMD_BUFFER_STATE *cb_node) {
     cb_node->submitCount++;
-    cb_node->in_use.fetch_add(1);
+    cb_node->BeginUse();
 
     // First Increment for all "generic" objects bound to cmd buffer, followed by special-case objects below
     IncrementBoundObjects(cb_node);
@@ -2245,7 +2170,7 @@ void ValidationStateTracker::DecrementBoundResources(CMD_BUFFER_STATE const *cb_
     for (const auto &obj : cb_node->object_bindings) {
         base_obj = GetStateStructPtrFromObject(obj);
         if (base_obj) {
-            base_obj->in_use.fetch_sub(1);
+            base_obj->EndUse();
         }
     }
 }
@@ -2261,7 +2186,7 @@ void ValidationStateTracker::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq
         for (auto &wait : submission.waitSemaphores) {
             auto semaphore_state = GetSemaphoreState(wait.semaphore);
             if (semaphore_state) {
-                semaphore_state->in_use.fetch_sub(1);
+                semaphore_state->EndUse();
             }
             if (wait.type == VK_SEMAPHORE_TYPE_TIMELINE) {
                 auto &last_counter = timeline_semaphore_counters[wait.semaphore];
@@ -2275,7 +2200,7 @@ void ValidationStateTracker::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq
         for (auto &signal : submission.signalSemaphores) {
             auto semaphore_state = GetSemaphoreState(signal.semaphore);
             if (semaphore_state) {
-                semaphore_state->in_use.fetch_sub(1);
+                semaphore_state->EndUse();
                 if (semaphore_state->type == VK_SEMAPHORE_TYPE_TIMELINE && semaphore_state->payload < signal.payload) {
                     semaphore_state->payload = signal.payload;
                 }
@@ -2285,7 +2210,7 @@ void ValidationStateTracker::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq
         for (auto &semaphore : submission.externalSemaphores) {
             auto semaphore_state = GetSemaphoreState(semaphore);
             if (semaphore_state) {
-                semaphore_state->in_use.fetch_sub(1);
+                semaphore_state->EndUse();
             }
         }
 
@@ -2313,7 +2238,7 @@ void ValidationStateTracker::RetireWorkOnQueue(QUEUE_STATE *pQueue, uint64_t seq
                     queryToStateMap[query_state_pair.first] = QUERYSTATE_AVAILABLE;
                 }
             }
-            cb_node->in_use.fetch_sub(1);
+            cb_node->EndUse();
         }
 
         auto fence_state = GetFenceState(submission.fence);
@@ -2409,7 +2334,7 @@ void ValidationStateTracker::RecordSubmitWaitSemaphore(CB_SUBMISSION &submission
                     wait.queue = semaphore_state->signaler.first;
                     wait.seq = semaphore_state->signaler.second;
                     submission.waitSemaphores.emplace_back(std::move(wait));
-                    semaphore_state->in_use.fetch_add(1);
+                    semaphore_state->BeginUse();
                 }
                 semaphore_state->signaler.first = VK_NULL_HANDLE;
                 semaphore_state->signaled = false;
@@ -2418,11 +2343,11 @@ void ValidationStateTracker::RecordSubmitWaitSemaphore(CB_SUBMISSION &submission
                 wait.seq = next_seq;
                 wait.payload = value;
                 submission.waitSemaphores.emplace_back(std::move(wait));
-                semaphore_state->in_use.fetch_add(1);
+                semaphore_state->BeginUse();
             }
         } else {
             submission.externalSemaphores.push_back(semaphore);
-            semaphore_state->in_use.fetch_add(1);
+            semaphore_state->BeginUse();
             if (semaphore_state->scope == kSyncScopeExternalTemporary) {
                 semaphore_state->scope = kSyncScopeInternal;
             }
@@ -2446,7 +2371,7 @@ bool ValidationStateTracker::RecordSubmitSignalSemaphore(CB_SUBMISSION &submissi
             } else {
                 signal.payload = value;
             }
-            semaphore_state->in_use.fetch_add(1);
+            semaphore_state->BeginUse();
             submission.signalSemaphores.emplace_back(std::move(signal));
         } else {
             // Retire work up until this submit early, we will not see the wait that corresponds to this signal
@@ -2557,8 +2482,6 @@ void ValidationStateTracker::PostCallRecordAllocateMemory(VkDevice device, const
 void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks *pAllocator) {
     if (!mem) return;
     DEVICE_MEMORY_STATE *mem_info = GetDevMemState(mem);
-    const VulkanTypedHandle obj_struct(mem, kVulkanObjectTypeDeviceMemory);
-
     // Clear mem binding for any bound objects
     for (const auto &obj : mem_info->obj_bindings) {
         BINDABLE *bindable_state = nullptr;
@@ -2595,9 +2518,8 @@ void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMe
         }
     }
     // Any bound cmd buffers are now invalid
-    InvalidateCommandBuffers(mem_info->cb_bindings, obj_struct);
     RemoveAliasingImages(mem_info->bound_images);
-    mem_info->destroyed = true;
+    mem_info->Destroy();
     fake_memory.Free(mem_info->fake_base_address);
     memObjMap.erase(mem);
 }
@@ -2615,15 +2537,21 @@ void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32
         for (uint32_t j = 0; j < bind_info.bufferBindCount; j++) {
             for (uint32_t k = 0; k < bind_info.pBufferBinds[j].bindCount; k++) {
                 auto sparse_binding = bind_info.pBufferBinds[j].pBinds[k];
-                SetSparseMemBinding(sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size,
-                                    VulkanTypedHandle(bind_info.pBufferBinds[j].buffer, kVulkanObjectTypeBuffer));
+                auto buffer_state = GetBufferState(bind_info.pBufferBinds[j].buffer);
+                auto mem_state = GetDevMemShared(sparse_binding.memory);
+                if (buffer_state && mem_state) {
+                    buffer_state->SetSparseMemBinding(mem_state, sparse_binding.memoryOffset, sparse_binding.size);
+                }
             }
         }
         for (uint32_t j = 0; j < bind_info.imageOpaqueBindCount; j++) {
             for (uint32_t k = 0; k < bind_info.pImageOpaqueBinds[j].bindCount; k++) {
                 auto sparse_binding = bind_info.pImageOpaqueBinds[j].pBinds[k];
-                SetSparseMemBinding(sparse_binding.memory, sparse_binding.memoryOffset, sparse_binding.size,
-                                    VulkanTypedHandle(bind_info.pImageOpaqueBinds[j].image, kVulkanObjectTypeImage));
+                auto image_state = GetImageState(bind_info.pImageOpaqueBinds[j].image);
+                auto mem_state = GetDevMemShared(sparse_binding.memory);
+                if (image_state && mem_state) {
+                    image_state->SetSparseMemBinding(mem_state, sparse_binding.memoryOffset, sparse_binding.size);
+                }
             }
         }
         for (uint32_t j = 0; j < bind_info.imageBindCount; j++) {
@@ -2631,8 +2559,11 @@ void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32
                 auto sparse_binding = bind_info.pImageBinds[j].pBinds[k];
                 // TODO: This size is broken for non-opaque bindings, need to update to comprehend full sparse binding data
                 VkDeviceSize size = sparse_binding.extent.depth * sparse_binding.extent.height * sparse_binding.extent.width * 4;
-                SetSparseMemBinding(sparse_binding.memory, sparse_binding.memoryOffset, size,
-                                    VulkanTypedHandle(bind_info.pImageBinds[j].image, kVulkanObjectTypeImage));
+                auto image_state = GetImageState(bind_info.pImageBinds[j].image);
+                auto mem_state = GetDevMemShared(sparse_binding.memory);
+                if (image_state && mem_state) {
+                    image_state->SetSparseMemBinding(mem_state, sparse_binding.memoryOffset, size);
+                }
             }
         }
         CB_SUBMISSION submission;
@@ -2662,19 +2593,7 @@ void ValidationStateTracker::PostCallRecordCreateSemaphore(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
                                                            VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto semaphore_state = std::make_shared<SEMAPHORE_STATE>();
-    semaphore_state->signaler.first = VK_NULL_HANDLE;
-    semaphore_state->signaler.second = 0;
-    semaphore_state->signaled = false;
-    semaphore_state->scope = kSyncScopeInternal;
-    semaphore_state->type = VK_SEMAPHORE_TYPE_BINARY;
-    semaphore_state->payload = 0;
-    auto semaphore_type_create_info = LvlFindInChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext);
-    if (semaphore_type_create_info) {
-        semaphore_state->type = semaphore_type_create_info->semaphoreType;
-        semaphore_state->payload = semaphore_type_create_info->initialValue;
-    }
-    semaphoreMap[*pSemaphore] = std::move(semaphore_state);
+    semaphoreMap[*pSemaphore] = std::make_shared<SEMAPHORE_STATE>(*pSemaphore, LvlFindInChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext));
 }
 
 void ValidationStateTracker::RecordImportSemaphoreState(VkSemaphore semaphore, VkExternalSemaphoreHandleTypeFlagBits handle_type,
@@ -2832,7 +2751,7 @@ void ValidationStateTracker::PostCallRecordDeviceWaitIdle(VkDevice device, VkRes
 void ValidationStateTracker::PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator) {
     if (!fence) return;
     auto fence_state = GetFenceState(fence);
-    fence_state->destroyed = true;
+    fence_state->Destroy();
     fenceMap.erase(fence);
 }
 
@@ -2840,16 +2759,14 @@ void ValidationStateTracker::PreCallRecordDestroySemaphore(VkDevice device, VkSe
                                                            const VkAllocationCallbacks *pAllocator) {
     if (!semaphore) return;
     auto semaphore_state = GetSemaphoreState(semaphore);
-    semaphore_state->destroyed = true;
+    semaphore_state->Destroy();
     semaphoreMap.erase(semaphore);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) {
     if (!event) return;
     EVENT_STATE *event_state = Get<EVENT_STATE>(event);
-    const VulkanTypedHandle obj_struct(event, kVulkanObjectTypeEvent);
-    InvalidateCommandBuffers(event_state->cb_bindings, obj_struct);
-    event_state->destroyed = true;
+    event_state->Destroy();
     eventMap.erase(event);
 }
 
@@ -2857,9 +2774,7 @@ void ValidationStateTracker::PreCallRecordDestroyQueryPool(VkDevice device, VkQu
                                                            const VkAllocationCallbacks *pAllocator) {
     if (!queryPool) return;
     QUERY_POOL_STATE *qp_state = GetQueryPoolState(queryPool);
-    const VulkanTypedHandle obj_struct(queryPool, kVulkanObjectTypeQueryPool);
-    InvalidateCommandBuffers(qp_state->cb_bindings, obj_struct);
-    qp_state->destroyed = true;
+    qp_state->Destroy();
     queryPoolMap.erase(queryPool);
 }
 
@@ -2876,7 +2791,10 @@ void ValidationStateTracker::UpdateBindBufferMemoryState(VkBuffer buffer, VkDevi
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     if (buffer_state) {
         // Track objects tied to memory
-        SetMemBinding(mem, buffer_state, memoryOffset, VulkanTypedHandle(buffer, kVulkanObjectTypeBuffer));
+        auto mem_state = GetDevMemShared(mem);
+        if (mem_state) {
+            buffer_state->SetMemBinding(mem_state, memoryOffset);
+        }
     }
 }
 
@@ -3009,7 +2927,7 @@ void ValidationStateTracker::PreCallRecordDestroyShaderModule(VkDevice device, V
                                                               const VkAllocationCallbacks *pAllocator) {
     if (!shaderModule) return;
     auto shader_module_state = GetShaderModuleState(shaderModule);
-    shader_module_state->destroyed = true;
+    shader_module_state->Destroy();
     shaderModuleMap.erase(shaderModule);
 }
 
@@ -3017,10 +2935,8 @@ void ValidationStateTracker::PreCallRecordDestroyPipeline(VkDevice device, VkPip
                                                           const VkAllocationCallbacks *pAllocator) {
     if (!pipeline) return;
     PIPELINE_STATE *pipeline_state = GetPipelineState(pipeline);
-    const VulkanTypedHandle obj_struct(pipeline, kVulkanObjectTypePipeline);
     // Any bound cmd buffers are now invalid
-    InvalidateCommandBuffers(pipeline_state->cb_bindings, obj_struct);
-    pipeline_state->destroyed = true;
+    pipeline_state->Destroy();
     pipelineMap.erase(pipeline);
 }
 
@@ -3028,7 +2944,7 @@ void ValidationStateTracker::PreCallRecordDestroyPipelineLayout(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator) {
     if (!pipelineLayout) return;
     auto pipeline_layout_state = GetPipelineLayout(pipelineLayout);
-    pipeline_layout_state->destroyed = true;
+    pipeline_layout_state->Destroy();
     pipelineLayoutMap.erase(pipelineLayout);
 }
 
@@ -3036,17 +2952,15 @@ void ValidationStateTracker::PreCallRecordDestroySampler(VkDevice device, VkSamp
                                                          const VkAllocationCallbacks *pAllocator) {
     if (!sampler) return;
     SAMPLER_STATE *sampler_state = GetSamplerState(sampler);
-    const VulkanTypedHandle obj_struct(sampler, kVulkanObjectTypeSampler);
     // Any bound cmd buffers are now invalid
     if (sampler_state) {
-        InvalidateCommandBuffers(sampler_state->cb_bindings, obj_struct);
 
         if (sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
             sampler_state->createInfo.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
             custom_border_color_sampler_count--;
         }
 
-        sampler_state->destroyed = true;
+        sampler_state->Destroy();
     }
     samplerMap.erase(sampler);
 }
@@ -3056,7 +2970,7 @@ void ValidationStateTracker::PreCallRecordDestroyDescriptorSetLayout(VkDevice de
     if (!descriptorSetLayout) return;
     auto layout_it = descriptorSetLayoutMap.find(descriptorSetLayout);
     if (layout_it != descriptorSetLayoutMap.end()) {
-        layout_it->second.get()->destroyed = true;
+        layout_it->second.get()->Destroy();
         descriptorSetLayoutMap.erase(layout_it);
     }
 }
@@ -3065,17 +2979,19 @@ void ValidationStateTracker::PreCallRecordDestroyDescriptorPool(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator) {
     if (!descriptorPool) return;
     DESCRIPTOR_POOL_STATE *desc_pool_state = GetDescriptorPoolState(descriptorPool);
-    const VulkanTypedHandle obj_struct(descriptorPool, kVulkanObjectTypeDescriptorPool);
     if (desc_pool_state) {
-        // Any bound cmd buffers are now invalid
-        InvalidateCommandBuffers(desc_pool_state->cb_bindings, obj_struct);
         // Free sets that were in this pool
         for (auto *ds : desc_pool_state->sets) {
             FreeDescriptorSet(ds);
         }
-        desc_pool_state->destroyed = true;
+        desc_pool_state->Destroy();
         descriptorPoolMap.erase(descriptorPool);
     }
+}
+
+void CMD_BUFFER_STATE::Destroy() {
+    Reset();
+    BASE_NODE::Destroy();
 }
 
 // Free all command buffers in given list, removing all references/links to them using ResetCommandBufferState
@@ -3083,6 +2999,9 @@ void ValidationStateTracker::FreeCommandBufferStates(COMMAND_POOL_STATE *pool_st
                                                      const VkCommandBuffer *command_buffers) {
     for (uint32_t i = 0; i < command_buffer_count; i++) {
         // Allow any derived class to clean up command buffer state
+        if (command_buffer_reset_callback) {
+            (*command_buffer_reset_callback)(command_buffers[i]);
+        }
         if (command_buffer_free_callback) {
             (*command_buffer_free_callback)(command_buffers[i]);
         }
@@ -3090,15 +3009,12 @@ void ValidationStateTracker::FreeCommandBufferStates(COMMAND_POOL_STATE *pool_st
         auto cb_state = GetCBState(command_buffers[i]);
         // Remove references to command buffer's state and delete
         if (cb_state) {
-            // reset prior to delete, removing various references to it.
-            // TODO: fix this, it's insane.
-            ResetCommandBufferState(cb_state->commandBuffer);
             // Remove the cb_state's references from COMMAND_POOL_STATEs
             pool_state->commandBuffers.erase(command_buffers[i]);
             // Remove the cb debug labels
             EraseCmdDebugUtilsLabel(report_data, cb_state->commandBuffer);
             // Remove CBState from CB map
-            cb_state->destroyed = true;
+            cb_state->Destroy();
             commandBufferMap.erase(cb_state->commandBuffer);
         }
     }
@@ -3114,22 +3030,14 @@ void ValidationStateTracker::PostCallRecordCreateCommandPool(VkDevice device, co
                                                              const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
                                                              VkResult result) {
     if (VK_SUCCESS != result) return;
-    VkCommandPool command_pool = *pCommandPool;
-    auto cmd_pool_state = std::make_shared<COMMAND_POOL_STATE>();
-    cmd_pool_state->commandPool = command_pool;
-    cmd_pool_state->createFlags = pCreateInfo->flags;
-    cmd_pool_state->queueFamilyIndex = pCreateInfo->queueFamilyIndex;
-    cmd_pool_state->unprotected = ((pCreateInfo->flags & VK_COMMAND_POOL_CREATE_PROTECTED_BIT) == 0);
-    commandPoolMap[command_pool] = std::move(cmd_pool_state);
+    commandPoolMap[*pCommandPool] = std::make_shared<COMMAND_POOL_STATE>(*pCommandPool, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
                                                            const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool,
                                                            VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto query_pool_state = std::make_shared<QUERY_POOL_STATE>();
-    query_pool_state->createInfo = *pCreateInfo;
-    query_pool_state->pool = *pQueryPool;
+    auto query_pool_state = std::make_shared<QUERY_POOL_STATE>(*pQueryPool, pCreateInfo);
     if (pCreateInfo->queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         const auto *perf = LvlFindInChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext);
         query_pool_state->perf_counter_index_count = perf->counterIndexCount;
@@ -3172,7 +3080,7 @@ void ValidationStateTracker::PreCallRecordDestroyCommandPool(VkDevice device, Vk
         // Create a vector, as FreeCommandBufferStates deletes from cp_state->commandBuffers during iteration.
         std::vector<VkCommandBuffer> cb_vec{cp_state->commandBuffers.begin(), cp_state->commandBuffers.end()};
         FreeCommandBufferStates(cp_state, static_cast<uint32_t>(cb_vec.size()), cb_vec.data());
-        cp_state->destroyed = true;
+        cp_state->Destroy();
         commandPoolMap.erase(commandPool);
     }
 }
@@ -3202,38 +3110,33 @@ void ValidationStateTracker::PostCallRecordResetFences(VkDevice device, uint32_t
 }
 
 // For given cb_nodes, invalidate them and track object causing invalidation.
-// InvalidateCommandBuffers and InvalidateLinkedCommandBuffers are essentially
-// the same, except one takes a map and one takes a set, and InvalidateCommandBuffers
-// can also unlink objects from command buffers.
-void ValidationStateTracker::InvalidateCommandBuffers(BASE_NODE::BindingsType &cb_nodes,
-                                                      const VulkanTypedHandle &obj, bool unlink) {
-    for (const auto &cb_node_pair : cb_nodes) {
+void BASE_NODE::Invalidate(bool unlink) {
+    for (const auto &cb_node_pair : cb_bindings_) {
         auto &cb_node = cb_node_pair.first;
         if (cb_node->state == CB_RECORDING) {
             cb_node->state = CB_INVALID_INCOMPLETE;
         } else if (cb_node->state == CB_RECORDED) {
             cb_node->state = CB_INVALID_COMPLETE;
         }
-        cb_node->broken_bindings.push_back(obj);
+        cb_node->broken_bindings.push_back(handle_);
 
         // if secondary, then propagate the invalidation to the primaries that will call us.
         if (cb_node->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
-            InvalidateLinkedCommandBuffers(cb_node->linkedCommandBuffers, obj);
+            cb_node->InvalidateLinkedCommandBuffers(handle_);
         }
         if (unlink) {
             int index = cb_node_pair.second;
-            assert(cb_node->object_bindings[index] == obj);
+            assert(cb_node->object_bindings[index] == handle_);
             cb_node->object_bindings[index] = VulkanTypedHandle();
         }
     }
     if (unlink) {
-        cb_nodes.clear();
+        cb_bindings_.clear();
     }
 }
 
-void ValidationStateTracker::InvalidateLinkedCommandBuffers(layer_data::unordered_set<CMD_BUFFER_STATE *> &cb_nodes,
-                                                            const VulkanTypedHandle &obj) {
-    for (auto *cb_node : cb_nodes) {
+void CMD_BUFFER_STATE::InvalidateLinkedCommandBuffers(const VulkanTypedHandle &obj) {
+    for (auto *cb_node : linkedCommandBuffers) {
         if (cb_node->state == CB_RECORDING) {
             cb_node->state = CB_INVALID_INCOMPLETE;
         } else if (cb_node->state == CB_RECORDED) {
@@ -3243,7 +3146,7 @@ void ValidationStateTracker::InvalidateLinkedCommandBuffers(layer_data::unordere
 
         // if secondary, then propagate the invalidation to the primaries that will call us.
         if (cb_node->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
-            InvalidateLinkedCommandBuffers(cb_node->linkedCommandBuffers, obj);
+            cb_node->InvalidateLinkedCommandBuffers(obj);
         }
     }
 }
@@ -3252,9 +3155,7 @@ void ValidationStateTracker::PreCallRecordDestroyFramebuffer(VkDevice device, Vk
                                                              const VkAllocationCallbacks *pAllocator) {
     if (!framebuffer) return;
     FRAMEBUFFER_STATE *framebuffer_state = GetFramebufferState(framebuffer);
-    const VulkanTypedHandle obj_struct(framebuffer, kVulkanObjectTypeFramebuffer);
-    InvalidateCommandBuffers(framebuffer_state->cb_bindings, obj_struct);
-    framebuffer_state->destroyed = true;
+    framebuffer_state->Destroy();
     frameBufferMap.erase(framebuffer);
 }
 
@@ -3262,20 +3163,14 @@ void ValidationStateTracker::PreCallRecordDestroyRenderPass(VkDevice device, VkR
                                                             const VkAllocationCallbacks *pAllocator) {
     if (!renderPass) return;
     RENDER_PASS_STATE *rp_state = GetRenderPassState(renderPass);
-    const VulkanTypedHandle obj_struct(renderPass, kVulkanObjectTypeRenderPass);
-    InvalidateCommandBuffers(rp_state->cb_bindings, obj_struct);
-    rp_state->destroyed = true;
+    rp_state->Destroy();
     renderPassMap.erase(renderPass);
 }
 
 void ValidationStateTracker::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkFence *pFence, VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto fence_state = std::make_shared<FENCE_STATE>();
-    fence_state->fence = *pFence;
-    fence_state->createInfo = *pCreateInfo;
-    fence_state->state = (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED;
-    fenceMap[*pFence] = std::move(fence_state);
+    fenceMap[*pFence] = std::make_shared<FENCE_STATE>(*pFence, pCreateInfo);
 }
 
 bool ValidationStateTracker::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -3302,7 +3197,7 @@ void ValidationStateTracker::PostCallRecordCreateGraphicsPipelines(VkDevice devi
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
-            (cgpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            (cgpl_state->pipe_state)[i]->SetHandle(pPipelines[i]);
             pipelineMap[pPipelines[i]] = std::move((cgpl_state->pipe_state)[i]);
         }
     }
@@ -3334,7 +3229,7 @@ void ValidationStateTracker::PostCallRecordCreateComputePipelines(VkDevice devic
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
-            (ccpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            (ccpl_state->pipe_state)[i]->SetHandle(pPipelines[i]);
             pipelineMap[pPipelines[i]] = std::move((ccpl_state->pipe_state)[i]);
         }
     }
@@ -3364,7 +3259,7 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
-            (crtpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            (crtpl_state->pipe_state)[i]->SetHandle(pPipelines[i]);
             pipelineMap[pPipelines[i]] = std::move((crtpl_state->pipe_state)[i]);
         }
     }
@@ -3397,7 +3292,7 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
-            (crtpl_state->pipe_state)[i]->pipeline = pPipelines[i];
+            (crtpl_state->pipe_state)[i]->SetHandle(pPipelines[i]);
             pipelineMap[pPipelines[i]] = std::move((crtpl_state->pipe_state)[i]);
         }
     }
@@ -3475,8 +3370,7 @@ void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device,
                                                                 VkPipelineLayout *pPipelineLayout, VkResult result) {
     if (VK_SUCCESS != result) return;
 
-    auto pipeline_layout_state = std::make_shared<PIPELINE_LAYOUT_STATE>();
-    pipeline_layout_state->layout = *pPipelineLayout;
+    auto pipeline_layout_state = std::make_shared<PIPELINE_LAYOUT_STATE>(*pPipelineLayout);
     pipeline_layout_state->set_layouts.resize(pCreateInfo->setLayoutCount);
     PipelineLayoutSetLayoutsDef set_layouts(pCreateInfo->setLayoutCount);
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
@@ -3581,8 +3475,7 @@ void ValidationStateTracker::PostCallRecordAllocateCommandBuffers(VkDevice devic
         for (uint32_t i = 0; i < pCreateInfo->commandBufferCount; i++) {
             // Add command buffer to its commandPool map
             pool->commandBuffers.insert(pCommandBuffer[i]);
-            auto cb_state = std::make_shared<CMD_BUFFER_STATE>();
-            cb_state->createInfo = *pCreateInfo;
+            auto cb_state = std::make_shared<CMD_BUFFER_STATE>(pCommandBuffer[i], pCreateInfo);
             cb_state->command_pool = pool;
             cb_state->unprotected = pool->unprotected;
             // Add command buffer to map
@@ -3593,18 +3486,21 @@ void ValidationStateTracker::PostCallRecordAllocateCommandBuffers(VkDevice devic
 }
 
 // Add bindings between the given cmd buffer & framebuffer and the framebuffer's children
-void ValidationStateTracker::AddFramebufferBinding(CMD_BUFFER_STATE *cb_state, FRAMEBUFFER_STATE *fb_state) {
-    AddCommandBufferBinding(fb_state->cb_bindings, VulkanTypedHandle(fb_state->framebuffer, kVulkanObjectTypeFramebuffer, fb_state),
-                            cb_state);
-    // If imageless fb, skip fb binding
-    if (!fb_state || fb_state->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) return;
-    const uint32_t attachment_count = fb_state->createInfo.attachmentCount;
-    for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
-        auto view_state = GetActiveAttachmentImageViewState(cb_state, attachment);
-        if (view_state) {
-            AddCommandBufferBindingImageView(cb_state, view_state);
+bool FRAMEBUFFER_STATE::AddParent(CMD_BUFFER_STATE *cb_state) {
+    if (BASE_NODE::AddParent(cb_state)) {
+        // If imageless fb, skip fb binding
+        if ((createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
+            const uint32_t attachment_count = createInfo.attachmentCount;
+            for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
+                auto view_state = cb_state->GetActiveAttachmentImageViewState(attachment);
+                if (view_state) {
+                    cb_state->AddChild(view_state);
+                }
+            }
         }
+        return true;
     }
+    return false;
 }
 
 void UpdateSubpassAttachments(const safe_VkSubpassDescription2 &subpass, std::vector<SUBPASS_INFO> &subpasses) {
@@ -3705,7 +3601,7 @@ void ValidationStateTracker::PreCallRecordBeginCommandBuffer(VkCommandBuffer com
                     UpdateAttachmentsView(*this, *cb_state, *cb_state->activeFramebuffer, nullptr);
 
                     // Connect this framebuffer and its children to this cmdBuffer
-                    AddFramebufferBinding(cb_state, cb_state->activeFramebuffer.get());
+                    cb_state->AddChild(cb_state->activeFramebuffer.get());
                 }
             }
 
@@ -3860,7 +3756,9 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
     const auto lv_bind_point = ConvertToLvlBindPoint(pipelineBindPoint);
     cb_state->lastBound[lv_bind_point].pipeline_state = pipe_state;
     SetPipelineState(pipe_state);
-    AddCommandBufferBinding(pipe_state->cb_bindings, VulkanTypedHandle(pipeline, kVulkanObjectTypePipeline), cb_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(pipe_state);
+    }
 
     for (auto &slot : pipe_state->active_slots) {
         for (auto &req : slot.second) {
@@ -3901,11 +3799,13 @@ void ValidationStateTracker::PreCallRecordCmdSetExclusiveScissorNV(VkCommandBuff
 
 void ValidationStateTracker::PreCallRecordCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                                     VkImageLayout imageLayout) {
+    if (disabled[command_buffer_state]) return;
+
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
 
     if (imageView != VK_NULL_HANDLE) {
         auto view_state = GetImageViewState(imageView);
-        AddCommandBufferBindingImageView(cb_state, view_state);
+        cb_state->AddChild(view_state);
     }
 }
 
@@ -3967,15 +3867,19 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresKHR(
         return;
     }
     for (uint32_t i = 0; i < infoCount; ++i) {
-        ACCELERATION_STRUCTURE_STATE_KHR *dst_as_state = GetAccelerationStructureStateKHR(pInfos[i].dstAccelerationStructure);
-        ACCELERATION_STRUCTURE_STATE_KHR *src_as_state = GetAccelerationStructureStateKHR(pInfos[i].srcAccelerationStructure);
+        auto *dst_as_state = GetAccelerationStructureStateKHR(pInfos[i].dstAccelerationStructure);
         if (dst_as_state != nullptr) {
             dst_as_state->built = true;
             dst_as_state->build_info_khr.initialize(&pInfos[i]);
-            AddCommandBufferBindingAccelerationStructure(cb_state, dst_as_state);
+            if (!disabled[command_buffer_state]) {
+                cb_state->AddChild(dst_as_state);
+            }
         }
-        if (src_as_state != nullptr) {
-            AddCommandBufferBindingAccelerationStructure(cb_state, src_as_state);
+        if (!disabled[command_buffer_state]) {
+            auto *src_as_state = GetAccelerationStructureStateKHR(pInfos[i].srcAccelerationStructure);
+            if (src_as_state != nullptr) {
+                cb_state->AddChild(src_as_state);
+            }
         }
     }
     cb_state->hasBuildAccelerationStructureCmd = true;
@@ -3990,15 +3894,19 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresIndirec
         return;
     }
     for (uint32_t i = 0; i < infoCount; ++i) {
-        ACCELERATION_STRUCTURE_STATE_KHR *dst_as_state = GetAccelerationStructureStateKHR(pInfos[i].dstAccelerationStructure);
-        ACCELERATION_STRUCTURE_STATE_KHR *src_as_state = GetAccelerationStructureStateKHR(pInfos[i].srcAccelerationStructure);
+        auto *dst_as_state = GetAccelerationStructureStateKHR(pInfos[i].dstAccelerationStructure);
         if (dst_as_state != nullptr) {
             dst_as_state->built = true;
             dst_as_state->build_info_khr.initialize(&pInfos[i]);
-            AddCommandBufferBindingAccelerationStructure(cb_state, dst_as_state);
+            if (!disabled[command_buffer_state]) {
+                cb_state->AddChild(dst_as_state);
+            }
         }
-        if (src_as_state != nullptr) {
-            AddCommandBufferBindingAccelerationStructure(cb_state, src_as_state);
+        if (!disabled[command_buffer_state]) {
+            auto *src_as_state = GetAccelerationStructureStateKHR(pInfos[i].srcAccelerationStructure);
+            if (src_as_state != nullptr) {
+                cb_state->AddChild(src_as_state);
+            }
         }
     }
     cb_state->hasBuildAccelerationStructureCmd = true;
@@ -4029,8 +3937,10 @@ void ValidationStateTracker::PostCallRecordBindAccelerationStructureMemoryNV(
         ACCELERATION_STRUCTURE_STATE *as_state = GetAccelerationStructureStateNV(info.accelerationStructure);
         if (as_state) {
             // Track objects tied to memory
-            SetMemBinding(info.memory, as_state, info.memoryOffset,
-                          VulkanTypedHandle(info.accelerationStructure, kVulkanObjectTypeAccelerationStructureNV));
+            auto mem_state = GetDevMemShared(info.memory);
+            if (mem_state) {
+                as_state->SetMemBinding(mem_state, info.memoryOffset);
+            }
 
             // GPU validation of top level acceleration structure building needs acceleration structure handles.
             // XXX TODO: Query device address for KHR extension
@@ -4049,15 +3959,19 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructureNV(
         return;
     }
 
-    ACCELERATION_STRUCTURE_STATE *dst_as_state = GetAccelerationStructureStateNV(dst);
-    ACCELERATION_STRUCTURE_STATE *src_as_state = GetAccelerationStructureStateNV(src);
+    auto *dst_as_state = GetAccelerationStructureStateNV(dst);
     if (dst_as_state != nullptr) {
         dst_as_state->built = true;
         dst_as_state->build_info.initialize(pInfo);
-        AddCommandBufferBindingAccelerationStructure(cb_state, dst_as_state);
+        if (!disabled[command_buffer_state]) {
+            cb_state->AddChild(dst_as_state);
+        }
     }
-    if (src_as_state != nullptr) {
-        AddCommandBufferBindingAccelerationStructure(cb_state, src_as_state);
+    if (!disabled[command_buffer_state]) {
+        auto *src_as_state = GetAccelerationStructureStateNV(src);
+        if (src_as_state != nullptr) {
+            cb_state->AddChild(src_as_state);
+        }
     }
     cb_state->hasBuildAccelerationStructureCmd = true;
 }
@@ -4073,8 +3987,10 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureNV(VkComm
         if (dst_as_state != nullptr && src_as_state != nullptr) {
             dst_as_state->built = true;
             dst_as_state->build_info = src_as_state->build_info;
-            AddCommandBufferBindingAccelerationStructure(cb_state, dst_as_state);
-            AddCommandBufferBindingAccelerationStructure(cb_state, src_as_state);
+            if (!disabled[command_buffer_state]) {
+                cb_state->AddChild(dst_as_state);
+                cb_state->AddChild(src_as_state);
+            }
         }
     }
 }
@@ -4085,10 +4001,7 @@ void ValidationStateTracker::PreCallRecordDestroyAccelerationStructureKHR(VkDevi
     if (!accelerationStructure) return;
     auto *as_state = GetAccelerationStructureStateKHR(accelerationStructure);
     if (as_state) {
-        const VulkanTypedHandle obj_struct(accelerationStructure, kVulkanObjectTypeAccelerationStructureKHR);
-        InvalidateCommandBuffers(as_state->cb_bindings, obj_struct);
-        ClearMemoryObjectBindings(obj_struct);
-        as_state->destroyed = true;
+        as_state->Destroy();
         accelerationStructureMap_khr.erase(accelerationStructure);
     }
 }
@@ -4099,10 +4012,7 @@ void ValidationStateTracker::PreCallRecordDestroyAccelerationStructureNV(VkDevic
     if (!accelerationStructure) return;
     auto *as_state = GetAccelerationStructureStateNV(accelerationStructure);
     if (as_state) {
-        const VulkanTypedHandle obj_struct(accelerationStructure, kVulkanObjectTypeAccelerationStructureNV);
-        InvalidateCommandBuffers(as_state->cb_bindings, obj_struct);
-        ClearMemoryObjectBindings(obj_struct);
-        as_state->destroyed = true;
+        as_state->Destroy();
         accelerationStructureMap.erase(accelerationStructure);
     }
 }
@@ -4372,7 +4282,9 @@ void ValidationStateTracker::PreCallRecordCmdBindIndexBuffer(VkCommandBuffer com
     cb_state->index_buffer_binding.offset = offset;
     cb_state->index_buffer_binding.index_type = indexType;
     // Add binding for this index buffer to this commandbuffer
-    AddCommandBufferBindingBuffer(cb_state, cb_state->index_buffer_binding.buffer_state.get());
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(cb_state->index_buffer_binding.buffer_state.get());
+    }
 }
 
 void ValidationStateTracker::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding,
@@ -4392,19 +4304,21 @@ void ValidationStateTracker::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer c
         vertex_buffer_binding.size = VK_WHOLE_SIZE;
         vertex_buffer_binding.stride = 0;
         // Add binding for this vertex buffer to this commandbuffer
-        if (pBuffers[i]) {
-            AddCommandBufferBindingBuffer(cb_state, vertex_buffer_binding.buffer_state.get());
+        if (pBuffers[i] && !disabled[command_buffer_state]) {
+            cb_state->AddChild(vertex_buffer_binding.buffer_state.get());
         }
     }
 }
 
 void ValidationStateTracker::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer,
                                                            VkDeviceSize dstOffset, VkDeviceSize dataSize, const void *pData) {
+    if (disabled[command_buffer_state]) return;
+
     auto cb_state = GetCBState(commandBuffer);
     auto dst_buffer_state = GetBufferState(dstBuffer);
 
     // Update bindings between buffer and cmd buffer
-    AddCommandBufferBindingBuffer(cb_state, dst_buffer_state);
+    cb_state->AddChild(dst_buffer_state);
 }
 
 bool ValidationStateTracker::SetEventStageMask(VkEvent event, VkPipelineStageFlags2KHR stageMask,
@@ -4415,9 +4329,11 @@ bool ValidationStateTracker::SetEventStageMask(VkEvent event, VkPipelineStageFla
 
 void ValidationStateTracker::RecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    auto event_state = GetEventState(event);
-    if (event_state) {
-        AddCommandBufferBinding(event_state->cb_bindings, VulkanTypedHandle(event, kVulkanObjectTypeEvent, event_state), cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto event_state = GetEventState(event);
+        if (event_state) {
+            cb_state->AddChild(event_state);
+        }
     }
     cb_state->events.push_back(event);
     if (!cb_state->waitedEvents.count(event)) {
@@ -4444,9 +4360,11 @@ void ValidationStateTracker::PreCallRecordCmdSetEvent2KHR(VkCommandBuffer comman
 void ValidationStateTracker::RecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
                                                  VkPipelineStageFlags2KHR stageMask) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    auto event_state = GetEventState(event);
-    if (event_state) {
-        AddCommandBufferBinding(event_state->cb_bindings, VulkanTypedHandle(event, kVulkanObjectTypeEvent, event_state), cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto event_state = GetEventState(event);
+        if (event_state) {
+            cb_state->AddChild(event_state);
+        }
     }
     cb_state->events.push_back(event);
     if (!cb_state->waitedEvents.count(event)) {
@@ -4472,10 +4390,11 @@ void ValidationStateTracker::PreCallRecordCmdResetEvent2KHR(VkCommandBuffer comm
 void ValidationStateTracker::RecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents) {
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     for (uint32_t i = 0; i < eventCount; ++i) {
-        auto event_state = GetEventState(pEvents[i]);
-        if (event_state) {
-            AddCommandBufferBinding(event_state->cb_bindings, VulkanTypedHandle(pEvents[i], kVulkanObjectTypeEvent, event_state),
-                                    cb_state);
+        if (!disabled[command_buffer_state]) {
+            auto event_state = GetEventState(pEvents[i]);
+            if (event_state) {
+                cb_state->AddChild(event_state);
+            }
         }
         cb_state->waitedEvents.insert(pEvents[i]);
         cb_state->events.push_back(pEvents[i]);
@@ -4531,9 +4450,10 @@ void ValidationStateTracker::RecordCmdBeginQuery(CMD_BUFFER_STATE *cb_state, con
         SetQueryState(QueryObject(query_obj, perfQueryPass), QUERYSTATE_RUNNING, localQueryToStateMap);
         return false;
     });
-    auto pool_state = GetQueryPoolState(query_obj.pool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(query_obj.pool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto pool_state = GetQueryPoolState(query_obj.pool);
+        cb_state->AddChild(pool_state);
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
@@ -4552,9 +4472,10 @@ void ValidationStateTracker::RecordCmdEndQuery(CMD_BUFFER_STATE *cb_state, const
                                                     QueryMap *localQueryToStateMap) {
         return SetQueryState(QueryObject(query_obj, perfQueryPass), QUERYSTATE_ENDED, localQueryToStateMap);
     });
-    auto pool_state = GetQueryPoolState(query_obj.pool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(query_obj.pool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto pool_state = GetQueryPoolState(query_obj.pool);
+        cb_state->AddChild(pool_state);
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) {
@@ -4580,22 +4501,23 @@ void ValidationStateTracker::PostCallRecordCmdResetQueryPool(VkCommandBuffer com
                                                                             QueryMap *localQueryToStateMap) {
         return SetQueryStateMulti(queryPool, firstQuery, queryCount, perfQueryPass, QUERYSTATE_RESET, localQueryToStateMap);
     });
-    auto pool_state = GetQueryPoolState(queryPool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(queryPool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto pool_state = GetQueryPoolState(queryPool);
+        cb_state->AddChild(pool_state);
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                                    uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
                                                                    VkDeviceSize dstOffset, VkDeviceSize stride,
                                                                    VkQueryResultFlags flags) {
-    if (disabled[query_validation]) return;
+    if (disabled[query_validation] || disabled[command_buffer_state]) return;
+
     auto cb_state = GetCBState(commandBuffer);
     auto dst_buff_state = GetBufferState(dstBuffer);
-    AddCommandBufferBindingBuffer(cb_state, dst_buff_state);
+    cb_state->AddChild(dst_buff_state);
     auto pool_state = GetQueryPoolState(queryPool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(queryPool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    cb_state->AddChild(pool_state);
 }
 
 void ValidationStateTracker::PostCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
@@ -4608,9 +4530,10 @@ void ValidationStateTracker::PostCallRecordCmdWriteTimestamp2KHR(VkCommandBuffer
                                                                  uint32_t slot) {
     if (disabled[query_validation]) return;
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    auto pool_state = GetQueryPoolState(queryPool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(queryPool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto pool_state = GetQueryPoolState(queryPool);
+        cb_state->AddChild(pool_state);
+    }
     QueryObject query = {queryPool, slot};
     cb_state->queryUpdates.emplace_back([query](const ValidationStateTracker *device_data, bool do_validate,
                                                 VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
@@ -4624,9 +4547,10 @@ void ValidationStateTracker::PostCallRecordCmdWriteAccelerationStructuresPropert
     VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {
     if (disabled[query_validation]) return;
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    auto pool_state = GetQueryPoolState(queryPool);
-    AddCommandBufferBinding(pool_state->cb_bindings, VulkanTypedHandle(queryPool, kVulkanObjectTypeQueryPool, pool_state),
-                            cb_state);
+    if (!disabled[command_buffer_state]) {
+        auto pool_state = GetQueryPoolState(queryPool);
+        cb_state->AddChild(pool_state);
+    }
     cb_state->queryUpdates.emplace_back(
         [queryPool, firstQuery, accelerationStructureCount](const ValidationStateTracker *device_data, bool do_validate,
                                                             VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
@@ -4880,7 +4804,7 @@ void ValidationStateTracker::PostCallRecordCreateRenderPass(VkDevice device, con
                                                             const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
                                                             VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto render_pass_state = std::make_shared<RENDER_PASS_STATE>(pCreateInfo);
+    auto render_pass_state = std::make_shared<RENDER_PASS_STATE>(*pRenderPass, pCreateInfo);
     RecordCreateRenderPassState(RENDER_PASS_VERSION_1, render_pass_state, pRenderPass);
 }
 
@@ -4888,7 +4812,7 @@ void ValidationStateTracker::RecordCreateRenderPass2(VkDevice device, const VkRe
                                                      const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
                                                      VkResult result) {
     if (VK_SUCCESS != result) return;
-    auto render_pass_state = std::make_shared<RENDER_PASS_STATE>(pCreateInfo);
+    auto render_pass_state = std::make_shared<RENDER_PASS_STATE>(*pRenderPass, pCreateInfo);
     RecordCreateRenderPassState(RENDER_PASS_VERSION_2, render_pass_state, pRenderPass);
 }
 
@@ -4919,9 +4843,9 @@ void ValidationStateTracker::RecordCmdBeginRenderPassState(VkCommandBuffer comma
         cb_state->activeSubpassContents = contents;
 
         // Connect this RP to cmdBuffer
-        AddCommandBufferBinding(
-            render_pass_state->cb_bindings,
-            VulkanTypedHandle(render_pass_state->renderPass, kVulkanObjectTypeRenderPass, render_pass_state.get()), cb_state);
+        if (!disabled[command_buffer_state]) {
+            cb_state->AddChild(render_pass_state.get());
+        }
 
         auto chained_device_group_struct = LvlFindInChain<VkDeviceGroupRenderPassBeginInfo>(pRenderPassBegin->pNext);
         if (chained_device_group_struct) {
@@ -4948,7 +4872,7 @@ void ValidationStateTracker::RecordCmdBeginRenderPassState(VkCommandBuffer comma
             UpdateAttachmentsView(*this, *cb_state, *cb_state->activeFramebuffer, pRenderPassBegin);
 
             // Connect this framebuffer and its children to this cmdBuffer
-            AddFramebufferBinding(cb_state, framebuffer.get());
+            cb_state->AddChild(framebuffer.get());
         }
     }
 }
@@ -5133,17 +5057,15 @@ void ValidationStateTracker::UpdateBindImageMemoryState(const VkBindImageMemoryI
             }
         } else {
             // Track bound memory range information
-            auto mem_info = GetDevMemState(bindInfo.memory);
+            auto mem_info = GetDevMemShared(bindInfo.memory);
             if (mem_info) {
-                InsertImageMemoryRange(image_state, mem_info, bindInfo.memoryOffset);
+                InsertImageMemoryRange(image_state, mem_info.get(), bindInfo.memoryOffset);
                 if (image_state->createInfo.flags & VK_IMAGE_CREATE_ALIAS_BIT) {
                     AddAliasingImage(image_state, &mem_info->bound_images);
                 }
+                // Track objects tied to memory
+                image_state->SetMemBinding(mem_info, bindInfo.memoryOffset);
             }
-
-            // Track objects tied to memory
-            SetMemBinding(bindInfo.memory, image_state, bindInfo.memoryOffset,
-                          VulkanTypedHandle(bindInfo.image, kVulkanObjectTypeImage));
         }
     }
 }
@@ -5320,7 +5242,7 @@ void ValidationStateTracker::PreCallRecordDestroySwapchainKHR(VkDevice device, V
             swapchain_image.bound_images.clear();
 
             if (swapchain_image.image_state) {
-                ClearMemoryObjectBindings(VulkanTypedHandle(swapchain_image.image_state->image, kVulkanObjectTypeImage));
+                swapchain_image.image_state->Destroy();
                 imageMap.erase(swapchain_image.image_state->image);
                 swapchain_image.image_state = nullptr;
             }
@@ -5330,7 +5252,7 @@ void ValidationStateTracker::PreCallRecordDestroySwapchainKHR(VkDevice device, V
         if (surface_state) {
             if (surface_state->swapchain == swapchain_data) surface_state->swapchain = nullptr;
         }
-        swapchain_data->destroyed = true;
+        swapchain_data->Destroy();
         swapchainMap.erase(swapchain);
     }
 }
@@ -5495,7 +5417,7 @@ void ValidationStateTracker::PreCallRecordDestroySurfaceKHR(VkInstance instance,
                                                             const VkAllocationCallbacks *pAllocator) {
     if (!surface) return;
     auto surface_state = GetSurfaceState(surface);
-    surface_state->destroyed = true;
+    surface_state->Destroy();
     surface_map.erase(surface);
 }
 
@@ -5890,7 +5812,7 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(Vk
         auto layout_data = GetPipelineLayout(layout);
         auto dsl = GetDslFromPipelineLayout(layout_data, set);
         const auto &template_ci = template_state->create_info;
-        if (dsl && !dsl->destroyed) {
+        if (dsl && !dsl->Destroyed()) {
             // Decode the template into a set of write updates
             cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state, pData,
                                                                     dsl->GetDescriptorSetLayout());
@@ -5944,7 +5866,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
 
 void ValidationStateTracker::RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo *create_info,
                                                                      VkSamplerYcbcrConversion ycbcr_conversion) {
-    auto ycbcr_state = std::make_shared<SAMPLER_YCBCR_CONVERSION_STATE>();
+    auto ycbcr_state = std::make_shared<SAMPLER_YCBCR_CONVERSION_STATE>(ycbcr_conversion);
 
     if (device_extensions.vk_android_external_memory_android_hardware_buffer) {
         RecordCreateSamplerYcbcrConversionANDROID(create_info, ycbcr_conversion, ycbcr_state.get());
@@ -5986,7 +5908,7 @@ void ValidationStateTracker::RecordDestroySamplerYcbcrConversionState(VkSamplerY
     }
 
     auto ycbcr_state = GetSamplerYcbcrConversionState(ycbcr_conversion);
-    ycbcr_state->destroyed = true;
+    ycbcr_state->Destroy();
     samplerYcbcrConversionMap.erase(ycbcr_conversion);
 }
 
@@ -6084,7 +6006,6 @@ void ValidationStateTracker::PerformAllocateDescriptorSets(const VkDescriptorSet
         auto new_ds = std::make_shared<cvdescriptorset::DescriptorSet>(descriptor_sets[i], pool_state, ds_data->layout_nodes[i],
                                                                        variable_count, this);
         pool_state->sets.insert(new_ds.get());
-        new_ds->in_use.store(0);
         setMap[descriptor_sets[i]] = std::move(new_ds);
     }
 }
@@ -6128,7 +6049,9 @@ void ValidationStateTracker::PostCallRecordCmdDrawIndirect(VkCommandBuffer comma
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, CMD_DRAWINDIRECT, VK_PIPELINE_BIND_POINT_GRAPHICS, "vkCmdDrawIndirect()");
-    AddCommandBufferBindingBuffer(cb_state, buffer_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(buffer_state);
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -6136,7 +6059,9 @@ void ValidationStateTracker::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffe
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     UpdateStateCmdDrawType(cb_state, CMD_DRAWINDEXEDINDIRECT, VK_PIPELINE_BIND_POINT_GRAPHICS, "vkCmdDrawIndexedIndirect()");
-    AddCommandBufferBindingBuffer(cb_state, buffer_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(buffer_state);
+    }
 }
 
 void ValidationStateTracker::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
@@ -6149,7 +6074,9 @@ void ValidationStateTracker::PostCallRecordCmdDispatchIndirect(VkCommandBuffer c
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     UpdateStateCmdDrawDispatchType(cb_state, CMD_DISPATCHINDIRECT, VK_PIPELINE_BIND_POINT_COMPUTE, "vkCmdDispatchIndirect()");
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
-    AddCommandBufferBindingBuffer(cb_state, buffer_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(buffer_state);
+    }
 }
 
 void ValidationStateTracker::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -6159,8 +6086,10 @@ void ValidationStateTracker::RecordCmdDrawIndirectCount(VkCommandBuffer commandB
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, CMD_DRAWINDIRECTCOUNT, VK_PIPELINE_BIND_POINT_GRAPHICS, function);
-    AddCommandBufferBindingBuffer(cb_state, buffer_state);
-    AddCommandBufferBindingBuffer(cb_state, count_buffer_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(buffer_state);
+        cb_state->AddChild(count_buffer_state);
+    }
 }
 
 void ValidationStateTracker::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -6185,8 +6114,10 @@ void ValidationStateTracker::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer c
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, CMD_DRAWINDEXEDINDIRECTCOUNT, VK_PIPELINE_BIND_POINT_GRAPHICS, function);
-    AddCommandBufferBindingBuffer(cb_state, buffer_state);
-    AddCommandBufferBindingBuffer(cb_state, count_buffer_state);
+    if (!disabled[command_buffer_state]) {
+        cb_state->AddChild(buffer_state);
+        cb_state->AddChild(count_buffer_state);
+    }
 }
 
 void ValidationStateTracker::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -6217,8 +6148,8 @@ void ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBu
     UpdateStateCmdDrawType(cb_state, CMD_DRAWMESHTASKSINDIRECTNV, VK_PIPELINE_BIND_POINT_GRAPHICS,
                            "vkCmdDrawMeshTasksIndirectNV()");
     BUFFER_STATE *buffer_state = GetBufferState(buffer);
-    if (buffer_state) {
-        AddCommandBufferBindingBuffer(cb_state, buffer_state);
+    if (!disabled[command_buffer_state] && buffer_state) {
+        cb_state->AddChild(buffer_state);
     }
 }
 
@@ -6231,11 +6162,13 @@ void ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkComm
     BUFFER_STATE *count_buffer_state = GetBufferState(countBuffer);
     UpdateStateCmdDrawType(cb_state, CMD_DRAWMESHTASKSINDIRECTCOUNTNV, VK_PIPELINE_BIND_POINT_GRAPHICS,
                            "vkCmdDrawMeshTasksIndirectCountNV()");
-    if (buffer_state) {
-        AddCommandBufferBindingBuffer(cb_state, buffer_state);
-    }
-    if (count_buffer_state) {
-        AddCommandBufferBindingBuffer(cb_state, count_buffer_state);
+    if (!disabled[command_buffer_state]) {
+        if (buffer_state) {
+            cb_state->AddChild(buffer_state);
+        }
+        if (count_buffer_state) {
+            cb_state->AddChild(count_buffer_state);
+        }
     }
 }
 
@@ -6449,8 +6382,10 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureKHR(VkCom
         if (dst_as_state != nullptr && src_as_state != nullptr) {
             dst_as_state->built = true;
             dst_as_state->build_info_khr = src_as_state->build_info_khr;
-            AddCommandBufferBindingAccelerationStructure(cb_state, dst_as_state);
-            AddCommandBufferBindingAccelerationStructure(cb_state, src_as_state);
+            if (!disabled[command_buffer_state]) {
+                cb_state->AddChild(dst_as_state);
+                cb_state->AddChild(src_as_state);
+            }
         }
     }
 }
@@ -6526,8 +6461,8 @@ void ValidationStateTracker::PreCallRecordCmdBindVertexBuffers2EXT(VkCommandBuff
         vertex_buffer_binding.size = (pSizes) ? pSizes[i] : VK_WHOLE_SIZE;
         vertex_buffer_binding.stride = (pStrides) ? pStrides[i] : 0;
         // Add binding for this vertex buffer to this commandbuffer
-        if (pBuffers[i]) {
-            AddCommandBufferBindingBuffer(cb_state, vertex_buffer_binding.buffer_state.get());
+        if (!disabled[command_buffer_state] && pBuffers[i]) {
+            cb_state->AddChild(vertex_buffer_binding.buffer_state.get());
         }
     }
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -61,7 +61,6 @@ enum FENCE_STATUS { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
 
 class FENCE_STATE : public BASE_NODE {
   public:
-    VkFence fence;
     VkFenceCreateInfo createInfo;
     std::pair<VkQueue, uint64_t> signaler;
     FENCE_STATUS state;
@@ -70,10 +69,11 @@ class FENCE_STATE : public BASE_NODE {
     // Default constructor
     FENCE_STATE(VkFence f, const VkFenceCreateInfo *pCreateInfo)
         : BASE_NODE(f, kVulkanObjectTypeFence),
-          fence(f),
           createInfo(*pCreateInfo),
           state((pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED),
           scope(kSyncScopeInternal) {}
+
+    VkFence fence() const { return handle_.Cast<VkFence>(); }
 };
 
 class SEMAPHORE_STATE : public BASE_NODE {
@@ -91,16 +91,19 @@ class SEMAPHORE_STATE : public BASE_NODE {
           scope(kSyncScopeInternal),
           type(type_create_info ? type_create_info->semaphoreType : VK_SEMAPHORE_TYPE_BINARY),
           payload(type_create_info ? type_create_info->initialValue : 0) {}
+
+    VkSemaphore semaphore() const { return handle_.Cast<VkSemaphore>(); }
 };
 
 class EVENT_STATE : public BASE_NODE {
   public:
     int write_in_use = 0;
     VkPipelineStageFlags2KHR stageMask = VkPipelineStageFlags2KHR(0);
-    VkEvent event = VK_NULL_HANDLE;
     VkEventCreateFlags flags;
     EVENT_STATE(VkEvent event_, VkEventCreateFlags flags_)
-        : BASE_NODE(event_, kVulkanObjectTypeEvent), event(event_), flags(flags_) {}
+        : BASE_NODE(event_, kVulkanObjectTypeEvent), flags(flags_) {}
+
+    VkEvent event() const { return handle_.Cast<VkEvent>(); }
 };
 
 class QUEUE_STATE {
@@ -115,7 +118,6 @@ class QUEUE_STATE {
 class QUERY_POOL_STATE : public BASE_NODE {
   public:
     VkQueryPoolCreateInfo createInfo;
-    VkQueryPool pool;
 
     bool has_perf_scope_command_buffer = false;
     bool has_perf_scope_render_pass = false;
@@ -124,12 +126,13 @@ class QUERY_POOL_STATE : public BASE_NODE {
 
     QUERY_POOL_STATE(VkQueryPool qp, const VkQueryPoolCreateInfo *pCreateInfo)
         : BASE_NODE(qp, kVulkanObjectTypeQueryPool),
-          pool(qp),
           createInfo(*pCreateInfo),
           has_perf_scope_command_buffer(false),
           has_perf_scope_render_pass(false),
           n_performance_passes(0),
           perf_counter_index_count(0) {}
+
+    VkQueryPool pool() const { return handle_.Cast<VkQueryPool>(); }
 };
 
 class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
@@ -140,6 +143,8 @@ class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
 
     SAMPLER_YCBCR_CONVERSION_STATE(VkSamplerYcbcrConversion ycbcr)
         : BASE_NODE(ycbcr, kVulkanObjectTypeSamplerYcbcrConversion) {}
+
+    VkSamplerYcbcrConversion ycbcr_conversion() const { return handle_.Cast<VkSamplerYcbcrConversion>(); }
 };
 
 class QUEUE_FAMILY_PERF_COUNTERS {
@@ -238,18 +243,20 @@ struct hash<GpuQueue> {
 }  // namespace std
 
 struct SURFACE_STATE : public BASE_NODE {
-    VkSurfaceKHR surface = VK_NULL_HANDLE;
     SWAPCHAIN_NODE* swapchain = nullptr;
     layer_data::unordered_map<GpuQueue, bool> gpu_queue_support;
 
-    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(surface, kVulkanObjectTypeSurfaceKHR), surface(s) {}
+    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR) {}
+
+    VkSurfaceKHR surface() const { return handle_.Cast<VkSurfaceKHR>(); }
 };
 
 struct DISPLAY_MODE_STATE : public BASE_NODE {
-    VkDisplayModeKHR display_mode = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device;
 
-    DISPLAY_MODE_STATE(VkDisplayModeKHR dm) : BASE_NODE(dm, kVulkanObjectTypeDisplayModeKHR), display_mode(dm) {}
+    DISPLAY_MODE_STATE(VkDisplayModeKHR dm) : BASE_NODE(dm, kVulkanObjectTypeDisplayModeKHR) {}
+
+    VkDisplayModeKHR display_mode() const { return handle_.Cast<VkDisplayModeKHR>(); }
 };
 
 struct SubpassLayout {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -59,7 +59,7 @@ enum SyncScope {
 
 enum FENCE_STATUS { FENCE_UNSIGNALED, FENCE_INFLIGHT, FENCE_RETIRED };
 
-class FENCE_STATE : public BASE_NODE {
+class FENCE_STATE : public REFCOUNTED_NODE {
   public:
     VkFenceCreateInfo createInfo;
     std::pair<VkQueue, uint64_t> signaler;
@@ -68,7 +68,7 @@ class FENCE_STATE : public BASE_NODE {
 
     // Default constructor
     FENCE_STATE(VkFence f, const VkFenceCreateInfo *pCreateInfo)
-        : BASE_NODE(f, kVulkanObjectTypeFence),
+        : REFCOUNTED_NODE(f, kVulkanObjectTypeFence),
           createInfo(*pCreateInfo),
           state((pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? FENCE_RETIRED : FENCE_UNSIGNALED),
           scope(kSyncScopeInternal) {}
@@ -76,7 +76,7 @@ class FENCE_STATE : public BASE_NODE {
     VkFence fence() const { return handle_.Cast<VkFence>(); }
 };
 
-class SEMAPHORE_STATE : public BASE_NODE {
+class SEMAPHORE_STATE : public REFCOUNTED_NODE {
   public:
     std::pair<VkQueue, uint64_t> signaler;
     bool signaled;
@@ -85,7 +85,7 @@ class SEMAPHORE_STATE : public BASE_NODE {
     uint64_t payload;
 
     SEMAPHORE_STATE(VkSemaphore sem, const VkSemaphoreTypeCreateInfo *type_create_info)
-        : BASE_NODE(sem, kVulkanObjectTypeSemaphore),
+        : REFCOUNTED_NODE(sem, kVulkanObjectTypeSemaphore),
           signaler(VK_NULL_HANDLE, 0),
           signaled(false),
           scope(kSyncScopeInternal),
@@ -450,8 +450,6 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map)
 
-    void AddAliasingImage(IMAGE_STATE* image_state, layer_data::unordered_set<IMAGE_STATE*>* bound_images);
-    void RemoveAliasingImage(IMAGE_STATE* image_state);
     static void RemoveAliasingImages(const layer_data::unordered_set<IMAGE_STATE*>& bound_images);
 
   public:
@@ -1298,10 +1296,7 @@ class ValidationStateTracker : public ValidationObject {
                                                 VkResult result) override;
 
     // State Utilty functions
-    bool AddCommandBufferMem(layer_data::unordered_map<CMD_BUFFER_STATE*, int>& cb_bindings, VkDeviceMemory obj,
-                             CMD_BUFFER_STATE* cb_node);
     void AddMemObjInfo(void* object, const VkDeviceMemory mem, const VkMemoryAllocateInfo* pAllocateInfo);
-    void DecrementBoundResources(CMD_BUFFER_STATE const* cb_node);
     void DeleteDescriptorSetPools();
     void FreeCommandBufferStates(COMMAND_POOL_STATE* pool_state, const uint32_t command_buffer_count,
                                  const VkCommandBuffer* command_buffers);
@@ -1314,10 +1309,8 @@ class ValidationStateTracker : public ValidationObject {
     std::vector<const IMAGE_VIEW_STATE*> GetCurrentAttachmentViews(const CMD_BUFFER_STATE& cb_state) const;
     BASE_NODE* GetStateStructPtrFromObject(const VulkanTypedHandle& object_struct);
     VkFormatFeatureFlags GetPotentialFormatFeatures(VkFormat format) const;
-    void IncrementBoundObjects(CMD_BUFFER_STATE const* cb_node);
     void IncrementResources(CMD_BUFFER_STATE* cb_node);
     void InsertImageMemoryRange(IMAGE_STATE* image_state, DEVICE_MEMORY_STATE* mem_info, VkDeviceSize mem_offset);
-    void InvalidateLinkedCommandBuffers(layer_data::unordered_set<CMD_BUFFER_STATE*>& cb_nodes, const VulkanTypedHandle& obj);
     void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo*, const VkDescriptorSet*,
                                        const cvdescriptorset::AllocateDescriptorSetsData*);
     void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const TEMPLATE_STATE* template_state,
@@ -1371,7 +1364,6 @@ class ValidationStateTracker : public ValidationObject {
     void RecordRenderPassDAG(RenderPassCreateVersion rp_version, const VkRenderPassCreateInfo2* pCreateInfo,
                              RENDER_PASS_STATE* render_pass);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
-    void RemoveImageMemoryRange(IMAGE_STATE* image, DEVICE_MEMORY_STATE* mem_info);
     void ResetCommandBufferState(const VkCommandBuffer cb);
     void RetireFence(VkFence fence);
     void RetireTimelineSemaphore(VkSemaphore semaphore, uint64_t until_payload);

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -285,7 +285,7 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
     // WORKAROUND for dev_sim and mock_icd not containing valid VkSubresourceLayout yet. Treat it as optimal image.
     if (image_->createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
         subres = {static_cast<VkImageAspectFlags>(AspectBit(0)), 0, 0};
-        DispatchGetImageSubresourceLayout(image_->store_device_as_workaround, image_->image, &subres, &layout);
+        DispatchGetImageSubresourceLayout(image_->store_device_as_workaround, image_->image(), &subres, &layout);
         if (layout.size > 0) {
             linear_image_ = true;
         }
@@ -307,7 +307,7 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
             auto subres_extent = GetImageSubresourceExtent(image_, &subres_layers);
 
             if (linear_image_) {
-                DispatchGetImageSubresourceLayout(image_->store_device_as_workaround, image_->image, &subres, &layout);
+                DispatchGetImageSubresourceLayout(image_->store_device_as_workaround, image_->image(), &subres, &layout);
                 if (is_3_d_) {
                     if ((layout.depthPitch == 0) && (subres_extent.depth == 1)) {
                         layout.depthPitch = layout.size;  // Certain implmentations don't supply pitches when size is 1

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1986,7 +1986,7 @@ bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32
         const auto &binding_description = pipe->vertex_binding_descriptions_[i];
         if (binding_description.binding < binding_buffers_size) {
             const auto &binding_buffer = binding_buffers[binding_description.binding];
-            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->destroyed) continue;
+            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->Destroyed()) continue;
 
             auto *buf_state = binding_buffer.buffer_state.get();
             const ResourceAccessRange range = GetBufferRange(binding_buffer.offset, buf_state->createInfo.size, firstVertex,
@@ -2016,7 +2016,7 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
         const auto &binding_description = pipe->vertex_binding_descriptions_[i];
         if (binding_description.binding < binding_buffers_size) {
             const auto &binding_buffer = binding_buffers[binding_description.binding];
-            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->destroyed) continue;
+            if (binding_buffer.buffer_state == nullptr || binding_buffer.buffer_state->Destroyed()) continue;
 
             auto *buf_state = binding_buffer.buffer_state.get();
             const ResourceAccessRange range = GetBufferRange(binding_buffer.offset, buf_state->createInfo.size, firstVertex,
@@ -2029,7 +2029,7 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
 
 bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const char *func_name) const {
     bool skip = false;
-    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->destroyed) {
+    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->Destroyed()) {
         return skip;
     }
 
@@ -2052,7 +2052,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t indexCount, ui
 }
 
 void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const ResourceUsageTag &tag) {
-    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->destroyed) return;
+    if (cb_state_->index_buffer_binding.buffer_state == nullptr || cb_state_->index_buffer_binding.buffer_state->Destroyed()) return;
 
     auto *index_buf_state = cb_state_->index_buffer_binding.buffer_state.get();
     const auto index_size = GetIndexAlignment(cb_state_->index_buffer_binding.index_type);

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -182,7 +182,7 @@ struct SyncEventState {
           barriers(0U),
           scope(),
           first_scope_tag(),
-          destroyed((event_state.get() == nullptr) || event_state->destroyed) {}
+          destroyed((event_state.get() == nullptr) || event_state->Destroyed()) {}
     SyncEventState() : SyncEventState(EventPointer()) {}
     void ResetFirstScope();
     const ScopeMap &FirstScope(AccessAddressType address_type) const { return first_scope[static_cast<size_t>(address_type)]; }

--- a/scripts/command_validation_generator.py
+++ b/scripts/command_validation_generator.py
@@ -387,7 +387,7 @@ bool CoreChecks::ValidateCmd(const CMD_BUFFER_STATE *cb_state, const CMD_TYPE cm
         default:
             assert(cmd != CMD_NONE);
             const auto error = kGeneratedMustBeRecordingList[cmd];
-            skip |= LogError(cb_state->commandBuffer, error, "You must call vkBeginCommandBuffer() before this call to %s.",
+            skip |= LogError(cb_state->commandBuffer(), error, "You must call vkBeginCommandBuffer() before this call to %s.",
                             caller_name);
     }
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4267,7 +4267,6 @@ TEST_F(VkLayerTest, InvalidCmdBufferImageDestroyed) {
     }
     // Destroy image dependency prior to submit to cause ERROR
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkImage");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
 
     VkSubmitInfo submit_info = {};
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -4342,7 +4341,6 @@ TEST_F(VkLayerTest, InvalidCmdBufferFramebufferImageDestroyed) {
     // Destroy image attached to framebuffer to invalidate cmd buffer
     // Now attempt to submit cmd buffer and verify error
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkImage");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
     m_commandBuffer->QueueCommandBuffer(false);
     m_errorMonitor->VerifyFound();
 
@@ -6987,7 +6985,6 @@ TEST_F(VkLayerTest, VertexBufferInvalid) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "CoreValidation-DrawState-InvalidCommandBuffer-VkBuffer");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
 
     {
         // Create and bind a vertex buffer in a reduced scope, which will cause it to be deleted upon leaving this scope

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -3774,9 +3774,8 @@ TEST_F(VkLayerTest, WriteDescriptorSetConsecutiveUpdates) {
         vk::CmdEndRenderPass(m_commandBuffer->handle());
         m_commandBuffer->end();
     }
-    // buffer2 just went out of scope and was destroyed along with its memory
+    // buffer2 just went out of scope and was destroyed
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkBuffer");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
 
     VkSubmitInfo submit_info = {};
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -3964,10 +3963,8 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
-    // Invalid VkBuffe
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffe");
-    // Invalid VkDeviceMemory
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " that is invalid because bound ");
+    // Invalid VkBuffer
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkBuffer");
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Replace the flat command buffer <-> every vulkan object tracking
structures with a tree-like implementation. Now, every vulkan object
is linked directly to the object(s) using it. For example, with the old
implementation, if a descriptor set uses 65k image descriptors,
any command buffer using it would have to maintain links to all 65k
image views. In the new implementation, the descriptor set maintains
65k links and the command buffer only has to track the descriptor set.
This saves many hash map insertions per draw call.

Additionally, the tree structure allows the removal of the in_use
refcounting from all vulkan objects except those directly used by
the queue submit functions. This saves many atomic increments per
submit. Instead, when checking if a non-refcounted object is in use,
the code looks up the tree to see if any owning command buffers are in
use. This operation happens far less frequently than the old reference
counting happened.
