### PR TITLE
layers: Add remaining pointer results to def index

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -359,12 +359,14 @@ SHADER_MODULE_STATE::SpirvStaticData::SpirvStaticData(const SHADER_MODULE_STATE 
                 has_specialization_constants = true;
                 break;
 
-                // Have a result that can be a pointer
+                // Have a result that can be a pointer (virtual or phyiscal)
             case spv::OpVariable:
             case spv::OpAccessChain:
             case spv::OpInBoundsAccessChain:
             case spv::OpFunctionParameter:
             case spv::OpImageTexelPointer:
+            case spv::OpBitcast:
+            case spv::OpConvertUToPtr:
                 def_index[insn.word(2)] = insn.offset();
                 break;
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3735

Went through SPIR-V spec and made sure all the valid Vulkan operations that have `Result Type` of a pointer are in the `def_index` so when calling `get_def()` it doesn't crash

This information is not in the grammar, otherwise I would have generated it

Wrote a reduced test of the shader used in original issue that would crash 