### PR TITLE
layers: Do not require PointSize for line mesh shaders

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -288,6 +288,7 @@ layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const
 
                 case spv::ExecutionModeIsolines:
                 case spv::ExecutionModeOutputLineStrip:
+                case spv::ExecutionModeOutputLinesNV:
                     result.emplace(VK_PRIMITIVE_TOPOLOGY_LINE_STRIP);
                     break;
 


### PR DESCRIPTION
The layers were incorrectly requiring mesh shaders emitting lines to set PointSize by emitting UNASSIGNED-CoreValidation-Shader-PointSizeMissing due to not taking into account the OutputLinesNV execution mode.