### PR TITLE
Unbind resources with multiview at render/subpass start

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -484,6 +484,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
   protected:
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;
     void UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPassBegin);
+    void UnbindResources();
 };
 
 // specializations for barriers that cannot do queue family ownership transfers

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -90,6 +90,7 @@ class RENDER_PASS_STATE : public BASE_NODE {
     };
     const bool use_dynamic_rendering;
     const bool use_dynamic_rendering_inherited;
+    const bool has_multiview_enabled;
     const safe_VkRenderingInfo dynamic_rendering_begin_rendering_info;
     const safe_VkPipelineRenderingCreateInfo dynamic_rendering_pipeline_create_info;
     const safe_VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info;


### PR DESCRIPTION
Fixes issue #3745. As stated in the spec, all resources should be rebound after `vkCmdBeginRenderPass` or `vkNextSubpass` if render pass is using multiview.