### PR TITLE
layers: Add helper to print out spirv instruction

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -634,6 +634,30 @@ std::string SHADER_MODULE_STATE::DescribeType(unsigned type) const {
     return ss.str();
 }
 
+std::string SHADER_MODULE_STATE::DescribeInstruction(const spirv_inst_iter &insn) const {
+    std::ostringstream ss;
+    const uint32_t opcode = insn.opcode();
+    uint32_t operand_offset = 1;  // where to start printing operands
+    // common disassembled for SPIR-V is
+    // %result = Opcode %result_type %operands
+    if (OpcodeHasResult(opcode)) {
+        operand_offset++;
+        ss << "%" << (OpcodeHasType(opcode) ? insn.word(2) : insn.word(1)) << " = ";
+    }
+
+    ss << string_SpvOpcode(opcode);
+
+    if (OpcodeHasType(opcode)) {
+        operand_offset++;
+        ss << " %" << insn.word(1);
+    }
+
+    for (uint32_t i = operand_offset; i < insn.len(); i++) {
+        ss << " %" << insn.word(i);
+    }
+    return ss.str();
+}
+
 const SHADER_MODULE_STATE::EntryPoint *SHADER_MODULE_STATE::FindEntrypointStruct(char const *name,
                                                                                  VkShaderStageFlagBits stageBits) const {
     auto range = static_data_.entry_points.equal_range(name);

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 The Khronos Group Inc.
+/* Copyright (c) 2021-2022 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -330,6 +330,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Used to get human readable strings for error messages
     void DescribeTypeInner(std::ostringstream &ss, unsigned type) const;
     std::string DescribeType(unsigned type) const;
+    std::string DescribeInstruction(const spirv_inst_iter &insn) const;
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(spirv_inst_iter entrypoint) const;
     layer_data::optional<VkPrimitiveTopology> GetTopology(const spirv_inst_iter &entrypoint) const;


### PR DESCRIPTION
Adds `DescribeInstruction` to improve SPIR-V based error message

In future plan to add to more `LogError` as well as make use of the `OpName` when possible

------

Example 1

```
[ VUID-RuntimeSpirv-vulkanMemoryModel-06265 ] Object 0: handle = 0x3853790, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7ab8899 | VkPhysicalDeviceVulkan12Features::vulkanMemoryModel is enabled and VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope is disabled, but Device memory scope is used.
```

now looks like

```
[ VUID-RuntimeSpirv-vulkanMemoryModel-06265 ] Object 0: handle = 0x2f37850, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7ab8899 | VkPhysicalDeviceVulkan12Features::vulkanMemoryModel is enabled and VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope is disabled, but
OpAtomicStore %13 %15 %18 %14
uses Device memory scope.
```

------

Example 2

```
[ VUID-RuntimeSpirv-None-06279 ] Object 0: handle = 0x2e00b60, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xd5709f48 | VkShaderModule 0x95a125000000001a[]: Can't use 64-bit int atomics operations (OpAtomicIAdd) with Workgroup storage class without shaderSharedInt64Atomics enabled.
```

now looks like

```
Validation Error: [ VUID-RuntimeSpirv-None-06279 ] Object 0: handle = 0x40adb60, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xd5709f48 | VkShaderModule 0x95a125000000001a[]: Can't use 64-bit int atomics operations
%13 = OpAtomicIAdd %6 %8 %11 %12 %9
with Workgroup storage class without shaderSharedInt64Atomics enabled.
```
