### PR TITLE
layers: Prevent invalid depth/stencil format

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -290,6 +290,8 @@ static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithout
 // static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageReadWithoutFormat_NonReadable = "UNASSIGNED-features-shaderStorageImageReadWithoutFormat-NonReadable";
 // static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithoutFormat_NonWritable = "UNASSIGNED-features-shaderStorageImageWriteWithoutFormat-NonWritable";
 
+static const char DECORATE_UNUSED *kVUID_Core_invalidDepthStencilFormat = "UNASSIGNED-CoreValidation-depthStencil-format";
+
 // clang-format on
 
 #undef DECORATE_UNUSED


### PR DESCRIPTION
First part of #3225

The WG agreed there should never be a depth/stencil `VkFormat` used for `VkBufferView` or Vertex Input Attribute as they should be using the color formats instead.

There is not going to be a dedicated VU, but we are going to start enforcing CTS to prevent drivers from accidentally exposing the wrong feature flags for depth/stencil formats

This adds 2 checks and wraps a few uses of `FormatElementSize` that should never be called with a depth/stencil format