### PR TITLE
layers: Add VK_KHR_dynamic_rendering VUs

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -96,6 +96,9 @@ struct DrawDispatchVuid {
     const char* dynamic_rendering_depth_sample = kVUIDUndefined;
     const char* dynamic_rendering_stencil_sample = kVUIDUndefined;
     const char* dynamic_rendering_multi_sample = kVUIDUndefined;
+    const char* dynamic_rendering_06189 = kVUIDUndefined;
+    const char* dynamic_rendering_06190 = kVUIDUndefined;
+    const char* dynamic_rendering_06198 = kVUIDUndefined;
 };
 
 struct ValidateBeginQueryVuids {

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -97,6 +97,9 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         dynamic_rendering_depth_sample     = "VUID-vkCmdDraw-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample   = "VUID-vkCmdDraw-pStencilAttachment-06187";
         dynamic_rendering_multi_sample     = "VUID-vkCmdDraw-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDraw-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDraw-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDraw-renderPass-06198";
     }
 };
 
@@ -154,6 +157,9 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         dynamic_rendering_depth_sample     = "VUID-vkCmdDrawMultiEXT-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample   = "VUID-vkCmdDrawMultiEXT-pStencilAttachment-06187";
         dynamic_rendering_multi_sample     = "VUID-vkCmdDrawMultiEXT-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDrawMultiEXT-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDrawMultiEXT-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDrawMultiEXT-renderPass-06198";
     }
 };
 
@@ -211,6 +217,9 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         dynamic_rendering_depth_sample     = "VUID-vkCmdDrawIndexed-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample   = "VUID-vkCmdDrawIndexed-pStencilAttachment-06187";
         dynamic_rendering_multi_sample     = "VUID-vkCmdDrawIndexed-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDrawIndexed-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDrawIndexed-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDrawIndexed-renderPass-06198";
     }
 };
 
@@ -268,6 +277,9 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         dynamic_rendering_depth_sample = "VUID-vkCmdDrawMultiIndexedEXT-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample = "VUID-vkCmdDrawIndexedIndirect-pStencilAttachment-06187";
         dynamic_rendering_multi_sample = "VUID-vkCmdDrawIndexedIndirect-colorAttachmentCount-06188";
+        dynamic_rendering_06189 = "VUID-vkCmdDrawIndexedIndirect-pDepthAttachment-06189";
+        dynamic_rendering_06190 = "VUID-vkCmdDrawIndexedIndirect-pStencilAttachment-06190";
+        dynamic_rendering_06198 = "VUID-vkCmdDrawIndexedIndirect-renderPass-06198";
     }
 };
 
@@ -327,6 +339,9 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         dynamic_rendering_depth_sample     = "VUID-vkCmdDrawIndirect-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample   = "VUID-vkCmdDrawIndirect-pStencilAttachment-06187";
         dynamic_rendering_multi_sample     = "VUID-vkCmdDrawIndirect-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDrawIndirect-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDrawIndirect-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDrawIndirect-renderPass-06198";
     }
 };
 
@@ -386,6 +401,9 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         dynamic_rendering_depth_sample     = "VUID-vkCmdDrawIndexedIndirect-pDepthAttachment-06186";
         dynamic_rendering_stencil_sample   = "VUID-vkCmdDrawIndexedIndirect-pStencilAttachment-06187";
         dynamic_rendering_multi_sample     = "VUID-vkCmdDrawIndexedIndirect-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDrawIndexedIndirect-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDrawIndexedIndirect-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDrawIndexedIndirect-renderPass-06198";
     }
 };
 
@@ -530,6 +548,20 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirectCount-pStrides-04884";
         vertex_input                       = kVUID_Core_CmdDrawIndexedIndirectCount_VertexInput;
         blend_enable                       = "VUID-vkCmdDrawIndexedIndirectCount-blendEnable-04727";
