### PR TITLE
layers: Revert typo in RENDER_PASS_STATE init

### DIFF
--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -236,7 +236,7 @@ static void InitRenderPassState(RENDER_PASS_STATE *render_pass) {
 
         const auto last_use = attachment_tracker.last[attachment];
         if (last_use != VK_SUBPASS_EXTERNAL) {
-            auto &subpass_dep = const_cast<SubpassDependencyGraphNode &>(render_pass->subpass_dependencies[first_use]);
+            auto &subpass_dep = const_cast<SubpassDependencyGraphNode &>(render_pass->subpass_dependencies[last_use]);
             if (render_pass->subpass_dependencies[last_use].barrier_to_external.size() == 0) {
                 // Add implicit to barrier  if they're aren't any
                 subpass_dep.implicit_barrier_to_external.reset(new VkSubpassDependency2(ImplicitDependencyToExternal(last_use)));


### PR DESCRIPTION
A recent change to InitRenderPassState (e83bd44) inadvertently switched
the subpass dependency index used to add an implicit barrier to external
from `last_use` to `first_use`. This commit just reverts the index back
to `last_use`.

Fixes #3360