### PR TITLE
layers: Clean up cmd version naming

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -273,7 +273,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDescriptorUpdateTemplate(const char* func_name, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo) const;
     bool ValidateCreateSamplerYcbcrConversion(const char* func_name, const VkSamplerYcbcrConversionCreateInfo* create_info) const;
     bool ValidateImportFence(VkFence fence, const char* vuid, const char* caller_name) const;
-    bool ValidateAcquireNextImage(VkDevice device, CommandVersion cmd_version, VkSwapchainKHR swapchain, uint64_t timeout,
+    bool ValidateAcquireNextImage(VkDevice device, AcquireVersion version, VkSwapchainKHR swapchain, uint64_t timeout,
                                   VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex, const char* func_name,
                                   const char* semaphore_type_vuid) const;
     bool VerifyRenderAreaBounds(const VkRenderPassBeginInfo* pRenderPassBegin, const char* func_name) const;

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -69,9 +69,15 @@ class EVENT_STATE;
 class SWAPCHAIN_NODE;
 class SURFACE_STATE;
 
+// These versions allow functions that are the same to share the same logic but can use different VUs
+// The common case are functions that were missing the pNext in Vulkan 1.0 and added via extension
+//
+// Added from VK_KHR_create_renderpass2
 enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };
+// Added from VK_KHR_copy_commands2
 enum CopyCommandVersion { COPY_COMMAND_VERSION_1 = 0, COPY_COMMAND_VERSION_2 = 1 };
-enum CommandVersion { CMD_VERSION_1 = 0, CMD_VERSION_2 = 1 };
+// Added from VK_KHR_device_group but added to VK_KHR_swapchain with Vulkan 1.1
+enum AcquireVersion { ACQUIRE_VERSION_1 = 0, ACQUIRE_VERSION_2 = 1 };
 
 // This structure is used to save data across the CreateGraphicsPipelines down-chain API call
 struct create_graphics_pipeline_api_state {


### PR DESCRIPTION
The name

```
enum CommandVersion { CMD_VERSION_1 = 0, CMD_VERSION_2 = 1 };
```

was misleading for how it was being used so made everything consistent and added some comments