### PR TITLE
Fix issue 1458 2521, Fix updating queries 

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -537,6 +537,7 @@ void CMD_BUFFER_STATE::BeginQuery(const QueryObject &query_obj) {
         SetQueryState(QueryObject(query_obj, perfQueryPass), QUERYSTATE_RUNNING, localQueryToStateMap);
         return false;
     });
+    updatedQueries.insert(query_obj);
 }
 
 void CMD_BUFFER_STATE::EndQuery(const QueryObject &query_obj) {
@@ -545,6 +546,7 @@ void CMD_BUFFER_STATE::EndQuery(const QueryObject &query_obj) {
                                           VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass, QueryMap *localQueryToStateMap) {
         return SetQueryState(QueryObject(query_obj, perfQueryPass), QUERYSTATE_ENDED, localQueryToStateMap);
     });
+    updatedQueries.insert(query_obj);
 }
 
 static bool SetQueryStateMulti(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, uint32_t perfPass, QueryState value,
@@ -560,6 +562,7 @@ void CMD_BUFFER_STATE::EndQueries(VkQueryPool queryPool, uint32_t firstQuery, ui
     for (uint32_t slot = firstQuery; slot < (firstQuery + queryCount); slot++) {
         QueryObject query = {queryPool, slot};
         activeQueries.erase(query);
+        updatedQueries.insert(query);
     }
     queryUpdates.emplace_back([queryPool, firstQuery, queryCount](const ValidationStateTracker *device_data, bool do_validate,
                                                                   VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
@@ -572,6 +575,7 @@ void CMD_BUFFER_STATE::ResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery
     for (uint32_t slot = firstQuery; slot < (firstQuery + queryCount); slot++) {
         QueryObject query = {queryPool, slot};
         resetQueries.insert(query);
+        updatedQueries.insert(query);
     }
 
     queryUpdates.emplace_back([queryPool, firstQuery, queryCount](const ValidationStateTracker *device_data, bool do_validate,
@@ -837,6 +841,7 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
         initial_device_mask = (1 << dev_data->physical_device_count) - 1;
     }
     performance_lock_acquired = dev_data->performance_lock_acquired;
+    updatedQueries.clear();
 }
 
 void CMD_BUFFER_STATE::End(VkResult result) {
@@ -1323,7 +1328,7 @@ void CMD_BUFFER_STATE::Submit(uint32_t perf_submit_pass) {
     }
 }
 
-void CMD_BUFFER_STATE::Retire(uint32_t perf_submit_pass) {
+void CMD_BUFFER_STATE::Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)>& is_query_updated_after) {
     // First perform decrement on general case bound objects
     for (auto event : writeEventsBeforeWait) {
         auto event_state = dev_data->Get<EVENT_STATE>(event);
@@ -1338,7 +1343,7 @@ void CMD_BUFFER_STATE::Retire(uint32_t perf_submit_pass) {
     }
 
     for (const auto &query_state_pair : local_query_to_state_map) {
-        if (query_state_pair.second == QUERYSTATE_ENDED) {
+        if (query_state_pair.second == QUERYSTATE_ENDED && !is_query_updated_after(query_state_pair.first)) {
             auto query_pool_state = dev_data->Get<QUERY_POOL_STATE>(query_state_pair.first.pool);
             query_pool_state->SetQueryState(query_state_pair.first.query, query_state_pair.first.perf_pass, QUERYSTATE_AVAILABLE);
         }

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -274,6 +274,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     layer_data::unordered_set<QueryObject> activeQueries;
     layer_data::unordered_set<QueryObject> startedQueries;
     layer_data::unordered_set<QueryObject> resetQueries;
+    layer_data::unordered_set<QueryObject> updatedQueries;
     CommandBufferImageLayoutMap image_layout_map;
     CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
 
@@ -461,7 +462,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     void SetImageInitialLayout(const IMAGE_STATE &image_state, const VkImageSubresourceLayers &layers, VkImageLayout layout);
 
     void Submit(uint32_t perf_submit_pass);
-    void Retire(uint32_t perf_submit_pass);
+    void Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after);
 
     uint32_t GetDynamicColorAttachmentCount() {
         if (activeRenderPass) {


### PR DESCRIPTION
When a command buffer is executed only update query status if no command buffer submitted after updates the same query

Closes #1458 and #2521 