### PR TITLE
Making VUIDs for special use extension warning more granular

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -36,10 +36,26 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_Deprecated
     "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_DeprecatedExtension =
     "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension";
-static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension";
-static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension_CADSupport =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-cadsupport";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension_D3DEmulation =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-d3demulation";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension_DevTools =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-devtools";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension_Debugging =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-debugging";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateInstance_SpecialUseExtension_GLEmulation =
+    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-glemulation";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension_CADSupport =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-cadsupport";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension_D3DEmulation =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-d3demulation";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension_DevTools =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-devtools";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension_Debugging =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-debugging";
+static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_SpecialUseExtension_GLEmulation =
+    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-glemulation";
 static const char DECORATE_UNUSED *kVUID_BestPractices_CreateDevice_API_Mismatch =
     "UNASSIGNED-BestPractices-vkCreateDevice-API-version-mismatch";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SharingModeExclusive =

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -49,6 +49,15 @@ struct DeprecationData {
     std::string target;
 };
 
+struct SpecialUseVUIDs
+{
+    const char* cadsupport;
+    const char* d3demulation;
+    const char* devtools;
+    const char* debugging;
+    const char* glemulation;
+};
+
 typedef enum {
     kBPVendorArm = 0x00000001,
 } BPVendorFlagBits;
@@ -141,7 +150,7 @@ class BestPractices : public ValidationStateTracker {
 
     bool ValidateDeprecatedExtensions(const char* api_name, const char* extension_name, uint32_t version, const char* vuid) const;
 
-    bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const char* vuid) const;
+    bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const SpecialUseVUIDs& special_use_vuids) const;
 
     bool PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -114,7 +114,7 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
 
     // Create a 1.1 vulkan instance and request an extension promoted to core in 1.1
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension");
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-debugging");
     VkInstance dummy;
     auto features = features_;
     auto ici = GetInstanceCreateInfo();
@@ -219,7 +219,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-d3demulation");
     vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
As discussed in #2890, I changed the existing VUIDs for best practices warnings that get logged when enabling special use instance or device extensions. This way, people can filter out messages that apply to special use extension categories specifically. Especially ones related to debugging extensions, which are typically enabled when best practices warnings are enabled, but without disabling warnings on other special use extensions.