### PR TITLE
layers: Simplify DeviceMemory state objects

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1690,7 +1690,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayoutANDROID(const VkImage image) c
 
     const IMAGE_STATE *image_state = GetImageState(image);
     if (image_state != nullptr) {
-        if (image_state->external_ahb && (0 == image_state->GetBoundMemory().size())) {
+        if (image_state->IsExternalAHB() && (0 == image_state->GetBoundMemory().size())) {
             skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-01895",
                              "vkGetImageSubresourceLayout(): Attempt to query layout from an image created with "
                              "VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID handleType which has not yet been "

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -911,14 +911,16 @@ bool CoreChecks::ValidateGeneralBufferDescriptor(const char *caller, const DrawD
     }
     if (buffer) {
         if (buffer_node && !buffer_node->sparse) {
-            for (const auto *mem_binding : buffer_node->GetBoundMemory()) {
-                if (mem_binding->Destroyed()) {
+            for (const auto &item: buffer_node->GetBoundMemory()) {
+                auto &binding = item.second;
+                if (binding.mem_state->Destroyed()) {
                     auto set = descriptor_set->GetSet();
                     return LogError(set, vuids.descriptor_valid,
                                     "Descriptor set %s encountered the following validation error at %s time: Descriptor in "
                                     "binding #%" PRIu32 " index %" PRIu32 " is uses buffer %s that references invalid memory %s.",
                                     report_data->FormatHandle(set).c_str(), caller, binding_info.first, index,
-                                    report_data->FormatHandle(buffer).c_str(), report_data->FormatHandle(mem_binding->mem()).c_str());
+                                    report_data->FormatHandle(buffer).c_str(),
+                                    report_data->FormatHandle(binding.mem_state->mem()).c_str());
                 }
             }
         }
@@ -1441,15 +1443,17 @@ bool CoreChecks::ValidateAccelerationDescriptor(const char *caller, const DrawDi
                                 report_data->FormatHandle(acc).c_str());
             }
         } else {
-            for (const auto *mem_binding : acc_node->GetBoundMemory()) {
-                if (mem_binding->Destroyed()) {
+            for (const auto &item: acc_node->GetBoundMemory()) {
+                auto &mem_binding = item.second;
+                if (mem_binding.mem_state->Destroyed()) {
                     auto set = descriptor_set->GetSet();
                     return LogError(set, vuids.descriptor_valid,
                                     "Descriptor set %s encountered the following validation error at %s time: Descriptor in "
                                     "binding #%" PRIu32 " index %" PRIu32
                                     " is using acceleration structure %s that references invalid memory %s.",
                                     report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                    report_data->FormatHandle(acc).c_str(), report_data->FormatHandle(mem_binding->mem()).c_str());
+                                    report_data->FormatHandle(acc).c_str(),
+                                    report_data->FormatHandle(mem_binding.mem_state->mem()).c_str());
                 }
             }
         }
@@ -1467,15 +1471,17 @@ bool CoreChecks::ValidateAccelerationDescriptor(const char *caller, const DrawDi
                                 report_data->FormatHandle(acc).c_str());
             }
         } else {
-            for (const auto *mem_binding : acc_node->GetBoundMemory()) {
-                if (mem_binding->Destroyed()) {
+            for (const auto &item : acc_node->GetBoundMemory()) {
+                auto &mem_binding = item.second;
+                if (mem_binding.mem_state->Destroyed()) {
                     auto set = descriptor_set->GetSet();
                     return LogError(set, vuids.descriptor_valid,
                                     "Descriptor set %s encountered the following validation error at %s time: Descriptor in "
                                     "binding #%" PRIu32 " index %" PRIu32
                                     " is using acceleration structure %s that references invalid memory %s.",
                                     report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                    report_data->FormatHandle(acc).c_str(), report_data->FormatHandle(mem_binding->mem()).c_str());
+                                    report_data->FormatHandle(acc).c_str(),
+                                    report_data->FormatHandle(mem_binding.mem_state->mem()).c_str());
                 }
             }
         }

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -62,12 +62,9 @@ class IMAGE_STATE : public BINDABLE {
     VkFormatFeatureFlags format_features = 0;
     // Need to memory requirments for each plane if image is disjoint
     bool disjoint;  // True if image was created with VK_IMAGE_CREATE_DISJOINT_BIT
-    VkMemoryRequirements plane0_requirements;
-    bool plane0_memory_requirements_checked;
-    VkMemoryRequirements plane1_requirements;
-    bool plane1_memory_requirements_checked;
-    VkMemoryRequirements plane2_requirements;
-    bool plane2_memory_requirements_checked;
+    static const int MAX_PLANES = 3;
+    std::array<VkMemoryRequirements, MAX_PLANES> requirements;
+    std::array<bool, MAX_PLANES> memory_requirements_checked;
 
     const image_layout_map::Encoder subresource_encoder;                             // Subresource resolution encoder
     std::unique_ptr<const subresource_adapter::ImageRangeEncoder> fragment_encoder;  // Fragment resolution encoder
@@ -131,20 +128,18 @@ class IMAGE_STATE : public BINDABLE {
         Destroy();
     };
 
-    void Destroy() override {
-        RemoveAliasingImages();
-        BINDABLE::Destroy();
-    }
+    void Destroy() override;
 
-    void AddAliasingImage(layer_data::unordered_set<IMAGE_STATE *> &bound_images);
-
-    void RemoveAliasingImages();
+    void AddAliasingImage(IMAGE_STATE *bound_images);
 
     VkExtent3D GetSubresourceExtent(const VkImageSubresourceLayers &subresource) const;
 
     VkImageSubresourceRange NormalizeSubresourceRange(const VkImageSubresourceRange &range) const {
         return ::NormalizeSubresourceRange(createInfo, range);
     }
+
+  protected:
+    virtual void NotifyInvalidate(const LogObjectList &invalid_handles, bool unlink) override;
 };
 
 class IMAGE_VIEW_STATE : public BASE_NODE {

--- a/layers/ray_tracing_state.h
+++ b/layers/ray_tracing_state.h
@@ -42,7 +42,7 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
     uint64_t opaque_handle = 0;
     const VkAllocationCallbacks *allocator = NULL;
     ACCELERATION_STRUCTURE_STATE(VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci)
-        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureNV),
+        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureNV, false, false, 0),
           create_infoNV(ci),
           memory_requirements{},
           build_scratch_memory_requirements_checked{},
@@ -68,7 +68,7 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
     uint64_t opaque_handle = 0;
     const VkAllocationCallbacks *allocator = NULL;
     ACCELERATION_STRUCTURE_STATE_KHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci)
-        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureKHR),
+        : BINDABLE(as, kVulkanObjectTypeAccelerationStructureKHR, false, false, 0),
           create_infoKHR(ci),
           memory_requirements{},
           build_scratch_memory_requirements_checked{},

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1101,7 +1101,6 @@ class ValidationStateTracker : public ValidationObject {
                                                 VkResult result) override;
 
     // State Utilty functions
