### PR TITLE
layers: Fix ValidateShaderStorageImageFormats to only check storage images

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1074,6 +1074,8 @@ bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *sr
         spirv_inst_iter type_def = src->GetImageFormatInst(loads, insn.word(1));
         if (type_def == src->end())
             continue;
+        // Only check storage images
+        if (type_def.word(7) != 2) continue;
         if (type_def.word(8) != spv::ImageFormatUnknown)
             continue;
 


### PR DESCRIPTION
This check was making a lot of ANGLE and Dawn tests fail because it
requires that regular sampled images have the NonWritable decoration
(since the format is Unknown), and that's disallowed by the SPIR-V
specification (these decorations are only allowed on storage images).

See also https://github.com/KhronosGroup/Vulkan-Docs/issues/1588

CC @djdeath @ncesario-lunarg 