### PR TITLE
layers: Avoid destroying BINDABLE multiple times

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -367,7 +367,11 @@ class BINDABLE : public BASE_NODE {
           unprotected(true),
           bound_memory_set_{} {};
 
-    virtual ~BINDABLE() { Destroy(); }
+    virtual ~BINDABLE() {
+        if (!Destroyed()) {
+            Destroy();
+        }
+    }
 
     void Destroy() override;
 


### PR DESCRIPTION
This works around CFI error for accessing destroyed parts
of IMAGE_STATE from BINDABLE destructor.

Fixes #2825