### PR TITLE
Add a shader validation cache to shader validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2546,7 +2546,7 @@ void CoreChecks::PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDevice
         });
 
     // Allocate shader validation cache
-    if (!core_checks->core_validation_cache) {
+    if (!disabled[shader_validation_caching] && !core_checks->core_validation_cache) {
         std::string validation_cache_path;
         auto tmp_path = GetEnvironment("TMPDIR");
         if (!tmp_path.size()) tmp_path = GetEnvironment("TMP");

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -119,6 +119,8 @@ class CoreChecks : public ValidationStateTracker {
     GlobalQFOTransferBarrierMap<QFOImageTransferBarrier> qfo_release_image_barrier_map;
     GlobalQFOTransferBarrierMap<QFOBufferTransferBarrier> qfo_release_buffer_barrier_map;
     GlobalImageLayoutMap imageLayoutMap;
+    VkValidationCacheEXT core_validation_cache = VK_NULL_HANDLE;
+    std::string validation_cache_path;
 
     CoreChecks() { container_type = LayerObjectTypeCoreValidation; }
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3140,6 +3140,7 @@ typedef enum DisableFlags {
     stateless_checks,
     handle_wrapping,
     shader_validation,
+    shader_validation_caching,
     // Insert new disables above this line
     kMaxDisableFlags,
 } DisableFlags;

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -370,6 +370,12 @@
                             "label": "Idle Descritor Set",
                             "description": "",
                             "view": "ADVANCED"
+                        },
+                        {
+                            "key": "VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT",
+                            "label": "Shader Validation Caching",
+                            "description": "Disable caching of shader validation results",
+                            "view": "ADVANCED"
                         }
                     ],
                     "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -67,6 +67,9 @@ void SetValidationFeatureDisable(CHECK_DISABLED &disable_data, const VkValidatio
         case VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT:
             disable_data[handle_wrapping] = true;
             break;
+        case VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT:
+            disable_data[shader_validation_caching] = true;
+            break;
         case VK_VALIDATION_FEATURE_DISABLE_ALL_EXT:
             // Set all disabled flags to true
             std::fill(disable_data.begin(), disable_data.end(), true);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -40,6 +40,7 @@ static const layer_data::unordered_map<std::string, VkValidationFeatureDisableEX
     {"VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT", VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT},
     {"VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT", VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT},
     {"VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT", VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT},
+    {"VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT", VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT},
     {"VK_VALIDATION_FEATURE_DISABLE_ALL_EXT", VK_VALIDATION_FEATURE_DISABLE_ALL_EXT},
 };
 
@@ -72,18 +73,19 @@ static const layer_data::unordered_map<std::string, ValidationCheckEnables> Vali
 
 // This should mirror the 'DisableFlags' enumerated type
 static const std::vector<std::string> DisableFlagNameHelper = {
-    "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",       // command_buffer_state,
-    "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",              // object_in_use,
-    "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",        // idle_descriptor_set,
-    "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",        // push_constant_range,
-    "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",           // query_validation,
-    "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",    // image_layout_validation,
-    "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",  // object_tracking,
-    "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",       // core_checks,
-    "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",     // thread_safety,
-    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",    // stateless_checks,
-    "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",    // handle_wrapping,
-    "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT"            // shader_validation,
+    "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",               // command_buffer_state,
+    "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                      // object_in_use,
+    "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",                // idle_descriptor_set,
+    "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",                // push_constant_range,
+    "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",                   // query_validation,
+    "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",            // image_layout_validation,
+    "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",          // object_tracking,
+    "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",               // core_checks,
+    "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",             // thread_safety,
+    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",            // stateless_checks,
+    "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",            // handle_wrapping,
+    "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",                   // shader_validation,
+    "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT"  // shader_validation_caching
 };
 
 // This should mirror the 'EnableFlags' enumerated type

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2352,6 +2352,8 @@ bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShad
     } else {
         auto cache = GetValidationCacheInfo(pCreateInfo);
         uint32_t hash = 0;
+        // If app isn't using a shader validation cache, use the default one from CoreChecks
+        if (!cache) cache = CastFromHandle<ValidationCache *>(core_validation_cache);
         if (cache) {
             hash = ValidationCache::MakeShaderHash(pCreateInfo);
             if (cache->Contains(hash)) return false;

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -330,6 +330,7 @@ typedef enum DisableFlags {
     stateless_checks,
     handle_wrapping,
     shader_validation,
+    shader_validation_caching,
     // Insert new disables above this line
     kMaxDisableFlags,
 } DisableFlags;


### PR DESCRIPTION
Skips shader validation if the shader has already been validated and is in the validation cache.

The disable of this feature is a little messy.  I wanted it to be consistent with other disables, but didn't see a need to get it put into the spec.  If others find it too messy, I can start the process of adding it to the spec.