### PR TITLE
Fix up depthStencilResolve

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -399,8 +399,7 @@ class CoreChecks : public ValidationStateTracker {
                                            const char* VUID) const;
     bool ValidateDeviceMaskToRenderPass(const CMD_BUFFER_STATE* pCB, uint32_t deviceMask, const char* VUID) const;
 
-    bool ValidateDepthStencilResolve(const VkPhysicalDeviceVulkan12Properties& core12_props,
-                                     const VkRenderPassCreateInfo2* pCreateInfo, const char* function_name) const;
+    bool ValidateDepthStencilResolve(const VkRenderPassCreateInfo2* pCreateInfo, const char* function_name) const;
 
     bool ValidateBindAccelerationStructureMemory(VkDevice device, const VkBindAccelerationStructureMemoryInfoNV& info) const;
     // Prototypes for CoreChecks accessor functions


### PR DESCRIPTION
closes #2311

Redone version of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2677 (all information there)

Pending on spec changes in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4331

Changes from old PR

- Kept in corechecks for now for ease of feature bits
- Using new wording of spec change, can `continue` out earlier instead of ugly conditional logic used before
- `%u` to `PRIu32`