### PR TITLE
layers: Fix multi-plane format compatibility

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5587,7 +5587,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         if ((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) && (image_format != view_format)) {
             if (FormatIsMultiplane(image_format)) {
                 VkFormat compat_format = FindMultiplaneCompatibleFormat(image_format, aspect_mask);
-                if (view_format != compat_format) {
+                if (FormatCompatibilityClass(compat_format) != FormatCompatibilityClass(view_format)) {
                     // View format must match the multiplane compatible format
                     std::stringstream ss;
                     ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -9009,7 +9009,7 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
         ivci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
         ivci.image = image_obj.image();
         ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        ivci.format = VK_FORMAT_R8_SNORM;  // Compat is VK_FORMAT_R8_UNORM
+        ivci.format = VK_FORMAT_R16_UNORM;  // Compat is VK_FORMAT_R8_UNORM
         ivci.subresourceRange.layerCount = 1;
         ivci.subresourceRange.baseMipLevel = 0;
         ivci.subresourceRange.levelCount = 1;
@@ -9020,6 +9020,10 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
 
         // Correct format succeeds
         ivci.format = VK_FORMAT_R8_UNORM;
+        CreateImageViewTest(*this, &ivci);
+
+        // Format compatible with the correct format succeeds
+        ivci.format = VK_FORMAT_R8_UINT;
         CreateImageViewTest(*this, &ivci);
 
         // Try a multiplane imageview


### PR DESCRIPTION
Fixes #473.

The Vulkan spec was updated to be clear that plane format compatibility
should be intepreted transitively, so update validation to match.