### PR TITLE
 layers: Improve VUID-VkBindImageMemoryInfo-memory-02629 checking

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -233,9 +233,11 @@ struct MemRange {
 struct DEVICE_MEMORY_STATE : public BASE_NODE {
     void *object;  // Dispatchable object used to create this memory (device of swapchain)
     safe_VkMemoryAllocateInfo alloc_info;
-    bool is_dedicated;
-    VkBuffer dedicated_buffer;
-    VkImage dedicated_image;
+    VulkanTypedHandle dedicated_handle;
+    union {
+        VkBufferCreateInfo buffer;
+        VkImageCreateInfo image;
+    } dedicated_create_info;
     bool is_export;
     bool is_import;
     bool is_import_ahb;   // The VUID check depends on if the imported memory is for AHB
@@ -259,9 +261,8 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
         : BASE_NODE(in_mem, kVulkanObjectTypeDeviceMemory),
           object(disp_object),
           alloc_info(p_alloc_info),
-          is_dedicated(false),
-          dedicated_buffer(VK_NULL_HANDLE),
-          dedicated_image(VK_NULL_HANDLE),
+          dedicated_handle(),
+          dedicated_create_info{},
           is_export(false),
           is_import(false),
           is_import_ahb(false),
@@ -275,6 +276,10 @@ struct DEVICE_MEMORY_STATE : public BASE_NODE {
           shadow_pad_size(0),
           p_driver_data(0),
           fake_base_address(fake_address){};
+
+    bool IsDedicatedBuffer() const { return dedicated_handle.type == kVulkanObjectTypeBuffer && dedicated_handle.handle != 0; }
+
+    bool IsDedicatedImage() const { return dedicated_handle.type == kVulkanObjectTypeImage && dedicated_handle.handle != 0; }
 
     VkDeviceMemory mem() const { return handle_.Cast<VkDeviceMemory>(); }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -982,9 +982,19 @@ void ValidationStateTracker::AddMemObjInfo(void *object, const VkDeviceMemory me
 
     auto dedicated = LvlFindInChain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext);
     if (dedicated) {
-        mem_info->is_dedicated = true;
-        mem_info->dedicated_buffer = dedicated->buffer;
-        mem_info->dedicated_image = dedicated->image;
+        if (dedicated->buffer) {
+            const auto *buffer_state = GetBufferState(dedicated->buffer);
+            if (buffer_state) {
+                mem_info->dedicated_handle = VulkanTypedHandle(dedicated->buffer, kVulkanObjectTypeBuffer);
+                mem_info->dedicated_create_info.buffer = buffer_state->createInfo;
+            }
+        } else if (dedicated->image) {
+            const auto *image_state = GetImageState(dedicated->image);
+            if (image_state) {
+                mem_info->dedicated_handle = VulkanTypedHandle(dedicated->image, kVulkanObjectTypeImage);
+                mem_info->dedicated_create_info.image = image_state->createInfo;
+            }
+        }
     }
     auto export_info = LvlFindInChain<VkExportMemoryAllocateInfo>(pAllocateInfo->pNext);
     if (export_info) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -10262,18 +10262,21 @@ TEST_F(VkLayerTest, DedicatedAllocationImageAliasing) {
     VkMemoryPropertyFlags mem_flags = 0;
     const VkDeviceSize resource_size = 1024;
 
-    VkImageObj image(m_device);
+    std::unique_ptr<VkImageObj> image(new VkImageObj(m_device));  // in a pointer so it can be easily destroyed.
     VkImageObj identical_image(m_device);
+    VkImageObj post_delete_image(m_device);
+
     auto image_info = VkImageObj::create_info();
     image_info.extent.width = resource_size;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image.init_no_mem(*m_device, image_info);
+    image->init_no_mem(*m_device, image_info);
     identical_image.init_no_mem(*m_device, image_info);
+    post_delete_image.init_no_mem(*m_device, image_info);
 
     auto image_dedicated_info = LvlInitStruct<VkMemoryDedicatedAllocateInfoKHR>();
-    image_dedicated_info.image = image.handle();
-    auto image_alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, image.memory_requirements(), mem_flags);
+    image_dedicated_info.image = image->handle();
+    auto image_alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, image->memory_requirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
     vk_testing::DeviceMemory dedicated_image_memory;
     dedicated_image_memory.init(*m_device, image_alloc_info);
@@ -10304,7 +10307,7 @@ TEST_F(VkLayerTest, DedicatedAllocationImageAliasing) {
 
     // Bind with a larger image (not supported, and not enough memory)
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-memory-02629");
-    if (larger_image.memory_requirements().size > image.memory_requirements().size) {
+    if (larger_image.memory_requirements().size > image->memory_requirements().size) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-size-01049");
     }
     vk::BindImageMemory(m_device->handle(), larger_image.handle(), dedicated_image_memory.handle(), 0);
@@ -10315,13 +10318,18 @@ TEST_F(VkLayerTest, DedicatedAllocationImageAliasing) {
                                          "VUID-vkBindImageMemory-memory-02629");  // offset must be zero
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkBindImageMemory-size-01049");  // offset pushes us past size
-    auto image_offset = image.memory_requirements().alignment;
-    vk::BindImageMemory(m_device->handle(), image.handle(), dedicated_image_memory.handle(), image_offset);
+    auto image_offset = image->memory_requirements().alignment;
+    vk::BindImageMemory(m_device->handle(), image->handle(), dedicated_image_memory.handle(), image_offset);
     m_errorMonitor->VerifyFound();
 
     // Bind correctly (depends on the "skip" above)
     m_errorMonitor->ExpectSuccess();
-    vk::BindImageMemory(m_device->handle(), image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(m_device->handle(), image->handle(), dedicated_image_memory.handle(), 0);
+    m_errorMonitor->VerifyNotFound();
+
+    m_errorMonitor->ExpectSuccess();
+    image.reset();  // destroy the original image
+    vk::BindImageMemory(m_device->handle(), post_delete_image.handle(), dedicated_image_memory.handle(), 0);
     m_errorMonitor->VerifyNotFound();
 }
 


### PR DESCRIPTION
When the dedicatedAllocationImageAliasing is enabled, it should be possible to bind a compatible image to a VkDeviceMemory even after  the original dedicated image is destroyed. Fix this check by caching the dedicated create info in DEVICE_MEMORY_STATE and using this instead  of looking up the dedicated image at bind time.

Update VkLayerTest.DedicatedAllocationImageAliasing to cover it.

Fixes #2730

