### PR TITLE
Adding vuid 00103, Validate secondary command buffers queryFlags 

### DIFF
--- a/layers/query_state.h
+++ b/layers/query_state.h
@@ -36,6 +36,7 @@ class QUERY_POOL_STATE : public BASE_NODE {
     bool has_perf_scope_render_pass;
     uint32_t n_performance_passes;
     uint32_t perf_counter_index_count;
+    VkQueryControlFlags control_flags;
 
     QUERY_POOL_STATE(VkQueryPool qp, const VkQueryPoolCreateInfo *pCreateInfo, uint32_t index_count, uint32_t n_perf_pass,
                      bool has_cb, bool has_rb)

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3368,7 +3368,7 @@ QueryState ValidationStateTracker::GetQueryState(const QueryMap *localQueryToSta
 }
 
 void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                                         VkFlags flags) {
+                                                         VkQueryControlFlags flags) {
     if (disabled[query_validation]) return;
 
     QueryObject query = {queryPool, slot};
@@ -3379,6 +3379,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer command
     if (!disabled[command_buffer_state]) {
         auto pool_state = GetQueryPoolState(query.pool);
         cb_state->AddChild(pool_state);
+        pool_state->control_flags = flags;
     }
 }
 
@@ -4387,6 +4388,8 @@ void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuff
     QueryObject query_obj = {queryPool, query, index};
     CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
     cb_state->BeginQuery(query_obj);
+    QUERY_POOL_STATE* qp_state = GetQueryPoolState(queryPool);
+    qp_state->control_flags = flags;
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -875,7 +875,8 @@ class ValidationStateTracker : public ValidationObject {
 
     // Recorded Commands
     void PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo) override;
-    void PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags) override;
+    void PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
+                                     VkQueryControlFlags flags) override;
     void PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                VkQueryControlFlags flags, uint32_t index) override;
     void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,


### PR DESCRIPTION
Secondary command buffers must be recorded with VkCommandBufferInheritanceInfo::queryFlags having all bits set that were set for the query