### PR TITLE
Shader Module consistency cleanup

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1407,7 +1407,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
     //       Discussion on validity of these checks can be found at https://gitlab.khronos.org/vulkan/vulkan/-/issues/2602.
     if (!cb_node->push_constant_data_ranges || (pipeline_layout->push_constant_ranges == cb_node->push_constant_data_ranges)) {
         for (const auto &stage : pipe->stage_state) {
-            const auto *entrypoint = stage.module->FindEntrypointStruct(stage.create_info->pName, stage.create_info->stage);
+            const auto *entrypoint = stage.module_state->FindEntrypointStruct(stage.create_info->pName, stage.create_info->stage);
             if (!entrypoint || !entrypoint->push_constant_used_in_shader.IsUsed()) {
                 continue;
             }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -563,41 +563,42 @@ class CoreChecks : public ValidationStateTracker {
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule) const override;
     bool ValidatePipelineShaderStage(const PIPELINE_STATE* pipeline, const PipelineStageState& stage_state,
                                      bool check_point_size) const;
-    bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint,
-                                      VkShaderStageFlagBits stage) const;
-    bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* src,
+    bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* module_state,
+                                      spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
+    bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, SHADER_MODULE_STATE const* module_state,
                                           spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
-    bool ValidateTexelOffsetLimits(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
-    bool ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
+    bool ValidateTexelOffsetLimits(SHADER_MODULE_STATE const* module_state, spirv_inst_iter& insn) const;
+    bool ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
                                                        bool has_atomic_descriptor) const;
-    bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
-                                              const PIPELINE_STATE* pipeline, spirv_inst_iter entrypoint) const;
-    bool ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const* src, const spirv_inst_iter& insn) const;
+    bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* module_state,
+                                              VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
+                                              spirv_inst_iter entrypoint) const;
+    bool ValidateShaderStorageImageFormats(SHADER_MODULE_STATE const* module_state, const spirv_inst_iter& insn) const;
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const PIPELINE_STATE* pipeline) const;
-    bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* src, VkShaderStageFlagBits stage,
+    bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* module_state, VkShaderStageFlagBits stage,
                                             spirv_inst_iter& insn) const;
