### PR TITLE
layers: Cleanup ValidateBuiltinLimits

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -542,8 +542,7 @@ class CoreChecks : public ValidationStateTracker {
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* src,
                                    VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
-    bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* src, const layer_data::unordered_set<uint32_t>& accessible_ids,
-                               VkShaderStageFlagBits stage) const;
+    bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;


### PR DESCRIPTION
I want to add more Builtin Limits VU (such as those I left behind in #1950) but realized the VU statement says

> If the **identified entry point** includes any variable in its **interface** that is declared with the SampleMask BuiltIn decoration

So fixed up the function to use `FindEntrypointInterfaces` instead