### PR TITLE
layers: Use range based iteraton for subresource layout checking

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -509,154 +509,157 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
         attachments = attachment_info->pAttachments;
     }
 
-    if (attachments != nullptr) {
-        const auto *const_p_cb = static_cast<const CMD_BUFFER_STATE *>(pCB);
-        for (uint32_t i = 0; i < render_pass_info->attachmentCount && i < framebuffer_info.attachmentCount; ++i) {
-            auto image_view = attachments[i];
-            auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
+    if (attachments == nullptr) {
+        return skip;
+    }
+    const auto *const_p_cb = static_cast<const CMD_BUFFER_STATE *>(pCB);
+    for (uint32_t i = 0; i < render_pass_info->attachmentCount && i < framebuffer_info.attachmentCount; ++i) {
+        auto image_view = attachments[i];
+        auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
 
-            if (!view_state) {
-                LogObjectList objlist(pRenderPassBegin->renderPass);
-                objlist.add(framebuffer_state->framebuffer());
-                objlist.add(image_view);
-                skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                                 "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
-                                 report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
-                                 report_data->FormatHandle(image_view).c_str());
-                continue;
-            }
-
-            const VkImage image = view_state->create_info.image;
-            const auto *image_state = view_state->image_state.get();
-
-            if (!image_state) {
-                LogObjectList objlist(pRenderPassBegin->renderPass);
-                objlist.add(framebuffer_state->framebuffer());
-                objlist.add(image_view);
-                objlist.add(image);
-                skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                                 "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
-                                 report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
-                                 report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
-                continue;
-            }
-            auto attachment_initial_layout = render_pass_info->pAttachments[i].initialLayout;
-            auto final_layout = render_pass_info->pAttachments[i].finalLayout;
-
-            // Default to expecting stencil in the same layout.
-            auto attachment_stencil_initial_layout = attachment_initial_layout;
-
-            // If a separate layout is specified, look for that.
-            const auto *attachment_description_stencil_layout =
-                LvlFindInChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
-            if (attachment_description_stencil_layout) {
-                attachment_stencil_initial_layout = attachment_description_stencil_layout->stencilInitialLayout;
-            }
-
-            const ImageSubresourceLayoutMap *subresource_map = nullptr;
-            bool has_queried_map = false;
-            bool subres_skip = false;
-
-            for (uint32_t aspect_index = 0; aspect_index < 32; aspect_index++) {
-                VkImageAspectFlags test_aspect = 1u << aspect_index;
-                if ((view_state->normalized_subresource_range.aspectMask & test_aspect) == 0) {
-                    continue;
-                }
-
-                // Allow for differing depth and stencil layouts
-                VkImageLayout check_layout = attachment_initial_layout;
-                if (test_aspect == VK_IMAGE_ASPECT_STENCIL_BIT) {
-                    check_layout = attachment_stencil_initial_layout;
-                }
-
-                if (check_layout != VK_IMAGE_LAYOUT_UNDEFINED) {  // If no layout information for image yet, will be checked at QueueSubmit time
-                    if (!has_queried_map) {
-                        // Cast pCB to const because we don't want to create entries that don't exist here (in case the key changes to something
-                        // in common with the non-const version.)
-                        // The lookup is expensive, so cache it.
-                        subresource_map = const_p_cb->GetImageSubresourceLayoutMap(*image_state);
-                        has_queried_map = true;
-                    }
-
-                    if (subresource_map) {
-                        auto normalized_range = view_state->normalized_subresource_range;
-                        normalized_range.aspectMask = test_aspect;
-                        auto pos = subresource_map->Find(normalized_range);
-                        LayoutUseCheckAndMessage layout_check(subresource_map, test_aspect);
-
-                        // IncrementInterval skips over all the subresources that have the same state as we just checked, incrementing to the next "constant value" range
-                        for (; !(pos.AtEnd()) && !subres_skip; pos.IncrementInterval()) {
-                            const VkImageSubresource &subres = pos->subresource;
-
-                            if (!layout_check.Check(subres, check_layout, pos->current_layout, pos->initial_layout)) {
-                                subres_skip |= LogError(
-                                    device, kVUID_Core_DrawState_InvalidRenderpass,
-                                    "You cannot start a render pass using attachment %u where the render pass initial layout is %s "
-                                    "and the %s layout of the attachment is %s. The layouts must match, or the render "
-                                    "pass initial layout for the attachment must be VK_IMAGE_LAYOUT_UNDEFINED",
-                                    i, string_VkImageLayout(check_layout), layout_check.message,
-                                    string_VkImageLayout(layout_check.layout));
-                            }
-                        }
-                    }
-                }
-            }
-
-            skip |= subres_skip;
-
-            ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_initial_layout, *view_state, framebuffer,
-                                                                 render_pass, i, "initial layout");
-
-            ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, final_layout, *view_state, framebuffer, render_pass, i,
-                                                                 "final layout");
+        if (!view_state) {
+            LogObjectList objlist(pRenderPassBegin->renderPass);
+            objlist.add(framebuffer_state->framebuffer());
+            objlist.add(image_view);
+            skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                             "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] = %s is not a valid VkImageView handle",
+                             report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
+                             report_data->FormatHandle(image_view).c_str());
+            continue;
         }
 
