### PR TITLE
layers: Add state tracking for host AS builds

### DIFF
--- a/layers/ray_tracing_state.h
+++ b/layers/ray_tracing_state.h
@@ -52,6 +52,11 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;
 
     VkAccelerationStructureNV acceleration_structure() const { return handle_.Cast<VkAccelerationStructureNV>(); }
+
+    void Build(const VkAccelerationStructureInfoNV *pInfo) {
+        built = true;
+        build_info.initialize(pInfo);
+    };
 };
 
 class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
@@ -78,6 +83,11 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BINDABLE {
     ACCELERATION_STRUCTURE_STATE_KHR(const ACCELERATION_STRUCTURE_STATE_KHR &rh_obj) = delete;
 
     VkAccelerationStructureKHR acceleration_structure() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
+
+    void Build(const VkAccelerationStructureBuildGeometryInfoKHR *pInfo) {
+        built = true;
+        build_info_khr.initialize(pInfo);
+    };
 };
 
 // Safe struct that spans NV and KHR VkRayTracingPipelineCreateInfo structures.

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -683,6 +683,10 @@ class ValidationStateTracker : public ValidationObject {
     void PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator,
                                                       VkAccelerationStructureKHR* pAccelerationStructure, VkResult result) override;
+    void PostCallRecordBuildAccelerationStructuresKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
+                                                      const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                      const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos,
+                                                      VkResult result) override;
     void PostCallRecordCmdBuildAccelerationStructuresKHR(
         VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
         const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) override;
@@ -1211,6 +1215,8 @@ class ValidationStateTracker : public ValidationObject {
     void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bindInfo);
     void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*) const;
 
+    void PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
+                                                    const VkCopyAccelerationStructureInfoKHR* pInfo, VkResult result) override;
     void PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                        const VkCopyAccelerationStructureInfoKHR* pInfo) override;
 


### PR DESCRIPTION
Adds the functions:

PostCallRecordBuildAccelerationStructuresKHR
PostCallRecordCopyAccelerationStructureKHR

to the ValidationStateTracker.

This allows for validation of host built acceleration structures