+        dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndexedIndirectCount-viewMask-06178";
+        dynamic_rendering_color_count      = "VUID-vkCmdDrawIndexedIndirectCount-colorAttachmentCount-06179";
+        dynamic_rendering_color_formats    = "VUID-vkCmdDrawIndexedIndirectCount-colorAttachmentCount-06180";
+        dynamic_rendering_depth_format     = "VUID-vkCmdDrawIndexedIndirectCount-pDepthAttachment-06181";
+        dynamic_rendering_stencil_format   = "VUID-vkCmdDrawIndexedIndirectCount-pStencilAttachment-06182";
+        dynamic_rendering_fsr              = "VUID-vkCmdDrawIndexedIndirectCount-imageView-06183";
+        dynamic_rendering_fdm              = "VUID-vkCmdDrawIndexedIndirectCount-imageView-06184";
+        dynamic_rendering_color_sample     = "VUID-vkCmdDrawIndexedIndirectCount-colorAttachmentCount-06185";
+        dynamic_rendering_depth_sample     = "VUID-vkCmdDrawIndexedIndirectCount-pDepthAttachment-06186";
+        dynamic_rendering_stencil_sample   = "VUID-vkCmdDrawIndexedIndirectCount-pStencilAttachment-06187";
+        dynamic_rendering_multi_sample     = "VUID-vkCmdDrawIndexedIndirectCount-colorAttachmentCount-06188";
+        dynamic_rendering_06189            = "VUID-vkCmdDrawIndexedIndirectCount-pDepthAttachment-06189";
+        dynamic_rendering_06190            = "VUID-vkCmdDrawIndexedIndirectCount-pStencilAttachment-06190";
+        dynamic_rendering_06198            = "VUID-vkCmdDrawIndexedIndirectCount-renderPass-06198";
     }
 };
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -215,7 +215,7 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODUL
     const bool alpha_to_coverage_enabled = pipeline->create_info.graphics.pMultisampleState != NULL &&
         pipeline->create_info.graphics.pMultisampleState->alphaToCoverageEnable == VK_TRUE;
 
