### PR TITLE
layers: Clean up RENDER_PASS_STATE and FRAMEBUFFER_STATE

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9835,7 +9835,7 @@ bool CoreChecks::ValidateDependencies(FRAMEBUFFER_STATE const *framebuffer, REND
     bool skip = false;
     auto const framebuffer_info = framebuffer->createInfo.ptr();
     auto const create_info = renderPass->createInfo.ptr();
-    auto const &subpass_to_node = renderPass->subpassToNode;
+    auto const &subpass_to_node = renderPass->subpass_to_node;
 
     struct Attachment {
         std::vector<SubpassLayout> outputs;

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -88,16 +88,22 @@ class RENDER_PASS_STATE : public BASE_NODE {
         AttachmentTransition(uint32_t prev_pass_, uint32_t attachment_, VkImageLayout old_layout_, VkImageLayout new_layout_)
             : prev_pass(prev_pass_), attachment(attachment_), old_layout(old_layout_), new_layout(new_layout_) {}
     };
-
-    safe_VkRenderPassCreateInfo2 createInfo;
-    std::vector<std::vector<uint32_t>> self_dependencies;
-    std::vector<DAGNode> subpassToNode;
-    layer_data::unordered_map<uint32_t, bool> attachment_first_read;
-    std::vector<uint32_t> attachment_first_subpass;
-    std::vector<uint32_t> attachment_last_subpass;
-    std::vector<bool> attachment_first_is_transition;
-    std::vector<SubpassDependencyGraphNode> subpass_dependencies;
-    std::vector<std::vector<AttachmentTransition>> subpass_transitions;
+    const safe_VkRenderPassCreateInfo2 createInfo;
+    using SubpassVec = std::vector<uint32_t>;
+    using SelfDepVec = std::vector<SubpassVec>;
+    const std::vector<SubpassVec> self_dependencies;
+    using DAGNodeVec = std::vector<DAGNode>;
+    const DAGNodeVec subpass_to_node;
+    using FirstReadMap = layer_data::unordered_map<uint32_t, bool>;
+    const FirstReadMap attachment_first_read;
+    const SubpassVec attachment_first_subpass;
+    const SubpassVec attachment_last_subpass;
+    using FirstIsTransitionVec = std::vector<bool>;
+    const FirstIsTransitionVec attachment_first_is_transition;
+    using SubpassGraphVec = std::vector<SubpassDependencyGraphNode>;
+    const SubpassGraphVec subpass_dependencies;
+    using TransitionVec = std::vector<std::vector<AttachmentTransition>>;
+    const TransitionVec subpass_transitions;
 
     RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo);
     RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo);
@@ -110,7 +116,7 @@ class RENDER_PASS_STATE : public BASE_NODE {
 
 class FRAMEBUFFER_STATE : public BASE_NODE {
   public:
-    safe_VkFramebufferCreateInfo createInfo;
+    const safe_VkFramebufferCreateInfo createInfo;
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_state;
 


### PR DESCRIPTION
All data in these state objects is set up during construction.