### PR TITLE
layers: Generate shader module def_index table

### DIFF
--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -606,6 +606,18 @@ bool OpcodeHasResult(uint32_t opcode) {
     return has_result;
 }
 
+// Helper to get the word position of the result operand.
+// Will either be 1 or 2 if it has a result.
+// Will be 0 if there is no result.
+uint32_t OpcodeResultWord(uint32_t opcode) {
+    uint32_t position = 0;
+    if (OpcodeHasResult(opcode)) {
+        position = 1;
+        position += OpcodeHasType(opcode) ? 1 : 0;
+    }
+    return position;
+}
+
 // Return operand position of Memory Scope <ID> or zero if there is none
 uint32_t OpcodeMemoryScopePosition(uint32_t opcode) {
     uint32_t position = 0;

--- a/layers/generated/spirv_grammar_helper.h
+++ b/layers/generated/spirv_grammar_helper.h
@@ -40,6 +40,7 @@ bool ImageSampleOperation(uint32_t opcode);
 
 bool OpcodeHasType(uint32_t opcode);
 bool OpcodeHasResult(uint32_t opcode);
+uint32_t OpcodeResultWord(uint32_t opcode);
 
 uint32_t OpcodeMemoryScopePosition(uint32_t opcode);
 uint32_t OpcodeExecutionScopePosition(uint32_t opcode);

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -365,6 +365,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
         if self.headerFile:
             output += 'bool OpcodeHasType(uint32_t opcode);\n'
             output += 'bool OpcodeHasResult(uint32_t opcode);\n'
+            output += 'uint32_t OpcodeResultWord(uint32_t opcode);\n'
             output += '\n'
             output += 'uint32_t OpcodeMemoryScopePosition(uint32_t opcode);\n'
             output += 'uint32_t OpcodeExecutionScopePosition(uint32_t opcode);\n'
@@ -388,6 +389,18 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
             output += '        has_result = format_info->second.has_result;\n'
             output += '    }\n'
             output += '    return has_result;\n'
+            output += '}\n\n'
+
+            output += '// Helper to get the word position of the result operand.\n'
+            output += '// Will either be 1 or 2 if it has a result.\n'
+            output += '// Will be 0 if there is no result.\n'
+            output += 'uint32_t OpcodeResultWord(uint32_t opcode) {\n'
+            output += '    uint32_t position = 0;\n'
+            output += '    if (OpcodeHasResult(opcode)) {\n'
+            output += '        position = 1;\n'
+            output += '        position += OpcodeHasType(opcode) ? 1 : 0;\n'
+            output += '    }\n'
+            output += '    return position;\n'
             output += '}\n\n'
 
             output += '// Return operand position of Memory Scope <ID> or zero if there is none\n'


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3735
(Wrote a reduced test of the atomic shader used in original issue that would crash)

Realized the `def_index` table could just use the new SPIR-V grammar generated logic to figure out and would reduce future cases of missing a random opcode not being added
 