-    for (uint32_t location = 0; location < pipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount; ++location) {
+    for (uint32_t location = 0; location < location_map.size(); ++location) {
          const auto output = location_map[location].output;
 
         if (!output && pipeline->attachments[location].colorWriteMask != 0) {
@@ -223,7 +223,8 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODUL
                 "Attachment %" PRIu32
                 " not written by fragment shader; undefined values will be written to attachment",
                 location);
-        } else if (output) {
+        } else if (output &&
+                  (location < pipeline->rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
             auto format = pipeline->rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
             const auto attachment_type = GetFormatType(format);
             const auto output_type = fs->GetFundamentalType(output->type_id);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(COMMON_CPP
     vklayertests_amd_best_practices.cpp
     vklayertests_gpu.cpp
     vklayertests_descriptor_renderpass_framebuffer.cpp
+    vklayertests_dynamic_rendering.cpp
     vklayertests_command.cpp
     vklayertests_imageless_framebuffer.cpp
     vklayertests_portability_subset.cpp

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -36,11 +36,6 @@
 
 #include "cast_utils.h"
 
-//
-// POSITIVE VALIDATION TESTS
-//
-// These tests do not expect to encounter ANY validation errors pass only if this is true
-
 TEST_F(VkPositiveLayerTest, DynamicRenderingDraw) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering.");
 
@@ -126,3 +121,4 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingDraw) {
 
     m_errorMonitor->VerifyNotFound();
 }
+

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2021 Google, Inc.
+ * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (C) 2021 ARM, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+#include "cast_utils.h"
+#include "layer_validation_tests.h"
+
+TEST_F(VkLayerTest, CommandBufferInheritanceRenderingInfoKHR) {
+    TEST_DESCRIPTION("VkCommandBufferInheritanceRenderingInfoKHR Dynamic Rendering Tests.");
+
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_2);
+    if (version < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required, skipping test.\n", kSkipPrefix);
+        return;
+    }
+    
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+
+    VkPhysicalDeviceFeatures2 features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>();
+    ASSERT_NO_FATAL_FAILURE(Init(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required for device, skipping test\n", kSkipPrefix);
+        return;
+    }
+    
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s is not supported; skipping\n", kSkipPrefix, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+        return;
+    }
+
+    VkPhysicalDeviceMultiviewProperties multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&multiview_props);
+    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+
+    if (multiview_props.maxMultiviewViewCount == 32) {
+        printf("%s VUID is not testable as maxMultiviewViewCount is 32, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    VkFormat color_format = VK_FORMAT_D32_SFLOAT;
+
+    auto cmd_buffer_inheritance_rendering_info = LvlInitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    cmd_buffer_inheritance_rendering_info.colorAttachmentCount = 1;
+    cmd_buffer_inheritance_rendering_info.pColorAttachmentFormats = &color_format;
+    cmd_buffer_inheritance_rendering_info.depthAttachmentFormat = VK_FORMAT_R8G8B8_UNORM;
+    cmd_buffer_inheritance_rendering_info.stencilAttachmentFormat = VK_FORMAT_R8G8B8_SNORM;
+    cmd_buffer_inheritance_rendering_info.viewMask = 1 << multiview_props.maxMultiviewViewCount;
+
+    auto sample_count_info_amd = LvlInitStruct<VkAttachmentSampleCountInfoAMD>();
+    sample_count_info_amd.pNext = &cmd_buffer_inheritance_rendering_info;
+    sample_count_info_amd.colorAttachmentCount = 2;
+    
+    auto cmd_buffer_inheritance_info = LvlInitStruct<VkCommandBufferInheritanceInfo>();
+    cmd_buffer_inheritance_info.pNext = &sample_count_info_amd;
+
+    auto cmd_buffer_allocate_info = LvlInitStruct<VkCommandBufferAllocateInfo>();
+    cmd_buffer_allocate_info.commandPool = m_commandPool->handle();
+    cmd_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
+    cmd_buffer_allocate_info.commandBufferCount = 0x1;
+
+    VkCommandBuffer secondary_cmd_buffer;
+    VkResult err = vk::AllocateCommandBuffers(m_device->device(), &cmd_buffer_allocate_info, &secondary_cmd_buffer);
+    ASSERT_VK_SUCCESS(err);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferBeginInfo-flags-06003");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfoKHR-colorAttachmentCount-06004");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfoKHR-variableMultisampleRate-06005");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfoKHR-depthAttachmentFormat-06007");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfoKHR-multiview-06008");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfoKHR-viewMask-06009");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                         "VUID-VkCommandBufferInheritanceRenderingInfoKHR-stencilAttachmentFormat-06199");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                         "VUID-VkCommandBufferInheritanceRenderingInfoKHR-depthAttachmentFormat-06200");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                         "VUID-VkCommandBufferInheritanceRenderingInfoKHR-pColorAttachmentFormats-06006");
+
+    VkCommandBufferBeginInfo cmd_buffer_begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
+    cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
+    vk::BeginCommandBuffer(secondary_cmd_buffer, &cmd_buffer_begin_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, CommandDrawDynamicRendering) {
+    TEST_DESCRIPTION("vkCmdDraw* Dynamic Rendering Tests.");
+
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_2);
+    if (version < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required, skipping test.\n", kSkipPrefix);
+        return;
+    }
+
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required for device, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s is not supported; skipping\n", kSkipPrefix, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+        return;
+    }
+
+    auto dynamic_rendering_features = LvlInitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&dynamic_rendering_features);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    if (!dynamic_rendering_features.dynamicRendering) {
+        printf("%s Test requires (unsupported) dynamicRendering , skipping\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    VkShaderObj vs(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+    pipe.AddDefaultColorAttachment();
+
+    VkDescriptorSetLayoutBinding dslb = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
+    const VkDescriptorSetLayoutObj dsl(m_device, {dslb});
+    const VkPipelineLayoutObj pl(m_device, {&dsl});
+ 
+    VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
+    auto pipeline_rendering_info = LvlInitStruct<VkPipelineRenderingCreateInfoKHR>();
+    pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
+
+    auto multisample_state_create_info = LvlInitStruct<VkPipelineMultisampleStateCreateInfo>();
+    multisample_state_create_info.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
+
+    auto create_info = LvlInitStruct<VkGraphicsPipelineCreateInfo>();
+    pipe.InitGraphicsPipelineCreateInfo(&create_info);
+    create_info.pMultisampleState = &multisample_state_create_info;
+    create_info.renderPass = VkRenderPass(0x1);
+    create_info.pNext = &pipeline_rendering_info;
+ 
+    VkResult err = pipe.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info);
+    ASSERT_VK_SUCCESS(err);
+
+    VkViewport viewport = {0, 0, 16, 16, 0, 1};
+    VkRect2D scissor = {{0, 0}, {16, 16}}; 
+
+    VkImageObj image(m_device);
+    image.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_LINEAR, 0);
+    ASSERT_TRUE(image.initialized());
+
+    VkImageViewCreateInfo ivci = {VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+                                  nullptr,
+                                  0,
+                                  image.handle(),
+                                  VK_IMAGE_VIEW_TYPE_2D,
+                                  depth_format,
+                                  {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                                   VK_COMPONENT_SWIZZLE_IDENTITY},
+                                  {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1}};
+
+    VkImageView depth_image_view;
+    err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &depth_image_view);
+    ASSERT_VK_SUCCESS(err);
+
+    VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+    depth_attachment.imageView = depth_image_view;
+ 
+    VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
+    begin_rendering_info.pDepthAttachment = &depth_attachment;
+    begin_rendering_info.pStencilAttachment = &depth_attachment;
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRendering(begin_rendering_info);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
+    vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-pDepthAttachment-06189");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-pStencilAttachment-06190");
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->EndRendering();
+    m_commandBuffer->end();
+}
+
+TEST_F(VkLayerTest, DynamicRenderingGraphicsPipelineCreateInfo) {
+    TEST_DESCRIPTION("Test graphics pipeline creation with dynamic rendering.");
+    
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_2);
+    if (version < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required, skipping test.\n", kSkipPrefix);
+        return;
+    }
+
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        printf("%s At least Vulkan version 1.2 is required for device, skipping test\n", kSkipPrefix);
+        return;
+    }
+
+     if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s is not supported; skipping\n", kSkipPrefix, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+        return;
+    }
+
+    auto dynamic_rendering_features = LvlInitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&dynamic_rendering_features);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    if (!dynamic_rendering_features.dynamicRendering) {
+        printf("%s Test requires (unsupported) dynamicRendering , skipping\n", kSkipPrefix);
+        return;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    const VkPipelineLayoutObj pl(m_device);
+    VkPipelineObj pipe(m_device);
+
+    VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
+
+    auto color_blend_state_create_info = LvlInitStruct<VkPipelineColorBlendStateCreateInfo>();
+    color_blend_state_create_info.attachmentCount = 1;
+    color_blend_state_create_info.pAttachments = &color_blend_attachment_state;
+
+    VkFormat color_format[2] = {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_D32_SFLOAT_S8_UINT};
+
+    auto pipeline_rendering_info = LvlInitStruct<VkPipelineRenderingCreateInfoKHR>();
+    pipeline_rendering_info.colorAttachmentCount = 2;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_format[0];
+    pipeline_rendering_info.viewMask = 0x2;
+
+    auto pipeline_tessellation_state_info = LvlInitStruct<VkPipelineTessellationStateCreateInfo>(); 
+    pipeline_tessellation_state_info.patchControlPoints = 1;
+
+    auto pipeline_input_assembly_state_info = LvlInitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    pipeline_input_assembly_state_info.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+
+    auto create_info = LvlInitStruct<VkGraphicsPipelineCreateInfo>();
+    VkShaderObj vs(m_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj gs(m_device, bindStateGeomShaderText, VK_SHADER_STAGE_GEOMETRY_BIT, this);
+    VkShaderObj te(m_device, bindStateTeshaderText, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
+    VkShaderObj tc(m_device, bindStateTscShaderText, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
+    pipe.AddShader(&vs);
+    pipe.AddShader(&gs);
+    pipe.AddShader(&te);
+    pipe.AddShader(&tc);
+    pipe.InitGraphicsPipelineCreateInfo(&create_info);
+    create_info.pColorBlendState = &color_blend_state_create_info;
+    create_info.pNext = &pipeline_rendering_info;
+    create_info.pTessellationState = &pipeline_tessellation_state_info;
+    create_info.pInputAssemblyState = &pipeline_input_assembly_state_info;
+    
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06055");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06057");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06058");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06060");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06062");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRenderingCreateInfoKHR-multiview-06066");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRenderingCreateInfoKHR-pColorAttachmentFormats-06064");
+    pipe.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info);
+    m_errorMonitor->VerifyFound();
+
+}


