### PR TITLE
Tests: Added tests for some dynamic rendering VUIDs

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2658,9 +2658,6 @@ bool CoreChecks::ValidateCmdSubpassState(const CMD_BUFFER_STATE *pCB, const CMD_
         skip |= LogError(pCB->commandBuffer(), kVUID_Core_DrawState_InvalidCommandBuffer,
                          "%s() cannot be called in a subpass using secondary command buffers.",
                           kGeneratedCommandNameList[cmd_type]);
-    } else if (pCB->activeSubpassContents == VK_SUBPASS_CONTENTS_INLINE && cmd_type == CMD_EXECUTECOMMANDS) {
-        skip |= LogError(pCB->commandBuffer(), kVUID_Core_DrawState_InvalidCommandBuffer,
-                         "vkCmdExecuteCommands() cannot be called in a subpass using inline commands.");
     }
     return skip;
 }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -13372,3 +13372,28 @@ TEST_F(VkLayerTest, ValidateCreateSamplerWithBorderColorSwizzle) {
 
     vk::DestroySampler(device(), sampler, nullptr);
 }
+
+TEST_F(VkLayerTest, ValidateBeginRenderingDisabled) {
+    TEST_DESCRIPTION("Validate VK_KHR_dynamic_rendering VUs when disabled");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+
+    if (!AddRequiredDeviceExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME)) {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    auto begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
+
+    m_commandBuffer->begin();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginRenderingKHR-dynamicRendering-06446");
+    m_commandBuffer->BeginRendering(begin_rendering_info);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
Added tests for the following:

VUID-vkCmdExecuteCommands-pCommandBuffers-06019
VUID-vkCmdExecuteCommands-pBeginInfo-06020
VUID-vkCmdExecuteCommands-pBeginInfo-06025
VUID-vkCmdExecuteCommands-flags-06026
VUID-vkCmdExecuteCommands-colorAttachmentCount-06027
VUID-vkCmdExecuteCommands-imageView-06028
VUID-vkCmdExecuteCommands-pDepthAttachment-06029
VUID-vkCmdExecuteCommands-pStencilAttachment-06030
VUID-vkCmdExecuteCommands-viewMask-06031
VUID-vkCmdBeginRenderingKHR-commandBuffer-06068
VUID-vkCmdBeginRenderingKHR-dynamicRendering-06446

I also added tests for VUID-vkCmdExecuteCommands-contents-06018 and VUID-vkCmdExecuteCommands-flags-06024, but they also generate the following:
UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer(ERROR / SPEC): msgNum: 298202768 - 
    Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer ] Object 0: 
    handle = 0x18e5fb48c90, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x11c63690 | 
    vkCmdExecuteCommands() cannot be called in a subpass using inline commands.

They're currently '#if 0"' as I wasn't sure what to do here.