### PR TITLE
gn: Fix build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -100,6 +100,7 @@ core_validation_sources = [
   "layers/image_state.h",
   "layers/image_state.cpp",
   "layers/pipeline_state.h",
+  "layers/qfo_transfer.h",
   "layers/query_state.h",
   "layers/queue_state.h",
   "layers/ray_tracing_state.h",


### PR DESCRIPTION
Missing header from BUILD.gn file.