### PR TITLE
layers: Move DescriptorSet cached validation to CMD_BUFFER_STATE

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -691,9 +691,7 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
 
 void CMD_BUFFER_STATE::End(VkResult result) {
     // Cached validation is specific to a specific recording of a specific command buffer.
-    for (auto *descriptor_set : validated_descriptor_sets) {
-        descriptor_set->ClearCachedValidation(this);
-    }
+    descriptorset_cache.clear();
     validated_descriptor_sets.clear();
     if (VK_SUCCESS == result) {
         state = CB_RECORDED;

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -298,7 +298,9 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::vector<std::function<bool(const ValidationStateTracker *device_data, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                    uint32_t perfQueryPass, QueryMap *localQueryToStateMap)>>
         queryUpdates;
-    layer_data::unordered_set<cvdescriptorset::DescriptorSet *> validated_descriptor_sets;
+    layer_data::unordered_set<const cvdescriptorset::DescriptorSet *> validated_descriptor_sets;
+    layer_data::unordered_map<const cvdescriptorset::DescriptorSet *, cvdescriptorset::DescriptorSet::CachedValidation>
+        descriptorset_cache;
     // Contents valid only after an index buffer is bound (CBSTATUS_INDEX_BUFFER_BOUND set)
     IndexBufferBinding index_buffer_binding;
     bool performance_lock_acquired = false;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2057,8 +2057,8 @@ void cvdescriptorset::DescriptorSet::FilterOneBindingReq(const BindingReqMap::va
 void cvdescriptorset::DescriptorSet::FilterBindingReqs(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
                                                        const BindingReqMap &in_req, BindingReqMap *out_req) const {
     // For const cleanliness we have to find in the maps...
-    const auto validated_it = cached_validation_.find(&cb_state);
-    if (validated_it == cached_validation_.cend()) {
+    const auto validated_it = cb_state.descriptorset_cache.find(this);
+    if (validated_it == cb_state.descriptorset_cache.end()) {
         // We have nothing validated, copy in to out
         for (const auto &binding_req_pair : in_req) {
             out_req->emplace(binding_req_pair);
@@ -2106,10 +2106,9 @@ void cvdescriptorset::DescriptorSet::FilterBindingReqs(const CMD_BUFFER_STATE &c
     }
 }
 
-void cvdescriptorset::DescriptorSet::UpdateValidationCache(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
+void cvdescriptorset::DescriptorSet::UpdateValidationCache(CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
                                                            const BindingReqMap &updated_bindings) {
-    // For const cleanliness we have to find in the maps...
-    auto &validated = cached_validation_[&cb_state];
+    auto &validated = cb_state.descriptorset_cache[this];
 
     auto &image_sample_version = validated.image_samplers[&pipeline];
     auto &dynamic_buffers = validated.dynamic_buffers;


### PR DESCRIPTION
Move the CachedValidation struct storage into CMD_BUFFER_STATE so that
it works like all the other per-CB caches.