### PR TITLE
corechecks: Add setting to enable fine-grained locking

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -98,6 +98,22 @@ using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 
+ReadLockGuard CoreChecks::ReadLock() {
+    if (fine_grained_locking) {
+        return ReadLockGuard(validation_object_mutex, std::defer_lock);
+    } else {
+        return ReadLockGuard(validation_object_mutex);
+    }
+}
+
+WriteLockGuard CoreChecks::WriteLock() {
+    if (fine_grained_locking) {
+        return WriteLockGuard(validation_object_mutex, std::defer_lock);
+    } else {
+        return WriteLockGuard(validation_object_mutex);
+    }
+}
+
 // Override base class, we have some extra work to do here
 void CoreChecks::InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
     if (add_obj) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -168,6 +168,9 @@ class CoreChecks : public ValidationStateTracker {
 
     CoreChecks() { container_type = LayerObjectTypeCoreValidation; }
 
+    ReadLockGuard ReadLock() override;
+    WriteLockGuard WriteLock() override;
+
     // Override base class, we have some extra work to do here
     void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj) override;
 

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ static const char DECORATE_UNUSED *kVUID_Core_CmdBuildAccelNV_NoUpdateMemReqQuer
 
 static const char DECORATE_UNUSED *kVUID_Core_CreatInstance_Status = "UNASSIGNED-khronos-validation-createinstance-status-message";
 static const char DECORATE_UNUSED *kVUID_Core_CreateInstance_Debug_Warning = "UNASSIGNED-khronos-Validation-debug-build-warning-message";
+static const char DECORATE_UNUSED *kVUID_Core_CreateInstance_Locking_Warning = "UNASSIGNED-khronos-Validation-fine-grained-locking-warning-message";
 
 static const char DECORATE_UNUSED *kVUID_Core_ImageMemoryBarrier_SharingModeExclusiveSameFamily = "UNASSIGNED-CoreValidation-VkImageMemoryBarrier-sharing-mode-exclusive-same-family";
 static const char DECORATE_UNUSED *kVUID_Core_ImageMemoryBarrier2_SharingModeExclusiveSameFamily = "UNASSIGNED-CoreValidation-VkImageMemoryBarrier2KHR-sharing-mode-exclusive-same-family";

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,6 +181,10 @@ void OutputLayerStatusInfo(ValidationObject *context) {
     context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Debug_Warning,
         "VALIDATION LAYERS WARNING: Using debug builds of the validation layers *will* adversely affect performance.");
 #endif
+    if (context->fine_grained_locking) {
+        context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Locking_Warning,
+                                       "Fine-grained locking is experimental, crashes or incorrect results are possible.");
+    }
 }
 
 // Non-code-generated chassis API functions
@@ -278,8 +282,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     // Set up enable and disable features flags
     CHECK_ENABLED local_enables {};
     CHECK_DISABLED local_disables {};
+    bool lock_setting;
     ConfigAndEnvSettings config_and_env_settings_data {OBJECT_LAYER_DESCRIPTION, pCreateInfo->pNext, local_enables, local_disables,
-        report_data->filter_message_ids, &report_data->duplicate_message_limit};
+        report_data->filter_message_ids, &report_data->duplicate_message_limit, &lock_setting};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
     layer_debug_messenger_actions(report_data, pAllocator, OBJECT_LAYER_DESCRIPTION);
 
@@ -337,6 +342,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     framework->container_type = LayerObjectTypeInstance;
     framework->disabled = local_disables;
     framework->enabled = local_enables;
+    framework->fine_grained_locking = lock_setting;
 
     framework->instance = *pInstance;
     layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3314,6 +3314,7 @@ class ValidationObject {
         DeviceExtensions device_extensions = {};
         CHECK_DISABLED disabled = {};
         CHECK_ENABLED enabled = {};
+        bool fine_grained_locking{false};
 
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -3355,6 +3356,7 @@ class ValidationObject {
             instance_dispatch_table = framework->instance_dispatch_table;
             enabled = framework->enabled;
             disabled = framework->disabled;
+            fine_grained_locking = framework->fine_grained_locking;
             instance = inst;
         }
 
@@ -3369,6 +3371,7 @@ class ValidationObject {
                 api_version = dev_obj->api_version;
                 disabled = inst_obj->disabled;
                 enabled = inst_obj->enabled;
+                fine_grained_locking = inst_obj->fine_grained_locking;
                 instance_dispatch_table = inst_obj->instance_dispatch_table;
                 instance_extensions = inst_obj->instance_extensions;
                 device_extensions = dev_obj->device_extensions;

--- a/layers/generated/chassis_dispatch_helper.h
+++ b/layers/generated/chassis_dispatch_helper.h
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -563,6 +563,16 @@
                         }
                     ],
                     "default": []
