### PR TITLE
layers: Add various VK_KHR_dynamic_rendering VUs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1091,6 +1091,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
                                              const VkRenderingInfoKHR* pRenderingInfo) const override;
     bool ValidateRenderingAttachmentInfoKHR(VkCommandBuffer commandBuffer, const VkRenderingAttachmentInfoKHR* pAttachments) const;
+    bool PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer) const override;
     bool PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer) const override;
     bool PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) const override;
     bool PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,


### PR DESCRIPTION
Add VUs for:

VUID-vkCmdBeginRenderingKHR-dynamicRendering-06446
VUID-vkCmdBeginRenderingKHR-commandBuffer-06068
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169
VUID-vkCmdEndRenderPass-None-06170
VUID-vkCmdEndRenderPass2-None-06171
VUID-VkPipelineRenderingCreateInfoKHR-pColorAttachmentFormats-06064
VUID-VkPipelineRenderingCreateInfoKHR-depthAttachmentFormat-06065
VUID-VkPipelineRenderingCreateInfoKHR-stencilAttachmentFormat-06164
VUID-VkPipelineRenderingCreateInfoKHR-depthAttachmentFormat-06165
VUID-VkPipelineRenderingCreateInfoKHR-multiview-06066
VUID-VkPipelineRenderingCreateInfoKHR-viewMask-06067
VUID-vkCmdExecuteCommands-contents-06018
VUID-vkCmdExecuteCommands-pCommandBuffers-06019
VUID-vkCmdExecuteCommands-pBeginInfo-06020
VUID-vkCmdExecuteCommands-flags-06024
VUID-vkCmdExecuteCommands-pBeginInfo-06025
VUID-vkCmdExecuteCommands-flags-06026
VUID-vkCmdExecuteCommands-colorAttachmentCount-06027
VUID-vkCmdExecuteCommands-imageView-06028
VUID-vkCmdExecuteCommands-pDepthAttachment-06029
VUID-vkCmdExecuteCommands-pStencilAttachment-06030
VUID-vkCmdExecuteCommands-viewMask-06031
VUID-vkCmdEndRenderingKHR-None-06161
VUID-vkCmdEndRenderingKHR-commandBuffer-06162

EDIT:
Removed these due to some duplicated VUs:
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168
VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169