### PR TITLE
tests: Fix tests failing with 1.3 devsim

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -793,6 +793,19 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
     if (!timeline_semaphore_features.timelineSemaphore) {
         return false;
     }
+
+    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
+        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(renderFramework->instance(),
+                                                                       "vkGetPhysicalDeviceProperties2KHR");
+    VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props =
+        LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
+    VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&timeline_semaphore_props);
+    vkGetPhysicalDeviceProperties2KHR(renderFramework->gpu(), &pd_props2);
+    if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
+        // If using MockICD and devsim the value might be zero'ed and cause false errors
+        return false;
+    }
+
     renderFramework->InitState(nullptr, &features2);
     return true;
 }

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2226,6 +2226,12 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    // need real device to produce output to check
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
+
     // glslang currenlty turned the GLSL to
     //      %19 = OpSpecConstantOp %uint UConvert %a
     // which causes issue (to be fixed outside scope of this test)

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -5865,6 +5865,14 @@ TEST_F(VkLayerTest, MultiDrawFeatures) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    auto multi_draw_props = LvlInitStruct<VkPhysicalDeviceMultiDrawPropertiesEXT>();
+    auto pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&multi_draw_props);
+    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+    if (multi_draw_props.maxMultiDrawCount == 0) {
+        // If using MockICD and devsim the value might be zero'ed and cause false errors
+        return;
+    }
+
     auto vkCmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT");
     auto vkCmdDrawMultiIndexedEXT =
         (PFN_vkCmdDrawMultiIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT");

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -14242,6 +14242,12 @@ TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&transform_feedback_props);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &pd_props2);
 
+    // seen sometimes when using devsim and will crash
+    if (transform_feedback_props.maxTransformFeedbackStreams == 0) {
+        printf("%s maxTransformFeedbackStreams is zero, skipping test.\n", kSkipPrefix);
+        return;
+    }
+
     {
         std::stringstream vsSource;
         vsSource << R"asm(

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -691,6 +691,11 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        // will throw a std::bad_alloc sometimes
+        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;
     ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));
@@ -855,6 +860,11 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        // will throw a std::bad_alloc sometimes
+        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
+        return;
+    }
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;
     ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));


### PR DESCRIPTION
Found when running MockICD with a 1.3 device via devsim layer