### PR TITLE
layers: Fix state tracking of Surfaces, Swapchains and Images

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1567,7 +1567,7 @@ void BestPractices::ValidateImageInQueueArm(const char* function_name, IMAGE_STA
                                             uint32_t array_layer, uint32_t mip_level) {
     // Swapchain images are implicitly read so clear after store is expected.
     if (usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_CLEARED && last_usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_STORED &&
-        !image->is_swapchain_image) {
+        !image->IsSwapchainImage()) {
         LogPerformanceWarning(
             device, kVUID_BestPractices_RenderPass_RedundantStore,
             "%s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -110,8 +110,8 @@ struct PHYSICAL_DEVICE_STATE_BP {
 
 class SWAPCHAIN_STATE_BP : public SWAPCHAIN_NODE {
   public:
-    SWAPCHAIN_STATE_BP(const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR swapchain)
-        : SWAPCHAIN_NODE(pCreateInfo, swapchain) {}
+    SWAPCHAIN_STATE_BP(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR swapchain)
+        : SWAPCHAIN_NODE(dev_data, pCreateInfo, swapchain) {}
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
 };
 
@@ -487,7 +487,7 @@ class BestPractices : public ValidationStateTracker {
 
     std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
                                                          VkSwapchainKHR swapchain) final {
-        return std::static_pointer_cast<SWAPCHAIN_NODE>(std::make_shared<SWAPCHAIN_STATE_BP>(create_info, swapchain));
+        return std::static_pointer_cast<SWAPCHAIN_NODE>(std::make_shared<SWAPCHAIN_STATE_BP>(this, create_info, swapchain));
     }
 
 // Include code-generated functions

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2194,7 +2194,7 @@ bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, con
     const IMAGE_STATE *image_state = GetImageState(image);
     bool skip = false;
     if (image_state) {
-        if (image_state->is_swapchain_image) {
+        if (image_state->IsSwapchainImage()) {
             skip |= LogError(device, "VUID-vkDestroyImage-image-04882",
                              "vkDestroyImage(): %s is a presentable image and it is controlled by the implementation and is "
                              "destroyed with vkDestroySwapchainKHR.",

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -148,7 +148,7 @@ template <typename LocType>
 bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, const LocType &location) const {
     bool result = false;
     if (image_state->create_from_swapchain != VK_NULL_HANDLE) {
-        if (image_state->bind_swapchain == VK_NULL_HANDLE) {
+        if (!image_state->bind_swapchain) {
             LogObjectList objlist(image_state->image());
             objlist.add(image_state->create_from_swapchain);
             result |= LogError(
@@ -157,17 +157,17 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const IMAGE_STATE *image_state, co
                 "includes VkBindImageMemorySwapchainInfoKHR.",
                 location.FuncName(), report_data->FormatHandle(image_state->image()).c_str(),
                 report_data->FormatHandle(image_state->create_from_swapchain).c_str());
-        } else if (image_state->create_from_swapchain != image_state->bind_swapchain) {
+        } else if (image_state->create_from_swapchain != image_state->bind_swapchain->swapchain()) {
             LogObjectList objlist(image_state->image());
             objlist.add(image_state->create_from_swapchain);
-            objlist.add(image_state->bind_swapchain);
+            objlist.add(image_state->bind_swapchain->Handle());
             result |=
                 LogError(objlist, location.Vuid(),
                          "%s: %s is created by %s, but the image is bound by %s. The image should be created and bound by the same "
                          "swapchain",
                          location.FuncName(), report_data->FormatHandle(image_state->image()).c_str(),
                          report_data->FormatHandle(image_state->create_from_swapchain).c_str(),
-                         report_data->FormatHandle(image_state->bind_swapchain).c_str());
+                         report_data->FormatHandle(image_state->bind_swapchain->Handle()).c_str());
         }
     } else if (image_state->IsExternalAHB()) {
         // TODO look into how to properly check for a valid bound memory for an external AHB

--- a/layers/device_memory_state.cpp
+++ b/layers/device_memory_state.cpp
@@ -129,3 +129,9 @@ void BINDABLE::SetSparseMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, co
     // Need to set mem binding for this object
     bound_memory_.insert({mem->mem(), sparse_binding});
 }
+
+VkDeviceSize BINDABLE::GetFakeBaseAddress() const {
+    assert(!sparse);  // not implemented yet
+    const auto *binding = Binding();
+    return binding ? binding->offset + binding->mem_state->fake_base_address : 0;
+}

--- a/layers/device_memory_state.h
+++ b/layers/device_memory_state.h
@@ -143,10 +143,12 @@ class BINDABLE : public BASE_NODE {
 
     const DEVICE_MEMORY_STATE *MemState() const { return Binding() ? Binding()->mem_state.get() : nullptr; }
 
-    void SetMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, VkDeviceSize memory_offset);
+    virtual void SetMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, VkDeviceSize memory_offset);
     void SetSparseMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize mem_offset, const VkDeviceSize mem_size);
 
     bool IsExternalAHB() const {
         return (external_memory_handle & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) != 0;
     }
+
+    virtual VkDeviceSize GetFakeBaseAddress() const;
 };

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -406,6 +406,11 @@ void SWAPCHAIN_NODE::Destroy() {
         // TODO: imageMap.erase(swapchain_image.image_state->image());
         swapchain_image.image_state = nullptr;
     }
+    images.clear();
+    if (surface) {
+        surface->RemoveParent(this);
+        surface = nullptr;
+    }
     BASE_NODE::Destroy();
 }
 
@@ -422,5 +427,20 @@ void SWAPCHAIN_NODE::NotifyInvalidate(const LogObjectList &invalid_handles, bool
             }
             swapchain_image.bound_images.erase(invalid_image->image());
         }
+        surface = nullptr;
     }
+}
+
+void SURFACE_STATE::Destroy() {
+    if (swapchain) {
+        swapchain = nullptr;
+    }
+    BASE_NODE::Destroy();
+}
+
+void SURFACE_STATE::RemoveParent(BASE_NODE *parent_node) {
+    if (swapchain == parent_node) {
+        swapchain = nullptr;
+    }
+    BASE_NODE::RemoveParent(parent_node);
 }

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -168,7 +168,7 @@ IMAGE_STATE::IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCr
         std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(new subresource_adapter::ImageRangeEncoder(*this));
 }
 
