### PR TITLE
practices: Improve check for redundant clear attachments and redundant attachment usage

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -149,6 +149,8 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_RobustBuffer
     "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess";
 static const char DECORATE_UNUSED *kVUID_BestPractices_EndRenderPass_DepthPrePassUsage =
     "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage";
+static const char DECORATE_UNUSED *kVUID_BestPractices_EndRenderPass_RedundantAttachmentOnTile =
+    "UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile";
 static const char DECORATE_UNUSED *kVUID_BestPractices_RenderPass_RedundantStore =
     "UNASSIGNED-BestPractices-RenderPass-redundant-store";
 static const char DECORATE_UNUSED *kVUID_BestPractices_RenderPass_RedundantClear =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1550,9 +1550,9 @@ void BestPractices::ValidateImageInQueue(const char* function_name, IMAGE_STATE_
 
 void BestPractices::AddDeferredQueueOperations(CMD_BUFFER_STATE* cb) {
     cb->queue_submit_functions.insert(cb->queue_submit_functions.end(),
-                                      queue_submit_functions_after_render_pass.begin(),
-                                      queue_submit_functions_after_render_pass.end());
-    queue_submit_functions_after_render_pass.clear();
+                                      cb->queue_submit_functions_after_render_pass.begin(),
+                                      cb->queue_submit_functions_after_render_pass.end());
+    cb->queue_submit_functions_after_render_pass.clear();
 }
 
 void BestPractices::PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer) {
@@ -1645,7 +1645,7 @@ void BestPractices::PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffe
                 image_view = GetImageViewState(framebuffer->createInfo.pAttachments[att]);
             }
 
-            QueueValidateImageView(queue_submit_functions_after_render_pass, "vkCmdEndRenderPass()", image_view, usage);
+            QueueValidateImageView(cb->queue_submit_functions_after_render_pass, "vkCmdEndRenderPass()", image_view, usage);
         }
     }
 }
@@ -3031,10 +3031,4 @@ void BestPractices::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount
             }
         }
     }