+                },
+                {
+                    "key": "fine_grained_locking",
+                    "env": "VK_LAYER_FINE_GRAINED_LOCKING",
+                    "label": "Fine Grained Locking",
+                    "description": "Enable fine grained locking for Core Validation, which should improve performance in multithreaded applications. This is an experimental feature which may cause stability problems or incorrect errors to be reported.",
+                    "status": "BETA",
+                    "type": "BOOL",
+                    "default": false,
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
                 }
             ]
         }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2021 The Khronos Group Inc.
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+/* Copyright (c) 2020-2022 The Khronos Group Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -301,6 +301,26 @@ const VkLayerSettingsEXT *FindSettingsInChain(const void *next) {
     return found;
 }
 
+static bool SetBool(std::string &config_string, std::string &env_string, bool default_val) {
+    bool result = default_val;
+
+    std::string setting;
+    if (!env_string.empty()) {
+        setting = env_string;
+    } else if (!config_string.empty()) {
+        setting = config_string;
+    }
+    if (!setting.empty()) {
+        transform(setting.begin(), setting.end(), setting.begin(), ::tolower);
+        if (setting == "true") {
+            result = true;
+        } else {
+            result = std::atoi(setting.c_str()) != 0;
+        }
+    }
+    return result;
+}
+
 // Process enables and disables set though the vk_layer_settings.txt config file or through an environment variable
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     const auto layer_settings_ext = FindSettingsInChain(settings_data->pnext_chain);
@@ -355,11 +375,13 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     std::string stypes_key(settings_data->layer_description);
     std::string filter_msg_key(settings_data->layer_description);
     std::string message_limit(settings_data->layer_description);
+    std::string fine_grained_locking(settings_data->layer_description);
     enable_key.append(".enables");
     disable_key.append(".disables");
     stypes_key.append(".custom_stype_list");
     filter_msg_key.append(".message_id_filter");
     message_limit.append(".duplicate_message_limit");
+    fine_grained_locking.append(".fine_grained_locking");
     std::string list_of_config_enables = getLayerOption(enable_key.c_str());
     std::string list_of_env_enables = GetLayerEnvVar("VK_LAYER_ENABLES");
     std::string list_of_config_disables = getLayerOption(disable_key.c_str());
@@ -370,6 +392,8 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     std::string list_of_env_stypes = GetLayerEnvVar("VK_LAYER_CUSTOM_STYPE_LIST");
     std::string config_message_limit = getLayerOption(message_limit.c_str());
     std::string env_message_limit = GetLayerEnvVar("VK_LAYER_DUPLICATE_MESSAGE_LIMIT");
+    std::string config_fine_grained_locking = getLayerOption(fine_grained_locking.c_str());
+    std::string env_fine_grained_locking = GetLayerEnvVar("VK_LAYER_FINE_GRAINED_LOCKING");
 
 #if defined(_WIN32)
     std::string env_delimiter = ";";
@@ -392,4 +416,5 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (config_limit_setting != 0) {
         *settings_data->duplicate_message_limit = config_limit_setting;
     }
+    *settings_data->fine_grained_locking = SetBool(config_fine_grained_locking, env_fine_grained_locking, false);
 }

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2021 The Khronos Group Inc.
- * Copyright (c) 2021 Valve Corporation
- * Copyright (c) 2021 LunarG, Inc.
+/* Copyright (c) 2022 The Khronos Group Inc.
+ * Copyright (c) 2022 Valve Corporation
+ * Copyright (c) 2022 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@ typedef struct {
     CHECK_DISABLED &disables;
     std::vector<uint32_t> &message_filter_list;
     int32_t *duplicate_message_limit;
+    bool *fine_grained_locking;
 } ConfigAndEnvSettings;
 
 static const layer_data::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -1,8 +1,8 @@
 /**************************************************************************
  *
- * Copyright 2014-2021 Valve Software
- * Copyright 2015-2021 Google Inc.
- * Copyright 2019-2021 LunarG, Inc.
+ * Copyright 2014-2022 Valve Software
+ * Copyright 2015-2022 Google Inc.
+ * Copyright 2019-2022 LunarG, Inc.
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -187,6 +187,7 @@ ConfigFile::ConfigFile() : file_is_parsed_(false) {
     value_map_["khronos_validation.debug_action"] = "VK_DBG_LAYER_ACTION_DEFAULT,VK_DBG_LAYER_ACTION_LOG_MSG";
 #endif  // WIN32
     value_map_["khronos_validation.log_filename"] = "stdout";
+    value_map_["khronos_validation.fine_grained_locking"] = "false";
 }
 
 const char *ConfigFile::GetOption(const string &option) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -157,4 +157,6 @@ khronos_validation.log_filename = stdout
 # Example of how to redirect debug printf messages from the debug callback to stdout
 #khronos_validation.printf_to_stdout = true
 
+# Example of how to enable fine grained locking
+#khronos_validation.fine_grained_locking = true
 ################################################################################


### PR DESCRIPTION
WIP! This is one of the last changes I intend to merge for the locking improvements, but it needs sooner review because it involves user-visible names that need to end up in documentation in several different places.

Add a setting to make calls to ValidationObject::ReadLock() and
WriteLock() be no-ops, because locking in other parts of the code
has made these global locks unnecessary.

Currently this only affects Core Validation, but eventually it should
also change the behavior of Best Practices and Synchronization
Validation.

The setting defaults to off for now and there is logging when fine grained
locking is enabled, since this is an experimental feature which
make cause stability problems or incorrect errors to be reported.
Once this stabilizes, the setting will default to on and the log message
will report when it is turned off, because that will be slow.