### PR TITLE
layers: Add BASE_NODE tree locking

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2021 The ANGLE Project Authors.
-# Copyright (C) 2019-2021 LunarG, Inc.
+# Copyright (C) 2019-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ config("vulkan_layer_config") {
 
 core_validation_sources = [
   "layers/android_ndk_types.h",
+  "layers/base_node.cpp",
   "layers/base_node.h",
   "layers/buffer_state.cpp",
   "layers/buffer_state.h",

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_USE_PLATFORM_ANDROID_KHR \
                      -fvisibility=hidden")
 add_library(VkLayer_khronos_validation SHARED
         ${SRC_DIR}/layers/state_tracker.cpp
+        ${SRC_DIR}/layers/base_node.cpp
         ${SRC_DIR}/layers/buffer_state.cpp
         ${SRC_DIR}/layers/cmd_buffer_state.cpp
         ${SRC_DIR}/layers/device_memory_state.cpp

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -38,6 +38,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_khronos_validation
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/state_tracker.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/device_memory_state.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/base_node.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_state.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/cmd_buffer_state.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/image_state.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2021 Valve Corporation
-# Copyright (c) 2014-2021 LunarG, Inc.
+# Copyright (c) 2014-2022 Valve Corporation
+# Copyright (c) 2014-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -162,6 +162,7 @@ set(CORE_VALIDATION_LIBRARY_FILES
     core_error_location.h
     core_error_location.cpp
     base_node.h
+    base_node.cpp
     device_memory_state.h
     device_memory_state.cpp
     buffer_state.h

--- a/layers/base_node.cpp
+++ b/layers/base_node.cpp
@@ -1,0 +1,81 @@
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
+ * Author: Tobin Ehlis <tobine@google.com>
+ * Author: Chris Forbes <chrisf@ijw.co.nz>
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
+ * Author: John Zulauf <jzulauf@lunarg.com>
+ * Author: Tobias Hector <tobias.hector@amd.com>
+ * Author: Jeremy Gebben <jeremyg@lunarg.com>
+ */
+#include "base_node.h"
+#include "vk_layer_utils.h"
+
+BASE_NODE::~BASE_NODE() { Destroy(); }
+
+void BASE_NODE::Destroy() {
+    Invalidate();
+    destroyed_ = true;
+}
+
+bool BASE_NODE::InUse() const {
+    bool result = false;
+    for (auto& node: parent_nodes_) {
+        result |= node->InUse();
+        if (result) {
+            break;
+        }
+    }
+    return result;
+}
+
+bool BASE_NODE::AddParent(BASE_NODE *parent_node) {
+    auto result = parent_nodes_.emplace(parent_node);
+    return result.second;
+}
+
+void BASE_NODE::RemoveParent(BASE_NODE *parent_node) {
+    parent_nodes_.erase(parent_node);
+}
+
+void BASE_NODE::Invalidate(bool unlink) {
+    NodeList invalid_nodes;
+    invalid_nodes.emplace_back(this);
+    for (auto& node: parent_nodes_) {
+        node->NotifyInvalidate(invalid_nodes, unlink);
+    }
+    if (unlink) {
+        parent_nodes_.clear();
+    }
+}
+
+void BASE_NODE::NotifyInvalidate(const NodeList& invalid_nodes, bool unlink) {
+    if (parent_nodes_.size() == 0) {
+        return;
+    }
+    NodeList up_nodes = invalid_nodes;
+    up_nodes.emplace_back(this);
+    for (auto& node: parent_nodes_) {
+        node->NotifyInvalidate(up_nodes, unlink);
+    }
+    if (unlink) {
+        parent_nodes_.clear();
+    }
+}

--- a/layers/base_node.h
+++ b/layers/base_node.h
@@ -31,6 +31,7 @@
 #include "vk_object_types.h"
 #include "vk_layer_data.h"
 #include "vk_layer_logging.h"
+#include "vk_layer_utils.h"
 
 #include <atomic>
 
@@ -45,16 +46,32 @@ struct hash<VulkanTypedHandle> {
 };
 }  // namespace std
 
-class BASE_NODE {
+// inheriting from enable_shared_from_this<> adds a method, shared_from_this(), which
+// returns a shared_ptr version of the current object. It requires the object to
+// be created with std::make_shared<> and it MUST NOT be used from the constructor
+class BASE_NODE : public std::enable_shared_from_this<BASE_NODE> {
   public:
-    using NodeSet = layer_data::unordered_set<BASE_NODE *>;
-    using NodeList = small_vector<BASE_NODE *, 4>;
+    // Parent nodes are stored as weak_ptrs to avoid cyclic memory dependencies.
+    // Because weak_ptrs cannot safely be used as hash keys, the parents are stored
+    // in a map keyed by VulkanTypedHandle. This also allows looking for specific
+    // parent types without locking every weak_ptr.
+    using NodeMap = layer_data::unordered_map<VulkanTypedHandle, std::weak_ptr<BASE_NODE>>;
+    using NodeList = small_vector<std::shared_ptr<BASE_NODE>, 4, uint32_t>;
 
     template <typename Handle>
     BASE_NODE(Handle h, VulkanObjectType t) : handle_(h, t), destroyed_(false) {}
 
+    // because shared_from_this() does not work from the constructor, this 2nd phase
+    // constructor is where a state object should call AddParent() on its child nodes.
+    // It is called as part of ValidationStateTracker::Add()
+    virtual void LinkChildNodes() {}
+
     virtual ~BASE_NODE();
 
+    // Because state objects are reference counted, they may outlive the vulkan objects
+    // they represent. Destroy() is called when the vulkan object is destroyed, so that
+    // it can be cleaned up before all references are gone. It also triggers notifications
+    // to parent objects.
     virtual void Destroy();
 
     bool Destroyed() const { return destroyed_; }
@@ -65,25 +82,38 @@ class BASE_NODE {
     virtual bool InUse() const;
 
     virtual bool AddParent(BASE_NODE *parent_node);
-
     virtual void RemoveParent(BASE_NODE *parent_node);
 
+    // Invalidate is called on a state object to inform its parents that it
+    // is being destroyed (unlink == true) or otherwise becoming invalid (unlink == false)
     void Invalidate(bool unlink = true);
 
+    // Helper to let objects examine their immediate parents without holding the tree lock.
+    NodeMap ObjectBindings() const;
+
   protected:
-    // NOTE: the entries in invalid_nodes will likely be destroyed & deleted
-    // after the NotifyInvalidate() calls finish.
+    // Called recursively for every parent object of something that has become invalid
     virtual void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink);
+
+    // returns a copy of the current set of parents so that they can be walked
+    // without the tree lock held. If unlink == true, parent_nodes_ is also cleared.
+    NodeMap GetParentsForInvalidate(bool unlink);
 
     VulkanTypedHandle handle_;
 
     // Set to true when the API-level object is destroyed, but this object may
     // hang around until its shared_ptr refcount goes to zero.
-    bool destroyed_;
+    std::atomic<bool> destroyed_;
+
+  private:
+    ReadLockGuard ReadLockTree() const { return ReadLockGuard(tree_lock_); }
+    WriteLockGuard WriteLockTree() { return WriteLockGuard(tree_lock_); }
 
     // Set of immediate parent nodes for this object. For an in-use object, the
     // parent nodes should form a tree with the root being a command buffer.
-    NodeSet parent_nodes_;
+    NodeMap parent_nodes_;
+    // Lock guarding parent_nodes_, this lock MUST NOT be used for other purposes.
+    mutable ReadWriteLock tree_lock_;
 };
 
 class REFCOUNTED_NODE : public BASE_NODE {

--- a/layers/base_node.h
+++ b/layers/base_node.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,64 +53,27 @@ class BASE_NODE {
     template <typename Handle>
     BASE_NODE(Handle h, VulkanObjectType t) : handle_(h, t), destroyed_(false) {}
 
-    virtual ~BASE_NODE() { Destroy(); }
+    virtual ~BASE_NODE();
 
-    virtual void Destroy() {
-        Invalidate();
-        destroyed_ = true;
-    }
+    virtual void Destroy();
 
     bool Destroyed() const { return destroyed_; }
 
     const VulkanTypedHandle &Handle() const { return handle_; }
     VulkanObjectType Type() const { return handle_.type; }
 
-    virtual bool InUse() const {
-        bool result = false;
-        for (auto& node: parent_nodes_) {
-            result |= node->InUse();
-            if (result) {
-                break;
-            }
-        }
-        return result;
-    }
+    virtual bool InUse() const;
 
-    virtual bool AddParent(BASE_NODE *parent_node) {
-        auto result = parent_nodes_.emplace(parent_node);
-        return result.second;
-    }
+    virtual bool AddParent(BASE_NODE *parent_node);
 
-    virtual void RemoveParent(BASE_NODE *parent_node) {
-        parent_nodes_.erase(parent_node);
-    }
+    virtual void RemoveParent(BASE_NODE *parent_node);
 
-    void Invalidate(bool unlink = true) {
-        NodeList invalid_nodes;
-        invalid_nodes.emplace_back(this);
-        for (auto& node: parent_nodes_) {
-            node->NotifyInvalidate(invalid_nodes, unlink);
-        }
-        if (unlink) {
-            parent_nodes_.clear();
-        }
-    }
+    void Invalidate(bool unlink = true);
+
   protected:
     // NOTE: the entries in invalid_nodes will likely be destroyed & deleted
     // after the NotifyInvalidate() calls finish.
-    virtual void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
-        if (parent_nodes_.size() == 0) {
-            return;
-        }
-        NodeList up_nodes = invalid_nodes;
-        up_nodes.emplace_back(this);
-        for (auto& node: parent_nodes_) {
-            node->NotifyInvalidate(up_nodes, unlink);
-        }
-        if (unlink) {
-            parent_nodes_.clear();
-        }
-    }
+    virtual void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink);
 
     VulkanTypedHandle handle_;
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -705,8 +705,8 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
 
     const auto mem_info = Get<DEVICE_MEMORY_STATE>(memory);
 
-    for (const auto& node: mem_info->ObjectBindings()) {
-        const auto& obj = node->Handle();
+    for (const auto& item : mem_info->ObjectBindings()) {
+        const auto& obj = item.first;
         LogObjectList objlist(device);
         objlist.add(obj);
         objlist.add(mem_info->mem());

--- a/layers/buffer_state.h
+++ b/layers/buffer_state.h
@@ -54,10 +54,11 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
 
     BUFFER_VIEW_STATE(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
                       VkFormatFeatureFlags2KHR ff)
-        : BASE_NODE(bv, kVulkanObjectTypeBufferView), create_info(*ci), buffer_state(bf), format_features(ff) {
-        if (buffer_state) {
-            buffer_state->AddParent(this);
-        }
+        : BASE_NODE(bv, kVulkanObjectTypeBufferView), create_info(*ci), buffer_state(bf), format_features(ff) {}
+
+    void LinkChildNodes() override {
+        // Connect child node(s), which cannot safely be done in the constructor.
+        buffer_state->AddParent(this);
     }
     virtual ~BUFFER_VIEW_STATE() {
         if (!Destroyed()) {

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -258,7 +258,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     layer_data::unordered_set<std::shared_ptr<FRAMEBUFFER_STATE>> framebuffers;
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
-    BASE_NODE::NodeSet object_bindings;
+    layer_data::unordered_set<std::shared_ptr<BASE_NODE>> object_bindings;
     layer_data::unordered_map<VulkanTypedHandle, LogObjectList> broken_bindings;
 
     QFOTransferBarrierSets<QFOBufferTransferBarrier> qfo_transfer_buffer_barriers;
@@ -331,14 +331,19 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     IMAGE_VIEW_STATE *GetActiveAttachmentImageViewState(uint32_t index);
     const IMAGE_VIEW_STATE *GetActiveAttachmentImageViewState(uint32_t index) const;
 
-    void AddChild(BASE_NODE *child_node);
-
+    void AddChild(std::shared_ptr<BASE_NODE> &base_node);
     template <typename StateObject>
     void AddChild(std::shared_ptr<StateObject> &child_node) {
-        AddChild(child_node.get());
+        auto base = std::static_pointer_cast<BASE_NODE>(child_node);
+        AddChild(base);
     }
 
-    void RemoveChild(BASE_NODE *child_node);
+    void RemoveChild(std::shared_ptr<BASE_NODE> &base_node);
+    template <typename StateObject>
+    void RemoveChild(std::shared_ptr<StateObject> &child_node) {
+        auto base = std::static_pointer_cast<BASE_NODE>(child_node);
+        RemoveChild(base);
+    }
 
     virtual void Reset();
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3359,10 +3359,10 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const CMD_BUFFE
         }
 
         // Ensure that any bound images or buffers created with SHARING_MODE_CONCURRENT have access to the current queue family
-        for (const auto *base_node : pCB->object_bindings) {
+        for (const auto &base_node : pCB->object_bindings) {
             switch (base_node->Type()) {
                 case kVulkanObjectTypeImage: {
-                    auto image_state = static_cast<const IMAGE_STATE *>(base_node);
+                    auto image_state = static_cast<const IMAGE_STATE *>(base_node.get());
                     if (image_state && image_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                         skip |= ValidImageBufferQueue(pCB, image_state->Handle(), queue_state->queueFamilyIndex,
                                                       image_state->createInfo.queueFamilyIndexCount,
@@ -3371,7 +3371,7 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const CMD_BUFFE
                     break;
                 }
                 case kVulkanObjectTypeBuffer: {
-                    auto buffer_state = static_cast<const BUFFER_STATE *>(base_node);
+                    auto buffer_state = static_cast<const BUFFER_STATE *>(base_node.get());
                     if (buffer_state && buffer_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                         skip |= ValidImageBufferQueue(pCB, buffer_state->Handle(), queue_state->queueFamilyIndex,
                                                       buffer_state->createInfo.queueFamilyIndexCount,

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -832,7 +832,6 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                     } else {
                         descriptors_.emplace_back(new ((free_descriptor++)->Sampler()) SamplerDescriptor(state_data, nullptr));
                     }
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             }
@@ -847,7 +846,6 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                         descriptors_.emplace_back(new ((free_descriptor++)->ImageSampler())
                                                       ImageSamplerDescriptor(state_data, nullptr));
                     }
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             }
@@ -857,27 +855,23 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->Image()) ImageDescriptor(type));
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->Texel()) TexelDescriptor(type));
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
             case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->Buffer()) BufferDescriptor(type));
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->InlineUniform()) InlineUniformDescriptor(type));
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
@@ -885,13 +879,11 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->AccelerationStructure())
                                                   AccelerationStructureDescriptor(type));
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_MUTABLE_VALVE:
                 for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                     descriptors_.emplace_back(new ((free_descriptor++)->Mutable()) MutableDescriptor());
