### PR TITLE
layers: inttypes.h size in parameter validation

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -967,21 +967,23 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (FormatIsDepthOrStencil(image_format)) {
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
                     if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
-                        skip |= LogError(
-                            device, "VUID-VkImageCreateInfo-Format-02536",
-                            "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                            "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%u) exceeds device "
-                            "maxFramebufferWidth (%u)",
-                            pCreateInfo->extent.width, device_limits.maxFramebufferWidth);
+                        skip |=
+                            LogError(device, "VUID-VkImageCreateInfo-Format-02536",
+                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%" PRIu32
+                                     ") exceeds device "
+                                     "maxFramebufferWidth (%" PRIu32 ")",
+                                     pCreateInfo->extent.width, device_limits.maxFramebufferWidth);
                     }
 
                     if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
-                        skip |= LogError(
-                            device, "VUID-VkImageCreateInfo-format-02537",
-                            "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
-                            "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%u) exceeds device "
-                            "maxFramebufferHeight (%u)",
-                            pCreateInfo->extent.height, device_limits.maxFramebufferHeight);
+                        skip |=
+                            LogError(device, "VUID-VkImageCreateInfo-format-02537",
+                                     "vkCreateImage(): Depth-stencil image contains VkImageStencilUsageCreateInfo structure with "
+                                     "stencilUsage including VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%" PRIu32
+                                     ") exceeds device "
+                                     "maxFramebufferHeight (%" PRIu32 ")",
+                                     pCreateInfo->extent.height, device_limits.maxFramebufferHeight);
                     }
                 }
 
@@ -1121,7 +1123,8 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             }
             if (pCreateInfo->mipLevels != 1) {
                 skip |= LogError(device, "VUID-VkImageCreateInfo-flags-02568",
-                                 "vkCreateImage: if flags includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, mipLevels (%d) must be 1.",
+                                 "vkCreateImage: if flags includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, mipLevels (%" PRIu32
+                                 ") must be 1.",
                                  pCreateInfo->mipLevels);
             }
         }
@@ -1141,7 +1144,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                      string_VkImageType(pCreateInfo->imageType));
                 }
                 if (pCreateInfo->mipLevels != 1) {
-                    skip |= LogError(device, vuid, "%s must have a mipLevels value of 1 instead of %u.", base_message,
+                    skip |= LogError(device, vuid, "%s must have a mipLevels value of 1 instead of %" PRIu32 ".", base_message,
                                      pCreateInfo->mipLevels);
                 }
                 if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
@@ -1187,14 +1190,15 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) == 0) && (viewFormatCount > 1)) {
                 skip |= LogError(device, "VUID-VkImageCreateInfo-flags-04738",
                                  "vkCreateImage(): If the VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT is not set, then "
-                                 "VkImageFormatListCreateInfo::viewFormatCount (%u) must be 0 or 1.",
+                                 "VkImageFormatListCreateInfo::viewFormatCount (%" PRIu32 ") must be 0 or 1.",
                                  viewFormatCount);
             }
             // Check if viewFormatCount is not zero that it is all compatible
             for (uint32_t i = 0; i < viewFormatCount; i++) {
                 if (FormatCompatibilityClass(format_list_info->pViewFormats[i]) != FormatCompatibilityClass(image_format)) {
                     skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-04737",
-                                     "vkCreateImage(): VkImageFormatListCreateInfo::pViewFormats[%u] (%s) and "
+                                     "vkCreateImage(): VkImageFormatListCreateInfo::pViewFormats[%" PRIu32
+                                     "] (%s) and "
                                      "VkImageCreateInfo::format (%s) are not compatible.",
                                      i, string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                 }
@@ -1220,14 +1224,15 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
         if (pCreateInfo->subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS) {
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE && pCreateInfo->subresourceRange.layerCount != 6) {
                 skip |= LogError(device, "VUID-VkImageViewCreateInfo-viewType-02960",
-                                 "vkCreateImageView(): subresourceRange.layerCount (%d) must be 6 or VK_REMAINING_ARRAY_LAYERS.",
+                                 "vkCreateImageView(): subresourceRange.layerCount (%" PRIu32
+                                 ") must be 6 or VK_REMAINING_ARRAY_LAYERS.",
                                  pCreateInfo->subresourceRange.layerCount);
             }
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && (pCreateInfo->subresourceRange.layerCount % 6) != 0) {
-                skip |= LogError(
-                    device, "VUID-VkImageViewCreateInfo-viewType-02961",
-                    "vkCreateImageView(): subresourceRange.layerCount (%d) must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
-                    pCreateInfo->subresourceRange.layerCount);
+                skip |= LogError(device, "VUID-VkImageViewCreateInfo-viewType-02961",
+                                 "vkCreateImageView(): subresourceRange.layerCount (%" PRIu32
+                                 ") must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
+                                 pCreateInfo->subresourceRange.layerCount);
             }
         }
 
@@ -1521,7 +1526,8 @@ bool StatelessValidation::manual_PreCallValidateCreatePipelineLayout(VkDevice de
     // Validate layout count against device physical limit
     if (pCreateInfo->setLayoutCount > device_limits.maxBoundDescriptorSets) {
         skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-setLayoutCount-00286",
-                         "vkCreatePipelineLayout(): setLayoutCount (%d) exceeds physical device maxBoundDescriptorSets limit (%d).",
+                         "vkCreatePipelineLayout(): setLayoutCount (%" PRIu32
+                         ") exceeds physical device maxBoundDescriptorSets limit (%" PRIu32 ").",
                          pCreateInfo->setLayoutCount, device_limits.maxBoundDescriptorSets);
     }
 
@@ -1534,33 +1540,39 @@ bool StatelessValidation::manual_PreCallValidateCreatePipelineLayout(VkDevice de
         // Prevent arithetic overflow here by avoiding addition and testing in this order.
         if (offset >= max_push_constants_size) {
             skip |= LogError(device, "VUID-VkPushConstantRange-offset-00294",
-                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%u].offset (%u) that exceeds this "
-                             "device's maxPushConstantSize of %u.",
+                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%" PRIu32 "].offset (%" PRIu32
+                             ") that exceeds this "
+                             "device's maxPushConstantSize of %" PRIu32 ".",
                              i, offset, max_push_constants_size);
         }
         if (size > max_push_constants_size - offset) {
             skip |= LogError(device, "VUID-VkPushConstantRange-size-00298",
-                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%u] offset (%u) and size (%u) "
-                             "together exceeds this device's maxPushConstantSize of %u.",
+                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%" PRIu32 "] offset (%" PRIu32
+                             ") and size (%" PRIu32
+                             ") "
+                             "together exceeds this device's maxPushConstantSize of %" PRIu32 ".",
                              i, offset, size, max_push_constants_size);
         }
 
         // size needs to be non-zero and a multiple of 4.
         if (size == 0) {
             skip |= LogError(device, "VUID-VkPushConstantRange-size-00296",
-                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%u].size (%u) is not greater than zero.",
+                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%" PRIu32 "].size (%" PRIu32
+                             ") is not greater than zero.",
                              i, size);
         }
         if (size & 0x3) {
             skip |= LogError(device, "VUID-VkPushConstantRange-size-00297",
-                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%u].size (%u) is not a multiple of 4.", i,
-                             size);
+                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%" PRIu32 "].size (%" PRIu32
+                             ") is not a multiple of 4.",
+                             i, size);
         }
 
         // offset needs to be a multiple of 4.
         if ((offset & 0x3) != 0) {
             skip |= LogError(device, "VUID-VkPushConstantRange-offset-00295",
-                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%u].offset (%u) is not a multiple of 4.",
+                             "vkCreatePipelineLayout(): pCreateInfo->pPushConstantRanges[%" PRIu32 "].offset (%" PRIu32
+                             ") is not a multiple of 4.",
                              i, offset);
         }
     }
