### PR TITLE
docs: Document layer settings for fine grained locking

### DIFF
--- a/LAYER_CONFIGURATION.md
+++ b/LAYER_CONFIGURATION.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2019 LunarG, Inc. -->
+<!-- Copyright 2015-2019,2022 LunarG, Inc. -->
 
 [![Khronos Vulkan][1]][2]
 
@@ -136,11 +136,16 @@ The settings file consists of comment lines and settings lines.  Comment lines b
 |                            | `debug`      | Reserved                                                |
 | *`LayerName`*`.debug_action` | `VK_DBG_LAYER_ACTION_IGNORE`   | Ignore message reporting                                          |
 |                            | `VK_DBG_LAYER_ACTION_LOG_MSG`  | Report messages to log                                            |
-|                            | `VK_DBG_LAYER_ACTION_DEBUG_OUTPUT`    | (Windows) Report messages to debug console of Microsoft Visual Studio
+|                            | `VK_DBG_LAYER_ACTION_DEBUG_OUTPUT`    | (Windows) Report messages to debug console of Microsoft Visual Studio|
 |                            | `VK_DBG_LAYER_ACTION_BREAK`    | Break on messages (not currently used)                                  |
 | *`LayerName`*`.log_filename` | *`filename`*`.txt`             | Name of file to log `report_flags` level messages; default is `stdout` |
 | *`LayerName`*`.enables` | comma separated list of `VkValidationFeatureEnableEXT` enum values as defined in the Vulkan Specification      | Enables the specified validation features         |
 | *`LayerName`*`.disables` | comma separated list of `VkValidationFeatureDisableEXT` enum values as defined in the Vulkan Specification      | Disables the specified validation features         |
+| *`LayerName`*.message_id_filter | comma separated list of VUIDs to be ignored | Any validation message with a VUID string that matches an entry in this list will be ignored |
+| *`LayerName`*`.duplicate_message_limit` | 0 | All validation messages are output |
+|  | any value greater than 0 | If greater than 0, this setting controls how many messages with the same VUID string will be output. Additional messages with the same VUID string will be ignored, which may reduce log file size and improve performance. |
+| *`LayerName`*`.fine_grained_locking` | false (or 0) | Validation code runs with a global lock held, which limits concurrency. This is the default behavior and is how earlier versions of the validation layer behaved. |
+|  | true (or 1) | **Experimental** - validation code runs without global locking. This should allow better performance for multi-threaded applications. But it may cause instability or incorrect errors. See [this document](docs/fine_grained_locking_usage.md) for more information|
 
 
 
