### PR TITLE
layers: Fix Vulkan 1.3 extended dynamic state validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2446,7 +2446,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
                                               "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
 
     // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03378
-    if (!enabled_features.extended_dynamic_state_features.extendedDynamicState &&
+    if (api_version < VK_API_VERSION_1_3 && !enabled_features.extended_dynamic_state_features.extendedDynamicState &&
         (IsDynamic(pPipeline, VK_DYNAMIC_STATE_CULL_MODE_EXT) || IsDynamic(pPipeline, VK_DYNAMIC_STATE_FRONT_FACE_EXT) ||
          IsDynamic(pPipeline, VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT) ||
          IsDynamic(pPipeline, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT) ||
@@ -2465,7 +2465,7 @@ bool CoreChecks::ValidatePipelineUnlocked(const PIPELINE_STATE *pPipeline, uint3
     }
 
     // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04868
-    if (!enabled_features.extended_dynamic_state2_features.extendedDynamicState2 &&
+    if (api_version < VK_API_VERSION_1_3 && !enabled_features.extended_dynamic_state2_features.extendedDynamicState2 &&
         (IsDynamic(pPipeline, VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT) ||
          IsDynamic(pPipeline, VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT) ||
          IsDynamic(pPipeline, VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT))) {
@@ -17669,7 +17669,7 @@ bool CoreChecks::PreCallValidateCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, 
 
     if (!enabled_features.extended_dynamic_state2_features.extendedDynamicState2LogicOp) {
         skip |= LogError(commandBuffer, "VUID-vkCmdSetLogicOpEXT-None-04867",
-                         "vkCmdSetLogicOpEXT: extendedDynamicState feature is not enabled.");
+                         "vkCmdSetLogicOpEXT: extendedDynamicState2LogicOp feature is not enabled.");
     }
     return skip;
 }
@@ -17681,7 +17681,7 @@ bool CoreChecks::PreCallValidateCmdSetPatchControlPointsEXT(VkCommandBuffer comm
 
     if (!enabled_features.extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints) {
         skip |= LogError(commandBuffer, "VUID-vkCmdSetPatchControlPointsEXT-None-04873",
-                         "vkCmdSetPatchControlPointsEXT: extendedDynamicState feature is not enabled.");
+                         "vkCmdSetPatchControlPointsEXT: extendedDynamicState2PatchControlPoints feature is not enabled.");
     }
     if (patchControlPoints > phys_dev_props.limits.maxTessellationPatchSize) {
         skip |= LogError(commandBuffer, "VUID-vkCmdSetPatchControlPointsEXT-patchControlPoints-04874",
@@ -17703,10 +17703,7 @@ bool CoreChecks::PreCallValidateCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer
 bool CoreChecks::PreCallValidateCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer,
                                                               VkBool32 rasterizerDiscardEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(*cb_state, CMD_SETRASTERIZERDISCARDENABLE,
-                                        enabled_features.extended_dynamic_state_features.extendedDynamicState,
-                                        "VUID-vkCmdSetRasterizerDiscardEnable-None-04871",
-                                        "vkCmdSetRasterizerDiscardEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETRASTERIZERDISCARDENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) const {
@@ -17718,9 +17715,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthBiasEnableEXT(VkCommandBuffer command
 
 bool CoreChecks::PreCallValidateCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETDEPTHBIASENABLE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetDepthBiasEnable-None-04872", "vkCmdSetDepthBiasEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETDEPTHBIASENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer,
@@ -17734,10 +17729,7 @@ bool CoreChecks::PreCallValidateCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer 
 
 bool CoreChecks::PreCallValidateCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(*cb_state, CMD_SETPRIMITIVERESTARTENABLE,
-                                        enabled_features.extended_dynamic_state_features.extendedDynamicState,
-                                        "VUID-vkCmdSetPrimitiveRestartEnable-None-04866",
-                                        "vkCmdSetPrimitiveRestartEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETPRIMITIVERESTARTENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) const {
@@ -17749,9 +17741,7 @@ bool CoreChecks::PreCallValidateCmdSetCullModeEXT(VkCommandBuffer commandBuffer,
 
 bool CoreChecks::PreCallValidateCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETCULLMODE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetCullMode-None-03384", "vkCmdSetCullMode: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETCULLMODE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) const {
@@ -17763,9 +17753,7 @@ bool CoreChecks::PreCallValidateCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer
 
 bool CoreChecks::PreCallValidateCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETFRONTFACE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetFrontFace-None-03383", "vkCmdSetFrontFace: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETFRONTFACE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer,
@@ -17779,9 +17767,7 @@ bool CoreChecks::PreCallValidateCmdSetPrimitiveTopologyEXT(VkCommandBuffer comma
 bool CoreChecks::PreCallValidateCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer,
                                                         VkPrimitiveTopology primitiveTopology) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETPRIMITIVETOPOLOGY, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetPrimitiveTopology-None-03347", "vkCmdSetPrimitiveTopology: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETPRIMITIVETOPOLOGY);
 }
 
 bool CoreChecks::PreCallValidateCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
@@ -17801,9 +17787,7 @@ bool CoreChecks::PreCallValidateCmdSetViewportWithCount(VkCommandBuffer commandB
                                                         const VkViewport *pViewports) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(
-        *cb_state, CMD_SETVIEWPORTWITHCOUNT, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetViewportWithCount-None-03393", "vkCmdSetViewportWithCount: extendedDynamicState feature is not enabled.");
+    skip = ValidateCmd(cb_state.get(), CMD_SETVIEWPORTWITHCOUNT);
     skip |= ForbidInheritedViewportScissor(commandBuffer, cb_state.get(), "VUID-vkCmdSetViewportWithCount-commandBuffer-04819",
                                            "vkCmdSetViewportWithCount");
 
@@ -17827,9 +17811,7 @@ bool CoreChecks::PreCallValidateCmdSetScissorWithCount(VkCommandBuffer commandBu
                                                        const VkRect2D *pScissors) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(
-        *cb_state, CMD_SETSCISSORWITHCOUNT, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetScissorWithCount-None-03396", "vkCmdSetScissorWithCount: extendedDynamicState feature is not enabled.");
+    skip = ValidateCmd(cb_state.get(), CMD_SETSCISSORWITHCOUNT);
     skip |= ForbidInheritedViewportScissor(commandBuffer, cb_state.get(), "VUID-vkCmdSetScissorWithCount-commandBuffer-04820",
                                            "vkCmdSetScissorWithCount");
 
@@ -17894,9 +17876,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthTestEnableEXT(VkCommandBuffer command
 
 bool CoreChecks::PreCallValidateCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETDEPTHTESTENABLE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetDepthTestEnable-None-03352", "vkCmdSetDepthTestEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETDEPTHTESTENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) const {
@@ -17908,9 +17888,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthWriteEnableEXT(VkCommandBuffer comman
 
 bool CoreChecks::PreCallValidateCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETDEPTHWRITEENABLE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetDepthWriteEnable-None-03354", "vkCmdSetDepthWriteEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETDEPTHWRITEENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) const {
@@ -17922,9 +17900,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthCompareOpEXT(VkCommandBuffer commandB
 
 bool CoreChecks::PreCallValidateCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETDEPTHCOMPAREOP, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetDepthCompareOp-None-03353", "vkCmdSetDepthCompareOp: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETDEPTHCOMPAREOP);
 }
 
 bool CoreChecks::PreCallValidateCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer,
@@ -17938,10 +17914,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer c
 
 bool CoreChecks::PreCallValidateCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(*cb_state, CMD_SETDEPTHBOUNDSTESTENABLE,
-                                        enabled_features.extended_dynamic_state_features.extendedDynamicState,
-                                        "VUID-vkCmdSetDepthBoundsTestEnable-None-03349",
-                                        "vkCmdSetDepthBoundsTestEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETDEPTHBOUNDSTESTENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) const {
@@ -17953,9 +17926,7 @@ bool CoreChecks::PreCallValidateCmdSetStencilTestEnableEXT(VkCommandBuffer comma
 
 bool CoreChecks::PreCallValidateCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETSTENCILTESTENABLE, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetStencilTestEnable-None-03350", "vkCmdSetStencilTestEnable: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETSTENCILTESTENABLE);
 }
 
 bool CoreChecks::PreCallValidateCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
@@ -17969,9 +17940,7 @@ bool CoreChecks::PreCallValidateCmdSetStencilOpEXT(VkCommandBuffer commandBuffer
 bool CoreChecks::PreCallValidateCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                 VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) const {
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    return ValidateExtendedDynamicState(
-        *cb_state, CMD_SETSTENCILOP, enabled_features.extended_dynamic_state_features.extendedDynamicState,
-        "VUID-vkCmdSetStencilOp-None-03351", "vkCmdSetStencilOp: extendedDynamicState feature is not enabled.");
+    return ValidateCmd(cb_state.get(), CMD_SETSTENCILOP);
 }
 
 bool CoreChecks::PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -10070,24 +10070,18 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-template <typename ExtType, typename CoreType, typename Parm>
-void ExtendedDynStateCalls(ErrorMonitor *error_monitor, VkCommandBuffer cmd_buf, ExtType ext_call, CoreType core_call,
-                           const char *vuid, Parm parm, bool vulkan_13) {
+template <typename ExtType, typename Parm>
+void ExtendedDynStateCalls(ErrorMonitor *error_monitor, VkCommandBuffer cmd_buf, ExtType ext_call,
+                           const char *vuid, Parm parm) {
     error_monitor->SetDesiredFailureMsg(kErrorBit, vuid);
     ext_call(cmd_buf, parm);
     error_monitor->VerifyFound();
-    if (vulkan_13) {
-        assert(core_call != nullptr);
-        error_monitor->SetDesiredFailureMsg(kErrorBit, vuid);
-        core_call(cmd_buf, parm);
-        error_monitor->VerifyFound();
-    }
 }
 
 TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state VUs");
 
-    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_3);
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_2);
     if (version < VK_API_VERSION_1_1) {
         printf("%s At least Vulkan version 1.1 is required, skipping test.\n", kSkipPrefix);
         return;
@@ -10113,7 +10107,6 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     extended_dynamic_state_features.extendedDynamicState = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
     auto vkCmdSetCullModeEXT = (PFN_vkCmdSetCullModeEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCullModeEXT");
     auto vkCmdSetFrontFaceEXT = (PFN_vkCmdSetFrontFaceEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFrontFaceEXT");
     auto vkCmdSetPrimitiveTopologyEXT =
@@ -10160,79 +10153,44 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     VkCommandBufferObj commandBuffer(m_device, m_commandPool);
     commandBuffer.begin();
 
-    auto vkCmdSetCullMode = reinterpret_cast<PFN_vkCmdSetCullMode>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCullMode"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetCullModeEXT, vkCmdSetCullMode,
-                          "VUID-vkCmdSetCullMode-None-03384", VK_CULL_MODE_NONE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetCullModeEXT,
+                          "VUID-vkCmdSetCullModeEXT-None-03384", VK_CULL_MODE_NONE);
 
-    auto vkCmdSetDepthBoundsTestEnable = reinterpret_cast<PFN_vkCmdSetDepthBoundsTestEnable>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBoundsTestEnable"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthBoundsTestEnableEXT, vkCmdSetDepthBoundsTestEnable,
-        "VUID-vkCmdSetDepthBoundsTestEnable-None-03349", VK_FALSE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthBoundsTestEnableEXT,
+        "VUID-vkCmdSetDepthBoundsTestEnableEXT-None-03349", VK_FALSE);
 
-    auto vkCmdSetDepthCompareOp = reinterpret_cast<PFN_vkCmdSetDepthCompareOp>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthCompareOp"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthCompareOpEXT, vkCmdSetDepthCompareOp,
-        "VUID-vkCmdSetDepthCompareOp-None-03353", VK_COMPARE_OP_NEVER, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthCompareOpEXT,
+        "VUID-vkCmdSetDepthCompareOpEXT-None-03353", VK_COMPARE_OP_NEVER);
 
-    auto vkCmdSetDepthTestEnable = reinterpret_cast<PFN_vkCmdSetDepthTestEnable>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthTestEnable"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthTestEnableEXT, vkCmdSetDepthTestEnable,
-        "VUID-vkCmdSetDepthTestEnable-None-03352", VK_FALSE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthTestEnableEXT,
+        "VUID-vkCmdSetDepthTestEnableEXT-None-03352", VK_FALSE);
 
-    auto vkCmdSetDepthWriteEnable = reinterpret_cast<PFN_vkCmdSetDepthWriteEnable>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthWriteEnable"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthWriteEnableEXT, vkCmdSetDepthWriteEnable,
-        "VUID-vkCmdSetDepthWriteEnable-None-03354", VK_FALSE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthWriteEnableEXT,
+        "VUID-vkCmdSetDepthWriteEnableEXT-None-03354", VK_FALSE);
 
-    auto vkCmdSetFrontFace =
-        reinterpret_cast<PFN_vkCmdSetFrontFace>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFrontFace"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetFrontFaceEXT, vkCmdSetFrontFace,
-                          "VUID-vkCmdSetFrontFace-None-03383", VK_FRONT_FACE_CLOCKWISE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetFrontFaceEXT,
+                          "VUID-vkCmdSetFrontFaceEXT-None-03383", VK_FRONT_FACE_CLOCKWISE);
 
-    auto vkCmdSetPrimitiveTopology =
-        reinterpret_cast<PFN_vkCmdSetPrimitiveTopology>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopology"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetPrimitiveTopologyEXT, vkCmdSetPrimitiveTopology,
-                          "VUID-vkCmdSetPrimitiveTopology-None-03347", VK_PRIMITIVE_TOPOLOGY_POINT_LIST, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetPrimitiveTopologyEXT,
+                          "VUID-vkCmdSetPrimitiveTopologyEXT-None-03347", VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-None-03396");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCountEXT-None-03396");
     VkRect2D scissor = {{0, 0}, {1, 1}};
     vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 1, &scissor);
     m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
-        auto vkCmdSetScissorWithCount =
-            reinterpret_cast<PFN_vkCmdSetScissorWithCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCount"));
-        assert(vkCmdSetScissorWithCount != nullptr);
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-None-03396");
-        vkCmdSetScissorWithCount(commandBuffer.handle(), 1, &scissor);
-        m_errorMonitor->VerifyFound();
-    }
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetStencilOp-None-03351");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetStencilOpEXT-None-03351");
     vkCmdSetStencilOpEXT(commandBuffer.handle(), VK_STENCIL_FACE_BACK_BIT, VK_STENCIL_OP_ZERO, VK_STENCIL_OP_ZERO,
                          VK_STENCIL_OP_ZERO, VK_COMPARE_OP_NEVER);
     m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
-        auto vkCmdSetStencilOp =
-            reinterpret_cast<PFN_vkCmdSetStencilOp>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilOp"));
-        assert(vkCmdSetStencilOp != nullptr);
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetStencilOp-None-03351");
-        vkCmdSetStencilOp(commandBuffer.handle(), VK_STENCIL_FACE_BACK_BIT, VK_STENCIL_OP_ZERO, VK_STENCIL_OP_ZERO,
-            VK_STENCIL_OP_ZERO, VK_COMPARE_OP_NEVER);
-        m_errorMonitor->VerifyFound();
-    }
 
-    auto vkCmdSetStencilTestEnable = reinterpret_cast<PFN_vkCmdSetStencilTestEnable>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilTestEnable"));
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetStencilTestEnableEXT, vkCmdSetStencilTestEnable,
-        "VUID-vkCmdSetStencilTestEnable-None-03350", VK_FALSE, vulkan_13);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetStencilTestEnableEXT,
+        "VUID-vkCmdSetStencilTestEnableEXT-None-03350", VK_FALSE);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-None-03393");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCountEXT-None-03393");
     VkViewport viewport = {0, 0, 1, 1, 0.0f, 0.0f};
     vkCmdSetViewportWithCountEXT(commandBuffer.handle(), 1, &viewport);
     m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
