### PR TITLE
 layers: Avoid crashing if VK_KHR_dynamic_rendering is enabled

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5447,6 +5447,25 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
     create_graphics_pipeline_api_state *cgpl_state = reinterpret_cast<create_graphics_pipeline_api_state *>(cgpl_state_data);
 
     for (uint32_t i = 0; i < count; i++) {
+        if (pCreateInfos[i].renderPass == VK_NULL_HANDLE) {
+            if (!enabled_features.dynamic_rendering_features.dynamicRendering) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-dynamicRendering-06052",
+                                 "vkCreateGraphicsPipeline: pCreateInfos[%" PRIu32
+                                 "].renderPass is VK_NULL_HANDLE but dynamicRendering is not enabled.",
+                                 i);
+
+            } else {
+                skip |= LogError(device, "UNASSIGNED-VkGraphicsPipelineCreateInfo-dynamicRendering-not-supported",
+                                 "vkCreateGraphicsPipeline: pCreateInfos[%" PRIu32
+                                 "].renderPass is VK_NULL_HANDLE. VK_KHR_dynamic_rendering is currently unsupported",
+                                 i);
+            }
+            // it is unsafe to continue validating so we need to always fail creation of the pipeline.
+            return true;
+        }
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
         skip |= ValidatePipelineLocked(cgpl_state->pipe_state, i);
     }
 

--- a/layers/device_state.h
+++ b/layers/device_state.h
@@ -89,6 +89,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features;
     VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT rgba10x6_formats_features;
     VkPhysicalDeviceMaintenance4FeaturesKHR maintenance4_features;
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };


### PR DESCRIPTION
Handle null render pass handles in vkCreateGraphicsPipeline(). This is an error if the feature is not enabled. But it needs to fail in any case until the pipeline creation code can be updated to properly create state objects using the extension.

Add a test case to pass null render pass handles without enabling the extension.