### PR TITLE
Fix Spec Constant ID not found

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -1706,29 +1706,6 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
     return out;
 }
 
-uint32_t SHADER_MODULE_STATE::GetSpecConstantByteSize(uint32_t const_id) const {
-    auto itr = spec_const_map.find(const_id);
-    if (itr != spec_const_map.cend()) {
-        const auto def_ins = get_def(itr->second);
-        const auto type_ins = get_def(def_ins.word(1));
-
-        // Specialization constants can only be of type bool, scalar integer, or scalar floating point
-        switch (type_ins.opcode()) {
-            case spv::OpTypeBool:
-                // VUID 00776 spec states: ...If the specialization constant is of type boolean, size must be the byte size of
-                // VkBool32
-                return sizeof(VkBool32);
-            case spv::OpTypeInt:
-                return type_ins.word(2) / 8;
-            case spv::OpTypeFloat:
-                return type_ins.word(2) / 8;
-            default:
-                return decoration_set::kInvalidValue;
-        }
-    }
-    return decoration_set::kInvalidValue;
-}
-
 // Assumes itr points to an OpConstant instruction
 uint32_t GetConstantValue(const spirv_inst_iter &itr) { return itr.word(3); }
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -289,8 +289,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::vector<uint32_t> CollectBuiltinBlockMembers(spirv_inst_iter entrypoint, uint32_t storageClass) const;
     std::vector<std::pair<uint32_t, interface_var>> CollectInterfaceByInputAttachmentIndex(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
-
-    uint32_t GetSpecConstantByteSize(uint32_t const_id) const;
 };
 
 // TODO - Most things below are agnostic of even the shader module and more of pure SPIR-V utils

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -10971,7 +10971,7 @@ TEST_F(VkLayerTest, NotSupportProvokingVertexModePerPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SpecializationInvalidSize) {
+TEST_F(VkLayerTest, SpecializationInvalidSizeZero) {
     TEST_DESCRIPTION("Make sure an error is logged when a specialization map entry's size is 0");
 
     ASSERT_NO_FATAL_FAILURE(Init());


### PR DESCRIPTION
Closes #2950

- `GetSpecConstantByteSize` was only used once, so didn't see a need to break it out as own function. Also make logic easier in one place then trying to over-engineer the function
- confirmed in `spirv-val` source what coverage it does (will make sure its a bool/int/float)
- Added `SpecializationUnused` which should cover @ShabbyX use case
- Added some more test in `SpecializationInvalidSizeMismatch` with various spec constant types to confirm change is still working finding the right size