### PR TITLE
layers: Fix min/maxTexelGatherOffset check for dynamic gather

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2094,7 +2094,8 @@ bool CoreChecks::ValidateTexelGatherOffset(SHADER_MODULE_STATE const *src, spirv
                         if (insn.len() > index && (i & offset_bits)) {
                             uint32_t constant_id = insn.word(index);
                             const auto &constant = src->get_def(constant_id);
-                            if (constant.opcode() == spv::OpConstantComposite) {
+                            const bool is_dynamic_offset = constant == src->end();
+                            if (!is_dynamic_offset && constant.opcode() == spv::OpConstantComposite) {
                                 for (uint32_t j = 3; j < constant.len(); ++j) {
                                     uint32_t comp_id = constant.word(j);
                                     const auto &comp = src->get_def(comp_id);


### PR DESCRIPTION
The offset argument to OpImage*Gather is verified against
minTexelGatherOffset and maxTexelGatherOffset.  However, this offset is
not always constant.  The id of the offset was used to look up the
instruction that defines this "constant", which returned an end()
iterator for dynamic offsets.  Accessing this iterator is an OOB bug.

Fixes #3401