### PR TITLE
tests: Use uint32_t for SPIR-V word size

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -3832,7 +3832,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-01376");
-    std::vector<unsigned int> shader;
+    std::vector<uint32_t> shader;
     VkShaderModuleCreateInfo module_create_info;
     VkShaderModule shader_module;
     module_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -3840,7 +3840,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     this->GLSLtoSPV(&m_device->props.limits, VK_SHADER_STAGE_VERTEX_BIT, bindStateVertShaderText, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
-    module_create_info.codeSize = shader.size() * sizeof(unsigned int) - 1;
+    module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
     module_create_info.flags = 0;
     vk::CreateShaderModule(m_device->handle(), &module_create_info, NULL, &shader_module);
 
@@ -4345,22 +4345,8 @@ TEST_F(VkLayerTest, CreateShaderModuleCheckBadCapability) {
         )";
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Capability ImageRect is not allowed by Vulkan");
-
-    std::vector<unsigned int> spv;
-    VkShaderModuleCreateInfo module_create_info;
-    VkShaderModule shader_module;
-    module_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    module_create_info.pNext = NULL;
-    ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, spv_source.data(), spv);
-    module_create_info.pCode = spv.data();
-    module_create_info.codeSize = spv.size() * sizeof(unsigned int);
-    module_create_info.flags = 0;
-
-    VkResult err = vk::CreateShaderModule(m_device->handle(), &module_create_info, NULL, &shader_module);
+    VkShaderObj::CreateFromASM(*m_device, *this, VK_SHADER_STAGE_VERTEX_BIT, spv_source, "main", nullptr, SPV_ENV_VULKAN_1_0);
     m_errorMonitor->VerifyFound();
-    if (err == VK_SUCCESS) {
-        vk::DestroyShaderModule(m_device->handle(), shader_module, NULL);
-    }
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {

--- a/tests/vkpositivelayertests.cpp
+++ b/tests/vkpositivelayertests.cpp
@@ -1616,22 +1616,9 @@ TEST_F(VkPositiveLayerTest, ShaderUboStd430Layout) {
                OpFunctionEnd
         )";
 
-    std::vector<unsigned int> spv;
-    VkShaderModuleCreateInfo module_create_info;
-    VkShaderModule shader_module;
-    module_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    module_create_info.pNext = NULL;
-    ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, spv_source.data(), spv);
-    module_create_info.pCode = spv.data();
-    module_create_info.codeSize = spv.size() * sizeof(unsigned int);
-    module_create_info.flags = 0;
-
     m_errorMonitor->ExpectSuccess();
-    VkResult err = vk::CreateShaderModule(m_device->handle(), &module_create_info, NULL, &shader_module);
+    VkShaderObj::CreateFromASM(*m_device, *this, VK_SHADER_STAGE_VERTEX_BIT, spv_source, "main", nullptr, SPV_ENV_VULKAN_1_0);
     m_errorMonitor->VerifyNotFound();
