### PR TITLE
layers: Fix ValidatePipelineDrawtimeState crash

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1036,7 +1036,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                         subpass_num_samples |= static_cast<unsigned>(render_pass_info->pAttachments[attachment].samples);
 
                         const auto *imageview_state = pCB->GetActiveAttachmentImageViewState(attachment);
-                        if (imageview_state != nullptr &&
+                        if (imageview_state != nullptr && pPipeline->create_info.graphics.pColorBlendState &&
                             attachment < pPipeline->create_info.graphics.pColorBlendState->attachmentCount) {
                             if ((imageview_state->format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR) == 0 &&
                                 pPipeline->create_info.graphics.pColorBlendState->pAttachments[i].blendEnable != VK_FALSE) {


### PR DESCRIPTION
layers: Fix ValidatePipelineDrawtimeState crash

Exception thrown: read access violation.
pPipeline->create_info.graphics.**pColorBlendState** was nullptr.