### PR TITLE
layers: Add generated SPIR-V grammar helper

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -116,6 +116,8 @@ core_validation_sources = [
   "layers/generated/corechecks_optick_instrumentation.cpp",
   "layers/generated/corechecks_optick_instrumentation.h",
   "layers/generated/spirv_validation_helper.cpp",
+  "layers/generated/spirv_grammar_helper.cpp",
+  "layers/generated/spirv_grammar_helper.h",
   "layers/generated/command_validation.cpp",
   "layers/generated/command_validation.h",
   "layers/generated/gpu_pre_draw_shader.h",

--- a/BUILD.md
+++ b/BUILD.md
@@ -274,7 +274,10 @@ directory which is not intended to be modified directly. Instead, changes should
 made to the corresponding generator in the `scripts` directory. The source files can
 then be regenerated using `scripts/generate_source.py`:
 
-    python3 scripts/generate_source.py PATH_TO_VULKAN_HEADERS_REGISTRY_DIR
+    python3 scripts/generate_source.py PATH_TO_VULKAN_HEADERS_REGISTRY_DIR PATH_TO_SPIRV_HEADERS_GRAMMAR_DIR
+
+    // Example
+    python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
 
 A helper CMake target `VulkanVL_generated_source` is also provided to simplify
 the invocation of `scripts/generate_source.py` from the build directory:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ endif()
 if(PYTHONINTERP_FOUND)
     add_custom_target(VulkanVL_generated_source
                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_source.py
-                              ${VulkanRegistry_DIR} --incremental
+                              ${VulkanRegistry_DIR} ${SPIRV_HEADERS_INSTALL_DIR}/include/spirv/unified1/ --incremental
                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/layers/generated
                       )
 else()

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(VkLayer_khronos_validation SHARED
         ${SRC_DIR}/layers/shader_module.cpp
         ${SRC_DIR}/layers/shader_validation.cpp
         ${SRC_DIR}/layers/generated/spirv_validation_helper.cpp
+        ${SRC_DIR}/layers/generated/spirv_grammar_helper.cpp
         ${SRC_DIR}/layers/generated/command_validation.cpp
         ${SRC_DIR}/layers/gpu_validation.cpp
         ${SRC_DIR}/layers/gpu_utils.cpp

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -50,6 +50,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_module.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/spirv_validation_helper.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/spirv_grammar_helper.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/command_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_utils.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -190,6 +190,7 @@ set(CORE_VALIDATION_LIBRARY_FILES
     sync_vuid_maps.cpp
     sync_vuid_maps.h
     generated/spirv_validation_helper.cpp
+    generated/spirv_grammar_helper.cpp
     generated/command_validation.cpp
     generated/synchronization_validation_types.cpp
     gpu_validation.cpp

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -1,0 +1,107 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See spirv_gramar_generator.py for modifications
+
+
+/***************************************************************************
+ *
+ * Copyright (c) 2021 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Spencer Fricke <s.fricke@samsung.com>
+ *
+ * This file is related to anything that is found in the SPIR-V grammar
+ * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.
+ *
+ ****************************************************************************/
+
+#include "spirv_grammar_helper.h"
+#include <spirv/unified1/spirv.hpp>
+
+// Any non supported operation will be covered with VUID 01090
+bool AtomicOperation(uint32_t opcode) {
+    bool found = false;
+    switch (opcode) {
+        case spv::OpAtomicLoad:
+        case spv::OpAtomicStore:
+        case spv::OpAtomicExchange:
+        case spv::OpAtomicCompareExchange:
+        case spv::OpAtomicIIncrement:
+        case spv::OpAtomicIDecrement:
+        case spv::OpAtomicIAdd:
+        case spv::OpAtomicISub:
+        case spv::OpAtomicSMin:
+        case spv::OpAtomicUMin:
+        case spv::OpAtomicSMax:
+        case spv::OpAtomicUMax:
+        case spv::OpAtomicAnd:
+        case spv::OpAtomicOr:
+        case spv::OpAtomicXor:
+        case spv::OpAtomicFMinEXT:
+        case spv::OpAtomicFMaxEXT:
+        case spv::OpAtomicFAddEXT:
+            found = true;
+            break;
+        default:
+            break;
+    }
+    return found;
+}
+
+// Any non supported operation will be covered with VUID 01090
+bool GroupOperation(uint32_t opcode) {
+    bool found = false;
+    switch (opcode) {
+        case spv::OpGroupNonUniformElect:
+        case spv::OpGroupNonUniformAll:
+        case spv::OpGroupNonUniformAny:
+        case spv::OpGroupNonUniformAllEqual:
+        case spv::OpGroupNonUniformBroadcast:
+        case spv::OpGroupNonUniformBroadcastFirst:
+        case spv::OpGroupNonUniformBallot:
+        case spv::OpGroupNonUniformInverseBallot:
+        case spv::OpGroupNonUniformBallotBitExtract:
+        case spv::OpGroupNonUniformBallotBitCount:
+        case spv::OpGroupNonUniformBallotFindLSB:
+        case spv::OpGroupNonUniformBallotFindMSB:
+        case spv::OpGroupNonUniformShuffle:
+        case spv::OpGroupNonUniformShuffleXor:
+        case spv::OpGroupNonUniformShuffleUp:
+        case spv::OpGroupNonUniformShuffleDown:
+        case spv::OpGroupNonUniformIAdd:
+        case spv::OpGroupNonUniformFAdd:
+        case spv::OpGroupNonUniformIMul:
+        case spv::OpGroupNonUniformFMul:
+        case spv::OpGroupNonUniformSMin:
+        case spv::OpGroupNonUniformUMin:
+        case spv::OpGroupNonUniformFMin:
+        case spv::OpGroupNonUniformSMax:
+        case spv::OpGroupNonUniformUMax:
+        case spv::OpGroupNonUniformFMax:
+        case spv::OpGroupNonUniformBitwiseAnd:
+        case spv::OpGroupNonUniformBitwiseOr:
+        case spv::OpGroupNonUniformBitwiseXor:
+        case spv::OpGroupNonUniformLogicalAnd:
+        case spv::OpGroupNonUniformLogicalOr:
+        case spv::OpGroupNonUniformLogicalXor:
+        case spv::OpGroupNonUniformQuadBroadcast:
+        case spv::OpGroupNonUniformQuadSwap:
+        case spv::OpGroupNonUniformPartitionNV:
+            found = true;
+            break;
+        default:
+            break;
+    }
+    return found;
+}
+

--- a/layers/generated/spirv_grammar_helper.h
+++ b/layers/generated/spirv_grammar_helper.h
@@ -1,0 +1,34 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See spirv_gramar_generator.py for modifications
+
+
+/***************************************************************************
+ *
+ * Copyright (c) 2021 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Spencer Fricke <s.fricke@samsung.com>
+ *
+ * This file is related to anything that is found in the SPIR-V grammar
+ * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.
+ *
+ ****************************************************************************/
+
+#pragma once
+#include <cstdint>
+
+bool AtomicOperation(uint32_t opcode);
+
+bool GroupOperation(uint32_t opcode);
+

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -20,6 +20,9 @@
  *
  * Author: Spencer Fricke <s.fricke@samsung.com>
  *
+ * This file is related to anything that is found in the Vulkan XML related
+ * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper
+ *
  ****************************************************************************/
 
 #include <string>

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -24,6 +24,7 @@
 #include "vk_layer_utils.h"
 #include "pipeline_state.h"
 #include "descriptor_sets.h"
+#include "spirv_grammar_helper.h"
 
 void decoration_set::merge(decoration_set const &other) {
     if (other.flags & location_bit) location = other.location;
@@ -1951,78 +1952,4 @@ std::vector<uint32_t> FindEntrypointInterfaces(const spirv_inst_iter &entrypoint
     for (; word < entrypoint.len(); word++) interfaces.push_back(entrypoint.word(word));
 
     return interfaces;
-}
-
-bool AtomicOperation(uint32_t opcode) {
-    switch (opcode) {
-        case spv::OpAtomicLoad:
-        case spv::OpAtomicStore:
-        case spv::OpAtomicExchange:
-        case spv::OpAtomicCompareExchange:
-        case spv::OpAtomicCompareExchangeWeak:
-        case spv::OpAtomicIIncrement:
-        case spv::OpAtomicIDecrement:
-        case spv::OpAtomicIAdd:
-        case spv::OpAtomicISub:
-        case spv::OpAtomicSMin:
-        case spv::OpAtomicUMin:
-        case spv::OpAtomicSMax:
-        case spv::OpAtomicUMax:
-        case spv::OpAtomicAnd:
-        case spv::OpAtomicOr:
-        case spv::OpAtomicXor:
-        case spv::OpAtomicFAddEXT:
-        case spv::OpAtomicFMinEXT:
-        case spv::OpAtomicFMaxEXT:
-            return true;
-        default:
-            return false;
-    }
-    return false;
-}
-
-// Only includes valid group operations used in Vulkan (for now thats only subgroup ops) and any non supported operation will be
-// covered with VUID 01090
-bool GroupOperation(uint32_t opcode) {
-    switch (opcode) {
-        case spv::OpGroupNonUniformElect:
-        case spv::OpGroupNonUniformAll:
-        case spv::OpGroupNonUniformAny:
-        case spv::OpGroupNonUniformAllEqual:
-        case spv::OpGroupNonUniformBroadcast:
-        case spv::OpGroupNonUniformBroadcastFirst:
-        case spv::OpGroupNonUniformBallot:
-        case spv::OpGroupNonUniformInverseBallot:
-        case spv::OpGroupNonUniformBallotBitExtract:
-        case spv::OpGroupNonUniformBallotBitCount:
-        case spv::OpGroupNonUniformBallotFindLSB:
-        case spv::OpGroupNonUniformBallotFindMSB:
-        case spv::OpGroupNonUniformShuffle:
-        case spv::OpGroupNonUniformShuffleXor:
-        case spv::OpGroupNonUniformShuffleUp:
-        case spv::OpGroupNonUniformShuffleDown:
-        case spv::OpGroupNonUniformIAdd:
-        case spv::OpGroupNonUniformFAdd:
-        case spv::OpGroupNonUniformIMul:
-        case spv::OpGroupNonUniformFMul:
-        case spv::OpGroupNonUniformSMin:
-        case spv::OpGroupNonUniformUMin:
-        case spv::OpGroupNonUniformFMin:
-        case spv::OpGroupNonUniformSMax:
-        case spv::OpGroupNonUniformUMax:
-        case spv::OpGroupNonUniformFMax:
-        case spv::OpGroupNonUniformBitwiseAnd:
-        case spv::OpGroupNonUniformBitwiseOr:
-        case spv::OpGroupNonUniformBitwiseXor:
-        case spv::OpGroupNonUniformLogicalAnd:
-        case spv::OpGroupNonUniformLogicalOr:
-        case spv::OpGroupNonUniformLogicalXor:
-        case spv::OpGroupNonUniformQuadBroadcast:
-        case spv::OpGroupNonUniformQuadSwap:
-        case spv::OpGroupNonUniformPartitionNV:
-            return true;
-        default:
-            return false;
-    }
-    return false;
 }

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -391,10 +391,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     static std::unordered_multimap<std::string, EntryPoint> ProcessEntryPoints(const SHADER_MODULE_STATE &mod);
 };
 
-// TODO - Most things below are agnostic of even the shader module and more of pure SPIR-V utils
-//        Stuff like this could be part of a future auto-generated file from the spirv grammar json
-bool AtomicOperation(uint32_t opcode);
-bool GroupOperation(uint32_t opcode);
+// String helpers functions to give better error messages
 char const *StorageClassName(unsigned sc);
 
 #endif  // VULKAN_SHADER_MODULE_H

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -36,6 +36,7 @@
 #include "vk_layer_utils.h"
 #include "chassis.h"
 #include "core_validation.h"
+#include "spirv_grammar_helper.h"
 
 #include "xxhash.h"
 

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -65,7 +65,7 @@ def IsWindows(): return 'windows' == platform.system().lower()
 # Verify consistency of generated source code
 def CheckVVLCodegenConsistency():
     print("Check Generated Source Code Consistency")
-    gen_check_cmd = 'python3 scripts/generate_source.py --verify %s/Vulkan-Headers/registry' % EXTERNAL_DIR
+    gen_check_cmd = 'python3 scripts/generate_source.py --verify %s/Vulkan-Headers/registry %s/SPIRV-Headers/include/spirv/unified1/' % (EXTERNAL_DIR, EXTERNAL_DIR)
     RunShellCmd(gen_check_cmd)
 
 #

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -36,6 +36,7 @@ verify_exclude = ['.clang-format',
 def main(argv):
     parser = argparse.ArgumentParser(description='Generate source code for this repository')
     parser.add_argument('registry', metavar='REGISTRY_PATH', help='path to the Vulkan-Headers registry directory')
+    parser.add_argument('grammar', metavar='GRAMMAR_PATH', help='path to the SPIRV-Headers grammar directory')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
@@ -43,6 +44,7 @@ def main(argv):
 
     gen_cmds = [*[[common_codegen.repo_relative('scripts/lvl_genvk.py'),
                    '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
+                   '-grammar', os.path.abspath(os.path.join(args.grammar,  'spirv.core.grammar.json')),
                    '-quiet',
                    filename] for filename in ["chassis.cpp",
                                               "chassis.h",
@@ -70,6 +72,8 @@ def main(argv):
                                               "best_practices.h",
                                               "best_practices.cpp",
                                               "spirv_validation_helper.cpp",
+                                              "spirv_grammar_helper.cpp",
+                                              "spirv_grammar_helper.h",
                                               "command_validation.cpp",
                                               "command_validation.h",
                                               "corechecks_optick_instrumentation.cpp",

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -512,6 +512,28 @@ def makeGenOpts(args):
             emitSpirv         = emitSpirvPat)
         ]
 
+    # Options for spirv_grammar_helper code-generated source
+    # Only uses spirv grammar and not the vk.xml
+    genOpts['spirv_grammar_helper.cpp'] = [
+          SpirvGrammarHelperOutputGenerator,
+          SpirvGrammarHelperOutputGeneratorOptions(
+            conventions       = conventions,
+            filename          = 'spirv_grammar_helper.cpp',
+            directory         = directory,
+            grammar           = args.grammar)
+        ]
+
+    # Options for spirv_grammar_helper code-generated header
+    # Only uses spirv grammar and not the vk.xml
+    genOpts['spirv_grammar_helper.h'] = [
+          SpirvGrammarHelperOutputGenerator,
+          SpirvGrammarHelperOutputGeneratorOptions(
+            conventions       = conventions,
+            filename          = 'spirv_grammar_helper.h',
+            directory         = directory,
+            grammar           = args.grammar)
+        ]
+
     # Options for command_validation code-generated header
     genOpts['command_validation.cpp'] = [
           CommandValidationOutputGenerator,
@@ -624,6 +646,9 @@ if __name__ == '__main__':
     parser.add_argument('-registry', action='store',
                         default='vk.xml',
                         help='Use specified registry file instead of vk.xml')
+    parser.add_argument('-grammar', action='store',
+                        default='spirv.core.grammar.json',
+                        help='Use specified grammar file instead of spirv.core.grammar.json')
     parser.add_argument('-time', action='store_true',
                         help='Enable timing')
     parser.add_argument('-validate', action='store_true',
@@ -670,6 +695,7 @@ if __name__ == '__main__':
     from lvt_file_generator import LvtFileOutputGenerator, LvtFileOutputGeneratorOptions
     from best_practices_generator import BestPracticesOutputGenerator, BestPracticesOutputGeneratorOptions
     from spirv_validation_generator import SpirvValidationHelperOutputGenerator, SpirvValidationHelperOutputGeneratorOptions
+    from spirv_grammar_generator import SpirvGrammarHelperOutputGenerator, SpirvGrammarHelperOutputGeneratorOptions
     from command_validation_generator import CommandValidationOutputGenerator, CommandValidationOutputGeneratorOptions
 
     # Temporary workaround for vkconventions python2 compatibility

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2021 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Spencer Fricke <s.fricke@samsung.com>
+
+import os,re,sys,string,json
+import xml.etree.ElementTree as etree
+from generator import *
+from collections import namedtuple
+from common_codegen import *
+
+# This is a workaround to use a Python 2.7 and 3.x compatible syntax
+from io import open
+
+class SpirvGrammarHelperOutputGeneratorOptions(GeneratorOptions):
+    def __init__(self,
+                 conventions = None,
+                 filename = None,
+                 directory = '.',
+                 genpath = None,
+                 apiname = 'vulkan',
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = 'vulkan',
+                 addExtensions = None,
+                 removeExtensions = None,
+                 emitExtensions = None,
+                 emitSpirv = None,
+                 sortProcedure = regSortFeatures,
+                 genFuncPointers = True,
+                 protectFile = True,
+                 protectFeature = True,
+                 apicall = 'VKAPI_ATTR ',
+                 apientry = 'VKAPI_CALL ',
+                 apientryp = 'VKAPI_PTR *',
+                 indentFuncProto = True,
+                 indentFuncPointer = False,
+                 alignFuncParam = 48,
+                 expandEnumerants = False,
+                 grammar = None):
+        GeneratorOptions.__init__(self,
+                conventions = conventions,
+                filename = filename,
+                directory = directory,
+                genpath = genpath,
+                apiname = apiname,
+                profile = profile,
+                versions = versions,
+                emitversions = emitversions,
+                defaultExtensions = defaultExtensions,
+                addExtensions = addExtensions,
+                removeExtensions = removeExtensions,
+                emitExtensions = emitExtensions,
+                emitSpirv = emitSpirv,
+                sortProcedure = sortProcedure)
+        self.genFuncPointers = genFuncPointers
+        self.protectFile     = protectFile
+        self.protectFeature  = protectFeature
+        self.apicall         = apicall
+        self.apientry        = apientry
+        self.apientryp       = apientryp
+        self.indentFuncProto = indentFuncProto
+        self.indentFuncPointer = indentFuncPointer
+        self.alignFuncParam  = alignFuncParam
+        self.expandEnumerants = expandEnumerants
+        self.grammar = grammar
+#
+# SpirvGrammarHelperOutputGenerator - Generate SPIR-V grammar helper
+# for SPIR-V opcodes, enums, etc
+class SpirvGrammarHelperOutputGenerator(OutputGenerator):
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+        self.headerFile = False # Header file generation flag
+        self.sourceFile = False # Source file generation flag
+
+        self.atomicsOps = []
+        self.groupOps = []
+
+        # Lots of switch statements share same ending
+        self.commonBoolSwitch  = '''            found = true;
+            break;
+        default:
+            break;
+    }
+    return found;
+}
+'''
+
+    #
+    # Called at beginning of processing as file is opened
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+        self.parseGrammar(genOpts.grammar)
+
+        self.headerFile = (genOpts.filename == 'spirv_grammar_helper.h')
+        self.sourceFile = (genOpts.filename == 'spirv_grammar_helper.cpp')
+        if not self.headerFile and not self.sourceFile:
+            print("Error: Output Filenames have changed, update generator source.\n")
+            sys.exit(1)
+
+        # File Comment
+        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
+        file_comment += '// See spirv_gramar_generator.py for modifications\n'
+        write(file_comment, file=self.outFile)
+        # Copyright Statement
+        copyright = ''
+        copyright += '\n'
+        copyright += '/***************************************************************************\n'
+        copyright += ' *\n'
+        copyright += ' * Copyright (c) 2021 The Khronos Group Inc.\n'
+        copyright += ' *\n'
+        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
+        copyright += ' * you may not use this file except in compliance with the License.\n'
+        copyright += ' * You may obtain a copy of the License at\n'
+        copyright += ' *\n'
+        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
+        copyright += ' *\n'
+        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
+        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
+        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
+        copyright += ' * See the License for the specific language governing permissions and\n'
+        copyright += ' * limitations under the License.\n'
+        copyright += ' *\n'
+        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
+        copyright += ' *\n'
+        copyright += ' * This file is related to anything that is found in the SPIR-V grammar\n'
+        copyright += ' * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.\n'
+        copyright += ' *\n'
+        copyright += ' ****************************************************************************/\n'
+        write(copyright, file=self.outFile)
+
+        if self.sourceFile:
+            write('#include "spirv_grammar_helper.h"', file=self.outFile)
+            write('#include <spirv/unified1/spirv.hpp>', file=self.outFile)
+        elif self.headerFile:
+            write('#pragma once', file=self.outFile)
+            write('#include <cstdint>', file=self.outFile)
+        write('', file=self.outFile)
+    #
+    # Write generated file content to output file
+    def endFile(self):
+        write(self.atomicOperation(), file=self.outFile)
+        write(self.groupOperation(), file=self.outFile)
+        # Finish processing in superclass
+        OutputGenerator.endFile(self)
+    #
+    # Takes the SPIR-V Grammar JSON and parses it
+    # Emulates the gen*() functions the vk.xml calls
+    #
+    # In the future, IF more then this generator wants to use the grammar
+    # it would be better to move the file opening to lvl_genvk.py
+    def parseGrammar(self, grammar):
+        with open(grammar, 'r') as jsonFile:
+            data = json.load(jsonFile)
+            instructions = data['instructions']
+            operandKinds = data['operand_kinds']
+            for instruction in instructions:
+                if 'capabilities' in instruction and len(instruction['capabilities']) == 1 and instruction['capabilities'][0] == 'Kernel':
+                    continue # If just 'Kernel' then op is ment for OpenCL
+                if instruction['class'] == 'Atomic':
+                    self.atomicsOps.append(instruction['opname'])
+                if instruction['class'] == 'Non-Uniform':
+                    self.groupOps.append(instruction['opname'])
+    #
+    # Generate functions for numeric based functions
+    def atomicOperation(self):
+        output = ''
+        if self.headerFile:
+            output += 'bool AtomicOperation(uint32_t opcode);\n'
+        elif self.sourceFile:
+            output += '// Any non supported operation will be covered with VUID 01090\n'
+            output += 'bool AtomicOperation(uint32_t opcode) {\n'
+            output += '    bool found = false;\n'
+            output += '    switch (opcode) {\n'
+            for f in self.atomicsOps:
+                output += '        case spv::{}:\n'.format(f)
+            output += self.commonBoolSwitch
+
+        return output;
+    #
+    # Generate functions for numeric based functions
+    def groupOperation(self):
+        output = ''
+        if self.headerFile:
+            output += 'bool GroupOperation(uint32_t opcode);\n'
+        elif self.sourceFile:
+            output += '// Any non supported operation will be covered with VUID 01090\n'
+            output += 'bool GroupOperation(uint32_t opcode) {\n'
+            output += '    bool found = false;\n'
+            output += '    switch (opcode) {\n'
+            for f in self.groupOps:
+                output += '        case spv::{}:\n'.format(f)
+            output += self.commonBoolSwitch
+
+        return output;

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -195,6 +195,9 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
         copyright += ' *\n'
         copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
         copyright += ' *\n'
+        copyright += ' * This file is related to anything that is found in the Vulkan XML related\n'
+        copyright += ' * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper\n'
+        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         write(copyright, file=self.outFile)
         write('#include <string>', file=self.outFile)


### PR DESCRIPTION
Closes #3423

This creates a `spirv_grammar_helper.cpp/h` file for all the SPIR-V utils functions (slightly different then `spirv_validation_helper.cpp` which I added comments too)

To start, just replaced 2 simple util functions from `shader_module.cpp`

**The main thing** is the generate code now will have to look like

```
python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
```

which I tried adding to the various places I grepped for `generate_source` but not sure if there are internal CI scripts that would need to be updated as well