### PR TITLE
layers: Fix 04737 error message always printing first format

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -1195,7 +1195,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                     skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-04737",
                                      "vkCreateImage(): VkImageFormatListCreateInfo::pViewFormats[%u] (%s) and "
                                      "VkImageCreateInfo::format (%s) are not compatible.",
-                                     i, string_VkFormat(format_list_info->pViewFormats[0]), string_VkFormat(image_format));
+                                     i, string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                 }
             }
         }


### PR DESCRIPTION
Hiya, I ran into a bug with this bit of code always displaying the first format in pViewFormats as the erroneous one. The index printed is correct but the format name isn't (unless i is 0).

This resulted in a very puzzling error message:
```
vkCreateImage(): VkImageFormatListCreateInfo::pViewFormats[1] (VK_FORMAT_R32_SFLOAT) and VkImageCreateInfo::format (VK_FORMAT_R32_SFLOAT) are not compatible.
```

I scanned the contributing guidelines and I'm not too sure if just submitting a pull request like this is all I need to do - let me know if I've missed anything.

Thanks!