### PR TITLE
build: Fix deprecated-copy warnings in clang 13

### DIFF
--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -70,6 +70,8 @@ struct Subresource : public VkImageSubresource {
         : VkImageSubresource({aspect_mask_, mip_level_, array_layer_}), aspect_index(aspect_index_) {}
     Subresource(VkImageAspectFlagBits aspect_, uint32_t mip_level_, uint32_t array_layer_, uint32_t aspect_index_)
         : Subresource(static_cast<VkImageAspectFlags>(aspect_), mip_level_, array_layer_, aspect_index_) {}
+
+    Subresource& operator=(const Subresource&) = default;
 };
 
 // Subresource is encoded in (from slowest varying to fastest)
@@ -415,6 +417,7 @@ class ImageRangeGenerator {
     inline const IndexRange& operator*() const { return pos_; }
     inline const IndexRange* operator->() const { return &pos_; }
     ImageRangeGenerator& operator++();
+    ImageRangeGenerator& operator=(const ImageRangeGenerator&) = default;
 
   private:
     bool Convert2DCompatibleTo3D();

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -272,6 +272,7 @@ class ResourceAccessState : public SyncStageAccess {
         VkPipelineStageFlags2KHR exec_scope;
         SyncStageAccessFlags access_scope;
         OrderingBarrier() = default;
+        OrderingBarrier(const OrderingBarrier &) = default;
         OrderingBarrier(VkPipelineStageFlags2KHR es, SyncStageAccessFlags as) : exec_scope(es), access_scope(as) {}
         OrderingBarrier &operator=(const OrderingBarrier &) = default;
         OrderingBarrier &operator|=(const OrderingBarrier &rhs) {
@@ -733,6 +734,7 @@ class AccessContext {
     struct TrackBack {
         std::vector<SyncBarrier> barriers;
         const AccessContext *context;
+        TrackBack(const TrackBack &) = default;
         TrackBack(const AccessContext *context_, VkQueueFlags queue_flags_,
                   const std::vector<const VkSubpassDependency2 *> &subpass_dependencies_)
             : barriers(), context(context_) {

--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -3906,6 +3906,8 @@ class VmaStlAllocator
 public:
     const VkAllocationCallbacks* const m_pCallbacks;
     typedef T value_type;
+
+    VmaStlAllocator(const VmaStlAllocator&) = default;
     
     VmaStlAllocator(const VkAllocationCallbacks* pCallbacks) : m_pCallbacks(pCallbacks) { }
     template<typename U> VmaStlAllocator(const VmaStlAllocator<U>& src) : m_pCallbacks(src.m_pCallbacks) { }


### PR DESCRIPTION
Starting in C++11, the use of the default copy constructor and
assignment operator is deprecated. The fix is to make the use of the
default copy constructor and assignment operator explicit.

Closes #3520.