@@ -1569,8 +1581,9 @@ bool StatelessValidation::manual_PreCallValidateCreatePipelineLayout(VkDevice de
     for (uint32_t i = 0; i < pCreateInfo->pushConstantRangeCount; ++i) {
         for (uint32_t j = i + 1; j < pCreateInfo->pushConstantRangeCount; ++j) {
             if (0 != (pCreateInfo->pPushConstantRanges[i].stageFlags & pCreateInfo->pPushConstantRanges[j].stageFlags)) {
-                skip |= LogError(device, "VUID-VkPipelineLayoutCreateInfo-pPushConstantRanges-00292",
-                                 "vkCreatePipelineLayout() Duplicate stage flags found in ranges %d and %d.", i, j);
+                skip |=
+                    LogError(device, "VUID-VkPipelineLayoutCreateInfo-pPushConstantRanges-00292",
+                             "vkCreatePipelineLayout() Duplicate stage flags found in ranges %" PRIu32 " and %" PRIu32 ".", i, j);
             }
         }
     }
@@ -1648,7 +1661,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_viewport == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_viewport = true;
@@ -1657,7 +1670,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_scissor == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_SCISSOR was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_scissor = true;
@@ -1666,7 +1679,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_line_width == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_LINE_WIDTH was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_line_width = true;
@@ -1675,7 +1688,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_depth_bias == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_BIAS was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_depth_bias = true;
@@ -1684,7 +1697,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_blend_constant == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_BLEND_CONSTANTS was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_blend_constant = true;
@@ -1693,7 +1706,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_depth_bounds == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_BOUNDS was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_depth_bounds = true;
@@ -1702,7 +1715,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_stencil_compare == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK was listed twice in "
-                                             "the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_stencil_compare = true;
@@ -1711,7 +1724,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_stencil_write == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_STENCIL_WRITE_MASK was listed twice in "
-                                             "the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_stencil_write = true;
@@ -1720,7 +1733,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_stencil_reference == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_STENCIL_REFERENCE was listed twice in "
-                                             "the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_stencil_reference = true;
@@ -1729,7 +1742,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_viewport_w_scaling_nv == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV was listed twice "
-                                             "in the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "in the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_viewport_w_scaling_nv = true;
@@ -1738,7 +1751,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_discard_rectangle_ext == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT was listed twice "
-                                             "in the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "in the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_discard_rectangle_ext = true;
@@ -1747,7 +1760,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_sample_locations_ext == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT was listed twice in "
-                                             "the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_sample_locations_ext = true;
@@ -1756,7 +1769,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_exclusive_scissor_nv == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV was listed twice in "
-                                             "the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_exclusive_scissor_nv = true;
@@ -1765,7 +1778,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_shading_rate_palette_nv == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV was "
-                                             "listed twice in the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "listed twice in the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_shading_rate_palette_nv = true;
@@ -1774,7 +1787,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_viewport_course_sample_order_nv == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT_COARSE_SAMPLE_ORDER_NV was "
-                                             "listed twice in the pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "listed twice in the pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_viewport_course_sample_order_nv = true;
@@ -1783,7 +1796,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_line_stipple == true) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_LINE_STIPPLE_EXT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_line_stipple = true;
@@ -1792,7 +1805,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_cull_mode) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_CULL_MODE_EXT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_cull_mode = true;
@@ -1801,7 +1814,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_front_face) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_FRONT_FACE_EXT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_front_face = true;
@@ -1811,7 +1824,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_primitive_topology = true;
@@ -1821,7 +1834,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_viewport_with_count = true;
@@ -1831,7 +1844,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_scissor_with_count = true;
@@ -1841,7 +1854,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT was "
                                              "listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_vertex_input_binding_stride = true;
@@ -1851,7 +1864,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_depth_test_enable = true;
@@ -1861,7 +1874,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_depth_write_enable = true;
@@ -1871,7 +1884,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |=
                                 LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                          "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT was listed twice in the "
-                                         "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                         "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                          i);
                         }
                         has_dynamic_depth_compare_op = true;
@@ -1881,7 +1894,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_depth_bounds_test_enable = true;
@@ -1891,7 +1904,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_dynamic_stencil_test_enable = true;
@@ -1900,7 +1913,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_dynamic_stencil_op) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_STENCIL_OP_EXT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_dynamic_stencil_op = true;
@@ -1910,7 +1923,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         skip |= LogError(
                             device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03578",
                             "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR was listed the "
-                            "pCreateInfos[%d].pDynamicState->pDynamicStates[%d] but not allowed in graphic pipelines.",
+                            "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates[%" PRIu32
+                            "] but not allowed in graphic pipelines.",
                             i, state_index);
                     }
                     if (dynamic_state == VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT) {
@@ -1918,7 +1932,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_patch_control_points = true;
@@ -1928,7 +1942,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_rasterizer_discard_enable = true;
@@ -1938,7 +1952,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_depth_bias_enable = true;
@@ -1947,7 +1961,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (has_logic_op) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                              "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_LOGIC_OP_EXT was listed twice in the "
-                                             "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                              i);
                         }
                         has_logic_op = true;
@@ -1957,7 +1971,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             skip |= LogError(
                                 device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
                                 "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                 i);
                         }
                         has_primitive_restart_enable = true;
@@ -1965,9 +1979,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (dynamic_state == VK_DYNAMIC_STATE_VERTEX_INPUT_EXT) {
                         if (has_dynamic_vertex_input) {
                             skip |= LogError(device, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442",
-                                "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VERTEX_INPUT_EXT was listed twice in the "
-                                "pCreateInfos[%d].pDynamicState->pDynamicStates array",
-                                i);
+                                             "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VERTEX_INPUT_EXT was listed twice in the "
+                                             "pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
+                                             i);
                         }
                         has_dynamic_vertex_input = true;
                     }
@@ -1977,14 +1991,15 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             if (has_dynamic_viewport_with_count && has_dynamic_viewport) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04132",
                                  "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT and "
-                                 "VK_DYNAMIC_STATE_VIEWPORT both listed in pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                 "VK_DYNAMIC_STATE_VIEWPORT both listed in pCreateInfos[%" PRIu32
+                                 "].pDynamicState->pDynamicStates array",
                                  i);
             }
 
             if (has_dynamic_scissor_with_count && has_dynamic_scissor) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04133",
                                  "vkCreateGraphicsPipelines: VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT_EXT and VK_DYNAMIC_STATE_SCISSOR "
-                                 "both listed in pCreateInfos[%d].pDynamicState->pDynamicStates array",
+                                 "both listed in pCreateInfos[%" PRIu32 "].pDynamicState->pDynamicStates array",
                                  i);
             }
 
@@ -2079,10 +2094,11 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 auto const &vertex_input_state = pCreateInfos[i].pVertexInputState;
 
                 if (pCreateInfos[i].pVertexInputState->flags != 0) {
-                    skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-flags-zerobitmask",
-                                     "vkCreateGraphicsPipelines: pararameter "
-                                     "pCreateInfos[%d].pVertexInputState->flags (%u) is reserved and must be zero.",
-                                     i, vertex_input_state->flags);
+                    skip |=
+                        LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-flags-zerobitmask",
+                                 "vkCreateGraphicsPipelines: pararameter "
+                                 "pCreateInfos[%" PRIu32 "].pVertexInputState->flags (%" PRIu32 ") is reserved and must be zero.",
+                                 i, vertex_input_state->flags);
                 }
 
                 const VkStructureType allowed_structs_vk_pipeline_vertex_input_state_create_info[] = {
@@ -2146,7 +2162,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             // see https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4849
                             skip |= LogError(device, kVUID_Core_invalidDepthStencilFormat,
                                              "vkCreateGraphicsPipelines: "
-                                             "pCreateInfos[%d].pVertexInputState->pVertexAttributeDescriptions[%d].format is a "
+                                             "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexAttributeDescriptions[%" PRIu32
+                                             "].format is a "
                                              "depth/stencil format (%s) but depth/stencil formats do not have a defined sizes for "
                                              "alignment, replace with a color format.",
                                              i, vertex_attribute_description_index, string_VkFormat(format));
@@ -2157,8 +2174,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 if (vertex_input_state->vertexBindingDescriptionCount > device_limits.maxVertexInputBindings) {
                     skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-vertexBindingDescriptionCount-00613",
                                      "vkCreateGraphicsPipelines: pararameter "
-                                     "pCreateInfo[%d].pVertexInputState->vertexBindingDescriptionCount (%u) is "
-                                     "greater than VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                     "pCreateInfo[%" PRIu32 "].pVertexInputState->vertexBindingDescriptionCount (%" PRIu32
+                                     ") is "
+                                     "greater than VkPhysicalDeviceLimits::maxVertexInputBindings (%" PRIu32 ").",
                                      i, vertex_input_state->vertexBindingDescriptionCount, device_limits.maxVertexInputBindings);
                 }
 
@@ -2166,8 +2184,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     skip |=
                         LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-vertexAttributeDescriptionCount-00614",
                                  "vkCreateGraphicsPipelines: pararameter "
-                                 "pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptionCount (%u) is "
-                                 "greater than VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
+                                 "pCreateInfo[%" PRIu32 "].pVertexInputState->vertexAttributeDescriptionCount (%" PRIu32
+                                 ") is "
+                                 "greater than VkPhysicalDeviceLimits::maxVertexInputAttributes (%" PRIu32 ").",
                                  i, vertex_input_state->vertexAttributeDescriptionCount, device_limits.maxVertexInputAttributes);
                 }
 
@@ -2178,7 +2197,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (binding_it != vertex_bindings.cend()) {
                         skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616",
                                          "vkCreateGraphicsPipelines: parameter "
-                                         "pCreateInfo[%d].pVertexInputState->pVertexBindingDescription[%d].binding "
+                                         "pCreateInfo[%" PRIu32 "].pVertexInputState->pVertexBindingDescription[%" PRIu32
+                                         "].binding "
                                          "(%" PRIu32 ") is not distinct.",
                                          i, d, vertex_bind_desc.binding);
                     }
