### PR TITLE
layers: Fix memory leaks from class BothRangeMap

### DIFF
--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -842,6 +842,15 @@ class BothRangeMap {
     BothRangeMap() = delete;
     BothRangeMap(index_type limit) : mode_(ComputeMode(limit)), big_map_(MakeBigMap()), small_map_(MakeSmallMap(limit)) {}
 
+    ~BothRangeMap() {
+        if (big_map_) {
+            big_map_->~BigMap();
+        }
+        if (small_map_) {
+            small_map_->~SmallMap();
+        }
+    }
+
     inline bool empty() const {
         if (SmallMode()) {
             return small_map_->empty();


### PR DESCRIPTION
This class makes use of placement new to share storage for the 2 different map implementations. But it wasn't calling  the destructor for the maps. This probably only matters for the "big" map (std::map), which allocates separate node  buffers in the heap.

Fix *some* of the leaks in Image and Layout test cases so it is easier to see stuff like this.
