### PR TITLE
Adding vuid 00030

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -6210,6 +6210,11 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
                          size, report_data->FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
     }
 
+    if (!device_extensions.vk_khr_maintenance1) {
+        skip |= ValidateCmdQueueFlags(cb_node, "vkCmdFillBuffer()", VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
+                                      "VUID-vkCmdFillBuffer-commandBuffer-00030");
+    }
+
     return skip;
 }
 


### PR DESCRIPTION
Check if the command buffer used in CmdFillBuffer was allocated from a pool that supported either graphics or compute operations