@@ -2187,18 +2207,21 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (vertex_bind_desc.binding >= device_limits.maxVertexInputBindings) {
                         skip |= LogError(device, "VUID-VkVertexInputBindingDescription-binding-00618",
                                          "vkCreateGraphicsPipelines: parameter "
-                                         "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].binding (%u) is "
-                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                         "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexBindingDescriptions[%" PRIu32
+                                         "].binding (%" PRIu32
+                                         ") is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%" PRIu32 ").",
                                          i, d, vertex_bind_desc.binding, device_limits.maxVertexInputBindings);
                     }
 
                     if (vertex_bind_desc.stride > device_limits.maxVertexInputBindingStride) {
-                        skip |=
-                            LogError(device, "VUID-VkVertexInputBindingDescription-stride-00619",
-                                     "vkCreateGraphicsPipelines: parameter "
-                                     "pCreateInfos[%u].pVertexInputState->pVertexBindingDescriptions[%u].stride (%u) is greater "
-                                     "than VkPhysicalDeviceLimits::maxVertexInputBindingStride (%u).",
-                                     i, d, vertex_bind_desc.stride, device_limits.maxVertexInputBindingStride);
+                        skip |= LogError(device, "VUID-VkVertexInputBindingDescription-stride-00619",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexBindingDescriptions[%" PRIu32
+                                         "].stride (%" PRIu32
+                                         ") is greater "
+                                         "than VkPhysicalDeviceLimits::maxVertexInputBindingStride (%" PRIu32 ").",
+                                         i, d, vertex_bind_desc.stride, device_limits.maxVertexInputBindingStride);
                     }
                 }
 
@@ -2207,45 +2230,52 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     auto const &vertex_attrib_desc = vertex_input_state->pVertexAttributeDescriptions[d];
                     auto const &location_it = attribute_locations.find(vertex_attrib_desc.location);
                     if (location_it != attribute_locations.cend()) {
-                        skip |= LogError(
-                            device, "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617",
-                            "vkCreateGraphicsPipelines: parameter "
-                            "pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptions[%d].location (%u) is not distinct.",
-                            i, d, vertex_attrib_desc.location);
+                        skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         "pCreateInfo[%" PRIu32 "].pVertexInputState->vertexAttributeDescriptions[%" PRIu32
+                                         "].location (%" PRIu32 ") is not distinct.",
+                                         i, d, vertex_attrib_desc.location);
                     }
                     attribute_locations.insert(vertex_attrib_desc.location);
 
                     auto const &binding_it = vertex_bindings.find(vertex_attrib_desc.binding);
                     if (binding_it == vertex_bindings.cend()) {
-                        skip |= LogError(
-                            device, "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
-                            "vkCreateGraphicsPipelines: parameter "
-                            " pCreateInfo[%d].pVertexInputState->vertexAttributeDescriptions[%d].binding (%u) does not exist "
-                            "in any pCreateInfo[%d].pVertexInputState->pVertexBindingDescription.",
-                            i, d, vertex_attrib_desc.binding, i);
+                        skip |= LogError(device, "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                         "vkCreateGraphicsPipelines: parameter "
+                                         " pCreateInfo[%" PRIu32 "].pVertexInputState->vertexAttributeDescriptions[%" PRIu32
+                                         "].binding (%" PRIu32
+                                         ") does not exist "
+                                         "in any pCreateInfo[%" PRIu32 "].pVertexInputState->pVertexBindingDescription.",
+                                         i, d, vertex_attrib_desc.binding, i);
                     }
 
                     if (vertex_attrib_desc.location >= device_limits.maxVertexInputAttributes) {
                         skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-location-00620",
                                          "vkCreateGraphicsPipelines: parameter "
-                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].location (%u) is "
-                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputAttributes (%u).",
+                                         "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexAttributeDescriptions[%" PRIu32
+                                         "].location (%" PRIu32
+                                         ") is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputAttributes (%" PRIu32 ").",
                                          i, d, vertex_attrib_desc.location, device_limits.maxVertexInputAttributes);
                     }
 
                     if (vertex_attrib_desc.binding >= device_limits.maxVertexInputBindings) {
                         skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-binding-00621",
                                          "vkCreateGraphicsPipelines: parameter "
-                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].binding (%u) is "
-                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%u).",
+                                         "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexAttributeDescriptions[%" PRIu32
+                                         "].binding (%" PRIu32
+                                         ") is "
+                                         "greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings (%" PRIu32 ").",
                                          i, d, vertex_attrib_desc.binding, device_limits.maxVertexInputBindings);
                     }
 
                     if (vertex_attrib_desc.offset > device_limits.maxVertexInputAttributeOffset) {
                         skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-offset-00622",
                                          "vkCreateGraphicsPipelines: parameter "
-                                         "pCreateInfos[%u].pVertexInputState->pVertexAttributeDescriptions[%u].offset (%u) is "
-                                         "greater than VkPhysicalDeviceLimits::maxVertexInputAttributeOffset (%u).",
+                                         "pCreateInfos[%" PRIu32 "].pVertexInputState->pVertexAttributeDescriptions[%" PRIu32
+                                         "].offset (%" PRIu32
+                                         ") is "
+                                         "greater than VkPhysicalDeviceLimits::maxVertexInputAttributeOffset (%" PRIu32 ").",
                                          i, d, vertex_attrib_desc.offset, device_limits.maxVertexInputAttributeOffset);
                     }
                 }
@@ -2255,9 +2285,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             if (has_control && has_eval) {
                 if (pCreateInfos[i].pTessellationState == nullptr) {
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-00731",
-                                     "vkCreateGraphicsPipelines: if pCreateInfos[%d].pStages includes a tessellation control "
+                                     "vkCreateGraphicsPipelines: if pCreateInfos[%" PRIu32
+                                     "].pStages includes a tessellation control "
                                      "shader stage and a tessellation evaluation shader stage, "
-                                     "pCreateInfos[%d].pTessellationState must not be NULL.",
+                                     "pCreateInfos[%" PRIu32 "].pTessellationState must not be NULL.",
                                      i, i);
                 } else {
                     const VkStructureType allowed_type = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO;
@@ -2277,8 +2308,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         pCreateInfos[i].pTessellationState->patchControlPoints > device_limits.maxTessellationPatchSize) {
                         skip |= LogError(device, "VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214",
                                          "vkCreateGraphicsPipelines: invalid parameter "
-                                         "pCreateInfos[%d].pTessellationState->patchControlPoints value %u. patchControlPoints "
-                                         "should be >0 and <=%u.",
+                                         "pCreateInfos[%" PRIu32 "].pTessellationState->patchControlPoints value %" PRIu32
+                                         ". patchControlPoints "
+                                         "should be >0 and <=%" PRIu32 ".",
                                          i, pCreateInfos[i].pTessellationState->patchControlPoints,
                                          device_limits.maxTessellationPatchSize);
                     }
@@ -2638,8 +2670,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                 if (pCreateInfos[i].pMultisampleState == nullptr) {
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00751",
-                                     "vkCreateGraphicsPipelines: if pCreateInfos[%d].pRasterizationState->rasterizerDiscardEnable "
-                                     "is VK_FALSE, pCreateInfos[%d].pMultisampleState must not be NULL.",
+                                     "vkCreateGraphicsPipelines: if pCreateInfos[%" PRIu32
+                                     "].pRasterizationState->rasterizerDiscardEnable "
+                                     "is VK_FALSE, pCreateInfos[%" PRIu32 "].pMultisampleState must not be NULL.",
                                      i, i);
                 } else {
                     const VkStructureType valid_next_stypes[] = {LvlTypeMap<VkPipelineCoverageModulationStateCreateInfoNV>::kSType,
@@ -2691,7 +2724,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (pCreateInfos[i].pMultisampleState->sType != VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO) {
                         skip |= LogError(device, "VUID-VkPipelineMultisampleStateCreateInfo-sType-sType",
-                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pMultisampleState->sType must be "
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%" PRIu32
+                                         "].pMultisampleState->sType must be "
                                          "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO",
                                          i);
                     }
@@ -2699,17 +2733,18 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         if (!physical_device_features.sampleRateShading) {
                             skip |= LogError(device, "VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784",
                                              "vkCreateGraphicsPipelines(): parameter "
-                                             "pCreateInfos[%d].pMultisampleState->sampleShadingEnable.",
+                                             "pCreateInfos[%" PRIu32 "].pMultisampleState->sampleShadingEnable.",
                                              i);
                         }
                         // TODO Add documentation issue about when minSampleShading must be in range and when it is ignored
                         // For now a "least noise" test *only* when sampleShadingEnable is VK_TRUE.
                         if (!in_inclusive_range(pCreateInfos[i].pMultisampleState->minSampleShading, 0.F, 1.0F)) {
-                            skip |= LogError(
-                                device,
+                            skip |= LogError(device,
 
-                                "VUID-VkPipelineMultisampleStateCreateInfo-minSampleShading-00786",
-                                "vkCreateGraphicsPipelines(): parameter pCreateInfos[%d].pMultisampleState->minSampleShading.", i);
+                                             "VUID-VkPipelineMultisampleStateCreateInfo-minSampleShading-00786",
+                                             "vkCreateGraphicsPipelines(): parameter pCreateInfos[%" PRIu32
+                                             "].pMultisampleState->minSampleShading.",
+                                             i);
                         }
                     }
 
@@ -2723,21 +2758,21 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                 skip |=
                                     LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
                                              "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                             "pCreateInfos[%d].pMultisampleState->alphaToCoverageEnable == VK_TRUE.",
+                                             "pCreateInfos[%" PRIu32 "].pMultisampleState->alphaToCoverageEnable == VK_TRUE.",
                                              i);
                             }
                             if (pCreateInfos[i].pMultisampleState->alphaToOneEnable) {
                                 skip |=
                                     LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
                                              "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                             "pCreateInfos[%d].pMultisampleState->alphaToOneEnable == VK_TRUE.",
+                                             "pCreateInfos[%" PRIu32 "].pMultisampleState->alphaToOneEnable == VK_TRUE.",
                                              i);
                             }
                             if (pCreateInfos[i].pMultisampleState->sampleShadingEnable) {
                                 skip |=
                                     LogError(device, "VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
                                              "vkCreateGraphicsPipelines(): Bresenham/Smooth line rasterization not supported with "
-                                             "pCreateInfos[%d].pMultisampleState->sampleShadingEnable == VK_TRUE.",
+                                             "pCreateInfos[%" PRIu32 "].pMultisampleState->sampleShadingEnable == VK_TRUE.",
                                              i);
                             }
                         }
