### PR TITLE
build: Update robin-hood-hashing to 3.11.2

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -41,7 +41,7 @@
       "url": "https://github.com/martinus/robin-hood-hashing.git",
       "sub_dir": "robin-hood-hashing",
       "build_step": "skip",
-      "commit": "eee46f9985c3c65a05b35660c6866f8f8f1a3ba3"
+      "commit": "3.11.2"
     }
   ]
 }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -37,7 +37,7 @@
       "build_dir": "robin-hood-hashing",
       "install_dir": "robin-hood-hashing",
       "build_step": "skip",
-      "commit": "eee46f9985c3c65a05b35660c6866f8f8f1a3ba3"
+      "commit": "3.11.2"
     }
   ],
   "install_names" : {


### PR DESCRIPTION
This version picks up fixes that should reduce the possibility
of getting "robin_hood::map overflow" errors.