### PR TITLE
Fix overlap descriptor set

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -3375,27 +3375,30 @@ bool CoreChecks::ValidateWriteUpdate(const DescriptorSet *dest_set, const VkWrit
                 break;  // prevents setting error here if bindings don't exist
             }
 
-            // Check for consistent stageFlags and descriptorType
-            if ((current_binding.GetStageFlags() != stage_flags) || (current_binding.GetType() != descriptor_type)) {
-                *error_code = "VUID-VkWriteDescriptorSet-descriptorCount-00317";
-                std::stringstream error_str;
-                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding index #"
-                          << current_binding.GetIndex() << " (" << i << " from dstBinding offset)"
-                          << " with a different stageFlag and/or descriptorType from previous bindings."
-                          << " All bindings must have consecutive stageFlag and/or descriptorType across a VkWriteDescriptorSet";
-                *error_msg = error_str.str();
-                return false;
-            }
-            // Check if all immutableSamplers or not
-            if ((current_binding.GetImmutableSamplerPtr() == nullptr) != immutable_samplers) {
-                *error_code = "VUID-VkWriteDescriptorSet-descriptorCount-00318";
-                std::stringstream error_str;
-                error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding index #"
-                          << current_binding.GetIndex() << " (" << i << " from dstBinding offset)"
-                          << " with a different usage of immutable samplers from previous bindings."
-                          << " All bindings must have all or none usage of immutable samplers across a VkWriteDescriptorSet";
-                *error_msg = error_str.str();
-                return false;
+            // All consecutive bindings updated, except those with a descriptorCount of zero, must have identical descType and stageFlags
+            if(current_binding.GetDescriptorCount() > 0) {
+                // Check for consistent stageFlags and descriptorType
+                if ((current_binding.GetStageFlags() != stage_flags) || (current_binding.GetType() != descriptor_type)) {
+                    *error_code = "VUID-VkWriteDescriptorSet-descriptorCount-00317";
+                    std::stringstream error_str;
+                    error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding index #"
+                              << current_binding.GetIndex() << " (" << i << " from dstBinding offset)"
+                              << " with a different stageFlag and/or descriptorType from previous bindings."
+                              << " All bindings must have consecutive stageFlag and/or descriptorType across a VkWriteDescriptorSet";
+                    *error_msg = error_str.str();
+                    return false;
+                }
+                // Check if all immutableSamplers or not
+                if ((current_binding.GetImmutableSamplerPtr() == nullptr) != immutable_samplers) {
+                    *error_code = "VUID-VkWriteDescriptorSet-descriptorCount-00318";
+                    std::stringstream error_str;
+                    error_str << "Attempting write update to " << dest_set->StringifySetAndLayout() << " binding index #"
+                              << current_binding.GetIndex() << " (" << i << " from dstBinding offset)"
+                              << " with a different usage of immutable samplers from previous bindings."
+                              << " All bindings must have all or none usage of immutable samplers across a VkWriteDescriptorSet";
+                    *error_msg = error_str.str();
+                    return false;
+                }
             }
 
             // Skip the remaining descriptors for this binding, and move to the next binding

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -341,7 +341,12 @@ class DescriptorSetLayout : public BASE_NODE {
                 (binding_ci->stageFlags != other_binding_ci->stageFlags) ||
                 (!hash_util::similar_for_nullity(binding_ci->pImmutableSamplers, other_binding_ci->pImmutableSamplers)) ||
                 (GetDescriptorBindingFlags() != other.GetDescriptorBindingFlags())) {
-                return false;
+
+                // A write update can overlap over following binding but bindings with descriptorCount == 0 must be skipped.
+                // Therefore we consider "consistent" a binding that should be skipped
+                if(other_binding_ci->descriptorCount != 0) {
+                    return false;
+                }
             }
             return true;
         }

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10259,8 +10259,12 @@ TEST_F(VkLayerTest, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) {
         allocInfo.descriptorSetCount = 1;
         allocInfo.descriptorPool = descPool.handle();
 
+        // The Galaxy S10 device used in LunarG CI fails to allocate this descriptor set
         res = vk::AllocateDescriptorSets(m_device->device(), &allocInfo, &descSetHandle);
-        ASSERT_EQ(res, VK_SUCCESS);
+        if (res != VK_SUCCESS) {
+            printf("%s vkAllocateDescriptorSets failed with error %d, skipping test.\n", kSkipPrefix, res);
+            return;
+        }
     }
     vk_testing::DescriptorSet descSet(*m_device, &descPool, descSetHandle);
 


### PR DESCRIPTION
Descriptor set update wasn't handling an update larger than the size
of the original binding correctly (Writing multiple bindings with one update).
The specs says "If a binding has a descriptorCount of zero, it is skipped."

Pull request https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2908 has been closed due to my rebase.
Test has been tested with and without the fix. Test is failing without the fix.