### PR TITLE
Adding vuid 04727, Validate image view format features support blend 

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -83,6 +83,7 @@ struct DrawDispatchVuid {
     const char* primitive_restart_enable = kVUIDUndefined;
     const char* vertex_input_binding_stride = kVUIDUndefined;
     const char* vertex_input = kVUIDUndefined;
+    const char* blend_enable = kVUIDUndefined;
 };
 
 struct ValidateBeginQueryVuids {
@@ -513,6 +514,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE* pPipeline) const;
     bool ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE* pPipeline, const CMD_BUFFER_STATE* pCB,
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
+    bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE* pPipeline) const;
     void RecordGraphicsPipelineShaderDynamicState(PIPELINE_STATE *pipeline);
     bool ValidateComputePipelineShaderState(PIPELINE_STATE* pPipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE* pipeline, VkShaderStageFlagBits stageBit) const;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -85,6 +85,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDraw-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDraw-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDraw_VertexInput;
+        blend_enable                       = "VUID-vkCmdDraw-blendEnable-04727";
     }
 };
 
@@ -130,6 +131,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawMultiEXT-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawMultiEXT-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawMultiEXT_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawMultiEXT-blendEnable-04727";
     }
 };
 
@@ -175,6 +177,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndexed-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexed-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndexed_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndexed-blendEnable-04727";
     }
 };
 
@@ -220,6 +223,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         primitive_restart_enable = "VUID-vkCmdDrawMultiIndexedEXT-None-04879";
         vertex_input_binding_stride = "VUID-vkCmdDrawMultiIndexedEXT-pStrides-04884";
         vertex_input = kVUID_Core_CmdDrawMultiIndexedEXT_VertexInput;
+        blend_enable = "VUID-vkCmdDrawMultiIndexedEXT-blendEnable-04727";
     }
 };
 
@@ -267,6 +271,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndirect-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirect-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndirect_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndirect-blendEnable-04727";
     }
 };
 
@@ -314,6 +319,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndexedIndirect-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirect-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndexedIndirect_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndexedIndirect-blendEnable-04727";
     }
 };
 
@@ -409,6 +415,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndirectCount-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectCount-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndirectCount_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndirectCount-blendEnable-04727";
     }
 };
 
@@ -456,6 +463,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndexedIndirectCount-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirectCount-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndexedIndirectCount_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndexedIndirectCount-blendEnable-04727";
     }
 };
 
@@ -568,6 +576,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksNV-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksNV-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawMeshTasksNV_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawMeshTasksNV-blendEnable-04727";
     }
 };
 
@@ -612,6 +621,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksIndirectNV-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawMeshTasksIndirectNV_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawMeshTasksIndirectNV-blendEnable-04727";
     }
 };
 
@@ -656,6 +666,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawMeshTasksIndirectCountNV-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawMeshTasksIndirectCountNV_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-blendEnable-04727";
     }
 };
 
@@ -703,6 +714,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         primitive_restart_enable           = "VUID-vkCmdDrawIndirectByteCountEXT-None-04879";
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectByteCountEXT-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndirectByteCountEXT_VertexInput;
+        blend_enable                       = "VUID-vkCmdDrawIndirectByteCountEXT-blendEnable-04727";
     }
 };
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -347,35 +347,8 @@ TEST_F(VkLayerTest, BlendingOnFormatWithoutBlendingSupport) {
     pipeline.AddColorAttachment(0, att_state);
     pipeline.CreateVKPipeline(descriptorSet.GetPipelineLayout(), rp);
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, non_blending_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    VkImageView imageView = image.targetView(non_blending_format);
-
-    VkFramebufferCreateInfo fbci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp, 1, &imageView, 32, 32, 1};
-    VkFramebuffer fb;
-    vk::CreateFramebuffer(m_device->device(), &fbci, nullptr, &fb);
-
-    VkRenderPassBeginInfo rpbi = {VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-                                  nullptr,
-                                  rp,
-                                  fb,
-                                  {{
-                                       0,
-                                       0,
-                                   },
-                                   {32, 32}},
-                                  0,
-                                  nullptr};
-
-    m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(rpbi);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.handle());
-    m_commandBuffer->EndRenderPass();
-    m_commandBuffer->end();
-
     m_errorMonitor->VerifyFound();
     vk::DestroyRenderPass(m_device->device(), rp, NULL);
-    vk::DestroyFramebuffer(m_device->device(), fb, NULL);
 }
 
 // Is the Pipeline compatible with the expectations of the Renderpass/subpasses?


### PR DESCRIPTION
Closes #2681

At draw active subpasses image views format features must contain VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT if pipelines blendEnabled is VK_TRUE
