### PR TITLE
layers: Clean up and document check disable options

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2113,7 +2113,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
 // Return false if no errors occur
 // Return true if validation error occurs and callback returns true (to skip upcoming API call down the chain)
 bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const char *func_str) const {
-    if (disabled[idle_descriptor_set]) return false;
+    if (disabled[object_in_use]) return false;
     bool skip = false;
     auto set_node = setMap.find(set);
     if (set_node != setMap.end()) {
@@ -5768,7 +5768,7 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                     VkDescriptorPoolResetFlags flags) const {
     // Make sure sets being destroyed are not currently in-use
-    if (disabled[idle_descriptor_set]) return false;
+    if (disabled[object_in_use]) return false;
     bool skip = false;
     const DESCRIPTOR_POOL_STATE *pool = GetDescriptorPoolState(descriptorPool);
     if (pool != nullptr) {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3141,8 +3141,6 @@ public:
 typedef enum ValidationCheckDisables {
     VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE,
     VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
-    VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET,
-    VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE,
     VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
     VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
 } ValidationCheckDisables;
@@ -3162,8 +3160,6 @@ typedef enum VkValidationFeatureEnable {
 typedef enum DisableFlags {
     command_buffer_state,
     object_in_use,
-    idle_descriptor_set,
-    push_constant_range,
     query_validation,
     image_layout_validation,
     object_tracking,

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -286,6 +286,7 @@
                     "label": "Duplicated Messages Limit",
                     "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
                     "type": "INT",
+                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                     "default": 10,
                     "range": {
                         "min": 0
@@ -296,6 +297,7 @@
                     "label": "Mute Message VUIDs",
                     "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
                     "type": "LIST",
+                    "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "default": []
                 },
                 {
@@ -303,6 +305,7 @@
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
+                    "env": "VK_LAYER_DISABLES",
                     "flags": [
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
@@ -373,6 +376,7 @@
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",
+                    "env": "VK_LAYER_ENABLES",
                     "flags": [
                         {
                             "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -7,6 +7,8 @@
         "api_version": "@VK_VERSION@",
         "implementation_version": "1",
         "description": "Khronos Validation Layer",
+        "introduction": "The main, comprehensive Khronos validation layer.\n\nVulkan is an Explicit API, enabling direct control over how GPUs actually work. By design, minimal error checking is done inside a Vulkan driver. Applications have full control and responsibility for correct operation. Any errors in how Vulkan is used can result in a crash. \n\nThe Khronos Valiation Layer can be enabled to assist development by enabling developers to verify their applications correctly use the Vulkan API.",
+        "platforms": [ "WINDOWS", "LINUX", "ANDROID" ],
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html",
         "instance_extensions": [
             {
@@ -90,9 +92,7 @@
                                 "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                                 "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                                 "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
-                                "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
-                                "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                                "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE"
+                                "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION"
                             ]
                         }
                     ]
@@ -331,44 +331,32 @@
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
-                            "label": "Disable Shaders",
-                            "description": "",
+                            "label": "Shaders",
+                            "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                             "label": "Command Buffer State",
-                            "description": "",
+                            "description": "Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                             "label": "Image Layout",
-                            "description": "",
+                            "description": "Check that layout of each image subresource is correct whenever it is used a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                             "label": "Query",
-                            "description": "",
-                            "view": "ADVANCED"
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
-                            "label": "Push Constant Range",
-                            "description": "",
+                            "description": "Checks for commands that use VkQueryPool objects.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                             "label": "Object in Use",
-                            "description": "",
-                            "view": "ADVANCED"
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descriptor Set",
-                            "description": "",
+                            "description": "Check that Vulkan objects are not in use by a command buffer when they are destroyed.",
                             "view": "ADVANCED"
                         },
                         {

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -402,6 +402,7 @@
                                     "description": "To redirect Debug Printf messages from the debug callback to stdout",
                                     "type": "BOOL",
                                     "default": true,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
                                     "dependence": {
                                         "mode": "ANY",
                                         "settings": [
@@ -414,10 +415,11 @@
                                 },
                                 {
                                     "key": "printf_verbose",
-                                    "label": "Verbose",
+                                    "label": "Printf verbose",
                                     "description": "Verbosity of debug printf messages",
                                     "type": "BOOL",
                                     "default": false,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
                                     "dependence": {
                                         "mode": "ANY",
                                         "settings": [
@@ -439,6 +441,7 @@
                                         "max": 1048576
                                     },
                                     "unit": "bytes",
+                                    "platforms": [ "WINDOWS", "LINUX" ],
                                     "dependence": {
                                         "mode": "ANY",
                                         "settings": [
@@ -464,6 +467,7 @@
                                     "description": "Enable buffer out of bounds checking",
                                     "type": "BOOL",
                                     "default": true,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
                                     "dependence": {
                                         "mode": "ANY",
                                         "settings": [
@@ -480,6 +484,7 @@
                                     "description": "Enable draw indirect checking",
                                     "type": "BOOL",
                                     "default": true,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
                                     "dependence": {
                                         "mode": "ANY",
                                         "settings": [

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -8,7 +8,7 @@
         "implementation_version": "1",
         "description": "Khronos Validation Layer",
         "introduction": "The main, comprehensive Khronos validation layer.\n\nVulkan is an Explicit API, enabling direct control over how GPUs actually work. By design, minimal error checking is done inside a Vulkan driver. Applications have full control and responsibility for correct operation. Any errors in how Vulkan is used can result in a crash. \n\nThe Khronos Valiation Layer can be enabled to assist development by enabling developers to verify their applications correctly use the Vulkan API.",
-        "platforms": [ "WINDOWS", "LINUX", "ANDROID" ],
+        "platforms": [ "WINDOWS", "LINUX", "ANDROID", "MACOS" ],
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html",
         "instance_extensions": [
             {
@@ -59,7 +59,7 @@
                 {
                     "label": "Standard",
                     "description": "Good default validation setup that balance validation coverage and performance.",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -100,7 +100,7 @@
                 {
                     "label": "Best Practices",
                     "description": "Provides warnings about potential API misuse but valid usages of the API.",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -124,7 +124,7 @@
                 {
                     "label": "Synchronization",
                     "description": "Identify resource access conflicts due to missing or incorrect synchronization operations between actions reading or writing the same regions of memory.",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -233,7 +233,8 @@
                         {
                             "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
                             "label": "Debug Output",
-                            "description": "Log a txt message using the Windows OutputDebugString function."
+                            "description": "Log a txt message using the Windows OutputDebugString function.",
+                            "platforms": [ "WINDOWS"]
                         },
                         {
                             "key": "VK_DBG_LAYER_ACTION_BREAK",
@@ -261,7 +262,7 @@
                         },
                         {
                             "key": "perf",
-                            "label": "performance",
+                            "label": "Performance",
                             "description": "Report using the API in a way that may cause suboptimal performance."
                         },
                         {
@@ -272,7 +273,8 @@
                         {
                             "key": "debug",
                             "label": "Debug",
-                            "description": "For layer development. Report messages for debugging layer behavior."
+                            "description": "For layer development. Report messages for debugging layer behavior.",
+                            "view": "HIDDEN"
                         }
                     ],
                     "default": [
@@ -334,7 +336,7 @@
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
-                            "label": "Shaders",
+                            "label": "Shader Validation",
                             "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
                             "view": "ADVANCED"
                         },
@@ -347,7 +349,7 @@
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                             "label": "Image Layout",
-                            "description": "Check that layout of each image subresource is correct whenever it is used a command buffer. These checks are very CPU intensive for some applications.",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
@@ -384,7 +386,7 @@
                             "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
                             "url": "${LUNARG_SDK}/synchronization_usage.html",
                             "status": "STABLE",
-                            "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
@@ -501,13 +503,13 @@
                             "label": "Best Practices",
                             "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
                             "url": "${LUNARG_SDK}/best_practices.html",
-                            "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
                         },
                         {
                             "key": "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM",
                             "label": "ARM-specific best practices",
                             "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                            "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
+                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
                         }
                     ],
                     "default": []

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -29,12 +29,6 @@ void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDis
         case VALIDATION_CHECK_DISABLE_OBJECT_IN_USE:
             disable_data[object_in_use] = true;
             break;
-        case VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET:
-            disable_data[idle_descriptor_set] = true;
-            break;
-        case VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE:
-            disable_data[push_constant_range] = true;
-            break;
         case VALIDATION_CHECK_DISABLE_QUERY_VALIDATION:
             disable_data[query_validation] = true;
             break;

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -60,8 +60,6 @@ static const layer_data::unordered_map<std::string, VkValidationFeatureEnable> V
 static const layer_data::unordered_map<std::string, ValidationCheckDisables> ValidationDisableLookup = {
     {"VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE", VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE},
     {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
-    {"VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET", VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET},
-    {"VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE", VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE},
     {"VALIDATION_CHECK_DISABLE_QUERY_VALIDATION", VALIDATION_CHECK_DISABLE_QUERY_VALIDATION},
     {"VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION", VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION},
 };
@@ -75,8 +73,6 @@ static const layer_data::unordered_map<std::string, ValidationCheckEnables> Vali
 static const std::vector<std::string> DisableFlagNameHelper = {
     "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",               // command_buffer_state,
     "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                      // object_in_use,
-    "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",                // idle_descriptor_set,
-    "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",                // push_constant_range,
     "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",                   // query_validation,
     "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",            // image_layout_validation,
     "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",          // object_tracking,

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -299,8 +299,6 @@ public:
 typedef enum ValidationCheckDisables {
     VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE,
     VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
-    VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET,
-    VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE,
     VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
     VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
 } ValidationCheckDisables;
@@ -320,8 +318,6 @@ typedef enum VkValidationFeatureEnable {
 typedef enum DisableFlags {
     command_buffer_state,
     object_in_use,
-    idle_descriptor_set,
-    push_constant_range,
     query_validation,
     image_layout_validation,
     object_tracking,


### PR DESCRIPTION
VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET is now part of ...DISABLE_OBJECT_IN_USE,
because it does the same thing for all non-descriptor objects.

VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE is removed because it was
not used by the code.

Add manifest descriptions for the rest, and add some other fields needed
by vkconfig.

Fixes #2897