### PR TITLE
layers: Fix format_feature_2 format features

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1261,50 +1261,52 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
         // format support is reported per format rather as a blankey physical
         // device feature.
         if (has_format_feature2) {
-            const VkFormatFeatureFlags2KHR img_format_feats = image_view_state->image_state->format_features;
+            const VkFormatFeatureFlags2 format_features = image_view_state->format_features;
 
             if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
                 if ((reqs & DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT) &&
-                    !(img_format_feats & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
+                    !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT)) {
                     auto set = descriptor_set->GetSet();
                     LogObjectList objlist(set);
                     objlist.add(image_view);
                     return LogError(objlist, vuids.storage_image_read_without_format,
                                     "Descriptor set %s encountered the following validation error at %s time: Descriptor "
                                     "in binding #%" PRIu32 " index %" PRIu32
-                                    ", %s, format %s, doesn't "
-                                    "contain VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
+                                    ", %s, image view format %s feature flags (%s) doesn't "
+                                    "contain VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                                     report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                    report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format));
+                                    report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
+                                    string_VkFormatFeatureFlags2(format_features).c_str());
                 }
 
                 if ((reqs & DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT) &&
-                    !(img_format_feats & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
+                    !(format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT)) {
                     auto set = descriptor_set->GetSet();
                     LogObjectList objlist(set);
                     objlist.add(image_view);
                     return LogError(objlist, vuids.storage_image_write_without_format,
                                     "Descriptor set %s encountered the following validation error at %s time: Descriptor "
                                     "in binding #%" PRIu32 " index %" PRIu32
-                                    ", %s, format %s, doesn't "
-                                    "contain VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
+                                    ", %s, image view format %s feature flags (%s) doesn't "
+                                    "contain VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                                     report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                    report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format));
+                                    report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
+                                    string_VkFormatFeatureFlags2(format_features).c_str());
                 }
             }
 
-            if ((reqs & DESCRIPTOR_REQ_IMAGE_DREF) &&
-                !(img_format_feats & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR)) {
+            if ((reqs & DESCRIPTOR_REQ_IMAGE_DREF) && !(format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT)) {
                 auto set = descriptor_set->GetSet();
                 LogObjectList objlist(set);
                 objlist.add(image_view);
                 return LogError(objlist, vuids.depth_compare_sample,
                                 "Descriptor set %s encountered the following validation error at %s time: Descriptor "
                                 "in binding #%" PRIu32 " index %" PRIu32
-                                ", %s, format %s, doesn't "
-                                "contain VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
+                                ", %s, image view format %s feature flags (%s) doesn't "
+                                "contain VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                                 report_data->FormatHandle(set).c_str(), caller, binding, index,
-                                report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format));
+                                report_data->FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
+                                string_VkFormatFeatureFlags2(format_features).c_str());
             }
         }
 

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -43,6 +43,7 @@ struct layer_data {
     VkInstance instance;
     VkPhysicalDeviceProperties phy_device_props;
     std::unordered_map<VkFormat, VkFormatProperties, std::hash<int> > format_properties_map;
+    std::unordered_map<VkFormat, VkFormatProperties3, std::hash<int> > format_properties3_map;
     VkPhysicalDeviceFeatures phy_device_features;
     VkLayerInstanceDispatchTable dispatch_table;
 };
