### PR TITLE
layers: Clean up PIPELINE_LAYOUT_STATE

### DIFF
--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -30,6 +30,14 @@
 #include "render_pass_state.h"
 #include "state_tracker.h"
 
+// Dictionary of canonical form of the pipeline set layout of descriptor set layouts
+static PipelineLayoutSetLayoutsDict pipeline_layout_set_layouts_dict;
+
+// Dictionary of canonical form of the "compatible for set" records
+static PipelineLayoutCompatDict pipeline_layout_compat_dict;
+
+static PushConstantRangesDict push_constant_ranges_dict;
+
 size_t PipelineLayoutCompatDef::hash() const {
     hash_util::HashCombiner hc;
     // The set number is integral to the CompatDef's distinctiveness
@@ -63,6 +71,80 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
     }
     return true;
 }
+
+static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId pcr_id,
+                                             const PipelineLayoutSetLayoutsId set_layouts_id) {
+    return pipeline_layout_compat_dict.look_up(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));
+}
+
+// For repeatable sorting, not very useful for "memory in range" search
+struct PushConstantRangeCompare {
+    bool operator()(const VkPushConstantRange *lhs, const VkPushConstantRange *rhs) const {
+        if (lhs->offset == rhs->offset) {
+            if (lhs->size == rhs->size) {
+                // The comparison is arbitrary, but avoids false aliasing by comparing all fields.
+                return lhs->stageFlags < rhs->stageFlags;
+            }
+            // If the offsets are the same then sorting by the end of range is useful for validation
+            return lhs->size < rhs->size;
+        }
+        return lhs->offset < rhs->offset;
+    }
+};
+
+static PushConstantRangesId GetCanonicalId(const VkPipelineLayoutCreateInfo *info) {
+    if (!info->pPushConstantRanges) {
+        // Hand back the empty entry (creating as needed)...
+        return push_constant_ranges_dict.look_up(PushConstantRanges());
+    }
+
+    // Sort the input ranges to ensure equivalent ranges map to the same id
+    std::set<const VkPushConstantRange *, PushConstantRangeCompare> sorted;
+    for (uint32_t i = 0; i < info->pushConstantRangeCount; i++) {
+        sorted.insert(info->pPushConstantRanges + i);
+    }
+
+    PushConstantRanges ranges;
+    ranges.reserve(sorted.size());
+    for (const auto *range : sorted) {
+        ranges.emplace_back(*range);
+    }
+    return push_constant_ranges_dict.look_up(std::move(ranges));
+}
+
+static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_data,
+                                                            const VkPipelineLayoutCreateInfo *pCreateInfo) {
+    PIPELINE_LAYOUT_STATE::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
+
+    for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
+        set_layouts[i] = dev_data->GetDescriptorSetLayoutShared(pCreateInfo->pSetLayouts[i]);
+    }
+    return set_layouts;
+}
+
+static std::vector<PipelineLayoutCompatId> GetCompatForSet(const PIPELINE_LAYOUT_STATE::SetLayoutVector &set_layouts,
+                                                           const PushConstantRangesId &push_constant_ranges) {
+    PipelineLayoutSetLayoutsDef set_layout_ids(set_layouts.size());
+    for (size_t i = 0; i < set_layouts.size(); i++) {
+        set_layout_ids[i] = set_layouts[i]->GetLayoutId();
+    }
+    auto set_layouts_id = pipeline_layout_set_layouts_dict.look_up(set_layout_ids);
+
+    std::vector<PipelineLayoutCompatId> compat_for_set;
+    compat_for_set.reserve(set_layouts.size());
+
+    for (uint32_t i = 0; i < set_layouts.size(); i++) {
+        compat_for_set.emplace_back(GetCanonicalId(i, push_constant_ranges, set_layouts_id));
+    }
+    return compat_for_set;
+}
+
+PIPELINE_LAYOUT_STATE::PIPELINE_LAYOUT_STATE(ValidationStateTracker *dev_data, VkPipelineLayout l,
+                                             const VkPipelineLayoutCreateInfo *pCreateInfo)
+    : BASE_NODE(l, kVulkanObjectTypePipelineLayout),
+      set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
+      push_constant_ranges(GetCanonicalId(pCreateInfo)),
+      compat_for_set(GetCompatForSet(set_layouts, push_constant_ranges)) {}
 
 void PIPELINE_STATE::initGraphicsPipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                                           std::shared_ptr<const RENDER_PASS_STATE> &&rpstate) {

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -122,21 +122,16 @@ using PipelineLayoutCompatId = PipelineLayoutCompatDict::Id;
 // Store layouts and pushconstants for PipelineLayout
 class PIPELINE_LAYOUT_STATE : public BASE_NODE {
   public:
-    std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> set_layouts;
-    PushConstantRangesId push_constant_ranges;
-    std::vector<PipelineLayoutCompatId> compat_for_set;
+    using SetLayoutVector = std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>>;
+    const SetLayoutVector set_layouts;
+    // canonical form IDs for the "compatible for set" contents
+    const PushConstantRangesId push_constant_ranges;
+    // table of "compatible for set N" cannonical forms for trivial accept validation
+    const std::vector<PipelineLayoutCompatId> compat_for_set;
 
-    PIPELINE_LAYOUT_STATE(VkPipelineLayout l)
-        : BASE_NODE(l, kVulkanObjectTypePipelineLayout), set_layouts{}, push_constant_ranges{}, compat_for_set{} {}
+    PIPELINE_LAYOUT_STATE(ValidationStateTracker *dev_data, VkPipelineLayout l, const VkPipelineLayoutCreateInfo *pCreateInfo);
 
     VkPipelineLayout layout() const { return handle_.Cast<VkPipelineLayout>(); }
-
-    void reset() {
-        handle_.handle = 0;
-        set_layouts.clear();
-        push_constant_ranges.reset();
-        compat_for_set.clear();
-    }
 
     std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> GetDsl(uint32_t set) const {
         std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> dsl = nullptr;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2475,78 +2475,12 @@ void ValidationStateTracker::PostCallRecordCreateDescriptorSetLayout(VkDevice de
     descriptorSetLayoutMap[*pSetLayout] = std::make_shared<cvdescriptorset::DescriptorSetLayout>(pCreateInfo, *pSetLayout);
 }
 
-// For repeatable sorting, not very useful for "memory in range" search
-struct PushConstantRangeCompare {
-    bool operator()(const VkPushConstantRange *lhs, const VkPushConstantRange *rhs) const {
-        if (lhs->offset == rhs->offset) {
-            if (lhs->size == rhs->size) {
-                // The comparison is arbitrary, but avoids false aliasing by comparing all fields.
-                return lhs->stageFlags < rhs->stageFlags;
-            }
-            // If the offsets are the same then sorting by the end of range is useful for validation
-            return lhs->size < rhs->size;
-        }
-        return lhs->offset < rhs->offset;
-    }
-};
-
-static PushConstantRangesDict push_constant_ranges_dict;
-
-PushConstantRangesId GetCanonicalId(const VkPipelineLayoutCreateInfo *info) {
-    if (!info->pPushConstantRanges) {
-        // Hand back the empty entry (creating as needed)...
-        return push_constant_ranges_dict.look_up(PushConstantRanges());
-    }
-
-    // Sort the input ranges to ensure equivalent ranges map to the same id
-    std::set<const VkPushConstantRange *, PushConstantRangeCompare> sorted;
-    for (uint32_t i = 0; i < info->pushConstantRangeCount; i++) {
-        sorted.insert(info->pPushConstantRanges + i);
-    }
-
-    PushConstantRanges ranges;
-    ranges.reserve(sorted.size());
-    for (const auto *range : sorted) {
-        ranges.emplace_back(*range);
-    }
-    return push_constant_ranges_dict.look_up(std::move(ranges));
-}
-
-// Dictionary of canoncial form of the pipeline set layout of descriptor set layouts
-static PipelineLayoutSetLayoutsDict pipeline_layout_set_layouts_dict;
-
-// Dictionary of canonical form of the "compatible for set" records
-static PipelineLayoutCompatDict pipeline_layout_compat_dict;
-
-static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId pcr_id,
-                                             const PipelineLayoutSetLayoutsId set_layouts_id) {
-    return pipeline_layout_compat_dict.look_up(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));
-}
-
 void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkPipelineLayout *pPipelineLayout, VkResult result) {
     if (VK_SUCCESS != result) return;
 
-    auto pipeline_layout_state = std::make_shared<PIPELINE_LAYOUT_STATE>(*pPipelineLayout);
-    pipeline_layout_state->set_layouts.resize(pCreateInfo->setLayoutCount);
-    PipelineLayoutSetLayoutsDef set_layouts(pCreateInfo->setLayoutCount);
-    for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        pipeline_layout_state->set_layouts[i] = GetDescriptorSetLayoutShared(pCreateInfo->pSetLayouts[i]);
-        set_layouts[i] = pipeline_layout_state->set_layouts[i]->GetLayoutId();
-    }
-
-    // Get canonical form IDs for the "compatible for set" contents
-    pipeline_layout_state->push_constant_ranges = GetCanonicalId(pCreateInfo);
-    auto set_layouts_id = pipeline_layout_set_layouts_dict.look_up(set_layouts);
-    pipeline_layout_state->compat_for_set.reserve(pCreateInfo->setLayoutCount);
-
-    // Create table of "compatible for set N" cannonical forms for trivial accept validation
-    for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        pipeline_layout_state->compat_for_set.emplace_back(
-            GetCanonicalId(i, pipeline_layout_state->push_constant_ranges, set_layouts_id));
-    }
-    pipelineLayoutMap[*pPipelineLayout] = std::move(pipeline_layout_state);
+    pipelineLayoutMap[*pPipelineLayout] = std::make_shared<PIPELINE_LAYOUT_STATE>(this, *pPipelineLayout, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,


### PR DESCRIPTION
Move intialization to the constructor and make all data
members 'const'. Note that there are some global static lookup
tables, but they are already internally locked, see hash_util.h.