### PR TITLE
tests: Fix tests failing on same devices

### DIFF
--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -979,11 +979,13 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
         TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci_same, rp2Supported,
                              "VUID-VkSubpassDescription-pDepthStencilAttachment-04438", nullptr);
 
-        safe_VkRenderPassCreateInfo2 create_info2;
-        ConvertVkRenderPassCreateInfoToV2KHR(rpci_same, &create_info2);
-        m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-        TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
-                                 "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+        if (rp2Supported) {
+            safe_VkRenderPassCreateInfo2 create_info2;
+            ConvertVkRenderPassCreateInfoToV2KHR(rpci_same, &create_info2);
+            m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
+            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
+                                     "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+        }
 
         // Same test but use 2 different VkAttachmentReference to point to same attachment
         subpass_same.pDepthStencilAttachment = &depth_1bit.data()[1];
@@ -992,10 +994,13 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
         TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci_same, rp2Supported,
                              "VUID-VkSubpassDescription-pDepthStencilAttachment-04438", nullptr);
 
-        ConvertVkRenderPassCreateInfoToV2KHR(rpci_same, &create_info2);
-        m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-        TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
-                                 "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+        if (rp2Supported) {
+            safe_VkRenderPassCreateInfo2 create_info2;
+            ConvertVkRenderPassCreateInfoToV2KHR(rpci_same, &create_info2);
+            m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
+            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
+                                     "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+        }
     }
 }
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -138,9 +138,11 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
     phys_dev_props_2.pNext = &bad_version_1_1_struct;
 
     // VkPhysDevVulkan12Props was introduced in 1.2, so try adding it to a 1.1 pNext chain
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
-    m_errorMonitor->VerifyFound();
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceProperties2-pNext-pNext");
+        vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+        m_errorMonitor->VerifyFound();
+    }
 
     // 1.1 context, VK_KHR_depth_stencil_resolve is NOT enabled, but using its struct is valid
     if (DeviceExtensionSupported(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME)) {

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -8336,7 +8336,8 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME) &&
+        DeviceExtensionSupported(gpu(), nullptr, VK_KHR_RAY_QUERY_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
         m_device_extension_names.push_back(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
         m_device_extension_names.push_back(VK_KHR_RAY_QUERY_EXTENSION_NAME);


### PR DESCRIPTION
Some devices/devsim locally were failing tests for various reasons, this lets them skip/pass now