### PR TITLE
tests: Disable RenderPassAsyncHazard on Pixel 3

### DIFF
--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2639,6 +2639,11 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
+    if (IsPlatform(kPixel3) || IsPlatform(kPixel3aXL)) {
+        printf("%s Temporarily disabling on Pixel 3 and Pixel 3a XL due to driver crash\n", kSkipPrefix);
+        return;
+    }
+
     // overall set up:
     // subpass 0:
     //   write image 0


### PR DESCRIPTION
@jeremyg-lunarg looks like this is still causing a crash after #3050. I'm inclined to revert it until we can figure out what's going on. Thoughts?