### PR TITLE
Guard against null pointer dereferences

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6616,22 +6616,25 @@ static bool UniqueImageViews(const VkRenderingInfoKHR* pRenderingInfo, VkImageVi
         }
     }
 
-    if (pRenderingInfo->pDepthAttachment->imageView == imageView) {
-        unique_views = false;
+    if (pRenderingInfo->pDepthAttachment) {
+        if (pRenderingInfo->pDepthAttachment->imageView == imageView) {
+            unique_views = false;
+        }
+
+        if (pRenderingInfo->pDepthAttachment->resolveImageView == imageView) {
+            unique_views = false;
+        }
     }
 
-    if (pRenderingInfo->pDepthAttachment->resolveImageView == imageView) {
-        unique_views = false;
-    }
+    if (pRenderingInfo->pStencilAttachment) {
+        if (pRenderingInfo->pStencilAttachment->imageView == imageView) {
+            unique_views = false;
+        }
 
-    if (pRenderingInfo->pStencilAttachment->imageView == imageView) {
-        unique_views = false;
+        if (pRenderingInfo->pStencilAttachment->resolveImageView == imageView) {
+            unique_views = false;
+        }
     }
-
-    if (pRenderingInfo->pStencilAttachment->resolveImageView == imageView) {
-        unique_views = false;
-    }
-
     return unique_views;
 }
 


### PR DESCRIPTION
Fixes crash in dEQP-VK.fragment_shading_rate.dynamic_rendering.basic.dynamic.attachment.noshaderrate.keep.keep.1x1.samples1.vs