### PR TITLE
layers: Fix state tracker GetCBState() calls that snuck in

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3536,13 +3536,13 @@ void ValidationStateTracker::PostCallRecordCmdEndTransformFeedbackEXT(VkCommandB
 
 void ValidationStateTracker::PostCallRecordCmdBeginConditionalRenderingEXT(
     VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin) {
-    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    auto *cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
 
     cb_state->conditional_rendering_active = true;
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
-    CMD_BUFFER_STATE *cb_state = GetCBState(commandBuffer);
+    auto *cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
 
     cb_state->conditional_rendering_active = false;
 


### PR DESCRIPTION
PR #3167 removed these methods from state tracker, but a different
PR added a few more calls right before 3167 merged.