### PR TITLE
tests: Add Extra Max Component test

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -832,6 +832,8 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 
     // XXX TODO: Would be nice to rewrite this to use CollectInterfaceByLocation (or something similar),
     // but that doesn't include builtins.
+    // When rewritten, using the CreatePipelineExceedVertexMaxComponentsWithBuiltins test it would be nice to also let the user know
+    // how many components were from builtins as it might not be obvious
     for (auto &var : variables) {
         // Check if the variable is a patch. Patches can also be members of blocks,
         // but if they are then the top-level arrayness has already been stripped


### PR DESCRIPTION
I wrote these tests a while ago while looking into https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2835

I was unaware before of the implicit 7 components GLSL injects for vertex shaders and figured other people would be caught off guard. The validation layers properly handle it, but think it could be a better error message. Added to the TODO until I have more time to refactor the shader module code, but for now, the extra tests don't hurt just getting checked in IMO