### PR TITLE
Fix handling of separate depth-stencil layouts

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4383,10 +4383,8 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const CMD_BUFFER_STATE *pCB, const G
             if (initial_layout == VK_IMAGE_LAYOUT_UNDEFINED) {
                 // TODO: Set memory invalid which is in mem_tracker currently
             } else if (image_layout != initial_layout) {
-                // Need to look up the inital layout *state* to get a bit more information
-                const auto *initial_layout_state = subres_map->GetSubresourceInitialLayoutState(pos->first.begin);
-                assert(initial_layout_state);  // There's no way we should have an initial layout without matching state...
-                bool matches = ImageLayoutMatches(initial_layout_state->aspect_mask, image_layout, initial_layout);
+                const auto aspect_mask = image_state->subresource_encoder.Decode(intersected_range.begin).aspectMask;
+                bool matches = ImageLayoutMatches(aspect_mask, image_layout, initial_layout);
                 if (!matches) {
                     // We can report all the errors for the intersected range directly
                     for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -10502,9 +10502,10 @@ TEST_F(VkPositiveLayerTest, SeparateDepthStencilSubresourceLayout) {
     VkAttachmentReference2 att = { VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2 };
     VkAttachmentDescriptionStencilLayout stencil_desc = { VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT };
     VkAttachmentReferenceStencilLayout stencil_att = { VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT };
-    stencil_desc.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
+    // Test that we can discard stencil layout.
+    stencil_desc.stencilInitialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     stencil_desc.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-    stencil_att.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
+    stencil_att.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
 
     desc.format = ds_format;
     desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;


### PR DESCRIPTION
In vkd3d-proton, I ran into many issues with image layout tracking. The main issue is that while the current validation layers track layout per aspect, the validation code would naively check the layout for all aspects at a time, leading to non-sensical errors where a depth-stencil layout would be compared against the stencil layout. The code also didn't handle the `VK_IMAGE_LAYOUT_{DEPTH,STENCIL}_{ATTACHMENT,READ_ONLY}_OPTIMAL` layouts in normalization path. The spec says that the combined image layout enums are equivalent to the separate ones, so the added test case should be in-spec as far as I can tell.

I added a reasonable exhaustive test here that trips all the cases I found.

I'm not sure if I did it the right way since I've never poked into this part of the validation layers before.

The fix was essentially to loop over all aspects one by one, and then calling MatchLayout with a specific aspect.