### PR TITLE
layers: Use allocator codegen hooks for acceleration structures

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8600,11 +8600,6 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device,
         skip |= ValidateObjectNotInUse(as_state.get(), "vkDestroyAccelerationStructureKHR",
                                        "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442");
     }
-    if (pAllocator && !as_state->allocator) {
-        skip |= LogError(device, "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02444",
-                         "vkDestroyAccelerationStructureKH:If no VkAllocationCallbacks were provided when accelerationStructure"
-                         "was created, pAllocator must be NULL.");
-    }
     return skip;
 }
 

--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -5904,7 +5904,7 @@ bool ObjectLifetimes::PreCallValidateDestroyAccelerationStructureNV(
     bool skip = false;
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyAccelerationStructureNV-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, true, "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-parameter", "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-parent");
-    skip |= ValidateDestroyObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, pAllocator, kVUIDUndefined, kVUIDUndefined);
+    skip |= ValidateDestroyObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureNV, pAllocator, "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03753", "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03754");
 
     return skip;
 }
@@ -7345,7 +7345,7 @@ bool ObjectLifetimes::PreCallValidateDestroyAccelerationStructureKHR(
     bool skip = false;
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkDestroyAccelerationStructureKHR-device-parameter", kVUIDUndefined);
     skip |= ValidateObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureKHR, true, "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-parameter", "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-parent");
-    skip |= ValidateDestroyObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureKHR, pAllocator, kVUIDUndefined, kVUIDUndefined);
+    skip |= ValidateDestroyObject(accelerationStructure, kVulkanObjectTypeAccelerationStructureKHR, pAllocator, "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02443", "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02444");
 
     return skip;
 }

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -225,6 +225,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             "VkComputePipelineCreateInfo-basePipelineHandle": "\"VUID-VkComputePipelineCreateInfo-flags-00697\"",
             "VkRayTracingPipelineCreateInfoNV-basePipelineHandle": "\"VUID-VkRayTracingPipelineCreateInfoNV-flags-03421\"",
 			"VkRayTracingPipelineCreateInfoKHR-basePipelineHandle": "\"VUID-VkRayTracingPipelineCreateInfoKHR-flags-03421\"",
+            "VkAccelerationStructureKHR-accelerationStructure-compatalloc": "\"VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02443\"",
+            "VkAccelerationStructureKHR-accelerationStructure-nullalloc": "\"VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02444\"",
+            "VkAccelerationStructureNV-accelerationStructure-compatalloc": "\"VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03753\"",
+            "VkAccelerationStructureNV-accelerationStructure-nullalloc": "\"VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03754\"",
            }
 
         # Commands shadowed by interface functions and are not implemented
@@ -740,6 +744,18 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             indent = self.decIndent(indent)
 
         return create_obj_code
+
+    def get_alloc_vuid(self, param_name, param_type, alloc_type):
+        lookup_string = '%s-%s' %(param_name, alloc_type)
+        vuid = self.manual_vuids.get(lookup_string, None)
+        if vuid is not None:
+            return vuid
+        lookup_string = '%s-%s-%s' %(param_type, param_name, alloc_type)
+        vuid = self.manual_vuids.get(lookup_string, None)
+        if vuid is not None:
+            return vuid
+        return "kVUIDUndefined"
+
     #
     # Generate source for destroying a non-dispatchable object
     def generate_destroy_object_code(self, indent, proto, cmd_info):
@@ -757,10 +773,8 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                 allocator = 'nullptr'
             else:
                 param = -2
-            compatalloc_vuid_string = '%s-compatalloc' % cmd_info[param].name
-            nullalloc_vuid_string = '%s-nullalloc' % cmd_info[param].name
-            compatalloc_vuid = self.manual_vuids.get(compatalloc_vuid_string, "kVUIDUndefined")
-            nullalloc_vuid = self.manual_vuids.get(nullalloc_vuid_string, "kVUIDUndefined")
+            compatalloc_vuid = self.get_alloc_vuid(cmd_info[param].name, cmd_info[param].type, "compatalloc")
+            nullalloc_vuid = self.get_alloc_vuid(cmd_info[param].name, cmd_info[param].type, "nullalloc")
             if cmd_info[param].type in self.handle_types:
                 if object_array == True:
                     # This API is freeing an array of handles -- add loop control


### PR DESCRIPTION
Use the object tracker generator to make code for:
VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02443
VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02444
VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03753
VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03754

Because there are 2 different handle types for acceleration structures,
the code generator needed to be extended to handle
param_type-param_name-alloc_type keys.