### PR TITLE
layers: Avoid self-merge deadlock in ValidationCache::Merge()

### DIFF
--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -100,6 +100,10 @@ class ValidationCache {
     }
 
     void Merge(ValidationCache const *other) {
+        // self-merging is invalid, but avoid deadlock below just in case.
+        if (other == this) {
+            return;
+        }
         auto other_guard = other->ReadLock();
         auto guard = WriteLock();
         good_shader_hashes_.reserve(good_shader_hashes_.size() + other->good_shader_hashes_.size());


### PR DESCRIPTION
Even though it is invalid to try to merge a validation cache with
itself, avoid deadlock if it happens.

VkLayerTest.ValidationCacheTestBadMerge already tests that self-merging
is invalid.