-        for (uint32_t j = 0; j < render_pass_info->subpassCount; ++j) {
-            auto &subpass = render_pass_info->pSubpasses[j];
-            for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].inputAttachmentCount; ++k) {
-                auto &attachment_ref = subpass.pInputAttachments[k];
-                if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                    auto image_view = attachments[attachment_ref.attachment];
-                    auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
+        const VkImage image = view_state->create_info.image;
+        const auto *image_state = view_state->image_state.get();
 
-                    if (view_state) {
+        if (!image_state) {
+            LogObjectList objlist(pRenderPassBegin->renderPass);
+            objlist.add(framebuffer_state->framebuffer());
+            objlist.add(image_view);
+            objlist.add(image);
+            skip |= LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
+                             "vkCmdBeginRenderPass(): %s pAttachments[%" PRIu32 "] =  %s references non-extant %s.",
+                             report_data->FormatHandle(framebuffer_state->framebuffer()).c_str(), i,
+                             report_data->FormatHandle(image_view).c_str(), report_data->FormatHandle(image).c_str());
+            continue;
+        }
+        auto attachment_initial_layout = render_pass_info->pAttachments[i].initialLayout;
+        auto final_layout = render_pass_info->pAttachments[i].finalLayout;
+
+        // Default to expecting stencil in the same layout.
+        auto attachment_stencil_initial_layout = attachment_initial_layout;
+
+        // If a separate layout is specified, look for that.
+        const auto *attachment_description_stencil_layout =
+            LvlFindInChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
+        if (attachment_description_stencil_layout) {
+            attachment_stencil_initial_layout = attachment_description_stencil_layout->stencilInitialLayout;
+        }
+
+        const ImageSubresourceLayoutMap *subresource_map = nullptr;
+        bool has_queried_map = false;
+        bool subres_skip = false;
+
+        for (uint32_t aspect_index = 0; aspect_index < 32; aspect_index++) {
+            VkImageAspectFlags test_aspect = 1u << aspect_index;
+            if ((view_state->normalized_subresource_range.aspectMask & test_aspect) == 0) {
+                continue;
+            }
+
+            // Allow for differing depth and stencil layouts
+            VkImageLayout check_layout = attachment_initial_layout;
+            if (test_aspect == VK_IMAGE_ASPECT_STENCIL_BIT) {
+                check_layout = attachment_stencil_initial_layout;
+            }
+
+            // If no layout information for image yet, will be checked at QueueSubmit time
+            if (check_layout == VK_IMAGE_LAYOUT_UNDEFINED) {
+                continue;
+            }
+            if (!has_queried_map) {
+                // Cast pCB to const because we don't want to create entries that don't exist here (in case the key changes to
+                // something in common with the non-const version.) The lookup is expensive, so cache it.
+                subresource_map = const_p_cb->GetImageSubresourceLayoutMap(*image_state);
+                has_queried_map = true;
+            }
+
+            if (!subresource_map) {
+                continue;
+            }
+            auto normalized_range = view_state->normalized_subresource_range;
+            normalized_range.aspectMask = test_aspect;
+            auto pos = subresource_map->Find(normalized_range);
+            LayoutUseCheckAndMessage layout_check(subresource_map, test_aspect);
+
+            // IncrementInterval skips over all the subresources that have the same state as we just checked, incrementing to the
+            // next "constant value" range
+            for (; !(pos.AtEnd()) && !subres_skip; pos.IncrementInterval()) {
+                const VkImageSubresource &subres = pos->subresource;
+
+                if (!layout_check.Check(subres, check_layout, pos->current_layout, pos->initial_layout)) {
+                    subres_skip |= LogError(
+                        device, kVUID_Core_DrawState_InvalidRenderpass,
+                        "You cannot start a render pass using attachment %u where the render pass initial layout is %s "
+                        "and the %s layout of the attachment is %s. The layouts must match, or the render "
+                        "pass initial layout for the attachment must be VK_IMAGE_LAYOUT_UNDEFINED",
+                        i, string_VkImageLayout(check_layout), layout_check.message, string_VkImageLayout(layout_check.layout));
+                }
+            }
+        }
+
+        skip |= subres_skip;
+
+        ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_initial_layout, *view_state, framebuffer,
+                                                             render_pass, i, "initial layout");
+
+        ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, final_layout, *view_state, framebuffer, render_pass, i,
+                                                             "final layout");
+    }
+
+    for (uint32_t j = 0; j < render_pass_info->subpassCount; ++j) {
+        auto &subpass = render_pass_info->pSubpasses[j];
+        for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].inputAttachmentCount; ++k) {
+            auto &attachment_ref = subpass.pInputAttachments[k];
+            if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
+                auto image_view = attachments[attachment_ref.attachment];
+                auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
+
+                if (view_state) {
+                    ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
+                                                                         framebuffer, render_pass, attachment_ref.attachment,
+                                                                         "input attachment layout");
+                }
+            }
+        }
+
+        for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].colorAttachmentCount; ++k) {
+            auto &attachment_ref = subpass.pColorAttachments[k];
+            if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
+                auto image_view = attachments[attachment_ref.attachment];
+                auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
+
+                if (view_state) {
+                    ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
+                                                                         framebuffer, render_pass, attachment_ref.attachment,
+                                                                         "color attachment layout");
+                    if (subpass.pResolveAttachments) {
                         ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
                                                                              framebuffer, render_pass, attachment_ref.attachment,
-                                                                             "input attachment layout");
+                                                                             "resolve attachment layout");
                     }
                 }
             }