@@ -94,12 +95,18 @@ VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFormatPropertiesEXT(VkPhysicalDevice
     layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     memcpy(&(phy_dev_data->format_properties_map[format]), &newProperties, sizeof(VkFormatProperties));
+
+    // Need to set in the case a test uses SetPhysicalDeviceFormatProperties1() functions but because it is a 1.3 device and
+    // the validation code will call GetPhysicalDeviceFormatProperties2() expecting VkFormatProperties3 to be filled
+    VkFormatProperties3 fmt_props_3 = LvlInitStruct<VkFormatProperties3>();
+    fmt_props_3.linearTilingFeatures = static_cast<VkFormatFeatureFlags2>(newProperties.linearTilingFeatures);
+    fmt_props_3.optimalTilingFeatures = static_cast<VkFormatFeatureFlags2>(newProperties.optimalTilingFeatures);
+    fmt_props_3.bufferFeatures = static_cast<VkFormatFeatureFlags2>(newProperties.bufferFeatures);
+    memcpy(&(phy_dev_data->format_properties3_map[format]), &fmt_props_3, sizeof(VkFormatProperties3));
 }
 
 VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceFormatProperties2EXT(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                          VkFormatProperties2 *properties) {
-    // Currently only supports getting VkFormatProperties
-    // TODO: Add support for VkDrmFormatModifierPropertiesListEXT and future pNext structs of VkFormatProperties2
     std::lock_guard<std::mutex> lock(global_lock);
     layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
     layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
@@ -112,6 +119,10 @@ VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFormatProperties2EXT(VkPhysicalDevic
     layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     memcpy(&(phy_dev_data->format_properties_map[format]), &(newProperties.formatProperties), sizeof(VkFormatProperties));
+    VkFormatProperties3 *fmt_props_3 = LvlFindModInChain<VkFormatProperties3>(newProperties.pNext);
+    if (fmt_props_3) {
+        memcpy(&(phy_dev_data->format_properties3_map[format]), fmt_props_3, sizeof(VkFormatProperties3));
+    }
 }
 
 VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceFeaturesEXT(VkPhysicalDevice physicalDevice,
@@ -210,7 +221,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice ph
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
                                                               VkFormatProperties2 *pProperties) {
-    VkFormatProperties3KHR *fmt_props_3 = LvlFindModInChain<VkFormatProperties3KHR>(pProperties->pNext);
+    VkFormatProperties3 *fmt_props_3 = LvlFindModInChain<VkFormatProperties3>(pProperties->pNext);
     std::lock_guard<std::mutex> lock(global_lock);
     layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
     layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
@@ -218,12 +229,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalDevice p
     if (device_format_map_it != phy_dev_data->format_properties_map.end()) {
         memcpy((void *)&(pProperties->formatProperties), &phy_dev_data->format_properties_map[format], sizeof(VkFormatProperties));
         if (fmt_props_3) {
-            fmt_props_3->linearTilingFeatures =
-                static_cast<VkFormatFeatureFlags2KHR>(pProperties->formatProperties.linearTilingFeatures);
-            fmt_props_3->optimalTilingFeatures =
-                static_cast<VkFormatFeatureFlags2KHR>(pProperties->formatProperties.optimalTilingFeatures);
-            fmt_props_3->bufferFeatures =
-                static_cast<VkFormatFeatureFlags2KHR>(pProperties->formatProperties.bufferFeatures);
+            memcpy(fmt_props_3, &phy_dev_data->format_properties3_map[format], sizeof(VkFormatProperties3));
         }
     } else {
         instance_data->dispatch_table.GetPhysicalDeviceFormatProperties2(physicalDevice, format, pProperties);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -13668,7 +13668,9 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidLevelOrLayerCount) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
-    if (!image.IsCompatibleCheck(image_create_info)) {
+    VkFormatProperties image_fmt;
+    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         printf("%s Image usage and format not compatible on device\n", kSkipPrefix);
         return;
     }
@@ -13831,7 +13833,9 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidType) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
-    if (!image.IsCompatibleCheck(image_create_info)) {
+    VkFormatProperties image_fmt;
+    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         printf("%s Image usage and format not compatible on device\n", kSkipPrefix);
         return;
     }
@@ -13880,7 +13884,9 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidFormat) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
-    if (!image.IsCompatibleCheck(image_create_info)) {
+    VkFormatProperties image_fmt;
+    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         printf("%s Image usage and format not compatible on device\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1834,7 +1834,7 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
         printf("%s Vulkan12Struct requires Vulkan 1.2+, skipping test\n", kSkipPrefix);
         return;
     }
- 
+
     VkPhysicalDevice16BitStorageFeatures sixteen_bit = LvlInitStruct<VkPhysicalDevice16BitStorageFeatures>();
     sixteen_bit.storageBuffer16BitAccess = true;
     VkPhysicalDeviceVulkan11Features features11 = LvlInitStruct<VkPhysicalDeviceVulkan11Features>(&sixteen_bit);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2212,7 +2212,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
     int n_tests = 0;
     bool has_without_format_test = false, has_with_format_test = false;
 
-    // Find storage formats with & without read without format support
+    // Find storage formats with & without write without format support
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
         if (has_without_format_test && has_with_format_test) break;
 
@@ -2223,12 +2223,12 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
 
         const bool has_storage =
             (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR) != 0;
-        const bool has_read_without_format =
-            (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR) != 0;
+        const bool has_write_without_format =
+            (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) != 0;
 
         if (!has_storage) continue;
 
-        if (has_read_without_format) {
+        if (has_write_without_format) {
             if (has_without_format_test) continue;
 
             tests[n_tests].format = (VkFormat)fmt;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1550,51 +1550,57 @@ void VkImageObj::SetLayout(VkImageAspectFlags aspect, VkImageLayout image_layout
     cmd_buf.QueueCommandBuffer();
 }
 
-bool VkImageObj::IsCompatible(const VkImageUsageFlags usages, const VkFormatFeatureFlags features) {
-    VkFormatFeatureFlags all_feature_flags =
-        VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT | VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT |
-        VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT | VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT |
-        VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT | VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT |
-        VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT |
-        VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT |
-        VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+bool VkImageObj::IsCompatible(const VkImageUsageFlags usages, const VkFormatFeatureFlags2 features) {
+    VkFormatFeatureFlags2 all_feature_flags =
+        VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT |
+        VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT | VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT |
+        VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT | VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT |
+        VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT | VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
+        VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT | VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
+        VK_FORMAT_FEATURE_2_BLIT_SRC_BIT | VK_FORMAT_FEATURE_2_BLIT_DST_BIT | VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
     if (m_device->IsEnabledExtension(VK_IMG_FILTER_CUBIC_EXTENSION_NAME)) {
-        all_feature_flags |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG;
+        all_feature_flags |= VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT;
     }
 
     if (m_device->IsEnabledExtension(VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
-        all_feature_flags |= VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR;
+        all_feature_flags |= VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR;
     }
 
     if (m_device->IsEnabledExtension(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME)) {
-        all_feature_flags |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT;
+        all_feature_flags |= VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT;
     }
 
     if (m_device->IsEnabledExtension(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME)) {
-        all_feature_flags |= VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR |
-                             VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR |
-                             VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR |
-                             VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR |
-                             VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR |
-                             VK_FORMAT_FEATURE_DISJOINT_BIT_KHR | VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR;
+        all_feature_flags |= VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR | VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR;
+    }
+
+    if (m_device->IsEnabledExtension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+        all_feature_flags |= VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR |
+                             VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR;
     }
 
     if ((features & all_feature_flags) == 0) return false;  // whole format unsupported
 
-    if ((usages & VK_IMAGE_USAGE_SAMPLED_BIT) && !(features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) return false;
-    if ((usages & VK_IMAGE_USAGE_STORAGE_BIT) && !(features & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) return false;
-    if ((usages & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) && !(features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) return false;
-    if ((usages & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) && !(features & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT))
+    if ((usages & VK_IMAGE_USAGE_SAMPLED_BIT) && !(features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) return false;
+    if ((usages & VK_IMAGE_USAGE_STORAGE_BIT) && !(features & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT)) return false;
+    if ((usages & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) && !(features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT)) return false;
+    if ((usages & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) && !(features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT))
         return false;
 
     if (m_device->IsEnabledExtension(VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
         // WORKAROUND: for DevSim not reporting extended enums, and possibly some drivers too
         const auto all_nontransfer_feature_flags =
-            all_feature_flags ^ (VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR);
+            all_feature_flags ^ (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR);
         const bool transfer_probably_supported_anyway = (features & all_nontransfer_feature_flags) > 0;
         if (!transfer_probably_supported_anyway) {
-            if ((usages & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) && !(features & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR)) return false;
-            if ((usages & VK_IMAGE_USAGE_TRANSFER_DST_BIT) && !(features & VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR)) return false;
+            if ((usages & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) && !(features & VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR)) return false;
+            if ((usages & VK_IMAGE_USAGE_TRANSFER_DST_BIT) && !(features & VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR)) return false;
         }
     }
 
@@ -1629,30 +1635,44 @@ void VkImageObj::InitNoLayout(uint32_t const width, uint32_t const height, uint3
 }
 
 void VkImageObj::InitNoLayout(const VkImageCreateInfo &create_info, VkMemoryPropertyFlags const reqs, bool memory) {
-    VkFormatProperties image_fmt;
+    VkFormatFeatureFlags2 linear_tiling_features;
+    VkFormatFeatureFlags2 optimal_tiling_features;
     // Touch up create info for tiling compatiblity...
     auto usage = create_info.usage;
     VkImageTiling requested_tiling = create_info.tiling;
     VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
 
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info.format, &image_fmt);
+    if (m_device->IsEnabledExtension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+        auto fmt_props_3 = LvlInitStruct<VkFormatProperties3KHR>();
+        auto fmt_props_2 = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
+        vk::GetPhysicalDeviceFormatProperties2(m_device->phy().handle(), create_info.format, &fmt_props_2);
+        linear_tiling_features = fmt_props_3.linearTilingFeatures;
+        optimal_tiling_features = fmt_props_3.optimalTilingFeatures;
+    } else {
+        VkFormatProperties format_properties;
+        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info.format, &format_properties);
+        linear_tiling_features = format_properties.linearTilingFeatures;
+        optimal_tiling_features = format_properties.optimalTilingFeatures;
+    }
 
-    if (requested_tiling == VK_IMAGE_TILING_LINEAR) {
-        if (IsCompatible(usage, image_fmt.linearTilingFeatures)) {
+    if ((create_info.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) != 0) {
+        tiling = requested_tiling;
+    } else if (requested_tiling == VK_IMAGE_TILING_LINEAR) {
+        if (IsCompatible(usage, linear_tiling_features)) {
             tiling = VK_IMAGE_TILING_LINEAR;
-        } else if (IsCompatible(usage, image_fmt.optimalTilingFeatures)) {
+        } else if (IsCompatible(usage, optimal_tiling_features)) {
             tiling = VK_IMAGE_TILING_OPTIMAL;
         } else {
             FAIL() << "VkImageObj::init() error: unsupported tiling configuration. Usage: " << std::hex << std::showbase << usage
-                   << ", supported linear features: " << image_fmt.linearTilingFeatures;
+                   << ", supported linear features: " << linear_tiling_features;
         }
-    } else if (IsCompatible(usage, image_fmt.optimalTilingFeatures)) {
+    } else if (IsCompatible(usage, optimal_tiling_features)) {
         tiling = VK_IMAGE_TILING_OPTIMAL;
-    } else if (IsCompatible(usage, image_fmt.linearTilingFeatures)) {
+    } else if (IsCompatible(usage, linear_tiling_features)) {
         tiling = VK_IMAGE_TILING_LINEAR;
     } else {
         FAIL() << "VkImageObj::init() error: unsupported tiling configuration. Usage: " << std::hex << std::showbase << usage
-               << ", supported optimal features: " << image_fmt.optimalTilingFeatures;
+               << ", supported optimal features: " << optimal_tiling_features;
     }
 
     VkImageCreateInfo imageCreateInfo = create_info;
@@ -1703,20 +1723,34 @@ void VkImageObj::Init(const VkImageCreateInfo &create_info, VkMemoryPropertyFlag
 }
 
 void VkImageObj::init(const VkImageCreateInfo *create_info) {
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info->format, &image_fmt);
+    VkFormatFeatureFlags2 linear_tiling_features;
+    VkFormatFeatureFlags2 optimal_tiling_features;
 
+    if (m_device->IsEnabledExtension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+        auto fmt_props_3 = LvlInitStruct<VkFormatProperties3KHR>();
+        auto fmt_props_2 = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
+        vk::GetPhysicalDeviceFormatProperties2(m_device->phy().handle(), create_info->format, &fmt_props_2);
+        linear_tiling_features = fmt_props_3.linearTilingFeatures;
+        optimal_tiling_features = fmt_props_3.optimalTilingFeatures;
+    } else {
+        VkFormatProperties format_properties;
+        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info->format, &format_properties);
+        linear_tiling_features = format_properties.linearTilingFeatures;
+        optimal_tiling_features = format_properties.optimalTilingFeatures;
+    }
+
+    const bool mutable_format = (create_info->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) != 0;
     switch (create_info->tiling) {
         case VK_IMAGE_TILING_OPTIMAL:
-            if (!IsCompatible(create_info->usage, image_fmt.optimalTilingFeatures)) {
+            if (!mutable_format && !IsCompatible(create_info->usage, optimal_tiling_features)) {
                 FAIL() << "VkImageObj::init() error: unsupported tiling configuration. Usage: " << std::hex << std::showbase
-                       << create_info->usage << ", supported optimal features: " << image_fmt.optimalTilingFeatures;
+                       << create_info->usage << ", supported optimal features: " << optimal_tiling_features;
             }
             break;
         case VK_IMAGE_TILING_LINEAR:
-            if (!IsCompatible(create_info->usage, image_fmt.linearTilingFeatures)) {
+            if (!mutable_format && !IsCompatible(create_info->usage, linear_tiling_features)) {
                 FAIL() << "VkImageObj::init() error: unsupported tiling configuration. Usage: " << std::hex << std::showbase
-                       << create_info->usage << ", supported linear features: " << image_fmt.linearTilingFeatures;
+                       << create_info->usage << ", supported linear features: " << linear_tiling_features;
             }
             break;
         default:
@@ -1739,20 +1773,6 @@ void VkImageObj::init(const VkImageCreateInfo *create_info) {
         image_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
     }
     SetLayout(image_aspect, VK_IMAGE_LAYOUT_GENERAL);
-}
-
-bool VkImageObj::IsCompatibleCheck(const VkImageCreateInfo &create_info) {
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), create_info.format, &image_fmt);
-
-    switch (create_info.tiling) {
-        case VK_IMAGE_TILING_OPTIMAL:
-            return IsCompatible(create_info.usage, image_fmt.optimalTilingFeatures);
-        case VK_IMAGE_TILING_LINEAR:
-            return IsCompatible(create_info.usage, image_fmt.linearTilingFeatures);
-        default:
-            return true;
-    }
 }
 
 VkResult VkImageObj::CopyImage(VkImageObj &src_image) {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -488,8 +488,7 @@ class VkRenderpassObj : public vk_testing::RenderPass {
 class VkImageObj : public vk_testing::Image {
   public:
     VkImageObj(VkDeviceObj *dev);
-    bool IsCompatible(VkImageUsageFlags usages, VkFormatFeatureFlags features);
-    bool IsCompatibleCheck(const VkImageCreateInfo &create_info);
+    bool IsCompatible(VkImageUsageFlags usages, VkFormatFeatureFlags2 features);
 
   public:
     static VkImageCreateInfo ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mipLevels,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3736

- `VUID-*-OpTypeImage-06423` and `VUID-*-OpTypeImage-06424` should be checking image view format
    - spec fix - https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5041
- `VUID-*-None-06479` also says "image view" but was checking the image format features
- Added a slight more information at error message time

cc @djdeath 