### PR TITLE
layers: Use find_package() for the dependencies that support it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,20 @@ else()
     message("********************************************************************************")
     find_package(PythonInterp 3 QUIET)
 endif()
+#backwards compatability settings for other parts of the build system that don't use find_package() variables yet
+if (ROBIN_HOOD_HASHING_INSTALL_DIR)
+    list(APPEND CMAKE_PREFIX_PATH ${ROBIN_HOOD_HASHING_INSTALL_DIR})
+endif()
+if (SPIRV_HEADERS_INSTALL_DIR)
+    list(APPEND CMAKE_PREFIX_PATH ${SPIRV_HEADERS_INSTALL_DIR})
+endif()
+if (SPIRV_TOOLS_INSTALL_DIR)
+    list(APPEND CMAKE_PREFIX_PATH ${SPIRV_TOOLS_INSTALL_DIR})
+endif()
+if (GOOGLETEST_INSTALL_DIR)
+    list(APPEND CMAKE_PREFIX_PATH ${GOOGLETEST_INSTALL_DIR})
+endif()
+
 
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
@@ -237,10 +251,11 @@ option(BUILD_LAYERS "Build layers" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Generate layer files" OFF) # For generating files when not building layers
 option(USE_ROBIN_HOOD_HASHING "Use robin-hood-hashing" ON)
 if (USE_ROBIN_HOOD_HASHING)
-    if(NOT ROBIN_HOOD_HASHING_INSTALL_DIR)
-	set(ROBIN_HOOD_HASHING_INSTALL_DIR $ENV{ROBIN_HOOD_HASHING_INSTALL_DIR} PATH "Path to robin-hood-hashing repository")
-    endif()
-    set(ROBIN_HOOD_HASHING_INCLUDE_DIR "${ROBIN_HOOD_HASHING_INSTALL_DIR}/src/include" PATH "Path to robin-hood-hashing/src/include")
+    find_package(robin_hood REQUIRED CONFIG)
+endif()
+
+if(BUILD_LAYERS OR BUILD_TESTS)
+    find_package(SPIRV-Headers REQUIRED CONFIG)
 endif()
 
 if(BUILD_TESTS)
@@ -254,20 +269,7 @@ if(BUILD_TESTS)
         set(GLSLANG_INSTALL_DIR $ENV{GLSLANG_INSTALL_DIR})
     endif()
 
-    # CMake command line option overrides environment variable
-    if(NOT SPIRV_HEADERS_INSTALL_DIR)
-        set(SPIRV_HEADERS_INSTALL_DIR $ENV{SPIRV_HEADERS_INSTALL_DIR})
-    endif()
-
-    if(NOT SPIRV_TOOLS_INSTALL_DIR)
-        set(SPIRV_TOOLS_INSTALL_DIR $ENV{SPIRV_TOOLS_INSTALL_DIR})
-    endif()
-
     if (NOT TARGET glslang)
-        if(NOT SPIRV_HEADERS_INSTALL_DIR)
-            message(FATAL_ERROR "Must define location of SPIRV-Headers -- see BUILD.md")
-        endif()
-
         message(STATUS "Using glslang install located at ${GLSLANG_INSTALL_DIR}")
         set(GLSLANG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
         set(GLSLANG_DEBUG_SEARCH_PATH "${GLSLANG_INSTALL_DIR}/lib")
@@ -299,34 +301,6 @@ if(BUILD_TESTS)
     else()
         set(GLSLANG_INCLUDE_DIR "${glslang_SOURCE_DIR}" CACHE PATH "Path to glslang headers")
         set(GLSLANG_LIBRARIES glslang SPIRV SPVRemapper)
-    endif()
-endif()
-
-if(BUILD_TESTS OR BUILD_LAYERS)
-    # spirv-tools
-    if (NOT TARGET SPIRV-Tools)
-        if(NOT SPIRV_TOOLS_INSTALL_DIR)
-            set(SPIRV_TOOLS_INSTALL_DIR "${GLSLANG_INSTALL_DIR}")
-        endif()
-
-        set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include" CACHE PATH "Path to spirv-headers")
-        set(SPIRV_TOOLS_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
-            CACHE PATH "User defined path to the SPIRV-Tools binaries for this project")
-        set(SPIRV_TOOLS_OPT_BINARY_ROOT "${SPIRV_TOOLS_INSTALL_DIR}/lib"
-            CACHE PATH "User defined path to the SPIRV-Tools-opt binaries for this project")
-        set(SPIRV_TOOLS_INCLUDE_DIR "${SPIRV_TOOLS_INSTALL_DIR}/include" CACHE PATH "Path to spirv tools headers")
-        set(SPIRV_TOOLS_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_OPT_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-        set(SPIRV_TOOLS_OPT_DEBUG_SEARCH_PATH "${SPIRV_TOOLS_INSTALL_DIR}/lib")
-
-        find_library(SPIRV_TOOLS_LIB NAMES SPIRV-Tools HINTS ${SPIRV_TOOLS_SEARCH_PATH})
-        find_library(SPIRV_TOOLS_OPT_LIB NAMES SPIRV-Tools-opt HINTS ${SPIRV_TOOLS_OPT_SEARCH_PATH})
-
-        set(SPIRV_TOOLS_LIBRARIES ${SPIRV_TOOLS_OPT_LIB} ${SPIRV_TOOLS_LIB})
-    else()
-        set(SPIRV_TOOLS_LIBRARIES SPIRV-Tools SPIRV-Tools-opt)
-        set(SPIRV_TOOLS_INCLUDE_DIR "${spirv-tools_SOURCE_DIR}/include" CACHE PATH "Path to spirv tools headers")
     endif()
 endif()
 
@@ -372,7 +346,7 @@ target_include_directories(VkLayer_utils
                                   ${VulkanHeaders_INCLUDE_DIR})
 
 if (USE_ROBIN_HOOD_HASHING)
-    target_include_directories(VkLayer_utils PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
+    target_link_libraries(VkLayer_utils PUBLIC robin_hood::robin_hood)
     target_compile_definitions(VkLayer_utils PUBLIC USE_ROBIN_HOOD_HASHING)
 endif()
 
@@ -413,37 +387,8 @@ endif()
 
 if(BUILD_TESTS)
     # Attempt to enable googletest if available.
-
-    if(TARGET gtest_main)
-        # Already enabled as a target (perhaps by a project enclosing this one)
-        message(STATUS "Vulkan-ValidationLayers/external: " "googletest already configured - using it")
-    elseif(IS_DIRECTORY "${GOOGLETEST_INSTALL_DIR}")
-        # The googletest directory exists, so enable it as a target.
-        message(STATUS "Vulkan-ValidationLayers/external: " "googletest found - configuring it for tests")
-        set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-        set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-        set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
-        set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-        # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
-        add_subdirectory("${GOOGLETEST_INSTALL_DIR}" ${CMAKE_BINARY_DIR}/googletest)
-    else()
-        message(SEND_ERROR "Could not find googletest directory. Be sure to run update_deps.py with the --tests option to download the appropriate version of googletest")
-        set(BUILD_TESTS OFF)
-    endif()
-
-    if (WIN32)
-        set_target_properties(gtest PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-        set_target_properties(gtest_main PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-    endif()
-
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set_target_properties(gtest PROPERTIES COMPILE_OPTIONS "-w")
-        set_target_properties(gtest_main PROPERTIES COMPILE_OPTIONS "-w")
-    endif()
-
-    if (BUILD_TESTS)
-        add_subdirectory(tests ${CMAKE_BINARY_DIR}/tests)
-    endif()
+    find_package(GTest REQUIRED CONFIG)
+    add_subdirectory(tests ${CMAKE_BINARY_DIR}/tests)
 endif()
 
 if(BUILD_LAYERS OR BUILD_LAYER_SUPPORT_FILES)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -269,6 +269,8 @@ if(INSTRUMENT_OPTICK)
 endif()
 
 if(BUILD_LAYERS)
+    find_package(SPIRV-Tools REQUIRED CONFIG)
+    find_package(SPIRV-Tools-opt REQUIRED CONFIG)
     AddVkLayer(khronos_validation "${KHRONOS_LAYER_COMPILE_DEFINITIONS}"
         ${CHASSIS_LIBRARY_FILES}
         ${CORE_VALIDATION_LIBRARY_FILES}
@@ -296,15 +298,14 @@ if(BUILD_LAYERS)
 
     # Khronos validation additional dependencies
     target_include_directories(VkLayer_khronos_validation PRIVATE ${GLSLANG_INCLUDE_DIR})
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
-    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     if(INSTRUMENT_OPTICK)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${OPTICK_SOURCE_DIR})
     endif()
     if (USE_ROBIN_HOOD_HASHING)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
     endif()
-    target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_LIBRARIES})
+    target_link_libraries(VkLayer_khronos_validation PRIVATE SPIRV-Headers::SPIRV-Headers SPIRV-Tools-static SPIRV-Tools-opt)
+
 
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
     # because the json format uses backslash escapes

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -76,16 +76,6 @@ def BuildVVL(args, build_tests=False):
     cmake_ver_cmd = 'cmake --version'
     RunShellCmd(cmake_ver_cmd)
 
-    GTEST_DIR = RepoRelative("external/googletest")
-    if not os.path.exists(GTEST_DIR):
-        print("Clone Testing Framework Source Code")
-        clone_gtest_cmd = f'git clone https://github.com/google/googletest.git {GTEST_DIR}'
-        RunShellCmd(clone_gtest_cmd)
-
-        print("Get Specified Testing Source")
-        gtest_checkout_cmd = 'git checkout tags/release-1.8.1'
-        RunShellCmd(gtest_checkout_cmd, GTEST_DIR)
-
     utils.make_dirs(VVL_BUILD_DIR)
     print("Run CMake for Validation Layers")
     cmake_cmd = f'cmake -DUPDATE_DEPS=ON -DCMAKE_BUILD_TYPE={args.configuration.capitalize()} {args.cmake} ..'

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -43,18 +43,24 @@
       "name": "robin-hood-hashing",
       "url": "https://github.com/martinus/robin-hood-hashing.git",
       "sub_dir": "robin-hood-hashing",
-      "build_dir": "robin-hood-hashing",
-      "install_dir": "robin-hood-hashing",
-      "build_step": "skip",
+      "build_dir": "robin-hood-hashing/build",
+      "install_dir": "robin-hood-hashing/build/install",
+      "cmake_options": [
+        "-DRH_STANDALONE_PROJECT=OFF"
+      ],
       "commit": "3.11.3"
     },
     {
         "name": "googletest",
         "url": "https://github.com/google/googletest.git",
         "sub_dir": "googletest",
-        "build_dir": "googletest",
-        "install_dir": "googletest",
-        "build_step": "skip",
+        "build_dir": "googletest/build",
+        "install_dir": "googletest/build/install",
+         "cmake_options": [
+              "-DBUILD_GMOCK=OFF",
+              "-Dgtest_force_shared_crt=ON",
+              "-DBUILD_SHARED_LIBS=OFF"
+        ],
         "commit": "release-1.8.1",
         "optional": ["tests"]
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,9 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+find_package(SPIRV-Tools REQUIRED CONFIG)
+find_package(SPIRV-Tools-opt REQUIRED CONFIG)
+
 set(LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
 
 set(COMMON_CPP
@@ -117,25 +120,16 @@ add_executable(vk_layer_validation_tests
                ${COMMON_CPP})
 add_test(NAME vk_layer_validation_tests COMMAND vk_layer_validation_tests)
 add_dependencies(vk_layer_validation_tests VkLayer_khronos_validation VkLayer_khronos_validation-json)
-if(NOT GTEST_IS_STATIC_LIB)
-    set_target_properties(vk_layer_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
-endif()
-# Note that there is no need to add GTEST directories here due to googletest exporting them via the gtest target.
 target_include_directories(vk_layer_validation_tests
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                   ${PROJECT_SOURCE_DIR}/layers
                                   ${PROJECT_SOURCE_DIR}/layers/generated
                                   ${GLSLANG_INCLUDE_DIR}
-                                  ${SPIRV_TOOLS_INCLUDE_DIR}
-                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_BINARY_DIR}
                                   ${PROJECT_BINARY_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
-if (USE_ROBIN_HOOD_HASHING)
-    target_include_directories(vk_layer_validation_tests PUBLIC ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
-endif()
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils)
 
@@ -157,10 +151,10 @@ endif()
 # Specify target_link_libraries
 target_link_libraries(vk_layer_validation_tests
                       PRIVATE VkLayer_utils
-                              gtest
-                              gtest_main
                               ${GLSLANG_LIBRARIES}
-                              ${SPIRV_TOOLS_LIBRARIES})
+			      SPIRV-Headers::SPIRV-Headers
+			      SPIRV-Tools-static SPIRV-Tools-opt
+			      GTest::gtest GTest::gtest_main)
 
 if(NOT WIN32)
     target_link_libraries(vk_layer_validation_tests PRIVATE dl)
@@ -168,16 +162,6 @@ if(NOT WIN32)
         target_link_libraries(vk_layer_validation_tests
                               PRIVATE ${XCB_LIBRARIES}
                                       ${X11_LIBRARIES})
-    endif()
-endif()
-
-if(WIN32)
-    # For Windows, copy necessary gtest DLLs to the right spot for the vk_layer_tests...
-    if(NOT GTEST_IS_STATIC_LIB)
-        file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/googletest/googletest/$<CONFIG>/*.dll SRC_GTEST_DLLS)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> DST_GTEST_DLLS)
-        add_custom_command(TARGET vk_layer_validation_tests POST_BUILD
-                           COMMAND xcopy /Y /I ${SRC_GTEST_DLLS} ${DST_GTEST_DLLS})
     endif()
 endif()
 


### PR DESCRIPTION
This allows the build to find dependencies that are in CMAKE_PREFIX_PATH, but the old \*_INSTALL_DIR variables are still supported as well. The only dependency still using the old way is glslang, which will either require a Find\*.cmake script or changes in that repo.

Fixes #3558
