### PR TITLE
Adding vuid 01985 01986 01987, Validate CmdEndConditionalRenderingEXT 

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -320,6 +320,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     bool transform_feedback_active{false};
     bool conditional_rendering_active{false};
+    bool conditional_rendering_inside_render_pass{false};
+    uint32_t conditional_rendering_subpass{0};
 
     CMD_BUFFER_STATE(ValidationStateTracker *, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
                      std::shared_ptr<COMMAND_POOL_STATE> &cmd_pool);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1542,6 +1542,7 @@ class CoreChecks : public ValidationStateTracker {
                                                   const VkBool32* pColorWriteEnables) const override;
     bool PreCallValidateCmdBeginConditionalRenderingEXT(
         VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) const override;
+    bool PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) const override;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     bool PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) const override;
 #endif

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3353,6 +3353,8 @@ void ValidationStateTracker::PostCallRecordCmdBeginConditionalRenderingEXT(
 
     cb_state->RecordCmd(CMD_BEGINCONDITIONALRENDERINGEXT);
     cb_state->conditional_rendering_active = true;
+    cb_state->conditional_rendering_inside_render_pass = cb_state->activeRenderPass != nullptr;
+    cb_state->conditional_rendering_subpass = cb_state->activeSubpass;
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
@@ -3360,7 +3362,8 @@ void ValidationStateTracker::PostCallRecordCmdEndConditionalRenderingEXT(VkComma
 
     cb_state->RecordCmd(CMD_ENDCONDITIONALRENDERINGEXT);
     cb_state->conditional_rendering_active = false;
-
+    cb_state->conditional_rendering_inside_render_pass = false;
+    cb_state->conditional_rendering_subpass = 0;
 }
 
 void ValidationStateTracker::PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer,


### PR DESCRIPTION
When CmdEndConditionalRenderingEXT is called, conditional rendering must be active, if it was begun outside of a render pass instance it also must be ended outside of a render pass instance, otherwise it must be begun and ended in the same subpass