### PR TITLE
Adding vuid 04812, Validate CmdCopyQueryPoolResults queryType

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8824,6 +8824,14 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
                              "VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL.",
                              report_data->FormatHandle(queryPool).c_str());
         }
+        if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_VIDEO_ENCODE_BITSTREAM_BUFFER_RANGE_KHR ||
+            query_pool_state->createInfo.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR) {
+            skip |=
+                LogError(queryPool, "VUID-vkCmdCopyQueryPoolResults-queryType-04812",
+                         "vkCmdCopyQueryPoolResults(): called but QueryPool %s was created with queryType "
+                         "%s.",
+                         report_data->FormatHandle(queryPool).c_str(), string_VkQueryType(query_pool_state->createInfo.queryType));
+        }
     }
 
     return skip;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -12944,3 +12944,58 @@ TEST_F(VkLayerTest, QueryPoolResultStatusOnly) {
 
     vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
 }
+
+TEST_F(VkLayerTest, InvalidCopyQueryResults) {
+    TEST_DESCRIPTION("Test CmdCopyQueryPoolResults with unsupported query type");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s Test does not run on Vulkan 1.0, skipping test\n", kSkipPrefix);
+        return;
+    }
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME)) {
+        m_device_extension_names.push_back(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
+    } else {
+        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    VkQueryPool query_pool_encode;
+    VkQueryPool query_pool_result;
+    VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
+    qpci.queryType = VK_QUERY_TYPE_VIDEO_ENCODE_BITSTREAM_BUFFER_RANGE_KHR;
+    qpci.queryCount = 1;
+
+    VkResult err;
+    err = vk::CreateQueryPool(m_device->device(), &qpci, nullptr, &query_pool_encode);
+    if (err != VK_SUCCESS) {
+        printf("%s Required query not supported, skipping tests\n", kSkipPrefix);
+        return;
+    }
+    qpci.queryType = VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR;
+    err = vk::CreateQueryPool(m_device->device(), &qpci, nullptr, &query_pool_result);
+    if (err != VK_SUCCESS) {
+        printf("%s Required query not supported, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
+    VkBufferObj buffer;
+    buffer.init(*m_device, 128, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    m_commandBuffer->begin();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyQueryPoolResults-queryType-04812");
+    vk::CmdCopyQueryPoolResults(m_commandBuffer->handle(), query_pool_encode, 0, 1, buffer.handle(), 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyQueryPoolResults-queryType-04812");
+    vk::CmdCopyQueryPoolResults(m_commandBuffer->handle(), query_pool_result, 0, 1, buffer.handle(), 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->end();
+
+    vk::DestroyQueryPool(device(), query_pool_encode, nullptr);
+    vk::DestroyQueryPool(device(), query_pool_result, nullptr);
+}


### PR DESCRIPTION
Query pools query type in CmdCopyQueryPoolResults must not be VK_QUERY_TYPE_VIDEO_ENCODE_BITSTREAM_BUFFER_RANGE_KHR or VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR