### PR TITLE
Depth/Stencil descriptor fixes

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10021,6 +10021,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
                     case VK_IMAGE_LAYOUT_GENERAL:
                     case VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR:
+                    case VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL:
+                    case VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL:
                         break;  // valid layouts
                     default:
                         skip |= LogError(device, vuid,
@@ -10028,6 +10030,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                          "VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR, "
                                          "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, "
                                          "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, "
+                                         "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL, "
+                                         "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL, "
                                          "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
                                          "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL, or "
                                          "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR",

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2227,13 +2227,15 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
             VkImageLayout layout;
             ExtEnabled DeviceExtensions::*extension;
         };
-        const static std::array<ExtensionLayout, 5> extended_layouts{{
+        const static std::array<ExtensionLayout, 7> extended_layouts{{
             //  Note double brace req'd for aggregate initialization
             {VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR, &DeviceExtensions::vk_khr_shared_presentable_image},
             {VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, &DeviceExtensions::vk_khr_maintenance2},
             {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, &DeviceExtensions::vk_khr_maintenance2},
             {VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR, &DeviceExtensions::vk_khr_synchronization2},
             {VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL_KHR, &DeviceExtensions::vk_khr_synchronization2},
+            {VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL, &DeviceExtensions::vk_khr_separate_depth_stencil_layouts},
+            {VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL, &DeviceExtensions::vk_khr_separate_depth_stencil_layouts},
         }};
         auto is_layout = [image_layout, this](const ExtensionLayout &ext_layout) {
             return device_extensions.*(ext_layout.extension) && (ext_layout.layout == image_layout);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1124,7 +1124,8 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
                 if (!subpass.used || !view_state || view_state->Destroyed()) {
                     continue;
                 }
-                if (ds_aspect && subpass.usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+                if (ds_aspect && (subpass.usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT ||
+                                  subpass.usage == VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
                     if ((image_layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL ||
                          image_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL ||
                          image_layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL) &&


### PR DESCRIPTION
There is a new set of proposed CTS tests (not yet landed as of the time I'm writing this) that check using depth/stencil images as descriptors and/or as read-only depth/stencil attachments works properly.

These new tests fail validation with multiple errors due to either:

* The spec failing to consider VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL and VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL as valid layouts for input attachments and/or depth/stencil attachments. There is a proposed Vulkan spec change to fix this and remove inconsistencies in the spec regarding these layouts. Not yet merged either. The layers work strictly according to the spec. The first commit in this pull request carries the same changes as the proposed spec changes, applied to the layers.

* The spec mentions a render pass may use a depth/stencil attachment both as an attachment and as a descriptor as long as both accesses are read-only, but the layers were not considering input attachments as a valid read-only access. This is what the second commit fixes.

I'll update this PR as soon as the spec changes land.