-    bool ValidateMemoryScope(SHADER_MODULE_STATE const* src, const spirv_inst_iter& insn) const;
-    bool ValidateWorkgroupSize(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateMemoryScope(SHADER_MODULE_STATE const* module_state, const spirv_inst_iter& insn) const;
+    bool ValidateWorkgroupSize(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
                                const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) const;
-    bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
-    bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* src, VkPipelineShaderStageCreateInfo const* pStage,
+    bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderSubgroupSizeControl(VkPipelineShaderStageCreateInfo const* pStage) const;
-    bool ValidateAtomicsTypes(SHADER_MODULE_STATE const* src) const;
-    bool ValidateExecutionModes(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
+    bool ValidateAtomicsTypes(SHADER_MODULE_STATE const* module_state) const;
+    bool ValidateExecutionModes(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
     bool ValidateViConsistency(VkPipelineVertexInputStateCreateInfo const* vi) const;
-    bool ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo const* vi, SHADER_MODULE_STATE const* vs,
+    bool ValidateViAgainstVsInputs(VkPipelineVertexInputStateCreateInfo const* vi, SHADER_MODULE_STATE const* module_state,
                                    spirv_inst_iter entrypoint) const;
-    bool ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const* fs, spirv_inst_iter entrypoint,
+    bool ValidateFsOutputsAgainstRenderPass(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint,
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
-    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODULE_STATE const* fs, spirv_inst_iter entrypoint,
+    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint,
                                                             PIPELINE_STATE const* pipeline) const;
-    bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* src,
+    bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, SHADER_MODULE_STATE const* module_state,
                                    VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
-    bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* src, spirv_inst_iter entrypoint) const;
+    bool ValidateBuiltinLimits(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;
@@ -608,9 +609,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateInterfaceBetweenStages(SHADER_MODULE_STATE const* producer, spirv_inst_iter producer_entrypoint,
                                         shader_stage_attributes const* producer_stage, SHADER_MODULE_STATE const* consumer,
                                         spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
-    bool ValidateDecorations(SHADER_MODULE_STATE const* module) const;
-    bool ValidateTransformFeedback(SHADER_MODULE_STATE const* src) const;
-    bool ValidateShaderClock(SHADER_MODULE_STATE const* module, spirv_inst_iter& insn) const;
+    bool ValidateDecorations(SHADER_MODULE_STATE const* module_state) const;
+    bool ValidateTransformFeedback(SHADER_MODULE_STATE const* module_state) const;
+    bool ValidateShaderClock(SHADER_MODULE_STATE const* module_state, spirv_inst_iter& insn) const;
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* src_img,
@@ -1549,7 +1550,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue, const char* apiName) const;
     bool PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
-    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* shader, const spirv_inst_iter& entrypoint,
+    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* module_state, const spirv_inst_iter& entrypoint,
                                        const PipelineStageState& stage_state) const;
 
     bool ValidateQueryRange(VkDevice device, VkQueryPool queryPool, uint32_t totalCount, uint32_t firstQuery, uint32_t queryCount,

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -478,9 +478,9 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string forma
 
 std::string DebugPrintf::FindFormatString(std::vector<unsigned int> pgm, uint32_t string_id) {
     std::string format_string;
-    SHADER_MODULE_STATE shader(pgm);
-    if (shader.words.size() > 0) {
-        for (const auto &insn : shader) {
+    SHADER_MODULE_STATE module_state(pgm);
+    if (module_state.words.size() > 0) {
+        for (const auto &insn : module_state) {
             if (insn.opcode() == spv::OpString) {
                 uint32_t offset = insn.offset();
                 if (pgm[offset + 1] == string_id) {

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -318,7 +318,7 @@ void DebugPrintf::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipel
     ValidationStateTracker::PreCallRecordDestroyPipeline(device, pipeline, pAllocator);
 }
 // Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
-bool DebugPrintf::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, std::vector<unsigned int> &new_pgm,
+bool DebugPrintf::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, std::vector<uint32_t> &new_pgm,
                                    uint32_t *unique_shader_id) {
     if (aborted) return false;
     if (pCreateInfo->pCode[0] != spv::MagicNumber) return false;
@@ -370,7 +370,7 @@ void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
     bool pass = InstrumentShader(pCreateInfo, csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
-        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(unsigned int);
+        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(uint32_t);
     }
 }
 
@@ -476,7 +476,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string forma
     return parsed_strings;
 }
 
-std::string DebugPrintf::FindFormatString(std::vector<unsigned int> pgm, uint32_t string_id) {
+std::string DebugPrintf::FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id) {
     std::string format_string;
     SHADER_MODULE_STATE module_state(pgm);
     if (module_state.words.size() > 0) {
@@ -547,7 +547,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
         std::stringstream shader_message;
         VkShaderModule shader_module_handle = VK_NULL_HANDLE;
         VkPipeline pipeline_handle = VK_NULL_HANDLE;
-        std::vector<unsigned int> pgm;
+        std::vector<uint32_t> pgm;
 
         DPFOutputRecord *debug_record = reinterpret_cast<DPFOutputRecord *>(&debug_output_buffer[index]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -44,7 +44,7 @@ struct DPFBufferInfo {
 struct DPFShaderTracker {
     VkPipeline pipeline;
     VkShaderModule shader_module;
-    std::vector<unsigned int> pgm;
+    std::vector<uint32_t> pgm;
 };
 
 enum vartype { varsigned, varunsigned, varfloat };
@@ -163,13 +163,12 @@ class DebugPrintf : public ValidationStateTracker {
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                     VkResult result, void* crtpl_state_data) override;
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator) override;
-    bool InstrumentShader(const VkShaderModuleCreateInfo* pCreateInfo, std::vector<unsigned int>& new_pgm,
-                          uint32_t* unique_shader_id);
+    bool InstrumentShader(const VkShaderModuleCreateInfo* pCreateInfo, std::vector<uint32_t>& new_pgm, uint32_t* unique_shader_id);
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
     std::vector<DPFSubstring> ParseFormatString(std::string format_string);
-    std::string FindFormatString(std::vector<unsigned int> pgm, uint32_t string_id);
+    std::string FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo &buffer_info,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer);
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -623,7 +623,7 @@ static inline const char* string_SpvCapability(uint32_t input_value) {
     };
 };
 
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const *src, spirv_inst_iter& insn) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const {
     bool skip = false;
 
     if (insn.opcode() == spv::OpCapability) {

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -489,7 +489,7 @@ bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::str
 
 // Extract the filename, line number, and column number from the correct OpLine and build a message string from it.
 // Scan the source (from OpSource) to find the line of source at the reported line number and place it in another message string.
-void UtilGenerateSourceMessages(const std::vector<unsigned int> &pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(const std::vector<uint32_t> &pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg) {
     using namespace spvtools;
     std::ostringstream filename_stream;

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2021 The Khronos Group Inc.
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+/* Copyright (c) 2020-2022 The Khronos Group Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,8 +391,9 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
 
 // Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
 // Split the single string into a vector of strings, one for each line, for easier processing.
-void ReadOpSource(const SHADER_MODULE_STATE &shader, const uint32_t reported_file_id, std::vector<std::string> &opsource_lines) {
-    for (auto insn : shader) {
+void ReadOpSource(const SHADER_MODULE_STATE &module_state, const uint32_t reported_file_id,
+                  std::vector<std::string> &opsource_lines) {
+    for (auto insn : module_state) {
         if ((insn.opcode() == spv::OpSource) && (insn.len() >= 5) && (insn.word(3) == reported_file_id)) {
             std::istringstream in_stream;
             std::string cur_line;

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -454,5 +454,5 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
                                const uint32_t *debug_record, const VkShaderModule shader_module_handle,
                                const VkPipeline pipeline_handle, const VkPipelineBindPoint pipeline_bind_point,
                                const uint32_t operation_index, std::string &msg);
-void UtilGenerateSourceMessages(const std::vector<unsigned int> &pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(const std::vector<uint32_t> &pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1278,7 +1278,7 @@ void GpuAssisted::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass r
 }
 
 // Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
-bool GpuAssisted::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, std::vector<unsigned int> &new_pgm,
+bool GpuAssisted::InstrumentShader(const VkShaderModuleCreateInfo *pCreateInfo, std::vector<uint32_t> &new_pgm,
                                    uint32_t *unique_shader_id) {
     if (aborted) return false;
     if (pCreateInfo->pCode[0] != spv::MagicNumber) return false;
@@ -1339,7 +1339,7 @@ void GpuAssisted::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
     bool pass = InstrumentShader(pCreateInfo, csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
-        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(unsigned int);
+        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(uint32_t);
     }
     ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
 }
@@ -1477,7 +1477,7 @@ void GpuAssisted::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
     std::string vuid_msg;
     VkShaderModule shader_module_handle = VK_NULL_HANDLE;
     VkPipeline pipeline_handle = VK_NULL_HANDLE;
-    std::vector<unsigned int> pgm;
+    std::vector<uint32_t> pgm;
     // The first record starts at this offset after the total_words.
     const uint32_t *debug_record = &debug_output_buffer[kDebugOutputDataOffset];
     // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -68,7 +68,7 @@ struct GpuAssistedBufferInfo {
 struct GpuAssistedShaderTracker {
     VkPipeline pipeline;
     VkShaderModule shader_module;
-    std::vector<unsigned int> pgm;
+    std::vector<uint32_t> pgm;
 };
 
 struct GpuVuid {
@@ -246,14 +246,13 @@ class GpuAssisted : public ValidationStateTracker {
                                                     VkResult result, void* crtpl_state_data) override;
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator) override;
     void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator) override;
-    bool InstrumentShader(const VkShaderModuleCreateInfo* pCreateInfo, std::vector<unsigned int>& new_pgm,
-                          uint32_t* unique_shader_id);
+    bool InstrumentShader(const VkShaderModuleCreateInfo* pCreateInfo, std::vector<uint32_t>& new_pgm, uint32_t* unique_shader_id);
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, GpuAssistedBufferInfo &buffer_info,
         uint32_t operation_index, uint32_t* const debug_output_buffer);
- 
+
     void SetDescriptorInitialized(uint32_t* pData, uint32_t index, const cvdescriptorset::Descriptor* descriptor);
     void UpdateInstrumentationBuffer(CMD_BUFFER_STATE_GPUAV* cb_node);
     const GpuVuid& GetGpuVuid(CMD_TYPE cmd_type) const;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -149,7 +149,7 @@ class PIPELINE_LAYOUT_STATE : public BASE_NODE {
 };
 
 struct PipelineStageState {
-    std::shared_ptr<const SHADER_MODULE_STATE> module;
+    std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
     spirv_inst_iter entrypoint;
@@ -160,7 +160,7 @@ struct PipelineStageState {
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;
 
-    PipelineStageState(const VkPipelineShaderStageCreateInfo *stage, std::shared_ptr<const SHADER_MODULE_STATE> &module);
+    PipelineStageState(const VkPipelineShaderStageCreateInfo *stage, std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
 };
 
 class PIPELINE_STATE : public BASE_NODE {

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -117,7 +117,7 @@ std::string shader_struct_member::GetLocationDesc(uint32_t index_used_bytes) con
     return desc;
 }
 
-static unsigned ExecutionModelToShaderStageFlagBits(unsigned mode) {
+static uint32_t ExecutionModelToShaderStageFlagBits(uint32_t mode) {
     switch (mode) {
         case spv::ExecutionModelVertex:
             return VK_SHADER_STAGE_VERTEX_BIT;
@@ -530,7 +530,7 @@ void SHADER_MODULE_STATE::PreprocessShaderBinary(const spv_target_env env) {
     }
 }
 
-char const *StorageClassName(unsigned sc) {
+char const *StorageClassName(uint32_t sc) {
     switch (sc) {
         case spv::StorageClassInput:
             return "input";
@@ -563,7 +563,7 @@ char const *StorageClassName(unsigned sc) {
     }
 }
 
-void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, unsigned type) const {
+void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, uint32_t type) const {
     auto insn = get_def(type);
     assert(insn != end());
 
@@ -599,7 +599,7 @@ void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, unsigned typ
             break;
         case spv::OpTypeStruct: {
             ss << "struct of (";
-            for (unsigned i = 2; i < insn.len(); i++) {
+            for (uint32_t i = 2; i < insn.len(); i++) {
                 DescribeTypeInner(ss, insn.word(i));
                 if (i == insn.len() - 1) {
                     ss << ")";
@@ -628,7 +628,7 @@ void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, unsigned typ
     }
 }
 
-std::string SHADER_MODULE_STATE::DescribeType(unsigned type) const {
+std::string SHADER_MODULE_STATE::DescribeType(uint32_t type) const {
     std::ostringstream ss;
     DescribeTypeInner(ss, type);
     return ss.str();
@@ -704,7 +704,7 @@ bool SHADER_MODULE_STATE::FindLocalSize(const spirv_inst_iter &entrypoint, uint3
 
 // If the instruction at id is a constant or copy of a constant, returns a valid iterator pointing to that instruction.
 // Otherwise, returns src->end().
-spirv_inst_iter SHADER_MODULE_STATE::GetConstantDef(unsigned id) const {
+spirv_inst_iter SHADER_MODULE_STATE::GetConstantDef(uint32_t id) const {
     auto value = get_def(id);
 
     // If id is a copy, see where it was copied from
@@ -720,7 +720,7 @@ spirv_inst_iter SHADER_MODULE_STATE::GetConstantDef(unsigned id) const {
 }
 
 // Either returns the constant value described by the instruction at id, or 1
-uint32_t SHADER_MODULE_STATE::GetConstantValueById(unsigned id) const {
+uint32_t SHADER_MODULE_STATE::GetConstantValueById(uint32_t id) const {
     auto value = GetConstantDef(id);
 
     if (end() == value) {
@@ -751,7 +751,7 @@ int32_t SHADER_MODULE_STATE::GetShaderResourceDimensionality(const interface_var
     }
 }
 
-unsigned SHADER_MODULE_STATE::GetLocationsConsumedByType(unsigned type, bool strip_array_level) const {
+uint32_t SHADER_MODULE_STATE::GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const {
     auto insn = get_def(type);
     assert(insn != end());
 
@@ -785,7 +785,7 @@ unsigned SHADER_MODULE_STATE::GetLocationsConsumedByType(unsigned type, bool str
     }
 }
 
-unsigned SHADER_MODULE_STATE::GetComponentsConsumedByType(unsigned type, bool strip_array_level) const {
+uint32_t SHADER_MODULE_STATE::GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const {
     auto insn = get_def(type);
     assert(insn != end());
 
@@ -834,7 +834,7 @@ unsigned SHADER_MODULE_STATE::GetComponentsConsumedByType(unsigned type, bool st
 
 // characterizes a SPIR-V type appearing in an interface to a FF stage, for comparison to a VkFormat's characterization above.
 // also used for input attachments, as we statically know their format.
-unsigned SHADER_MODULE_STATE::GetFundamentalType(unsigned type) const {
+uint32_t SHADER_MODULE_STATE::GetFundamentalType(uint32_t type) const {
     auto insn = get_def(type);
     assert(insn != end());
 
@@ -1225,18 +1225,18 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_
 // Used by the collection functions to help aid in state tracking
 struct shader_module_used_operators {
     bool updated;
-    std::vector<unsigned> image_read_members;
-    std::vector<unsigned> image_write_members;
-    std::vector<unsigned> atomic_members;
-    std::vector<unsigned> store_members;
-    std::vector<unsigned> atomic_store_members;
-    std::vector<unsigned> sampler_implicitLod_dref_proj_members;      // sampler Load id
-    std::vector<unsigned> sampler_bias_offset_members;                // sampler Load id
-    std::vector<unsigned> image_dref_members;
-    std::vector<std::pair<unsigned, unsigned>> sampled_image_members;  // <image,sampler> Load id
-    layer_data::unordered_map<unsigned, unsigned> load_members;
-    layer_data::unordered_map<unsigned, std::pair<unsigned, unsigned>> accesschain_members;
-    layer_data::unordered_map<unsigned, unsigned> image_texel_pointer_members;
+    std::vector<uint32_t> image_read_members;
+    std::vector<uint32_t> image_write_members;
+    std::vector<uint32_t> atomic_members;
+    std::vector<uint32_t> store_members;
+    std::vector<uint32_t> atomic_store_members;
+    std::vector<uint32_t> sampler_implicitLod_dref_proj_members;  // sampler Load id
+    std::vector<uint32_t> sampler_bias_offset_members;            // sampler Load id
+    std::vector<uint32_t> image_dref_members;
+    std::vector<std::pair<uint32_t, uint32_t>> sampled_image_members;  // <image,sampler> Load id
+    layer_data::unordered_map<uint32_t, uint32_t> load_members;
+    layer_data::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> accesschain_members;
+    layer_data::unordered_map<uint32_t, uint32_t> image_texel_pointer_members;
 
     shader_module_used_operators() : updated(false) {}
 
@@ -1324,7 +1324,7 @@ struct shader_module_used_operators {
                 }
                 case spv::OpSampledImage: {
                     // 3: image load id, 4: sampler load id
-                    sampled_image_members.emplace_back(std::pair<unsigned, unsigned>(insn.word(3), insn.word(4)));
+                    sampled_image_members.emplace_back(std::pair<uint32_t, uint32_t>(insn.word(3), insn.word(4)));
                     break;
                 }
                 case spv::OpLoad: {
@@ -1336,10 +1336,10 @@ struct shader_module_used_operators {
                     if (insn.len() == 4) {
                         // If it is for struct, the length is only 4.
                         // 2: AccessChain id, 3: object id
-                        accesschain_members.emplace(insn.word(2), std::pair<unsigned, unsigned>(insn.word(3), 0));
+                        accesschain_members.emplace(insn.word(2), std::pair<uint32_t, uint32_t>(insn.word(3), 0));
                     } else {
                         // 2: AccessChain id, 3: object id, 4: object id of array index
-                        accesschain_members.emplace(insn.word(2), std::pair<unsigned, unsigned>(insn.word(3), insn.word(4)));
+                        accesschain_members.emplace(insn.word(2), std::pair<uint32_t, uint32_t>(insn.word(3), insn.word(4)));
                     }
                     break;
                 }
@@ -1363,9 +1363,9 @@ struct shader_module_used_operators {
     }
 };
 
-static bool CheckObjectIDFromOpLoad(uint32_t object_id, const std::vector<unsigned> &operator_members,
-                                    const layer_data::unordered_map<unsigned, unsigned> &load_members,
-                                    const layer_data::unordered_map<unsigned, std::pair<unsigned, unsigned>> &accesschain_members) {
+static bool CheckObjectIDFromOpLoad(uint32_t object_id, const std::vector<uint32_t> &operator_members,
+                                    const layer_data::unordered_map<uint32_t, uint32_t> &load_members,
+                                    const layer_data::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> &accesschain_members) {
     for (auto load_id : operator_members) {
         if (object_id == load_id) return true;
         auto load_it = load_members.find(load_id);
@@ -1393,7 +1393,7 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
                                                    interface_var &out_interface_var,
                                                    shader_module_used_operators &used_operators) const {
     uint32_t type_id = id_it.word(1);
-    unsigned int id = id_it.word(2);
+    uint32_t id = id_it.word(2);
 
     auto type = get_def(type_id);
 
@@ -1514,7 +1514,7 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
         }
 
         case spv::OpTypeStruct: {
-            layer_data::unordered_set<unsigned> nonwritable_members;
+            layer_data::unordered_set<uint32_t> nonwritable_members;
             if (get_decorations(type.word(1)).flags & decoration_set::buffer_block_bit) is_storage_buffer = true;
             for (auto insn : static_data_.member_decoration_inst) {
                 if (insn.word(1) == type.word(1) && insn.word(3) == spv::DecorationNonWritable) {
@@ -1565,8 +1565,8 @@ std::vector<std::pair<DescriptorSlot, interface_var>> SHADER_MODULE_STATE::Colle
              insn.word(3) == spv::StorageClassUniformConstant ||
              insn.word(3) == spv::StorageClassStorageBuffer)) {
             auto d = get_decorations(insn.word(2));
-            unsigned set = d.descriptor_set;
-            unsigned binding = d.binding;
+            uint32_t set = d.descriptor_set;
+            uint32_t binding = d.binding;
 
             interface_var v = {};
             v.id = insn.word(2);
@@ -1585,8 +1585,8 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLo
     const spirv_inst_iter &entrypoint) const {
     layer_data::unordered_set<uint32_t> location_list;
     const auto outputs = CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, false);
-    layer_data::unordered_set<unsigned> store_members;
-    layer_data::unordered_map<unsigned, unsigned> accesschain_members;
+    layer_data::unordered_set<uint32_t> store_members;
+    layer_data::unordered_map<uint32_t, uint32_t> accesschain_members;
 
     for (auto insn : *this) {
         switch (insn.opcode()) {
@@ -1643,17 +1643,17 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
         return false;
     }
 
-    layer_data::unordered_map<unsigned, unsigned> member_components;
-    layer_data::unordered_map<unsigned, unsigned> member_relaxed_precision;
-    layer_data::unordered_map<unsigned, unsigned> member_patch;
+    layer_data::unordered_map<uint32_t, uint32_t> member_components;
+    layer_data::unordered_map<uint32_t, uint32_t> member_relaxed_precision;
+    layer_data::unordered_map<uint32_t, uint32_t> member_patch;
 
     // Walk all the OpMemberDecorate for type's result id -- first pass, collect components.
     for (auto insn : static_data_.member_decoration_inst) {
         if (insn.word(1) == type.word(1)) {
-            unsigned member_index = insn.word(2);
+            uint32_t member_index = insn.word(2);
 
             if (insn.word(3) == spv::DecorationComponent) {
-                unsigned component = insn.word(4);
+                uint32_t component = insn.word(4);
                 member_components[member_index] = component;
             }
 
@@ -1672,18 +1672,18 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
     // Second pass -- produce the output, from Location decorations
     for (auto insn : static_data_.member_decoration_inst) {
         if (insn.word(1) == type.word(1)) {
-            unsigned member_index = insn.word(2);
-            unsigned member_type_id = type.word(2 + member_index);
+            uint32_t member_index = insn.word(2);
+            uint32_t member_type_id = type.word(2 + member_index);
 
             if (insn.word(3) == spv::DecorationLocation) {
-                unsigned location = insn.word(4);
-                unsigned num_locations = GetLocationsConsumedByType(member_type_id, false);
+                uint32_t location = insn.word(4);
+                uint32_t num_locations = GetLocationsConsumedByType(member_type_id, false);
                 auto component_it = member_components.find(member_index);
-                unsigned component = component_it == member_components.end() ? 0 : component_it->second;
+                uint32_t component = component_it == member_components.end() ? 0 : component_it->second;
                 bool is_relaxed_precision = member_relaxed_precision.find(member_index) != member_relaxed_precision.end();
                 bool member_is_patch = is_patch || member_patch.count(member_index) > 0;
 
-                for (unsigned int offset = 0; offset < num_locations; offset++) {
+                for (uint32_t offset = 0; offset < num_locations; offset++) {
                     interface_var v = {};
                     v.id = id;
                     // TODO: member index in interface_var too?
@@ -1717,12 +1717,12 @@ std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocat
         bool passthrough = sinterface == spv::StorageClassOutput && insn.word(3) == spv::StorageClassInput &&
                            (d.flags & decoration_set::passthrough_bit) != 0;
         if (insn.word(3) == static_cast<uint32_t>(sinterface) || passthrough) {
-            unsigned id = insn.word(2);
-            unsigned type = insn.word(1);
+            uint32_t id = insn.word(2);
+            uint32_t type = insn.word(1);
 
             auto location = d.location;
             int builtin = d.builtin;
-            unsigned component = d.component;
+            uint32_t component = d.component;
             bool is_patch = (d.flags & decoration_set::patch_bit) != 0;
             bool is_relaxed_precision = (d.flags & decoration_set::relaxed_precision_bit) != 0;
             bool is_per_vertex = (d.flags & decoration_set::per_vertex_bit) != 0;
@@ -1733,8 +1733,8 @@ std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocat
                        location != decoration_set::kInvalidValue) {
                 // A user-defined interface variable, with a location. Where a variable occupied multiple locations, emit
                 // one result for each.
-                unsigned num_locations = GetLocationsConsumedByType(type, (is_array_of_verts && !is_patch) || is_per_vertex);
-                for (unsigned int offset = 0; offset < num_locations; offset++) {
+                uint32_t num_locations = GetLocationsConsumedByType(type, (is_array_of_verts && !is_patch) || is_per_vertex);
+                for (uint32_t offset = 0; offset < num_locations; offset++) {
                     interface_var v = {};
                     v.id = id;
                     v.type_id = type;
@@ -1804,7 +1804,7 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
                 assert(def != end());
                 if (def.opcode() == spv::OpVariable && def.word(3) == spv::StorageClassUniformConstant) {
                     auto num_locations = GetLocationsConsumedByType(def.word(1), false);
-                    for (unsigned int offset = 0; offset < num_locations; offset++) {
+                    for (uint32_t offset = 0; offset < num_locations; offset++) {
                         interface_var v = {};
                         v.id = id;
                         v.type_id = def.word(1);

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -652,8 +652,14 @@ std::string SHADER_MODULE_STATE::DescribeInstruction(const spirv_inst_iter &insn
         ss << " %" << insn.word(1);
     }
 
+    // TODO - For now don't list the '%' for any operands since they are only for reference IDs. Without generating a table of each
+    // instructions operand types and covering the many edge cases (such as optional, paired, or variable operands) this is the
+    // simplest way to print the instruction and give the developer something to look into when an error occurs.
+    //
+    // For now this safely should be able to assume it will never come across a LiteralString such as in OpExtInstImport or
+    // OpEntryPoint
     for (uint32_t i = operand_offset; i < insn.len(); i++) {
-        ss << " %" << insn.word(i);
+        ss << " " << insn.word(i);
     }
     return ss.str();
 }

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -49,7 +49,7 @@ struct spirv_inst_iter {
 
     uint32_t opcode() const { return *it & 0x0ffffu; }
 
-    uint32_t const &word(unsigned n) const {
+    uint32_t const &word(uint32_t n) const {
         assert(n < len());
         return it[n];
     }
@@ -128,7 +128,7 @@ enum FORMAT_TYPE {
     FORMAT_TYPE_UINT = 4,
 };
 
-typedef std::pair<unsigned, unsigned> location_t;
+typedef std::pair<uint32_t, uint32_t> location_t;
 
 struct decoration_set {
     enum {
@@ -172,9 +172,9 @@ struct atomic_instruction {
 };
 
 struct function_set {
-    unsigned id;
-    unsigned offset;
-    unsigned length;
+    uint32_t id;
+    uint32_t offset;
+    uint32_t length;
     std::unordered_multimap<uint32_t, uint32_t> op_lists;  // key: spv::Op,  value: offset
 
     function_set() : id(0), offset(0), length(0) {}
@@ -222,7 +222,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     struct EntryPoint {
         uint32_t offset;  // into module to get OpEntryPoint instruction
         VkShaderStageFlagBits stage;
-        std::unordered_multimap<unsigned, unsigned> decorate_list;  // key: spv::Op,  value: offset
+        std::unordered_multimap<uint32_t, uint32_t> decorate_list;  // key: spv::Op,  value: offset
         std::vector<function_set> function_set_list;
         shader_struct_member push_constant_used_in_shader;
     };
@@ -234,8 +234,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
         // A mapping of <id> to the first word of its def. this is useful because walking type
         // trees, constant expressions, etc requires jumping all over the instruction stream.
-        layer_data::unordered_map<unsigned, unsigned> def_index;
-        layer_data::unordered_map<unsigned, decoration_set> decorations;
+        layer_data::unordered_map<uint32_t, uint32_t> def_index;
+        layer_data::unordered_map<uint32_t, decoration_set> decorations;
         // <Specialization constant ID -> target ID> mapping
         layer_data::unordered_map<uint32_t, uint32_t> spec_const_map;
         // Find all decoration instructions to prevent relooping module later - many checks need this info
@@ -308,7 +308,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     VkShaderModule vk_shader_module() const { return handle_.Cast<VkShaderModule>(); }
 
-    decoration_set get_decorations(unsigned id) const {
+    decoration_set get_decorations(uint32_t id) const {
         // return the actual decorations for this id, or a default set.
         auto it = static_data_.decorations.find(id);
         if (it != static_data_.decorations.end()) return it->second;
@@ -319,10 +319,10 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     spirv_inst_iter begin() const { return spirv_inst_iter(words.begin(), words.begin() + 5); }  // First insn
     spirv_inst_iter end() const { return spirv_inst_iter(words.begin(), words.end()); }          // Just past last insn
     // Given an offset into the module, produce an iterator there.
-    spirv_inst_iter at(unsigned offset) const { return spirv_inst_iter(words.begin(), words.begin() + offset); }
+    spirv_inst_iter at(uint32_t offset) const { return spirv_inst_iter(words.begin(), words.begin() + offset); }
 
     // Gets an iterator to the definition of an id
-    spirv_inst_iter get_def(unsigned id) const {
+    spirv_inst_iter get_def(uint32_t id) const {
         auto it = static_data_.def_index.find(id);
         if (it == static_data_.def_index.end()) {
             return end();
@@ -331,8 +331,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     }
 
     // Used to get human readable strings for error messages
-    void DescribeTypeInner(std::ostringstream &ss, unsigned type) const;
-    std::string DescribeType(unsigned type) const;
+    void DescribeTypeInner(std::ostringstream &ss, uint32_t type) const;
+    std::string DescribeType(uint32_t type) const;
     std::string DescribeInstruction(const spirv_inst_iter &insn) const;
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(spirv_inst_iter entrypoint) const;
@@ -343,12 +343,12 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     bool FindLocalSize(const spirv_inst_iter &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y,
                        uint32_t &local_size_z) const;
 
-    spirv_inst_iter GetConstantDef(unsigned id) const;
-    uint32_t GetConstantValueById(unsigned id) const;
+    spirv_inst_iter GetConstantDef(uint32_t id) const;
+    uint32_t GetConstantValueById(uint32_t id) const;
     int32_t GetShaderResourceDimensionality(const interface_var &resource) const;
-    unsigned GetLocationsConsumedByType(unsigned type, bool strip_array_level) const;
-    unsigned GetComponentsConsumedByType(unsigned type, bool strip_array_level) const;
-    unsigned GetFundamentalType(unsigned type) const;
+    uint32_t GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const;
+    uint32_t GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const;
+    uint32_t GetFundamentalType(uint32_t type) const;
     spirv_inst_iter GetStructType(spirv_inst_iter def, bool is_array_of_verts) const;
 
     void DefineStructMember(const spirv_inst_iter &it, const std::vector<uint32_t> &member_decorate_offsets,
@@ -401,6 +401,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 };
 
 // String helpers functions to give better error messages
-char const *StorageClassName(unsigned sc);
+char const *StorageClassName(uint32_t sc);
 
 #endif  // VULKAN_SHADER_MODULE_H

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -230,7 +230,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Static/const data extracted from a SPIRV module.
     struct SpirvStaticData {
         SpirvStaticData() = default;
-        SpirvStaticData(const SHADER_MODULE_STATE &mod);
+        SpirvStaticData(const SHADER_MODULE_STATE &module_state);
 
         // A mapping of <id> to the first word of its def. this is useful because walking type
         // trees, constant expressions, etc requires jumping all over the instruction stream.
@@ -361,7 +361,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
                              const shader_struct_member &data) const;
 
     // Push consants
-    static void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &mod,
+    static void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &module_state,
                                             std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> &entry_points);
 
     uint32_t DescriptorTypeToReqs(uint32_t type_id) const;
@@ -397,7 +397,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Used to populate the shader module object
     void PreprocessShaderBinary(spv_target_env env);
 
-    static std::unordered_multimap<std::string, EntryPoint> ProcessEntryPoints(const SHADER_MODULE_STATE &mod);
+    static std::unordered_multimap<std::string, EntryPoint> ProcessEntryPoints(const SHADER_MODULE_STATE &module_state);
 };
 
 // String helpers functions to give better error messages

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -92,7 +92,7 @@ static bool TypesMatch(SHADER_MODULE_STATE const *a, SHADER_MODULE_STATE const *
     return BaseTypesMatch(a, b, a_base_insn, b_base_insn);
 }
 
-static unsigned GetLocationsConsumedByFormat(VkFormat format) {
+static uint32_t GetLocationsConsumedByFormat(VkFormat format) {
     switch (format) {
         case VK_FORMAT_R64G64B64A64_SFLOAT:
         case VK_FORMAT_R64G64B64A64_SINT:
@@ -106,7 +106,7 @@ static unsigned GetLocationsConsumedByFormat(VkFormat format) {
     }
 }
 
-static unsigned GetFormatType(VkFormat fmt) {
+static uint32_t GetFormatType(VkFormat fmt) {
     if (FormatIsSINT(fmt)) return FORMAT_TYPE_SINT;
     if (FormatIsUINT(fmt)) return FORMAT_TYPE_UINT;
     // Formats such as VK_FORMAT_D16_UNORM_S8_UINT are both
@@ -127,7 +127,7 @@ bool CoreChecks::ValidateViConsistency(VkPipelineVertexInputStateCreateInfo cons
     layer_data::unordered_map<uint32_t, VkVertexInputBindingDescription const *> bindings;
     bool skip = false;
 
-    for (unsigned i = 0; i < vi->vertexBindingDescriptionCount; i++) {
+    for (uint32_t i = 0; i < vi->vertexBindingDescriptionCount; i++) {
         auto desc = &vi->pVertexBindingDescriptions[i];
         auto &binding = bindings[desc->binding];
         if (binding) {
@@ -503,7 +503,7 @@ bool CoreChecks::ValidateSpecializations(VkPipelineShaderStageCreateInfo const *
 
 // TODO (jbolz): Can this return a const reference?
 static std::set<uint32_t> TypeToDescriptorTypeSet(SHADER_MODULE_STATE const *module_state, uint32_t type_id,
-                                                  unsigned &descriptor_count, bool is_khr) {
+                                                  uint32_t &descriptor_count, bool is_khr) {
     auto type = module_state->get_def(type_id);
     bool is_storage_buffer = false;
     descriptor_count = 1;
@@ -1407,7 +1407,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_sta
                     // Validate that the type parameters are all supported for one of the
                     // operands of a cooperative matrix property.
                     bool valid = false;
-                    for (unsigned i = 0; i < cooperative_matrix_properties.size(); ++i) {
+                    for (uint32_t i = 0; i < cooperative_matrix_properties.size(); ++i) {
                         if (cooperative_matrix_properties[i].AType == m.component_type &&
                             cooperative_matrix_properties[i].MSize == m.rows && cooperative_matrix_properties[i].KSize == m.cols &&
                             cooperative_matrix_properties[i].scope == m.scope) {
@@ -1460,7 +1460,7 @@ bool CoreChecks::ValidateCooperativeMatrix(SHADER_MODULE_STATE const *module_sta
                     // Validate that the type parameters are all supported for the same
                     // cooperative matrix property.
                     bool valid = false;
-                    for (unsigned i = 0; i < cooperative_matrix_properties.size(); ++i) {
+                    for (uint32_t i = 0; i < cooperative_matrix_properties.size(); ++i) {
                         if (cooperative_matrix_properties[i].AType == a.component_type &&
                             cooperative_matrix_properties[i].MSize == a.rows && cooperative_matrix_properties[i].KSize == a.cols &&
                             cooperative_matrix_properties[i].scope == a.scope &&
@@ -2690,7 +2690,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     for (auto use : stage_state.descriptor_uses) {
         // Verify given pipelineLayout has requested setLayout with requested binding
         const auto &binding = GetDescriptorBinding(pipeline->pipeline_layout.get(), use.first);
-        unsigned required_descriptor_count;
+        uint32_t required_descriptor_count;
         bool is_khr = binding && binding->descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
         std::set<uint32_t> descriptor_types =
             TypeToDescriptorTypeSet(module_state, use.second.type_id, required_descriptor_count, is_khr);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -125,7 +125,7 @@ struct create_buffer_api_state {
 struct create_shader_module_api_state {
     uint32_t unique_shader_id;
     VkShaderModuleCreateInfo instrumented_create_info;
-    std::vector<unsigned int> instrumented_pgm;
+    std::vector<uint32_t> instrumented_pgm;
 };
 
 #define VALSTATETRACK_MAP_AND_TRAITS_IMPL(handle_type, state_type, map_member, instance_scope)        \

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -385,7 +385,7 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
     # The main function to validate all the extensions and capabilities
     def validateFunction(self):
         output = '''
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(SHADER_MODULE_STATE const *src, spirv_inst_iter& insn) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const {
     bool skip = false;
 
     if (insn.opcode() == spv::OpCapability) {


### PR DESCRIPTION
- Consistent name for `SHADER_MODULE_STATE` variables
- use `uint32_t` instead of `unsigned`/`unsigned int` as SPIR-V is specified as a 32-bit word IR