### PR TITLE
layers: Handle allocation failures in vkCreateInstance()

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3416,9 +3416,16 @@ void ValidationStateTracker::PostCallRecordCreateInstance(const VkInstanceCreate
         return;
     }
     uint32_t count = 0;
-    DispatchEnumeratePhysicalDevices(*pInstance, &count, nullptr);
+    // this can fail if the allocator fails
+    result = DispatchEnumeratePhysicalDevices(*pInstance, &count, nullptr);
+    if (result != VK_SUCCESS) {
+        return;
+    }
     std::vector<VkPhysicalDevice> physdev_handles(count);
-    DispatchEnumeratePhysicalDevices(*pInstance, &count, physdev_handles.data());
+    result = DispatchEnumeratePhysicalDevices(*pInstance, &count, physdev_handles.data());
+    if (result != VK_SUCCESS) {
+        return;
+    }
 
     physical_device_map.reserve(count);
     for (auto physdev : physdev_handles) {


### PR DESCRIPTION
This fixes a crash introduced by commit ee3a3a229 in the CTS case:
dEQP-VK.api.device_init.create_instance_device_intentional_alloc_fail