### PR TITLE
[WIP] build: Refactor Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(LAYERS_HELPER_FOLDER "Helper Targets")
 
 # Options for Linux only
-if(UNIX AND NOT APPLE) # i.e. Linux
+if(UNIX AND (NOT (APPLE OR ANDROID))) # i.e. Linux
     include(FindPkgConfig)
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
@@ -165,72 +165,8 @@ if(UNIX AND NOT APPLE) # i.e. Linux
     endif()
 endif()
 
-# Platform-specific compiler switches
-option(BUILD_WERROR "Treat compiler warnings as errors" ON)
-if(MAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wconversion
-
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
-                        -Wno-string-conversion
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion)
-
-endif()
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall
-                        -Wextra
-                        -Wno-unused-parameter
-                        -Wno-missing-field-initializers
-                        -fno-strict-aliasing
-                        -fno-builtin-memcmp
-                        -fvisibility=hidden)
-
-    # Treat warnings as errors for versions of GCC and c++11-compliant Clang versions that are shipped on Ubuntu 18.04 or older.
-    if(BUILD_WERROR)
-        if ((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
-           (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0)))
-            add_compile_options(-Werror)
-        endif()
-    endif()
-
-    set(CMAKE_C_STANDARD 99)
-
-    # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
-    # all compilers until they all accept the C++17 standard.
-    if(CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.1))
-        add_compile_options(-Wimplicit-fallthrough=0)
-    endif()
-elseif(MSVC)
-    if(BUILD_WERROR)
-        # Treat warnings as errors
-        add_compile_options("/WX")
-    endif()
-    # Warn about nested declarations
-    add_compile_options("/w34456")
-    # Warn about potentially uninitialized variables
-    add_compile_options("/w34701")
-    add_compile_options("/w34703")
-    # Warn about different indirection types.
-    add_compile_options("/w34057")
-    # Warn about signed/unsigned mismatch.
-    add_compile_options("/w34245")
-endif()
-
-if(MAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wconversion
-
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
-                        -Wno-string-conversion
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion)
-
-endif()
+# Accumulates built targets for adding common options
+set(VVL_COMPILED_TARGETS)
 
 option(INSTALL_TESTS "Install tests" OFF)
 option(BUILD_LAYERS "Build layers" ON)
@@ -243,7 +179,48 @@ if (USE_ROBIN_HOOD_HASHING)
     set(ROBIN_HOOD_HASHING_INCLUDE_DIR "${ROBIN_HOOD_HASHING_INSTALL_DIR}/src/include" PATH "Path to robin-hood-hashing/src/include")
 endif()
 
