### PR TITLE
Correctly enable the VK_EXT_scalar_block_layout validation in spirv-tools

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2865,7 +2865,7 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
     if (device_extensions.vk_khr_uniform_buffer_standard_layout && enabled_features.core12.uniformBufferStandardLayout == VK_TRUE) {
         options.SetUniformBufferStandardLayout(true);
     }
-    if (device_extensions.vk_ext_scalar_block_layout && enabled_features.core12.scalarBlockLayout == VK_TRUE) {
+    if (device_extensions.vk_ext_scalar_block_layout || enabled_features.core12.scalarBlockLayout == VK_TRUE) {
         options.SetScalarBlockLayout(true);
     }
     if (device_extensions.vk_khr_workgroup_memory_explicit_layout &&


### PR DESCRIPTION
Without being 100% sure I think the statement that enables the VK_EXT_scalar_block_layout validation is incorrect. CC-ing @Tony-LunarG who introduced this line for confirmation. 