### PR TITLE
build: Renamed use_x11 to ozone_platform_x11

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -340,7 +340,7 @@ foreach(layer_info, layers) {
     if (is_linux || is_android) {
       ldflags = [ "-Wl,-Bsymbolic,--exclude-libs,ALL" ]
     }
-    if (use_x11) {
+    if (ozone_platform_x11) {
       defines += [ "VK_USE_PLATFORM_XLIB_KHR" ]
     }
     if (is_android) {

--- a/build-gn/secondary/build_overrides/vulkan_validation_layers.gni
+++ b/build-gn/secondary/build_overrides/vulkan_validation_layers.gni
@@ -23,4 +23,4 @@ vulkan_data_subdir = ""
 vulkan_gen_subdir = ""
 
 # Build options
-use_x11 = true
+ozone_platform_x11 = true


### PR DESCRIPTION
use_x11 that was added in https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/1ca0960a36fc9d4a2f5ce1364ece8d45cd66151b
is deprecated in Chromium. Instead, chrome is going to use
Ozone abstraction which has ozone_platform_x11 backend.
Thus, rename this gn to ozone_platform_x11.