### PR TITLE
Issue 1495 proposal

### DIFF
--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -29,7 +29,6 @@
 #include "vk_format_utils.h"
 #include "vk_layer_utils.h"
 #include <map>
-#include <vector>
 
 
 enum class COMPONENT_TYPE {
@@ -1902,3 +1901,16 @@ double FormatTexelSize(VkFormat format, VkImageAspectFlags aspectMask) {
 }
 
 
+// Utils/misc
+const std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> &FormatUsageFeaturesMap() {
+    static std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> map = {
+        {VK_IMAGE_USAGE_SAMPLED_BIT, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT},
+        {VK_IMAGE_USAGE_STORAGE_BIT, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT},
+        {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT},
+        {VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT},
+        {VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, static_cast<VkFormatFeatureFlagBits>(VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
+                                                                                   VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)},
+        {VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR}};
+
+    return map;
+}

--- a/layers/generated/vk_format_utils.h
+++ b/layers/generated/vk_format_utils.h
@@ -28,6 +28,7 @@
 
 #pragma once
 #include <vulkan/vk_layer.h>
+#include <vector>
 
 #ifdef __cplusplus
 extern "C" {
@@ -212,6 +213,9 @@ static inline bool FormatIsBlockedImage(VkFormat format) {
 static inline bool FormatIsColor(VkFormat format) {
     return !(FormatIsUndef(format) || FormatIsDepthOrStencil(format) || FormatIsMultiplane(format));
 }
+
+VK_LAYER_EXPORT const std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> &FormatUsageFeaturesMap();
+
 
 #ifdef __cplusplus
 }

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -152,10 +152,10 @@ class FormatUtilsOutputGenerator(OutputGenerator):
             write('#include "vk_format_utils.h"', file=self.outFile)
             write('#include "vk_layer_utils.h"', file=self.outFile)
             write('#include <map>', file=self.outFile)
-            write('#include <vector>', file=self.outFile)
         elif self.headerFile:
             write('#pragma once', file=self.outFile)
             write('#include <vulkan/vk_layer.h>', file=self.outFile)
+            write('#include <vector>', file=self.outFile)
             export = '''
 #ifdef __cplusplus
 extern "C" {
@@ -798,5 +798,23 @@ static inline bool FormatIsBlockedImage(VkFormat format) {
 // So anything that could NOT be a "color format" is a color format
 static inline bool FormatIsColor(VkFormat format) {
     return !(FormatIsUndef(format) || FormatIsDepthOrStencil(format) || FormatIsMultiplane(format));
+}
+
+VK_LAYER_EXPORT const std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> &FormatUsageFeaturesMap();
+'''
+        elif self.sourceFile:
+            output += '''
+// Utils/misc
+const std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> &FormatUsageFeaturesMap() {
+    static std::vector<std::pair<VkImageUsageFlags, VkFormatFeatureFlagBits>> map = {
+        {VK_IMAGE_USAGE_SAMPLED_BIT, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT},
+        {VK_IMAGE_USAGE_STORAGE_BIT, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT},
+        {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT},
+        {VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT},
+        {VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, static_cast<VkFormatFeatureFlagBits>(VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
+                                                                                   VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)},
+        {VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR}};
+
+    return map;
 }'''
         return output

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -2505,3 +2505,72 @@ TEST_F(VkPositiveLayerTest, ImagelessLayoutTracking) {
     vk::DestroySemaphore(m_device->device(), image_acquired, nullptr);
     vk::DestroyFramebuffer(m_device->device(), framebuffer, nullptr);
 }
+
+TEST_F(VkPositiveLayerTest, ValidExtendedUsageImage) {
+    // This test is meant to reproduce an error seen in CTS test dEQP-VK.image.sample_texture.128_bit_compressed_format
+    TEST_DESCRIPTION("Create an image using VK_IMAGE_CREATE_EXTENDED_USAGE_BIT");
+
+    m_errorMonitor->ExpectSuccess();
+
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(Init());
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not available\n", kSkipPrefix, VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
+        return;
+    }
+
+    // --------------------------------------------------------------------------------------
+    // From here, I think we can agree this is legal
+    auto image_ci = LvlInitStruct<VkImageCreateInfo>();
+    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    image_ci.format = VK_FORMAT_BC3_UNORM_BLOCK;
+    image_ci.extent = {
+        64,  // width
+        64,  // height
+        1,   // depth
+    };
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image_ci.queueFamilyIndexCount = 0;
+    image_ci.pQueueFamilyIndices = nullptr;
+
+    vk_testing::Image image(*m_device, image_ci);
+    ASSERT_TRUE(image.handle() != VK_NULL_HANDLE);
+
+    auto ivci = LvlInitStruct<VkImageViewCreateInfo>();
+    ivci.image = image.handle();
+    ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    ivci.format = VK_FORMAT_BC3_UNORM_BLOCK;
+    ivci.subresourceRange.layerCount = 1;
+    ivci.subresourceRange.baseMipLevel = 0;
+    ivci.subresourceRange.levelCount = 1;
+    ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+
+    vk_testing::ImageView view(*m_device, ivci);
+    ASSERT_TRUE(view.handle() != VK_NULL_HANDLE);
+    // Until here, I think we can agree this is legal
+    // --------------------------------------------------------------------------------------
+
+    // --------------------------------------------------------------------------------------
+    // Now, from here, from my point of view, it should be completely legal
+    image_ci.flags =
+        VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+    image_ci.usage =
+        VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    vk_testing::Image image2(*m_device, image_ci);
+    ASSERT_TRUE(image2.handle() != VK_NULL_HANDLE);
+
+    // This view should only be used for sampling though
+    ivci.image = image2.handle();
+    vk_testing::ImageView view2(*m_device, ivci);
+    ASSERT_TRUE(view2.handle() != VK_NULL_HANDLE);
+    // Until here, from my point of view, it should be completely legal
+    // --------------------------------------------------------------------------------------
+
+    m_errorMonitor->ExpectSuccess();
+}


### PR DESCRIPTION
Here's the proposal to fix issue #1495. Eases the restrictions for image view creations when an image was created with extended usage bit.

Solves the following scenario (just an example of what we are trying to solve):
Image created with storage and sample bits for usage. Compressed format. Flags contain extended usage, mutable and block texel view compatible bits (nasty combination that it's legal).
Image view with compressed format for sampling.
Image view with uncompressed format for storing.