+if(BUILD_TESTS OR BUILD_LAYERS)
+    # spirv-tools
+    if (NOT TARGET SPIRV-Tools)
+        if(NOT SPIRV_TOOLS_INSTALL_DIR)
+            set(SPIRV_TOOLS_INSTALL_DIR "${GLSLANG_INSTALL_DIR}")
+        endif()
+
+        set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include" CACHE PATH "Path to spirv-headers")
+        set(SPIRV_TOOLS_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
+            CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
+        set(SPIRV_TOOLS_OPT_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
+            CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
+        set(SPIRV_TOOLS_INCLUDE_DIR "${SPIRV_TOOLS_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
+        set(SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
+        set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
+
+        set(SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
+    else()
+        set(SPIRV_TOOLS_INCLUDE_DIR "${spirv-tools_SOURCE_DIR}/include" CACHE PATH "Path to spirv tools headers")
+    endif()
+    set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools SPIRV-Tools-opt)
+endif()
+
+if (ANDROID)
+    set(SPIRV-Headers_SOURCE_DIR ${SPIRV_HEADERS_SOURCE_DIR})
+    add_subdirectory(${SPIRV_TOOLS_SOURCE_DIR} ${CMAKE_BINARY_DIR}/SPIRV-Tools)
+endif()
+
+if(NOT SPIRV_HEADERS_INSTALL_DIR)
+    message(FATAL_ERROR "Must define location of SPIRV-Headers -- see BUILD.md")
+endif()
+
 if(BUILD_TESTS)
+    if (ANDROID)
+        if (NOT GLSLANG_SOURCE_DIR)
+            message(FATAL_ERROR "GLSLANG_SOURCE_DIR must point to the glslang source directory for Android builds")
+        endif()
+        add_subdirectory(${GLSLANG_SOURCE_DIR} ${CMAKE_BINARY_DIR}/glslang)
+    endif()
+
     set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
     if(NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR} AND NOT TARGET glslang)
         message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
@@ -259,14 +236,7 @@ if(BUILD_TESTS)
         set(SPIRV_HEADERS_INSTALL_DIR $ENV{SPIRV_HEADERS_INSTALL_DIR})
     endif()
 
-    if(NOT SPIRV_TOOLS_INSTALL_DIR)
-        set(SPIRV_TOOLS_INSTALL_DIR $ENV{SPIRV_TOOLS_INSTALL_DIR})
-    endif()
-
     if (NOT TARGET glslang)
-        if(NOT SPIRV_HEADERS_INSTALL_DIR)
-            message(FATAL_ERROR "Must define location of SPIRV-Headers -- see BUILD.md")
-        endif()
 
         message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
         set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
@@ -302,34 +272,6 @@ if(BUILD_TESTS)
     endif()
 endif()
 
-if(BUILD_TESTS OR BUILD_LAYERS)
-    # spirv-tools
-    if (NOT TARGET SPIRV-Tools)
-        if(NOT SPIRV_TOOLS_INSTALL_DIR)
-            set(SPIRV_TOOLS_INSTALL_DIR "${GLSLANG_INSTALL_DIR}")
-        endif()
-
-        set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include" CACHE PATH "Path to spirv-headers")
-        set(SPIRV_TOOLS_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
-            CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
-        set(SPIRV_TOOLS_OPT_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
-            CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
-        set(SPIRV_TOOLS_INCLUDE_DIR "${SPIRV_TOOLS_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
-        set(SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-
-        find_library(SPIRV_TOOLS_LIB NAMES SPIRV-Tools HINTS ${SPIRV_TOOLS_SEARCH_PATH})
-        find_library(SPIRV_TOOLS_OPT_LIB NAMES SPIRV-Tools-opt HINTS ${SPIRV_TOOLS_OPT_SEARCH_PATH})
-
-        set(SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
-    else()
-        set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools SPIRV-Tools-opt)
-        set(SPIRV_TOOLS_INCLUDE_DIR "${spirv-tools_SOURCE_DIR}/include" CACHE PATH "Path to spirv tools headers")
-    endif()
-endif()
-
 # Generate dependent helper files ------------------------------------------------------------------------------------------------
 
 set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/scripts")
@@ -345,6 +287,7 @@ add_library(VkLayer_utils
             layers/vk_layer_extension_utils.cpp
             layers/vk_layer_utils.cpp
             layers/vk_format_utils.cpp)
+list(APPEND VVL_COMPILED_TARGETS VkLayer_utils)
 target_link_libraries(VkLayer_utils PUBLIC Vulkan::Headers)
 set_target_properties(VkLayer_utils PROPERTIES CXX_STANDARD ${VVL_CPP_STANDARD})
 if (VVL_ENABLE_ASAN)
@@ -449,3 +392,73 @@ endif()
 if(BUILD_LAYERS OR BUILD_LAYER_SUPPORT_FILES)
     add_subdirectory(layers)
 endif()
+
+# Platform-specific compiler switches
+foreach (_target ${VVL_COMPILED_TARGETS})
+    option(BUILD_WERROR "Treat compiler warnings as errors" ON)
+    if(MAKE_C_COMPILER_ID MATCHES "Clang")
+        target_compile_options(${_target} PRIVATE -Wconversion
+
+                            # TODO These warnings also get turned on with -Wconversion in some versions of clang.
+                            #      Leave off until further investigation.
+                            -Wno-sign-conversion
+                            -Wno-shorten-64-to-32
+                            -Wno-string-conversion
+                            -Wno-implicit-int-conversion
+                            -Wno-enum-enum-conversion)
+
+    endif()
+    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        target_compile_options(${_target} PRIVATE -Wall
+                            -Wextra
+                            -Wno-unused-parameter
+                            -Wno-missing-field-initializers
+                            -fno-strict-aliasing
+                            -fno-builtin-memcmp
+                            -fvisibility=hidden)
+
+        # Treat warnings as errors for versions of GCC and c++11-compliant Clang versions that are shipped on Ubuntu 18.04 or older.
+        if(BUILD_WERROR)
+            if ((CMAKE_COMPILER_IS_GNUCXX AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.3.0)) OR
+               (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0)))
+                target_compile_options(${_target} PRIVATE -Werror)
+            endif()
+        endif()
+
+        set(CMAKE_C_STANDARD 99)
+
+        # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
+        # all compilers until they all accept the C++17 standard.
+        if(CMAKE_COMPILER_IS_GNUCC AND NOT (CMAKE_CXX_COMPILER_VERSION LESS 7.1))
+            target_compile_options(${_target} PRIVATE -Wimplicit-fallthrough=0)
+        endif()
+    elseif(MSVC)
+        if(BUILD_WERROR)
+            # Treat warnings as errors
+            target_compile_options(${_target} PRIVATE "/WX")
+        endif()
+        target_compile_options(${_target} PRIVATE
+            # Warn about nested declarations
+            "/w34456"
+            # Warn about potentially uninitialized variables
+            "/w34701"
+            "/w34703"
+            # Warn about different indirection types.
+            "/w34057"
+            # Warn about signed/unsigned mismatch.
+            "/w34245")
+    endif()
+
+    if(MAKE_C_COMPILER_ID MATCHES "Clang")
+        target_compile_options(${_target} PRIVATE -Wconversion
+
+                            # TODO These warnings also get turned on with -Wconversion in some versions of clang.
+                            #      Leave off until further investigation.
+                            -Wno-sign-conversion
+                            -Wno-shorten-64-to-32
+                            -Wno-string-conversion
+                            -Wno-implicit-int-conversion
+                            -Wno-enum-enum-conversion)
+
+    endif()
+endforeach()

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -81,6 +81,7 @@ set(TARGET_NAMES
 # System-specific macro to create a library target.
 macro(AddVkLayer target LAYER_COMPILE_DEFINITIONS)
     add_library(VkLayer_${target} SHARED ${ARGN})
+    list(APPEND VVL_COMPILED_TARGETS VkLayer_${target})
     set_target_properties(VkLayer_${target} PROPERTIES CXX_STANDARD ${VVL_CPP_STANDARD})
     target_compile_definitions(VkLayer_${target} PUBLIC ${LAYER_COMPILE_DEFINITIONS})
     target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
@@ -291,9 +292,6 @@ if(BUILD_LAYERS)
     endif()
 
     # Khronos validation additional dependencies
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${GLSLANG_INCLUDE_DIR})
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     if(INSTRUMENT_OPTICK)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${OPTICK_SOURCE_DIR})
     endif()

--- a/layers/libVkLayer_khronos_validation.map
+++ b/layers/libVkLayer_khronos_validation.map
@@ -2,6 +2,8 @@
   global:
     vkGetInstanceProcAddr;
     vkGetDeviceProcAddr;
+    vkEnumerateDeviceExtensionProperties;
+    vkEnumerateDeviceLayerProperties;
     vkEnumerateInstanceLayerProperties;
     vkEnumerateInstanceExtensionProperties;
     vkNegotiateLoaderLayerInterfaceVersion;

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -52,7 +52,11 @@ DEFAULT_ARCH = ARCHS[0]
 def RunShellCmd(command, start_dir = PROJECT_ROOT, env=None, verbose=False):
     if start_dir != PROJECT_ROOT:
         start_dir = RepoRelative(start_dir)
-    cmd_list = command.split(" ")
+    cmd_list = None
+    if type(command) is str:
+        cmd_list = command.split(" ")
+    else:
+        cmd_list = command
     if verbose or ('VVL_CI_VERBOSE' in os.environ and os.environ['VVL_CI_VERBOSE'] != '0'):
         print(f'CICMD({cmd_list}, env={env})')
     subprocess.check_call(cmd_list, cwd=start_dir, env=env)

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -313,12 +313,14 @@ class GoodRepo(object):
         'json':  A fully populated JSON object describing the repo.
         'args':  Results from ArgumentParser
         """
+        dir_top = os.path.abspath(args.dir)
         self._json = json
         self._args = args
         # Required JSON elements
         self.name = json['name']
         self.url = json['url']
         self.sub_dir = json['sub_dir']
+        self.src_dir = os.path.join(dir_top, os.path.normpath(self.sub_dir))
         self.commit = json['commit']
         # Optional JSON elements
         self.build_dir = None
@@ -341,7 +343,6 @@ class GoodRepo(object):
         self.build_platforms = json['build_platforms'] if ('build_platforms' in json) else []
         self.optional = set(json.get('optional', []))
         # Absolute paths for a repo's directories
-        dir_top = os.path.abspath(args.dir)
         self.repo_dir = os.path.join(dir_top, self.sub_dir)
         if self.build_dir:
             self.build_dir = os.path.join(dir_top, self.build_dir)
@@ -596,6 +597,7 @@ def CreateHelper(args, repos, filename):
     install_names = GetInstallNames(args)
     with open(filename, 'w') as helper_file:
         for repo in repos:
+            helper_file.write(f'set({repo.name.replace("-","_").upper()}_SOURCE_DIR "{escape(repo.src_dir)}" CACHE STRING "" FORCE)\n')
             if install_names and repo.name in install_names and repo.on_build_platform:
                 helper_file.write('set({var} "{dir}" CACHE STRING "" FORCE)\n'
                                   .format(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,20 +98,34 @@ if(NOT TARGET vulkan)
 endif()
 
 set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
-add_executable(vk_layer_validation_tests
-               layer_validation_tests.cpp
-               ../layers/vk_format_utils.cpp
-               ../layers/convert_to_renderpass2.cpp
-               ../layers/generated/vk_safe_struct.cpp
-               ../layers/generated/lvt_function_pointers.cpp
-               ${COMMON_CPP})
-add_test(NAME vk_layer_validation_tests COMMAND vk_layer_validation_tests)
-add_dependencies(vk_layer_validation_tests VkLayer_khronos_validation VkLayer_khronos_validation-json)
-if(NOT GTEST_IS_STATIC_LIB)
-    set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+if (NOT ANDROID)
+    set(layer_test_target_ vk_layer_validation_tests)
+    add_executable(${layer_test_target_}
+                   layer_validation_tests.cpp
+                   ../layers/vk_format_utils.cpp
+                   ../layers/convert_to_renderpass2.cpp
+                   ../layers/generated/vk_safe_struct.cpp
+                   ../layers/generated/lvt_function_pointers.cpp
+                   ${COMMON_CPP})
+else()
+    set(layer_test_target_ VulkanLayerValidationTests)
+    add_library(${layer_test_target_} SHARED
+                   layer_validation_tests.cpp
+                   ../layers/vk_format_utils.cpp
+                   ../layers/convert_to_renderpass2.cpp
+                   ../layers/generated/vk_safe_struct.cpp
+                   ../layers/generated/lvt_function_pointers.cpp
+                   ${COMMON_CPP})
+endif()
+list(APPEND VVL_COMPILED_TARGETS ${layer_test_target_})
+
+add_test(NAME ${layer_test_target_} COMMAND vk_layer_validation_tests)
+add_dependencies(${layer_test_target_} VkLayer_khronos_validation VkLayer_khronos_validation-json)
+if ((NOT GTEST_IS_STATIC_LIB) AND (NOT ANDROID))
+    set_target_properties(${layer_test_target_} PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 endif()
 # Note that there is no need to add GTEST directories here due to googletest exporting them via the gtest target.
-target_include_directories(vk_layer_validation_tests
+target_include_directories(${layer_test_target_}
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                   ${PROJECT_SOURCE_DIR}/layers
                                   ${PROJECT_SOURCE_DIR}/layers/generated
@@ -124,40 +138,53 @@ target_include_directories(vk_layer_validation_tests
                                   ${VulkanHeaders_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
 if (USE_ROBIN_HOOD_HASHING)
-    target_include_directories(vk_layer_validation_tests PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+    target_include_directories(${layer_test_target_} PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
 endif()
-add_dependencies(vk_layer_validation_tests
+add_dependencies(${layer_test_target_}
                  VkLayer_utils)
 
 option(PORTABILITY_TESTS_USE_DEVSIM "Automatically add the devsim layer for portability tests" OFF)
 if (PORTABILITY_TESTS_USE_DEVSIM)
-    target_compile_definitions(vk_layer_validation_tests PRIVATE PORTABILITY_TESTS_USE_DEVSIM=1)
+    target_compile_definitions(${layer_test_target_} PRIVATE PORTABILITY_TESTS_USE_DEVSIM=1)
 endif()
 
 if (VVL_ENABLE_ASAN)
-    target_compile_options(vk_layer_validation_tests  PRIVATE -fsanitize=address)
+    target_compile_options(${layer_test_target_} PRIVATE -fsanitize=address)
     # NOTE: Use target_link_options when cmake 3.13 is available on CI
-    target_link_libraries(vk_layer_validation_tests  PRIVATE "-fsanitize=address")
+    target_link_libraries(${layer_test_target_} PRIVATE "-fsanitize=address")
 endif()
 
 if (NOT MSVC)
-    target_compile_options(vk_layer_validation_tests PRIVATE "-Wno-sign-compare")
+    target_compile_options(${layer_test_target_} PRIVATE "-Wno-sign-compare")
 endif()
 
 # Specify target_link_libraries
-target_link_libraries(vk_layer_validation_tests
-                      PRIVATE VkLayer_utils
-                              gtest
-                              gtest_main
-                              ${GLSLANG_LIBRARIES}
-                              ${SPIRV_TOOLS_LIBRARIES})
+target_link_libraries(${layer_test_target_}
+                      PRIVATE VkLayer_utils)
 
-if(NOT WIN32)
-    target_link_libraries(vk_layer_validation_tests PRIVATE dl)
+if(WIN32)
+    set_target_properties(gtest PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+    set_target_properties(gtest_main PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
+    target_link_libraries(${layer_test_target_}
+                          PRIVATE gtest
+                                  gtest_main
+                                  ${GLSLANG_LIBRARIES})
+else()
+    target_compile_options(${layer_test_target_} PRIVATE "-Wno-sign-compare")
     if(BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
-        target_link_libraries(vk_layer_validation_tests
+        target_link_libraries(${layer_test_target_}
                               PRIVATE ${XCB_LIBRARIES}
-                                      ${X11_LIBRARIES})
+                                      ${X11_LIBRARIES}
+                                      gtest
+                                      gtest_main
+                                      dl
+                                      ${GLSLANG_LIBRARIES})
+    else()
+        target_link_libraries(${layer_test_target_}
+                              PRIVATE gtest
+                                      gtest_main
+                                      dl
+                                      ${GLSLANG_LIBRARIES})
     endif()
 endif()
 
@@ -166,13 +193,72 @@ if(WIN32)
     if(NOT GTEST_IS_STATIC_LIB)
         file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/googletest/googletest/$<CONFIG>/*.dll SRC_GTEST_DLLS)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> DST_GTEST_DLLS)
-        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
+        add_custom_command(TARGET ${layer_test_target_} POST_BUILD
                            COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
     endif()
 endif()
 
 if(INSTALL_TESTS)
-    install(TARGETS vk_layer_validation_tests DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS ${layer_test_target_} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-add_subdirectory(layers)
+if (ANDROID)
+    if (NOT ANDROID_SDK_HOME)
+        set(ANDROID_SDK_HOME $ENV{ANDROID_SDK_HOME})
+    endif()
+    if (NOT ANDROID_SDK_HOME)
+        message(FATAL_ERROR "Please specify ANDROID_SDK_HOME")
+    endif()
+
+    if (NOT ANDROID_NDK_HOME)
+        set(ANDROID_NDK_HOME $ENV{ANDROID_NDK_HOME})
+    endif()
+    if (NOT ANDROID_NDK_HOME)
+        message(FATAL_ERROR "Please specify ANDROID_NDK_HOME. This is commonly $ANDROID_SDK_HOME/ndk-bundle.")
+    endif()
+
+    if (NOT ANDROID_BUILD_TOOLS)
+        set(ANDROID_BUILD_TOOLS $ENV{ANDROID_BUILD_TOOLS})
+    endif()
+    if (NOT ANDROID_BUILD_TOOLS)
+        message(FATAL_ERROR "Please specify ANDROID_BUILD_TOOLS version ($ANDROID_SDK_HOME/build-tools/<version>)")
+    endif()
+
+    if (NOT ANDROID_STL)
+        set(ANDROID_STL $ENV{ANDROID_STL})
+    endif()
+    if (NOT ANDROID_STL)
+        set(ANDROID_STL c++_static)
+    endif()
+
+    # Necessary for vulkan_wrapper.h
+    target_include_directories(${layer_test_target_} PRIVATE ${ANDROID_NDK_HOME}/sources/third_party/vulkan/src/common)
+
+    set(_app_glue_dir ${ANDROID_NDK_HOME}/sources/android/native_app_glue)
+    target_sources(${layer_test_target_} PRIVATE ${_app_glue_dir}/android_native_app_glue.c)
+    target_include_directories(${layer_test_target_} PRIVATE ${_app_glue_dir})
+    target_compile_definitions(${layer_test_target_} PRIVATE VALIDATION_APK VK_PROTOTYPES)
+
+    # TODO use target_link_options if using cmake >= 3.13
+    target_link_libraries(${layer_test_target_} PRIVATE "-u ANativeActivity_onCreate")
+
+    target_link_libraries(${layer_test_target_} PRIVATE SPIRV-Tools log android)
+
+    set(_android_jar ${ANDROID_SDK_HOME}/platforms/android-${ANDROID_PLATFORM}/android.jar)
+    set(_aapt ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/aapt)
+    set(_zipalign ${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}/zipalign)
+    add_custom_command(TARGET ${layer_test_target_} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_BINARY_DIR}/apk
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/apk/out
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/AndroidManifest.xml ${CMAKE_BINARY_DIR}/apk/AndroidManifest.xml
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${layer_test_target_}> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:${layer_test_target_}>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:VkLayer_khronos_validation> ${CMAKE_BINARY_DIR}/apk/out/lib/${ANDROID_ABI}/$<TARGET_FILE_NAME:VkLayer_khronos_validation>
+        COMMAND ${_aapt} package -f -M ${CMAKE_BINARY_DIR}/apk/AndroidManifest.xml -I ${_android_jar} -S ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/res -F ${CMAKE_BINARY_DIR}/apk/out/${layer_test_target_}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out
+        COMMAND jarsigner -verbose -keystore $ENV{HOME}/.android/debug.keystore -storepass android -keypass android ${CMAKE_BINARY_DIR}/apk/out/${layer_test_target_}-unaligned.apk androiddebugkey
+        COMMAND ${_zipalign} -f 4 ${CMAKE_BINARY_DIR}/apk/out/${layer_test_target_}-unaligned.apk ${CMAKE_BINARY_DIR}/apk/out/${layer_test_target_}.apk
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
+endif()
+
+if (NOT ANDROID)
+    add_subdirectory(layers)
+endif()

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2016-2019 Valve Corporation
-# Copyright (c) 2016-2019 LunarG, Inc.
+# Copyright (c) 2016-2021 Valve Corporation
+# Copyright (c) 2016-2021 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ if(WIN32)
         set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
 
         add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
+        list(APPEND VVL_COMPILED_TARGETS VKLayer_${target})
         add_dependencies(VkLayer_${target} VkLayer_utils)
         target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
         target_compile_definitions(VkLayer_${target} PRIVATE "_CRT_SECURE_NO_WARNINGS")
@@ -77,14 +78,25 @@ if(WIN32)
 elseif(APPLE)
     macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
+        list(APPEND VVL_COMPILED_TARGETS VKLayer_${target})
         add_dependencies(VkLayer_${target} VkLayer_utils)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl")
         target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
         target_compile_options(VkLayer_${target} PRIVATE "-Wpointer-arith" "-Wno-unused-function")
     endmacro()
-else(UNIX AND NOT APPLE) # i.e.: Linux
+elseif(ANDROID)
     macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
+        list(APPEND VVL_COMPILED_TARGETS VkLayer_${target})
+        add_dependencies(VkLayer_${target} VkLayer_utils)
+        set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_${target}.map,-Bsymbolic")
+        target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils log)
+        target_compile_options(VkLayer_${target} PRIVATE "-Wpointer-arith" "-Wno-unused-function")
+    endmacro()
+elseif(UNIX) # i.e.: Linux since we know NOT (APPLE OR ANDROID)
+    macro(AddVkLayer target)
+        add_library(VkLayer_${target} SHARED ${ARGN})
+        list(APPEND VVL_COMPILED_TARGETS VKLayer_${target})
         add_dependencies(VkLayer_${target} VkLayer_utils)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_${target}.map,-Bsymbolic")
         target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)

--- a/tests/platforms/android/AndroidManifest.xml
+++ b/tests/platforms/android/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.VulkanLayerValidationTests" android:versionCode="1" android:versionName="1.0">
+
+    <!-- This is the platform API where NativeActivity was introduced. -->
+    <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="26"/>
+
+    <!-- This .apk has no Java code itself, so set hasCode to false. -->
+    <application android:label="@string/app_name" android:hasCode="false" android:debuggable='true'>
+
+        <!-- This allows writing log files to sdcard -->
+        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+        <!-- Our activity is the built-in NativeActivity framework class.
+             This will take care of integrating with our NDK code. -->
+        <activity android:name="android.app.NativeActivity" android:label="@string/app_name" android:exported="true">
+            <!-- Tell NativeActivity the name of or .so -->
+            <meta-data android:name="android.app.lib_name" android:value="VulkanLayerValidationTests"/>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+

--- a/tests/platforms/android/res/values/strings.xml
+++ b/tests/platforms/android/res/values/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- This file contains resource definitions for displayed strings, allowing
+     them to be changed based on the locale and options. -->
+
+<resources>
+    <!-- Simple strings. -->
+    <string name="app_name">VulkanLayerValidationTests</string>
+
+</resources>

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -24,12 +24,7 @@
 
 #include "lvt_function_pointers.h"
 
-#ifdef ANDROID
-#include "vktestframeworkandroid.h"
-class VkImageObj;
-#else
 #include "vktestframework.h"
-#endif
 
 #if defined(ANDROID)
 #include <android/log.h>
@@ -668,8 +663,6 @@ class VkShaderObj : public vk_testing::ShaderModule {
                                                       const VkSpecializationInfo *spec_info = nullptr,
                                                       const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
 
-    // TODO (ncesario) remove ifndef once android build consolidation changes go in
-#ifndef __ANDROID__
     struct GlslangTargetEnv {
         GlslangTargetEnv(const spv_target_env env) {
             switch (env) {
@@ -719,7 +712,6 @@ class VkShaderObj : public vk_testing::ShaderModule {
         glslang::EShTargetLanguageVersion language_version = glslang::EShTargetSpv_1_0;
         glslang::EShTargetClientVersion client_version = glslang::EShTargetVulkan_1_0;
     };
-#endif
 
   protected:
     VkPipelineShaderStageCreateInfo m_stage_info;

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -32,8 +32,8 @@
 #endif
 // TODO FIXME remove this once glslang doesn't define this
 #undef BadValue
-#include "glslang/SPIRV/GlslangToSpv.h"
-#include "glslang/SPIRV/SPVRemapper.h"
+#include "SPIRV/GlslangToSpv.h"
+#include "SPIRV/SPVRemapper.h"
 #if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
 #pragma warning(pop)
 #endif
@@ -133,6 +133,10 @@ bool VkTestFramework::m_devsim_layer = false;
 int VkTestFramework::m_width = 0;
 int VkTestFramework::m_height = 0;
 int VkTestFramework::m_phys_device_index = -1;
+
+#ifdef __ANDROID__
+ANativeWindow *VkTestFramework::window = nullptr;
+#endif
 
 bool VkTestFramework::optionMatch(const char *option, char *optionLine) {
     if (strncmp(option, optionLine, strlen(option)) == 0)

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -22,7 +22,7 @@
 #ifndef VKTESTFRAMEWORK_H
 #define VKTESTFRAMEWORK_H
 
-#include "glslang/SPIRV/GLSL.std.450.h"
+#include "SPIRV/GLSL.std.450.h"
 #include "spirv-tools/libspirv.h"
 #include "glslang/Public/ShaderLang.h"
 #include "icd-spv.h"
@@ -69,6 +69,10 @@ class VkTestFramework : public ::testing::Test {
 
     char **ReadFileData(const char *fileName);
     void FreeFileData(char **data);
+
+#ifdef __ANDROID__
+    static ANativeWindow *window;
+#endif
 
   protected:
     VkTestFramework();


### PR DESCRIPTION
Android build refactor:
- Removes dependency on ndk-build/Android.mk build tools
- Remove shaderc dependency in the Android build for tests
- Use single `known_good.json` for desktop and Android

Still WIP:
- Adding an "easy" way to build and package multiple architectures (may or may not be needed depending on CI)
- Still investigating some test failures

Creating this now to get early feedback on the build process. In short, setting up an Android build would look something like:
```bash
cmake -GNinja -Bbuild-android-cmake \
  -DCMAKE_BUILD_TYPE=Debug \
  -DUPDATE_DEPS=ON \
  -DCMAKE_TOOLCHAIN_FILE=<ndk-path>/build/cmake/android.toolchain.cmake \
  -DANDROID_NDK_HOME=<ndk-path> \
  -DANDROID_SDK_HOME=<sdk-path> \
  -DANDROID_PLATFORM=26 \
  -DANDROID_BUILD_TOOLS=31.0.0-rc1 \
  -DANDROID_ABI=arm64-v8a \
  -DANDROID_STL=c++_static
```
I removed the need for using environment variables to set `ANDROID_{S,N}DK_HOME` as I'm not personally a fan of this (though you can still do it that way if you prefer with this change). Also, using `UPDATE_DEPS=ON` this should be a similar "one-time-setup" as with desktop.

FYI @Tony-LunarG @jeremyg-lunarg @ziga-lunarg @mikes-lunarg.

FYI @lunarpapillo @johnzupin as this would eventually require some changes to CI. The big one (I'm guessing) is that each arch would need its own cmake build (instead of specifying all archs in `Application.mk`).