@@ -2745,7 +2780,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             if (line_state->lineStippleFactor < 1 || line_state->lineStippleFactor > 256) {
                                 skip |=
                                     LogError(device, "VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineStippleFactor = %d must be in the "
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] lineStippleFactor = %" PRIu32
+                                             " must be in the "
                                              "range [1,256].",
                                              i, line_state->lineStippleFactor);
                             }
@@ -2756,7 +2792,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             (!line_features || !line_features->rectangularLines)) {
                             skip |=
                                 LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02768",
-                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                         "] lineRasterizationMode = "
                                          "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT requires the rectangularLines feature.",
                                          i);
                         }
@@ -2764,7 +2801,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             (!line_features || !line_features->bresenhamLines)) {
                             skip |=
                                 LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769",
-                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                         "] lineRasterizationMode = "
                                          "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT requires the bresenhamLines feature.",
                                          i);
                         }
@@ -2772,7 +2810,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                             (!line_features || !line_features->smoothLines)) {
                             skip |=
                                 LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02770",
-                                         "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                         "] lineRasterizationMode = "
                                          "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT requires the smoothLines feature.",
                                          i);
                         }
@@ -2781,7 +2820,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                 (!line_features || !line_features->stippledRectangularLines)) {
                                 skip |=
                                     LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02771",
-                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                             "] lineRasterizationMode = "
                                              "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT with stipple requires the "
                                              "stippledRectangularLines feature.",
                                              i);
@@ -2790,7 +2830,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                 (!line_features || !line_features->stippledBresenhamLines)) {
                                 skip |=
                                     LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02772",
-                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                             "] lineRasterizationMode = "
                                              "VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT with stipple requires the "
                                              "stippledBresenhamLines feature.",
                                              i);
@@ -2799,7 +2840,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                 (!line_features || !line_features->stippledSmoothLines)) {
                                 skip |=
                                     LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02773",
-                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                             "] lineRasterizationMode = "
                                              "VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT with stipple requires the "
                                              "stippledSmoothLines feature.",
                                              i);
@@ -2808,7 +2850,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                 (!line_features || !line_features->stippledSmoothLines || !device_limits.strictLines)) {
                                 skip |=
                                     LogError(device, "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774",
-                                             "vkCreateGraphicsPipelines(): pCreateInfos[%d] lineRasterizationMode = "
+                                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                             "] lineRasterizationMode = "
                                              "VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT with stipple requires the "
                                              "stippledRectangularLines and strictLines features.",
                                              i);
@@ -2922,7 +2965,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (pCreateInfos[i].pDepthStencilState->sType != VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO) {
                         skip |= LogError(device, "VUID-VkPipelineDepthStencilStateCreateInfo-sType-sType",
-                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pDepthStencilState->sType must be "
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%" PRIu32
+                                         "].pDepthStencilState->sType must be "
                                          "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO",
                                          i);
                     }
@@ -3087,7 +3131,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
 
                     if (pCreateInfos[i].pColorBlendState->sType != VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO) {
                         skip |= LogError(device, "VUID-VkPipelineColorBlendStateCreateInfo-sType-sType",
-                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%d].pColorBlendState->sType must be "
+                                         "vkCreateGraphicsPipelines: parameter pCreateInfos[%" PRIu32
+                                         "].pColorBlendState->sType must be "
                                          "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO",
                                          i);
                     }
@@ -3109,7 +3154,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
                         skip |=
                             LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00724",
-                                     "vkCreateGraphicsPipelines parameter, pCreateInfos[%u]->basePipelineHandle, must be "
+                                     "vkCreateGraphicsPipelines parameter, pCreateInfos[%" PRIu32
+                                     "]->basePipelineHandle, must be "
                                      "VK_NULL_HANDLE if pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag "
                                      "and pCreateInfos->basePipelineIndex is not -1.",
                                      i);
@@ -3119,7 +3165,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
                     if (pCreateInfos[i].basePipelineIndex != -1) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00725",
-                                         "vkCreateGraphicsPipelines parameter, pCreateInfos[%u]->basePipelineIndex, must be -1 if "
+                                         "vkCreateGraphicsPipelines parameter, pCreateInfos[%" PRIu32
+                                         "]->basePipelineIndex, must be -1 if "
                                          "pCreateInfos->flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag and "
                                          "pCreateInfos->basePipelineHandle is not VK_NULL_HANDLE.",
                                          i);
@@ -3128,8 +3175,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                     if (static_cast<uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
                         skip |=
                             LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00723",
-                                     "vkCreateGraphicsPipelines parameter pCreateInfos[%u]->basePipelineIndex (%d) must be a valid"
-                                     "index into the pCreateInfos array, of size %d.",
+                                     "vkCreateGraphicsPipelines parameter pCreateInfos[%" PRIu32 "]->basePipelineIndex (%" PRId32
+                                     ") must be a valid"
+                                     "index into the pCreateInfos array, of size %" PRIu32 ".",
                                      i, pCreateInfos[i].basePipelineIndex, createInfoCount);
                     }
                 }
@@ -3147,7 +3195,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                (physical_device_features.fillModeNonSolid == false)) {
                         skip |= LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01413",
                                          "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                         "pCreateInfos[%u]->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
+                                         "pCreateInfos[%" PRIu32
+                                         "]->pRasterizationState->polygonMode cannot be VK_POLYGON_MODE_POINT or "
                                          "VK_POLYGON_MODE_LINE if VkPhysicalDeviceFeatures->fillModeNonSolid is false.",
                                          i);
                     }
@@ -3158,7 +3207,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                         skip |=
                             LogError(device, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507",
                                      "vkCreateGraphicsPipelines parameter, VkPolygonMode "
-                                     "pCreateInfos[%u]->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
+                                     "pCreateInfos[%" PRIu32
+                                     "]->pRasterizationState->polygonMode must be VK_POLYGON_MODE_FILL or "
                                      "VK_POLYGON_MODE_FILL_RECTANGLE_NV if VkPhysicalDeviceFeatures->fillModeNonSolid is false.",
                                      i);
                     }
@@ -3178,55 +3228,64 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             // Validate no flags not allowed are used
             if ((flags & VK_PIPELINE_CREATE_DISPATCH_BASE) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-00764",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_DISPATCH_BASE.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03371",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_LIBRARY_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03372",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03373",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03374",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03375",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03376",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03377",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR.",
                                  i, flags);
             }
             if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR) != 0) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-03577",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]->flags (0x%x) must not include "
                                  "VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR.",
                                  i, flags);
             }
@@ -3258,69 +3317,79 @@ bool StatelessValidation::manual_PreCallValidateCreateComputePipelines(VkDevice 
         // Make sure compute stage is selected
         if (pCreateInfos[i].stage.stage != VK_SHADER_STAGE_COMPUTE_BIT) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-stage-00701",
-                             "vkCreateComputePipelines(): the pCreateInfo[%u].stage.stage (%s) is not VK_SHADER_STAGE_COMPUTE_BIT",
+                             "vkCreateComputePipelines(): the pCreateInfo[%" PRIu32
+                             "].stage.stage (%s) is not VK_SHADER_STAGE_COMPUTE_BIT",
                              i, string_VkShaderStageFlagBits(pCreateInfos[i].stage.stage));
         }
 
         const VkPipelineCreateFlags flags = pCreateInfos[i].flags;
         // Validate no flags not allowed are used
         if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) != 0) {
-            skip |= LogError(
-                device, "VUID-VkComputePipelineCreateInfo-flags-03364",
-                "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include VK_PIPELINE_CREATE_LIBRARY_BIT_KHR.",
-                i, flags);
+            skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03364",
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include VK_PIPELINE_CREATE_LIBRARY_BIT_KHR.",
+                             i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03365",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03366",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03367",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03368",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03369",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03370",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-03576",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-04945",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV.",
                              i, flags);
         }
         if ((flags & VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV) != 0) {
             skip |= LogError(device, "VUID-VkComputePipelineCreateInfo-flags-02874",
-                             "vkCreateComputePipelines(): pCreateInfos[%u]->flags (0x%x) must not include "
+                             "vkCreateComputePipelines(): pCreateInfos[%" PRIu32
+                             "]->flags (0x%x) must not include "
                              "VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV.",
                              i, flags);
         }
@@ -3588,7 +3657,8 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
                         if (pCreateInfo->pBindings[i].pImmutableSamplers[descriptor_index] == VK_NULL_HANDLE) {
                             skip |= LogError(device, "VUID-VkDescriptorSetLayoutBinding-descriptorType-00282",
                                              "vkCreateDescriptorSetLayout: required parameter "
-                                             "pCreateInfo->pBindings[%d].pImmutableSamplers[%d] specified as VK_NULL_HANDLE",
+                                             "pCreateInfo->pBindings[%" PRIu32 "].pImmutableSamplers[%" PRIu32
+                                             "] specified as VK_NULL_HANDLE",
                                              i, descriptor_index);
                         }
                     }
