### PR TITLE
layers: Label 06530 and add testing

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -171,7 +171,7 @@ static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidImageView = "UNAS
 
 //static const char DECORATE_UNUSED *kVUID_Core_Shader_DescriptorNotAccessibleFromStage = "UNASSIGNED-CoreValidation-Shader-DescriptorNotAccessibleFromStage";
 //static const char DECORATE_UNUSED *kVUID_Core_Shader_DescriptorTypeMismatch = "UNASSIGNED-CoreValidation-Shader-DescriptorTypeMismatch";
-static const char DECORATE_UNUSED *kVUID_Core_Shader_MaxComputeSharedMemorySize = "UNASSIGNED-CoreValidation-Shader-MaxComputeSharedMemorySize";
+// static const char DECORATE_UNUSED *kVUID_Core_Shader_MaxComputeSharedMemorySize = "UNASSIGNED-CoreValidation-Shader-MaxComputeSharedMemorySize";
 // static const char DECORATE_UNUSED *kVUID_Core_Shader_ExceedDeviceLimit = "UNASSIGNED-CoreValidation-Shader-ExceedDeviceLimit";
 // static const char DECORATE_UNUSED *kVUID_Core_Shader_FeatureNotEnabled = "UNASSIGNED-CoreValidation-Shader-FeatureNotEnabled";
 static const char DECORATE_UNUSED *kVUID_Core_Shader_InconsistentSpirv = "UNASSIGNED-CoreValidation-Shader-InconsistentSpirv";

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2681,9 +2681,11 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     }
 
     if (total_shared_size > phys_dev_props.limits.maxComputeSharedMemorySize) {
-        skip |= LogError(device, kVUID_Core_Shader_MaxComputeSharedMemorySize,
-                         "Shader uses %" PRIu32 " bytes of shared memory, more than allowed by physicalDeviceLimits::maxComputeSharedMemorySize (%" PRIu32 ")",
-                         total_shared_size, phys_dev_props.limits.maxComputeSharedMemorySize);
+        skip |=
+            LogError(device, "VUID-RuntimeSpirv-Workgroup-06530",
+                     "Shader uses %" PRIu32
+                     " bytes of shared memory, more than allowed by physicalDeviceLimits::maxComputeSharedMemorySize (%" PRIu32 ")",
+                     total_shared_size, phys_dev_props.limits.maxComputeSharedMemorySize);
     }
 
     skip |= ValidateTransformFeedback(module_state);


### PR DESCRIPTION
Label `VUID-RuntimeSpirv-Workgroup-06530`

`maxComputeSharedMemorySize` has a statement for `VK_KHR_workgroup_memory_explicit_layout`

> When variables declared with the Workgroup storage class are explicitly laid out (hence they are also decorated with Block), the amount of storage consumed is the size of the largest Block variable, not counting any padding at the end.

So added tests making sure validation was not doing a `ADD` and was doing a `MAX` (which it does :tada:)