### PR TITLE
layers: Initialize SURFACE_STATE::swapchain in the constructor

### DIFF
--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -272,7 +272,7 @@ class SURFACE_STATE : public BASE_NODE {
     SWAPCHAIN_NODE *swapchain;
     layer_data::unordered_map<GpuQueue, bool> gpu_queue_support;
 
-    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR) {}
+    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR), swapchain(nullptr), gpu_queue_support() {}
 
     ~SURFACE_STATE() {
         if (!Destroyed()) {

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -8931,6 +8931,28 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
     vk::FreeMemory(m_device->device(), buffer_mem, NULL);
 }
 
+TEST_F(VkPositiveLayerTest, CreateSurface) {
+    TEST_DESCRIPTION("Create and destroy a surface without ever creating a swapchain");
+
+    if (!AddSurfaceInstanceExtension()) {
+        printf("%s surface extensions not supported, skipping CreateSurface  test\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    m_errorMonitor->ExpectSuccess();
+    if (!InitSurface()) {
+        printf("%s Cannot create surface, skipping test\n", kSkipPrefix);
+        return;
+    }
+    DestroySwapchain(); // cleans up both surface and swapchain, if they were created
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
     TEST_DESCRIPTION("Run vkCmdCopyImage with a swapchain image");
 


### PR DESCRIPTION
This field used to be a smart pointer and skated by with default
constructor initialization.

Fixes #3087