### PR TITLE
layers: Simplify push DescriptorSet management

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -413,8 +413,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     void UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE *pipeline_layout,
                                        uint32_t first_set, uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
-                                       cvdescriptorset::DescriptorSet *push_descriptor_set, uint32_t dynamic_offset_count,
-                                       const uint32_t *p_dynamic_offsets);
+                                       std::shared_ptr<cvdescriptorset::DescriptorSet> &push_descriptor_set,
+                                       uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets);
 
     void PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint, PIPELINE_LAYOUT_STATE *pipeline_layout, uint32_t set,
                                 uint32_t descriptorWriteCount, const VkWriteDescriptorSet *pDescriptorWrites);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1294,7 +1294,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
             result |= LogError(cb_node->commandBuffer(), kVUID_Core_DrawState_DescriptorSetNotBound,
                                "%s(): %s uses set #%u but that set is not bound.", CommandTypeString(cmd_type),
                                report_data->FormatHandle(pipe->pipeline()).c_str(), set_index);
-        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[set_index].bound_descriptor_set, pipeline_layout,
+        } else if (!VerifySetLayoutCompatibility(report_data, state.per_set[set_index].bound_descriptor_set.get(), pipeline_layout,
                                                  set_index, error_string)) {
             // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
             VkDescriptorSet set_handle = state.per_set[set_index].bound_descriptor_set->GetSet();
@@ -1306,7 +1306,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                report_data->FormatHandle(pipeline_layout->layout()).c_str(), error_string.c_str());
         } else {  // Valid set is bound and layout compatible, validate that it's updated
             // Pull the set node
-            const cvdescriptorset::DescriptorSet *descriptor_set = state.per_set[set_index].bound_descriptor_set;
+            const auto *descriptor_set = state.per_set[set_index].bound_descriptor_set.get();
             // Validate the draw-time state for this descriptor set
             std::string err_str;
             // For the "bindless" style resource usage with many descriptors, need to optimize command <-> descriptor

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -815,9 +815,6 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
       state_data_(state_data),
       variable_count_(variable_count),
       change_count_(0) {
-    if (pool_state_) {
-        pool_state_->AddParent(this);
-    }
     // Foreach binding, create default descriptors of given type
     descriptors_.reserve(layout_->GetTotalDescriptorCount());
     descriptor_store_.resize(layout_->GetTotalDescriptorCount());
@@ -913,9 +910,6 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
 }
 
 void cvdescriptorset::DescriptorSet::Destroy() {
-    if (pool_state_) {
-        pool_state_->RemoveParent(this);
-    }
     for (auto &desc: descriptors_) {
         desc->RemoveParent(this);
     }
@@ -2156,10 +2150,6 @@ void cvdescriptorset::DescriptorSet::PerformCopyUpdate(ValidationStateTracker *d
 void cvdescriptorset::DescriptorSet::UpdateDrawState(ValidationStateTracker *device_data, CMD_BUFFER_STATE *cb_node,
                                                      CMD_TYPE cmd_type, const PIPELINE_STATE *pipe,
                                                      const BindingReqMap &binding_req_map) {
-    if (!device_data->disabled[command_buffer_state] && !IsPushDescriptor()) {
-        cb_node->AddChild(this);
-    }
-
     // Descriptor UpdateDrawState only call image layout validation callbacks. If it is disabled, skip the entire loop.
     if (device_data->disabled[image_layout_validation]) {
         return;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -825,9 +825,6 @@ class DescriptorSet : public BASE_NODE {
 
     void Destroy() override;
 
-    void Reset() {
-        parent_nodes_.clear();
-    }
     // Cached binding and validation support:
     //
     // For the lifespan of a given command buffer recording, do lazy evaluation, caching, and dirtying of

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2021 The Khronos Group Inc.
- * Copyright (c) 2018-2021 Valve Corporation
- * Copyright (c) 2018-2021 LunarG, Inc.
+/* Copyright (c) 2018-2022 The Khronos Group Inc.
+ * Copyright (c) 2018-2022 Valve Corporation
+ * Copyright (c) 2018-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -743,7 +743,7 @@ struct GPUAV_RESTORABLE_PIPELINE_STATE {
             pipeline_layout = last_bound.pipeline_layout;
             descriptor_sets.reserve(last_bound.per_set.size());
             for (std::size_t i = 0; i < last_bound.per_set.size(); i++) {
-                const auto *bound_descriptor_set = last_bound.per_set[i].bound_descriptor_set;
+                const auto &bound_descriptor_set = last_bound.per_set[i].bound_descriptor_set;
                 if (bound_descriptor_set) {
                     descriptor_sets.push_back(bound_descriptor_set->GetSet());
                     if (bound_descriptor_set->IsPushDescriptor()) {

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -298,27 +298,19 @@ struct LAST_BOUND_STATE {
     LAST_BOUND_STATE() { Reset(); }  // must define default constructor for portability reasons
     PIPELINE_STATE *pipeline_state;
     VkPipelineLayout pipeline_layout;
-    std::unique_ptr<cvdescriptorset::DescriptorSet> push_descriptor_set;
+    std::shared_ptr<cvdescriptorset::DescriptorSet> push_descriptor_set;
 
     // Ordered bound set tracking where index is set# that given set is bound to
     struct PER_SET {
-        PER_SET()
-            : bound_descriptor_set(nullptr),
-              compat_id_for_set(0),
-              validated_set(nullptr),
-              validated_set_change_count(~0ULL),
-              validated_set_image_layout_change_count(~0ULL),
-              validated_set_binding_req_map() {}
-
-        cvdescriptorset::DescriptorSet *bound_descriptor_set;
+        std::shared_ptr<cvdescriptorset::DescriptorSet> bound_descriptor_set;
         // one dynamic offset per dynamic descriptor bound to this CB
         std::vector<uint32_t> dynamicOffsets;
-        PipelineLayoutCompatId compat_id_for_set;
+        PipelineLayoutCompatId compat_id_for_set{0};
 
         // Cache most recently validated descriptor state for ValidateCmdBufDrawState/UpdateDrawState
-        const cvdescriptorset::DescriptorSet *validated_set;
-        uint64_t validated_set_change_count;
-        uint64_t validated_set_image_layout_change_count;
+        const cvdescriptorset::DescriptorSet *validated_set{nullptr};
+        uint64_t validated_set_change_count{~0ULL};
+        uint64_t validated_set_image_layout_change_count{~0ULL};
         BindingReqMap validated_set_binding_req_map;
     };
 
@@ -326,7 +318,7 @@ struct LAST_BOUND_STATE {
 
     void Reset();
 
-    void UnbindAndResetPushDescriptorSet(CMD_BUFFER_STATE *cb_state, cvdescriptorset::DescriptorSet *ds);
+    void UnbindAndResetPushDescriptorSet(CMD_BUFFER_STATE *cb_state, std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds);
 
     inline bool IsUsing() const { return pipeline_state ? true : false; }
 };

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2535,9 +2535,10 @@ void ValidationStateTracker::PreCallRecordCmdBindDescriptorSets(VkCommandBuffer 
     auto cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordCmd(CMD_BINDDESCRIPTORSETS);
     auto pipeline_layout = Get<PIPELINE_LAYOUT_STATE>(layout);
+    std::shared_ptr<cvdescriptorset::DescriptorSet> no_push_desc;
 
-    cb_state->UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout.get(), firstSet, setCount, pDescriptorSets, nullptr,
-                                            dynamicOffsetCount, pDynamicOffsets);
+    cb_state->UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout.get(), firstSet, setCount, pDescriptorSets,
+                                            no_push_desc, dynamicOffsetCount, pDynamicOffsets);
 }
 
 void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer,

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2021 The Khronos Group Inc.
- * Copyright (c) 2019-2021 Valve Corporation
- * Copyright (c) 2019-2021 LunarG, Inc.
+/* Copyright (c) 2019-2022 The Khronos Group Inc.
+ * Copyright (c) 2019-2022 Valve Corporation
+ * Copyright (c) 2019-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1855,7 +1855,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
             continue;
         }
         for (const auto &set_binding : stage_state.descriptor_uses) {
-            cvdescriptorset::DescriptorSet *descriptor_set = (*per_sets)[set_binding.first.set].bound_descriptor_set;
+            const auto *descriptor_set = (*per_sets)[set_binding.first.set].bound_descriptor_set.get();
             cvdescriptorset::DescriptorSetLayout::ConstBindingIterator binding_it(descriptor_set->GetLayout().get(),
                                                                                   set_binding.first.binding);
             const auto descriptor_type = binding_it.GetType();
@@ -1991,7 +1991,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
             continue;
         }
         for (const auto &set_binding : stage_state.descriptor_uses) {
-            cvdescriptorset::DescriptorSet *descriptor_set = (*per_sets)[set_binding.first.set].bound_descriptor_set;
+            const auto *descriptor_set = (*per_sets)[set_binding.first.set].bound_descriptor_set.get();
             cvdescriptorset::DescriptorSetLayout::ConstBindingIterator binding_it(descriptor_set->GetLayout().get(),
                                                                                   set_binding.first.binding);
             const auto descriptor_type = binding_it.GetType();


### PR DESCRIPTION
Create push DescriptorSets with std::make_shared<>() so that
they can be used more like normal ones.