### PR TITLE
practices: Fix leaks in struct GraphicsPipelineCIs

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -975,14 +975,13 @@ void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device,
 
         auto& create_info = cgpl_state->pCreateInfos[i];
 
-        cis.colorBlendStateCI =
-            create_info.pColorBlendState
-                ? new safe_VkPipelineColorBlendStateCreateInfo(create_info.pColorBlendState)
-                : nullptr;
-        cis.depthStencilStateCI =
-            cgpl_state->pCreateInfos[i].pDepthStencilState
-                ? new safe_VkPipelineDepthStencilStateCreateInfo(create_info.pDepthStencilState)
-                : nullptr;
+        if (create_info.pColorBlendState) {
+            cis.colorBlendStateCI.emplace(create_info.pColorBlendState);
+        }
+
+        if (create_info.pDepthStencilState) {
+            cis.depthStencilStateCI.emplace(create_info.pDepthStencilState);
+        }
 
         // Record which frame buffer attachments we should consider to be accessed when a draw call is performed.
         RENDER_PASS_STATE* rp = GetRenderPassState(create_info.renderPass);
@@ -1370,8 +1369,8 @@ void BestPractices::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer,
             render_pass_state.nextDrawTouchesAttachments = gp_cis->second.accessFramebufferAttachments;
             render_pass_state.drawTouchAttachments = true;
 
-            const auto* blend_state = gp_cis->second.colorBlendStateCI;
-            const auto* stencil_state = gp_cis->second.depthStencilStateCI;
+            const auto& blend_state = gp_cis->second.colorBlendStateCI;
+            const auto& stencil_state = gp_cis->second.depthStencilStateCI;
 
             if (blend_state) {
                 // assume the pipeline is depth-only unless any of the attachments have color writes enabled

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -528,8 +528,8 @@ class BestPractices : public ValidationStateTracker {
     };
 
     struct GraphicsPipelineCIs {
-        const safe_VkPipelineDepthStencilStateCreateInfo* depthStencilStateCI;
-        const safe_VkPipelineColorBlendStateCreateInfo* colorBlendStateCI;
+        layer_data::optional<safe_VkPipelineDepthStencilStateCreateInfo> depthStencilStateCI;
+        layer_data::optional<safe_VkPipelineColorBlendStateCreateInfo> colorBlendStateCI;
         std::vector<AttachmentInfo> accessFramebufferAttachments;
     };
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -126,13 +126,13 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     // Create a 1.0 vulkan instance and request an extension promoted to core in 1.1
     m_errorMonitor->ExpectSuccess(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT);
     m_errorMonitor->SetUnexpectedError("UNASSIGNED-khronos-Validation-debug-build-warning-message");
-    VkApplicationInfo* new_info = new VkApplicationInfo;
-    new_info->apiVersion = VK_API_VERSION_1_0;
-    new_info->pApplicationName = ici.pApplicationInfo->pApplicationName;
-    new_info->applicationVersion = ici.pApplicationInfo->applicationVersion;
-    new_info->pEngineName = ici.pApplicationInfo->pEngineName;
-    new_info->engineVersion = ici.pApplicationInfo->engineVersion;
-    ici.pApplicationInfo = new_info;
+    VkApplicationInfo new_info{};
+    new_info.apiVersion = VK_API_VERSION_1_0;
+    new_info.pApplicationName = ici.pApplicationInfo->pApplicationName;
+    new_info.applicationVersion = ici.pApplicationInfo->applicationVersion;
+    new_info.pEngineName = ici.pApplicationInfo->pEngineName;
+    new_info.engineVersion = ici.pApplicationInfo->engineVersion;
+    ici.pApplicationInfo = &new_info;
     vk::CreateInstance(&ici, nullptr, &dummy);
     vk::DestroyInstance(dummy, nullptr);
     m_errorMonitor->VerifyNotFound();
@@ -654,6 +654,9 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     vk::CreateFramebuffer(m_device->device(), &fb_info, nullptr, &fb);
 
     m_errorMonitor->VerifyFound();
+    vk::DestroyImageView(m_device->device(), image_view, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {


### PR DESCRIPTION
Use optional rather than raw new to avoid having to remember to clean up this structure.

Fix leaks in test cases too.