### PR TITLE
layers: Update spirv xml version generator

### DIFF
--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -319,8 +319,9 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
     def createMapValue(self, name, enable, isExtension):
         output = ''
         if enable['version'] != None:
-            # Version should be VK_API_VERSION_x_x as defined in header
-            output = '{' + enable['version'] + ', nullptr, nullptr, ""}'
+            # Version should be VK_VERSION_x_x as defined in header but need to get as VK_API_VERSION_x_x
+            version = enable['version'].replace('VK_VERSION', 'VK_API_VERSION')
+            output = '{' + version + ', nullptr, nullptr, ""}'
         elif enable['feature'] != None:
             output = '{0, &' + enable['feature']['struct'] + '::'  + enable['feature']['feature'] + ', nullptr, ""}'
         elif enable['extension'] != None:


### PR DESCRIPTION
To make other things easier (see https://gitlab.khronos.org/vulkan/vulkan/-/issues/2896)

```patch
<spirvextension name="SPV_KHR_variable_pointers">
-    <enable version="VK_API_VERSION_1_1"/>
+    <enable version="VK_VERSION_1_1"/>
     <enable extension="VK_KHR_variable_pointers"/>
</spirvextension>
```

will happen in the future XML

Nice part of this change is if merged now, the comment will be a lie for a bit, but when the new headers come in things will just work as :magic_wand: 