### PR TITLE
Invalid message "...sizeof(vkCmdDrawIndexedIndirectCount)..."

### DIFF
--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -1047,7 +1047,7 @@ bool CoreChecks::ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuff
                          "call this command.",
                          apiName);
     }
-    skip |= ValidateCmdDrawStrideWithStruct(commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-stride-03142", stride, apiName,
+    skip |= ValidateCmdDrawStrideWithStruct(commandBuffer, "VUID-vkCmdDrawIndexedIndirectCount-stride-03142", stride, "VkDrawIndexedIndirectCommand",
                                             sizeof(VkDrawIndexedIndirectCommand));
     if (maxDrawCount > 1) {
         const BUFFER_STATE *buffer_state = GetBufferState(buffer);


### PR DESCRIPTION
We should replace part of vaidation error message "sizeof(vkCmdDrawIndexedIndirectCount)" to "sizeof(VkDrawIndexedIndirectCommand)"
Example:

[VUID-vkCmdDrawIndexedIndirectCount-stride-03142] Code 786497355 : Validation Error: [ VUID-vkCmdDrawIndexedIndirectCount-stride-03142 ] Object 0: handle = 0x2168e40d5f0, name = RT_CommandBuffer1, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x2ee0ff4b | stride 0 is invalid or less than sizeof(**vkCmdDrawIndexedIndirectCount**) 20. The Vulkan spec states: stride must be a multiple of 4 and must be greater than or equal to sizeof(VkDrawIndexedIndirectCommand) (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-vkCmdDrawIndexedIndirectCount-stride-03142)

Correct Message:

[VUID-vkCmdDrawIndexedIndirectCount-stride-03142] Code 786497355 : Validation Error: [ VUID-vkCmdDrawIndexedIndirectCount-stride-03142 ] Object 0: handle = 0x2168e40d5f0, name = RT_CommandBuffer1, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x2ee0ff4b | stride 0 is invalid or less than sizeof(**VkDrawIndexedIndirectCommand**) 20. The Vulkan spec states: stride must be a multiple of 4 and must be greater than or equal to sizeof(VkDrawIndexedIndirectCommand) (https://vulkan.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-vkCmdDrawIndexedIndirectCount-stride-03142)