### PR TITLE
layers: Fix maxTexelGatherOffset check

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2077,13 +2077,14 @@ bool CoreChecks::ValidateTexelGatherOffset(SHADER_MODULE_STATE const *src, spirv
                                     uint32_t comp_id = constant.word(j);
                                     const auto &comp = src->get_def(comp_id);
                                     // Get operand value
-                                    int offset = comp.word(3);
+                                    auto offset = static_cast<int32_t>(comp.word(3));
                                     if (offset < phys_dev_props.limits.minTexelGatherOffset) {
                                         skip |= LogError(device, "VUID-RuntimeSpirv-OpImage-06376",
                                                          "vkCreateShaderModule(): Shader uses OpImageGather with offset (%" PRIi32
                                                          ") less than VkPhysicalDeviceLimits::minTexelGatherOffset (%" PRIu32 ").",
                                                          offset, phys_dev_props.limits.minTexelGatherOffset);
-                                    } else if (static_cast<uint32_t>(offset) > phys_dev_props.limits.maxTexelGatherOffset) {
+                                    } else if ((offset > 0) &&
+                                               (static_cast<uint32_t>(offset) > phys_dev_props.limits.maxTexelGatherOffset)) {
                                         skip |=
                                             LogError(device, "VUID-RuntimeSpirv-OpImage-06377",
                                                      "vkCreateShaderModule(): Shader uses OpImageGather with offset (%" PRIi32


### PR DESCRIPTION
Negative offsets were being cast to unsigned integers, causing them to
wrap and fail the comparison against
VkPhysicalDeviceLimits::maxTexelGatherOffset.

Error found here: https://ci.chromium.org/ui/p/angle/builders/try/linux-clang-rel/24675/overview

Sample validation output before the fix:
> RendererVk.cpp:562 (DebugUtilsMessenger): [ VUID-RuntimeSpirv-OpImage-06377 ] Validation Error: [ VUID-RuntimeSpirv-OpImage-06377 ] Object 0: handle = 0x55b0ea2e74b8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xd630c4bb | vkCreateShaderModule(): Shader uses OpImageGather with offset (-32) greater than VkPhysicalDeviceLimits::maxTexelGatherOffset (31). The Vulkan spec states: If an OpImage*Gather operation has an image operand of Offset, ConstOffset, or ConstOffsets the offset value must be less than or equal to maxTexelGatherOffset (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-RuntimeSpirv-OpImage-06377)
>                               Object: 0x55b0ea2e74b8 (type = Device(3))
