### PR TITLE
scripts: Check optional for deref array lengths

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -17147,9 +17147,6 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureBuildSizesKHR(
             }
         }
     }
-    if (pBuildInfo != NULL) {
-        skip |= validate_array("vkGetAccelerationStructureBuildSizesKHR", "pBuildInfo->geometryCount", "pMaxPrimitiveCounts", pBuildInfo->geometryCount, &pMaxPrimitiveCounts, true, false, kVUIDUndefined, "VUID-vkGetAccelerationStructureBuildSizesKHR-pMaxPrimitiveCounts-parameter");
-    }
     skip |= validate_struct_type("vkGetAccelerationStructureBuildSizesKHR", "pSizeInfo", "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR", pSizeInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR, true, "VUID-vkGetAccelerationStructureBuildSizesKHR-pSizeInfo-parameter", "VUID-VkAccelerationStructureBuildSizesInfoKHR-sType-sType");
     if (!skip) skip |= manual_PreCallValidateGetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
     return skip;

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -7669,7 +7669,14 @@ bool StatelessValidation::manual_PreCallValidateGetAccelerationStructureBuildSiz
         ((ray_tracing_pipeline_features && ray_tracing_pipeline_features->rayTracingPipeline == VK_FALSE) ||
          (ray_query_features && ray_query_features->rayQuery == VK_FALSE))) {
         skip |= LogError(device, "VUID-vkGetAccelerationStructureBuildSizesKHR-rayTracingPipeline-03617",
-                         "vkGetAccelerationStructureBuildSizesKHR:The rayTracingPipeline or rayQuery feature must be enabled");
+                         "vkGetAccelerationStructureBuildSizesKHR: The rayTracingPipeline or rayQuery feature must be enabled");
+    }
+    if (pBuildInfo != nullptr) {
+        if (pBuildInfo->geometryCount != 0 && pMaxPrimitiveCounts == nullptr) {
+            skip |= LogError(device, "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03619",
+                             "vkGetAccelerationStructureBuildSizesKHR: If pBuildInfo->geometryCount is not 0, pMaxPrimitiveCounts "
+                             "must be a valid pointer to an array of pBuildInfo->geometryCount uint32_t values");
+        }
     }
     return skip;
 }

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -1387,6 +1387,15 @@ class ParameterValidationOutputGenerator(OutputGenerator):
                             else:
                                 if lenParam.isoptional:
                                     cpReq = 'false'
+                                # In case of count as field in another struct, look up field to see if count is optional.
+                                len_deref = value.len.split('->')
+                                if len(len_deref) == 2:
+                                    struct_fields = next((struct.members for struct in self.structMembers if struct.name == lenParam.type), None)
+                                    if struct_fields:
+                                        len_field_name = len_deref[1]
+                                        struct_field = next((field for field in struct_fields if field.name == len_field_name), None)
+                                        if struct_field and struct_field.isoptional:
+                                            cvReq = 'false'
                         else:
                             if lenParam.isoptional:
                                 cvReq = 'false'


### PR DESCRIPTION
Adds checking of the optional-flag for dereferenced count fields in
other structs when used to specify length of arrays.

This fixes validation issues when the count fields are optional, and the
array length is therefore allowed to be zero.

Specifically, this fixes the following erroneous validation error in
vkGetAccelerationStructureBuildSizesKHR when using a BLAS with
geometryCount of zero:

vkGetAccelerationStructureBuildSizesKHR: parameter pBuildInfo->geometryCount must be greater than 0.