### PR TITLE
Adding vuid 02676 02677 02678, Validate acquire and release full screen exclusive access

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -20665,6 +20665,36 @@ bool CoreChecks::PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice devic
                 "the pNext chain with fullScreenExclusive equal to VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT.",
                 report_data->FormatHandle(swapchain).c_str());
         }
+        if (swapchain_state->exclusive_full_screen_access) {
+            skip |= LogError(device, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02676",
+                             "vkAcquireFullScreenExclusiveModeEXT(): swapchain %s already has exclusive full-screen access.",
+                             report_data->FormatHandle(swapchain).c_str());
+        }
+    }
+
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) const {
+    bool skip = false;
+
+    const auto swapchain_state = Get<SWAPCHAIN_NODE>(swapchain);
+    if (swapchain_state) {
+        if (swapchain_state->retired) {
+            skip |= LogError(device, "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-02677",
+                             "vkReleaseFullScreenExclusiveModeEXT(): swapchain %s is retired.",
+                             report_data->FormatHandle(swapchain).c_str());
+        }
+        const auto *surface_full_screen_exclusive_info =
+            LvlFindInChain<VkSurfaceFullScreenExclusiveInfoEXT>(swapchain_state->createInfo.pNext);
+        if (!surface_full_screen_exclusive_info ||
+            surface_full_screen_exclusive_info->fullScreenExclusive != VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
+            skip |= LogError(
+                device, "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-02678",
+                "vkReleaseFullScreenExclusiveModeEXT(): swapchain %s was not created with VkSurfaceFullScreenExclusiveInfoEXT in "
+                "the pNext chain with fullScreenExclusive equal to VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT.",
+                report_data->FormatHandle(swapchain).c_str());
+        }
     }
 
     return skip;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1815,6 +1815,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) const override;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     bool PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) const override;
+    bool PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) const override;
 #endif
 
     bool ValidatePhysicalDeviceSurfaceSupport(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, const char* vuid,

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -581,6 +581,8 @@ SWAPCHAIN_NODE::SWAPCHAIN_NODE(ValidationStateTracker *dev_data_, const VkSwapch
                                VkSwapchainKHR swapchain)
     : BASE_NODE(swapchain, kVulkanObjectTypeSwapchainKHR),
       createInfo(pCreateInfo),
+      images(),
+      exclusive_full_screen_access(false),
       shared_presentable(VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR == pCreateInfo->presentMode ||
                          VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR == pCreateInfo->presentMode),
       image_create_info(GetImageCreateInfo(pCreateInfo)),

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -284,6 +284,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     const safe_VkSwapchainCreateInfoKHR createInfo;
     std::vector<SWAPCHAIN_IMAGE> images;
     bool retired = false;
+    bool exclusive_full_screen_access;
     const bool shared_presentable;
     uint32_t get_swapchain_image_count = 0;
     uint64_t max_present_id = 0;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4941,6 +4941,24 @@ void ValidationStateTracker::PreCallRecordCmdSetColorWriteEnableEXT(VkCommandBuf
     cb_state->RecordColorWriteEnableStateCmd(CMD_SETCOLORWRITEENABLEEXT, status_flags, attachmentCount);
 }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+void ValidationStateTracker::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
+                                                                             VkResult result) {
+    if (result != VK_SUCCESS) return;
+
+    auto swapchain_state = Get<SWAPCHAIN_NODE>(swapchain);
+    swapchain_state->exclusive_full_screen_access = true;
+}
+
+void ValidationStateTracker::PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
+                                                                             VkResult result) {
+    if (result != VK_SUCCESS) return;
+
+    auto swapchain_state = Get<SWAPCHAIN_NODE>(swapchain);
+    swapchain_state->exclusive_full_screen_access = false;
+}
+#endif
+
 void ValidationStateTracker::RecordGetBufferDeviceAddress(const VkBufferDeviceAddressInfo *pInfo, VkDeviceAddress address) {
     auto buffer_state = Get<BUFFER_STATE>(pInfo->buffer);
     if (buffer_state && address != 0) {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1098,6 +1098,10 @@ class ValidationStateTracker : public ValidationObject {
                                            const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) override;
     void PreCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                 const VkBool32* pColorWriteEnables) override;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    void PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain, VkResult result) override;
+    void PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain, VkResult result) override;
+#endif
     template <typename CreateInfo>
     VkFormatFeatureFlags2KHR GetExternalFormatFeaturesANDROID(const CreateInfo* create_info) const;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -2264,9 +2264,15 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
 
     auto vkAcquireFullScreenExclusiveModeEXT = reinterpret_cast<PFN_vkAcquireFullScreenExclusiveModeEXT>(
         vk::GetInstanceProcAddr(instance(), "vkAcquireFullScreenExclusiveModeEXT"));
+    auto vkReleaseFullScreenExclusiveModeEXT = reinterpret_cast<PFN_vkReleaseFullScreenExclusiveModeEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkReleaseFullScreenExclusiveModeEXT"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02675");
     vkAcquireFullScreenExclusiveModeEXT(device(), m_swapchain);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-02678");
+    vkReleaseFullScreenExclusiveModeEXT(device(), m_swapchain);
     m_errorMonitor->VerifyFound();
 
     const POINT pt_zero = {0, 0};
@@ -2303,6 +2309,17 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02674");
     vkAcquireFullScreenExclusiveModeEXT(device(), swapchain_one);
     m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-02677");
+    vkReleaseFullScreenExclusiveModeEXT(device(), swapchain_one);
+    m_errorMonitor->VerifyFound();
+
+    VkResult res = vkAcquireFullScreenExclusiveModeEXT(device(), swapchain_two);
+    if (res == VK_SUCCESS) {
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02676");
+        vkAcquireFullScreenExclusiveModeEXT(device(), swapchain_two);
+        m_errorMonitor->VerifyFound();
+    }
 
     vk::DestroySwapchainKHR(device(), swapchain_one, nullptr);
     vk::DestroySwapchainKHR(device(), swapchain_two, nullptr);


### PR DESCRIPTION
Full-screen exclusive access must not be acquired when it is already active.
When releasing full-screen exclusive access swapchain must not be retird and must have been created with VkSurfaceFullScreenExclusiveInfoEXT in the pNext chain with fullScreenExclusive equal to VK_FULL_SCREEN_EXLUSIVE_APPLICATION_CONTROLLED_EXT