-void IMAGE_STATE::Destroy() {
+void IMAGE_STATE::Unlink() {
     for (auto *alias_state : aliasing_images) {
         assert(alias_state);
         alias_state->aliasing_images.erase(this);
@@ -178,17 +178,17 @@ void IMAGE_STATE::Destroy() {
         bind_swapchain->RemoveParent(this);
         bind_swapchain = nullptr;
     }
+}
+
+void IMAGE_STATE::Destroy() {
+    Unlink();
     BINDABLE::Destroy();
 }
 
 void IMAGE_STATE::NotifyInvalidate(const LogObjectList &invalid_handles, bool unlink) {
     BINDABLE::NotifyInvalidate(invalid_handles, unlink);
     if (unlink) {
-        aliasing_images.clear();
-        if (bind_swapchain) {
-            bind_swapchain->RemoveParent(this);
-            bind_swapchain = nullptr;
-        }
+        Unlink();
     }
 }
 

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -125,7 +125,6 @@ IMAGE_STATE::IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCr
       get_sparse_reqs_called(false),
       sparse_metadata_required(false),
       sparse_metadata_bound(false),
-      is_swapchain_image(GetSwapchain(pCreateInfo) != VK_NULL_HANDLE),
       ahb_format(GetExternalFormat(pCreateInfo)),
       full_range{MakeImageFullRange(*pCreateInfo)},
       create_from_swapchain(GetSwapchain(pCreateInfo)),
@@ -153,7 +152,6 @@ IMAGE_STATE::IMAGE_STATE(VkDevice dev, VkImage img, const VkImageCreateInfo *pCr
       get_sparse_reqs_called(false),
       sparse_metadata_required(false),
       sparse_metadata_bound(false),
-      is_swapchain_image(true),
       ahb_format(GetExternalFormat(pCreateInfo)),
       full_range{MakeImageFullRange(*pCreateInfo)},
       create_from_swapchain(swapchain),
@@ -224,7 +222,7 @@ bool IMAGE_STATE::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const V
 }
 
 bool IMAGE_STATE::IsCompatibleAliasing(IMAGE_STATE *other_image_state) const {
-    if (!is_swapchain_image && !other_image_state->is_swapchain_image &&
+    if (!IsSwapchainImage() && !other_image_state->IsSwapchainImage() &&
         !(createInfo.flags & other_image_state->createInfo.flags & VK_IMAGE_CREATE_ALIAS_BIT)) {
         return false;
     }
@@ -263,7 +261,7 @@ void IMAGE_STATE::SetMemBinding(std::shared_ptr<DEVICE_MEMORY_STATE> &mem, VkDev
 }
 
 void IMAGE_STATE::SetSwapchain(std::shared_ptr<SWAPCHAIN_NODE> &swapchain, uint32_t swapchain_index) {
-    assert(is_swapchain_image);
+    assert(IsSwapchainImage());
     bind_swapchain = swapchain;
     swapchain_image_index = swapchain_index;
     bind_swapchain->AddParent(this);
@@ -278,7 +276,7 @@ void IMAGE_STATE::SetSwapchain(std::shared_ptr<SWAPCHAIN_NODE> &swapchain, uint3
 }
 
 VkDeviceSize IMAGE_STATE::GetFakeBaseAddress() const {
-    if (!is_swapchain_image) {
+    if (!IsSwapchainImage()) {
         return BINDABLE::GetFakeBaseAddress();
     }
     if (!bind_swapchain) {

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -73,7 +73,6 @@ class IMAGE_STATE : public BINDABLE {
     bool get_sparse_reqs_called;         // Track if GetImageSparseMemoryRequirements() has been called for this image
     bool sparse_metadata_required;       // Track if sparse metadata aspect is required for this image
     bool sparse_metadata_bound;          // Track if sparse metadata aspect is bound to this image
-    const bool is_swapchain_image;       // True if image is a swapchain image
     const uint64_t ahb_format;           // External Android format, if provided
     const VkImageSubresourceRange full_range;  // The normalized ISR for all levels, layers (slices), and aspects
     const VkSwapchainKHR create_from_swapchain;
@@ -106,6 +105,8 @@ class IMAGE_STATE : public BINDABLE {
 
     bool IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const;
     bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_createInfo) const;
+
+    bool IsSwapchainImage() const { return create_from_swapchain != VK_NULL_HANDLE; }
 
     inline bool IsImageTypeEqual(const VkImageCreateInfo &other_createInfo) const {
         return createInfo.imageType == other_createInfo.imageType;

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -167,6 +167,7 @@ class IMAGE_STATE : public BINDABLE {
 
   protected:
     void AddAliasingImage(IMAGE_STATE *bound_image);
+    void Unlink();
     void NotifyInvalidate(const LogObjectList &invalid_handles, bool unlink) override;
 };
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1157,7 +1157,7 @@ class ValidationStateTracker : public ValidationObject {
     virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
                                                                  VkSwapchainKHR swapchain);
     void RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain,
-                                    SURFACE_STATE* surface_state, SWAPCHAIN_NODE* old_swapchain_state);
+                                    std::shared_ptr<SURFACE_STATE>&& surface_state, SWAPCHAIN_NODE* old_swapchain_state);
     void RecordDestroySamplerYcbcrConversionState(VkSamplerYcbcrConversion ycbcr_conversion);
     void RecordEnumeratePhysicalDeviceGroupsState(uint32_t* pPhysicalDeviceGroupCount,
                                                   VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1360,7 +1360,7 @@ class ValidationStateTracker : public ValidationObject {
         }
 
       private:
-        VkDeviceSize free_ = 0;
+        VkDeviceSize free_ = 1U << 20; // start at 1mb to leave room for a NULL address
     };
     FakeAllocator fake_memory;
 };

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -29,8 +29,8 @@
 static bool SimpleBinding(const BINDABLE &bindable) { return !bindable.sparse && bindable.Binding(); }
 
 static bool SimpleBinding(const IMAGE_STATE &image_state) {
-    bool simple = SimpleBinding(static_cast<const BINDABLE &>(image_state)) || image_state.is_swapchain_image ||
-                  (VK_NULL_HANDLE != image_state.bind_swapchain);
+    bool simple =
+        SimpleBinding(static_cast<const BINDABLE &>(image_state)) || image_state.is_swapchain_image || image_state.bind_swapchain;
 
     // If it's not simple we must have an encoder.
     assert(!simple || image_state.fragment_encoder.get());
@@ -225,19 +225,7 @@ ResourceAccessState::OrderingBarriers ResourceAccessState::kOrderingRules = {
 static const ResourceUsageTag kCurrentCommandTag(ResourceUsageTag::kMaxIndex, ResourceUsageTag::kMaxCount,
                                                  ResourceUsageTag::kMaxCount, CMD_NONE);
 
-static VkDeviceSize ResourceBaseAddress(const BINDABLE &bindable) {
-    const auto *binding = bindable.Binding();
-    return binding ? binding->offset + binding->mem_state->fake_base_address : 0;
-}
-static VkDeviceSize ResourceBaseAddress(const IMAGE_STATE &image_state) {
-    VkDeviceSize base_address;
-    if (image_state.is_swapchain_image || (VK_NULL_HANDLE != image_state.bind_swapchain)) {
-        base_address = image_state.swapchain_fake_address;
-    } else {
-        base_address = ResourceBaseAddress(static_cast<const BINDABLE &>(image_state));
-    }
-    return base_address;
-}
+static VkDeviceSize ResourceBaseAddress(const BINDABLE &bindable) { return bindable.GetFakeBaseAddress(); }
 
 inline VkDeviceSize GetRealWholeSize(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize whole_size) {
     if (size == VK_WHOLE_SIZE) {

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -30,7 +30,7 @@ static bool SimpleBinding(const BINDABLE &bindable) { return !bindable.sparse &&
 
 static bool SimpleBinding(const IMAGE_STATE &image_state) {
     bool simple =
-        SimpleBinding(static_cast<const BINDABLE &>(image_state)) || image_state.is_swapchain_image || image_state.bind_swapchain;
+        SimpleBinding(static_cast<const BINDABLE &>(image_state)) || image_state.IsSwapchainImage() || image_state.bind_swapchain;
 
     // If it's not simple we must have an encoder.
     assert(!simple || image_state.fragment_encoder.get());


### PR DESCRIPTION
PRs #2964 and #2980 made bad assumptions about how these objects interact, especially how SWAPCHAIN_IMAGE::bound_images was handled. 

Remove SWAPCHAIN_NODE::bound_images, which was used to allow all images bound to the same swapchain and index to share the same fake virtual address for sync validation. Instead, store a fake address in SWAPCHAIN_IMAGE and allow Swapchains to have Images as their parent. This allows Swapchain and VK_IMAGE_CREATE_ALIAS_BIT aliasing to work in almost the same way. This also lets bound Images be invalidate if their Swapchain or Surface gets destroyed.
    
Give SWAPCHAIN_NODE a back pointer to the state tracker so that  its Destroy() can remove Images from the device level handle map.

Fake address lookup is now hidden behind a BINDABLE / IMAGE_STATE method. This should make it easier to add addresses for sparse buffers and images at some point.

Swapchains should be the parent their Surface in the object tracking tree because destroying the Surface will invalidate the Swapchain. Make their state objects follow the convention of 'parent holds shared_ptr on child object'.
    
Because Surfaces are tracked at the Instance level, Swapchains need to be explicitly destroyed in DestroyDevice() to avoid potential accesses to the Device level state after it is destroyed. VkBestPracticesLayerTest.ValidateReturnCodes + ASan hits this condition.