-    if (err == VK_SUCCESS) {
-        vk::DestroyShaderModule(m_device->handle(), shader_module, NULL);
-    }
 }
 
 TEST_F(VkPositiveLayerTest, ShaderScalarBlockLayout) {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1852,12 +1852,12 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const char *shader_code, VkShaderS
 }
 
 bool VkShaderObj::InitFromGLSL(VkRenderFramework &framework, const char *shader_code, bool debug, const spv_target_env env) {
-    std::vector<unsigned int> spv;
+    std::vector<uint32_t> spv;
     framework.GLSLtoSPV(&m_device.props.limits, m_stage_info.stage, shader_code, spv, debug, env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    moduleCreateInfo.codeSize = spv.size() * sizeof(unsigned int);
+    moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
     init(m_device, moduleCreateInfo);
@@ -1869,12 +1869,12 @@ bool VkShaderObj::InitFromGLSL(VkRenderFramework &framework, const char *shader_
 // due to supplying an invalid/unknown SPIR-V capability/operation. This is called after VkShaderObj creation when tests are found
 // to crash on a CI device
 VkResult VkShaderObj::InitFromGLSLTry(VkRenderFramework &framework, const char *shader_code, bool debug, const spv_target_env env) {
-    std::vector<unsigned int> spv;
+    std::vector<uint32_t> spv;
     framework.GLSLtoSPV(&m_device.props.limits, m_stage_info.stage, shader_code, spv, debug, env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    moduleCreateInfo.codeSize = spv.size() * sizeof(unsigned int);
+    moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
     const auto result = init_try(m_device, moduleCreateInfo);
@@ -1889,12 +1889,12 @@ VkShaderObj::VkShaderObj(VkDeviceObj *device, const string spv_source, VkShaderS
 }
 
 bool VkShaderObj::InitFromASM(VkRenderFramework &framework, const std::string &spv_source, const spv_target_env env) {
-    vector<unsigned int> spv;
+    vector<uint32_t> spv;
     framework.ASMtoSPV(env, 0, spv_source.data(), spv);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    moduleCreateInfo.codeSize = spv.size() * sizeof(unsigned int);
+    moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
     init(m_device, moduleCreateInfo);
@@ -1903,12 +1903,12 @@ bool VkShaderObj::InitFromASM(VkRenderFramework &framework, const std::string &s
 }
 
 VkResult VkShaderObj::InitFromASMTry(VkRenderFramework &framework, const std::string &spv_source, const spv_target_env spv_env) {
-    vector<unsigned int> spv;
+    vector<uint32_t> spv;
     framework.ASMtoSPV(spv_env, 0, spv_source.data(), spv);
 
     VkShaderModuleCreateInfo moduleCreateInfo = {};
     moduleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    moduleCreateInfo.codeSize = spv.size() * sizeof(unsigned int);
+    moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
     const auto result = init_try(m_device, moduleCreateInfo);

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -752,7 +752,7 @@ EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_typ
 // Return value of false means an error was encountered.
 //
 bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
-                                const char *pshader, std::vector<unsigned int> &spirv, bool debug, const spv_target_env spv_env) {
+                                const char *pshader, std::vector<uint32_t> &spirv, bool debug, const spv_target_env spv_env) {
     glslang::TProgram program;
     const char *shaderStrings[1];
 
@@ -838,7 +838,7 @@ bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limit
 // Return value of false means an error was encountered.
 //
 bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm,
-                               std::vector<unsigned int> &spv) {
+                               std::vector<uint32_t> &spv) {
     spv_binary binary;
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(target_env);

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -59,8 +59,8 @@ class VkTestFramework : public ::testing::Test {
     static void Finish();
 
     bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
-                   std::vector<unsigned int> &spv, bool debug = false, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
-    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
+                   std::vector<uint32_t> &spv, bool debug = false, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
+    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<uint32_t> &spv);
     static bool m_canonicalize_spv;
     static bool m_strip_spv;
     static bool m_do_everything_spv;

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -85,7 +85,7 @@ shaderc_shader_kind MapShadercType(VkShaderStageFlagBits vkShader) {
 // Compile a given string containing GLSL into SPIR-V
 // Return value of false means an error was encountered
 bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
-                                const char *pshader, std::vector<unsigned int> &spirv, bool debug, const spv_target_env spv_env) {
+                                const char *pshader, std::vector<uint32_t> &spirv, bool debug, const spv_target_env spv_env) {
     // On Android, use shaderc instead.
     shaderc::Compiler compiler;
     shaderc::CompileOptions options;
@@ -156,7 +156,7 @@ bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limit
 // Return value of false means an error was encountered.
 //
 bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm,
-                               std::vector<unsigned int> &spv) {
+                               std::vector<uint32_t> &spv) {
     spv_binary binary;
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(target_env);

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -38,8 +38,8 @@ class VkTestFramework : public ::testing::Test {
 
     VkFormat GetFormat(VkInstance instance, vk_testing::Device *device);
     bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
-                   std::vector<unsigned int> &spv, bool debug = false, const spv_target_env spv_ev = SPV_ENV_VULKAN_1_0);
-    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<unsigned int> &spv);
+                   std::vector<uint32_t> &spv, bool debug = false, const spv_target_env spv_ev = SPV_ENV_VULKAN_1_0);
+    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<uint32_t> &spv);
     static bool m_devsim_layer;
     static int m_phys_device_index;
     static ANativeWindow *window;


### PR DESCRIPTION
Use `uint32_t` instead of `unsigned int` for SPIR-V word size

This is also what `libspirv.h` uses

```c
typedef struct spv_binary_t {
  uint32_t* code;
  size_t wordCount;
} spv_binary_t;

typedef spv_binary_t* spv_binary;
```