### PR TITLE
layers: Fix typo on VUID-01979 error message

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7055,7 +7055,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                                         LogError(objlist, "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979",
                                                  "vkCmdBindDescriptorSets(): pDynamicOffsets[%u] is 0x%x which when added to the "
                                                  "buffer descriptor's range (0x%" PRIxLEAST64
-                                                 ") is greater then the size of the buffer (0x%" PRIxLEAST64
+                                                 ") is greater than the size of the buffer (0x%" PRIxLEAST64
                                                  ") in descriptorSet #%u binding #%u descriptor[%u].",
                                                  cur_dyn_offset, offset, bound_range, buffer_state->createInfo.size, set_idx,
                                                  binding_index, j);


### PR DESCRIPTION
Fixed a typo on `VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979` error message, than must be used instead of then:

> ... buffer descriptor's range is greater **then** the size of the buffer ...

> ... buffer descriptor's range is greater **than** the size of the buffer ...