@@ -160,6 +165,25 @@ On Windows, you can find a sample layer settings file in `Config\vk_layer_settin
 Consult these sample layer settings files for additional information and detail related to available options and settings.
 
 Note: If layers are activated via `VK_INSTANCE_LAYERS` environment variable and if neither an application-defined callback is defined nor a layer settings file is present, the loader/layers will provide default callbacks enabling output of error-level messages to standard out (and via `OutputDebugString` on Windows).
+
+### Environment Variables
+
+Some settings from the settings file can also be set using environment variables. If an environment variable is set, its value takes precedence over the value in the settings file.
+
+ 
+
+| Setting                                 | Environment variable               |
+| --------------------------------------- | ---------------------------------- |
+| *`LayerName`*`.report_flags`            | *None*                             |
+| *`LayerName`*`.debug_action`            | *None*                             |
+| *`LayerName`*`.log_filename`            | *None*                             |
+| *`LayerName`*`.enables`                 | `VK_LAYER_ENABLES`                 |
+| *`LayerName`*`.disables`                | `VK_LAYER_DISABLES`                |
+| *`LayerName`*.message_id_filter         | `VK_LAYER_MESSAGE_ID_FILTER`       |
+| *`LayerName`*`.duplicate_message_limit` | `VK_LAYER_DUPLICATE_MESSAGE_LIMIT` |
+| *`LayerName`*`.fine_grained_locking`    | `VK_LAYER_FINE_GRAINED_LOCKING`    |
+
+
 
 ### Advanced Layer Configuration, Installation, and Discovery Details
 The Vulkan loader searches specific platform-specific locations to find installed layers.

--- a/docs/fine_grained_locking_usage.md
+++ b/docs/fine_grained_locking_usage.md
@@ -1,0 +1,54 @@
+<!-- markdownlint-disable MD041 -->
+<!-- Copyright 2021-2022 LunarG, Inc. -->
+[![Khronos Vulkan][1]][2]
+
+[1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
+[2]: https://www.khronos.org/vulkan/
+
+# Fine Grained Locking
+
+The Vulkan-ValidationLayer code has been updated to not globally lock every Vulkan call. Waiting on this lock causes performance problems for multi-threaded applications, and most Vulkan games are heavily multi-threaded.  This feature has been tested with 15+ released games and improves performance in almost all of them, and many improve by about 150%.
+
+However, changes to locking strategy in a multi threaded program are a frequent cause of crashes, incorrect results, or deadlock. For the first release of this feature, it is off by default and can be enabled using the instructions below. Once the new locking strategy has been proven to not cause stability problems, it will be on by default and then can be turned off, if necessary for debugging.
+
+Currently, this Fine Grained Locking is only available for Core Validation.  Best Practices, Synchronization Validation, GPU Assisted Validation and Debug Printf still always run with global locking. Support for these types of validation will be added in a future release.
+
+Thread Safety, Object Lifetime, Handle Wrapping and Stateless validation have always avoided global locking and they are thus unaffected by this feature.
+
+Fine grained locking can easily be enabled and configured using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html) included with the Vulkan SDK. You can also manually enable it following instructions below.
+
+
+
+## Enabling Fine Grained Locking
+
+This feature is disabled by default. To turn it on, add the following to your layer settings file,
+`vk_layer_settings.txt`:
+
+```code
+khronos_validation.fine_grained_locking = true
+```
+
+To enable using environment variables, set the following variable:
+
+```code
+VK_LAYER_FINE_GRAINED_LOCKING=1
+```
+
+### Known Limitations
+
+Currently there is not a way to enable this setting via `VK_EXT_validation_features` or other programmatic interface. This will be addressed in a future release.
+
+The locking in Vulkan-ValidationLayer is not intended to provide correct results for programs that violate the thread safety guidelines described in *section 3.6 Threading Behavior* of the Vulkan specification. We will attempt to fix crash bugs in the layer resulting from insufficient external synchronization, but incorrect or inconsistent error messages will be likely. Please run Thread Safety violation to find problems like this.
+
+
+### Debugging Tips
+
+As mentioned above, solving all problems found by Thread Safety validation is highly recommended before trying to use Core Validation with Fine Grained Locking. 
+
+If you encounter a crash, deadlock or incorrect behavior, re-run with Fine Grained Locking disabled. If your problem goes away, it is most likely a problem with the layer's locking code. If it remains, then it is probably caused by something else and will require further debugging.
+
+For crashes or deadlocks, it will be extremely helpful you provide stack traces for any threads in your program that were executing in the layer at the time the problem occurred.  In Microsoft Visual Studio, the [Parallel Stacks](https://docs.microsoft.com/en-us/visualstudio/debugger/using-the-parallel-stacks-window?view=vs-2022) window is a good way to check the status of all threads in your program.  With [gdb](https://sourceware.org/gdb/current/onlinedocs/gdb/Threads.html#Threads), you usually need to use the `info thread` and `thread` commands to view the stacks from each thread.
+
+Replay tools such as `gfxrecon` are not always helpful when debugging problems in multi-threaded code. Because these tools usually need to serialize all vulkan commands into a single stream, they will not be able to recreate interactions between threads during replay.  Often, the only way to recreate problems is to rerun the program, but sometimes changes in timing may cause problems to only happen on some types of hardware.
+
+Please file a [Github issue](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues) if you need help or have feedback on this feature. The more information you can provide about what was happening, the better we will be able to help!


### PR DESCRIPTION
This change also documents settings related to message filtering
and the environment variable equivalents to some of the file
settings.