### PR TITLE
Fix discrepancy around VUID-vkCmdBlitImage-filter-00237

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3924,10 +3924,10 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
                              func_name, string_VkFormat(dst_format));
         }
 
-        if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_3D != src_type)) {
+        if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_2D != src_type)) {
             vuid = is_2khr ? "VUID-VkBlitImageInfo2KHR-filter-00237" : "VUID-vkCmdBlitImage-filter-00237";
             skip |= LogError(cb_node->commandBuffer(), vuid,
-                             "%s: source image type must be VK_IMAGE_TYPE_3D when cubic filtering is specified.", func_name);
+                             "%s: source image type must be VK_IMAGE_TYPE_2D when cubic filtering is specified.", func_name);
         }
 
         // Validate consistency for unsigned formats


### PR DESCRIPTION
[VUID-vkCmdBlitImage-filter-00237](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBlitImage.html#VUID-vkCmdBlitImage-filter-00237) and [VkBlitImageInfo2KHR-filter-00237](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlitImageInfo2KHR.html#VUID-VkBlitImageInfo2KHR-filter-00237) specify:
`If filter is VK_FILTER_CUBIC_EXT, srcImage must be of type VK_IMAGE_TYPE_2D`