### PR TITLE
layers: Remove excess state object lookups

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -537,8 +537,7 @@ bool BestPractices::ValidateAttachments(const VkRenderPassCreateInfo2* rpci, uin
 
         auto view_state = GetImageViewState(image_views[i]);
         if (view_state) {
-            const auto& ivci = view_state->create_info;
-            const auto& ici = Get<IMAGE_STATE>(ivci.image)->createInfo;
+            const auto& ici = view_state->image_state->createInfo;
 
             bool image_is_transient = (ici.usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0;
 

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -285,7 +285,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::vector<std::function<bool(const ValidationStateTracker *device_data, const class QUEUE_STATE *queue_state)>>
         queue_submit_functions_after_render_pass;
     // Validation functions run when secondary CB is executed in primary
-    std::vector<std::function<bool(const CMD_BUFFER_STATE *, const FRAMEBUFFER_STATE *)>> cmd_execute_commands_functions;
+    std::vector<std::function<bool(const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *primary, const FRAMEBUFFER_STATE *)>>
+        cmd_execute_commands_functions;
     std::vector<
         std::function<bool(const ValidationStateTracker *device_data, bool do_validate, EventToStageMap *localEventToStageMap)>>
         eventUpdates;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -594,7 +594,7 @@ class CoreChecks : public ValidationStateTracker {
                                        const char* param_name, const char* image_layer_count_var_name, const VkImage image,
                                        const SubresourceRangeErrorCodes& errorCodes) const;
     bool ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPassCreateVersion rp_version, VkImageLayout layout,
-                                                              VkImage image, VkImageView image_view, VkFramebuffer framebuffer,
+                                                              const IMAGE_VIEW_STATE& image_view_state, VkFramebuffer framebuffer,
                                                               VkRenderPass renderpass, uint32_t attachment_index,
                                                               const char* variable_name) const;
     template <typename RegionType>
@@ -620,7 +620,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateImageAttributes(const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
                                  const char* param_name) const;
 
-    bool ValidateClearAttachmentExtent(VkCommandBuffer command_buffer, uint32_t attachment_index,
+    bool ValidateClearAttachmentExtent(const CMD_BUFFER_STATE &cb_node, uint32_t attachment_index,
                                        const IMAGE_VIEW_STATE *image_view_state, const VkRect2D& render_area,
                                        uint32_t rect_count, const VkClearRect* clear_rects) const;
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2251,7 +2251,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     VkImage image = iv_state->create_info.image;
     VkFormat format = VK_FORMAT_MAX_ENUM;
     VkImageUsageFlags usage = 0;
-    auto image_node = GetImageState(image);
+    auto *image_node = iv_state->image_state.get();
     assert(image_node);
 
     format = image_node->createInfo.format;


### PR DESCRIPTION
Remove some places where we were doing unnecessary lookups of
state objects from handles, when there is already a pointer to the
state object available. None of these seem to have a measurable
performance difference, but that might change once we move to
fine grained locking.