+        }
 
-            for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].colorAttachmentCount; ++k) {
-                auto &attachment_ref = subpass.pColorAttachments[k];
-                if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                    auto image_view = attachments[attachment_ref.attachment];
-                    auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
+        if (render_pass_info->pSubpasses[j].pDepthStencilAttachment) {
+            auto &attachment_ref = *subpass.pDepthStencilAttachment;
+            if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
+                auto image_view = attachments[attachment_ref.attachment];
+                auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
 
-                    if (view_state) {
-                        ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
-                                                                             framebuffer, render_pass, attachment_ref.attachment,
-                                                                             "color attachment layout");
-                        if (subpass.pResolveAttachments) {
-                            ValidateRenderPassLayoutAgainstFramebufferImageUsage(
-                                rp_version, attachment_ref.layout, *view_state, framebuffer, render_pass, attachment_ref.attachment,
-                                "resolve attachment layout");
-                        }
-                    }
-                }
-            }
-
-            if (render_pass_info->pSubpasses[j].pDepthStencilAttachment) {
-                auto &attachment_ref = *subpass.pDepthStencilAttachment;
-                if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                    auto image_view = attachments[attachment_ref.attachment];
-                    auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
-
-                    if (view_state) {
-                        ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
-                                                                             framebuffer, render_pass, attachment_ref.attachment,
-                                                                             "input attachment layout");
-                    }
+                if (view_state) {
+                    ValidateRenderPassLayoutAgainstFramebufferImageUsage(rp_version, attachment_ref.layout, *view_state,
+                                                                         framebuffer, render_pass, attachment_ref.attachment,
+                                                                         "input attachment layout");
                 }
             }
         }
