### PR TITLE
layers: Handle pNext usage of VkBufferOpaqueCaptureAddressCreateInfo

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -231,6 +231,18 @@ void GpuAssisted::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreat
     }
 }
 
+void GpuAssisted::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
+                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer, VkResult result) {
+    ValidationStateTracker::PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, result);
+    if (pCreateInfo) {
+        const auto *opaque_capture_address = LvlFindInChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
+        if (opaque_capture_address) {
+            // Validate against the size requested when the buffer was created
+            buffer_map[opaque_capture_address->opaqueCaptureAddress] = pCreateInfo->size;
+        }
+    }
+}
+
 // Turn on necessary device features.
 void GpuAssisted::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *create_info,
                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -201,6 +201,8 @@ class GpuAssisted : public ValidationStateTracker {
                                           const VkDependencyInfoKHR* pDependencyInfos) const override;
     void PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkBuffer* pBuffer, void* cb_state_data) override;
+    void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                    VkBuffer* pBuffer, VkResult result) override;
     void CreateAccelerationStructureBuildValidationState(GpuAssisted* device_GpuAssisted);
     void DestroyAccelerationStructureBuildValidationState();
     void PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer, const VkAccelerationStructureInfoNV* pInfo,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -337,6 +337,15 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
 
     auto buffer_state = std::make_shared<BUFFER_STATE>(*pBuffer, pCreateInfo);
 
+    if (pCreateInfo) {
+        const auto *opaque_capture_address = LvlFindInChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
+        if (opaque_capture_address) {
+            // address is used for GPU-AV and ray tracing buffer validation
+            buffer_state->deviceAddress = opaque_capture_address->opaqueCaptureAddress;
+            buffer_address_map_.emplace(opaque_capture_address->opaqueCaptureAddress, buffer_state.get());
+        }
+    }
+
     // Get a set of requirements in the case the app does not
     DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
 


### PR DESCRIPTION
If an opaque buffer address is available by means other than vkGetBufferDeviceAddress/vkGetBufferDeviceAddressKHR/vkGetBufferDeviceAddressEXT a buffer may be requested to be created using this handle (as may be the case with capture/playback tools). In this case calling vkGetBufferDeviceAddress/vkGetBufferDeviceAddressKHR/vkGetBufferDeviceAddressEXT is redundant and may be skipped.