### PR TITLE
corechecks: Remove extra GetRead() call in dynamic rendering

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7163,8 +7163,6 @@ bool CoreChecks::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuff
 
 bool CoreChecks::ValidateRenderingAttachmentInfoKHR(VkCommandBuffer commandBuffer,
                                                     const VkRenderingAttachmentInfoKHR *pAttachment) const {
-    const auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    if (!cb_state) return false;
     bool skip = false;
 
     if (pAttachment->imageView != VK_NULL_HANDLE) {


### PR DESCRIPTION
ValidateRenderingAttachmentInfoKHR() doesn't need to access
command buffer state. Its calling code already has a read-locked
command buffer, so this extra call could lead to deadlock.