### PR TITLE
layers: Add warnings if VK_KHR_dynamic_rendering is enabled

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -240,5 +240,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SyncObjects_HighNumberOfF
     "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfFences";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SyncObjects_HighNumberOfSemaphores =
     "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfSemaphores";
+static const char DECORATE_UNUSED *kVUID_BestPractices_DynamicRendering_NotSupported =
+    "UNASSIGNED-BestPractices-DynamicRendering-NotSupported";
 
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1058,7 +1058,13 @@ void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device,
         if (create_info.pDepthStencilState) {
             cis.depthStencilStateCI.emplace(create_info.pDepthStencilState);
         }
-
+        if (create_info.renderPass == VK_NULL_HANDLE) {
+            // TODO: this is necessary to avoid crashing
+            LogWarning(device, kVUID_BestPractices_DynamicRendering_NotSupported,
+                       "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "].renderPass is VK_NULL_HANDLE, VK_KHR_dynamic_rendering is not supported.\n",
+                       static_cast<uint32_t>(i));
+            continue;
+        }
         // Record which frame buffer attachments we should consider to be accessed when a draw call is performed.
         RENDER_PASS_STATE* rp = GetRenderPassState(create_info.renderPass);
         auto& subpass = rp->createInfo.pSubpasses[create_info.subpass];

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -45,6 +45,7 @@ def main(argv):
     gen_cmds = [*[[common_codegen.repo_relative('scripts/lvl_genvk.py'),
                    '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
                    '-grammar', os.path.abspath(os.path.join(args.grammar,  'spirv.core.grammar.json')),
+                   '-warnExtensions', 'VK_KHR_dynamic_rendering',
                    '-quiet',
                    filename] for filename in ["chassis.cpp",
                                               "chassis.h",

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -59,6 +59,9 @@ def makeGenOpts(args):
     # Extensions to emit (list of extensions)
     emitExtensions = args.emitExtensions
 
+    # Extensions to warn about, if enabled(list of extensions)
+    warnExtensions = args.warnExtensions
+
     # Features to include (list of features)
     features = args.feature
 
@@ -372,6 +375,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            warnExtensions    = warnExtensions,
             helper_file_type  = 'layer_chassis_header')
         ]
 
@@ -387,6 +391,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            warnExtensions    = warnExtensions,
             helper_file_type  = 'layer_chassis_source')
         ]
 
@@ -623,6 +628,9 @@ if __name__ == '__main__':
     parser.add_argument('-emitExtensions', action='append',
                         default=[],
                         help='Specify an extension or extensions to emit in targets')
+    parser.add_argument('-warnExtensions', action='append',
+                        default=[],
+                        help='Specify an extension with partial support. Warning will be log if it is enabled')
     parser.add_argument('-feature', action='append',
                         default=[],
                         help='Specify a core API feature name or names to add to targets')


### PR DESCRIPTION
All types of validation will output:
`Validation Warning: [ VUID_Undefined ] Object 0: handle = 0x55e86db81ee0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x79de34d4 | Device Extension VK_KHR_dynamic_rendering support is incomplete, incorrect results are possible.`


Best Practices has problems in vkCreateGraphicsPipelines() so it also warns there:
`Validation Warning: [ UNASSIGNED-BestPractices-DynamicRendering-NotSupported ] Object 0: handle = 0x55f9555b6360, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xeac72bc0 | vkCreateGraphicsPipelines: pCreateInfos[0].renderPass is VK_NULL_HANDLE, VK_KHR_dynamic_rendering is not supported.`
