### PR TITLE
layers: Remove added warnings from #2777

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1034,10 +1034,6 @@ bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *sr
                                                "shaderStorageImageReadWithoutFormat",
                                                kVUID_Features_shaderStorageImageReadWithoutFormat);
                     }
-                } else {
-                    skip |= LogWarning(device, kVUIDUndefined,
-                                       "Cannot find image definition (id = %" PRIu32 ")",
-                                       insn.word(3));
                 }
                 break;
             }
@@ -1049,10 +1045,6 @@ bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *sr
                                                "shaderStorageImageWriteWithoutFormat",
                                                kVUID_Features_shaderStorageImageWriteWithoutFormat);
                     }
-                } else {
-                    skip |= LogWarning(device, kVUIDUndefined,
-                                       "Cannot find image definition (id = %" PRIu32 ")",
-                                       insn.word(1));
                 }
                 break;
             }


### PR DESCRIPTION
In general warnings are reserved for best practices unless explicitly stated in the Vulkan spec (I missed this in #2777).

FYI @llandwerlin-intel.