### PR TITLE
Adding vuid 04890

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1602,6 +1602,15 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                         }
                     }
                 }
+                if (subpass_desc->pDepthStencilAttachment->layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) {
+                    if (pPipeline->graphicsPipelineCI.pDepthStencilState->depthWriteEnable == VK_TRUE) {
+                        skip |= LogError(
+                            device, "VUID-VkGraphicsPipelineCreateInfo-subpass-04890",
+                            "vkCreateGraphicsPipelines(): pCreateInfo[%" PRIu32
+                            "]: subpass uses read-only depth aspect layout, but pDepthStencilState->depthWriteEnable is VK_TRUE.",
+                            pipelineIndex);
+                    }
+                }
             }
 
             // If subpass uses color attachments, pColorBlendState must be valid pointer


### PR DESCRIPTION
When creating a graphics pipeline, if subpass uses a read-only depth/stencil attachment then depthWriteEnable member of pDepthStencilState must be VK_FALSE