-}
-
-void BestPractices::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo) {
-    ValidationStateTracker::PreCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo);
-    // This should not be required, but guards against buggy applications which do not call EndRenderPass correctly.
-    queue_submit_functions_after_render_pass.clear();
 }

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -860,7 +860,10 @@ bool BestPractices::ValidateMultisampledBlendingArm(uint32_t createInfoCount,
         auto rp_state = GetRenderPassState(create_info->renderPass);
         const auto& subpass = rp_state->createInfo.pSubpasses[create_info->subpass];
 
-        for (uint32_t j = 0; j < create_info->pColorBlendState->attachmentCount; j++) {
+        // According to spec, pColorBlendState must be ignored if subpass does not have color attachments.
+        uint32_t num_color_attachments = std::min(subpass.colorAttachmentCount, create_info->pColorBlendState->attachmentCount);
+
+        for (uint32_t j = 0; j < num_color_attachments; j++) {
             const auto& blend_att = create_info->pColorBlendState->pAttachments[j];
             uint32_t att = subpass.pColorAttachments[j].attachment;
 
@@ -970,7 +973,9 @@ void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device,
         cis.accessFramebufferAttachments.clear();
 
         if (cis.colorBlendStateCI) {
-            for (uint32_t j = 0; j < cis.colorBlendStateCI->attachmentCount; j++) {
+            // According to spec, pColorBlendState must be ignored if subpass does not have color attachments.
+            uint32_t num_color_attachments = std::min(subpass.colorAttachmentCount, cis.colorBlendStateCI->attachmentCount);
+            for (uint32_t j = 0; j < num_color_attachments; j++) {
                 if (cis.colorBlendStateCI->pAttachments[j].colorWriteMask != 0) {
                     uint32_t attachment = subpass.pColorAttachments[j].attachment;
                     if (attachment != VK_ATTACHMENT_UNUSED) {

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -933,6 +933,15 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
     return skip;
 }
 
+void BestPractices::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator)
+{
+    auto itr = graphicsPipelineCIs.find(pipeline);
+    if (itr != graphicsPipelineCIs.end()) {
+        graphicsPipelineCIs.erase(itr);
+    }
+    ValidationStateTracker::PreCallRecordDestroyPipeline(device, pipeline, pAllocator);
+}
+
 void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2085,7 +2085,7 @@ bool BestPractices::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
         }
         auto& secondary = secondary_itr->second;
         for (auto& clear : secondary.earlyClearAttachments) {
-            if (ClearAttachmentsIsFullClear(primary, clear.rects.size(), clear.rects.data())) {
+            if (ClearAttachmentsIsFullClear(primary, uint32_t(clear.rects.size()), clear.rects.data())) {
                 skip |= ValidateClearAttachment(commandBuffer, primary,
                                                 clear.framebufferAttachment, clear.colorAttachment,
                                                 clear.aspects, true);
@@ -2104,10 +2104,10 @@ void BestPractices::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
         auto& secondary = cbRenderPassState[pCommandBuffers[i]];
 
         for (auto& early_clear : secondary.earlyClearAttachments) {
-            if (ClearAttachmentsIsFullClear(primary, early_clear.rects.size(), early_clear.rects.data())) {
+            if (ClearAttachmentsIsFullClear(primary, uint32_t(early_clear.rects.size()), early_clear.rects.data())) {
                 RecordAttachmentClearAttachments(primary, primary_state, early_clear.framebufferAttachment,
                                                  early_clear.colorAttachment, early_clear.aspects,
-                                                 early_clear.rects.size(), early_clear.rects.data());
+                                                 uint32_t(early_clear.rects.size()), early_clear.rects.data());
             } else {
                 RecordAttachmentAccess(primary_state, early_clear.framebufferAttachment,
                                        early_clear.aspects);

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1635,9 +1635,28 @@ void BestPractices::PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuf
     AddDeferredQueueOperations(GetCBState(commandBuffer));
 }
 
-void BestPractices::PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+void BestPractices::PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer,
+                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
                                                     VkSubpassContents contents) {
     ValidationStateTracker::PreCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
+    RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin);
+}
+
+void BestPractices::PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer,
+                                                     const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                     const VkSubpassBeginInfo* pSubpassBeginInfo) {
+    ValidationStateTracker::PreCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+    RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin);
+}
+
+void BestPractices::PreCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
+                                                        const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                        const VkSubpassBeginInfo* pSubpassBeginInfo) {
+    ValidationStateTracker::PreCallRecordCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+    RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin);
+}
+
+void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin) {
 
     if (!pRenderPassBegin) {
         return;
@@ -2361,10 +2380,29 @@ bool BestPractices::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, ui
     return skip;
 }
 
+bool BestPractices::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const {
+    bool skip = false;
+    skip |= StateTracker::PreCallValidateCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
+    skip |= ValidateCmdEndRenderPass(commandBuffer);
+    return skip;
+}
+
+bool BestPractices::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const {
+    bool skip = false;
+    skip |= StateTracker::PreCallValidateCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+    skip |= ValidateCmdEndRenderPass(commandBuffer);
+    return skip;
+}
+
 bool BestPractices::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const {
     bool skip = false;
-
     skip |= StateTracker::PreCallValidateCmdEndRenderPass(commandBuffer);
+    skip |= ValidateCmdEndRenderPass(commandBuffer);
+    return skip;
+}
+
+bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const {
+    bool skip = false;
 
     auto render_pass_state = cbRenderPassState.find(commandBuffer);
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1442,7 +1442,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
             const auto& attachment = rp_state->createInfo.pAttachments[att];
 
             bool attachment_has_readback = false;
-            if (!FormatHasStencil(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
+            if (!FormatIsStencilOnly(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
                 attachment_has_readback = true;
             }
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2738,8 +2738,8 @@ bool BestPractices::ValidateClearAttachment(VkCommandBuffer commandBuffer, const
     if (!cmd->hasDrawCmd) {
         skip |= LogPerformanceWarning(
             commandBuffer, kVUID_BestPractices_DrawState_ClearCmdBeforeDraw,
-            "vkCmdClearAttachments() issued on %s prior to any Draw Cmds. It is recommended you "
-            "use RenderPass LOAD_OP_CLEAR on Attachments prior to any Draw.",
+            "vkCmdClearAttachments() issued on %s prior to any Draw Cmds in current render pass. It is recommended you "
+            "use RenderPass LOAD_OP_CLEAR on attachments instead.",
             report_data->FormatHandle(commandBuffer).c_str());
     }
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2103,6 +2103,9 @@ void BestPractices::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
             RecordAttachmentAccess(primary_state, touch.framebufferAttachment,
                                    touch.aspects);
         }
+
+        primary_state.numDrawCallsDepthEqualCompare += secondary.numDrawCallsDepthEqualCompare;
+        primary_state.numDrawCallsDepthOnly += secondary.numDrawCallsDepthOnly;
     }
 
     ValidationStateTracker::PreCallRecordCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -139,8 +139,6 @@ class BestPractices : public ValidationStateTracker {
 
     void RecordCmdDrawType(VkCommandBuffer cmd_buffer, uint32_t draw_count, const char* caller);
 
-    void RecordCmdDrawTypeArm(VkCommandBuffer cmd_buffer, uint32_t draw_count, const char* caller);
-
     bool ValidateDeprecatedExtensions(const char* api_name, const char* extension_name, uint32_t version, const char* vuid) const;
 
     bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const char* vuid) const;
@@ -509,13 +507,14 @@ class BestPractices : public ValidationStateTracker {
         uint32_t iteration = 0;
     };
 
+    struct AttachmentInfo {
+        uint32_t framebufferAttachment;
+        VkImageAspectFlags aspects;
+    };
+
     struct GraphicsPipelineCIs {
         const safe_VkPipelineDepthStencilStateCreateInfo* depthStencilStateCI;
         const safe_VkPipelineColorBlendStateCreateInfo* colorBlendStateCI;
-        struct AttachmentInfo {
-            uint32_t framebufferAttachment;
-            VkImageAspectFlags aspects;
-        };
         std::vector<AttachmentInfo> accessFramebufferAttachments;
     };
 
@@ -539,14 +538,13 @@ class BestPractices : public ValidationStateTracker {
             std::vector<VkClearRect> rects;
         };
 
-        struct AttachmentInfo {
-            uint32_t framebufferAttachment;
-            VkImageAspectFlags aspects;
-        };
-
         std::vector<ClearInfo> earlyClearAttachments;
         std::vector<AttachmentInfo> touchesAttachments;
+        std::vector<AttachmentInfo> nextDrawTouchesAttachments;
+        bool drawTouchAttachments = false;
     };
+
+    void RecordCmdDrawTypeArm(RenderPassState& render_pass_state, uint32_t draw_count, const char* caller);
 
     // used to track heuristic data per command buffer
     layer_data::unordered_map<VkCommandBuffer, RenderPassState> cbRenderPassState = {};

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -504,8 +504,8 @@ class BestPractices : public ValidationStateTracker {
     // used to track CreateInfos for graphics pipelines
     layer_data::unordered_map<VkPipeline, GraphicsPipelineCIs> graphicsPipelineCIs = {};
 
-    // used to track state regarding depth pre-pass heuristic checks
-    struct DepthPrePassState {
+    // used to track state regarding render pass heuristic checks
+    struct RenderPassState {
         bool depthAttachment = false;
         bool colorAttachment = false;
         bool depthOnly = false;
@@ -514,8 +514,8 @@ class BestPractices : public ValidationStateTracker {
         uint32_t numDrawCallsDepthEqualCompare = 0;
     };
 
-    // used to track depth pre-pass heuristic data per command buffer
-    layer_data::unordered_map<VkCommandBuffer, DepthPrePassState> cbDepthPrePassStates = {};
+    // used to track heuristic data per command buffer
+    layer_data::unordered_map<VkCommandBuffer, RenderPassState> cbRenderPassState = {};
 
     // Used for instance versions of this object
     layer_data::unordered_map<VkSwapchainKHR, SWAPCHAIN_STATE_BP> swapchain_bp_state_map;

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -537,6 +537,5 @@ class BestPractices : public ValidationStateTracker {
     void ReleaseImageUsageState(VkImage image);
     std::unordered_map<VkImage, IMAGE_STATE_BP> imageUsageMap;
 
-    QueueCallbacks queue_submit_functions_after_render_pass;
     void AddDeferredQueueOperations(CMD_BUFFER_STATE* cb);
 };

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -503,6 +503,11 @@ class BestPractices : public ValidationStateTracker {
     struct GraphicsPipelineCIs {
         const safe_VkPipelineDepthStencilStateCreateInfo* depthStencilStateCI;
         const safe_VkPipelineColorBlendStateCreateInfo* colorBlendStateCI;
+        struct AttachmentInfo {
+            uint32_t framebufferAttachment;
+            VkImageAspectFlags aspects;
+        };
+        std::vector<AttachmentInfo> accessFramebufferAttachments;
     };
 
     // used to track CreateInfos for graphics pipelines

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -214,6 +214,7 @@ class BestPractices : public ValidationStateTracker {
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                void* pipe_state) const override;
     bool ValidateCreateComputePipelineArm(const VkComputePipelineCreateInfo& createInfo) const;
+    void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator) override;
 
     bool CheckPipelineStageFlags(const std::string& api_name, VkPipelineStageFlags flags) const;
     bool CheckPipelineStageFlags(const std::string& api_name, VkPipelineStageFlags2KHR flags) const;

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -458,6 +458,9 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;
 
     void PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo) override;
+    void PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool pool, const VkAllocationCallbacks *pAllocation) override;
+    void PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
+                                         uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers) override;
 
     std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
                                                          VkSwapchainKHR swapchain) final {

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -256,6 +256,10 @@ class BestPractices : public ValidationStateTracker {
 
     void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          VkSubpassContents contents) override;
+    void PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                          const VkSubpassBeginInfo *pSubpassBeginInfo) override;
+    void PreCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                             const VkSubpassBeginInfo *pSubpassBeginInfo) override;
     void PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer) override;
     void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) override;
     void PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR *pSubpassEndInfo) override;
