### PR TITLE
layers: Make many state tracker data members protected or private

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -817,12 +817,11 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
     assert(cb_state != nullptr);
 
     std::vector<uint64_t> current_valid_handles;
-    for (const auto &as_state_kv : acceleration_structure_nv_map_) {
-        const ACCELERATION_STRUCTURE_STATE &as_state = *as_state_kv.second;
+    ForEach<ACCELERATION_STRUCTURE_STATE>([&current_valid_handles](const ACCELERATION_STRUCTURE_STATE &as_state) {
         if (as_state.built && as_state.create_infoNV.info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV) {
             current_valid_handles.push_back(as_state.opaque_handle);
         }
-    }
+    });
 
     GpuAssistedAccelerationStructureBuildValidationBufferInfo as_validation_buffer_info = {};
     as_validation_buffer_info.acceleration_structure = dst;


### PR DESCRIPTION
Reduce visibility of state tracker data members, especially the state maps, which are now all private.