### PR TITLE
layers: Simplify Image, ImageView and Swapchain state objects

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1513,7 +1513,8 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
 void BestPractices::QueueValidateImageView(QueueCallbacks &funcs, const char* function_name,
                                            IMAGE_VIEW_STATE* view, IMAGE_SUBRESOURCE_USAGE_BP usage) {
     if (view) {
-        QueueValidateImage(funcs, function_name, GetImageUsageState(view->create_info.image), usage, view->create_info.subresourceRange);
+        QueueValidateImage(funcs, function_name, GetImageUsageState(view->create_info.image), usage,
+                           view->normalized_subresource_range);
     }
 }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1693,7 +1693,7 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
     bool skip = false;
     const IMAGE_STATE *image_state = GetImageState(create_info->image);
 
-    if (image_state->has_ahb_format) {
+    if (image_state->HasAHBFormat()) {
         if (VK_FORMAT_UNDEFINED != create_info->format) {
             skip |= LogError(create_info->image, "VUID-VkImageViewCreateInfo-image-02399",
                              "vkCreateImageView(): VkImageViewCreateInfo struct has a chained VkExternalFormatANDROID struct, but "
@@ -3447,7 +3447,7 @@ bool CoreChecks::ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, u
         if (image_view_state) {
             // The layers specified by a given element of pRects must be contained within every attachment that
             // pAttachments refers to
-            const auto attachment_layer_count = image_view_state->create_info.subresourceRange.layerCount;
+            const auto attachment_layer_count = image_view_state->normalized_subresource_range.layerCount;
             if ((clear_rects[j].baseArrayLayer >= attachment_layer_count) ||
                 (clear_rects[j].baseArrayLayer + clear_rects[j].layerCount > attachment_layer_count)) {
                 skip |= LogError(command_buffer, "VUID-vkCmdClearAttachments-pRects-00017",
@@ -4528,7 +4528,7 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(IMAGE_STATE const *image_state,
     const VkFormatFeatureFlags image_format_features = image_state->format_features;
     if ((image_format_features & desired) != desired) {
         // Same error, but more details if it was an AHB external format
-        if (image_state->has_ahb_format == true) {
+        if (image_state->HasAHBFormat()) {
             skip |= LogError(image_state->image(), vuid,
                              "In %s, VkFormatFeatureFlags (0x%08X) does not support required feature %s for the external format "
                              "found in VkAndroidHardwareBufferFormatPropertiesANDROID::formatFeatures used by %s.",
@@ -5473,7 +5473,7 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const IMAGE_STATE *image_state,
     VkFormatFeatureFlags tiling_features = VK_FORMAT_FEATURE_FLAG_BITS_MAX_ENUM;
     const VkImageTiling image_tiling = image_state->createInfo.tiling;
 
-    if (image_state->has_ahb_format == true) {
+    if (image_state->HasAHBFormat()) {
         // AHB image view and image share same feature sets
         tiling_features = image_state->format_features;
     } else if (image_tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1079,7 +1079,7 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
 
         // Verify if attachments are used in DescriptorSet
         if (attachments && attachments->size() > 0 && subpasses && (descriptor_type != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
-            bool ds_aspect = (image_view_state->create_info.subresourceRange.aspectMask &
+            bool ds_aspect = (image_view_state->normalized_subresource_range.aspectMask &
                               (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
                                  ? true
                                  : false;
@@ -2011,7 +2011,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     // Note that when an imageview is created, we validated that memory is bound so no need to re-check here
     // Validate that imageLayout is compatible with aspect_mask and image format
     //  and validate that image usage bits are correct for given usage
-    VkImageAspectFlags aspect_mask = iv_state->create_info.subresourceRange.aspectMask;
+    VkImageAspectFlags aspect_mask = iv_state->normalized_subresource_range.aspectMask;
     VkImage image = iv_state->create_info.image;
     VkFormat format = VK_FORMAT_MAX_ENUM;
     VkImageUsageFlags usage = 0;

--- a/layers/device_state.h
+++ b/layers/device_state.h
@@ -106,36 +106,6 @@ class PHYSICAL_DEVICE_STATE {
     bool vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called = false;
 };
 
-struct GpuQueue {
-    VkPhysicalDevice gpu;
-    uint32_t queue_family_index;
-};
-
-inline bool operator==(GpuQueue const& lhs, GpuQueue const& rhs) {
-    return (lhs.gpu == rhs.gpu && lhs.queue_family_index == rhs.queue_family_index);
-}
-
-namespace std {
-template <>
-struct hash<GpuQueue> {
-    size_t operator()(GpuQueue gq) const throw() {
-        return hash<uint64_t>()((uint64_t)(gq.gpu)) ^ hash<uint32_t>()(gq.queue_family_index);
-    }
-};
-}  // namespace std
-
-class SWAPCHAIN_NODE;
-
-class SURFACE_STATE : public BASE_NODE {
-  public:
-    SWAPCHAIN_NODE* swapchain = nullptr;
-    layer_data::unordered_map<GpuQueue, bool> gpu_queue_support;
-
-    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR) {}
-
-    VkSurfaceKHR surface() const { return handle_.Cast<VkSurfaceKHR>(); }
-};
-
 class DISPLAY_MODE_STATE : public BASE_NODE {
   public:
     VkPhysicalDevice physical_device;

--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -82,7 +82,7 @@ InitialLayoutState::InitialLayoutState(const CMD_BUFFER_STATE& cb_state_, const 
     : image_view(VK_NULL_HANDLE), aspect_mask(0), label(cb_state_.debug_label) {
     if (view_state_) {
         image_view = view_state_->image_view();
-        aspect_mask = view_state_->create_info.subresourceRange.aspectMask;
+        aspect_mask = view_state_->normalized_subresource_range.aspectMask;
     }
 }
 bool ImageSubresourceLayoutMap::SubresourceLayout::operator==(const ImageSubresourceLayoutMap::SubresourceLayout& rhs) const {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -66,6 +66,8 @@ class RENDER_PASS_STATE;
 class SAMPLER_STATE;
 class SAMPLER_YCBCR_CONVERSION_STATE;
 class EVENT_STATE;
+class SWAPCHAIN_NODE;
+class SURFACE_STATE;
 
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };
 enum CopyCommandVersion { COPY_COMMAND_VERSION_1 = 0, COPY_COMMAND_VERSION_2 = 1 };
@@ -265,8 +267,6 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR, accelerationStructureMap_khr)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map)
-
-    static void RemoveAliasingImages(const layer_data::unordered_set<IMAGE_STATE*>& bound_images);
 
   public:
     template <typename State>


### PR DESCRIPTION
Clean up construction of these state objects, especially for
swapchain images.

NOTE that we no longer do 'light normalization' of
IMAGE_VIEW_STATE::create_info.subresourceRange. Code that needs
the normalized version should just use normalized_subresource_range.