### PR TITLE
tests: Add extra positive spec constant

### DIFF
--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2199,6 +2199,195 @@ void main() {
     m_errorMonitor->VerifyNotFound();
 }
 
+TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
+    TEST_DESCRIPTION("Make sure a specialization constant entry can stide over a word boundry");
+
+    // require to make enable logic simpler
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
+        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Extension %s is not supported, skipping test.\n", kSkipPrefix, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+        return;
+    }
+
+    auto float16int8_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&float16int8_features);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    if (float16int8_features.shaderInt8 == VK_FALSE) {
+        printf("%s shaderInt8 feature not supported; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // glslang currenlty turned the GLSL to
+    //      %19 = OpSpecConstantOp %uint UConvert %a
+    // which causes issue (to be fixed outside scope of this test)
+    // but move the UConvert to inside the function as
+    //      %19 = OpUConvert %uint %a
+    //
+    // #version 450
+    // #extension GL_EXT_shader_explicit_arithmetic_types_int8 : enable
+    // layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+    // // All spec constants will write zero by default
+    // layout (constant_id = 0) const uint8_t a = uint8_t(0);
+    // layout (constant_id = 1) const uint b = 0;
+    // layout (constant_id = 3) const uint c = 0;
+    // layout (constant_id = 4) const uint d = 0;
+    // layout (constant_id = 5) const uint8_t e = uint8_t(0);
+    //
+    // layout(set = 0, binding = 0) buffer ssbo {
+    //     uint data[5];
+    // };
+    //
+    // void main() {
+    //     data[0] = 0; // clear full word
+    //     data[0] = uint(a);
+    //     data[1] = b;
+    //     data[2] = c;
+    //     data[3] = d;
+    //     data[4] = 0; // clear full word
+    //     data[4] = uint(e);
+    // }
+    std::string cs_src = R"(
+               OpCapability Shader
+               OpCapability Int8
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_int8"
+               OpDecorate %_arr_uint_uint_5 ArrayStride 4
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %ssbo BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %a SpecId 0
+               OpDecorate %b SpecId 1
+               OpDecorate %c SpecId 3
+               OpDecorate %d SpecId 4
+               OpDecorate %e SpecId 5
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_5 = OpConstant %uint 5
+%_arr_uint_uint_5 = OpTypeArray %uint %uint_5
+       %ssbo = OpTypeStruct %_arr_uint_uint_5
+%_ptr_Uniform_ssbo = OpTypePointer Uniform %ssbo
+          %_ = OpVariable %_ptr_Uniform_ssbo Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+      %uchar = OpTypeInt 8 0
+          %a = OpSpecConstant %uchar 0
+      %int_1 = OpConstant %int 1
+          %b = OpSpecConstant %uint 0
+      %int_2 = OpConstant %int 2
+          %c = OpSpecConstant %uint 0
+      %int_3 = OpConstant %int 3
+          %d = OpSpecConstant %uint 0
+      %int_4 = OpConstant %int 4
+          %e = OpSpecConstant %uchar 0
+     %v3uint = OpTypeVector %uint 3
+     %uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpUConvert %uint %a
+         %33 = OpUConvert %uint %e
+         %16 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_0
+               OpStore %16 %uint_0
+         %20 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_0
+               OpStore %20 %19
+         %23 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_1
+               OpStore %23 %b
+         %26 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_2
+               OpStore %26 %c
+         %29 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_3
+               OpStore %29 %d
+         %31 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_4
+               OpStore %31 %uint_0
+         %34 = OpAccessChain %_ptr_Uniform_uint %_ %int_0 %int_4
+               OpStore %34 %33
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // Use strange combinations of size and offsets around word boundry
+    VkSpecializationMapEntry entries[5] = {
+        {0, 1, 1},  // OpTypeInt 8
+        {1, 1, 4},  // OpTypeInt 32
+        {3, 2, 4},  // OpTypeInt 32
+        {4, 3, 4},  // OpTypeInt 32
+        {5, 3, 1},  // OpTypeInt 8
+    };
+
+    uint8_t data[8] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    VkSpecializationInfo specialization_info = {
+        5,
+        entries,
+        sizeof(uint8_t) * 8,
+        reinterpret_cast<void *>(data),
+    };
+
+    std::vector<VkDescriptorSetLayoutBinding> bindings = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.dsl_bindings_.resize(bindings.size());
+    memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
+    pipe.cs_.reset(new VkShaderObj(this, cs_src.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
+                                   &specialization_info));
+    pipe.InitState();
+    m_errorMonitor->ExpectSuccess();
+    pipe.CreateComputePipeline();
+
+    // Submit shader to see SSBO output
+    VkBufferObj buffer;
+    auto bci = LvlInitStruct<VkBufferCreateInfo>();
+    bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    bci.size = 1024;
+    VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    buffer.init(*m_device, bci, mem_props);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_);
+    vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
+    m_commandBuffer->end();
+
+    VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+    vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(m_device->m_queue);
+
+    // Make sure spec constants were updated correctly
+    void *pData;
+    ASSERT_VK_SUCCESS(vk::MapMemory(m_device->device(), buffer.memory().handle(), 0, VK_WHOLE_SIZE, 0, &pData));
+    uint32_t *ssbo_data = reinterpret_cast<uint32_t *>(pData);
+    ASSERT_EQ(ssbo_data[0], 0x02);
+    ASSERT_EQ(ssbo_data[1], 0x05040302);
+    ASSERT_EQ(ssbo_data[2], 0x06050403);
+    ASSERT_EQ(ssbo_data[3], 0x07060504);
+    ASSERT_EQ(ssbo_data[4], 0x04);
+    vk::UnmapMemory(m_device->device(), buffer.memory().handle());
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkPositiveLayerTest, WriteDescriptorSetAccelerationStructureNVNullDescriptor) {
     TEST_DESCRIPTION("Validate using NV acceleration structure descriptor writing with null descriptor.");
 


### PR DESCRIPTION
Wrote test for #3035 but seems to be not properly setting the `shaderInt8` values for `CreateSetSpecConstantDefaultValuePass`... but this might be a `spirv-opt` issue actually

Wanted to post the test so it doesn't get lost