### PR TITLE
layers: Make SURFACE_STATE, DESCRIPTOR_POOL_STATE, QUERY_POOL_STATE and ValidationCache threadsafe

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -6615,15 +6615,9 @@ bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescripto
     if (disabled[object_in_use]) return false;
     bool skip = false;
     const auto pool = Get<DESCRIPTOR_POOL_STATE>(descriptorPool);
-    if (pool) {
-        for (const auto &entry : pool->sets) {
-            const auto *ds = entry.second;
-            if (ds && ds->InUse()) {
-                skip |= LogError(descriptorPool, "VUID-vkResetDescriptorPool-descriptorPool-00313",
-                                 "It is invalid to call vkResetDescriptorPool() with descriptor sets in use by a command buffer.");
-                if (skip) break;
-            }
-        }
+    if (pool && pool->InUse()) {
+        skip |= LogError(descriptorPool, "VUID-vkResetDescriptorPool-descriptorPool-00313",
+                         "It is invalid to call vkResetDescriptorPool() with descriptor sets in use by a command buffer.");
     }
     return skip;
 }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,16 +54,6 @@ struct AllocateDescriptorSetsData;
 
 class DESCRIPTOR_POOL_STATE : public BASE_NODE {
   public:
-    ValidationStateTracker *dev_data;
-    const uint32_t maxSets;  // Max descriptor sets allowed in this pool
-    uint32_t availableSets;  // Available descriptor sets in this pool
-
-    const safe_VkDescriptorPoolCreateInfo createInfo;
-    using TypeCountMap = layer_data::unordered_map<uint32_t, uint32_t>;
-    const TypeCountMap maxDescriptorTypeCount;  // Max # of descriptors of each type in this pool
-    TypeCountMap availableDescriptorTypeCount;  // Available # of descriptors of each type in this pool
-    layer_data::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> sets;  // Collection of all sets in this pool
-
     DESCRIPTOR_POOL_STATE(ValidationStateTracker *dev, const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo *pCreateInfo);
     ~DESCRIPTOR_POOL_STATE() { Destroy(); }
 
@@ -72,6 +62,32 @@ class DESCRIPTOR_POOL_STATE : public BASE_NODE {
     void Free(uint32_t count, const VkDescriptorSet *descriptor_sets);
     void Reset();
     void Destroy() override;
+
+    bool InUse() const override;
+    uint32_t GetAvailableCount(uint32_t type) const {
+        auto guard = ReadLock();
+        auto iter = available_counts_.find(type);
+        return iter != available_counts_.end() ? iter->second : 0;
+    }
+
+    uint32_t GetAvailableSets() const {
+        auto guard = ReadLock();
+        return available_sets_;
+    }
+
+    const uint32_t maxSets;  // Max descriptor sets allowed in this pool
+    const safe_VkDescriptorPoolCreateInfo createInfo;
+    using TypeCountMap = layer_data::unordered_map<uint32_t, uint32_t>;
+    const TypeCountMap maxDescriptorTypeCount;  // Max # of descriptors of each type in this pool
+private:
+  ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
+  WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
+
+  uint32_t available_sets_;        // Available descriptor sets in this pool
+  TypeCountMap available_counts_;  // Available # of descriptors of each type in this pool
+  layer_data::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> sets_;  // Collection of all sets in this pool
+  ValidationStateTracker *dev_data_;
+  mutable ReadWriteLock lock_;
 };
 
 class UPDATE_TEMPLATE_STATE : public BASE_NODE {

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -579,12 +579,14 @@ void SURFACE_STATE::RemoveParent(BASE_NODE *parent_node) {
 }
 
 void SURFACE_STATE::SetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi, bool supported) {
+    auto guard = Lock();
     assert(phys_dev);
     GpuQueue key{phys_dev, qfi};
     gpu_queue_support_[key] = supported;
 }
 
 bool SURFACE_STATE::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const {
+    auto guard = Lock();
     assert(phys_dev);
     GpuQueue key{phys_dev, qfi};
     auto iter = gpu_queue_support_.find(key);
@@ -598,11 +600,13 @@ bool SURFACE_STATE::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) con
 }
 
 void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, std::vector<VkPresentModeKHR> &&modes) {
+    auto guard = Lock();
     assert(phys_dev);
     present_modes_[phys_dev] = std::move(modes);
 }
 
 std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice phys_dev) const {
+    auto guard = Lock();
     assert(phys_dev);
     auto iter = present_modes_.find(phys_dev);
     if (iter != present_modes_.end()) {
@@ -617,11 +621,13 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice ph
 }
 
 void SURFACE_STATE::SetFormats(VkPhysicalDevice phys_dev, std::vector<VkSurfaceFormatKHR> &&fmts) {
+    auto guard = Lock();
     assert(phys_dev);
     formats_[phys_dev] = std::move(fmts);
 }
 
 std::vector<VkSurfaceFormatKHR> SURFACE_STATE::GetFormats(VkPhysicalDevice phys_dev) const {
+    auto guard = Lock();
     assert(phys_dev);
     auto iter = formats_.find(phys_dev);
     if (iter != formats_.end()) {
@@ -637,11 +643,13 @@ std::vector<VkSurfaceFormatKHR> SURFACE_STATE::GetFormats(VkPhysicalDevice phys_
 }
 
 void SURFACE_STATE::SetCapabilities(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR &caps) {
+    auto guard = Lock();
     assert(phys_dev);
     capabilities_[phys_dev] = caps;
 }
 
 VkSurfaceCapabilitiesKHR SURFACE_STATE::GetCapabilities(VkPhysicalDevice phys_dev) const {
+    auto guard = Lock();
     assert(phys_dev);
     auto iter = capabilities_.find(phys_dev);
     if (iter != capabilities_.end()) {

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -249,6 +249,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     uint32_t get_swapchain_image_count = 0;
     uint64_t max_present_id = 0;
     const safe_VkImageCreateInfo image_create_info;
+
     std::shared_ptr<SURFACE_STATE> surface;
     ValidationStateTracker *dev_data;
     uint32_t acquired_images = 0;
@@ -329,6 +330,8 @@ class SURFACE_STATE : public BASE_NODE {
     SWAPCHAIN_NODE *swapchain{nullptr};
 
   private:
+    std::unique_lock<std::mutex> Lock() const { return std::unique_lock<std::mutex>(lock_); }
+    mutable std::mutex lock_;
     mutable layer_data::unordered_map<GpuQueue, bool> gpu_queue_support_;
     mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>> present_modes_;
     mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;


### PR DESCRIPTION
These state objects are 'easy' to make thread safe because non-const data can be fully encapsulated with get methods that do appropriate locking.