### PR TITLE
layers: Add depcrecated WorkgroupSize BP warning

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -33,6 +33,10 @@ ASSERT_NO_FATAL_FAILURE(Init());
 
 ASSERT_NO_FATAL_FAILURE(InitFramework());
 ASSERT_NO_FATAL_FAILURE(InitState());
+
+// For Best Practices tests
+ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+ASSERT_NO_FATAL_FAILURE(InitState());
 ```
 
 to set it up. This will create the `VkInstance` and `VkDevice` for you.

--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -118,6 +118,8 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SuboptimalSwapchainImageC
     "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count";
 static const char DECORATE_UNUSED *kVUID_BestPractices_Swapchain_InvalidCount = "UNASSIGNED-BestPractices-SwapchainInvalidCount";
 static const char DECORATE_UNUSED *kVUID_BestPractices_DepthBiasNoAttachment = "UNASSIGNED-BestPractices-DepthBiasNoAttachment";
+static const char DECORATE_UNUSED *kVUID_BestPractices_SpirvDeprecated_WorkgroupSize =
+    "UNASSIGNED-BestPractices-SpirvDeprecated_WorkgroupSize";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =


### PR DESCRIPTION
From the SPIR-V Spec

> #620: The WorkgroupSize [built-in](https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#BuiltIn) is deprecated starting with version 1.6.

added check to warn user if they have `VK_KHR_maintenance4`