### PR TITLE
layers: Avoid crash without vertex shader

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1023,7 +1023,7 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                                           VendorSpecificTag(kBPVendorAMD));
         }
 
-        if (pCreateInfos->pInputAssemblyState->primitiveRestartEnable) {
+        if (pCreateInfos->pInputAssemblyState && pCreateInfos->pInputAssemblyState->primitiveRestartEnable) {
             skip |= LogPerformanceWarning(device, kVUID_BestPractices_CreatePipelines_AvoidPrimitiveRestart,
                                           "%s Performance warning: Use of primitive restart is not recommended",
                                           VendorSpecificTag(kBPVendorAMD));


### PR DESCRIPTION
Fix a crash that would occur in the (unlikely) event no vertex
shader (and therefore no pInputAssemblyState) is present at
CreateGraphicsPipelines time.

See https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/f08084490093b33374e17fbd434b39308bafc4a8#r55614446 for context.

There is no test added as `VkPositiveLayerTest.MeshShaderOnly` will cover this case if mesh shaders are supported on AMD hardware in the future (although, if that happens I would imagine a different extension would be used).