### PR TITLE
Simplify shader module GetImageFormatInst()

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -429,6 +429,10 @@ void SHADER_MODULE_STATE::BuildDefIndex() {
                 execution_mode_inst[insn.word(1)].push_back(insn);
             } break;
 
+            case spv::OpLoad: {
+                def_index[insn.word(2)] = insn.offset();
+            } break;
+
             default:
                 // We don't care about any other defs for now.
                 break;
@@ -1709,20 +1713,15 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
     return out;
 }
 
-spirv_inst_iter SHADER_MODULE_STATE::GetImageFormatInst(const std::map<uint32_t, uint32_t>& loads, uint32_t id) const
+spirv_inst_iter SHADER_MODULE_STATE::GetImageFormatInst(uint32_t id) const
 {
     do {
-        const auto iter = loads.find(id);
-        if (iter != loads.end()) {
-            id = iter->second;
-            continue;
-        }
-
         auto def = get_def(id);
+        if (def == end())
+            return def;
+
         switch (def.opcode()) {
            case spv::OpLoad:
-               return end();
-
            case spv::OpAccessChain:
            case spv::OpCompositeConstruct:
            case spv::OpVariable: {

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -291,7 +291,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::vector<std::pair<uint32_t, interface_var>> CollectInterfaceByInputAttachmentIndex(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
 
-    spirv_inst_iter GetImageFormatInst(const std::map<uint32_t, uint32_t>& loads, uint32_t id) const;
+    // Get the image type from a variable id or load operation that reference an image
+    spirv_inst_iter GetImageFormatInst(uint32_t id) const;
 
 };
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1015,24 +1015,12 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const 
 bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *src) const {
     bool skip = false;
 
-    std::map<uint32_t, uint32_t> loads;
-    for (auto insn : *src) {
-        switch (insn.opcode()) {
-            case spv::OpLoad: {
-                loads.insert(std::make_pair(insn.word(2), insn.word(1)));
-                break;
-            }
-            default:
-                break;
-        }
-    }
-
     // Got through all ImageRead/Write instructions
     for (auto insn : *src) {
         switch (insn.opcode()) {
             case spv::OpImageSparseRead:
             case spv::OpImageRead: {
-                spirv_inst_iter type_def = src->GetImageFormatInst(loads, insn.word(3));
+                spirv_inst_iter type_def = src->GetImageFormatInst(insn.word(3));
                 if (type_def != src->end()) {
                     if (type_def.word(8) == spv::ImageFormatUnknown) {
                         skip |= RequireFeature(enabled_features.core.shaderStorageImageReadWithoutFormat,
@@ -1047,7 +1035,7 @@ bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *sr
                 break;
             }
             case spv::OpImageWrite: {
-                spirv_inst_iter type_def = src->GetImageFormatInst(loads, insn.word(1));
+                spirv_inst_iter type_def = src->GetImageFormatInst(insn.word(1));
                 if (type_def != src->end()) {
                     if (type_def.word(8) == spv::ImageFormatUnknown) {
                         skip |= RequireFeature(enabled_features.core.shaderStorageImageWriteWithoutFormat,
@@ -1071,7 +1059,7 @@ bool CoreChecks::ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const *sr
             continue;
 
         uint32_t var = insn.word(2);
-        spirv_inst_iter type_def = src->GetImageFormatInst(loads, insn.word(1));
+        spirv_inst_iter type_def = src->GetImageFormatInst(insn.word(1));
         if (type_def == src->end())
             continue;
         if (type_def.word(8) != spv::ImageFormatUnknown)


### PR DESCRIPTION
By just adding OpLoad instructions to the def_index map.