### PR TITLE
tests: Change error monitor default

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5826,7 +5826,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             }
         }
 
-        if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT && !FormatIsCompressed(image_format) &&
+        if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT && !FormatIsCompressed(view_format) &&
             pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_3D) {
             skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-04739",
                              "vkCreateImageView(): Image was created with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT bit and "

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1739,13 +1739,6 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                              "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT "
                              "flag bit is set");
         }
-
-        if ((pCreateInfo->extent.width != pCreateInfo->extent.height) || (pCreateInfo->arrayLayers < 6)) {
-            skip |= LogError(device, "VUID-VkImageCreateInfo-imageType-00954",
-                             "vkCreateImage(): If VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT flag bit is set, width (%d) must equal "
-                             "height (%d) and arrayLayers (%d) must be >= 6.",
-                             pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->arrayLayers);
-        }
     }
 
     const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -262,6 +262,8 @@ class VkLayerTest : public VkRenderFramework {
     bool AddSwapchainDeviceExtension();
     VkCommandBufferObj *CommandBuffer();
     void OOBRayTracingShadersTestBody(bool gpu_assisted);
+    bool AddYCbCrDeviceExtensions();
+    bool AddImageDrmFormatModifierDeviceExtensions();
 
   protected:
     uint32_t m_instance_api_version = 0;
@@ -506,7 +508,7 @@ struct CreatePipelineHelper {
         for (const auto &error : errors) test.Monitor().SetDesiredFailureMsg(flags, error);
         helper.CreateGraphicsPipeline();
 
-        if (positive_test) {
+        if (positive_test || (errors.size() == 0)) {
             test.Monitor().VerifyNotFound();
         } else {
             test.Monitor().VerifyFound();

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -8061,6 +8061,7 @@ TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {
         printf("%s Cannot make VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT not supported.  Skipping test.\n", kSkipPrefix);
         return;
     }
+    m_errorMonitor->SetUnexpectedError("VUID-VkBufferViewCreateInfo-buffer-00934");
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkPhysicalDeviceFeatures device_features = {};

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1644,17 +1644,25 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
     if (gpdp2_support) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME)) {
         printf("%s Descriptor Update Template Extensions not supported, skipped.\n", kSkipPrefix);
         return;
+    } else {
+        m_device_extension_names.push_back(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
+    }
+    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE1_EXTENSION_NAME)) {
+        printf("%s %s not supported, skipped.\n", kSkipPrefix, VK_KHR_MAINTENANCE1_EXTENSION_NAME);
+        return;
+    } else {
+        m_device_extension_names.push_back(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
     }
     if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME)) {
         printf("%s %s not supported, skipped.\n", kSkipPrefix, VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
         return;
+    } else {
+        m_device_extension_names.push_back(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
     }
-    m_device_extension_names.push_back(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
-    m_device_extension_names.push_back(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
 
     // Note: Includes workaround for some implementations which incorrectly return 0 maxPushDescriptors
     bool push_descriptor_support = gpdp2_support &&

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1587,6 +1587,20 @@ void VkImageObj::init(const VkImageCreateInfo *create_info) {
     SetLayout(image_aspect, VK_IMAGE_LAYOUT_GENERAL);
 }
 
+bool VkImageObj::IsCompatibleCheck(const VkImageCreateInfo &create_info) {
+    VkFormatProperties image_fmt;
+    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info.format, &image_fmt);
+
+    switch (create_info.tiling) {
+        case VK_IMAGE_TILING_OPTIMAL:
+            return IsCompatible(create_info.usage, image_fmt.optimalTilingFeatures);
+        case VK_IMAGE_TILING_LINEAR:
+            return IsCompatible(create_info.usage, image_fmt.linearTilingFeatures);
+        default:
+            return true;
+    }
+}
+
 VkResult VkImageObj::CopyImage(VkImageObj &src_image) {
     VkImageLayout src_image_layout, dest_image_layout;
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -448,6 +448,7 @@ class VkImageObj : public vk_testing::Image {
   public:
     VkImageObj(VkDeviceObj *dev);
     bool IsCompatible(VkImageUsageFlags usages, VkFormatFeatureFlags features);
+    bool IsCompatibleCheck(const VkImageCreateInfo &create_info);
 
   public:
     static VkImageCreateInfo ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mipLevels,

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -93,7 +93,12 @@ class VkDeviceObj : public vk_testing::Device {
 // failure was encountered.
 class ErrorMonitor {
   public:
-    ErrorMonitor();
+    enum Behavior {
+        DefaultSuccess = 0,
+        DefaultIgnore,
+    };
+
+    ErrorMonitor(Behavior = Behavior::DefaultIgnore);
 
     ~ErrorMonitor() NOEXCEPT;
 
@@ -129,6 +134,13 @@ class ErrorMonitor {
 
     // ExpectSuccess now takes an optional argument allowing a custom combination of debug flags
     void ExpectSuccess(VkDebugReportFlagsEXT const message_flag_mask = kErrorBit);
+    bool ExpectingSuccess() const {
+        return (desired_message_strings_.size() == 1) &&
+               (desired_message_strings_.count("") == 1 && ignore_message_strings_.size() == 0);
+    }
+    bool NeedCheckSuccess() const {
+        return (behavior_ == Behavior::DefaultSuccess) && ExpectingSuccess();
+    }
 
     void VerifyFound();
     void VerifyNotFound();
@@ -152,6 +164,7 @@ class ErrorMonitor {
     test_platform_thread_mutex mutex_;
     bool *bailout_;
     bool message_found_;
+    Behavior behavior_;
 };
 
 struct DebugReporter {
@@ -611,7 +624,8 @@ class VkShaderObj : public vk_testing::ShaderModule {
     VkResult InitFromGLSLTry(VkRenderFramework &framework, const char *shader_code, bool debug = false,
                              uint32_t spirv_minor_version = 0);
     bool InitFromASM(VkRenderFramework &framework, const std::string &spv_source, const spv_target_env env = SPV_ENV_VULKAN_1_0);
-    VkResult InitFromASMTry(VkRenderFramework &framework, const std::string &spv_source);
+    VkResult InitFromASMTry(VkRenderFramework &framework, const std::string &spv_source,
+                            const spv_target_env env = SPV_ENV_VULKAN_1_0);
 
   protected:
     VkPipelineShaderStageCreateInfo m_stage_info;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -838,6 +838,8 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
 
 class RenderPass : public internal::NonDispHandle<VkRenderPass> {
   public:
+    RenderPass() = default;
+    RenderPass(const Device &dev, const VkRenderPassCreateInfo &info) { init(dev, info); }
     ~RenderPass() NOEXCEPT;
 
     // vkCreateRenderPass()
@@ -847,6 +849,8 @@ class RenderPass : public internal::NonDispHandle<VkRenderPass> {
 
 class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
   public:
+    Framebuffer() = default;
+    Framebuffer(const Device &dev, const VkFramebufferCreateInfo &info) { init(dev, info); }
     ~Framebuffer() NOEXCEPT;
 
     // vkCreateFramebuffer()


### PR DESCRIPTION
Changes the default behavior of the ErrorMonitor to always "expect
success." Previously, all validation errors were ignored unless
ExpectSuccess was explicitly called.

Still some failing tests, but getting this up there to see what else CI catches.

Commit summary:
1. Removes a duplicate check in core validation
2. Fixes a bug with 04739
3. Testing framework updates for optionally making the default behavior "expect success" (had to make the default "ignore failures" in order to get the fixes in incrementally)
4. Test fixes found by running the tests with "expect success" default behavior

For the 04739 check, I'm fairly certain it is correct, but still need to verify (planning to with CTS).

This is related to #3177, which should be closed once making default behavior "expect success" can be checked in.