@@ -3598,8 +3668,10 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
                 if ((pCreateInfo->pBindings[i].stageFlags != 0) &&
                     ((pCreateInfo->pBindings[i].stageFlags & (~AllVkShaderStageFlagBits)) != 0)) {
                     skip |= LogError(device, "VUID-VkDescriptorSetLayoutBinding-descriptorCount-00283",
-                                     "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%d].descriptorCount is not 0, "
-                                     "pCreateInfo->pBindings[%d].stageFlags must be a valid combination of VkShaderStageFlagBits "
+                                     "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%" PRIu32
+                                     "].descriptorCount is not 0, "
+                                     "pCreateInfo->pBindings[%" PRIu32
+                                     "].stageFlags must be a valid combination of VkShaderStageFlagBits "
                                      "values.",
                                      i, i);
                 }
@@ -3607,12 +3679,13 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
                 if ((pCreateInfo->pBindings[i].descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) &&
                     (pCreateInfo->pBindings[i].stageFlags != 0) &&
                     (pCreateInfo->pBindings[i].stageFlags != VK_SHADER_STAGE_FRAGMENT_BIT)) {
-                    skip |=
-                        LogError(device, "VUID-VkDescriptorSetLayoutBinding-descriptorType-01510",
-                                 "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%d].descriptorCount is not 0 and "
-                                 "descriptorType is VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT then pCreateInfo->pBindings[%d].stageFlags "
-                                 "must be 0 or VK_SHADER_STAGE_FRAGMENT_BIT but is currently %s",
-                                 i, i, string_VkShaderStageFlags(pCreateInfo->pBindings[i].stageFlags).c_str());
+                    skip |= LogError(device, "VUID-VkDescriptorSetLayoutBinding-descriptorType-01510",
+                                     "vkCreateDescriptorSetLayout(): if pCreateInfo->pBindings[%" PRIu32
+                                     "].descriptorCount is not 0 and "
+                                     "descriptorType is VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT then pCreateInfo->pBindings[%" PRIu32
+                                     "].stageFlags "
+                                     "must be 0 or VK_SHADER_STAGE_FRAGMENT_BIT but is currently %s",
+                                     i, i, string_VkShaderStageFlags(pCreateInfo->pBindings[i].stageFlags).c_str());
                 }
             }
         }
@@ -3639,9 +3712,9 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
         for (uint32_t i = 0; i < descriptorWriteCount; ++i) {
             // descriptorCount must be greater than 0
             if (pDescriptorWrites[i].descriptorCount == 0) {
-                skip |=
-                    LogError(device, "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
-                             "%s(): parameter pDescriptorWrites[%d].descriptorCount must be greater than 0.", vkCallingFunction, i);
+                skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
+                                 "%s(): parameter pDescriptorWrites[%" PRIu32 "].descriptorCount must be greater than 0.",
+                                 vkCallingFunction, i);
             }
 
             // If called from vkCmdPushDescriptorSetKHR, the dstSet member is ignored.
@@ -3662,12 +3735,14 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                 // pImageInfo must be a pointer to an array of descriptorCount valid VkDescriptorImageInfo structures.
                 // Valid imageView handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
                 if (pDescriptorWrites[i].pImageInfo == nullptr) {
-                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00322",
-                                     "%s(): if pDescriptorWrites[%d].descriptorType is "
-                                     "VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
-                                     "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
-                                     "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%d].pImageInfo must not be NULL.",
-                                     vkCallingFunction, i, i);
+                    skip |=
+                        LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00322",
+                                 "%s(): if pDescriptorWrites[%" PRIu32
+                                 "].descriptorType is "
+                                 "VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
+                                 "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
+                                 "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%" PRIu32 "].pImageInfo must not be NULL.",
+                                 vkCallingFunction, i, i);
                 } else if (pDescriptorWrites[i].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER) {
                     // If descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
                     // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageLayout
@@ -3691,10 +3766,11 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                 // Valid buffer handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
                 if (pDescriptorWrites[i].pBufferInfo == nullptr) {
                     skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00324",
-                                     "%s(): if pDescriptorWrites[%d].descriptorType is "
+                                     "%s(): if pDescriptorWrites[%" PRIu32
+                                     "].descriptorType is "
                                      "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, "
                                      "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, "
-                                     "pDescriptorWrites[%d].pBufferInfo must not be NULL.",
+                                     "pDescriptorWrites[%" PRIu32 "].pBufferInfo must not be NULL.",
                                      vkCallingFunction, i, i);
                 } else {
                     const auto *robustness2_features =
@@ -3706,7 +3782,8 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                                 (pDescriptorWrites[i].pBufferInfo[descriptor_index].offset != 0 ||
                                  pDescriptorWrites[i].pBufferInfo[descriptor_index].range != VK_WHOLE_SIZE)) {
                                 skip |= LogError(device, "VUID-VkDescriptorBufferInfo-buffer-02999",
-                                                 "%s(): if pDescriptorWrites[%d].buffer is VK_NULL_HANDLE, "
+                                                 "%s(): if pDescriptorWrites[%" PRIu32
+                                                 "].buffer is VK_NULL_HANDLE, "
                                                  "offset (%" PRIu64 ") must be zero and range (%" PRIu64 ") must be VK_WHOLE_SIZE.",
                                                  vkCallingFunction, i, pDescriptorWrites[i].pBufferInfo[descriptor_index].offset,
                                                  pDescriptorWrites[i].pBufferInfo[descriptor_index].range);
@@ -3727,7 +3804,7 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                         if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment) != 0) {
                             skip |=
                                 LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00327",
-                                         "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
                                          ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment);
                         }
@@ -3741,7 +3818,7 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                         if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment) != 0) {
                             skip |=
                                 LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00328",
-                                         "%s(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
                                          ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment);
                         }
@@ -3756,7 +3833,7 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-02382",
                                      "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, the pNext"
                                      "chain must include a VkWriteDescriptorSetAccelerationStructureKHR structure whose "
-                                     "accelerationStructureCount %d member equals descriptorCount %d.",
+                                     "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
                                      vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
                                      pDescriptorWrites[i].descriptorCount);
                 }
@@ -3765,7 +3842,8 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
                         skip |= LogError(
                             device, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-02236",
-                            "%s(): accelerationStructureCount %d must be equal to descriptorCount %d in the extended structure "
+                            "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
+                            " in the extended structure "
                             ".",
                             vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
                     }
@@ -3793,7 +3871,7 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-03817",
                                      "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, the pNext"
                                      "chain must include a VkWriteDescriptorSetAccelerationStructureNV structure whose "
-                                     "accelerationStructureCount %d member equals descriptorCount %d.",
+                                     "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
                                      vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
                                      pDescriptorWrites[i].descriptorCount);
                 }
@@ -3802,7 +3880,8 @@ bool StatelessValidation::validate_WriteDescriptorSet(const char *vkCallingFunct
                     if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
                         skip |= LogError(
                             device, "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-03747",
-                            "%s(): accelerationStructureCount %d must be equal to descriptorCount %d in the extended structure "
+                            "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
+                            " in the extended structure "
                             ".",
                             vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
                     }
@@ -4073,12 +4152,14 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndirect(VkCommandBuffer 
 
     if (!physical_device_features.multiDrawIndirect && ((drawCount > 1))) {
         skip |= LogError(device, "VUID-vkCmdDrawIndirect-drawCount-02718",
-                         "CmdDrawIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", drawCount);
+                         "CmdDrawIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %" PRIu32 "",
+                         drawCount);
     }
     if (drawCount > device_limits.maxDrawIndirectCount) {
-        skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndirect-drawCount-02719",
-                         "CmdDrawIndirect(): drawCount (%u) is not less than or equal to the maximum allowed (%u).", drawCount,
-                         device_limits.maxDrawIndirectCount);
+        skip |=
+            LogError(commandBuffer, "VUID-vkCmdDrawIndirect-drawCount-02719",
+                     "CmdDrawIndirect(): drawCount (%" PRIu32 ") is not less than or equal to the maximum allowed (%" PRIu32 ").",
+                     drawCount, device_limits.maxDrawIndirectCount);
     }
     return skip;
 }
