### PR TITLE
tests: Disable driver check

### DIFF
--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -276,6 +276,7 @@ class VkRenderFramework : public VkTestFramework {
     void DestroyRenderTarget();
     bool InitFrameworkAndRetrieveFeatures(VkPhysicalDeviceFeatures2KHR &features2);
 
+    static bool IgnoreDisableChecks();
     bool IsDriver(VkDriverId driver_id);
     bool IsPlatform(PlatformType platform);
     void GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features);


### PR DESCRIPTION
Disable the IsDriver check if the VK_LAYER_TESTS_SKIP_PLATFORM_CHECK
environment variable is set.