@@ -297,6 +301,8 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) const override;
     bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const override;
+    bool PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) const override;
+    bool PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) const override;
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                               uint32_t firstInstance) override;
     void PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
@@ -580,4 +586,7 @@ class BestPractices : public ValidationStateTracker {
     bool ValidateClearAttachment(VkCommandBuffer commandBuffer, const CMD_BUFFER_STATE* cmd,
                                  uint32_t fb_attachment, uint32_t color_attachment,
                                  VkImageAspectFlags aspects, bool secondary) const;
+
+    bool ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const;
+    void RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin);
 };

--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -264,6 +264,7 @@ void CMD_BUFFER_STATE::Reset() {
     Invalidate(true);
 
     queue_submit_functions.clear();
+    queue_submit_functions_after_render_pass.clear();
     cmd_execute_commands_functions.clear();
     eventUpdates.clear();
     queryUpdates.clear();

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -286,6 +286,10 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     // Validation functions run at primary CB queue submit time
     std::vector<std::function<bool(const ValidationStateTracker *device_data, const class QUEUE_STATE *queue_state)>>
         queue_submit_functions;
+    // Used by some layers to defer actions until vkCmdEndRenderPass time.
+    // Layers using this are responsible for inserting the callbacks into queue_submit_functions.
+    std::vector<std::function<bool(const ValidationStateTracker *device_data, const class QUEUE_STATE *queue_state)>>
+        queue_submit_functions_after_render_pass;
     // Validation functions run when secondary CB is executed in primary
     std::vector<std::function<bool(const CMD_BUFFER_STATE *, const FRAMEBUFFER_STATE *)>> cmd_execute_commands_functions;
     std::vector<

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1298,10 +1298,11 @@ VkBufferTest::~VkBufferTest() {
 }
 
 std::unique_ptr<VkImageObj> VkArmBestPracticesLayerTest::CreateImage(VkFormat format, const uint32_t width,
-                                                                     const uint32_t height) {
+                                                                     const uint32_t height,
+                                                                     VkImageUsageFlags attachment_usage) {
     auto img = std::unique_ptr<VkImageObj>(new VkImageObj(m_device));
     img->Init(width, height, 1, format,
-              VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+              VK_IMAGE_USAGE_SAMPLED_BIT | attachment_usage |
               VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
               VK_IMAGE_TILING_OPTIMAL);
     return img;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -289,7 +289,8 @@ class VkBestPracticesLayerTest : public VkLayerTest {
 
 class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
   public:
-    std::unique_ptr<VkImageObj> CreateImage(VkFormat format, const uint32_t width, const uint32_t height);
+    std::unique_ptr<VkImageObj> CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
+                                            VkImageUsageFlags attachment_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkRenderPass CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op = VK_ATTACHMENT_LOAD_OP_CLEAR,
                                   VkAttachmentStoreOp store_op = VK_ATTACHMENT_STORE_OP_STORE);
     VkFramebuffer CreateFramebuffer(const uint32_t width, const uint32_t height, VkImageView image_view, VkRenderPass renderpass);

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -941,6 +941,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -1061,6 +1062,9 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
     graphics_pipeline.InitInfo();
 
     graphics_pipeline.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    graphics_pipeline.cb_attachments_.colorWriteMask = 0xf;
+    graphics_pipeline.cb_ci_.attachmentCount = 1;
+    graphics_pipeline.cb_ci_.pAttachments = &graphics_pipeline.cb_attachments_;
     graphics_pipeline.InitState();
 
     graphics_pipeline.gp_ci_.renderPass = renderpasses[0];
@@ -1143,6 +1147,9 @@ TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
     graphics_pipeline.InitInfo();
 
     graphics_pipeline.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    graphics_pipeline.cb_attachments_.colorWriteMask = 0xf;
+    graphics_pipeline.cb_ci_.attachmentCount = 1;
+    graphics_pipeline.cb_ci_.pAttachments = &graphics_pipeline.cb_attachments_;
     graphics_pipeline.InitState();
 
     graphics_pipeline.gp_ci_.renderPass = renderpasses[0];
@@ -1233,6 +1240,9 @@ TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
     graphics_pipeline.dsl_bindings_[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     graphics_pipeline.dsl_bindings_[1].binding = 10;
     graphics_pipeline.dsl_bindings_[1].descriptorCount = 4;
+    graphics_pipeline.cb_ci_.attachmentCount = 1;
+    graphics_pipeline.cb_ci_.pAttachments = &graphics_pipeline.cb_attachments_;
+    graphics_pipeline.cb_attachments_.colorWriteMask = 0xf;
     graphics_pipeline.InitState();
 
     graphics_pipeline.gp_ci_.renderPass = renderpasses[0];
@@ -1355,6 +1365,7 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
     m_commandBuffer->begin();
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -244,11 +244,14 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
+    VkClearRect clear_rect_small = {{{0, 0}, {(uint32_t)m_width - 1u, (uint32_t)m_height - 1u}}, 0, 1};
     VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
 
+    // Small clears which don't cover the render area should not trigger the warning.
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect_small);
+    m_errorMonitor->VerifyNotFound();
     // Call for full-sized FB Color attachment prior to issuing a Draw
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
-
     vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -680,17 +680,25 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     m_clear_via_load_op = false;  // Force LOAD_OP_LOAD
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
-
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-store");
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-clear");
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
 
+    CreatePipelineHelper pipe_masked(*this);
+    pipe_masked.InitInfo();
+    pipe_masked.InitState();
+    pipe_masked.cb_attachments_.colorWriteMask = 0;
+    pipe_masked.CreateGraphicsPipeline();
+
+    CreatePipelineHelper pipe_writes(*this);
+    pipe_writes.InitInfo();
+    pipe_writes.InitState();
+    pipe_writes.cb_attachments_.colorWriteMask = 0xf;
+    pipe_writes.CreateGraphicsPipeline();
+
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -701,9 +709,98 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     color_attachment.colorAttachment = 0;
     VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
 
-    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+    // Plain clear after load.
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    {
+        vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+        m_errorMonitor->VerifyFound();
+    }
+    m_commandBuffer->EndRenderPass();
 
-    m_errorMonitor->VerifyFound();
+    // Test that a masked write is ignored before clear
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    {
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_masked.pipeline_);
+        m_commandBuffer->Draw(1, 0, 0, 0);
+        vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+        m_errorMonitor->VerifyFound();
+    }
+    m_commandBuffer->EndRenderPass();
+
+    // Test that an actual write will not trigger the clear warning
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    {
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_writes.pipeline_);
+        m_commandBuffer->Draw(1, 0, 0, 0);
+        vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
+        m_errorMonitor->VerifyNotFound();
+    }
+    m_commandBuffer->EndRenderPass();
+
+    // Try the same thing, but now with secondary command buffers.
+    VkCommandBufferBeginInfo begin_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT |
+                       VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    VkCommandBufferInheritanceInfo inherit_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO };
+    begin_info.pInheritanceInfo = &inherit_info;
+    inherit_info.subpass = 0;
+    inherit_info.renderPass = m_renderPassBeginInfo.renderPass;
+
+    auto* secondary_clear = new VkCommandBufferObj(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    auto* secondary_draw_masked = new VkCommandBufferObj(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    auto* secondary_draw_write = new VkCommandBufferObj(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+
+    secondary_clear->begin(&begin_info);
+    secondary_draw_masked->begin(&begin_info);
+    secondary_draw_write->begin(&begin_info);
+
+    vk::CmdClearAttachments(secondary_clear->handle(), 1, &color_attachment, 1, &clear_rect);
+
+    vk::CmdBindPipeline(secondary_draw_masked->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_masked.pipeline_);
+    secondary_draw_masked->Draw(1, 0, 0, 0);
+
+    vk::CmdBindPipeline(secondary_draw_write->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_writes.pipeline_);
+    secondary_draw_write->Draw(1, 0, 0, 0);
+
+    secondary_clear->end();
+    secondary_draw_masked->end();
+    secondary_draw_write->end();
+
+    // Plain clear after load.
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    {
+        vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_clear->handle());
+        m_errorMonitor->VerifyFound();
+    }
+    m_commandBuffer->EndRenderPass();
+
+    // Test that a masked write is ignored before clear
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    {
+        vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_draw_masked->handle());
+        vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_clear->handle());
+        m_errorMonitor->VerifyFound();
+    }
+    m_commandBuffer->EndRenderPass();
+
+    // Test that an actual write will not trigger the clear warning
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    {
+        vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_draw_write->handle());
+        vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_clear->handle());
+        m_errorMonitor->VerifyNotFound();
+    }
+    m_commandBuffer->EndRenderPass();
+
+    delete secondary_clear;
+    delete secondary_draw_write;
+    delete secondary_draw_masked;
 }
 
 TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -2199,8 +2199,8 @@ void VkCommandBufferObj::PrepareAttachments(const vector<std::unique_ptr<VkImage
     }
 }
 
