### PR TITLE
layers: Fix ImageSubresourceLayoutMap update corner cases

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1392,15 +1392,6 @@ void CoreChecks::RecordTransitionImageLayout(CMD_BUFFER_STATE *cb_state, const I
         }
     }
     auto normalized_isr = image_state->NormalizeSubresourceRange(mem_barrier.subresourceRange);
-    const auto &image_create_info = image_state->createInfo;
-
-    // Special case for 3D images with VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT flag bit, where <extent.depth> and
-    // <arrayLayers> can potentially alias.  When recording layout for the entire image, pre-emptively record layouts
-    // for all (potential) layer sub_resources.
-    if (0 != (image_create_info.flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT)) {
-        normalized_isr.baseArrayLayer = 0;
-        normalized_isr.layerCount = image_create_info.extent.depth;  // Treat each depth slice as a layer subresource
-    }
 
     VkImageLayout initial_layout = NormalizeSynchronization2Layout(mem_barrier.subresourceRange.aspectMask, mem_barrier.oldLayout);
     VkImageLayout new_layout = NormalizeSynchronization2Layout(mem_barrier.subresourceRange.aspectMask, mem_barrier.newLayout);

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -33,9 +33,6 @@ uint32_t FullMipChainLevels(uint32_t height, uint32_t width = 1, uint32_t depth 
 uint32_t FullMipChainLevels(VkExtent3D);
 uint32_t FullMipChainLevels(VkExtent2D);
 
-uint32_t ResolveRemainingLevels(const VkImageSubresourceRange *range, uint32_t mip_levels);
-
-uint32_t ResolveRemainingLayers(const VkImageSubresourceRange *range, uint32_t layers);
 GlobalImageLayoutRangeMap *GetLayoutRangeMap(GlobalImageLayoutMap &map, const IMAGE_STATE &image_state);
 const GlobalImageLayoutRangeMap *GetLayoutRangeMap(const GlobalImageLayoutMap &map, VkImage image);
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -94,7 +94,7 @@ using std::vector;
 
 void CoreChecks::AddInitialLayoutintoImageLayoutMap(const IMAGE_STATE &image_state, GlobalImageLayoutMap &image_layout_map) {
     auto *range_map = GetLayoutRangeMap(image_layout_map, image_state);
-    auto range_gen = subresource_adapter::RangeGenerator(image_state.subresource_encoder, image_state.full_range);
+    auto range_gen = subresource_adapter::RangeGenerator(image_state.subresource_encoder);
     for (; range_gen->non_empty(); ++range_gen) {
         range_map->insert(range_map->end(), std::make_pair(*range_gen, image_state.createInfo.initialLayout));
     }

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2085,8 +2085,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
 
     // KHR_maintenance1 allows rendering into 2D or 2DArray views which slice a 3D image,
     // but not binding them to descriptor sets.
-    if (image_node->createInfo.imageType == VK_IMAGE_TYPE_3D && (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D ||
-                                                                 iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY)) {
+    if (iv_state->IsDepthSliced()) {
         *error_code = "VUID-VkDescriptorImageInfo-imageView-00343";
         *error_msg = "ImageView must not be a 2D or 2DArray view of a 3D image";
         return false;

--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -98,7 +98,7 @@ ImageSubresourceLayoutMap::ImageSubresourceLayoutMap(const IMAGE_STATE& image_st
       initial_layout_states_() {}
 
 ImageSubresourceLayoutMap::ConstIterator ImageSubresourceLayoutMap::Begin(bool always_get_initial) const {
-    return Find(image_state_.full_range, /* skip_invalid */ true, always_get_initial);
+    return ConstIterator(layouts_, encoder_, encoder_.FullRange(), true, always_get_initial);
 }
 
 // Use the unwrapped maps from the BothMap in the actual implementation

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -41,8 +41,8 @@ static inline bool operator==(const VkImageSubresource &lhs, const VkImageSubres
 }
 
 VkImageSubresourceRange NormalizeSubresourceRange(const VkImageCreateInfo &image_create_info, const VkImageSubresourceRange &range);
-uint32_t ResolveRemainingLevels(const VkImageSubresourceRange *range, uint32_t mip_levels);
-uint32_t ResolveRemainingLayers(const VkImageSubresourceRange *range, uint32_t layers);
+VkImageSubresourceRange NormalizeSubresourceRange(const VkImageCreateInfo &image_create_info,
+                                                  const VkImageViewCreateInfo &view_create_info);
 
 // Transfer VkImageSubresourceRange into VkImageSubresourceLayers struct
 static inline VkImageSubresourceLayers LayersFromRange(const VkImageSubresourceRange &subresource_range) {
@@ -95,11 +95,10 @@ class IMAGE_STATE : public BINDABLE {
     bool sparse_metadata_required;       // Track if sparse metadata aspect is required for this image
     bool sparse_metadata_bound;          // Track if sparse metadata aspect is bound to this image
     const uint64_t ahb_format;           // External Android format, if provided
-    const VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers (slices), and aspects
+    const VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers, and aspects
     const VkSwapchainKHR create_from_swapchain;
     std::shared_ptr<SWAPCHAIN_NODE> bind_swapchain;
     uint32_t swapchain_image_index;
-    image_layout_map::Encoder range_encoder;
     const VkFormatFeatureFlags format_features;
     // Need to memory requirments for each plane if image is disjoint
     bool disjoint;  // True if image was created with VK_IMAGE_CREATE_DISJOINT_BIT
@@ -223,6 +222,11 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     bool OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) const;
 
     void Destroy() override;
+
+    bool IsDepthSliced() const;
+
+    VkOffset3D GetOffset() const;
+    VkExtent3D GetExtent() const;
 };
 
 struct SWAPCHAIN_IMAGE {

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -1720,7 +1720,8 @@ bool splice(DstRangeMap &to, const SrcRangeMap &from, SourceIterator begin, Sour
                     // otherwise we need to split the destination range.
                     auto value_to_update = write_it->second; // intentional copy
                     updated |= updater.update(value_to_update, read_it->second);
-                    to.overwrite_range(to_lb->lower_bound, std::make_pair(range, value_to_update));
+                    auto intersected_range = write_it->first & range;
+                    to.overwrite_range(to_lb->lower_bound, std::make_pair(intersected_range, value_to_update));
                     par_it.invalidate_A();  // we've changed map 'to' behind to_lb's back... let it know.
                 }
             } else {

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -193,9 +193,9 @@ static bool IsValid(const RangeEncoder& encoder, const VkImageSubresourceRange& 
 // the encoder) will span the levelCount mip levels as weill.
 RangeGenerator::RangeGenerator(const RangeEncoder& encoder, const VkImageSubresourceRange& subres_range)
     : encoder_(&encoder), isr_pos_(encoder, subres_range), pos_(), aspect_base_() {
-    assert((((isr_pos_.Limits()).aspectMask & (encoder.Limits()).aspectMask) == (isr_pos_.Limits()).aspectMask) &&
-           ((isr_pos_.Limits()).baseMipLevel + (isr_pos_.Limits()).levelCount <= (encoder.Limits()).mipLevel) &&
-           ((isr_pos_.Limits()).baseArrayLayer + (isr_pos_.Limits()).layerCount <= (encoder.Limits()).arrayLayer));
+    assert((((isr_pos_.Limits()).aspectMask & (encoder.Limits()).aspectMask) == (isr_pos_.Limits()).aspectMask));
+    assert((isr_pos_.Limits()).baseMipLevel + (isr_pos_.Limits()).levelCount <= (encoder.Limits()).mipLevel);
+    assert((isr_pos_.Limits()).baseArrayLayer + (isr_pos_.Limits()).layerCount <= (encoder.Limits()).arrayLayer);
 
     // To see if we have a full range special case, need to compare the subres_range against the *encoders* limits
     const auto& limits = encoder.Limits();


### PR DESCRIPTION
Handle more cases where the range we're updating partially overlaps  with an existing range, by only updating the intersection of the two. This seems to require more paranoia about invalidating the cached lower bound after changes.
    
This fix exposes another problem with VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT Images.  These ImageViews affect the entire mip level, not just the slice the view references. Rather than swapping depth and arrayLayer in the Image subresource range, just store the simpler subresource range in the ImageView. 

Fixes #2910 