-                    descriptors_.back()->AddParent(this);
                 }
                 break;
             default:
@@ -899,13 +891,19 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                     for (uint32_t di = 0; di < layout_->GetDescriptorCountFromIndex(i); ++di) {
                         dynamic_offset_idx_to_descriptor_list_.push_back(descriptors_.size());
                         descriptors_.emplace_back(new ((free_descriptor++)->Buffer()) BufferDescriptor(type));
-                        descriptors_.back()->AddParent(this);
                     }
                 } else {
                     assert(0);  // Bad descriptor type specified
                 }
                 break;
         }
+    }
+}
+
+void cvdescriptorset::DescriptorSet::LinkChildNodes() {
+    // Connect child node(s), which cannot safely be done in the constructor.
+    for (auto &desc : descriptors_) {
+        desc->AddParent(this);
     }
 }
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -739,6 +739,7 @@ class DescriptorSet : public BASE_NODE {
     using StateTracker = ValidationStateTracker;
     DescriptorSet(const VkDescriptorSet, DESCRIPTOR_POOL_STATE *, const std::shared_ptr<DescriptorSetLayout const> &,
                   uint32_t variable_count, const StateTracker *state_data_const);
+    void LinkChildNodes() override;
     ~DescriptorSet() { Destroy(); }
 
     // A number of common Get* functions that return data based on layout from which this set was created

--- a/layers/device_memory_state.h
+++ b/layers/device_memory_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,8 +80,6 @@ class DEVICE_MEMORY_STATE : public BASE_NODE {
     bool IsDedicatedImage() const { return dedicated && dedicated->handle.type == kVulkanObjectTypeImage; }
 
     VkDeviceMemory mem() const { return handle_.Cast<VkDeviceMemory>(); }
-
-    const NodeSet &ObjectBindings() const { return parent_nodes_; }
 };
 
 // Generic memory binding struct to track objects bound to objects

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -212,8 +212,12 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
                      VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     IMAGE_VIEW_STATE(const IMAGE_VIEW_STATE &rh_obj) = delete;
-
     VkImageView image_view() const { return handle_.Cast<VkImageView>(); }
+
+    void LinkChildNodes() override {
+        // Connect child node(s), which cannot safely be done in the constructor.
+        image_state->AddParent(this);
+    }
 
     virtual ~IMAGE_VIEW_STATE() {
         if (!Destroyed()) {
@@ -270,8 +274,6 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     void AcquireImage(uint32_t image_index);
 
     void Destroy() override;
-
-    const NodeSet &ObjectBindings() const { return parent_nodes_; }
 
   protected:
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -439,7 +439,7 @@ void LAST_BOUND_STATE::UnbindAndResetPushDescriptorSet(CMD_BUFFER_STATE *cb_stat
     if (push_descriptor_set) {
         for (auto &ps : per_set) {
             if (ps.bound_descriptor_set == push_descriptor_set) {
-                cb_state->RemoveChild(ps.bound_descriptor_set.get());
+                cb_state->RemoveChild(ps.bound_descriptor_set);
                 ps.bound_descriptor_set.reset();
             }
         }

--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -316,7 +316,10 @@ FRAMEBUFFER_STATE::FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreate
     : BASE_NODE(fb, kVulkanObjectTypeFramebuffer),
       createInfo(pCreateInfo),
       rp_state(rpstate),
-      attachments_view_state(std::move(attachments)) {
+      attachments_view_state(std::move(attachments)) {}
+
+void FRAMEBUFFER_STATE::LinkChildNodes() {
+    // Connect child node(s), which cannot safely be done in the constructor.
     for (auto &a : attachments_view_state) {
         a->AddParent(this);
     }

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,6 +131,7 @@ class FRAMEBUFFER_STATE : public BASE_NODE {
 
     FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
                       std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments);
+    void LinkChildNodes() override;
 
     VkFramebuffer framebuffer() const { return handle_.Cast<VkFramebuffer>(); }
 

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -280,7 +280,9 @@ class ValidationStateTracker : public ValidationObject {
     void Add(std::shared_ptr<State>&& state_object) {
         auto& map = GetStateMap<State>();
         auto handle = state_object->Handle().template Cast<typename AccessorTraits<State>::HandleType>();
-
+        // Finish setting up the object node tree, which cannot be done from the state object contructors
+        // due to use of shared_from_this()
+        state_object->LinkChildNodes();
         map.insert_or_assign(handle, std::move(state_object));
     }
 


### PR DESCRIPTION
Maintaining the tree of which objects are in use by command buffers is performance critical and also likely to cause interactions between threads. Make access to the tree thread safe by guarding each nodes parent_nodes_ set with a separate r/w lock.