-void VkCommandBufferObj::BeginRenderPass(const VkRenderPassBeginInfo &info) {
-    vk::CmdBeginRenderPass(handle(), &info, VK_SUBPASS_CONTENTS_INLINE);
+void VkCommandBufferObj::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents) {
+    vk::CmdBeginRenderPass(handle(), &info, contents);
 }
 
 void VkCommandBufferObj::EndRenderPass() { vk::CmdEndRenderPass(handle()); }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -872,7 +872,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         att.loadOp = (m_clear_via_load_op) ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
         ;
         att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-        att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        att.stencilLoadOp = (m_clear_via_load_op) ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
         att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
         att.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         att.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -373,7 +373,7 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
     void BindDescriptorSet(VkDescriptorSetObj &descriptorSet);
     void BindIndexBuffer(VkBufferObj *indexBuffer, VkDeviceSize offset, VkIndexType indexType);
     void BindVertexBuffer(VkConstantBufferObj *vertexBuffer, VkDeviceSize offset, uint32_t binding);
-    void BeginRenderPass(const VkRenderPassBeginInfo &info);
+    void BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
     void EndRenderPass();
     void FillBuffer(VkBuffer buffer, VkDeviceSize offset, VkDeviceSize fill_size, uint32_t data);
     void Draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);


### PR DESCRIPTION
This is a fairly long-winded PR, but I've tried my best to make the commits flow logically and atomically so that it is easier to review in isolation. I can split the PR into several stages if it helps.

This PR accomplishes:
- First, fix a bug with deferred command buffer ops. They should be cmd_buffer local, not global. Fixes a regression in the state tracking.
- Rewrite clear attachments check to be more accurate. Track which attachments are actually written, and only report errors if clear attachments happens before any access is made to the attachment.
- Repurpose the depth-prepass state tracking struct to be more general, since we will use it to handle attachment access tracking now as well.
- Handle secondary command buffers w.r.t. tracking.
- Add tests to check secondary behavior.
- Fix some small nit bugs while I was at it.