@@ -4088,13 +4169,15 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndexedIndirect(VkCommand
                                                                        uint32_t stride) const {
     bool skip = false;
     if (!physical_device_features.multiDrawIndirect && ((drawCount > 1))) {
-        skip |= LogError(device, "VUID-vkCmdDrawIndexedIndirect-drawCount-02718",
-                         "CmdDrawIndexedIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d",
-                         drawCount);
+        skip |=
+            LogError(device, "VUID-vkCmdDrawIndexedIndirect-drawCount-02718",
+                     "CmdDrawIndexedIndirect(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %" PRIu32 "",
+                     drawCount);
     }
     if (drawCount > device_limits.maxDrawIndirectCount) {
         skip |= LogError(commandBuffer, "VUID-vkCmdDrawIndexedIndirect-drawCount-02719",
-                         "CmdDrawIndexedIndirect(): drawCount (%u) is not less than or equal to the maximum allowed (%u).",
+                         "CmdDrawIndexedIndirect(): drawCount (%" PRIu32
+                         ") is not less than or equal to the maximum allowed (%" PRIu32 ").",
                          drawCount, device_limits.maxDrawIndirectCount);
     }
     return skip;
@@ -4202,15 +4285,15 @@ bool StatelessValidation::manual_PreCallValidateCmdClearAttachments(VkCommandBuf
     for (uint32_t rect = 0; rect < rectCount; rect++) {
         if (pRects[rect].layerCount == 0) {
             skip |= LogError(commandBuffer, "VUID-vkCmdClearAttachments-layerCount-01934",
-                             "CmdClearAttachments(): pRects[%d].layerCount is zero.", rect);
+                             "CmdClearAttachments(): pRects[%" PRIu32 "].layerCount is zero.", rect);
         }
         if (pRects[rect].rect.extent.width == 0) {
             skip |= LogError(commandBuffer, "VUID-vkCmdClearAttachments-rect-02682",
-                             "CmdClearAttachments(): pRects[%d].rect.extent.width is zero.", rect);
+                             "CmdClearAttachments(): pRects[%" PRIu32 "].rect.extent.width is zero.", rect);
         }
         if (pRects[rect].rect.extent.height == 0) {
             skip |= LogError(commandBuffer, "VUID-vkCmdClearAttachments-rect-02683",
-                             "CmdClearAttachments(): pRects[%d].rect.extent.height is zero.", rect);
+                             "CmdClearAttachments(): pRects[%" PRIu32 "].rect.extent.height is zero.", rect);
         }
     }
     return skip;
@@ -4323,7 +4406,7 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyBuffer(VkCommandBuffer co
         for (uint32_t i = 0; i < regionCount; i++) {
             if (pRegions[i].size == 0) {
                 skip |= LogError(device, "VUID-VkBufferCopy-size-01988",
-                                 "vkCmdCopyBuffer() pRegions[%u].size must be greater than zero", i);
+                                 "vkCmdCopyBuffer() pRegions[%" PRIu32 "].size must be greater than zero", i);
             }
         }
     }
@@ -4338,7 +4421,7 @@ bool StatelessValidation::manual_PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffe
         for (uint32_t i = 0; i < pCopyBufferInfo->regionCount; i++) {
             if (pCopyBufferInfo->pRegions[i].size == 0) {
                 skip |= LogError(device, "VUID-VkBufferCopy2KHR-size-01988",
-                                 "vkCmdCopyBuffer2KHR() pCopyBufferInfo->pRegions[%u].size must be greater than zero", i);
+                                 "vkCmdCopyBuffer2KHR() pCopyBufferInfo->pRegions[%" PRIu32 "].size must be greater than zero", i);
             }
         }
     }
@@ -4427,7 +4510,8 @@ bool StatelessValidation::ValidateSwapchainCreateInfo(const char *func_name, VkS
             if (((pCreateInfo->flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) == 0) && (viewFormatCount > 1)) {
                 skip |= LogError(device, "VUID-VkSwapchainCreateInfoKHR-flags-04100",
                                  "%s: If the VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR is not set, then "
-                                 "VkImageFormatListCreateInfo::viewFormatCount (%u) must be 0 or 1 if it is in the pNext chain.",
+                                 "VkImageFormatListCreateInfo::viewFormatCount (%" PRIu32
+                                 ") must be 0 or 1 if it is in the pNext chain.",
                                  func_name, viewFormatCount);
             }
 
@@ -4437,7 +4521,8 @@ bool StatelessValidation::ValidateSwapchainCreateInfo(const char *func_name, VkS
                     FormatCompatibilityClass(format_list_info->pViewFormats[i])) {
                     skip |= LogError(device, "VUID-VkSwapchainCreateInfoKHR-pNext-04099",
                                      "%s: VkImageFormatListCreateInfo::pViewFormats[0] (%s) and "
-                                     "VkImageFormatListCreateInfo::pViewFormats[%u] (%s) are not compatible in the pNext chain.",
+                                     "VkImageFormatListCreateInfo::pViewFormats[%" PRIu32
+                                     "] (%s) are not compatible in the pNext chain.",
                                      func_name, string_VkFormat(format_list_info->pViewFormats[0]), i,
                                      string_VkFormat(format_list_info->pViewFormats[i]));
                 }
@@ -4884,11 +4969,13 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawMeshTasksIndirectNV(VkCom
     if (!physical_device_features.multiDrawIndirect && ((drawCount > 1))) {
         skip |= LogError(
             commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02718",
-            "vkCmdDrawMeshTasksIndirectNV(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %d", drawCount);
+            "vkCmdDrawMeshTasksIndirectNV(): Device feature multiDrawIndirect disabled: count must be 0 or 1 but is %" PRIu32 "",
+            drawCount);
     }
     if (drawCount > device_limits.maxDrawIndirectCount) {
         skip |= LogError(commandBuffer, "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02719",
-                         "vkCmdDrawMeshTasksIndirectNV: drawCount (%u) is not less than or equal to the maximum allowed (%u).",
+                         "vkCmdDrawMeshTasksIndirectNV: drawCount (%" PRIu32
+                         ") is not less than or equal to the maximum allowed (%" PRIu32 ").",
                          drawCount, device_limits.maxDrawIndirectCount);
     }
     return skip;
@@ -5236,7 +5323,8 @@ bool StatelessValidation::ValidateAccelerationStructureInfoNV(const VkAccelerati
             const VkGeometryNV &geometry = info.pGeometries[i];
             if (geometry.geometryType != first_geometry_type) {
                 skip |= LogError(device, "VUID-VkAccelerationStructureInfoNV-type-02786",
-                                 "VkAccelerationStructureInfoNV: info.pGeometries[%d].geometryType does not match "
+                                 "VkAccelerationStructureInfoNV: info.pGeometries[%" PRIu32
+                                 "].geometryType does not match "
                                  "info.pGeometries[0].geometryType.",
                                  i);
             }
@@ -5605,8 +5693,9 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                 if (static_cast<uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
                     skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-03422",
                                      "vkCreateRayTracingPipelinesKHR: if flags contains the VK_PIPELINE_CREATE_DERIVATIVE_BIT and"
-                                     "basePipelineHandle is VK_NULL_HANDLE, basePipelineIndex (%d) must be a valid into the calling"
-                                     "commands pCreateInfos parameter %d.",
+                                     "basePipelineHandle is VK_NULL_HANDLE, basePipelineIndex (%" PRId32
+                                     ") must be a valid into the calling"
+                                     "commands pCreateInfos parameter %" PRIu32 ".",
                                      pCreateInfos[i].basePipelineIndex, createInfoCount);
                 }
             } else {
@@ -5737,7 +5826,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetLineStippleEXT(VkCommandBu
 
     if (lineStippleFactor < 1 || lineStippleFactor > 256) {
         skip |= LogError(commandBuffer, "VUID-vkCmdSetLineStippleEXT-lineStippleFactor-02776",
-                         "vkCmdSetLineStippleEXT::lineStippleFactor=%d is not in [1,256].", lineStippleFactor);
+                         "vkCmdSetLineStippleEXT::lineStippleFactor=%" PRIu32 " is not in [1,256].", lineStippleFactor);
     }
 
     return skip;
@@ -5766,13 +5855,15 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBu
                                                                      const VkDeviceSize *pOffsets) const {
     bool skip = false;
     if (firstBinding > device_limits.maxVertexInputBindings) {
-        skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-firstBinding-00624",
-                         "vkCmdBindVertexBuffers() firstBinding (%u) must be less than maxVertexInputBindings (%u)", firstBinding,
-                         device_limits.maxVertexInputBindings);
+        skip |=
+            LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-firstBinding-00624",
+                     "vkCmdBindVertexBuffers() firstBinding (%" PRIu32 ") must be less than maxVertexInputBindings (%" PRIu32 ")",
+                     firstBinding, device_limits.maxVertexInputBindings);
     } else if ((firstBinding + bindingCount) > device_limits.maxVertexInputBindings) {
         skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-firstBinding-00625",
-                         "vkCmdBindVertexBuffers() sum of firstBinding (%u) and bindingCount (%u) must be less than "
-                         "maxVertexInputBindings (%u)",
+                         "vkCmdBindVertexBuffers() sum of firstBinding (%" PRIu32 ") and bindingCount (%" PRIu32
+                         ") must be less than "
+                         "maxVertexInputBindings (%" PRIu32 ")",
                          firstBinding, bindingCount, device_limits.maxVertexInputBindings);
     }
 
@@ -5780,12 +5871,15 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBu
         if (pBuffers[i] == VK_NULL_HANDLE) {
             const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
             if (!(robustness2_features && robustness2_features->nullDescriptor)) {
-                skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-pBuffers-04001",
-                                 "vkCmdBindVertexBuffers() required parameter pBuffers[%d] specified as VK_NULL_HANDLE", i);
+                skip |=
+                    LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-pBuffers-04001",
+                             "vkCmdBindVertexBuffers() required parameter pBuffers[%" PRIu32 "] specified as VK_NULL_HANDLE", i);
             } else {
                 if (pOffsets[i] != 0) {
                     skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers-pBuffers-04002",
-                                     "vkCmdBindVertexBuffers() pBuffers[%d] is VK_NULL_HANDLE, but pOffsets[%d] is not 0", i, i);
+                                     "vkCmdBindVertexBuffers() pBuffers[%" PRIu32 "] is VK_NULL_HANDLE, but pOffsets[%" PRIu32
+                                     "] is not 0",
+                                     i, i);
                 }
             }
         }
