### PR TITLE
Adding vuid 01982, Validate ConditionalRendering buffer usage

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -15881,3 +15881,22 @@ bool CoreChecks::PreCallValidateCmdSetColorWriteEnableEXT(VkCommandBuffer comman
 
     return skip;
 }
+
+bool CoreChecks::PreCallValidateCmdBeginConditionalRenderingEXT(
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin) const {
+    bool skip = false;
+
+    if (pConditionalRenderingBegin) {
+        const BUFFER_STATE *buffer_state = GetBufferState(pConditionalRenderingBegin->buffer);
+        if (buffer_state) {
+            if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT) == 0) {
+                skip |= LogError(commandBuffer, "VUID-VkConditionalRenderingBeginInfoEXT-buffer-01982",
+                                 "vkCmdBeginConditionalRenderingEXT(): pConditionalRenderingBegin->buffer (%s) was not create with "
+                                 "VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT bit.",
+                                 report_data->FormatHandle(pConditionalRenderingBegin->buffer).c_str());
+            }
+        }
+    }
+
+    return skip;
+}

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1531,6 +1531,8 @@ class CoreChecks : public ValidationStateTracker {
                                                      const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) const override;
     bool PreCallValidateCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                   const VkBool32* pColorWriteEnables) const override;
+    bool PreCallValidateCmdBeginConditionalRenderingEXT(
+        VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) const override;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     bool PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(


### PR DESCRIPTION
The buffer used in CmdBeginConditionalRenderingEXT must have be created with VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT bit