### PR TITLE
tests: Fix missing return statement when skipping test

### DIFF
--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1333,12 +1333,14 @@ class ValidationStateTracker : public ValidationObject {
         assert(ext_prop);
         if (enabled) {
             *ext_prop = LvlInitStruct<ExtProp>();
-            if (api_version < VK_API_VERSION_1_1) {
+            if (device_extensions.vk_khr_get_physical_device_properties2) {
                 auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2>(ext_prop);
                 DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
-            } else {
+            } else if (api_version >= VK_API_VERSION_1_1) {
                 auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2>(ext_prop);
                 DispatchGetPhysicalDeviceProperties2(gpu, &prop2);
+            } else {
+              // Probably leaves *ext_prop default initialized?
             }
         }
     }

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1656,17 +1656,6 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
     m_device_extension_names.push_back(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
     m_device_extension_names.push_back(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
 
-    // Note: Includes workaround for some implementations which incorrectly return 0 maxPushDescriptors
-    bool push_descriptor_support = gpdp2_support &&
-                                   DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME) &&
-                                   (GetPushDescriptorProperties(instance(), gpu()).maxPushDescriptors > 0);
-    if (push_descriptor_support) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
-        printf("%s Push Descriptor Extension not supported, push descriptor cases skipped.\n", kSkipPrefix);
-        return;
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1664,6 +1664,7 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
         m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     } else {
         printf("%s Push Descriptor Extension not supported, push descriptor cases skipped.\n", kSkipPrefix);
+        return;
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));


### PR DESCRIPTION
Simple bug fix, taken out from PR #3013.