### PR TITLE
Fix swapchain test crashes in Best Practices

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -295,9 +295,13 @@ void BestPractices::PreCallRecordDestroyImage(VkDevice device, VkImage image, co
 }
 
 void BestPractices::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator) {
-    SWAPCHAIN_NODE* chain = GetSwapchainState(swapchain);
-    for (auto& image : chain->images) {
-        ReleaseImageUsageState(image.image_state->image());
+    if (VK_NULL_HANDLE != swapchain) {
+        SWAPCHAIN_NODE* chain = GetSwapchainState(swapchain);
+        for (auto& image : chain->images) {
+            if (image.image_state) {
+                ReleaseImageUsageState(image.image_state->image());
+            }
+        }
     }
     ValidationStateTracker::PreCallRecordDestroySwapchainKHR(device, swapchain, pAllocator);
 }


### PR DESCRIPTION
Fixes running:
dEQP-VK.wsi.win32.swapchain.create.image_swapchain_create_info and
dEQP-VK.wsi.win32.swapchain.destroy.null_handle
with Best Practices enabled

