### PR TITLE
Fix assert expression

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -3323,7 +3323,7 @@ void ResourceAccessState::TouchupFirstForLayoutTransition(ResourceUsageTag tag, 
     assert(first_accesses_.size());
     if (first_accesses_.back().tag == tag) {
         // If this layout transition is the the first write, add the additional ordering rules that guard the ILT
-        assert(first_accesses_.back().usage_index = SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
+        assert(first_accesses_.back().usage_index == SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
         first_write_layout_ordering_ = layout_ordering;
     }
 }


### PR DESCRIPTION
GCC 11.1 printed out this warning:

../layers/synchronization_validation.cpp: In member function ‘void
ResourceAccessState::TouchupFirstForLayoutTransition(ResourceUsageTag,
const ResourceAccessState::OrderingBar
rier&)’:
../layers/synchronization_validation.cpp:3326:51: warning: suggest
parentheses around assignment used as truth value [-Wparentheses]
 3326 |         assert(first_accesses_.back().usage_index =
 SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
       |
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This looks like an error in the code.

Signed-off-by: Samuel Iglesias Gonsálvez <siglesias@igalia.com>