### PR TITLE
Validate creating win32 surface

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -9664,6 +9664,7 @@ bool StatelessValidation::PreCallValidateCreateWin32SurfaceKHR(
         }
     }
     skip |= validate_required_pointer("vkCreateWin32SurfaceKHR", "pSurface", pSurface, "VUID-vkCreateWin32SurfaceKHR-pSurface-parameter");
+    if (!skip) skip |= manual_PreCallValidateCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     return skip;
 }
 

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -266,6 +266,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetDiscardRectangleEXT',
             'vkGetQueryPoolResults',
             'vkCmdBeginConditionalRenderingEXT',
+            'vkCreateWin32SurfaceKHR'
             ]
 
         # Commands to ignore

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -2420,3 +2420,26 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
 #endif
 }
 #endif
+
+TEST_F(VkLayerTest, TestCreatingWin32Surface) {
+    TEST_DESCRIPTION("Test creating win32 surface with invalid hwnd");
+
+#ifndef VK_USE_PLATFORM_WIN32_KHR
+    printf("%s test not supported on platform, skipping test.\n", kSkipPrefix);
+#else
+    if (!AddSurfaceInstanceExtension()) {
+        printf("%s surface extensions not supported, skipping test.\n", kSkipPrefix);
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    VkWin32SurfaceCreateInfoKHR surface_create_info = LvlInitStruct<VkWin32SurfaceCreateInfoKHR>();
+    surface_create_info.hinstance = GetModuleHandle(0);
+    surface_create_info.hwnd = NULL; // Invalid
+
+    VkSurfaceKHR surface;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308");
+    vk::CreateWin32SurfaceKHR(instance(), &surface_create_info, nullptr, &surface);
+    m_errorMonitor->VerifyFound();
+#endif
+}


### PR DESCRIPTION
Function manual_PreCallValidateCreateWin32SurfaceKHR already existed, but was never called

Closes #3628 