### PR TITLE
scripts: Fix object wrapping in ray trace pipeline creation

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_dispatch_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -9525,14 +9525,9 @@ VkResult DispatchCreateRayTracingPipelinesKHR(
     }
 
     if (deferredOperation != VK_NULL_HANDLE) {
-        auto cleanup_fn = [local_pCreateInfos,pPipelines,createInfoCount,layer_data](){
+        auto cleanup_fn = [local_pCreateInfos](){
                               if (local_pCreateInfos) {
                                   delete[] local_pCreateInfos;
-                              }
-                              for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {
-                                  if (pPipelines[index0] != VK_NULL_HANDLE) {
-                                      pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);
-                                  }
                               }
                           };
         layer_data->deferred_operation_cleanup.insert(deferredOperation, cleanup_fn);
@@ -9540,10 +9535,10 @@ VkResult DispatchCreateRayTracingPipelinesKHR(
         if (local_pCreateInfos) {
             delete[] local_pCreateInfos;
         }
-        for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {
-            if (pPipelines[index0] != VK_NULL_HANDLE) {
-                pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);
-            }
+    }
+    for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {
+        if (pPipelines[index0] != VK_NULL_HANDLE) {
+            pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);
         }
     }
 

--- a/layers/generated/layer_chassis_dispatch.h
+++ b/layers/generated/layer_chassis_dispatch.h
@@ -3,10 +3,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_dispatch_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2021 The Khronos Group Inc.
-# Copyright (c) 2015-2021 Valve Corporation
-# Copyright (c) 2015-2021 LunarG, Inc.
-# Copyright (c) 2015-2021 Google Inc.
+# Copyright (c) 2015-2022 The Khronos Group Inc.
+# Copyright (c) 2015-2022 Valve Corporation
+# Copyright (c) 2015-2022 LunarG, Inc.
+# Copyright (c) 2015-2022 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -129,10 +129,10 @@ class LayerChassisDispatchOutputGenerator(OutputGenerator):
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_dispatch_generator.py for modifications.
 
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2028,14 +2028,9 @@ VkResult DispatchDeferredOperationJoinKHR(
                 self.appendSection('source_file', copy_feedback_source)
             if ('CreateRayTracingPipelinesKHR' in cmdname):
                 ray_tracing_source    = '    if (deferredOperation != VK_NULL_HANDLE) {\n'
-                ray_tracing_source   += '        auto cleanup_fn = [local_pCreateInfos,pPipelines,createInfoCount,layer_data](){\n'
+                ray_tracing_source   += '        auto cleanup_fn = [local_pCreateInfos](){\n'
                 ray_tracing_source   += '                              if (local_pCreateInfos) {\n'
                 ray_tracing_source   += '                                  delete[] local_pCreateInfos;\n'
-                ray_tracing_source   += '                              }\n'
-                ray_tracing_source   += '                              for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {\n'
-                ray_tracing_source   += '                                  if (pPipelines[index0] != VK_NULL_HANDLE) {\n'
-                ray_tracing_source   += '                                      pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);\n'
-                ray_tracing_source   += '                                  }\n'
                 ray_tracing_source   += '                              }\n'
                 ray_tracing_source   += '                          };\n'
                 ray_tracing_source   += '        layer_data->deferred_operation_cleanup.insert(deferredOperation, cleanup_fn);\n'
@@ -2043,10 +2038,10 @@ VkResult DispatchDeferredOperationJoinKHR(
                 ray_tracing_source   += '        if (local_pCreateInfos) {\n'
                 ray_tracing_source   += '            delete[] local_pCreateInfos;\n'
                 ray_tracing_source   += '        }\n'
-                ray_tracing_source   += '        for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {\n'
-                ray_tracing_source   += '            if (pPipelines[index0] != VK_NULL_HANDLE) {\n'
-                ray_tracing_source   += '                pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);\n'
-                ray_tracing_source   += '            }\n'
+                ray_tracing_source   += '    }\n'
+                ray_tracing_source   += '    for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {\n'
+                ray_tracing_source   += '        if (pPipelines[index0] != VK_NULL_HANDLE) {\n'
+                ray_tracing_source   += '            pPipelines[index0] = layer_data->WrapNew(pPipelines[index0]);\n'
                 ray_tracing_source   += '        }\n'
                 ray_tracing_source   += '    }\n'
                 self.appendSection('source_file', ray_tracing_source)


### PR DESCRIPTION
Fixes #3645. Object wrapping should be independent to memory tracking.