### PR TITLE
layers/CMake: Fix library install paths in MinGW.

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -98,7 +98,10 @@ macro(AddVkLayer target LAYER_COMPILE_DEFINITIONS)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_${target}.map,-Bsymbolic,--exclude-libs,ALL")
     endif()
 
-    install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(TARGETS VkLayer_${target}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endmacro()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/generated ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
In MinGW environment, DLL file should be installed
in bin folder. Without this change, DLL is installed
in lib folder.