### PR TITLE
Fixing compilation error by CLANG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ endif()
 option(BUILD_WERROR "Treat compiler warnings as errors" ON)
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall
+                        -Wconversion
                         -Wextra
                         -Wno-unused-parameter
                         -Wno-missing-field-initializers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,20 @@ endif()
 
 # Platform-specific compiler switches
 option(BUILD_WERROR "Treat compiler warnings as errors" ON)
+if(MAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wconversion
+
+                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
+                        #      Leave off until further investigation.
+                        -Wno-sign-conversion
+                        -Wno-shorten-64-to-32
+                        -Wno-string-conversion
+                        -Wno-implicit-int-conversion
+                        -Wno-enum-enum-conversion)
+
+endif()
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall
-                        -Wconversion
                         -Wextra
                         -Wno-unused-parameter
                         -Wno-missing-field-initializers
@@ -200,6 +211,19 @@ elseif(MSVC)
     add_compile_options("/w34057")
     # Warn about signed/unsigned mismatch.
     add_compile_options("/w34245")
+endif()
+
+if(MAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wconversion
+
+                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
+                        #      Leave off until further investigation.
+                        -Wno-sign-conversion
+                        -Wno-shorten-64-to-32
+                        -Wno-string-conversion
+                        -Wno-implicit-int-conversion
+                        -Wno-enum-enum-conversion)
+
 endif()
 
 if(TARGET gtest OR IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -171,8 +171,8 @@ static const char *GetBufferImageCopyCommandVUID(std::string id, bool image_to_b
     // clang-format on
 
     uint8_t index = 0;
-    index |= (image_to_buffer) ? 0x1 : 0;
-    index |= (copy2) ? 0x2 : 0;
+    index |= uint8_t((image_to_buffer) ? 0x1 : 0);
+    index |= uint8_t((copy2) ? 0x2 : 0);
     return copy_imagebuffer_vuid.at(id).at(index);
 }
 

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -480,7 +480,7 @@ bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::str
         // Remove enclosing double quotes.  The regex guarantees the quotes and at least one char.
         filename = captures[3].str().substr(1, captures[3].str().size() - 2);
     }
-    *linenumber = std::stoul(captures[1]);
+    *linenumber = (uint32_t)std::stoul(captures[1]);
     return true;
 }
 #endif  // GCC_VERSION

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -288,7 +288,7 @@ const VkLayerSettingsEXT *FindSettingsInChain(const void *next) {
     const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
     const VkLayerSettingsEXT *found = nullptr;
     while (current) {
-        if (static_cast<VkStructureType>(VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT) == current->sType) {
+        if (VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT == static_cast<uint32_t>(current->sType)) {
             found = reinterpret_cast<const VkLayerSettingsEXT *>(current);
             current = nullptr;
         } else {

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -349,5 +349,5 @@ static LvlBindPoint inline ConvertToLvlBindPoint(VkPipelineBindPoint bind_point)
         default:
             return static_cast<LvlBindPoint>(bind_point);
     }
-    return LvlBindPoint(~0U);
+    return BindPoint_Count;
 }

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -377,7 +377,7 @@ class ImageRangeEncoder : public RangeEncoder {
     const IMAGE_STATE* image_;
     std::vector<double> texel_sizes_;
     SubresInfoVector subres_info_;
-    small_vector<IndexType, 4> aspect_sizes_;
+    small_vector<IndexType, 4, uint32_t> aspect_sizes_;
     IndexType total_size_;
     VkExtent3D texel_extent_;
     bool is_3_d_;

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -406,7 +406,7 @@ class ResourceAccessState : public SyncStageAccess {
 
     VkPipelineStageFlags2KHR last_read_stages;
     VkPipelineStageFlags2KHR read_execution_barriers;
-    small_vector<ReadState, 3> last_reads;
+    small_vector<ReadState, 3, uint32_t> last_reads;
 
     // Pending execution state to support independent parallel barriers
     VkPipelineStageFlags2KHR pending_write_dep_chain;

--- a/layers/xxhash.c
+++ b/layers/xxhash.c
@@ -385,7 +385,7 @@ FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state, const void
 #endif
 
     state->total_len_32 += (unsigned)len;
-    state->large_len |= (len>=16) | (state->total_len_32>=16);
+    state->large_len |= (unsigned)(len>=16) | (unsigned)(state->total_len_32>=16);
 
     if (state->memsize + len < 16)  {   /* fill in tmp buffer */
         XXH_memcpy((BYTE*)(state->mem32) + state->memsize, input, len);


### PR DESCRIPTION
By default, small_vector class uses uint8_t as size_type. However, there are a couple of spots where uint32_t is used as index for such small_vectors and this generates error in CLANG in strict mode. This PR fixes this error.

The errors look as follows:
```
../layers/subresource_adapter.h:365:88: error: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'small_vector<unsigned long, 4, unsigned char>::size_type' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
    inline IndexType GetAspectSize(uint32_t aspect_index) const { return aspect_sizes_[aspect_index]; }
                                                                         ~~~~~~~~~~~~~ ^~~~~~~~~~~~
../layers/synchronization_validation.cpp:2748:49: error: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'small_vector<ResourceAccessState::ReadState, 3, unsigned char>::size_type' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
            auto &other_read = other.last_reads[other_read_index];
```