### PR TITLE
ci: Remove windows-2016 github actions runner

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         arch: [ x64, Win32 ]
         config: [ debug, release ]
-        os: [ windows-2016, windows-2019 ]
+        os: [ windows-latest ]
         exclude:
           - arch: Win32
             config: release


### PR DESCRIPTION
This runner has been deprecated and will be completely removed in the future.

https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/