### PR TITLE
Fix deleting pGeometries in AccelerationStructure

### DIFF
--- a/layers/generated/vk_safe_struct.cpp
+++ b/layers/generated/vk_safe_struct.cpp
@@ -43392,7 +43392,7 @@ safe_VkAccelerationStructureBuildGeometryInfoKHR& safe_VkAccelerationStructureBu
              delete ppGeometries[i];
         }
         delete[] ppGeometries;
-    } else {
+    } else if(pGeometries) {
         delete[] pGeometries;
     }
     if (pNext)
@@ -43432,7 +43432,7 @@ safe_VkAccelerationStructureBuildGeometryInfoKHR::~safe_VkAccelerationStructureB
              delete ppGeometries[i];
         }
         delete[] ppGeometries;
-    } else {
+    } else if(pGeometries) {
         delete[] pGeometries;
     }
     if (pNext)

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -1679,7 +1679,7 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
                     '             delete ppGeometries[i];\n'
                     '        }\n'
                     '        delete[] ppGeometries;\n'
-                    '    } else {\n'
+                    '    } else if(pGeometries) {\n'
                     '        delete[] pGeometries;\n'
                     '    }\n'
            }


### PR DESCRIPTION
Check if pGeometries in safe_VkAccelerationStructureBuildGeometryInfoKHR is not nullptr before deleting