### PR TITLE
layers: Add unwrap of ASReference in host builds

### DIFF
--- a/layers/generated/vk_safe_struct.h
+++ b/layers/generated/vk_safe_struct.h
@@ -11899,12 +11899,12 @@ struct safe_VkAccelerationStructureGeometryKHR {
     VkGeometryTypeKHR geometryType;
     VkAccelerationStructureGeometryDataKHR geometry;
     VkGeometryFlagsKHR flags;
-    safe_VkAccelerationStructureGeometryKHR(const VkAccelerationStructureGeometryKHR* in_struct);
+    safe_VkAccelerationStructureGeometryKHR(const VkAccelerationStructureGeometryKHR* in_struct, const bool is_host, const VkAccelerationStructureBuildRangeInfoKHR *build_range_info);
     safe_VkAccelerationStructureGeometryKHR(const safe_VkAccelerationStructureGeometryKHR& copy_src);
     safe_VkAccelerationStructureGeometryKHR& operator=(const safe_VkAccelerationStructureGeometryKHR& copy_src);
     safe_VkAccelerationStructureGeometryKHR();
     ~safe_VkAccelerationStructureGeometryKHR();
-    void initialize(const VkAccelerationStructureGeometryKHR* in_struct);
+    void initialize(const VkAccelerationStructureGeometryKHR* in_struct, const bool is_host, const VkAccelerationStructureBuildRangeInfoKHR *build_range_info);
     void initialize(const safe_VkAccelerationStructureGeometryKHR* copy_src);
     VkAccelerationStructureGeometryKHR *ptr() { return reinterpret_cast<VkAccelerationStructureGeometryKHR *>(this); }
     VkAccelerationStructureGeometryKHR const *ptr() const { return reinterpret_cast<VkAccelerationStructureGeometryKHR const *>(this); }
@@ -11922,12 +11922,12 @@ struct safe_VkAccelerationStructureBuildGeometryInfoKHR {
     safe_VkAccelerationStructureGeometryKHR* pGeometries{};
     safe_VkAccelerationStructureGeometryKHR** ppGeometries{};
     safe_VkDeviceOrHostAddressKHR scratchData;
-    safe_VkAccelerationStructureBuildGeometryInfoKHR(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct);
+    safe_VkAccelerationStructureBuildGeometryInfoKHR(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct, const bool is_host, const VkAccelerationStructureBuildRangeInfoKHR *build_range_infos);
     safe_VkAccelerationStructureBuildGeometryInfoKHR(const safe_VkAccelerationStructureBuildGeometryInfoKHR& copy_src);
     safe_VkAccelerationStructureBuildGeometryInfoKHR& operator=(const safe_VkAccelerationStructureBuildGeometryInfoKHR& copy_src);
     safe_VkAccelerationStructureBuildGeometryInfoKHR();
     ~safe_VkAccelerationStructureBuildGeometryInfoKHR();
-    void initialize(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct);
+    void initialize(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct, const bool is_host, const VkAccelerationStructureBuildRangeInfoKHR *build_range_infos);
     void initialize(const safe_VkAccelerationStructureBuildGeometryInfoKHR* copy_src);
     VkAccelerationStructureBuildGeometryInfoKHR *ptr() { return reinterpret_cast<VkAccelerationStructureBuildGeometryInfoKHR *>(this); }
     VkAccelerationStructureBuildGeometryInfoKHR const *ptr() const { return reinterpret_cast<VkAccelerationStructureBuildGeometryInfoKHR const *>(this); }

--- a/layers/ray_tracing_state.h
+++ b/layers/ray_tracing_state.h
@@ -104,9 +104,10 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
         }
     }
 
-    void Build(const VkAccelerationStructureBuildGeometryInfoKHR *pInfo) {
+    void Build(const VkAccelerationStructureBuildGeometryInfoKHR *pInfo, const bool is_host,
+               const VkAccelerationStructureBuildRangeInfoKHR *build_range_info) {
         built = true;
-        build_info_khr.initialize(pInfo);
+        build_info_khr.initialize(pInfo, is_host, build_range_info);
     };
 
     const safe_VkAccelerationStructureCreateInfoKHR create_infoKHR = {};

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2574,7 +2574,7 @@ void ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(
     for (uint32_t i = 0; i < infoCount; ++i) {
         auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].dstAccelerationStructure);
         if (dst_as_state != nullptr) {
-            dst_as_state->Build(&pInfos[i]);
+            dst_as_state->Build(&pInfos[i], true, *ppBuildRangeInfos);
         }
     }
 }
