### PR TITLE
layers: Use protectedNoFault correctly

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3527,7 +3527,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
         {
             const VkRenderPassCreateInfo2* renderpass_create_info = cb_node->activeRenderPass->createInfo.ptr();
             const VkSubpassDescription2* subpass_desc = &renderpass_create_info->pSubpasses[cb_node->activeSubpass];
-            
+
             for (uint32_t attachment_index = 0; attachment_index < attachmentCount; attachment_index++) {
                 const auto clear_desc = &pAttachments[attachment_index];
                 uint32_t fb_attachment = VK_ATTACHMENT_UNUSED;
@@ -6904,7 +6904,9 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
 bool CoreChecks::ValidateProtectedImage(const CMD_BUFFER_STATE *cb_state, const IMAGE_STATE *image_state, const char *cmd_name,
                                         const char *vuid, const char *more_message) const {
     bool skip = false;
-    if ((cb_state->unprotected == true) && (image_state->unprotected == false)) {
+
+    // if driver supports protectedNoFault the operation is valid, just has undefined values
+    if ((!phys_dev_props_core11.protectedNoFault) && (cb_state->unprotected == true) && (image_state->unprotected == false)) {
         LogObjectList objlist(cb_state->commandBuffer());
         objlist.add(image_state->image());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while image %s is a protected image.%s", cmd_name,
@@ -6918,7 +6920,9 @@ bool CoreChecks::ValidateProtectedImage(const CMD_BUFFER_STATE *cb_state, const 
 bool CoreChecks::ValidateUnprotectedImage(const CMD_BUFFER_STATE *cb_state, const IMAGE_STATE *image_state, const char *cmd_name,
                                           const char *vuid, const char *more_message) const {
     bool skip = false;
-    if ((cb_state->unprotected == false) && (image_state->unprotected == true)) {
+
+    // if driver supports protectedNoFault the operation is valid, just has undefined values
+    if ((!phys_dev_props_core11.protectedNoFault) && (cb_state->unprotected == false) && (image_state->unprotected == true)) {
         LogObjectList objlist(cb_state->commandBuffer());
         objlist.add(image_state->image());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while image %s is an unprotected image.%s", cmd_name,
@@ -6932,7 +6936,9 @@ bool CoreChecks::ValidateUnprotectedImage(const CMD_BUFFER_STATE *cb_state, cons
 bool CoreChecks::ValidateProtectedBuffer(const CMD_BUFFER_STATE *cb_state, const BUFFER_STATE *buffer_state, const char *cmd_name,
                                          const char *vuid, const char *more_message) const {
     bool skip = false;
-    if ((cb_state->unprotected == true) && (buffer_state->unprotected == false)) {
+
+    // if driver supports protectedNoFault the operation is valid, just has undefined values
+    if ((!phys_dev_props_core11.protectedNoFault) && (cb_state->unprotected == true) && (buffer_state->unprotected == false)) {
         LogObjectList objlist(cb_state->commandBuffer());
         objlist.add(buffer_state->buffer());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is unprotected while buffer %s is a protected buffer.%s", cmd_name,
@@ -6946,7 +6952,9 @@ bool CoreChecks::ValidateProtectedBuffer(const CMD_BUFFER_STATE *cb_state, const
 bool CoreChecks::ValidateUnprotectedBuffer(const CMD_BUFFER_STATE *cb_state, const BUFFER_STATE *buffer_state, const char *cmd_name,
                                            const char *vuid, const char *more_message) const {
     bool skip = false;
-    if ((cb_state->unprotected == false) && (buffer_state->unprotected == true)) {
+
+    // if driver supports protectedNoFault the operation is valid, just has undefined values
+    if ((!phys_dev_props_core11.protectedNoFault) && (cb_state->unprotected == false) && (buffer_state->unprotected == true)) {
         LogObjectList objlist(cb_state->commandBuffer());
         objlist.add(buffer_state->buffer());
         skip |= LogError(objlist, vuid, "%s: command buffer %s is protected while buffer %s is an unprotected buffer.%s", cmd_name,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2674,6 +2674,7 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
 
     for (uint32_t i = 0; i < info_count; ++i) {
         const auto requested_queue_family = infos[i].queueFamilyIndex;
+        const bool protected_create_bit = (infos[i].flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) != 0;
 
         std::string queue_family_var_name = "pCreateInfo->pQueueCreateInfos[" + std::to_string(i) + "].queueFamilyIndex";
         skip |= ValidateQueueFamilyIndex(pd_state, requested_queue_family, "VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381",
@@ -2695,7 +2696,7 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
             if (it == queue_family_map.end()) {
                 // Add first time seeing queue family index and what the create flags were
                 create_flags new_flags = {not_used, not_used};
-                if ((infos[i].flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) != 0) {
+                if (protected_create_bit) {
                     new_flags.protected_index = requested_queue_family;
                 } else {
                     new_flags.unprocted_index = requested_queue_family;
@@ -2703,7 +2704,7 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
                 queue_family_map.emplace(requested_queue_family, new_flags);
             } else {
                 // The queue family was seen, so now need to make sure the flags were different
-                if ((infos[i].flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) != 0) {
+                if (protected_create_bit) {
                     if (it->second.protected_index != not_used) {
                         skip |= LogError(pd_state->Handle(), "VUID-VkDeviceCreateInfo-queueFamilyIndex-02802",
                                          "CreateDevice(): %s (=%" PRIu32
@@ -2728,13 +2729,23 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
             }
         }
 
+        const VkQueueFamilyProperties requested_queue_family_props = pd_state->queue_family_properties[requested_queue_family];
+
+        // if using protected flag, make sure queue supports it
+        if (protected_create_bit && ((requested_queue_family_props.queueFlags & VK_QUEUE_PROTECTED_BIT) == 0)) {
+            skip |= LogError(
+                pd_state->Handle(), "VUID-VkDeviceQueueCreateInfo-flags-06449",
+                "CreateDevice(): %s (=%" PRIu32
+                ") does not have VK_QUEUE_PROTECTED_BIT supported, but VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT is being used.",
+                queue_family_var_name.c_str(), requested_queue_family);
+        }
+
         // Verify that requested queue count of queue family is known to be valid at this point in time
         if (requested_queue_family < pd_state->queue_family_known_count) {
             const auto requested_queue_count = infos[i].queueCount;
             const bool queue_family_has_props = requested_queue_family < pd_state->queue_family_properties.size();
             // spec guarantees at least one queue for each queue family
-            const uint32_t available_queue_count =
-                queue_family_has_props ? pd_state->queue_family_properties[requested_queue_family].queueCount : 1;
+            const uint32_t available_queue_count = queue_family_has_props ? requested_queue_family_props.queueCount : 1;
             const char *conditional_ext_cmd = instance_extensions.vk_khr_get_physical_device_properties2
                                                   ? " or vkGetPhysicalDeviceQueueFamilyProperties2[KHR]"
                                                   : "";
@@ -2742,8 +2753,7 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
             if (requested_queue_count > available_queue_count) {
                 const std::string count_note =
                     queue_family_has_props
-                        ? "i.e. is not less than or equal to " +
-                              std::to_string(pd_state->queue_family_properties[requested_queue_family].queueCount)
+                        ? "i.e. is not less than or equal to " + std::to_string(requested_queue_family_props.queueCount)
                         : "the pQueueFamilyProperties[" + std::to_string(requested_queue_family) + "] was never obtained";
 
                 skip |= LogError(
@@ -3738,8 +3748,8 @@ bool CoreChecks::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCo
 
         skip |= ValidateSemaphoresForSubmit(sem_submit_state, queue, submit, loc);
 
-        bool protectedSubmit = (submit->flags & VK_SUBMIT_PROTECTED_BIT_KHR) != 0;
-        if ((protectedSubmit == true) && ((queue_state->flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT)) == 0) {
+        bool protected_submit = (submit->flags & VK_SUBMIT_PROTECTED_BIT_KHR) != 0;
+        if ((protected_submit == true) && ((queue_state->flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT)) == 0) {
             skip |= LogError(queue, "VUID-vkQueueSubmit2KHR-queue-06447",
                              "vkQueueSubmit2KHR(): pSubmits[%u] contains a protected submission to %s which was not created with "
                              "VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT",
@@ -3758,7 +3768,7 @@ bool CoreChecks::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCo
             // Make sure command buffers are all protected or unprotected
             const CMD_BUFFER_STATE *cb_state = GetCBState(submit->pCommandBufferInfos[i].commandBuffer);
             if (cb_state != nullptr) {
-                if ((cb_state->unprotected == true) && (protectedSubmit == true)) {
+                if ((cb_state->unprotected == true) && (protected_submit == true)) {
                     LogObjectList objlist(cb_state->commandBuffer());
                     objlist.add(queue);
                     skip |= LogError(objlist, "VUID-VkSubmitInfo2KHR-flags-03886",
@@ -3767,7 +3777,7 @@ bool CoreChecks::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCo
                                      report_data->FormatHandle(cb_state->commandBuffer()).c_str(),
                                      report_data->FormatHandle(queue).c_str(), submit_idx);
                 }
-                if ((cb_state->unprotected == false) && (protectedSubmit == false)) {
+                if ((cb_state->unprotected == false) && (protected_submit == false)) {
                     LogObjectList objlist(cb_state->commandBuffer());
                     objlist.add(queue);
                     skip |= LogError(objlist, "VUID-VkSubmitInfo2KHR-flags-03887",
@@ -5473,7 +5483,7 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
                                  i);
 
                 return true;
-            } 
+            }
         }
     }
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -9266,8 +9266,82 @@ TEST_F(VkLayerTest, UniqueQueueDeviceCreationBothProtected) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DisabledProtectedMemory) {
-    TEST_DESCRIPTION("Validate cases where protectedMemory feature is not enabled");
+TEST_F(VkLayerTest, InvalidProtectedQueue) {
+    TEST_DESCRIPTION("Try creating queue without VK_QUEUE_PROTECTED_BIT capability");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("%s Did not find VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME; skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s test requires Vulkan 1.1 extensions, not available.  Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
+        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+
+    auto protected_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&protected_features);
+    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+
+    if (protected_features.protectedMemory == VK_FALSE) {
+        printf("%s test requires protectedMemory, not available. Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    // Try to find a protected queue family type
+    bool unprotected_queue = false;
+    uint32_t queue_family_index = 0;
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+
+    // need to find a queue without protected support
+    for (size_t i = 0; i < queue_families.size(); i++) {
+        if ((queue_families[i].queueFlags & VK_QUEUE_PROTECTED_BIT) == 0) {
+            unprotected_queue = true;
+            queue_family_index = i;
+            break;
+        }
+    }
+
+    if (unprotected_queue == false) {
+        printf("%s test requires queue without VK_QUEUE_PROTECTED_BIT. Skipping.\n", kSkipPrefix);
+        return;
+    }
+
+    float queue_priority = 1.0;
+    VkDeviceQueueCreateInfo queue_create_info = LvlInitStruct<VkDeviceQueueCreateInfo>();
+    queue_create_info.flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
+    queue_create_info.queueFamilyIndex = queue_family_index;
+    queue_create_info.queueCount = 1;
+    queue_create_info.pQueuePriorities = &queue_priority;
+
+    VkDevice test_device = VK_NULL_HANDLE;
+    VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&protected_features);
+    device_create_info.flags = 0;
+    device_create_info.pQueueCreateInfos = &queue_create_info;
+    device_create_info.queueCreateInfoCount = 1;
+    device_create_info.pEnabledFeatures = nullptr;
+    device_create_info.enabledLayerCount = 0;
+    device_create_info.enabledExtensionCount = 0;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceQueueCreateInfo-flags-06449");
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, InvalidProtectedSubmit) {
+    TEST_DESCRIPTION("Setting protectedSubmit with a queue not created with VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -9285,18 +9359,8 @@ TEST_F(VkLayerTest, DisabledProtectedMemory) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
-
-    auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
-    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&protected_memory_features);
-    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
-
-    // Set false to trigger VUs
-    protected_memory_features.protectedMemory = VK_FALSE;
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    // creates a queue without VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkCommandPool command_pool;
     VkCommandPoolCreateInfo pool_create_info = {};


### PR DESCRIPTION
Based off (and waiting for change to get merged in headers) https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4775

- Uses `protectedNoFault` correctly by not throwing the validation warnings
- remove `VUID-VkProtectedSubmitInfo-protectedSubmit-01816` and `VUID-VkSubmitInfo2KHR-flags-03885`
- Adds 3 new VUs (not labeled yet) `VUID-VkDeviceCreateInfo-flags-TODO`, `VUID-vkQueueSubmit-queue-TODO`, `VUID-vkQueueSubmit2KHR-queue-TODO`

