### PR TITLE
layers: Fix crashing in best practices

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1049,6 +1049,16 @@ void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device,
         GraphicsPipelineCIs& cis = graphicsPipelineCIs[pipeline_handle];
 
         auto& create_info = cgpl_state->pCreateInfos[i];
+
+        if (create_info.renderPass == VK_NULL_HANDLE) {
+            // TODO: this is necessary to avoid crashing
+            LogWarning(device, kVUID_BestPractices_DynamicRendering_NotSupported,
+                       "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32
+                       "].renderPass is VK_NULL_HANDLE, VK_KHR_dynamic_rendering is not supported.\n",
+                       static_cast<uint32_t>(i));
+            continue;
+        }
+
         auto rp = Get<RENDER_PASS_STATE>(create_info.renderPass);
 
         if (create_info.pColorBlendState) {
@@ -1071,14 +1081,6 @@ void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device,
             if (uses_depth_stencil && !create_info.pRasterizationState->rasterizerDiscardEnable) {
                 cis.depthStencilStateCI.emplace(create_info.pDepthStencilState);
             }
-        }
-
-        if (create_info.renderPass == VK_NULL_HANDLE) {
-            // TODO: this is necessary to avoid crashing
-            LogWarning(device, kVUID_BestPractices_DynamicRendering_NotSupported,
-                       "vkCreateGraphicsPipelines: pCreateInfos[%" PRIu32 "].renderPass is VK_NULL_HANDLE, VK_KHR_dynamic_rendering is not supported.\n",
-                       static_cast<uint32_t>(i));
-            continue;
         }
         // Record which frame buffer attachments we should consider to be accessed when a draw call is performed.
         auto& subpass = rp->createInfo.pSubpasses[create_info.subpass];


### PR DESCRIPTION
I encountered this issue when I tried to use current master with dynamic rendering.

This seems to be caused by commit https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/f9b894b68a712ba0f7880c176074ac9fbb67cc7d which forgot to move renderPass null check before trying to use it.