### PR TITLE
Adding vuid 04493, Validate BlendState attachmentCount 

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1381,6 +1381,20 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                              pipelineIndex, report_data->FormatHandle(pPipeline->rp_state->renderPass()).c_str(),
                              create_info.subpass, subpass_desc->colorAttachmentCount, color_blend_state->attachmentCount);
         }
+        for (uint32_t i = 0; i < subpass_desc->colorAttachmentCount; ++i) {
+            if (subpass_desc->pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
+                if (color_blend_state->attachmentCount <= subpass_desc->pColorAttachments[i].attachment) {
+                    skip |=
+                        LogError(device, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-04493",
+                                 "vkCreateGraphicsPipelines() pCreateInfo[%" PRIu32 "]: pColorBlendState->attachmentCount (%" PRIu32
+                                 ") is not greater than VkRenderPass %s subpass %" PRIu32 " pColorAttachments[%" PRIu32
+                                 "].attachment (%" PRIu32 ").",
+                                 pipelineIndex, color_blend_state->attachmentCount,
+                                 report_data->FormatHandle(pPipeline->rp_state->renderPass()).c_str(), create_info.subpass, i,
+                                 subpass_desc->pColorAttachments[i].attachment);
+                }
+            }
+        }
         if (!enabled_features.core.independentBlend) {
             if (pPipeline->attachments.size() > 1) {
                 const VkPipelineColorBlendAttachmentState *const attachments = &pPipeline->attachments[0];

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -13961,3 +13961,13 @@ TEST_F(VkLayerTest, RayTracingLibraryFlags) {
     vk::DestroyPipeline(m_device->handle(), library, nullptr);
     vk::DestroyPipeline(m_device->handle(), invalid_library, nullptr);
 }
+
+TEST_F(VkLayerTest, InvalidBlendAttachmentCount) {
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    const auto set_attachment_count = [&](CreatePipelineHelper &helper) { helper.cb_ci_.attachmentCount = 0; };
+    CreatePipelineHelper::OneshotTest(*this, set_attachment_count, kErrorBit,
+                                      std::vector<std::string>{"VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-04493",
+                                                               "VUID-VkGraphicsPipelineCreateInfo-attachmentCount-00746"});
+}


### PR DESCRIPTION
VkPipelineColorBlendStateCreateInfo::attachmentCount must be greater than all of color attachment indexes of the used subpass