-    void AddMemObjInfo(void* object, const VkDeviceMemory mem, const VkMemoryAllocateInfo* pAllocateInfo);
     void DeleteDescriptorSetPools();
     void FreeCommandBufferStates(COMMAND_POOL_STATE* pool_state, const uint32_t command_buffer_count,
                                  const VkCommandBuffer* command_buffers);
@@ -1128,7 +1127,6 @@ class ValidationStateTracker : public ValidationObject {
                                          uint32_t set, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites);
     void RecordCreateImageANDROID(const VkImageCreateInfo* create_info, IMAGE_STATE* is_node);
-    void RecordCreateBufferANDROID(const VkBufferCreateInfo* create_info, BUFFER_STATE* bs_node);
     void RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo* create_info,
                                                  VkSamplerYcbcrConversion ycbcr_conversion);
     void RecordCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo* create_info,


### PR DESCRIPTION
-Make most fields in DEVICE_MEMORY_STATE and BINDABLE be const.
Fields that don't change after object creation may not need as much
locking for safe accesses.

-Remove DEVICE_MEMORY_STATE::bound_images. All bound images of a
DeviceMemory are already tracked as its parents. Also, they can
clean up their aliasing_images sets in NotifyInvalidate().

-Move memory requirements tracking out of BINDABLE, since all four
derived classes need to implement it differently.