### PR DESCRIPTION
VU Statements:
VUID-VkCommandBufferInheritanceRenderingInfoKHR-colorAttachmentCount-06004
VUID-VkCommandBufferInheritanceRenderingInfoKHR-variableMultisampleRate-06005
VUID-vkCmdDraw*-pDepthAttachment-06189
VUID-vkCmdDraw*-pStencilAttachment-06190
VUID-vkCmdDraw*-renderPass-06198
VUID-VkGraphicsPipelineCreateInfo-renderPass-06055
VUID-VkGraphicsPipelineCreateInfo-renderPass-06057
VUID-VkGraphicsPipelineCreateInfo-renderPass-06058
VUID-VkGraphicsPipelineCreateInfo-renderPass-06060
VUID-VkGraphicsPipelineCreateInfo-renderPass-06062
VUID-VkRenderingAttachmentInfoKHR-imageView-06129
VUID-VkRenderingAttachmentInfoKHR-imageView-06130

Tests:
VUID-VkCommandBufferInheritInfoKHR-colorAttachmentCount-06004
VUID-VkCommandBufferInheritInfoKHR-variableMultisampleRate-06005
VUID-VkCommandBufferInheritInfoKHR-pColorAttachmentFormats-06006
VUID-VkCommandBufferInheritInfoKHR-depthAttachmentFormat-06007
VUID-VkCommandBufferInheritInfoKHR-multiview-06008
VUID-VkCommandBufferInheritInfoKHR-viewMask-06009
VUID-VkCommandBufferInheritInfoKHR-stencilAttachmentFormat-06199
VUID-VkCommandBufferInheritInfoKHR-depthAttachmentFormat-06200
VUID-VkCommandBufferBeginInfo-flags-06003
VUID-vkCmdDraw-pDepthAttachment-06189
VUID-vkCmdDraw-pStencilAttachment-06190
VUID-VkGraphicsPipelineCreateInfo-renderPass-06055
VUID-VkGraphicsPipelineCreateInfo-renderPass-06057 
VUID-VkGraphicsPipelineCreateInfo-renderPass-06058
VUID-VkGraphicsPipelineCreateInfo-renderPass-06060
VUID-VkGraphicsPipelineCreateInfo-renderPass-06062
VUID-VkPipelineRenderingCreateInfoKHR-pColorAttachmentFormats-06064
VUID-VkPipelineRenderingCreateInfoKHR-multiview-06066

Other:
Fixes #3595
