### PR TITLE
layers: Make more BUFFER_STATE member data be const

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -83,6 +83,7 @@ config("vulkan_layer_config") {
 core_validation_sources = [
   "layers/android_ndk_types.h",
   "layers/base_node.h",
+  "layers/buffer_state.cpp",
   "layers/buffer_state.h",
   "layers/buffer_validation.cpp",
   "layers/buffer_validation.h",

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_USE_PLATFORM_ANDROID_KHR \
                      -fvisibility=hidden")
 add_library(VkLayer_khronos_validation SHARED
         ${SRC_DIR}/layers/state_tracker.cpp
+        ${SRC_DIR}/layers/buffer_state.cpp
         ${SRC_DIR}/layers/cmd_buffer_state.cpp
         ${SRC_DIR}/layers/device_memory_state.cpp
         ${SRC_DIR}/layers/image_state.cpp

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -38,6 +38,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_khronos_validation
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/state_tracker.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/device_memory_state.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_state.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/cmd_buffer_state.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/image_state.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/pipeline_state.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -165,6 +165,7 @@ set(CORE_VALIDATION_LIBRARY_FILES
     device_memory_state.h
     device_memory_state.cpp
     buffer_state.h
+    buffer_state.cpp
     cmd_buffer_state.h
     cmd_buffer_state.cpp
     image_state.h

--- a/layers/buffer_state.cpp
+++ b/layers/buffer_state.cpp
@@ -1,0 +1,51 @@
+/* Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (C) 2015-2021 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
+ * Author: Tobin Ehlis <tobine@google.com>
+ * Author: Chris Forbes <chrisf@ijw.co.nz>
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
+ * Author: Tobias Hector <tobias.hector@amd.com>
+ * Author: Jeremy Gebben <jeremyg@lunarg.com>
+ */
+#include "buffer_state.h"
+#include "layer_chassis_dispatch.h"
+#include "state_tracker.h"
+
+static VkExternalMemoryHandleTypeFlags GetExternalHandleType(const VkBufferCreateInfo *create_info) {
+    const auto *external_memory_info = LvlFindInChain<VkExternalMemoryBufferCreateInfo>(create_info->pNext);
+    return external_memory_info ? external_memory_info->handleTypes : 0;
+}
+
+static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker *dev_data, VkBuffer buffer) {
+    VkMemoryRequirements result{};
+    DispatchGetBufferMemoryRequirements(dev_data->device, buffer, &result);
+    return result;
+}
+
+BUFFER_STATE::BUFFER_STATE(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo)
+    : BINDABLE(buff, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
+               (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleType(pCreateInfo)),
+          safe_create_info(pCreateInfo),
+          createInfo(*safe_create_info.ptr()),
+          deviceAddress(0),
+          requirements(GetMemoryRequirements(dev_data, buff)),
+          memory_requirements_checked(false) {}
+

--- a/layers/buffer_state.h
+++ b/layers/buffer_state.h
@@ -28,32 +28,22 @@
 #pragma once
 #include "device_memory_state.h"
 
+class ValidationStateTracker;
+
 class BUFFER_STATE : public BINDABLE {
   public:
     const safe_VkBufferCreateInfo safe_create_info;
     const VkBufferCreateInfo &createInfo;
     VkDeviceAddress deviceAddress;
-    VkMemoryRequirements requirements;
+    const VkMemoryRequirements requirements;
     bool memory_requirements_checked;
 
-    BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo)
-        : BINDABLE(buff, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
-                   (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleType(pCreateInfo)),
-          safe_create_info(pCreateInfo),
-          createInfo(*safe_create_info.ptr()),
-          deviceAddress(0),
-          requirements(),
-          memory_requirements_checked(false) {}
+    BUFFER_STATE(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo);
 
     BUFFER_STATE(BUFFER_STATE const &rh_obj) = delete;
 
     VkBuffer buffer() const { return handle_.Cast<VkBuffer>(); }
 
-  private:
-    static inline VkExternalMemoryHandleTypeFlags GetExternalHandleType(const VkBufferCreateInfo *pCreateInfo) {
-        auto *external_memory_info = LvlFindInChain<VkExternalMemoryBufferCreateInfo>(pCreateInfo->pNext);
-        return external_memory_info ? external_memory_info->handleTypes : 0;
-    }
 };
 
 class BUFFER_VIEW_STATE : public BASE_NODE {

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -266,7 +266,7 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
                                                         VkResult result) {
     if (result != VK_SUCCESS) return;
 
-    auto buffer_state = std::make_shared<BUFFER_STATE>(*pBuffer, pCreateInfo);
+    auto buffer_state = std::make_shared<BUFFER_STATE>(this, *pBuffer, pCreateInfo);
 
     if (pCreateInfo) {
         const auto *opaque_capture_address = LvlFindInChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
@@ -276,10 +276,6 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
             buffer_address_map_.emplace(opaque_capture_address->opaqueCaptureAddress, buffer_state.get());
         }
     }
-
-    // Get a set of requirements in the case the app does not
-    DispatchGetBufferMemoryRequirements(device, *pBuffer, &buffer_state->requirements);
-
     bufferMap.emplace(*pBuffer, std::move(buffer_state));
 }
 


### PR DESCRIPTION
Query memory requirements and device address during creation.
Add buffer_state.cpp to avoid circular include madness with
state_tracker.h.