### PR TITLE
Add CPU side validation for VK_EXT_multi_draw

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1169,8 +1169,16 @@ class CoreChecks : public ValidationStateTracker {
                                              const VkBuffer* pBuffers, const VkDeviceSize* pOffsets) const override;
     bool PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                                 uint32_t firstInstance) const override;
+    bool PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawInfoEXT* pVertexInfo,
+                                        uint32_t instanceCount, uint32_t firstInstance, uint32_t stride) const override;
+    bool ValidateCmdDrawIndexedBufferSize(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t firstIndex,
+                                          const char* caller, const char* first_index_vuid) const;
     bool PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                        uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) const override;
+    bool PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                               const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
+                                               uint32_t firstInstance, uint32_t stride,
+                                               const int32_t* pVertexOffset) const override;
     bool PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                uint32_t drawCount, uint32_t stride) const override;
     bool ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -267,7 +267,9 @@ static const char DECORATE_UNUSED *kVUID_Portability_InterpolationFunction = "UN
 
 // Pending VUIDs from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4585
 static const char DECORATE_UNUSED *kVUID_Core_CmdDraw_VertexInput = "UNASSIGNED-vkCmdDraw-vertexInput-not-specified";
+static const char DECORATE_UNUSED *kVUID_Core_CmdDrawMultiEXT_VertexInput = "UNASSIGNED-vkCmdDrawMultiEXT-vertexInput-not-specified";
 static const char DECORATE_UNUSED *kVUID_Core_CmdDrawIndexed_VertexInput = "UNASSIGNED-vkCmdDrawIndexed-vertexInput-not-specified";
+static const char DECORATE_UNUSED *kVUID_Core_CmdDrawMultiIndexedEXT_VertexInput = "UNASSIGNED-vkCmdDrawMultiIndexedEXT-vertexInput-not-specified";
 static const char DECORATE_UNUSED *kVUID_Core_CmdDrawIndirect_VertexInput = "UNASSIGNED-vkCmdDrawIndirect-vertexInput-not-specified";
 static const char DECORATE_UNUSED *kVUID_Core_CmdDrawIndexedIndirect_VertexInput = "UNASSIGNED-vkCmdDrawIndexedIndirect-vertexInput-not-specified";
 static const char DECORATE_UNUSED *kVUID_Core_CmdDrawIndirectCount_VertexInput = "UNASSIGNED-vkCmdDrawIndirectCount-vertexInput-not-specified";

--- a/layers/device_state.h
+++ b/layers/device_state.h
@@ -77,6 +77,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features;
     VkPhysicalDeviceInheritedViewportScissorFeaturesNV inherited_viewport_scissor_features;
     VkPhysicalDeviceProvokingVertexFeaturesEXT provoking_vertex_features;
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -88,6 +88,51 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
     }
 };
 
+struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
+    DispatchVuidsCmdDrawMultiEXT() : DrawDispatchVuid() {
+        pipeline_bound                     = "VUID-vkCmdDrawMultiEXT-None-02700";
+        dynamic_state                      = "VUID-vkCmdDrawMultiEXT-commandBuffer-02701";
+        vertex_binding                     = "VUID-vkCmdDrawMultiEXT-None-04007";
+        vertex_binding_null                = "VUID-vkCmdDrawMultiEXT-None-04008";
+        compatible_pipeline                = "VUID-vkCmdDrawMultiEXT-None-02697";
+        render_pass_compatible             = "VUID-vkCmdDrawMultiEXT-renderPass-02684";
+        subpass_index                      = "VUID-vkCmdDrawMultiEXT-subpass-02685";
+        sample_location                    = "VUID-vkCmdDrawMultiEXT-sampleLocationsEnable-02689";
+        linear_sampler                     = "VUID-vkCmdDrawMultiEXT-magFilter-04553";
+        cubic_sampler                      = "VUID-vkCmdDrawMultiEXT-None-02692";
+        viewport_count                     = "VUID-vkCmdDrawMultiEXT-viewportCount-03417";
+        scissor_count                      = "VUID-vkCmdDrawMultiEXT-scissorCount-03418";
+        viewport_scissor_count             = "VUID-vkCmdDrawMultiEXT-viewportCount-03419";
+        primitive_topology                 = "VUID-vkCmdDrawMultiEXT-primitiveTopology-03420";
+        corner_sampled_address_mode        = "VUID-vkCmdDrawMultiEXT-flags-02696";
+        subpass_input                      = "VUID-vkCmdDrawMultiEXT-None-02686";
+        imageview_atomic                   = "VUID-vkCmdDrawMultiEXT-None-02691";
+        push_constants_set                 = "VUID-vkCmdDrawMultiEXT-None-02698";
+        image_subresources                 = "VUID-vkCmdDrawMultiEXT-None-04584";
+        descriptor_valid                   = "VUID-vkCmdDrawMultiEXT-None-02699";
+        sampler_imageview_type             = "VUID-vkCmdDrawMultiEXT-None-02702";
+        sampler_implicitLod_dref_proj      = "VUID-vkCmdDrawMultiEXT-None-02703";
+        sampler_bias_offset                = "VUID-vkCmdDrawMultiEXT-None-02704";
+        vertex_binding_attribute           = "VUID-vkCmdDrawMultiEXT-None-02721";
+        dynamic_state_setting_commands     = "VUID-vkCmdDrawMultiEXT-None-02859";
+        rasterization_samples              = "VUID-vkCmdDrawMultiEXT-rasterizationSamples-04740";
+        unprotected_command_buffer         = "VUID-vkCmdDrawMultiEXT-commandBuffer-02707";
+        protected_command_buffer           = "VUID-vkCmdDrawMultiEXT-commandBuffer-02712";
+        max_multiview_instance_index       = "VUID-vkCmdDrawMultiEXT-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic                   = "VUID-vkCmdDrawMultiEXT-None-02693";
+        filter_cubic                       = "VUID-vkCmdDrawMultiEXT-filterCubic-02694";
+        filter_cubic_min_max               = "VUID-vkCmdDrawMultiEXT-filterCubicMinmax-02695";
+        viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMultiEXT-primitiveFragmentShadingRateWithMultipleViewports-04552";
+        patch_control_points               = "VUID-vkCmdDrawMultiEXT-None-04875";
+        rasterizer_discard_enable          = "VUID-vkCmdDrawMultiEXT-None-04876";
+        depth_bias_enable                  = "VUID-vkCmdDrawMultiEXT-None-04877";
+        logic_op                           = "VUID-vkCmdDrawMultiEXT-logicOp-04878";
+        primitive_restart_enable           = "VUID-vkCmdDrawMultiEXT-None-04879";
+        vertex_input_binding_stride        = "VUID-vkCmdDrawMultiEXT-pStrides-04884";
+        vertex_input                       = kVUID_Core_CmdDrawMultiEXT_VertexInput;
+    }
+};
+
 struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
     DispatchVuidsCmdDrawIndexed() : DrawDispatchVuid() {
         pipeline_bound                     = "VUID-vkCmdDrawIndexed-None-02700";
@@ -130,6 +175,51 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndexed-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexed-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndexed_VertexInput;
+    }
+};
+
+struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
+    DispatchVuidsCmdDrawMultiIndexedEXT() : DrawDispatchVuid() {
+        pipeline_bound = "VUID-vkCmdDrawMultiIndexedEXT-None-02700";
+        dynamic_state = "VUID-vkCmdDrawMultiIndexedEXT-commandBuffer-02701";
+        vertex_binding = "VUID-vkCmdDrawMultiIndexedEXT-None-04007";
+        vertex_binding_null = "VUID-vkCmdDrawMultiIndexedEXT-None-04008";
+        compatible_pipeline = "VUID-vkCmdDrawMultiIndexedEXT-None-02697";
+        render_pass_compatible = "VUID-vkCmdDrawMultiIndexedEXT-renderPass-02684";
+        subpass_index = "VUID-vkCmdDrawMultiIndexedEXT-subpass-02685";
+        sample_location = "VUID-vkCmdDrawMultiIndexedEXT-sampleLocationsEnable-02689";
+        linear_sampler = "VUID-vkCmdDrawMultiIndexedEXT-magFilter-04553";
+        cubic_sampler = "VUID-vkCmdDrawMultiIndexedEXT-None-02692";
+        viewport_count = "VUID-vkCmdDrawMultiIndexedEXT-viewportCount-03417";
+        scissor_count = "VUID-vkCmdDrawMultiIndexedEXT-scissorCount-03418";
+        viewport_scissor_count = "VUID-vkCmdDrawMultiIndexedEXT-viewportCount-03419";
+        primitive_topology = "VUID-vkCmdDrawMultiIndexedEXT-primitiveTopology-03420";
+        corner_sampled_address_mode = "VUID-vkCmdDrawMultiIndexedEXT-flags-02696";
+        subpass_input = "VUID-vkCmdDrawMultiIndexedEXT-None-02686";
+        imageview_atomic = "VUID-vkCmdDrawMultiIndexedEXT-None-02691";
+        push_constants_set = "VUID-vkCmdDrawMultiIndexedEXT-None-02698";
+        image_subresources = "VUID-vkCmdDrawMultiIndexedEXT-None-04584";
+        descriptor_valid = "VUID-vkCmdDrawMultiIndexedEXT-None-02699";
+        sampler_imageview_type = "VUID-vkCmdDrawMultiIndexedEXT-None-02702";
+        sampler_implicitLod_dref_proj = "VUID-vkCmdDrawMultiIndexedEXT-None-02703";
+        sampler_bias_offset = "VUID-vkCmdDrawMultiIndexedEXT-None-02704";
+        vertex_binding_attribute = "VUID-vkCmdDrawMultiIndexedEXT-None-02721";
+        dynamic_state_setting_commands = "VUID-vkCmdDrawMultiIndexedEXT-None-02859";
+        rasterization_samples = "VUID-vkCmdDrawMultiIndexedEXT-rasterizationSamples-04740";
+        unprotected_command_buffer = "VUID-vkCmdDrawMultiIndexedEXT-commandBuffer-02707";
+        protected_command_buffer = "VUID-vkCmdDrawMultiIndexedEXT-commandBuffer-02712";
+        max_multiview_instance_index = "VUID-vkCmdDrawMultiIndexedEXT-maxMultiviewInstanceIndex-02688";
+        img_filter_cubic = "VUID-vkCmdDrawMultiIndexedEXT-None-02693";
+        filter_cubic = "VUID-vkCmdDrawMultiIndexedEXT-filterCubic-02694";
+        filter_cubic_min_max = "VUID-vkCmdDrawMultiIndexedEXT-filterCubicMinmax-02695";
+        viewport_count_primitive_shading_rate = "VUID-vkCmdDrawMultiIndexedEXT-primitiveFragmentShadingRateWithMultipleViewports-04552";
+        patch_control_points = "VUID-vkCmdDrawMultiIndexedEXT-None-04875";
+        rasterizer_discard_enable = "VUID-vkCmdDrawMultiIndexedEXT-None-04876";
+        depth_bias_enable = "VUID-vkCmdDrawMultiIndexedEXT-None-04877";
+        logic_op = "VUID-vkCmdDrawMultiIndexedEXT-logicOp-04878";
+        primitive_restart_enable = "VUID-vkCmdDrawMultiIndexedEXT-None-04879";
+        vertex_input_binding_stride = "VUID-vkCmdDrawMultiIndexedEXT-pStrides-04884";
+        vertex_input = kVUID_Core_CmdDrawMultiIndexedEXT_VertexInput;
     }
 };
 
