### PR TITLE
Update subresource generator when iterator is incremented to next constant value range

### DIFF
--- a/layers/image_layout_map.cpp
+++ b/layers/image_layout_map.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2021 The Khronos Group Inc.
- * Copyright (c) 2019-2021 Valve Corporation
- * Copyright (c) 2019-2021 LunarG, Inc.
- * Copyright (C) 2019-2021 Google Inc.
+/* Copyright (c) 2019-2022 The Khronos Group Inc.
+ * Copyright (c) 2019-2022 Valve Corporation
+ * Copyright (c) 2019-2022 LunarG, Inc.
+ * Copyright (C) 2019-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -293,6 +293,7 @@ void ImageSubresourceLayoutMap::ConstIterator::IncrementInterval() {
     // When current index is set to point to that, UpdateRangeAndValue skips to the next constant value range,
     // setting that state as the current position / state for the iterator.
     current_index_ = constant_value_bound_;
+    range_gen_.GetSubresourceGenerator().Seek(current_index_);
     UpdateRangeAndValue();
 }
 


### PR DESCRIPTION
Fixes issue #3751. Correctly updates subresource generator when subresource layout map's const iterator is incremented via IncrementInterval that sets the index to next constant value range.