### PR TITLE
build: Update SPIRV-Tools

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -28,7 +28,7 @@
       "name" : "SPIRV-Tools",
       "url" : "https://github.com/KhronosGroup/SPIRV-Tools.git",
       "sub_dir" : "shaderc/third_party/spirv-tools",
-      "commit" : "45dd184c790d6bfc78a5a74a10c37e888b1823fa"
+      "commit" : "471428a04f9b4561801eb90f29d69bc484ef5473"
     },
     {
       "name" : "SPIRV-Headers",

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "45dd184c790d6bfc78a5a74a10c37e888b1823fa"
+#define SPIRV_TOOLS_COMMIT_ID "471428a04f9b4561801eb90f29d69bc484ef5473"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -37,7 +37,7 @@
       "cmake_options": [
         "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers"
       ],
-      "commit": "45dd184c790d6bfc78a5a74a10c37e888b1823fa"
+      "commit": "471428a04f9b4561801eb90f29d69bc484ef5473"
     },
     {
       "name": "robin-hood-hashing",


### PR DESCRIPTION
Update SPIRV-Tools to include proper `spirv-opt` support 
https://github.com/KhronosGroup/SPIRV-Tools/pull/4719
needed for 
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3758