### PR TITLE
Add warning for zero-sized render area

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -155,6 +155,8 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CmdDrawIndexed_PostTransf
     "UNASSIGNED-BestPractices-vkCmdDrawIndexed-post-transform-cache-thrashing";
 static const char DECORATE_UNUSED *kVUID_BestPractices_BeginCommandBuffer_OneTimeSubmit =
     "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit";
+static const char DECORATE_UNUSED *kVUID_BestPractices_BeginRenderPass_ZeroSizeRenderArea =
+    "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-zero-size-render-area";
 static const char DECORATE_UNUSED *kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback =
     "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateSwapchain_PresentMode =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2015-2021 The Khronos Group Inc.
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
  * Copyright (c) 2015-2021 Valve Corporation
  * Copyright (c) 2015-2021 LunarG, Inc.
  *
@@ -1462,6 +1462,12 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
 
     if (!pRenderPassBegin) {
         return skip;
+    }
+
+    if (pRenderPassBegin->renderArea.extent.width == 0 || pRenderPassBegin->renderArea.extent.height == 0) {
+        skip |= LogWarning(device, kVUID_BestPractices_BeginRenderPass_ZeroSizeRenderArea,
+                           "This render pass has a zero-size render area. It cannot write to any attachments, "
+                           "and can only be used for side effects such as layout transitions.");
     }
 
     auto rp_state = GetRenderPassState(pRenderPassBegin->renderPass);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -337,9 +337,6 @@ TEST_F(VkBestPracticesLayerTest, CmdBeginRenderPassZeroSizeRenderArea) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->VerifyFound();
-
-    m_commandBuffer->EndRenderPass();
-    m_commandBuffer->end();
 }
 
 TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -323,6 +323,25 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     m_commandBuffer->EndRenderPass();
 }
 
+TEST_F(VkBestPracticesLayerTest, CmdBeginRenderPassZeroSizeRenderArea) {
+    TEST_DESCRIPTION("Test for getting warned when render area is 0 in VkRenderPassBeginInfo during vkCmdBeginRenderPass");
+
+    InitBestPracticesFramework();
+    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-zero-size-render-area");
+
+    m_commandBuffer->begin();
+    m_renderPassBeginInfo.renderArea.extent.width = 0;
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}
+
 TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
     InitBestPracticesFramework();
     InitState();


### PR DESCRIPTION
A mistake that's caught me far too many times. Render passes with a zero-sized render area seem to be allowed by the spec but seem to be rarely intended. They can cause useful side-effects like layout transitions (amongst a whole host of other things), but there's generally a simpler/better replacement if you aren't actually writing to any framebuffer attachments.

I assume I need to write a test for this? If so ping me and I'll add one.