### PR TITLE
layers: Fix a Wbitwise-instead-of-logical warning

### DIFF
--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -132,7 +132,7 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, REND
             const auto prev_pass = prev.first->pass;
             const auto &prev_depends = pass_depends[prev_pass];
             for (uint32_t j = 0; j < prev_pass; j++) {
-                depends[j] = depends[j] | prev_depends[j];
+                depends[j] = depends[j] || prev_depends[j];
             }
             depends[prev_pass] = true;
         }


### PR DESCRIPTION
`a || b` only evaluates b if a is false. `a | b` always evaluates
both a and b. If a and b are of type bool, `||` is usually what you
want, so clang now warns on `|` where both arguments are of type bool.

Here, it doesn't make a difference. Use `||` to make clang happy.