### PR TITLE
layers: ComputeWorkGroupSize with spec const

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -580,8 +580,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderStageGroupNonUniform(SHADER_MODULE_STATE const* module_state, VkShaderStageFlagBits stage,
                                             spirv_inst_iter& insn) const;
     bool ValidateMemoryScope(SHADER_MODULE_STATE const* module_state, const spirv_inst_iter& insn) const;
-    bool ValidateWorkgroupSize(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
-                               const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) const;
     bool ValidateCooperativeMatrix(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* module_state, VkPipelineShaderStageCreateInfo const* pStage,
@@ -1552,7 +1550,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE* module_state, const spirv_inst_iter& entrypoint,
-                                       const PipelineStageState& stage_state) const;
+                                       const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
+                                       uint32_t local_size_z) const;
 
     bool ValidateQueryRange(VkDevice device, VkQueryPool queryPool, uint32_t totalCount, uint32_t firstQuery, uint32_t queryCount,
                             const char* vuid_badfirst, const char* vuid_badrange, const char* apiName) const;

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -64,6 +64,8 @@ struct spirv_inst_iter {
 
     bool operator!=(spirv_inst_iter const &other) const { return it != other.it; }
 
+    bool operator!=(std::vector<uint32_t>::const_iterator other) const { return it != other; }
+
     spirv_inst_iter operator++(int) {  // x++
         spirv_inst_iter ii = *this;
         it += len();
@@ -383,8 +385,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
 
     uint32_t GetNumComponentsInBaseType(const spirv_inst_iter &iter) const;
-    std::array<uint32_t, 3> GetWorkgroupSize(VkPipelineShaderStageCreateInfo const *pStage,
-                                             const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) const;
     uint32_t GetTypeBitsSize(const spirv_inst_iter &iter) const;
     uint32_t GetTypeBytesSize(const spirv_inst_iter &iter) const;
     uint32_t GetBaseType(const spirv_inst_iter &iter) const;


### PR DESCRIPTION
spiritual successor to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3499

So this change does a few things, which I tried to test all cases

- Add proper support for `LocalSizeId` which was added in Vulkan 1.3 / `VK_KHR_maintenance4` (pending https://github.com/KhronosGroup/SPIRV-Tools/pull/4719 still though as tests will fail when it hits `spirv-opt` otherwise)
- Make sure if the `WorkgroupSize` built-in is used, it takes  precedence over any `LocalSize` or `LocalSizeId`
- Fix the "how we use `spirv-opt`" issue
    - A `OpSpecConstant` has a default value, so IF the pipeline has a value to override it, then we add `CreateSetSpecConstantDefaultValuePass`
    - If there are any `OpSpecConstant` we always will run `CreateFreezeSpecConstantValuePass` and `CreateFoldSpecConstantOpAndCompositePass` to get everything to constants.
    - We always need to run `spirv-opt` to make sure `VUID-VkPipelineShaderStageCreateInfo-module-04145` is not triggered
    - After `spirv-opt` a manual re-parsing of the new modified SPIR-V is required since it will not match the `SHADER_MODULE_STATE` shader, for now it is very non-invasive and should not be an issue just checking for the Workgropu Size
    - When this merged, will then add support for using spec constants to check for shared memory size too (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3282)... was going to add here, but it added a lot more churn to the PR then I wanted