@@ -5949,10 +6043,10 @@ bool StatelessValidation::manual_PreCallValidateCmdDrawIndirectByteCountEXT(VkCo
     bool skip = false;
 
     if ((vertexStride <= 0) || (vertexStride > phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride)) {
-        skip |= LogError(
-            counterBuffer, "VUID-vkCmdDrawIndirectByteCountEXT-vertexStride-02289",
-            "vkCmdDrawIndirectByteCountEXT: vertexStride (%d) must be between 0 and maxTransformFeedbackBufferDataStride (%d).",
-            vertexStride, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride);
+        skip |= LogError(counterBuffer, "VUID-vkCmdDrawIndirectByteCountEXT-vertexStride-02289",
+                         "vkCmdDrawIndirectByteCountEXT: vertexStride (%" PRIu32
+                         ") must be between 0 and maxTransformFeedbackBufferDataStride (%" PRIu32 ").",
+                         vertexStride, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride);
     }
 
     if ((counterOffset % 4) != 0) {
@@ -6264,7 +6358,7 @@ bool StatelessValidation::manual_PreCallValidateWriteAccelerationStructuresPrope
     if (dataSize < accelerationStructureCount * stride) {
         skip |= LogError(device, "VUID-vkWriteAccelerationStructuresPropertiesKHR-dataSize-03452",
                          "vkWriteAccelerationStructuresPropertiesKHR: dataSize (%zu) must be greater than or equal to "
-                         "accelerationStructureCount (%d) *stride(%zu).",
+                         "accelerationStructureCount (%" PRIu32 ") *stride(%zu).",
                          dataSize, accelerationStructureCount, stride);
     }
     if (!(queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR ||
@@ -6681,12 +6775,14 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2EXT(VkComma
     bool skip = false;
     if (firstBinding >= device_limits.maxVertexInputBindings) {
         skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-firstBinding-03355",
-                         "vkCmdBindVertexBuffers2EXT() firstBinding (%u) must be less than maxVertexInputBindings (%u)",
+                         "vkCmdBindVertexBuffers2EXT() firstBinding (%" PRIu32
+                         ") must be less than maxVertexInputBindings (%" PRIu32 ")",
                          firstBinding, device_limits.maxVertexInputBindings);
     } else if ((firstBinding + bindingCount) > device_limits.maxVertexInputBindings) {
         skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-firstBinding-03356",
-                         "vkCmdBindVertexBuffers2EXT() sum of firstBinding (%u) and bindingCount (%u) must be less than "
-                         "maxVertexInputBindings (%u)",
+                         "vkCmdBindVertexBuffers2EXT() sum of firstBinding (%" PRIu32 ") and bindingCount (%" PRIu32
+                         ") must be less than "
+                         "maxVertexInputBindings (%" PRIu32 ")",
                          firstBinding, bindingCount, device_limits.maxVertexInputBindings);
     }
 
@@ -6694,22 +6790,24 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2EXT(VkComma
         if (pBuffers[i] == VK_NULL_HANDLE) {
             const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
             if (!(robustness2_features && robustness2_features->nullDescriptor)) {
-                skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pBuffers-04111",
-                                 "vkCmdBindVertexBuffers2EXT() required parameter pBuffers[%d] specified as VK_NULL_HANDLE", i);
+                skip |= LogError(
+                    commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pBuffers-04111",
+                    "vkCmdBindVertexBuffers2EXT() required parameter pBuffers[%" PRIu32 "] specified as VK_NULL_HANDLE", i);
             } else {
                 if (pOffsets[i] != 0) {
-                    skip |=
-                        LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pBuffers-04112",
-                                 "vkCmdBindVertexBuffers2EXT() pBuffers[%d] is VK_NULL_HANDLE, but pOffsets[%d] is not 0", i, i);
+                    skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pBuffers-04112",
+                                     "vkCmdBindVertexBuffers2EXT() pBuffers[%" PRIu32 "] is VK_NULL_HANDLE, but pOffsets[%" PRIu32
+                                     "] is not 0",
+                                     i, i);
                 }
             }
         }
         if (pStrides) {
             if (pStrides[i] > device_limits.maxVertexInputBindingStride) {
-                skip |=
-                    LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03362",
-                             "vkCmdBindVertexBuffers2EXT() pStrides[%d] (%" PRIu64 ") must be less than maxVertexInputBindingStride (%u)", i,
-                             pStrides[i], device_limits.maxVertexInputBindingStride);
+                skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2EXT-pStrides-03362",
+                                 "vkCmdBindVertexBuffers2EXT() pStrides[%" PRIu32 "] (%" PRIu64
+                                 ") must be less than maxVertexInputBindingStride (%" PRIu32 ")",
+                                 i, pStrides[i], device_limits.maxVertexInputBindingStride);
             }
         }
     }
@@ -7003,21 +7101,25 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
             if (i == k) continue;
             bool found = false;
             if (pInfos[i].dstAccelerationStructure == pInfos[k].dstAccelerationStructure) {
-                skip |= LogError(
-                    device, "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698",
-                    "vkCmdBuildAccelerationStructuresKHR:The dstAccelerationStructure member of any element (%d) of pInfos must "
-                    "not be "
-                    "the same acceleration structure as the dstAccelerationStructure member of any other element (%d) of pInfos.",
-                    i, k);
+                skip |=
+                    LogError(device, "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698",
+                             "vkCmdBuildAccelerationStructuresKHR:The dstAccelerationStructure member of any element (%" PRIu32
+                             ") of pInfos must "
+                             "not be "
+                             "the same acceleration structure as the dstAccelerationStructure member of any other element (%" PRIu32
+                             ") of pInfos.",
+                             i, k);
                 found = true;
             }
             if (pInfos[i].srcAccelerationStructure == pInfos[k].dstAccelerationStructure) {
-                skip |= LogError(
-                    device, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03403",
-                    "vkCmdBuildAccelerationStructuresKHR:The srcAccelerationStructure member of any element (%d) of pInfos must "
-                    "not be "
-                    "the same acceleration structure as the dstAccelerationStructure member of any other element (%d) of pInfos.",
-                    i, k);
+                skip |=
+                    LogError(device, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03403",
+                             "vkCmdBuildAccelerationStructuresKHR:The srcAccelerationStructure member of any element (%" PRIu32
+                             ") of pInfos must "
+                             "not be "
+                             "the same acceleration structure as the dstAccelerationStructure member of any other element (%" PRIu32
+                             ") of pInfos.",
+                             i, k);
                 found = true;
             }
             if (found) break;
@@ -7121,12 +7223,13 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresIn
         for (uint32_t k = 0; k < infoCount; ++k) {
             if (i == k) continue;
             if (pInfos[i].srcAccelerationStructure == pInfos[k].dstAccelerationStructure) {
-                skip |=
-                    LogError(device, "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03403",
-                             "vkCmdBuildAccelerationStructuresIndirectKHR:The srcAccelerationStructure member of any element (%d) "
-                             "of pInfos must not be the same acceleration structure as the dstAccelerationStructure member of "
-                             "any other element [%d) of pInfos.",
-                             i, k);
+                skip |= LogError(
+                    device, "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03403",
+                    "vkCmdBuildAccelerationStructuresIndirectKHR:The srcAccelerationStructure member of any element (%" PRIu32
+                    ") "
+                    "of pInfos must not be the same acceleration structure as the dstAccelerationStructure member of "
+                    "any other element [%" PRIu32 ") of pInfos.",
+                    i, k);
                 break;
             }
         }
@@ -7229,21 +7332,25 @@ bool StatelessValidation::manual_PreCallValidateBuildAccelerationStructuresKHR(
             if (i == j) continue;
             bool found = false;
             if (pInfos[i].dstAccelerationStructure == pInfos[j].dstAccelerationStructure) {
-                skip |= LogError(
-                    device, "VUID-vkBuildAccelerationStructuresKHR-dstAccelerationStructure-03698",
-                    "vkBuildAccelerationStructuresKHR(): The dstAccelerationStructure member of any element (%d) of pInfos must "
-                    "not be "
-                    "the same acceleration structure as the dstAccelerationStructure member of any other element (%d) of pInfos.",
-                    i, j);
+                skip |=
+                    LogError(device, "VUID-vkBuildAccelerationStructuresKHR-dstAccelerationStructure-03698",
+                             "vkBuildAccelerationStructuresKHR(): The dstAccelerationStructure member of any element (%" PRIu32
+                             ") of pInfos must "
+                             "not be "
+                             "the same acceleration structure as the dstAccelerationStructure member of any other element (%" PRIu32
+                             ") of pInfos.",
+                             i, j);
                 found = true;
             }
             if (pInfos[i].srcAccelerationStructure == pInfos[j].dstAccelerationStructure) {
-                skip |= LogError(
-                    device, "VUID-vkBuildAccelerationStructuresKHR-pInfos-03403",
-                    "vkBuildAccelerationStructuresKHR(): The srcAccelerationStructure member of any element (%d) of pInfos must "
-                    "not be "
-                    "the same acceleration structure as the dstAccelerationStructure member of any other element (%d) of pInfos.",
-                    i, j);
+                skip |=
+                    LogError(device, "VUID-vkBuildAccelerationStructuresKHR-pInfos-03403",
+                             "vkBuildAccelerationStructuresKHR(): The srcAccelerationStructure member of any element (%" PRIu32
+                             ") of pInfos must "
+                             "not be "
+                             "the same acceleration structure as the dstAccelerationStructure member of any other element (%" PRIu32
+                             ") of pInfos.",
+                             i, j);
                 found = true;
             }
             if (found) break;
@@ -7322,9 +7429,9 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
             }
         }
         if (!binding_found) {
-            skip |=
-                LogError(device, "VUID-vkCmdSetVertexInputEXT-binding-04793",
-                         "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%u] references an unspecified binding", attribute);
+            skip |= LogError(
+                device, "VUID-vkCmdSetVertexInputEXT-binding-04793",
+                "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32 "] references an unspecified binding", attribute);
         }
     }
 
