### PR TITLE
layers: Always run spirv-opt

### DIFF
--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -257,7 +257,9 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     SHADER_MODULE_STATE(const uint32_t *code, std::size_t count, spv_target_env env = SPV_ENV_VULKAN_1_0)
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          words(code, code + (count / sizeof(uint32_t))) {
+          words(code, code + (count / sizeof(uint32_t))),
+          static_data_(*this),
+          has_valid_spirv(true) {
         PreprocessShaderBinary(env);
     }
 

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -133,7 +133,7 @@ class ValidationCache {
     }
 };
 
-spv_target_env PickSpirvEnv(uint32_t api_version, bool spirv_1_4);
+spv_target_env PickSpirvEnv(uint32_t api_version, bool spirv_1_4, VkShaderStageFlagBits stage = VK_SHADER_STAGE_ALL_GRAPHICS);
 
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &options);

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -3537,8 +3537,10 @@ TEST_F(VkPositiveLayerTest, Storage8and16bit) {
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
                 layout(location = 0) out float16_t outData;
+                // Using spec constant to force glslang to use OpCapability Float16
+                layout(constant_id = 0) const float16_t x = 1.0hf;
                 void main(){
-                   outData = float16_t(1);
+                   outData = x;
                    gl_Position = vec4(0.0);
                 }
             )glsl";
@@ -3635,8 +3637,10 @@ TEST_F(VkPositiveLayerTest, Storage8and16bit) {
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
                 layout(location = 0) out int16_t outData;
+                // Using spec constant to force glslang to use OpCapability Int16
+                layout(constant_id = 0) const int16_t x = 1s;
                 void main(){
-                   outData = int16_t(1);
+                   outData = x;
                    gl_Position = vec4(0.0);
                 }
             )glsl";

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -707,6 +707,8 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
 
 class Sampler : public internal::NonDispHandle<VkSampler> {
   public:
+    Sampler() = default;
+    Sampler(const Device &dev, const VkSamplerCreateInfo &info) { init(dev, info); }
     ~Sampler() NOEXCEPT;
 
     // vkCreateSampler()


### PR DESCRIPTION
Always run spirv-opt to remove dead code and ensure instructions such
as OpSpecConstantOp are replaced with non-spec-const instructions.

Closes #3477.