### PR TITLE
layers: Refactoring ValidateShaderStorageImageFormats

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -573,7 +573,7 @@ class CoreChecks : public ValidationStateTracker {
                                                        bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
                                               const PIPELINE_STATE* pipeline, spirv_inst_iter entrypoint) const;
-    bool ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const* src) const;
+    bool ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const* src, const spirv_inst_iter& insn) const;
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage,
                                             spirv_inst_iter& insn) const;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -1795,40 +1795,6 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
     return out;
 }
 
-spirv_inst_iter SHADER_MODULE_STATE::GetImageFormatInst(uint32_t id) const
-{
-    do {
-        auto def = get_def(id);
-        if (def == end())
-            return def;
-
-        switch (def.opcode()) {
-           case spv::OpLoad:
-           case spv::OpAccessChain:
-           case spv::OpCompositeConstruct:
-           case spv::OpVariable: {
-               id = def.word(1);
-               break;
-           }
-
-           case spv::OpTypeArray:
-           case spv::OpTypeRuntimeArray:
-               id = def.word(2);
-               break;
-
-           case spv::OpTypePointer:
-               id = def.word(3);
-               break;
-
-           case spv::OpTypeImage:
-               return def;
-
-           default:
-               return end();
-        }
-    } while (true);
-}
-
 uint32_t SHADER_MODULE_STATE::GetNumComponentsInBaseType(const spirv_inst_iter &iter) const {
     const uint32_t opcode = iter.opcode();
     if (opcode == spv::OpTypeFloat || opcode == spv::OpTypeInt) {
@@ -1956,6 +1922,12 @@ uint32_t SHADER_MODULE_STATE::GetBaseType(const spirv_inst_iter &iter) const {
         return GetBaseType(type);
     }
     return 0;
+}
+
+// Returns type_id if id has type or zero otherwise
+uint32_t SHADER_MODULE_STATE::GetTypeId(uint32_t id) const {
+    const auto type = get_def(id);
+    return OpcodeHasType(type.opcode()) ? type.word(1) : 0;
 }
 
 uint32_t SHADER_MODULE_STATE::CalcComputeSharedMemory(VkShaderStageFlagBits stage,

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 The Khronos Group Inc.
+/* Copyright (c) 2021-2022 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ class PIPELINE_STATE;
 
 // A forward iterator over spirv instructions. Provides easy access to len, opcode, and content words
 // without the caller needing to care too much about the physical SPIRV module layout.
+//
+// For more information of the physical module layout to help understand this struct:
+// https://github.com/KhronosGroup/SPIRV-Guide/blob/master/chapters/parsing_instructions.md
 struct spirv_inst_iter {
     std::vector<uint32_t>::const_iterator zero;
     std::vector<uint32_t>::const_iterator it;
@@ -378,15 +381,13 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::vector<std::pair<uint32_t, interface_var>> CollectInterfaceByInputAttachmentIndex(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
 
-    // Get the image type from a variable id or load operation that reference an image
-    spirv_inst_iter GetImageFormatInst(uint32_t id) const;
-
     uint32_t GetNumComponentsInBaseType(const spirv_inst_iter &iter) const;
     std::array<uint32_t, 3> GetWorkgroupSize(VkPipelineShaderStageCreateInfo const *pStage,
                                              const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) const;
     uint32_t GetTypeBitsSize(const spirv_inst_iter &iter) const;
     uint32_t GetTypeBytesSize(const spirv_inst_iter &iter) const;
     uint32_t GetBaseType(const spirv_inst_iter &iter) const;
+    uint32_t GetTypeId(uint32_t id) const;
     uint32_t CalcComputeSharedMemory(VkShaderStageFlagBits stage,
                                      const spirv_inst_iter &insn) const;
 


### PR DESCRIPTION
Slight refactoring of #2777 (cc @djdeath)

1. Moved to the per-instruction static check loop to avoid looping entire module 2 extra times
2. Got rid of `GetImageFormatInst` in favor of being able to make assumptions that the `spirv-val` check will give us
    a. To be fair, this function had warnings removed (#3037) and also didn't account for non-storage images using `OpTypeSampledImage`
3. Created new `GetTypeId` helper function (matches `spirv-val` logic) which we can now use thanks to the new `OpcodeHasType` SPIR-V generated function we have now!