### PR TITLE
WIP: Skip tests that crash on newer drivers

### DIFF
--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10109,6 +10109,11 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
 TEST_F(VkLayerTest, ValidateDescriptorBindingUpdateAfterBindWithAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure descriptor writing.");
 
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        printf("%s This test is being skipped on the Nvidia driver\n", kSkipPrefix);
+        return;
+    }
+
     if (!InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -236,7 +236,10 @@ TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
 
 TEST_F(VkLayerTest, DestroyInstanceHandleLeak) {
     TEST_DESCRIPTION("Test vkDestroyInstance while leaking a VkDevice object.");
-
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        printf("%s This test is being skipped on the Nvidia driver\n", kSkipPrefix);
+        return;
+    }
     const auto ici = GetInstanceCreateInfo();
 
     VkInstance instance;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1358,7 +1358,10 @@ TEST_F(VkLayerTest, SubmitSignaledFence) {
 
 TEST_F(VkLayerTest, LeakAnObject) {
     TEST_DESCRIPTION("Create a fence and destroy its device without first destroying the fence.");
-
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        printf("%s This test is being skipped on the Nvidia driver\n", kSkipPrefix);
+        return;
+    }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
@@ -1804,6 +1807,12 @@ TEST_F(VkLayerTest, InvalidCmdBufferEventDestroyed) {
 
 TEST_F(VkLayerTest, InvalidCmdBufferQueryPoolDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a query pool dependency being destroyed.");
+
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        printf("%s This test is being skipped on the Nvidia driver\n", kSkipPrefix);
+        return;
+    }
+
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkQueryPool query_pool;
@@ -12165,6 +12174,10 @@ TEST_F(VkLayerTest, WriteTimeStampInvalidQuery) {
 TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
     TEST_DESCRIPTION("Duplicated physical devices in DeviceGroupDeviceCreateInfo.");
 
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        printf("%s This test is being skipped on the Nvidia driver\n", kSkipPrefix);
+        return;
+    }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     uint32_t physical_device_group_count = 0;
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, nullptr);


### PR DESCRIPTION
Newer Nvidia drivers are less tolerant of bad test behavior, particularly
leaking objects.  Skip misbehaving tests until they can be fixed.
Use #3414 to track fixing and re-enabling them