@@ -642,7 +732,9 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
 // This LUT is created to allow a static listing of each VUID that is covered by drawdispatch commands
 static const std::map<CMD_TYPE, DrawDispatchVuid> kDrawdispatchVuid = {
     {CMD_DRAW, DispatchVuidsCmdDraw()},
+    {CMD_DRAWMULTIEXT, DispatchVuidsCmdDrawMultiEXT()},
     {CMD_DRAWINDEXED, DispatchVuidsCmdDrawIndexed()},
+    {CMD_DRAWMULTIINDEXEDEXT, DispatchVuidsCmdDrawMultiIndexedEXT()},
     {CMD_DRAWINDIRECT, DispatchVuidsCmdDrawIndirect()},
     {CMD_DRAWINDEXEDINDIRECT, DispatchVuidsCmdDrawIndexedIndirect()},
     {CMD_DISPATCH, DispatchVuidsCmdDispatch()},
@@ -712,31 +804,89 @@ bool CoreChecks::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t 
     return skip;
 }
 
+bool CoreChecks::PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
+                                                uint32_t firstInstance, uint32_t stride) const {
+    bool skip = false;
+    if (!enabled_features.multi_draw_features.multiDraw) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiEXT-None-04933",
+                         "vkCmdDrawMultiEXT(): The multiDraw feature must be enabled to "
+                         "call this command.");
+    }
+    if (drawCount > phys_dev_ext_props.multi_draw_props.maxMultiDrawCount) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiEXT-drawCount-04934",
+                         "vkCmdDrawMultiEXT(): parameter, uint32_t drawCount (%" PRIu32
+                         ") must be less than VkPhysicalDeviceMultiDrawPropertiesEXT::maxMultiDrawCount (%" PRIu32 ").",
+                         drawCount, phys_dev_ext_props.multi_draw_props.maxMultiDrawCount);
+    }
+
+    skip |= ValidateCmdDrawInstance(commandBuffer, instanceCount, firstInstance, CMD_DRAWMULTIEXT, "vkCmdDrawMultiEXT()");
+    skip |= ValidateCmdDrawType(commandBuffer, false, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWMULTIEXT, "vkCmdDrawMultiEXT()");
+    return skip;
+}
+
+bool CoreChecks::ValidateCmdDrawIndexedBufferSize(VkCommandBuffer commandBuffer, uint32_t indexCount,
+    uint32_t firstIndex, const char *caller, const char *first_index_vuid) const {
+    bool skip = false;
+    const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    if (cb_state->status & CBSTATUS_INDEX_BUFFER_BOUND) {
+        unsigned int index_size = 0;
+        const auto &index_buffer_binding = cb_state->index_buffer_binding;
+        if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT16) {
+            index_size = 2;
+        }
+        else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT32) {
+            index_size = 4;
+        }
+        else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT8_EXT) {
+            index_size = 1;
+        }
+        VkDeviceSize end_offset = (index_size * (static_cast<VkDeviceSize>(firstIndex) + indexCount)) + index_buffer_binding.offset;
+        if (end_offset > index_buffer_binding.size) {
+            skip |= LogError(index_buffer_binding.buffer_state->buffer(), first_index_vuid,
+                             "%s: index size (%u) * (firstIndex (%u) + indexCount (%u)) "
+                             "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
+                             " bytes, which is greater than the index buffer size (%" PRIuLEAST64 ").",
+                             caller, index_size, firstIndex, indexCount, index_buffer_binding.offset, end_offset,
+                             index_buffer_binding.size);
+        }
+    }
+    return skip;
+}
+
 bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) const {
     bool skip = false;
     skip |= ValidateCmdDrawInstance(commandBuffer, instanceCount, firstInstance, CMD_DRAWINDEXED, "vkCmdDrawIndexed()");
     skip |= ValidateCmdDrawType(commandBuffer, true, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWINDEXED, "vkCmdDrawIndexed()");
-    const CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
-    if (!skip && (cb_state->status & CBSTATUS_INDEX_BUFFER_BOUND)) {
-        unsigned int index_size = 0;
-        const auto &index_buffer_binding = cb_state->index_buffer_binding;
-        if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT16) {
-            index_size = 2;
-        } else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT32) {
-            index_size = 4;
-        } else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT8_EXT) {
-            index_size = 1;
-        }
-        VkDeviceSize end_offset = (index_size * (static_cast<VkDeviceSize>(firstIndex) + indexCount)) + index_buffer_binding.offset;
-        if (end_offset > index_buffer_binding.size) {
-            skip |=
-                LogError(index_buffer_binding.buffer_state->buffer(), "VUID-vkCmdDrawIndexed-firstIndex-04932",
-                         "vkCmdDrawIndexed() index size (%d) * (firstIndex (%d) + indexCount (%d)) "
-                         "+ binding offset (%" PRIuLEAST64 ") = an ending offset of %" PRIuLEAST64
-                         " bytes, which is greater than the index buffer size (%" PRIuLEAST64 ").",
-                         index_size, firstIndex, indexCount, index_buffer_binding.offset, end_offset, index_buffer_binding.size);
-        }
+    skip |= ValidateCmdDrawIndexedBufferSize(commandBuffer, indexCount, firstIndex, "vkCmdDrawIndexed()",
+                                             "VUID-vkCmdDrawIndexed-firstIndex-04932");
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                       const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
+                                                       uint32_t firstInstance, uint32_t stride,
+                                                       const int32_t *pVertexOffset) const {
+    bool skip = false;
+    if (!enabled_features.multi_draw_features.multiDraw) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiIndexedEXT-None-04937",
+                         "vkCmdDrawMultiIndexedEXT(): The multiDraw feature must be enabled to "
+                         "call this command.");
+    }
+    if (drawCount > phys_dev_ext_props.multi_draw_props.maxMultiDrawCount) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiIndexedEXT-drawCount-04939",
+                         "vkCmdDrawMultiIndexedEXT(): parameter, uint32_t drawCount (0x%" PRIu32
+                         ") must be less than VkPhysicalDeviceMultiDrawPropertiesEXT::maxMultiDrawCount (0x%" PRIu32 ").",
+                         drawCount, phys_dev_ext_props.multi_draw_props.maxMultiDrawCount);
+    }
+    skip |=
+        ValidateCmdDrawInstance(commandBuffer, instanceCount, firstInstance, CMD_DRAWMULTIINDEXEDEXT, "vkCmdDrawMultiIndexedEXT()");
+    skip |= ValidateCmdDrawType(commandBuffer, true, VK_PIPELINE_BIND_POINT_GRAPHICS, CMD_DRAWMULTIINDEXEDEXT,
+                                "vkCmdDrawMultiIndexedEXT()");
+    for (uint32_t i = 0; i < drawCount; i++) {
+        skip |= ValidateCmdDrawIndexedBufferSize(commandBuffer, pIndexInfo[i].indexCount, pIndexInfo[i].firstIndex,
+                                                 "vkCmdDrawMultiIndexedEXT()", "VUID-vkCmdDrawMultiIndexedEXT-firstIndex-04938");
     }
     return skip;
 }

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -14996,6 +14996,7 @@ bool StatelessValidation::PreCallValidateCmdDrawMultiEXT(
     bool skip = false;
     if (!device_extensions.vk_ext_multi_draw) skip |= OutputExtensionError("vkCmdDrawMultiEXT", VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     // No xml-driven validation
+    if (!skip) skip |= manual_PreCallValidateCmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
     return skip;
 }
 
@@ -15010,6 +15011,7 @@ bool StatelessValidation::PreCallValidateCmdDrawMultiIndexedEXT(
     bool skip = false;
     if (!device_extensions.vk_ext_multi_draw) skip |= OutputExtensionError("vkCmdDrawMultiIndexedEXT", VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     // No xml-driven validation
+    if (!skip) skip |= manual_PreCallValidateCmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride, pVertexOffset);
     return skip;
 }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -3973,6 +3973,39 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndexedIndirectCountKHR(V
     return ValidateCmdDrawIndexedIndirectCount(commandBuffer, offset, countBufferOffset, true);
 }
 
+bool StatelessValidation::manual_PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                                const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
+                                                                uint32_t firstInstance, uint32_t stride) const {
+    bool skip = false;
+    if (stride & 3) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiEXT-stride-04936",
+                         "CmdDrawMultiEXT: parameter, uint32_t stride (%" PRIu32 ") is not a multiple of 4.", stride);
+    }
+    if (drawCount && nullptr == pVertexInfo) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiEXT-drawCount-04935",
+                         "CmdDrawMultiEXT: parameter, VkMultiDrawInfoEXT *pVertexInfo must be a valid pointer to memory containing "
+                         "one or more valid instances of VkMultiDrawInfoEXT structures");
+    }
+    return skip;
+}
+
+bool StatelessValidation::manual_PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                                       const VkMultiDrawIndexedInfoEXT *pIndexInfo,
+                                                                       uint32_t instanceCount, uint32_t firstInstance,
+                                                                       uint32_t stride, const int32_t *pVertexOffset) const {
+    bool skip = false;
+    if (stride & 3) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiIndexedEXT-stride-04941",
+                         "CmdDrawMultiIndexedEXT: parameter, uint32_t stride (%" PRIu32 ") is not a multiple of 4.", stride);
+    }
+    if (drawCount && nullptr == pIndexInfo) {
+        skip |= LogError(commandBuffer, "VUID-vkCmdDrawMultiIndexedEXT-drawCount-04940",
+                         "CmdDrawMultiIndexedEXT: parameter, VkMultiDrawIndexedInfoEXT *pIndexInfo must be a valid pointer to "
+                         "memory containing one or more valid instances of VkMultiDrawIndexedInfoEXT structures");
+    }
+    return skip;
+}
+
 bool StatelessValidation::manual_PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                                     const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                                     const VkClearRect *pRects) const {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1343,6 +1343,11 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
         state_tracker->enabled_features.inherited_viewport_scissor_features = *inherited_viewport_scissor_features;
     }
 
