### PR TITLE
layers: VK_EXT_vertex_input fixes

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1004,6 +1004,10 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     skip |= ValidateStatus(pCB, CBSTATUS_LOGIC_OP_SET, "Dynamic state logicOp not set for this command buffer", vuid.logic_op);
     skip |= ValidateStatus(pCB, CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET,
                            "Dynamic primitive restart enable not set for this command buffer", vuid.primitive_restart_enable);
+    skip |= ValidateStatus(pCB, CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET,
+                           "Dynamic vertex input binding stride not set for this command buffer", vuid.vertex_input_binding_stride);
+    skip |=
+        ValidateStatus(pCB, CBSTATUS_VERTEX_INPUT_SET, "Dynamic vertex input not set for this command buffer", vuid.vertex_input);
 
     // VUID {refpage}-primitiveTopology-03420
     skip |= ValidateStatus(pCB, CBSTATUS_PRIMITIVE_TOPOLOGY_SET, "Dynamic primitive topology state not set for this command buffer",

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -78,6 +78,8 @@ struct DrawDispatchVuid {
     const char* depth_bias_enable = kVUIDUndefined;
     const char* logic_op = kVUIDUndefined;
     const char* primitive_restart_enable = kVUIDUndefined;
+    const char* vertex_input_binding_stride = kVUIDUndefined;
+    const char* vertex_input = kVUIDUndefined;
 };
 
 struct ValidateBeginQueryVuids {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -719,7 +719,8 @@ enum CBStatusFlagBits : uint64_t {
     CBSTATUS_DEPTH_BIAS_ENABLE_SET           = 0x80000000,
     CBSTATUS_LOGIC_OP_SET                    = 0x100000000,
     CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET    = 0x200000000,
-    CBSTATUS_ALL_STATE_SET                   = 0x3FFFFFDFF,   // All state set (intentionally exclude index buffer)
+    CBSTATUS_VERTEX_INPUT_SET                = 0x400000000,
+    CBSTATUS_ALL_STATE_SET                   = 0x7FFFFFDFF,   // All state set (intentionally exclude index buffer)
     // clang-format on
 };
 

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -83,6 +83,8 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
         logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
         primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDraw-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDraw-undefined";
     }
 };
 
@@ -121,11 +123,13 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndexed-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexed-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexed-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndexed-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndexed-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndexed-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndexed-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndexed-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndexed-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndexed-undefined";
     }
 };
 
@@ -166,11 +170,13 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndirect-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirect-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirect-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndirect-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndirect-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndirect-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndirect-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndirect-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndirect-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndirect-undefined";
     }
 };
 
@@ -211,11 +217,13 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndexedIndirect-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexedIndirect-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexedIndirect-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndexedIndirect-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndexedIndirect-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndexedIndirect-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndexedIndirect-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndexedIndirect-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirect-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndexedIndirect-undefined";
     }
 };
 
@@ -304,11 +312,13 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndirectCount-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirectCount-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirectCount-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndirectCount-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndirectCount-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndirectCount-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndirectCount-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndirectCount-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectCount-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndirectCount-undefined";
     }
 };
 
@@ -349,11 +359,13 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndexedIndirectCount-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndexedIndirectCount-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndexedIndirectCount-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndexedIndirectCount-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndexedIndirectCount-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndexedIndirectCount-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndexedIndirectCount-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndexedIndirectCount-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirectCount-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndexedIndirectCount-undefined";
     }
 };
 
@@ -459,11 +471,13 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawMeshTasksNV-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawMeshTasksNV-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksNV-None-04877";
+        logic_op                           = "VUID-vkCmdDrawMeshTasksNV-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksNV-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksNV-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawMeshTasksNV-undefined";
     }
 };
 
@@ -501,11 +515,13 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksIndirectNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksIndirectNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04877";
+        logic_op                           = "VUID-vkCmdDrawMeshTasksIndirectNV-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksIndirectNV-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawMeshTasksIndirectNV-undefined";
     }
 };
 
@@ -543,11 +559,13 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawMeshTasksIndirectCountNV-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMeshTasksIndirectCountNV-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04877";
+        logic_op                           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksIndirectCountNV-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-undefined";
     }
 };
 
