### PR TITLE
build: Update SPIRV-Tools

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -28,7 +28,7 @@
       "name" : "SPIRV-Tools",
       "url" : "https://github.com/KhronosGroup/SPIRV-Tools.git",
       "sub_dir" : "shaderc/third_party/spirv-tools",
-      "commit" : "1fbed83c8aab8517d821fcb4164c08567951938f"
+      "commit" : "9529d3c2c647bf7c7aa1a2601d0209da98f8fa1e"
     },
     {
       "name" : "SPIRV-Headers",

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "2fb89a0072ae7316af1c856f22663fde4928128a"
+#define SPIRV_TOOLS_COMMIT_ID "9529d3c2c647bf7c7aa1a2601d0209da98f8fa1e"

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -79,7 +79,7 @@ def main(argv):
                  '-export_header'],
                 [common_codegen.repo_relative('scripts/external_revision_generator.py'),
                  '--json_file', common_codegen.repo_relative('scripts/known_good.json'),
-                 '--json_keys', 'repos,0,commit',
+                 '--json_keys', 'repos,3,commit',
                  '-s', 'SPIRV_TOOLS_COMMIT_ID',
                  '-o', 'spirv_tools_commit_id.h']]
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -37,7 +37,7 @@
       "cmake_options": [
         "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers"
       ],
-      "commit": "1fbed83c8aab8517d821fcb4164c08567951938f"
+      "commit": "9529d3c2c647bf7c7aa1a2601d0209da98f8fa1e"
     },
     {
       "name": "robin-hood-hashing",


### PR DESCRIPTION
Includes build fix for SPIRV-tools on some versions of gcc. See
https://github.com/KhronosGroup/SPIRV-Tools/pull/4556.

Closes #3367.

@mikes-lunarg Not sure what else needs to be updated for this?