### PR TITLE
Adding vuid 01407 01408, Validate independent advanced blend

### DIFF
--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1461,6 +1461,7 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateViewport(const VkViewport &viewport, const char *fn_name, const ParameterName &parameter_name,
                                         VkCommandBuffer object) const;
 
+    bool IsAdvancedBlendOp(VkBlendOp blend_op) const;
     bool manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                     const VkAllocationCallbacks *pAllocator,
                                                     VkPipelineLayout *pPipelineLayout) const;


### PR DESCRIPTION
If advancedBlendIndependentBlend is VK_FALSE and any attachment uses an advanced color or alpha blend operation, then all attachment must use the same color or alpha blend operation