### PR TITLE
tests: Add env var to enable all tests

### DIFF
--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -658,7 +658,12 @@ void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *feat
 }
 
 bool VkRenderFramework::IsPlatform(PlatformType platform) {
-    return (!vk_gpu_table.find(platform)->second.compare(physDevProps().deviceName));
+    static const bool skip_platform_check = GetEnvironment("VK_LAYER_TESTS_SKIP_PLATFORM_CHECK") != "";
+    if (skip_platform_check) {
+        return false;
+    } else {
+        return (!vk_gpu_table.find(platform)->second.compare(physDevProps().deviceName));
+    }
 }
 
 bool VkRenderFramework::IsDriver(VkDriverId driver_id) {


### PR DESCRIPTION
Adds support for setting the VK_LAYER_TESTS_SKIP_PLATFORM_CHECK
environment variable to ignore platform checks per test, effectively
forcing all tests to run regardless of platfom (except for tests that
are removed/disabled at compile time such as Android, Win32, etc.).

@lunarpapillo found this while going though some stale local branches. Do you still want this?