### PR TITLE
layers: Avoid out of bounds access in UpdateDrawState()

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -949,6 +949,9 @@ void CMD_BUFFER_STATE::UpdateDrawState(CMD_TYPE cmd_type, const VkPipelineBindPo
     if (VK_NULL_HANDLE != state.pipeline_layout) {
         for (const auto &set_binding_pair : pipe->active_slots) {
             uint32_t set_index = set_binding_pair.first;
+            if (set_index >= state.per_set.size()) {
+                continue;
+            }
             // Pull the set node
             auto &descriptor_set = state.per_set[set_index].bound_descriptor_set;
 


### PR DESCRIPTION
I'm not 100% sure how this happens -- I'm debugging a third-party application through Mesa/Zink.  I think the problem is as simple as binding a pipeline that uses *n* descriptor sets with only *n - 1* of those descriptor sets bound.

Using the validation layers from the Vulkan SDK 1.3.204.0 I get a crash in STL code beneath `CMD_BUFFER_STATE::UpdateDrawState()` line 1007.

Using locally built validation layers in debug mode I get an assert that access to `state.per_set[set_index]` in `CMD_BUFFER_STATE::UpdateDrawState()` is out of bounds.  Where `set_index` is 5 but there are only 5 elements in `state.per_set`.  Note that assert is not the same position as the crash but it seems to be the same call-stack.

With this fix in place I'm able to run successfully with locally built validation layers in debug.  Validation layers report `VkPipeline ... uses set #5 but that set is not bound`.

Thanks,
Charles