@@ -7335,7 +7442,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
             for (uint32_t next_binding = binding + 1; next_binding < vertexBindingDescriptionCount; ++next_binding) {
                 if (binding_value == pVertexBindingDescriptions[next_binding].binding) {
                     skip |= LogError(device, "VUID-vkCmdSetVertexInputEXT-pVertexBindingDescriptions-04794",
-                        "vkCmdSetVertexInputEXT(): binding description for binding %u already specified", binding_value);
+                                     "vkCmdSetVertexInputEXT(): binding description for binding %" PRIu32 " already specified",
+                                     binding_value);
                 }
             }
         }
@@ -7348,7 +7456,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
             for (uint32_t next_attribute = attribute + 1; next_attribute < vertexAttributeDescriptionCount; ++next_attribute) {
                 if (location == pVertexAttributeDescriptions[next_attribute].location) {
                     skip |= LogError(device, "VUID-vkCmdSetVertexInputEXT-pVertexAttributeDescriptions-04795",
-                        "vkCmdSetVertexInputEXT(): attribute description for location %u already specified", location);
+                                     "vkCmdSetVertexInputEXT(): attribute description for location %" PRIu32 " already specified",
+                                     location);
                 }
             }
         }
@@ -7357,24 +7466,26 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     for (uint32_t binding = 0; binding < vertexBindingDescriptionCount; ++binding) {
         // VUID-VkVertexInputBindingDescription2EXT-binding-04796
         if (pVertexBindingDescriptions[binding].binding > device_limits.maxVertexInputBindings) {
-            skip |= LogError(
-                device, "VUID-VkVertexInputBindingDescription2EXT-binding-04796",
-                "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].binding is greater than maxVertexInputBindings", binding);
+            skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-binding-04796",
+                             "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                             "].binding is greater than maxVertexInputBindings",
+                             binding);
         }
 
         // VUID-VkVertexInputBindingDescription2EXT-stride-04797
         if (pVertexBindingDescriptions[binding].stride > device_limits.maxVertexInputBindingStride) {
-            skip |= LogError(
-                device, "VUID-VkVertexInputBindingDescription2EXT-stride-04797",
-                "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].stride is greater than maxVertexInputBindingStride",
-                binding);
+            skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-stride-04797",
+                             "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                             "].stride is greater than maxVertexInputBindingStride",
+                             binding);
         }
 
         // VUID-VkVertexInputBindingDescription2EXT-divisor-04798
         if (pVertexBindingDescriptions[binding].divisor == 0 &&
             (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateZeroDivisor)) {
             skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-04798",
-                             "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].divisor is zero but "
+                             "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                             "].divisor is zero but "
                              "vertexAttributeInstanceRateZeroDivisor is not enabled",
                              binding);
         }
@@ -7383,26 +7494,27 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
             // VUID-VkVertexInputBindingDescription2EXT-divisor-04799
             if (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateDivisor) {
                 skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-04799",
-                                 "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].divisor is greater than one but "
+                                 "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                                 "].divisor is greater than one but "
                                  "vertexAttributeInstanceRateDivisor is not enabled",
                                  binding);
             } else {
                 // VUID-VkVertexInputBindingDescription2EXT-divisor-06226
                 if (pVertexBindingDescriptions[binding].divisor >
                     phys_dev_ext_props.vertex_attribute_divisor_props.maxVertexAttribDivisor) {
-                    skip |= LogError(
-                        device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06226",
-                        "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].divisor is greater than maxVertexAttribDivisor",
-                        binding);
+                    skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06226",
+                                     "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                                     "].divisor is greater than maxVertexAttribDivisor",
+                                     binding);
                 }
 
                 // VUID-VkVertexInputBindingDescription2EXT-divisor-06227
                 if (pVertexBindingDescriptions[binding].inputRate != VK_VERTEX_INPUT_RATE_INSTANCE) {
-                    skip |=
-                        LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06227",
-                                 "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%u].divisor is greater than 1 but inputRate "
-                                 "is not VK_VERTEX_INPUT_RATE_INSTANCE",
-                                 binding);
+                    skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06227",
+                                     "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
+                                     "].divisor is greater than 1 but inputRate "
+                                     "is not VK_VERTEX_INPUT_RATE_INSTANCE",
+                                     binding);
                 }
             }
         }
@@ -7411,26 +7523,26 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
         // VUID-VkVertexInputAttributeDescription2EXT-location-06228
         if (pVertexAttributeDescriptions[attribute].location > device_limits.maxVertexInputAttributes) {
-            skip |= LogError(
-                device, "VUID-VkVertexInputAttributeDescription2EXT-location-06228",
-                "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%u].location is greater than maxVertexInputAttributes",
-                attribute);
+            skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-location-06228",
+                             "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
+                             "].location is greater than maxVertexInputAttributes",
+                             attribute);
         }
 
         // VUID-VkVertexInputAttributeDescription2EXT-binding-06229
         if (pVertexAttributeDescriptions[attribute].binding > device_limits.maxVertexInputBindings) {
-            skip |= LogError(
-                device, "VUID-VkVertexInputAttributeDescription2EXT-binding-06229",
-                "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%u].binding is greater than maxVertexInputBindings",
-                attribute);
+            skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-binding-06229",
+                             "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
+                             "].binding is greater than maxVertexInputBindings",
+                             attribute);
         }
 
         // VUID-VkVertexInputAttributeDescription2EXT-offset-06230
         if (pVertexAttributeDescriptions[attribute].offset > device_limits.maxVertexInputAttributeOffset) {
-            skip |= LogError(
-                device, "VUID-VkVertexInputAttributeDescription2EXT-offset-06230",
-                "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%u].offset is greater than maxVertexInputAttributeOffset",
-                attribute);
+            skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-offset-06230",
+                             "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
+                             "].offset is greater than maxVertexInputAttributeOffset",
+                             attribute);
         }
 
         // VUID-VkVertexInputAttributeDescription2EXT-format-04805
@@ -7438,7 +7550,8 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
         DispatchGetPhysicalDeviceFormatProperties(physical_device, pVertexAttributeDescriptions[attribute].format, &properties);
         if ((properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
             skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-format-04805",
-                             "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%u].format is not a "
+                             "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
+                             "].format is not a "
                              "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT supported format",
                              attribute);
         }
@@ -7455,26 +7568,28 @@ bool StatelessValidation::manual_PreCallValidateCmdPushConstants(VkCommandBuffer
     // Check that offset + size don't exceed the max.
     // Prevent arithetic overflow here by avoiding addition and testing in this order.
     if (offset >= max_push_constants_size) {
-        skip |= LogError(device, "VUID-vkCmdPushConstants-offset-00370",
-                         "vkCmdPushConstants(): offset (%u) that exceeds this device's maxPushConstantSize of %u.", offset,
-                         max_push_constants_size);
+        skip |=
+            LogError(device, "VUID-vkCmdPushConstants-offset-00370",
+                     "vkCmdPushConstants(): offset (%" PRIu32 ") that exceeds this device's maxPushConstantSize of %" PRIu32 ".",
+                     offset, max_push_constants_size);
     }
     if (size > max_push_constants_size - offset) {
         skip |= LogError(device, "VUID-vkCmdPushConstants-size-00371",
-                         "vkCmdPushConstants(): offset (%u) and size (%u) that exceeds this device's maxPushConstantSize of %u.",
+                         "vkCmdPushConstants(): offset (%" PRIu32 ") and size (%" PRIu32
+                         ") that exceeds this device's maxPushConstantSize of %" PRIu32 ".",
                          offset, size, max_push_constants_size);
     }
 
     // size needs to be non-zero and a multiple of 4.
     if (size & 0x3) {
-        skip |= LogError(device, "VUID-vkCmdPushConstants-size-00369", "vkCmdPushConstants(): size (%u) must be a multiple of 4.",
-                         size);
+        skip |= LogError(device, "VUID-vkCmdPushConstants-size-00369",
+                         "vkCmdPushConstants(): size (%" PRIu32 ") must be a multiple of 4.", size);
     }
 
     // offset needs to be a multiple of 4.
     if ((offset & 0x3) != 0) {
         skip |= LogError(device, "VUID-vkCmdPushConstants-offset-00368",
-                         "vkCmdPushConstants(): offset (%u) must be a multiple of 4.", offset);
+                         "vkCmdPushConstants(): offset (%" PRIu32 ") must be a multiple of 4.", offset);
     }
     return skip;
 }


### PR DESCRIPTION
as promised in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3346#discussion_r717668075

Changed all the `%d`/`%u` to `PRIu32`

There was only 2 spots where `%d` was actually an `int32_t` instead of `uint32_t` and those are `PRId32`