-        auto vkCmdSetViewportWithCount =
-            reinterpret_cast<PFN_vkCmdSetViewportWithCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCount"));
-        assert(vkCmdSetViewportWithCount != nullptr);
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-None-03393");
-        vkCmdSetViewportWithCount(commandBuffer.handle(), 1, &viewport);
-        m_errorMonitor->VerifyFound();
-    }
 
     commandBuffer.end();
 }
@@ -11202,7 +11160,7 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
 TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 VUs");
 
-    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_3);
+    uint32_t version = SetTargetApiVersion(VK_API_VERSION_1_2);
     if (version < VK_API_VERSION_1_1) {
         printf("%s At least Vulkan version 1.1 is required, skipping test.\n", kSkipPrefix);
         return;
@@ -11232,24 +11190,12 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     extended_dynamic_state2_features.extendedDynamicState2 = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
     auto vkCmdSetRasterizerDiscardEnableEXT =
         (PFN_vkCmdSetRasterizerDiscardEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetRasterizerDiscardEnableEXT");
     auto vkCmdSetDepthBiasEnableEXT =
         (PFN_vkCmdSetDepthBiasEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBiasEnableEXT");
     auto vkCmdSetPrimitiveRestartEnableEXT =
         (PFN_vkCmdSetPrimitiveRestartEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveRestartEnableEXT");
-    auto vkCmdSetRasterizerDiscardEnable =
-        (PFN_vkCmdSetRasterizerDiscardEnable)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetRasterizerDiscardEnable");
-    auto vkCmdSetDepthBiasEnable =
-        (PFN_vkCmdSetDepthBiasEnable)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBiasEnable");
-    auto vkCmdSetPrimitiveRestartEnable =
-        (PFN_vkCmdSetPrimitiveRestartEnable)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveRestartEnable");
-    if (vulkan_13) {
-        assert(vkCmdSetRasterizerDiscardEnable != nullptr);
-        assert(vkCmdSetDepthBiasEnable != nullptr);
-        assert(vkCmdSetPrimitiveRestartEnable != nullptr);
-    }
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11269,31 +11215,17 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     VkCommandBufferObj m_commandBuffer(m_device, m_commandPool);
     m_commandBuffer.begin();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnable-None-04871");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnableEXT-None-04871");
     vkCmdSetRasterizerDiscardEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetDepthBiasEnable-None-04872");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetDepthBiasEnableEXT-None-04872");
     vkCmdSetDepthBiasEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPrimitiveRestartEnable-None-04866");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPrimitiveRestartEnableEXT-None-04866");
     vkCmdSetPrimitiveRestartEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
-
-    if (vulkan_13) {
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnable-None-04871");
-        vkCmdSetRasterizerDiscardEnable(m_commandBuffer.handle(), VK_TRUE);
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetDepthBiasEnable-None-04872");
-        vkCmdSetDepthBiasEnable(m_commandBuffer.handle(), VK_TRUE);
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPrimitiveRestartEnable-None-04866");
-        vkCmdSetPrimitiveRestartEnable(m_commandBuffer.handle(), VK_TRUE);
-        m_errorMonitor->VerifyFound();
-    }
 
     m_commandBuffer.end();
 }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -10154,40 +10154,40 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     commandBuffer.begin();
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetCullModeEXT,
-                          "VUID-vkCmdSetCullModeEXT-None-03384", VK_CULL_MODE_NONE);
+                          "VUID-vkCmdSetCullMode-None-03384", VK_CULL_MODE_NONE);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthBoundsTestEnableEXT,
-        "VUID-vkCmdSetDepthBoundsTestEnableEXT-None-03349", VK_FALSE);
+        "VUID-vkCmdSetDepthBoundsTestEnable-None-03349", VK_FALSE);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthCompareOpEXT,
-        "VUID-vkCmdSetDepthCompareOpEXT-None-03353", VK_COMPARE_OP_NEVER);
+        "VUID-vkCmdSetDepthCompareOp-None-03353", VK_COMPARE_OP_NEVER);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthTestEnableEXT,
-        "VUID-vkCmdSetDepthTestEnableEXT-None-03352", VK_FALSE);
+        "VUID-vkCmdSetDepthTestEnable-None-03352", VK_FALSE);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetDepthWriteEnableEXT,
-        "VUID-vkCmdSetDepthWriteEnableEXT-None-03354", VK_FALSE);
+        "VUID-vkCmdSetDepthWriteEnable-None-03354", VK_FALSE);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetFrontFaceEXT,
-                          "VUID-vkCmdSetFrontFaceEXT-None-03383", VK_FRONT_FACE_CLOCKWISE);
+                          "VUID-vkCmdSetFrontFace-None-03383", VK_FRONT_FACE_CLOCKWISE);
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetPrimitiveTopologyEXT,
-                          "VUID-vkCmdSetPrimitiveTopologyEXT-None-03347", VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
+                          "VUID-vkCmdSetPrimitiveTopology-None-03347", VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCountEXT-None-03396");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-None-03396");
     VkRect2D scissor = {{0, 0}, {1, 1}};
     vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 1, &scissor);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetStencilOpEXT-None-03351");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetStencilOp-None-03351");
     vkCmdSetStencilOpEXT(commandBuffer.handle(), VK_STENCIL_FACE_BACK_BIT, VK_STENCIL_OP_ZERO, VK_STENCIL_OP_ZERO,
                          VK_STENCIL_OP_ZERO, VK_COMPARE_OP_NEVER);
     m_errorMonitor->VerifyFound();
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vkCmdSetStencilTestEnableEXT,
-        "VUID-vkCmdSetStencilTestEnableEXT-None-03350", VK_FALSE);
+        "VUID-vkCmdSetStencilTestEnable-None-03350", VK_FALSE);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCountEXT-None-03393");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-None-03393");
     VkViewport viewport = {0, 0, 1, 1, 0.0f, 0.0f};
     vkCmdSetViewportWithCountEXT(commandBuffer.handle(), 1, &viewport);
     m_errorMonitor->VerifyFound();
