### PR TITLE
Adding validations for 02746 and 02747 regarding fragment density map extension + tests

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10314,6 +10314,15 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
     auto rp_state = Get<RENDER_PASS_STATE>(pCreateInfo->renderPass);
     if (rp_state) {
         const VkRenderPassCreateInfo2 *rpci = rp_state->createInfo.ptr();
+
+        bool b_has_non_zero_view_masks = false;
+        for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
+            if (rpci->pSubpasses[i].viewMask != 0) {
+                b_has_non_zero_view_masks = true;
+                break;
+            }
+        }
+
         if (rpci->attachmentCount != pCreateInfo->attachmentCount) {
             skip |= LogError(pCreateInfo->renderPass, "VUID-VkFramebufferCreateInfo-attachmentCount-00876",
                              "vkCreateFramebuffer(): VkFramebufferCreateInfo attachmentCount of %u does not match attachmentCount "
@@ -10449,6 +10458,35 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                                     }
                                 }
                             }
+
+                            if (enabled_features.fragment_density_map_features.fragmentDensityMap &&
+                                api_version >= VK_API_VERSION_1_1) {
+                                const VkRenderPassFragmentDensityMapCreateInfoEXT *fdm_attachment;
+                                fdm_attachment = LvlFindInChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
+
+                                if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
+                                    uint32_t layer_count = view_state->normalized_subresource_range.layerCount;
+                                    if (b_has_non_zero_view_masks && layer_count != 1 && layer_count <= highest_view_bit) {
+                                        skip |= LogError(
+                                            device, "VUID-VkFramebufferCreateInfo-renderPass-02746",
+                                            "vkCreateFrameBuffer(): VkFramebufferCreateInfo attachment #%" PRIu32
+                                            " has a layer count (%" PRIu32
+                                            ") different than 1 or lower than the most significant bit in viewMask (%" PRIu32
+                                            ") but renderPass (%s) was specified with non-zero view masks\n",
+                                            i, layer_count, highest_view_bit,
+                                            report_data->FormatHandle(pCreateInfo->renderPass).c_str());
+                                    }
+
+                                    if (!b_has_non_zero_view_masks && layer_count != 1) {
+                                        skip |= LogError(
+                                            device, "VUID-VkFramebufferCreateInfo-renderPass-02747",
+                                            "vkCreateFrameBuffer(): VkFramebufferCreateInfo attachment #%" PRIu32
+                                            " had a layer count (%" PRIu32
+                                            ") not equal to 1 but renderPass (%s) was not specified with non-zero view masks\n",
+                                            i, layer_count, report_data->FormatHandle(pCreateInfo->renderPass).c_str());
+                                    }
+                                }
+                            }
                         }
 
                         if (enabled_features.fragment_density_map_features.fragmentDensityMap) {
@@ -10487,7 +10525,8 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                                         "height: %u, the ceiling value: %u\n",
                                         i, subresource_range.baseMipLevel, i, i, mip_height, ceiling_height);
                                 }
-                                if (view_state->normalized_subresource_range.layerCount != 1) {
+                                if (view_state->normalized_subresource_range.layerCount != 1 &&
+                                    !(api_version >= VK_API_VERSION_1_1 || IsExtEnabled(device_extensions.vk_khr_multiview))) {
                                     skip |= LogError(device, "VUID-VkFramebufferCreateInfo-pAttachments-02744",
                                                      "vkCreateFramebuffer(): pCreateInfo->pAttachments[%" PRIu32
                                                      "] is referenced by "
@@ -10878,13 +10917,6 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                 }
             }
 
-            bool b_has_non_zero_view_masks = false;
-            for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
-                if (rpci->pSubpasses[i].viewMask != 0) {
-                    b_has_non_zero_view_masks = true;
-                    break;
-                }
-            }
 
             if (b_has_non_zero_view_masks && pCreateInfo->layers != 1) {
                 skip |= LogError(pCreateInfo->renderPass, "VUID-VkFramebufferCreateInfo-renderPass-02531",

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
- * Copyright (c) 2015-2021 Google, Inc.
- * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2022 Google, Inc.
+ * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1650,6 +1650,8 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
     TEST_DESCRIPTION(
         "Test creating a framebuffer with fragment density map reference to an attachment with layer count different from 1");
 
+    SetTargetApiVersion(VK_API_VERSION_1_0);
+
     if (!InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         return;
     }
@@ -1660,6 +1662,12 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
         printf("%s %s extension not supported skipped.\n", kSkipPrefix, VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
         return;
     }
+
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
+        printf("%s Tests requires a Vulkan version prior to 1.1, skipping test\n", kSkipPrefix);
+        return;
+    }
+
     m_device_extension_names.push_back(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = LvlInitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
     VkPhysicalDeviceFeatures2 features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&fdm_features);


### PR DESCRIPTION
- Adding validations for 02746 and 02747 regarding fragment density map extension + tests
- Removed obsolete validation 02744 (which seems to come from an older version of the spec)