### PR TITLE
layers: Fix line topology class check

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -976,6 +976,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 switch (pCB->primitiveTopology) {
                     case VK_PRIMITIVE_TOPOLOGY_LINE_LIST:
                     case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
+                    case VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY:
+                    case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY:
                         compatible_topology = true;
                         break;
                     default:


### PR DESCRIPTION
Fix checking line topology class when setting input assembly topology
dynamically.

Closes #3486.

FYI @pdaniell-nv as I _think_ this is correct, but it looks like the original change was intentional.