### PR TITLE
tests: Fix cleanup in VkPositiveLayerTest.CopyImageSubresource

### DIFF
--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -12527,6 +12527,7 @@ TEST_F(VkPositiveLayerTest, CopyImageSubresource) {
 
     m_errorMonitor->ExpectSuccess();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(m_device->m_queue);
     m_errorMonitor->VerifyNotFound();
 }
 


### PR DESCRIPTION
This test does a vk::QueueSubmit(), so it needs to vk::QueueWaitIdle()
to make sure the driver is in a good state for the next test.