### PR TITLE
layers: Move VkIndexType from formats untils

### DIFF
--- a/layers/vk_format_utils.cpp
+++ b/layers/vk_format_utils.cpp
@@ -1539,18 +1539,3 @@ VK_LAYER_EXPORT bool FormatIsYChromaSubsampled(VkFormat format) {
 
     return is_y_chroma_subsampled;
 }
-
-VK_LAYER_EXPORT VkDeviceSize GetIndexAlignment(VkIndexType indexType) {
-    switch (indexType) {
-        case VK_INDEX_TYPE_UINT16:
-            return 2;
-        case VK_INDEX_TYPE_UINT32:
-            return 4;
-        case VK_INDEX_TYPE_UINT8_EXT:
-            return 1;
-        default:
-            // Not a real index type. Express no alignment requirement here; we expect upper layer
-            // to have already picked up on the enum being nonsense.
-            return 1;
-    }
-}

--- a/layers/vk_format_utils.h
+++ b/layers/vk_format_utils.h
@@ -171,7 +171,6 @@ VK_LAYER_EXPORT bool FormatSizesAreEqual(VkFormat srcFormat, VkFormat dstFormat,
 VK_LAYER_EXPORT bool FormatRequiresYcbcrConversion(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsXChromaSubsampled(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsYChromaSubsampled(VkFormat format);
-VK_LAYER_EXPORT VkDeviceSize GetIndexAlignment(VkIndexType indexType);
 
 VK_LAYER_EXPORT uint32_t FormatDepthSize(VkFormat format);
 VK_LAYER_EXPORT VkFormatNumericalType FormatDepthNumericalType(VkFormat format);

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -198,6 +198,21 @@ static inline bool IsIdentitySwizzle(VkComponentMapping components) {
     // clang-format on
 }
 
+static inline VkDeviceSize GetIndexAlignment(VkIndexType indexType) {
+    switch (indexType) {
+        case VK_INDEX_TYPE_UINT16:
+            return 2;
+        case VK_INDEX_TYPE_UINT32:
+            return 4;
+        case VK_INDEX_TYPE_UINT8_EXT:
+            return 1;
+        default:
+            // Not a real index type. Express no alignment requirement here; we expect upper layer
+            // to have already picked up on the enum being nonsense.
+            return 1;
+    }
+}
+
 extern "C" {
 #endif
 


### PR DESCRIPTION
`GetIndexAlignment` should not be in format utils as it has nothing to do with `VkFormats`