### PR TITLE
Adding vuid 02279

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7155,6 +7155,14 @@ bool CoreChecks::ValidateGetImageMemoryRequirements2(const VkImageMemoryRequirem
                          func_name, report_data->FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
     }
 
+    if (image_state->disjoint && (image_state->createInfo.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) && !image_plane_info) {
+        skip |= LogError(
+            pInfo->image, "VUID-VkImageMemoryRequirementsInfo2-image-02279",
+            "%s: %s image was created with VK_IMAGE_CREATE_DISJOINT_BIT and has tiling of VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, "
+            "but the current pNext does not include a VkImagePlaneMemoryRequirementsInfo struct",
+            func_name, report_data->FormatHandle(pInfo->image).c_str());
+    }
+
     if (image_plane_info != nullptr) {
         if ((image_tiling == VK_IMAGE_TILING_LINEAR) || (image_tiling == VK_IMAGE_TILING_OPTIMAL)) {
             // Make sure planeAspect is only a single, valid plane

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8926,7 +8926,7 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    const uint64_t dummy_modifiers[2] = {0, 1};
+    constexpr std::array<uint64_t, 2> dummy_modifiers = {0, 1};
 
     VkImageCreateInfo image_info = LvlInitStruct<VkImageCreateInfo>();
     image_info.imageType = VK_IMAGE_TYPE_2D;
@@ -8964,8 +8964,8 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
     VkSubresourceLayout dummyPlaneLayout = {0, 0, 0, 0, 0};
 
     VkImageDrmFormatModifierListCreateInfoEXT drm_format_mod_list = LvlInitStruct<VkImageDrmFormatModifierListCreateInfoEXT>();
-    drm_format_mod_list.drmFormatModifierCount = 2;
-    drm_format_mod_list.pDrmFormatModifiers = dummy_modifiers;
+    drm_format_mod_list.drmFormatModifierCount = dummy_modifiers.size();
+    drm_format_mod_list.pDrmFormatModifiers = dummy_modifiers.data();
 
     VkImageDrmFormatModifierExplicitCreateInfoEXT drm_format_mod_explicit =
         LvlInitStruct<VkImageDrmFormatModifierExplicitCreateInfoEXT>();


### PR DESCRIPTION
If image was created with disjoint bit and drm format modifier tiling there must be a VkImagePlaneMemoryRequirementsInfo in pNext chain