### PR TITLE
corechecks: Fix a crash in PreCallValidateQueueBindSparse()

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -14751,7 +14751,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                     } else {
                         auto loc = outer_loc.dot(Field::pSignalSemaphoreValues, i);
                         skip |= ValidateMaxTimelineSemaphoreValueDifference(
-                            loc, *semaphore_state, timeline_semaphore_submit_info->pWaitSemaphoreValues[i]);
+                            loc, *semaphore_state, timeline_semaphore_submit_info->pSignalSemaphoreValues[i]);
                     }
                     break;
                 case VK_SEMAPHORE_TYPE_BINARY:


### PR DESCRIPTION
This was causing a crash in
dEQP-VK.synchronization.timeline_semaphore.sparse_bind.no_wait_sig