### PR TITLE
2 EndRendering/EndRenderpass tests and some minor VUID tweaks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2022 Valve Corporation
  * Copyright (c) 2015-2022 LunarG, Inc.
  * Copyright (C) 2015-2022 Google Inc.
- * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -7342,7 +7342,8 @@ bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer
     bool skip = false;
 
     if (cb_state->activeRenderPass) {
-        if (cb_state->activeRenderPass->use_dynamic_rendering == false) {
+        if ((cb_state->activeRenderPass->use_dynamic_rendering == false) &&
+            (cb_state->activeRenderPass->use_dynamic_rendering_inherited == false)) {
             skip |= LogError(
                 commandBuffer, "VUID-vkCmdEndRenderingKHR-None-06161",
                 "Calling vkCmdEndRenderingKHR() in a render pass instance that was not begun with vkCmdBeginRenderingKHR().");
@@ -13196,7 +13197,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(RenderPassCreateVersion rp_version, Vk
 
     RENDER_PASS_STATE *rp_state = cb_state->activeRenderPass.get();
     if (rp_state) {
-        if (cb_state->activeSubpass != rp_state->createInfo.subpassCount - 1) {
+        if ((cb_state->activeSubpass != rp_state->createInfo.subpassCount - 1) && !rp_state->use_dynamic_rendering) {
             vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-03103" : "VUID-vkCmdEndRenderPass-None-00910";
             skip |= LogError(commandBuffer, vuid, "%s: Called before reaching final subpass.", function_name);
         }


### PR DESCRIPTION
Added tests for:
VUID-vkCmdEndRenderingKHR-None-06161
VUID-vkCmdEndRenderingKHR-commandBuffer-06162
VUID-vkCmdEndRenderPass-None-06170
VUID-vkCmdEndRenderPass2-None-06171

Tweaked a couple of EndRendering/EndRenderpass VUIDs that were incorrectly triggering when incorrectly mixing types of renderpass instance