### PR TITLE
layers: Combine ValidateCmdCopyBuffer functions

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -846,6 +846,10 @@ class CoreChecks : public ValidationStateTracker {
 
     void PreCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo) override;
 
+    template <typename RegionType>
+    bool ValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
+                               const RegionType* pRegions, CopyCommandVersion version) const;
+
     bool PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
                                       const VkBufferCopy* pRegions) const override;
 


### PR DESCRIPTION
When doing https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3371 I realized we have a single function for `vkCmdCopyImage`, `vkCmdCopyImageToBuffer` and `vkCmdCopyBufferToImage` but was missing the same logic for `vkCmdCopyBuffer`

This just makes it a single nice function