### PR TITLE
layers: Refactor Swapchain BP state

### DIFF
--- a/layers/generated/best_practices.cpp
+++ b/layers/generated/best_practices.cpp
@@ -945,7 +945,6 @@ void BestPractices::PostCallRecordCreateSwapchainKHR(
     VkSwapchainKHR*                             pSwapchain,
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, result);
-    ManualPostCallRecordCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, result);
     if (result != VK_SUCCESS) {
         static const std::vector<VkResult> error_codes = {VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR,VK_ERROR_INITIALIZATION_FAILED};
         static const std::vector<VkResult> success_codes = {};

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4323,7 +4323,7 @@ void ValidationStateTracker::RecordCreateSwapchainState(VkResult result, const V
                                                         VkSwapchainKHR *pSwapchain, SURFACE_STATE *surface_state,
                                                         SWAPCHAIN_NODE *old_swapchain_state) {
     if (VK_SUCCESS == result) {
-        auto swapchain_state = std::make_shared<SWAPCHAIN_NODE>(pCreateInfo, *pSwapchain);
+        auto swapchain_state = CreateSwapchainState(pCreateInfo, *pSwapchain);
         if (VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR == pCreateInfo->presentMode ||
             VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR == pCreateInfo->presentMode) {
             swapchain_state->shared_presentable = true;
@@ -5700,4 +5700,9 @@ void ValidationStateTracker::PostCallRecordGetBufferDeviceAddressKHR(VkDevice de
 void ValidationStateTracker::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
                                                                      VkDeviceAddress address) {
     RecordGetBufferDeviceAddress(pInfo, address);
+}
+
+std::shared_ptr<SWAPCHAIN_NODE> ValidationStateTracker::CreateSwapchainState(const VkSwapchainCreateInfoKHR *create_info,
+                                                                             VkSwapchainKHR swapchain) {
+    return std::make_shared<SWAPCHAIN_NODE>(create_info, swapchain);
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1132,6 +1132,8 @@ class ValidationStateTracker : public ValidationObject {
     void RecordCreateSamplerYcbcrConversionANDROID(const VkSamplerYcbcrConversionCreateInfo* create_info,
                                                    VkSamplerYcbcrConversion ycbcr_conversion,
                                                    SAMPLER_YCBCR_CONVERSION_STATE* ycbcr_state);
+    virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
+                                                                 VkSwapchainKHR swapchain);
     void RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain,
                                     SURFACE_STATE* surface_state, SWAPCHAIN_NODE* old_swapchain_state);
     void RecordDestroySamplerYcbcrConversionState(VkSamplerYcbcrConversion ycbcr_conversion);

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -119,7 +119,6 @@ class BestPracticesOutputGenerator(OutputGenerator):
             'vkGetPhysicalDeviceSurfaceFormatsKHR',
             'vkGetPhysicalDeviceSurfaceFormats2KHR',
             'vkGetPhysicalDeviceDisplayPlanePropertiesKHR',
-            'vkCreateSwapchainKHR',
             'vkGetSwapchainImagesKHR',
             'vkEnumeratePhysicalDevices',
             'vkCreateDevice',


### PR DESCRIPTION
Make SWAPCHAIN_STATE_BP derive from SWAPCHAIN_NODE (base swapchain
state) and remove associated state life cycle management in BP VO.

If this seems like a good idea I'll start making these changes incrementally with other state structures.