@@ -11215,15 +11215,15 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     VkCommandBufferObj m_commandBuffer(m_device, m_commandPool);
     m_commandBuffer.begin();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnableEXT-None-04871");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnable-None-04871");
     vkCmdSetRasterizerDiscardEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetDepthBiasEnableEXT-None-04872");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetDepthBiasEnable-None-04872");
     vkCmdSetDepthBiasEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPrimitiveRestartEnableEXT-None-04866");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPrimitiveRestartEnable-None-04866");
     vkCmdSetPrimitiveRestartEnableEXT(m_commandBuffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
This validation change is related to this Vulkan 1.3 spec fix: https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5034

Without this change an application attempting to use the new Vulkan 1.3 extended dynamic state will get false validation errors:
```
Validation Error: [ VUID-vkCmdSetStencilOp-None-03351 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x792ad08 | vkCmdSetStencilOp: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetStencilOp-None-03351](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetStencilOp-None-03351&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973456901174%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=E%2BQuCOpQQ5ljOM5aJn8pA6mrGqKcmGXWBJF%2FLtbQUMM%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetCullMode-None-03384 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x1093bebb | vkCmdSetCullMode: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetCullMode-None-03384](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetCullMode-None-03384&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973456901174%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=DU7Lnul5uSkGhUuE5QENyWqZejAPYX6z3fVO%2FiWBuqs%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetFrontFace-None-03383 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x93e1ba4e | vkCmdSetFrontFace: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetFrontFace-None-03383](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetFrontFace-None-03383&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=fonZ%2FcR6C1Cf6%2BEb9XYQo%2Fw7EBcNioCS0nvW80LDqNg%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthBiasEnable-None-04872 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xb13c8036 | vkCmdSetDepthBiasEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState2 feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthBiasEnable-None-04872](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthBiasEnable-None-04872&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=MzXnlw%2FTCPuF%2FHABrxNNlgd5GtW9xD79jZ6EuQOAyt8%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthTestEnable-None-03352 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x9215850f | vkCmdSetDepthTestEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthTestEnable-None-03352](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthTestEnable-None-03352&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=xjBmyi9wS4APJSeQ%2FblEoAPj7lFGCLlhc%2FgiOTScvKQ%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthWriteEnable-None-03354 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x86bf18dc | vkCmdSetDepthWriteEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthWriteEnable-None-03354](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthWriteEnable-None-03354&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=6tMLv8Rltrlaf%2FfNvxnscMgsV62VcdI5U1hUz8CblfY%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthCompareOp-None-03353 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x8b7159a7 | vkCmdSetDepthCompareOp: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthCompareOp-None-03353](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthCompareOp-None-03353&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=pWZ5G6hxMkoH8jdvkt9Hprl%2FycQrgUZvecheUsSdQYA%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetStencilTestEnable-None-03350 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xac9c13c5 | vkCmdSetStencilTestEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetStencilTestEnable-None-03350](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetStencilTestEnable-None-03350&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=4TPbKPqcSvXlDWo8UI4JAHtW37wBdW7jql0Aat9l%2Bng%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetStencilOp-None-03351 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x792ad08 | vkCmdSetStencilOp: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetStencilOp-None-03351](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetStencilOp-None-03351&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=YToCSHSIcsBObncIeJj9hsYLChOnW7eyN3mit0zw6P0%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetCullMode-None-03384 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x1093bebb | vkCmdSetCullMode: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetCullMode-None-03384](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetCullMode-None-03384&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=%2FYo%2ByYOo57A332gaW7WdtAqCPRU1PRZ1sx8jl%2F6G5kI%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetFrontFace-None-03383 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x93e1ba4e | vkCmdSetFrontFace: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetFrontFace-None-03383](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetFrontFace-None-03383&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=fonZ%2FcR6C1Cf6%2BEb9XYQo%2Fw7EBcNioCS0nvW80LDqNg%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthBiasEnable-None-04872 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xb13c8036 | vkCmdSetDepthBiasEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState2 feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthBiasEnable-None-04872](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthBiasEnable-None-04872&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=MzXnlw%2FTCPuF%2FHABrxNNlgd5GtW9xD79jZ6EuQOAyt8%3D&reserved=0))
Validation Error: [ VUID-vkCmdSetDepthTestEnable-None-03352 ] Object 0: handle = 0x27441dea3c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x9215850f | vkCmdSetDepthTestEnable: extendedDynamicState feature is not enabled. The Vulkan spec states: The extendedDynamicState feature must be enabled ([https://vulkan.lunarg.com/doc/view/1.3.203.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdSetDepthTestEnable-None-03352](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fvulkan.lunarg.com%2Fdoc%2Fview%2F1.3.203.0%2Fwindows%2F1.3-extensions%2Fvkspec.html%23VUID-vkCmdSetDepthTestEnable-None-03352&data=04%7C01%7Cpdaniell%40nvidia.com%7C9d55e52b0f91471759b508d9e80f02cf%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637795973457057387%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=xjBmyi9wS4APJSeQ%2FblEoAPj7lFGCLlhc%2FgiOTScvKQ%3D&reserved=0))
```