### PR TITLE
layers: Avoid destroying BINDABLE multiple times

### DIFF
--- a/layers/device_memory_state.h
+++ b/layers/device_memory_state.h
@@ -156,7 +156,11 @@ class BINDABLE : public BASE_NODE {
           unprotected(true),
           bound_memory_set_{} {};
 
-    virtual ~BINDABLE() { Destroy(); }
+    virtual ~BINDABLE() {
+        if (!Destroyed()) {
+            Destroy();
+        }
+    }
 
     void Destroy() override;
 


### PR DESCRIPTION
This is a reland of #2836,
which was lost in #2849.

This works around CFI error for accessing destroyed parts
of IMAGE_STATE from BINDABLE destructor.

Fixes #2825