### PR TITLE
Fix errors when defaultSuccess is chosen

### DIFF
--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4459,7 +4459,6 @@ TEST_F(VkPositiveLayerTest, PhysicalStorageBuffer) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     std::vector<const char *> exts = {
-        "VK_EXT_buffer_device_address",  // TODO (ncesario) why does VK_KHR_buffer_device_address not work?
         "VK_KHR_shader_non_semantic_info",
         "VK_EXT_scalar_block_layout",
     };

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7137,6 +7137,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 4;
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
         VkBufferObj const buffer_obj(*m_device, info);
 
         VkDeviceSize const offsets[1]{};
@@ -7266,6 +7267,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
         info.size = 4;
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
         VkBufferObj const buffer_obj(*m_device, info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-pCounterBuffers-02372");
@@ -7395,6 +7397,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
             auto info = LvlInitStruct<VkBufferCreateInfo>();
             // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
             info.size = 4;
+            m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
             VkBufferObj const buffer_obj(*m_device, info);
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndTransformFeedbackEXT-pCounterBuffers-02380");
@@ -9194,7 +9197,8 @@ TEST_F(VkLayerTest, InvalidClearColorAttachmentsWithMultiview) {
 
     VkImageObj image(m_device);
     image.Init(image_create_info);
-    VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+    VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
+                                             VK_REMAINING_ARRAY_LAYERS, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
     VkFramebufferCreateInfo framebufferCreateInfo = LvlInitStruct<VkFramebufferCreateInfo>();
     framebufferCreateInfo.width = 32;

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -334,8 +334,12 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageViewMismatchTests) {
     renderPassAttachmentBeginInfo.pAttachments = &imageView2;
     framebufferAttachmentImageInfo.height = framebufferAttachmentImageInfo.height / 2;
     framebufferAttachmentImageInfo.width = framebufferAttachmentImageInfo.width / 2;
+    framebufferCreateInfo.height = framebufferCreateInfo.height / 2;
+    framebufferCreateInfo.width = framebufferCreateInfo.width / 2;
     vk::CreateFramebuffer(m_device->device(), &framebufferCreateInfo, nullptr, &framebuffer);
     renderPassBeginInfo.framebuffer = framebuffer;
+    renderPassBeginInfo.renderArea.extent.height = renderPassBeginInfo.renderArea.extent.height / 2;
+    renderPassBeginInfo.renderArea.extent.width = renderPassBeginInfo.renderArea.extent.width / 2;
     vk::BeginCommandBuffer(m_commandBuffer->handle(), &cmd_begin_info);
     m_errorMonitor->ExpectSuccess();
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
@@ -1520,11 +1524,10 @@ TEST_F(VkLayerTest, FramebufferAttachmentImageInfoPNext) {
     TEST_DESCRIPTION("Begin render pass with missing framebuffer attachment");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME)) {
+    if (!AddRequiredDeviceExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME)) {
         printf("%s test requires VK_KHR_imageless_framebuffer, not available.  Skipping.\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -976,6 +976,10 @@ TEST_F(VkLayerTest, ViewportInheritanceScissorMissingFeature) {
 TEST_F(VkLayerTest, PipelineMissingDynamicStateDiscardRectangle) {
     TEST_DESCRIPTION("Bind pipeline with missing dynamic state discard rectangle.");
 
+    if (!AddRequiredInstanceExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        return;
+    }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -381,6 +381,11 @@ TEST_F(VkLayerTest, ValidSwapchainImageParams) {
         return;
     }
 
+    if (!AddRequiredInstanceExtensions(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
+        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
+        return;
+    }
+
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (!AddSwapchainDeviceExtension()) {
@@ -898,11 +903,8 @@ TEST_F(VkLayerTest, InvalidSwapchainImageFormatList) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME) &&
-        DeviceExtensionSupported(gpu(), nullptr, VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
-    } else {
+    if (!AddRequiredDeviceExtensions(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME) ||
+        !AddRequiredDeviceExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME)) {
         printf("%s Required extensions not supported, skipping tests\n", kSkipPrefix);
         return;
     }


### PR DESCRIPTION
Fixed following tests when `defaultSuccess` is enabled:
```
VkPositiveLayerTest.PhysicalStorageBuffer                                [CRASH] [FIXED] [PASS]
VkLayerTest.TransformFeedbackCmdBindTransformFeedbackBuffersEXT          [CRASH] [FIXED] [PASS]
VkLayerTest.TransformFeedbackCmdBeginTransformFeedbackEXT                [CRASH] [FIXED] [PASS]
VkLayerTest.TransformFeedbackCmdEndTransformFeedbackEXT                  [CRASH] [FIXED] [PASS]
VkLayerTest.InvalidClearColorAttachmentsWithMultiview                    [CRASH] [FIXED] [PASS]
VkLayerTest.InvalidSampleLocations                                       [CRASH] [FIXED] [PASS]
VkLayerTest.DrawWithPipelineIncompatibleWithRenderPassFragmentDensityMap [CRASH] [FIXED] [PASS]
VkLayerTest.InvalidCreateDescriptorPoolAllocateFlags                     [CRASH] [FIXED] [CAN'T RUN]
VkLayerTest.InvalidRenderArea                                            [CRASH] [FIXED] [PASS]
VkLayerTest.InvalidDeviceGroupRenderArea                                 [CRASH] [FIXED] [PASS]
VkLayerTest.AccelerationStructureBindings                                [CRASH] [FIXED] [CAN'T RUN]
VkLayerTest.ImagelessFramebufferRenderPassBeginImageViewMismatchTests    [CRASH] [FIXED] [FAIL]
VkLayerTest.FramebufferAttachmentImageInfoPNext                          [CRASH] [FIXED] [FAIL]
VkLayerTest.PipelineMissingDynamicStateDiscardRectangle                  [CRASH] [FIXED] [PASS]
```