### PR TITLE
layers: Make global QFO and Image Layout state threadsafe

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1304,8 +1304,11 @@ void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier> &cb
     // Add release barriers from this submit to the global map
     for (const auto &release : cb_barriers.release) {
         // the global barrier list is mapped by resource handle to allow cleanup on resource destruction
-        // NOTE: We're using [] because creation of a Set is a needed side effect for new handles
-        global_release_barriers[release.handle].insert(release);
+        // NOTE: vl_concurrent_ordered_map::find() makes a thread safe copy of the result, so we must
+        // copy back after updating.
+        auto iter = global_release_barriers.find(release.handle);
+        iter->second.insert(release);
+        global_release_barriers.insert_or_assign(release.handle, iter->second);
     }
 
     // Erase acquired barriers from this submit from the global map -- essentially marking releases as consumed
@@ -1316,7 +1319,11 @@ void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier> &cb
             QFOTransferBarrierSet<TransferBarrier> &set_for_handle = set_it->second;
             set_for_handle.erase(acquire);
             if (set_for_handle.size() == 0) {  // Clean up empty sets
-                global_release_barriers.erase(set_it);
+                global_release_barriers.erase(acquire.handle);
+            } else {
+                // NOTE: vl_concurrent_ordered_map::find() makes a thread safe copy of the result, so we must
+                // copy back after updating.
+                global_release_barriers.insert_or_assign(acquire.handle, set_for_handle);
             }
         }
     }

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -167,7 +167,10 @@ struct CBVertexBufferBindingInfo {
     std::vector<BufferBinding> vertex_buffer_bindings;
 };
 
-typedef layer_data::unordered_map<const IMAGE_STATE *, layer_data::optional<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
+typedef layer_data::unordered_map<const IMAGE_STATE *, std::shared_ptr<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
+
+typedef layer_data::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutMap>>
+    CommandBufferAliasedLayoutMap;
 
 class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
   public:
@@ -271,6 +274,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     layer_data::unordered_set<QueryObject> startedQueries;
     layer_data::unordered_set<QueryObject> resetQueries;
     CommandBufferImageLayoutMap image_layout_map;
+    CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
+
     CBVertexBufferBindingInfo current_vertex_buffer_binding_info;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -127,7 +127,6 @@ struct SubresourceRangeErrorCodes {
     const char *base_mip_err, *mip_count_err, *base_layer_err, *layer_count_err;
 };
 
-typedef subresource_adapter::BothRangeMap<VkImageLayout, 16> GlobalImageLayoutRangeMap;
 typedef layer_data::unordered_map<const IMAGE_STATE*, layer_data::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
 // Much of the data stored in CMD_BUFFER_STATE is only used by core validation, and is
@@ -164,7 +163,6 @@ class CoreChecks : public ValidationStateTracker {
 
     GlobalQFOTransferBarrierMap<QFOImageTransferBarrier> qfo_release_image_barrier_map;
     GlobalQFOTransferBarrierMap<QFOBufferTransferBarrier> qfo_release_buffer_barrier_map;
-    GlobalImageLayoutMap imageLayoutMap;
     VkValidationCacheEXT core_validation_cache = VK_NULL_HANDLE;
     std::string validation_cache_path;
 
@@ -313,8 +311,6 @@ class CoreChecks : public ValidationStateTracker {
     bool VerifyRenderAreaBounds(const VkRenderPassBeginInfo* pRenderPassBegin, const char* func_name) const;
     bool VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBeginInfo* pRenderPassBeginInfo, const char* func_name) const;
     bool ValidatePrimaryCommandBuffer(const CMD_BUFFER_STATE* pCB, char const* cmd_name, const char* error_code) const;
-
-    void AddInitialLayoutintoImageLayoutMap(const IMAGE_STATE &image_state, GlobalImageLayoutMap &image_layout_map);
 
     void RecordCmdNextSubpassLayouts(VkCommandBuffer commandBuffer, VkSubpassContents contents);
     bool ValidateCmdEndRenderPass(RenderPassCreateVersion rp_version, VkCommandBuffer commandBuffer, CMD_TYPE cmd_type) const;
@@ -795,8 +791,7 @@ class CoreChecks : public ValidationStateTracker {
 
     void PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo) override;
 
-    bool ValidateCmdBufImageLayouts(const Location& loc, const CMD_BUFFER_STATE* pCB,
-                                    const GlobalImageLayoutMap& globalImageLayoutMap, GlobalImageLayoutMap& overlayLayoutMap) const;
+    bool ValidateCmdBufImageLayouts(const Location& loc, const CMD_BUFFER_STATE* pCB, GlobalImageLayoutMap& overlayLayoutMap) const;
 
     void UpdateCmdBufImageLayouts(CMD_BUFFER_STATE* pCB);
 
@@ -1356,10 +1351,16 @@ class CoreChecks : public ValidationStateTracker {
                                                      const VkMappedMemoryRange* pMemRanges) const override;
     bool PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem,
                                         VkDeviceSize memoryOffset) const override;
+    void PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset,
+                                       VkResult result) override;
     bool PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount,
                                          const VkBindImageMemoryInfo* pBindInfos) const override;
+    void PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                        VkResult result) override;
     bool PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
                                             const VkBindImageMemoryInfo* pBindInfos) const override;
+    void PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                           VkResult result) override;
     bool PreCallValidateSetEvent(VkDevice device, VkEvent event) const override;
     bool PreCallValidateResetEvent(VkDevice device, VkEvent event) const override;
     bool PreCallValidateGetEventStatus(VkDevice device, VkEvent event) const override;

--- a/layers/qfo_transfer.h
+++ b/layers/qfo_transfer.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -176,7 +176,7 @@ struct QFOTransferBarrierSets {
 // The layer_data stores the map of pending release barriers
 template <typename TransferBarrier>
 using GlobalQFOTransferBarrierMap =
-    layer_data::unordered_map<typename TransferBarrier::HandleType, QFOTransferBarrierSet<TransferBarrier>>;
+    vl_concurrent_unordered_map<typename TransferBarrier::HandleType, QFOTransferBarrierSet<TransferBarrier>>;
 
 // Submit queue uses the Scoreboard to track all release/acquire operations in a batch.
 template <typename TransferBarrier>

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -442,6 +442,7 @@ class vl_concurrent_unordered_map {
     // find()/end() return a FindResult containing a copy of the value. For end(),
     // return a default value.
     FindResult end() const { return FindResult(false, T()); }
+    FindResult cend() const { return end(); }
 
     FindResult find(const Key &key) const {
         uint32_t h = ConcurrentMapHashObject(key);


### PR DESCRIPTION
Make the global Queue Family Ownership Transfer state be thread safe by using vl_concurrent_unordered_map.

Move the global Image Layout state into an IMAGE_STATE shared_ptr member that is only setup by CoreChecks code.  This avoids repeated lookups into a global map.  It also allows aliasing images to directly use the same layout state, rather than repeating layout state updates by walking IMAGE_STATE::aliasing_images, This lets it be thread safe with a lock around each layout map. The original code would have a required some way to manage locking of all IMAGE_STATE structures whenever an aliasing image was created or destroyed.
