### PR TITLE
layers: Pre generated format utils changes

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3968,7 +3968,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
         }
 
         // Validate consistency for unsigned formats
-        if (FormatIsUInt(src_format) != FormatIsUInt(dst_format)) {
+        if (FormatIsUINT(src_format) != FormatIsUINT(dst_format)) {
             std::stringstream ss;
             ss << func_name << ": If one of srcImage and dstImage images has unsigned integer format, "
                << "the other one must also have unsigned integer format.  "
@@ -3978,7 +3978,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
         }
 
         // Validate consistency for signed formats
-        if (FormatIsSInt(src_format) != FormatIsSInt(dst_format)) {
+        if (FormatIsSINT(src_format) != FormatIsSINT(dst_format)) {
             std::stringstream ss;
             ss << func_name << ": If one of srcImage and dstImage images has signed integer format, "
                << "the other one must also have signed integer format.  "

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -15805,7 +15805,7 @@ bool CoreChecks::ValidateCreateSamplerYcbcrConversion(const char *func_name,
     }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
-    if ((external_format == false) && (FormatIsUNorm(conversion_format) == false)) {
+    if ((external_format == false) && (FormatIsUNORM(conversion_format) == false)) {
         const char *vuid = IsExtEnabled(device_extensions.vk_android_external_memory_android_hardware_buffer)
                                ? "VUID-VkSamplerYcbcrConversionCreateInfo-format-04061"
                                : "VUID-VkSamplerYcbcrConversionCreateInfo-format-04060";

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -930,8 +930,8 @@ static char const *StringDescriptorReqComponentType(DescriptorReqFlags req) {
 }
 
 unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt) {
-    if (FormatIsSInt(fmt)) return DESCRIPTOR_REQ_COMPONENT_TYPE_SINT;
-    if (FormatIsUInt(fmt)) return DESCRIPTOR_REQ_COMPONENT_TYPE_UINT;
+    if (FormatIsSINT(fmt)) return DESCRIPTOR_REQ_COMPONENT_TYPE_SINT;
+    if (FormatIsUINT(fmt)) return DESCRIPTOR_REQ_COMPONENT_TYPE_UINT;
     // Formats such as VK_FORMAT_D16_UNORM_S8_UINT are both
     if (FormatIsDepthAndStencil(fmt)) return DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT | DESCRIPTOR_REQ_COMPONENT_TYPE_UINT;
     if (fmt == VK_FORMAT_UNDEFINED) return 0;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -1245,7 +1245,8 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
                                  "vkCreateImageView(): VkImageViewASTCDecodeModeEXT::decodeMode must be "
                                  "VK_FORMAT_R16G16B16A16_SFLOAT, VK_FORMAT_R8G8B8A8_UNORM, or VK_FORMAT_E5B9G9R9_UFLOAT_PACK32.");
             }
-            if (FormatIsCompressed_ASTC(pCreateInfo->format) == false) {
+            if ((FormatIsCompressed_ASTC_LDR(pCreateInfo->format) == false) &&
+                (FormatIsCompressed_ASTC_HDR(pCreateInfo->format) == false)) {
                 skip |= LogError(device, "VUID-VkImageViewASTCDecodeModeEXT-format-04084",
                                  "vkCreateImageView(): is using a VkImageViewASTCDecodeModeEXT but the image view format is %s and "
                                  "not an ASTC format.",

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -107,8 +107,8 @@ static unsigned GetLocationsConsumedByFormat(VkFormat format) {
 }
 
 static unsigned GetFormatType(VkFormat fmt) {
-    if (FormatIsSInt(fmt)) return FORMAT_TYPE_SINT;
-    if (FormatIsUInt(fmt)) return FORMAT_TYPE_UINT;
+    if (FormatIsSINT(fmt)) return FORMAT_TYPE_SINT;
+    if (FormatIsUINT(fmt)) return FORMAT_TYPE_UINT;
     // Formats such as VK_FORMAT_D16_UNORM_S8_UINT are both
     if (FormatIsDepthAndStencil(fmt)) return FORMAT_TYPE_FLOAT | FORMAT_TYPE_UINT;
     if (fmt == VK_FORMAT_UNDEFINED) return 0;

--- a/layers/vk_format_utils.h
+++ b/layers/vk_format_utils.h
@@ -38,7 +38,8 @@
 extern "C" {
 #endif
 
-#define VK_MULTIPLANE_FORMAT_MAX_PLANES 3
+static constexpr uint32_t FORMAT_MAX_PLANES = 3;
+static constexpr uint32_t FORMAT_MAX_COMPONENTS = 4;
 
 typedef enum VkFormatCompatibilityClass {
     VK_FORMAT_COMPATIBILITY_CLASS_NONE_BIT = 0,
@@ -146,23 +147,21 @@ VK_LAYER_EXPORT bool FormatIsDepthAndStencil(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsDepthOnly(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsStencilOnly(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed_ETC2_EAC(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsCompressed_ASTC(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed_ASTC_LDR(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed_ASTC_HDR(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed_BC(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed_PVRTC(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsSinglePlane_422(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsBlockedImage(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsNorm(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsUNorm(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsSNorm(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsInt(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsSInt(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsUInt(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsFloat(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsUNORM(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsSNORM(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsSINT(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsUINT(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsSFLOAT(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsUFLOAT(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsSRGB(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsUScaled(VkFormat format);
-VK_LAYER_EXPORT bool FormatIsSScaled(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsUSCALED(VkFormat format);
+VK_LAYER_EXPORT bool FormatIsSSCALED(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsSampledInt(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsSampledFloat(VkFormat format);
 VK_LAYER_EXPORT bool FormatIsCompressed(VkFormat format);
@@ -182,7 +181,6 @@ VK_LAYER_EXPORT VkExtent3D FormatTexelBlockExtent(VkFormat format);
 VK_LAYER_EXPORT uint32_t FormatElementSize(VkFormat format, VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT);
 VK_LAYER_EXPORT double FormatTexelSize(VkFormat format, VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT);
 VK_LAYER_EXPORT VkFormatCompatibilityClass FormatCompatibilityClass(VkFormat format);
-VK_LAYER_EXPORT uint32_t GetPlaneIndex(VkImageAspectFlags aspect);
 VK_LAYER_EXPORT VkFormat FindMultiplaneCompatibleFormat(VkFormat fmt, VkImageAspectFlags plane_aspect);
 VK_LAYER_EXPORT VkExtent2D FindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspectFlags plane_aspect);
 

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -223,6 +223,25 @@ static inline VkDeviceSize GetIndexAlignment(VkIndexType indexType) {
     }
 }
 
+static inline uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
+    // Returns an out of bounds index on error
+    switch (aspect) {
+        case VK_IMAGE_ASPECT_PLANE_0_BIT:
+            return 0;
+            break;
+        case VK_IMAGE_ASPECT_PLANE_1_BIT:
+            return 1;
+            break;
+        case VK_IMAGE_ASPECT_PLANE_2_BIT:
+            return 2;
+            break;
+        default:
+            // If more than one plane bit is set, return error condition
+            return FORMAT_MAX_PLANES;
+            break;
+    }
+}
+
 // Perform a zero-tolerant modulo operation
 static inline VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor) {
     VkDeviceSize result = 0;


### PR DESCRIPTION
I have a change that generates the `vk_format_utils.cpp` file using the new `<formats>` tags in the 1.2.199 Header's `vk.xml`

There are some things that distract from the real change of generating the code, so decided to make it as a first commit/PR to ease the next on the eyes a bit

commented reasons inline