### PR TITLE
build: Handle many permutations of SPIRV-Headers locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,10 +256,23 @@ if (USE_ROBIN_HOOD_HASHING)
     endif()
 endif()
 
-set(SPIRV_HEADERS_INCLUDE_DIR "" CACHE STRING "")
 if(BUILD_LAYERS OR BUILD_TESTS)
-    if (SPIRV_HEADERS_INCLUDE_DIR STREQUAL "")
-        find_package(SPIRV-Headers REQUIRED CONFIG)
+    find_package(SPIRV-Headers CONFIG QUIET)
+    if(SPIRV-Headers_FOUND)
+	# pefer the package if found. Note that if SPIRV_HEADERS_INSTALL_DIR points at an 'installed'
+	# version of SPIRV-Headers, the package will be found.
+	get_target_property(SPIRV_HEADERS_INCLUDE_DIR SPIRV-Headers::SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
+    elseif(SPIRV_HEADERS_INCLUDE_DIR)
+	# This is set by SPIRV-Tools (in parent scope!) and also some packages that include VVL with add_subdirectory
+	if (NOT EXISTS "${SPIRV_HEADERS_INCLUDE_DIR}/spirv/unified1/spirv.h")
+	    message(FATAL_ERROR "Cannot find SPIRV-Headers from SPIRV_HEADERS_INCLUDE_DIR: ${SPIRV_HEADERS_INCLUDE_DIR}")
+        endif()
+    elseif(SPIRV_HEADERS_INSTALL_DIR)
+        # This is our official variable for setting SPIRV-Headers location, but pointing at the raw source of SPIRV-Headers
+	if (NOT EXISTS "${SPIRV_HEADERS_INSTALL_DIR}/include/spirv/unified1/spirv.h")
+	    message(FATAL_ERROR "Cannot find SPIRV-Headers from SPIRV_HEADERS_INSTALL_DIR: ${SPIRV_HEADERS_INSTALL_DIR}")
+        endif()
+	set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include")
     endif()
 endif()
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -309,12 +309,7 @@ if(BUILD_LAYERS)
     if (USE_ROBIN_HOOD_HASHING)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
     endif()
-    if (SPIRV_HEADERS_INCLUDE_DIR STREQUAL "")
-        target_link_libraries(VkLayer_khronos_validation PRIVATE SPIRV-Headers::SPIRV-Headers)
-    else()
-        target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
-    endif()
-
+    target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     target_link_libraries(VkLayer_khronos_validation PRIVATE SPIRV-Tools-static SPIRV-Tools-opt)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2021 Valve Corporation
-# Copyright (c) 2014-2021 LunarG, Inc.
+# Copyright (c) 2014-2022 Valve Corporation
+# Copyright (c) 2014-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -149,11 +149,11 @@ if (NOT MSVC)
     target_compile_options(vk_layer_validation_tests PRIVATE "-Wno-sign-compare")
 endif()
 
+target_include_directories(vk_layer_validation_tests PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
 # Specify target_link_libraries
 target_link_libraries(vk_layer_validation_tests
                       PRIVATE VkLayer_utils
                               ${GLSLANG_LIBRARIES}
-			      SPIRV-Headers::SPIRV-Headers
 			      SPIRV-Tools-static SPIRV-Tools-opt
 			      GTest::gtest GTest::gtest_main)
 


### PR DESCRIPTION
If the SPIRV-Headers package is not found, fall back to looking for
headers in SPIRV_HEADERS_INSTALL_DIR or SPIRV_HEADERS_INCLUDE_DIR.

Fixes #3765