+    const auto *multi_draw_features = LvlFindInChain<VkPhysicalDeviceMultiDrawFeaturesEXT>(pCreateInfo->pNext);
+    if (multi_draw_features) {
+        state_tracker->enabled_features.multi_draw_features = *multi_draw_features;
+    }
+
     // Store physical device properties and physical device mem limits into CoreChecks structs
     DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
     DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);
@@ -1439,6 +1444,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_multiview, &phys_dev_props->multiview_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_portability_subset, &phys_dev_props->portability_props);
     GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_provoking_vertex, &phys_dev_props->provoking_vertex_props);
+    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_multi_draw, &phys_dev_props->multi_draw_props);
 
     if (!state_tracker->device_extensions.vk_feature_version_1_2 && dev_ext.vk_khr_timeline_semaphore) {
         VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1272,6 +1272,7 @@ class ValidationStateTracker : public ValidationObject {
         VkPhysicalDevicePortabilitySubsetPropertiesKHR portability_props;
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
         VkPhysicalDeviceProvokingVertexPropertiesEXT provoking_vertex_props;
+        VkPhysicalDeviceMultiDrawPropertiesEXT multi_draw_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties;

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1468,6 +1468,14 @@ class StatelessValidation : public ValidationObject {
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride) const;
 
+    bool manual_PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                               const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
+                                               uint32_t firstInstance, uint32_t stride) const;
+
+    bool manual_PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                      const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
+                                                      uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset) const;
+
     bool manual_PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                    const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                    const VkClearRect *pRects) const;

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -171,6 +171,8 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetLineWidth',
             'vkCmdDrawIndirect',
             'vkCmdDrawIndexedIndirect',