@@ -588,11 +606,13 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         filter_cubic                       = "VUID-vkCmdDrawIndirectByteCountEXT-filterCubic-02694";
         filter_cubic_min_max               = "VUID-vkCmdDrawIndirectByteCountEXT-filterCubicMinmax-02695";
         viewport_count_primitive_shading_rate = "VUID-vkCmdDrawIndirectByteCountEXT-primitiveFragmentShadingRateWithMultipleViewports-04552";
-        patch_control_points               = "VUID-vkCmdDraw-None-04875";
-        rasterizer_discard_enable          = "VUID-vkCmdDraw-None-04876";
-        depth_bias_enable                  = "VUID-vkCmdDraw-None-04877";
-        logic_op                           = "VUID-vkCmdDraw-logicOp-04878";
-        primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
+        patch_control_points               = "VUID-vkCmdDrawIndirectByteCountEXT-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawIndirectByteCountEXT-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawIndirectByteCountEXT-None-04877";
+        logic_op                           = "VUID-vkCmdDrawIndirectByteCountEXT-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawIndirectByteCountEXT-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectByteCountEXT-pStrides-04884";
+        vertex_input                       = "VUID-vkCmdDrawIndirectByteCountEXT-undefined";
     }
 };
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2026,7 +2026,8 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
         skip |= ValidateViConsistency(vi);
     }
 
-    if (shaders[vertex_stage] && shaders[vertex_stage]->has_valid_spirv) {
+    if (shaders[vertex_stage] && shaders[vertex_stage]->has_valid_spirv &&
+        !IsDynamic(pipeline, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
         skip |= ValidateViAgainstVsInputs(vi, shaders[vertex_stage], entrypoints[vertex_stage]);
     }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -119,6 +119,8 @@ VkDynamicState ConvertToDynamicState(CBStatusFlagBits flag) {
             return VK_DYNAMIC_STATE_LOGIC_OP_EXT;
         case CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET:
             return VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT;
+        case CBSTATUS_VERTEX_INPUT_SET:
+            return VK_DYNAMIC_STATE_VERTEX_INPUT_EXT;
         default:
             // CBSTATUS_INDEX_BUFFER_BOUND is not in VkDynamicState
             return VK_DYNAMIC_STATE_MAX_ENUM;
@@ -194,6 +196,8 @@ CBStatusFlagBits ConvertToCBStatusFlagBits(VkDynamicState state) {
             return CBSTATUS_LOGIC_OP_SET;
         case VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT:
             return CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET;
+        case VK_DYNAMIC_STATE_VERTEX_INPUT_EXT:
+            return CBSTATUS_VERTEX_INPUT_SET;
         default:
             return CBSTATUS_NONE;
     }
@@ -6624,4 +6628,13 @@ void ValidationStateTracker::PreCallRecordCmdSetPrimitiveRestartEnableEXT(VkComm
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     cb_state->status |= CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET;
     cb_state->static_status &= ~CBSTATUS_PRIMITIVE_RESTART_ENABLE_SET;
+}
+
+void ValidationStateTracker::PreCallRecordCmdSetVertexInputEXT(
+    VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
+    const VkVertexInputBindingDescription2EXT *pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
+    const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions) {
+    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    cb_state->status |= CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET | CBSTATUS_VERTEX_INPUT_SET;
+    cb_state->static_status &= ~(CBSTATUS_VERTEX_INPUT_BINDING_STRIDE_SET | CBSTATUS_VERTEX_INPUT_SET);
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1215,6 +1215,10 @@ class ValidationStateTracker : public ValidationObject {
                                                                    uint32_t firstQuery) override;
     void PreCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                                const VkViewportWScalingNV* pViewportWScalings) override;
+    void PreCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
+                                           const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions,
+                                           uint32_t vertexAttributeDescriptionCount,
+                                           const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) override;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     void PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                  VkAndroidHardwareBufferPropertiesANDROID* pProperties,


### PR DESCRIPTION
Validation fixes for VK_EXT_vertex_input:
- Add draw-time validation to check that if the active pipeline has VK_DYNAMIC_STATE_VERTEX_INPUT_EXT enabled then vkCmdSetVertexInputEXT() must have been called (pending spec change https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4585)
- Add draw-time validation to check that if the active pipeline has VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT enabled then vkCmdBindVertexBuffers2EXT() or vkCmdSetVertexInputEXT() must have been called
- Ignore the graphics pipeline pVertexInput state if VK_DYNAMIC_STATE_VERTEX_INPUT_EXT is enabled for SPIR-V vertex shader input checking