### PR TITLE
layers: Fix option for seting C++ standard and check for std::shared_mutex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,7 @@ enable_testing()
 # This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
 # with the CACHE property.
 
-option(VVL_CPP_STANDARD "Set the C++ standard to build against. The value will be passed to cmake's CXX_STANDARD property. Default = 11" 11)
-if (NOT VVL_CPP_STANDARD)
-    set(VVL_CPP_STANDARD 11)
-endif()
+set(VVL_CPP_STANDARD 11 CACHE STRING "Set the C++ standard to build against. The value will be passed to cmake's CXX_STANDARD property.")
 
 option(VVL_ENABLE_ASAN "Use address sanitization (specifically -fsanitize=address)" OFF)
 

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -267,16 +267,23 @@ static inline int u_ffs(int val) {
 }
 #endif
 
+#ifdef __cplusplus
 // Minimum Visual Studio 2015 Update 2, or libc++ with C++17
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && \
-    (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
+#if defined(_MSC_FULL_VER)
+#if _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2
+#define VVL_USE_SHARED_MUTEX 1
+#endif
+#elif __cplusplus >= 201703
+#define VVL_USE_SHARED_MUTEX 1
+#endif
+
+#if defined(VVL_USE_SHARED_MUTEX)
 #include <shared_mutex>
 #endif
 
 class ReadWriteLock {
   private:
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && \
-    (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
+#if defined(VVL_USE_SHARED_MUTEX)
     typedef std::shared_mutex lock_t;
 #else
     typedef std::mutex lock_t;
@@ -286,8 +293,7 @@ class ReadWriteLock {
     void lock() { m_lock.lock(); }
     bool try_lock() { return m_lock.try_lock(); }
     void unlock() { m_lock.unlock(); }
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && \
-    (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
+#if defined(VVL_USE_SHARED_MUTEX)
     void lock_shared() { m_lock.lock_shared(); }
     bool try_lock_shared() { return m_lock.try_lock_shared(); }
     void unlock_shared() { m_lock.unlock_shared(); }
@@ -300,8 +306,7 @@ class ReadWriteLock {
     lock_t m_lock;
 };
 
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && NTDDI_VERSION > NTDDI_WIN10_RS2 && \
-    (!defined(_LIBCPP_VERSION) || __cplusplus >= 201703)
+#if defined(VVL_USE_SHARED_MUTEX)
 typedef std::shared_lock<ReadWriteLock> read_lock_guard_t;
 typedef std::unique_lock<ReadWriteLock> write_lock_guard_t;
 #else
@@ -450,3 +455,4 @@ class vl_concurrent_unordered_map {
         return hash;
     }
 };
+#endif


### PR DESCRIPTION
Using VVL_CPP_STANDARD set to 17 or higher, which allows use of std::shared_mutex, will improve performance. Make it possible to enable this setting on non-MSVC compilers.