@@ -2584,7 +2584,7 @@ void ValidationStateTracker::RecordDeviceAccelerationStructureBuildInfo(CMD_BUFF
                                                                         const VkAccelerationStructureBuildGeometryInfoKHR &info) {
     auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info.dstAccelerationStructure);
     if (dst_as_state) {
-        dst_as_state->Build(&info);
+        dst_as_state->Build(&info, false, nullptr);
     }
     if (disabled[command_buffer_state]) {
         return;

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1365,6 +1365,61 @@ VkResult DispatchGetDeferredOperationResultKHR(
 
     return result;
 }
+
+VkResult DispatchBuildAccelerationStructuresKHR(
+    VkDevice                                    device,
+    VkDeferredOperationKHR                      deferredOperation,
+    uint32_t                                    infoCount,
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos)
+{
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    if (!wrap_handles) return layer_data->device_dispatch_table.BuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos);
+    safe_VkAccelerationStructureBuildGeometryInfoKHR *local_pInfos = NULL;
+    {
+        deferredOperation = layer_data->Unwrap(deferredOperation);
+        if (pInfos) {
+            local_pInfos = new safe_VkAccelerationStructureBuildGeometryInfoKHR[infoCount];
+            for (uint32_t index0 = 0; index0 < infoCount; ++index0) {
+                local_pInfos[index0].initialize(&pInfos[index0], true, ppBuildRangeInfos[index0]);
+                if (pInfos[index0].srcAccelerationStructure) {
+                    local_pInfos[index0].srcAccelerationStructure = layer_data->Unwrap(pInfos[index0].srcAccelerationStructure);
+                }
+                if (pInfos[index0].dstAccelerationStructure) {
+                    local_pInfos[index0].dstAccelerationStructure = layer_data->Unwrap(pInfos[index0].dstAccelerationStructure);
+                }
+                for (uint32_t geometry_index = 0; geometry_index < local_pInfos[index0].geometryCount; ++geometry_index) {
+                    safe_VkAccelerationStructureGeometryKHR &geometry_info = local_pInfos[index0].pGeometries != nullptr ? local_pInfos[index0].pGeometries[geometry_index] : *(local_pInfos[index0].ppGeometries[geometry_index]);
+                    if (geometry_info.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+                        if (geometry_info.geometry.instances.arrayOfPointers) {
+                            const uint8_t *byte_ptr = reinterpret_cast<const uint8_t*>(geometry_info.geometry.instances.data.hostAddress);
+                            VkAccelerationStructureInstanceKHR **instances = (VkAccelerationStructureInstanceKHR **)(byte_ptr + ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
+                            for (uint32_t instance_index = 0; instance_index < ppBuildRangeInfos[index0][geometry_index].primitiveCount; ++instance_index) {
+                                instances[instance_index]->accelerationStructureReference = layer_data->Unwrap(instances[instance_index]->accelerationStructureReference);
+                            }
+                        } else {
+                            const uint8_t *byte_ptr = reinterpret_cast<const uint8_t*>(geometry_info.geometry.instances.data.hostAddress);
+                            VkAccelerationStructureInstanceKHR *instances = (VkAccelerationStructureInstanceKHR *)(byte_ptr + ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
+                            for (uint32_t instance_index = 0; instance_index < ppBuildRangeInfos[index0][geometry_index].primitiveCount; ++instance_index) {
+                                instances[instance_index].accelerationStructureReference = layer_data->Unwrap(instances[instance_index].accelerationStructureReference);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    VkResult result = layer_data->device_dispatch_table.BuildAccelerationStructuresKHR(device, deferredOperation, infoCount, (const VkAccelerationStructureBuildGeometryInfoKHR*)local_pInfos, ppBuildRangeInfos);
+    if (local_pInfos) {
+        if (deferredOperation != VK_NULL_HANDLE) {
+            std::vector<std::function<void()>> cleanup{ [local_pInfos](){ delete[] local_pInfos; } };
+            layer_data->deferred_operation_post_completion.insert(deferredOperation, cleanup);
+        } else {
+            delete[] local_pInfos;
+        }
+    }
+    return result;
+}
 """
     # Separate generated text for source and headers
     ALL_SECTIONS = ['source_file', 'header_file']
@@ -1427,6 +1482,7 @@ VkResult DispatchGetDeferredOperationResultKHR(
             'vkGetDeferredOperationResultKHR',
             'vkSetPrivateData',
             'vkGetPrivateData',
+            'vkBuildAccelerationStructuresKHR',
             # These are for special-casing the pInheritanceInfo issue (must be ignored for primary CBs)
             'vkAllocateCommandBuffers',
             'vkFreeCommandBuffers',
@@ -1934,7 +1990,11 @@ VkResult DispatchGetDeferredOperationResultKHR(
                         indent = self.incIndent(indent)
                         if first_level_param == True:
                             if 'safe_' in safe_type:
-                                pre_code += '%s    %s[%s].initialize(&%s[%s]);\n' % (indent, new_prefix, index, member.name, index)
+                                # Handle special initialize function for VkAccelerationStructureBuildGeometryInfoKHR
+                                if member.type == "VkAccelerationStructureBuildGeometryInfoKHR":
+                                    pre_code += '%s    %s[%s].initialize(&%s[%s], false, nullptr);\n' % (indent, new_prefix, index, member.name, index)
+                                else:
+                                    pre_code += '%s    %s[%s].initialize(&%s[%s]);\n' % (indent, new_prefix, index, member.name, index)
                             else:
                                 pre_code += '%s    %s[%s] = %s[%s];\n' % (indent, new_prefix, index, member.name, index)
                             if process_pnext:
@@ -1972,7 +2032,11 @@ VkResult DispatchGetDeferredOperationResultKHR(
                             else:
                                 pre_code += '%s    local_%s = new %s;\n' % (indent, member.name, safe_type)
                             if 'safe_' in safe_type:
-                                pre_code += '%s    local_%s%s->initialize(%s);\n' % (indent, prefix, member.name, member.name)
+                                # Handle special initialize function for VkAccelerationStructureBuildGeometryInfoKHR
+                                if member.type == "VkAccelerationStructureBuildGeometryInfoKHR":
+                                    pre_code += '%s    local_%s%s->initialize(%s, false, nullptr);\n' % (indent, prefix, member.name, member.name)
+                                else:
+                                    pre_code += '%s    local_%s%s->initialize(%s);\n' % (indent, prefix, member.name, member.name)
                             else:
                                 pre_code += '%s    *local_%s%s = *%s;\n' % (indent, prefix, member.name, member.name)
                         # Process sub-structs in this struct


### PR DESCRIPTION
Hi maintainers,

I'm creating this draft PR mostly as a basis for discussion, as I'm not sure the current approach is the best way to solve this problem.

The issue I'm trying so solve is that [accelerationStructureReference in VkAccelerationStructureInstanceKHR](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureInstanceKHR.html) are wrapped when using the Validation Layer, which leads to issues for host builds when dereferencing them.

The current solution adds an unwrap of the accelerationStructureReference to [DispatchBuildAccelerationStructuresKHR](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3559/files#diff-dd8b2540519d29de84eacbb70d2221a96f68acabcb7e0a363743f51fb6f4878aR1263) in case of host builds, which requires additional changes:
The constructor of [VkAccelerationStructureGeometryKHR](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3559/files#diff-6cb4072fbb883af4aa2e29886c4425a795cf86487bdd9920aba0404c1a1dc0f8R1581) (and by extension [VkAccelerationStructureBuildGeometryInfoKHR](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3559/files#diff-6cb4072fbb883af4aa2e29886c4425a795cf86487bdd9920aba0404c1a1dc0f8R1572)) needs to know whether the build is on host and requires access to VkAccelerationStructureBuildRangeInfoKHR. This is needed in order to make additional allocations that we later can modify by unwrapping the accelerationStructureReference.

While the current patch works, it is not ideal: it is quite large, contains pointer arithmetic and currently leaks the buffer allocations in VkAccelerationStructureGeometryKHR's constructor.

I'm therefore wondering if there are better ways to achieve this unwrapping, or if the current approach should be cleaned up and added for review?