### PR TITLE
layers: Add min/maxTexelOffset check

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -535,7 +535,7 @@ class CoreChecks : public ValidationStateTracker {
                                       VkShaderStageFlagBits stage) const;
     bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src,
                                           spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
-    bool ValidateTexelGatherOffset(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
+    bool ValidateTexelOffsetLimits(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
     bool ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
                                                        bool has_atomic_descriptor) const;


### PR DESCRIPTION
adds

- VUID-RuntimeSpirv-OpImageSample-06435
- VUID-RuntimeSpirv-OpImageSample-06436

Tried to make use of the logic already there for the `(max)/(min)TexelGatherOffset` check