+            'vkCmdDrawMultiEXT',
+            'vkCmdDrawMultiIndexedEXT',
             'vkCmdClearAttachments',
             'vkCmdBindIndexBuffer',
             'vkCmdCopyBuffer',

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -318,7 +318,7 @@ TEST_F(VkLayerTest, IndexBufferBadSize) {
     TEST_DESCRIPTION("Run indexed draw call with bad index buffer size.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed() index size ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed(): index size ");
     VKTriangleTest(BsoFailIndexBufferBadSize);
     m_errorMonitor->VerifyFound();
 }
@@ -327,7 +327,7 @@ TEST_F(VkLayerTest, IndexBufferBadOffset) {
     TEST_DESCRIPTION("Run indexed draw call with bad index buffer offset.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed() index size ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed(): index size ");
     VKTriangleTest(BsoFailIndexBufferBadOffset);
     m_errorMonitor->VerifyFound();
 }
@@ -336,7 +336,7 @@ TEST_F(VkLayerTest, IndexBufferBadBindSize) {
     TEST_DESCRIPTION("Run bind index buffer with a size greater than the index buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed() index size ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed(): index size ");
     VKTriangleTest(BsoFailIndexBufferBadMapSize);
     m_errorMonitor->VerifyFound();
 }
@@ -345,7 +345,7 @@ TEST_F(VkLayerTest, IndexBufferBadBindOffset) {
     TEST_DESCRIPTION("Run bind index buffer with an offset greater than the size of the index buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed() index size ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdDrawIndexed(): index size ");
     VKTriangleTest(BsoFailIndexBufferBadMapOffset);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
This brings vkCmdDrawMultiEXT and vkCmdDrawMultiIndexedEXT up to CPU side validation parity with the rest of the draw/dispatch calls.  GPU-AV and Debug Printf support will be in a future PR 