@@ -821,139 +824,138 @@ bool CoreChecks::ValidateBarriersToImages(const Location &outer_loc, const CMD_B
         const auto &img_barrier = pImageMemoryBarriers[i];
 
         auto image_state = Get<IMAGE_STATE>(img_barrier.image);
-        if (image_state) {
-            VkImageUsageFlags usage_flags = image_state->createInfo.usage;
-            skip |=
-                ValidateBarrierLayoutToImageUsage(loc.dot(Field::oldLayout), img_barrier.image, img_barrier.oldLayout, usage_flags);
-            skip |=
-                ValidateBarrierLayoutToImageUsage(loc.dot(Field::newLayout), img_barrier.image, img_barrier.newLayout, usage_flags);
+        if (!image_state) {
+            continue;
+        }
+        VkImageUsageFlags usage_flags = image_state->createInfo.usage;
+        skip |= ValidateBarrierLayoutToImageUsage(loc.dot(Field::oldLayout), img_barrier.image, img_barrier.oldLayout, usage_flags);
+        skip |= ValidateBarrierLayoutToImageUsage(loc.dot(Field::newLayout), img_barrier.image, img_barrier.newLayout, usage_flags);
 
-            // Make sure layout is able to be transitioned, currently only presented shared presentable images are locked
-            if (image_state->layout_locked) {
-                // TODO: Add unique id for error when available
-                skip |= LogError(
-                    img_barrier.image, "VUID-Undefined",
-                    "%s Attempting to transition shared presentable %s"
-                    " from layout %s to layout %s, but image has already been presented and cannot have its layout transitioned.",
-                    loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                    string_VkImageLayout(img_barrier.oldLayout), string_VkImageLayout(img_barrier.newLayout));
-            }
+        // Make sure layout is able to be transitioned, currently only presented shared presentable images are locked
+        if (image_state->layout_locked) {
+            // TODO: Add unique id for error when available
+            skip |= LogError(
+                img_barrier.image, "VUID-Undefined",
+                "%s Attempting to transition shared presentable %s"
+                " from layout %s to layout %s, but image has already been presented and cannot have its layout transitioned.",
+                loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                string_VkImageLayout(img_barrier.oldLayout), string_VkImageLayout(img_barrier.newLayout));
+        }
 
-            const VkImageCreateInfo &image_create_info = image_state->createInfo;
-            const VkFormat image_format = image_create_info.format;
-            const VkImageAspectFlags aspect_mask = img_barrier.subresourceRange.aspectMask;
-            // For a Depth/Stencil image both aspects MUST be set
-            auto image_loc = loc.dot(Field::image);
-            if (FormatIsDepthAndStencil(image_format)) {
-                if (enabled_features.core12.separateDepthStencilLayouts) {
-                    if (!(aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-                        auto vuid = GetImageBarrierVUID(loc, ImageError::kNotDepthOrStencilAspect);
-                        skip |= LogError(img_barrier.image, vuid,
-                                         "%s references %s of format %s that must have either the depth or stencil "
-                                         "aspects set, but its aspectMask is 0x%" PRIx32 ".",
-                                         image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                         string_VkFormat(image_format), aspect_mask);
-                    }
-                } else {
-                    auto const ds_mask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-                    if ((aspect_mask & ds_mask) != (ds_mask)) {
-                        auto error = IsExtEnabled(device_extensions.vk_khr_separate_depth_stencil_layouts)
-                                         ? ImageError::kNotSeparateDepthAndStencilAspect
-                                         : ImageError::kNotDepthAndStencilAspect;
-                        auto vuid = GetImageBarrierVUID(image_loc, error);
-                        skip |= LogError(img_barrier.image, vuid,
-                                         "%s references %s of format %s that must have the depth and stencil "
-                                         "aspects set, but its aspectMask is 0x%" PRIx32 ".",
-                                         image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                         string_VkFormat(image_format), aspect_mask);
-                    }
-                }
-            }
-
-            if (img_barrier.oldLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
-                // TODO: Set memory invalid which is in mem_tracker currently
-            } else if (!QueueFamilyIsExternal(img_barrier.srcQueueFamilyIndex)) {
-                auto &write_subresource_map = layout_updates[image_state.get()];
-                bool new_write = false;
-                if (!write_subresource_map) {
-                    write_subresource_map = std::make_shared<ImageSubresourceLayoutMap>(*image_state);
-                    new_write = true;
-                }
-                const auto &current_subresource_map = current_map.find(image_state.get());
-                const auto &read_subresource_map = (new_write && current_subresource_map != current_map.end())
-                                                       ? (*current_subresource_map).second
-                                                       : write_subresource_map;
-
-                bool subres_skip = false;
-                // Validate aspects in isolation.
-                // This is required when handling separate depth-stencil layouts.
-                for (uint32_t aspect_index = 0; aspect_index < 32; aspect_index++) {
-                    VkImageAspectFlags test_aspect = 1u << aspect_index;
-                    if ((img_barrier.subresourceRange.aspectMask & test_aspect) == 0) {
-                        continue;
-                    }
-
-                    LayoutUseCheckAndMessage layout_check(read_subresource_map.get(), test_aspect);
-                    auto normalized_isr = image_state->NormalizeSubresourceRange(img_barrier.subresourceRange);
-                    normalized_isr.aspectMask = test_aspect;
-                    // IncrementInterval skips over all the subresources that have the same state as we just checked, incrementing to the next "constant value" range
-                    for (auto pos = read_subresource_map->Find(normalized_isr); !(pos.AtEnd()) && !subres_skip;
-                         pos.IncrementInterval()) {
-                        const auto &value = *pos;
-                        auto old_layout = NormalizeSynchronization2Layout(test_aspect, img_barrier.oldLayout);
-                        if (!layout_check.Check(value.subresource, old_layout, value.current_layout, value.initial_layout)) {
-                            const auto &vuid = GetImageBarrierVUID(loc, ImageError::kConflictingLayout);
-                            subres_skip =
-                                LogError(cb_state->commandBuffer(), vuid,
-                                         "%s %s cannot transition the layout of aspect=%d level=%d layer=%d from %s when the "
-                                         "%s layout is %s.",
-                                         loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                         value.subresource.aspectMask, value.subresource.mipLevel, value.subresource.arrayLayer,
-                                         string_VkImageLayout(img_barrier.oldLayout), layout_check.message,
-                                         string_VkImageLayout(layout_check.layout));
-                        }
-                    }
-                    write_subresource_map->SetSubresourceRangeLayout(*cb_state, normalized_isr, img_barrier.newLayout);
-                }
-                skip |= subres_skip;
-            }
-
-            // checks color format and (single-plane or non-disjoint)
-            // if ycbcr extension is not supported then single-plane and non-disjoint are always both true
-            if ((FormatIsColor(image_format) == true) &&
-                ((FormatIsMultiplane(image_format) == false) || (image_state->disjoint == false))) {
-                if (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) {
-                    auto error = IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion) ? ImageError::kNotColorAspect
-                                                                                                 : ImageError::kNotColorAspectYcbcr;
-                    const auto &vuid = GetImageBarrierVUID(loc, error);
+        const VkImageCreateInfo &image_create_info = image_state->createInfo;
+        const VkFormat image_format = image_create_info.format;
+        const VkImageAspectFlags aspect_mask = img_barrier.subresourceRange.aspectMask;
+        // For a Depth/Stencil image both aspects MUST be set
+        auto image_loc = loc.dot(Field::image);
+        if (FormatIsDepthAndStencil(image_format)) {
+            if (enabled_features.core12.separateDepthStencilLayouts) {
+                if (!(aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
+                    auto vuid = GetImageBarrierVUID(loc, ImageError::kNotDepthOrStencilAspect);
                     skip |= LogError(img_barrier.image, vuid,
-                                     "%s references %s of format %s that must be only VK_IMAGE_ASPECT_COLOR_BIT, "
-                                     "but its aspectMask is 0x%" PRIx32 ".",
+                                     "%s references %s of format %s that must have either the depth or stencil "
+                                     "aspects set, but its aspectMask is 0x%" PRIx32 ".",
+                                     image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                                     string_VkFormat(image_format), aspect_mask);
+                }
+            } else {
+                auto const ds_mask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+                if ((aspect_mask & ds_mask) != (ds_mask)) {
+                    auto error = IsExtEnabled(device_extensions.vk_khr_separate_depth_stencil_layouts)
+                                     ? ImageError::kNotSeparateDepthAndStencilAspect
+                                     : ImageError::kNotDepthAndStencilAspect;
+                    auto vuid = GetImageBarrierVUID(image_loc, error);
+                    skip |= LogError(img_barrier.image, vuid,
+                                     "%s references %s of format %s that must have the depth and stencil "
+                                     "aspects set, but its aspectMask is 0x%" PRIx32 ".",
                                      image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
                                      string_VkFormat(image_format), aspect_mask);
                 }
             }
+        }
 
-            VkImageAspectFlags valid_disjoint_mask =
-                VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
-            if ((FormatIsMultiplane(image_format) == true) && (image_state->disjoint == true) &&
-                ((aspect_mask & valid_disjoint_mask) == 0)) {
-                const auto &vuid = GetImageBarrierVUID(image_loc, ImageError::kBadMultiplanarAspect);
+        if (img_barrier.oldLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
+            // TODO: Set memory invalid which is in mem_tracker currently
+        } else if (!QueueFamilyIsExternal(img_barrier.srcQueueFamilyIndex)) {
+            auto &write_subresource_map = layout_updates[image_state.get()];
+            bool new_write = false;
+            if (!write_subresource_map) {
+                write_subresource_map = std::make_shared<ImageSubresourceLayoutMap>(*image_state);
+                new_write = true;
+            }
+            const auto &current_subresource_map = current_map.find(image_state.get());
+            const auto &read_subresource_map = (new_write && current_subresource_map != current_map.end())
+                                                   ? (*current_subresource_map).second
+                                                   : write_subresource_map;
+
+            bool subres_skip = false;
+            // Validate aspects in isolation.
+            // This is required when handling separate depth-stencil layouts.
+            for (uint32_t aspect_index = 0; aspect_index < 32; aspect_index++) {
+                VkImageAspectFlags test_aspect = 1u << aspect_index;
+                if ((img_barrier.subresourceRange.aspectMask & test_aspect) == 0) {
+                    continue;
+                }
+
+                LayoutUseCheckAndMessage layout_check(read_subresource_map.get(), test_aspect);
+                auto normalized_isr = image_state->NormalizeSubresourceRange(img_barrier.subresourceRange);
+                normalized_isr.aspectMask = test_aspect;
+                // IncrementInterval skips over all the subresources that have the same state as we just checked, incrementing to
+                // the next "constant value" range
+                for (auto pos = read_subresource_map->Find(normalized_isr); !(pos.AtEnd()) && !subres_skip;
+                     pos.IncrementInterval()) {
+                    const auto &value = *pos;
+                    auto old_layout = NormalizeSynchronization2Layout(test_aspect, img_barrier.oldLayout);
+                    if (!layout_check.Check(value.subresource, old_layout, value.current_layout, value.initial_layout)) {
+                        const auto &vuid = GetImageBarrierVUID(loc, ImageError::kConflictingLayout);
+                        subres_skip = LogError(cb_state->commandBuffer(), vuid,
+                                               "%s %s cannot transition the layout of aspect=%d level=%d layer=%d from %s when the "
+                                               "%s layout is %s.",
+                                               loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                                               value.subresource.aspectMask, value.subresource.mipLevel,
+                                               value.subresource.arrayLayer, string_VkImageLayout(img_barrier.oldLayout),
+                                               layout_check.message, string_VkImageLayout(layout_check.layout));
+                    }
+                }
+                write_subresource_map->SetSubresourceRangeLayout(*cb_state, normalized_isr, img_barrier.newLayout);
+            }
+            skip |= subres_skip;
+        }
+
+        // checks color format and (single-plane or non-disjoint)
+        // if ycbcr extension is not supported then single-plane and non-disjoint are always both true
+        if ((FormatIsColor(image_format) == true) &&
+            ((FormatIsMultiplane(image_format) == false) || (image_state->disjoint == false))) {
+            if (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) {
+                auto error = IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion) ? ImageError::kNotColorAspect
+                                                                                             : ImageError::kNotColorAspectYcbcr;
+                const auto &vuid = GetImageBarrierVUID(loc, error);
                 skip |= LogError(img_barrier.image, vuid,
-                                 "%s references %s of format %s has aspectMask (0x%" PRIx32
-                                 ") but needs to include either an VK_IMAGE_ASPECT_PLANE_*_BIT or VK_IMAGE_ASPECT_COLOR_BIT.",
+                                 "%s references %s of format %s that must be only VK_IMAGE_ASPECT_COLOR_BIT, "
+                                 "but its aspectMask is 0x%" PRIx32 ".",
                                  image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
                                  string_VkFormat(image_format), aspect_mask);
             }
+        }
 
-            if ((FormatPlaneCount(image_format) == 2) && ((aspect_mask & VK_IMAGE_ASPECT_PLANE_2_BIT) != 0)) {
-                const auto &vuid = GetImageBarrierVUID(image_loc, ImageError::kBadPlaneCount);
-                skip |= LogError(img_barrier.image, vuid,
-                                 "%s references %s of format %s has only two planes but included "
-                                 "VK_IMAGE_ASPECT_PLANE_2_BIT in its aspectMask (0x%" PRIx32 ").",
-                                 image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
-                                 string_VkFormat(image_format), aspect_mask);
-            }
+        VkImageAspectFlags valid_disjoint_mask =
+            VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
+        if ((FormatIsMultiplane(image_format) == true) && (image_state->disjoint == true) &&
+            ((aspect_mask & valid_disjoint_mask) == 0)) {
+            const auto &vuid = GetImageBarrierVUID(image_loc, ImageError::kBadMultiplanarAspect);
+            skip |= LogError(img_barrier.image, vuid,
+                             "%s references %s of format %s has aspectMask (0x%" PRIx32
+                             ") but needs to include either an VK_IMAGE_ASPECT_PLANE_*_BIT or VK_IMAGE_ASPECT_COLOR_BIT.",
+                             image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                             string_VkFormat(image_format), aspect_mask);
+        }
+
+        if ((FormatPlaneCount(image_format) == 2) && ((aspect_mask & VK_IMAGE_ASPECT_PLANE_2_BIT) != 0)) {
+            const auto &vuid = GetImageBarrierVUID(image_loc, ImageError::kBadPlaneCount);
+            skip |= LogError(img_barrier.image, vuid,
+                             "%s references %s of format %s has only two planes but included "
+                             "VK_IMAGE_ASPECT_PLANE_2_BIT in its aspectMask (0x%" PRIx32 ").",
+                             image_loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),
+                             string_VkFormat(image_format), aspect_mask);
         }
     }
     return skip;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -695,6 +695,10 @@ class CoreChecks : public ValidationStateTracker {
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,
                            bool* error) const;
 
+    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state,
+                           const IMAGE_VIEW_STATE* image_view_state, VkImageLayout explicit_layout, const char* caller,
+                           const char* layout_mismatch_msg_code, bool *error) const;
+
     bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
                            const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error) const {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -690,6 +690,11 @@ class CoreChecks : public ValidationStateTracker {
     bool VerifyClearImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state,
                                 const VkImageSubresourceRange& range, VkImageLayout dest_image_layout, const char* func_name) const;
 
+    template <typename RangeFactory>
+    bool VerifyImageLayoutRange(const CMD_BUFFER_STATE& cb_node, const IMAGE_STATE& image_state, VkImageAspectFlags aspect_mask,
+                                VkImageLayout explicit_layout, const RangeFactory& range_factory, const char* caller,
+                                const char* layout_mismatch_msg_code, bool* error) const;
+
     bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                            VkImageAspectFlags view_aspect, VkImageLayout explicit_layout, VkImageLayout optimal_layout,
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -695,9 +695,8 @@ class CoreChecks : public ValidationStateTracker {
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,
                            bool* error) const;
 
-    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state,
-                           const IMAGE_VIEW_STATE* image_view_state, VkImageLayout explicit_layout, const char* caller,
-                           const char* layout_mismatch_msg_code, bool *error) const;
+    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE* image_view_state, VkImageLayout explicit_layout,
+                           const char* caller, const char* layout_mismatch_msg_code, bool* error) const;
 
     bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -952,8 +952,8 @@ bool CoreChecks::ValidateImageDescriptor(
             }
             if (!already_validated) {
                 bool hit_error = false;
-                VerifyImageLayout(cb_node, image_state, image_view_state, image_layout, caller,
-                                  "VUID-VkDescriptorImageInfo-imageLayout-00344", &hit_error);
+                VerifyImageLayout(cb_node, image_view_state, image_layout, caller, "VUID-VkDescriptorImageInfo-imageLayout-00344",
+                                  &hit_error);
                 if (hit_error) {
                     auto set = descriptor_set->GetSet();
                     return LogError(set, vuids.descriptor_valid,

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -952,9 +952,8 @@ bool CoreChecks::ValidateImageDescriptor(
             }
             if (!already_validated) {
                 bool hit_error = false;
-                VerifyImageLayout(cb_node, image_state, image_view_state->normalized_subresource_range,
-                                  image_view_ci.subresourceRange.aspectMask, image_layout, VK_IMAGE_LAYOUT_UNDEFINED, caller,
-                                  kVUIDUndefined, "VUID-VkDescriptorImageInfo-imageLayout-00344", &hit_error);
+                VerifyImageLayout(cb_node, image_state, image_view_state, image_layout, caller,
+                                  "VUID-VkDescriptorImageInfo-imageLayout-00344", &hit_error);
                 if (hit_error) {
                     auto set = descriptor_set->GetSet();
                     return LogError(set, vuids.descriptor_valid,

--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -192,33 +192,4 @@ bool ImageSubresourceLayoutMap::UpdateFrom(const ImageSubresourceLayoutMap& othe
     return sparse_container::splice(layouts_, other.layouts_, LayoutEntry::Updater());
 }
 
-bool ImageSubresourceLayoutMap::AnyInRange(const VkImageSubresourceRange& normalized_range,
-                                           std::function<bool(const VkImageSubresource&, const LayoutEntry&)> func) const {
-    if (!encoder_.InRange(normalized_range)) {
-        return false;
-    }
-    for (auto range_gen = RangeGenerator(encoder_, normalized_range); range_gen->non_empty(); ++range_gen) {
-        for (auto pos = layouts_.lower_bound(*range_gen); (pos != layouts_.end()) && (range_gen->intersects(pos->first)); ++pos) {
-            auto subres = encoder_.Decode(pos->first.begin);
-            if (func(subres, pos->second)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-bool ImageSubresourceLayoutMap::AnyInRange(const RangeGenerator& gen,
-                                           std::function<bool(const VkImageSubresource&, const LayoutEntry&)> func) const {
-    for (auto range_gen = gen; range_gen->non_empty(); ++range_gen) {
-        for (auto pos = layouts_.lower_bound(*range_gen); (pos != layouts_.end()) && (range_gen->intersects(pos->first)); ++pos) {
-            auto subres = encoder_.Decode(pos->first.begin);
-            if (func(subres, pos->second)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 }  // namespace image_layout_map

--- a/layers/image_layout_map.h
+++ b/layers/image_layout_map.h
@@ -136,12 +136,17 @@ class ImageSubresourceLayoutMap {
         return encoder_.MakeVkSubresource(subres);
     }
 
+    RangeGenerator RangeGen(const VkImageSubresourceRange& subres_range) const {
+        if (encoder_.InRange(subres_range)) {
+            return (RangeGenerator(encoder_, subres_range));
+        }
+        // Return empty range generator
+        return RangeGenerator();
+    }
+
     bool AnyInRange(const VkImageSubresourceRange& normalized_range,
             std::function<bool(const VkImageSubresource& subres, const LayoutEntry& state)> &&func) const {
-        if (!encoder_.InRange(normalized_range)) {
-            return false;
-        }
-        return AnyInRange(RangeGenerator(encoder_, normalized_range), std::move(func));
+        return AnyInRange(RangeGen(normalized_range), std::move(func));
     }
 
     bool AnyInRange(const RangeGenerator& gen,

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2021 The Khronos Group Inc.
- * Copyright (c) 2019-2021 Valve Corporation
- * Copyright (c) 2019-2021 LunarG, Inc.
- * Copyright (C) 2019-2021 Google Inc.
+/* Copyright (c) 2019-2022 The Khronos Group Inc.
+ * Copyright (c) 2019-2022 Valve Corporation
+ * Copyright (c) 2019-2022 LunarG, Inc.
+ * Copyright (C) 2019-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,9 @@ class RangeEncoder {
     Subresource Decode(const IndexType& index) const { return (this->*decode_function_)(index); }
 
     inline Subresource BeginSubresource(const VkImageSubresourceRange& range) const {
+        if (!InRange(range)) {
+            return limits_;
+        }
         const auto aspect_index = LowerBoundFromMask(range.aspectMask);
         Subresource begin(aspect_bits_[aspect_index], range.baseMipLevel, range.baseArrayLayer, aspect_index);
         return begin;
@@ -460,141 +463,6 @@ class ImageRangeGenerator {
         void Set(uint32_t y_count_, uint32_t layer_z_count_, IndexType base, IndexType span, IndexType y_step, IndexType z_step);
     };
     IncrementerState incr_state_;
-};
-
-// Designed for use with RangeMap of MappedType
-template <typename Map>
-class ConstMapView {
-  public:
-    using KeyType = typename Map::key_type;
-    using MappedType = typename Map::mapped_type;
-    using MapValueType = typename Map::mapped_type;
-    using MapIterator = typename Map::const_iterator;
-    using CachedLowerBound = typename sparse_container::cached_lower_bound_impl<const Map>;
-
-    struct ValueType {
-        const VkImageSubresource& subresource;
-        MapIterator it;
-        ValueType(const VkImageSubresource& subresource_) : subresource(subresource_), it(){};
-    };
-    class ConstIterator {
-      public:
-        ConstIterator()
-            : view_(nullptr),
-              range_gen_(),
-              cached_it_(),
-              pos_(range_gen_.GetSubresource()),
-              current_index_(),
-              constant_value_bound_() {}
-        ConstIterator& operator++() {
-            Increment();
-            return *this;
-        }
-        const ValueType* operator->() const { return &pos_; }
-        const ValueType& operator*() const { return pos_; }
-        // Only for comparisons to end()
-        // Note: if a fully function == is needed, the AtEnd needs to be maintained, as end_iterator is a static.
-        bool AtEnd() const { return pos_.subresource.aspectMask == 0; }
-        bool operator==(const ConstIterator& other) const { return AtEnd() && other.AtEnd(); };
-        bool operator!=(const ConstIterator& other) const { return AtEnd() != other.AtEnd(); };
-
-      protected:
-        friend ConstMapView;
-        ConstIterator(const ConstMapView& view, const VkImageSubresourceRange& range)
-            : view_(&view),
-              range_gen_(view.GetEncoder(), range),
-              cached_it_(view.GetMap(), range_gen_->begin),
-              pos_(range_gen_.GetSubresource()),
-              current_index_(range_gen_->begin),
-              constant_value_bound_(current_index_) {
-            UpdateRangeAndValue();
-        }
-
-        void Increment() {
-            ++current_index_;
-            ++(range_gen_.GetSubresourceGenerator());
-            if (constant_value_bound_ <= current_index_) {
-                UpdateRangeAndValue();
-            }
-        }
-
-        void ForceEndCondition() { range_gen_.GetSubresource().aspectMask = 0; }
-
-        // Constant value range logice, subreource / lower bound position advance logic
-        // TODO: convert this piece into a template _impl function suitable for const and non-const view iterators
-        void UpdateRangeAndValue() {
-            bool not_found = true;
-            while (range_gen_->non_empty() && not_found) {
-                if (!cached_it_.includes(current_index_)) {
-                    // The result of the seek can be invalid, valid, or end...
-                    cached_it_.seek(current_index_);
-                }
-
-                if (cached_it_->lower_bound == view_->GetMap().end()) {
-                    // We're past the end of mapped data. Set end condtion.
-                    ForceEndCondition();
-                    not_found = false;
-                } else {
-                    // Search within the current range_ for a constant valid constant value interval
-                    // The while condition allows the parallel iterator to advance constant value ranges as needed.
-                    while (range_gen_->includes(current_index_) && not_found) {
-                        if (cached_it_->valid) {
-                            // Our position with in the map is valid so we can update our value
-                            pos_.it = cached_it_->lower_bound;
-                            constant_value_bound_ = std::min(cached_it_->lower_bound->first.end, range_gen_->end);
-                            not_found = false;
-                        } else {
-                            // We're skipping this gap in Map, set the index to the exclusive end and look again
-                            // Note that we ONLY need to Seek the Subresource generator on a skip condition.
-                            current_index_ = std::min(cached_it_->lower_bound->first.begin, range_gen_->end);
-                            constant_value_bound_ = current_index_;
-                            // Move the subresource to the end of the skipped range
-                            range_gen_.GetSubresourceGenerator().Seek(current_index_);
-                            cached_it_.seek(current_index_);
-                        }
-                    }
-
-                    if (not_found) {
-                        // We need to advance the index range to search as the current cached_it_ lies outside it, and there's
-                        // no easy way to seek RangeGen
-                        // ++range_gen will update Subresource.
-                        ++range_gen_;
-                        current_index_ = range_gen_->begin;
-                    }
-                }
-            }
-
-            if (range_gen_->empty()) {
-                ForceEndCondition();
-            }
-        }
-
-      private:
-        const ConstMapView* view_;
-        RangeGenerator range_gen_;
-        CachedLowerBound cached_it_;
-        ValueType pos_;
-        IndexType current_index_;
-        IndexType constant_value_bound_;
-    };
-
-    const Map& GetMap() const { return *map_; }
-    const RangeEncoder& GetEncoder() const { return *encoder_; }
-
-    inline ConstIterator Begin(const VkImageSubresourceRange& range) const { return ConstIterator(*this, range); }
-    inline const ConstIterator& End() const { return end_; }
-
-    // Enable range based for....
-    inline ConstIterator begin() const { return Begin(encoder_->FullRange()); }
-    inline const ConstIterator& end() const { return End(); }
-
-    ConstMapView() : map_(nullptr), encoder_(nullptr), end_() {}
-    ConstMapView(const Map& map, const RangeEncoder& encoder) : map_(&map), encoder_(&encoder), end_() {}
-
-  private:
-    const Map* map_;
-    const RangeEncoder* encoder_;
-    const ConstIterator end_;
 };
 
 // double wrapped map variants.. to avoid needing to templatize on the range map type.  The underlying maps are available for


### PR DESCRIPTION
Remove ImageSubresourceLayoutMap::ConstIterator, which went through
a bunch of trouble to iterate over every single subresource in a
range with the same layout. It is sufficient to check each range
once.