### PR TITLE
layers: Add VUIDs 04961 and 04962

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -11278,7 +11278,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Rende
                                                      VK_ATTACHMENT_LOAD_OP_CLEAR)) {
                 clear_op_size = static_cast<uint32_t>(i) + 1;
 
-                if (FormatHasDepth(attachment->format)) {
+                if (FormatHasDepth(attachment->format) && pRenderPassBegin->pClearValues) {
                     skip |= ValidateClearDepthStencilValue(commandBuffer, pRenderPassBegin->pClearValues[i].depthStencil,
                                                            function_name);
                 }

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -6374,6 +6374,7 @@ bool StatelessValidation::PreCallValidateCmdClearColorImage(
             skip |= validate_flags("vkCmdClearColorImage", ParameterName("pRanges[%i].aspectMask", ParameterName::IndexVector{ rangeIndex }), "VkImageAspectFlagBits", AllVkImageAspectFlagBits, pRanges[rangeIndex].aspectMask, kRequiredFlags, "VUID-VkImageSubresourceRange-aspectMask-parameter", "VUID-VkImageSubresourceRange-aspectMask-requiredbitmask");
         }
     }
+    if (!skip) skip |= manual_PreCallValidateCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
     return skip;
 }
 
@@ -6694,6 +6695,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass(
         // No xml-driven validation
     }
     skip |= validate_ranged_enum("vkCmdBeginRenderPass", "contents", "VkSubpassContents", AllVkSubpassContentsEnums, contents, "VUID-vkCmdBeginRenderPass-contents-parameter");
+    if (!skip) skip |= manual_PreCallValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
     return skip;
 }
 
@@ -7555,6 +7557,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass2(
 
         skip |= validate_ranged_enum("vkCmdBeginRenderPass2", "pSubpassBeginInfo->contents", "VkSubpassContents", AllVkSubpassContentsEnums, pSubpassBeginInfo->contents, "VUID-VkSubpassBeginInfo-contents-parameter");
     }
+    if (!skip) skip |= manual_PreCallValidateCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     return skip;
 }
 
@@ -9736,6 +9739,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass2KHR(
 
         skip |= validate_ranged_enum("vkCmdBeginRenderPass2KHR", "pSubpassBeginInfo->contents", "VkSubpassContents", AllVkSubpassContentsEnums, pSubpassBeginInfo->contents, "VUID-VkSubpassBeginInfo-contents-parameter");
     }
+    if (!skip) skip |= manual_PreCallValidateCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     return skip;
 }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -7340,3 +7340,46 @@ bool StatelessValidation::manual_PreCallValidateMergePipelineCaches(VkDevice dev
     }
     return skip;
 }
+
+bool StatelessValidation::manual_PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image,
+                                                                   VkImageLayout imageLayout, const VkClearColorValue *pColor,
+                                                                   uint32_t rangeCount,
+                                                                   const VkImageSubresourceRange *pRanges) const {
+    bool skip = false;
+    if (!pColor) {
+        skip |=
+            LogError(commandBuffer, "VUID-vkCmdClearColorImage-pColor-04961", "vkCmdClearColorImage(): pColor must not be null");
+    }
+    return skip;
+}
+
+bool StatelessValidation::ValidateCmdBeginRenderPass(const char *const func_name,
+                                                     const VkRenderPassBeginInfo *const rp_begin) const {
+    bool skip = false;
+    if ((rp_begin->clearValueCount != 0) && !rp_begin->pClearValues) {
+        skip |= LogError(rp_begin->renderPass, "VUID-VkRenderPassBeginInfo-clearValueCount-04962",
+                         "%s: VkRenderPassBeginInfo::clearValueCount != 0 (%" PRIu32
+                         "), but VkRenderPassBeginInfo::pClearValues is not null.",
+                         func_name, rp_begin->clearValueCount);
+    }
+    return skip;
+}
+
+bool StatelessValidation::manual_PreCallValidateCmdBeginRenderPass(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                                   VkSubpassContents) const {
+    bool skip = ValidateCmdBeginRenderPass("vkCmdBeginRenderPass", pRenderPassBegin);
+    return skip;
+}
+
+bool StatelessValidation::manual_PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer,
+                                                                       const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                                       const VkSubpassBeginInfo *) const {
+    bool skip = ValidateCmdBeginRenderPass("vkCmdBeginRenderPass2KHR", pRenderPassBegin);
+    return skip;
+}
+
+bool StatelessValidation::manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo *) const {
+    bool skip = ValidateCmdBeginRenderPass("vkCmdBeginRenderPass2", pRenderPassBegin);
+    return skip;
+}

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1759,5 +1759,17 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                    const VkPipelineCache *pSrcCaches) const;
 
+    bool manual_PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
+                                                  const VkClearColorValue *pColor, uint32_t rangeCount,
+                                                  const VkImageSubresourceRange *pRanges) const;
+
+    bool ValidateCmdBeginRenderPass(const char *const func_name, const VkRenderPassBeginInfo *const rp_begin) const;
+    bool manual_PreCallValidateCmdBeginRenderPass(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                  VkSubpassContents) const;
+    bool manual_PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                      const VkSubpassBeginInfo *) const;
+    bool manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                   const VkSubpassBeginInfo *) const;
+
 #include "parameter_validation.h"
 };  // Class StatelessValidation

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -248,7 +248,11 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetVertexInputEXT',
             'vkCmdPushConstants',
             'vkMergePipelineCaches',
-            'vkGetPhysicalDeviceVideoFormatPropertiesKHR'
+            'vkGetPhysicalDeviceVideoFormatPropertiesKHR',
+            'vkCmdClearColorImage',
+            'vkCmdBeginRenderPass',
+            'vkCmdBeginRenderPass2KHR',
+            'vkCmdBeginRenderPass2',
             ]
 
         # Commands to ignore

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -9160,3 +9160,26 @@ TEST_F(VkLayerTest, CommandBufferMissingOcclusionQueryEnabled) {
 
     vk::DestroyQueryPool(device(), query_pool, nullptr);
 }
+
+TEST_F(VkLayerTest, CmdClearColorImageNullColor) {
+    TEST_DESCRIPTION("Test invalid null entries for clear color");
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    VkImageObj image(m_device);
+    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+
+    VkImageSubresourceRange isr = {};
+    isr.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    isr.baseArrayLayer = 0;
+    isr.baseMipLevel = 0;
+    isr.layerCount = 1;
+    isr.levelCount = 1;
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearColorImage-pColor-04961");
+    vk::CmdClearColorImage(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, nullptr, 1, &isr);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10006,3 +10006,17 @@ TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
 
     DestroySwapchain();
 }
+
+TEST_F(VkLayerTest, RenderPassBeginNullValues) {
+    TEST_DESCRIPTION("Test invalid null entries for clear color");
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    auto rpbi = m_renderPassBeginInfo;
+    rpbi.clearValueCount = 1;
+    rpbi.pClearValues = nullptr;  // clearValueCount != 0, but pClearValues = null, leads to 04962
+    TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &rpbi, false,
+                        "VUID-VkRenderPassBeginInfo-clearValueCount-04962", nullptr);
+}


### PR DESCRIPTION
Adds missing manual parameter validation for `vkCmdClearColorImage` and `vkCmdBeginRenderPass*`.

This also adds a null check to avoid a crash at CmdBeginRenderPass time.

Closes #3097.