### PR TITLE
layers: Fix regressions from PR #2964

### DIFF
--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -388,9 +388,9 @@ void SWAPCHAIN_NODE::Destroy() {
         // TODO: missing validation that the bound images are empty (except for image_state above)
         // Clean up the aliases and the bound_images *before* erasing the image_state.
         // TODO: RemoveAliasingImages(swapchain_image.bound_images);
-        for (auto &image : swapchain_image.bound_images) {
-            image->RemoveParent(this);
-            image->Destroy();
+        for (auto &entry : swapchain_image.bound_images) {
+            entry.second->RemoveParent(this);
+            entry.second->Destroy();
         }
         swapchain_image.bound_images.clear();
         // TODO: imageMap.erase(swapchain_image.image_state->image());
@@ -407,10 +407,10 @@ void SWAPCHAIN_NODE::NotifyInvalidate(const LogObjectList &invalid_handles, bool
             IMAGE_STATE *invalid_image = static_cast<IMAGE_STATE *>(immediate_child.node);
             assert(invalid_image);
             auto &swapchain_image = images[invalid_image->bind_swapchain_imageIndex];
-            swapchain_image.bound_images.erase(invalid_image);
             if (swapchain_image.image_state == invalid_image) {
                 swapchain_image.image_state = nullptr;
             }
+            swapchain_image.bound_images.erase(invalid_image->image());
         }
     }
 }

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -185,7 +185,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     bool retired;
     const bool shared_presentable;
     uint32_t get_swapchain_image_count;
-    const VkImageCreateInfo image_create_info;
+    const safe_VkImageCreateInfo image_create_info;
 
     SWAPCHAIN_NODE(const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
 

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -131,7 +131,7 @@ class IMAGE_STATE : public BINDABLE {
 
     void Destroy() override;
 
-    void AddAliasingImage(IMAGE_STATE *bound_images);
+    void AddAliasingImage(IMAGE_STATE *bound_image);
 
     VkExtent3D GetSubresourceExtent(const VkImageSubresourceLayers &subresource) const;
 
@@ -175,7 +175,7 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
 
 struct SWAPCHAIN_IMAGE {
     IMAGE_STATE *image_state = nullptr;
-    layer_data::unordered_set<IMAGE_STATE *> bound_images;
+    layer_data::unordered_map<VkImage, std::shared_ptr<IMAGE_STATE>> bound_images;
 };
 
 class SWAPCHAIN_NODE : public BASE_NODE {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -5374,7 +5374,7 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
                 GetImageFormatFeatures(physical_device, device, pSwapchainImages[i], swapchain_state->image_create_info.format,
                                        swapchain_state->image_create_info.tiling);
 
-            auto image_state = std::make_shared<IMAGE_STATE>(device, pSwapchainImages[i], &swapchain_state->image_create_info,
+            auto image_state = std::make_shared<IMAGE_STATE>(device, pSwapchainImages[i], swapchain_state->image_create_info.ptr(),
                                                              swapchain, i, format_features);
 
             if (swapchain_image.bound_images.empty()) {


### PR DESCRIPTION
-Fix a crash due to corrupting SWAPCHAIN_IMAGE::bound_images (Issue #2975)

-Fix another crash due to a bad pNext value when creating swapchain images. 