### PR TITLE
Allow VkDeviceImageMemoryRequirements.planeAspect to be VK_IMAGE_ASPECT_NONE

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -10212,8 +10212,6 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirements(
 
             skip |= validate_ranged_enum("vkGetDeviceImageMemoryRequirements", "pInfo->pCreateInfo->initialLayout", "VkImageLayout", AllVkImageLayoutEnums, pInfo->pCreateInfo->initialLayout, "VUID-VkImageCreateInfo-initialLayout-parameter");
         }
-
-        skip |= validate_flags("vkGetDeviceImageMemoryRequirements", "pInfo->planeAspect", "VkImageAspectFlagBits", AllVkImageAspectFlagBits, pInfo->planeAspect, kRequiredSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter", "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
     skip |= validate_struct_type("vkGetDeviceImageMemoryRequirements", "pMemoryRequirements", "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true, "VUID-vkGetDeviceImageMemoryRequirements-pMemoryRequirements-parameter", "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != NULL)
@@ -10222,6 +10220,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirements(
 
         skip |= validate_struct_pnext("vkGetDeviceImageMemoryRequirements", "pMemoryRequirements->pNext", "VkMemoryDedicatedRequirements", pMemoryRequirements->pNext, ARRAY_SIZE(allowed_structs_VkMemoryRequirements2), allowed_structs_VkMemoryRequirements2, GeneratedVulkanHeaderVersion, "VUID-VkMemoryRequirements2-pNext-pNext", "VUID-VkMemoryRequirements2-sType-unique", false, false);
     }
+    if (!skip) skip |= manual_PreCallValidateGetDeviceImageMemoryRequirements(device, pInfo, pMemoryRequirements);
     return skip;
 }
 
@@ -10262,8 +10261,6 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirements(
 
             skip |= validate_ranged_enum("vkGetDeviceImageSparseMemoryRequirements", "pInfo->pCreateInfo->initialLayout", "VkImageLayout", AllVkImageLayoutEnums, pInfo->pCreateInfo->initialLayout, "VUID-VkImageCreateInfo-initialLayout-parameter");
         }
-
-        skip |= validate_flags("vkGetDeviceImageSparseMemoryRequirements", "pInfo->planeAspect", "VkImageAspectFlagBits", AllVkImageAspectFlagBits, pInfo->planeAspect, kRequiredSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter", "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
     skip |= validate_struct_type_array("vkGetDeviceImageSparseMemoryRequirements", "pSparseMemoryRequirementCount", "pSparseMemoryRequirements", "VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2", pSparseMemoryRequirementCount, pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false, false, "VUID-VkSparseImageMemoryRequirements2-sType-sType", "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirements-parameter", kVUIDUndefined);
     if (pSparseMemoryRequirements != NULL)
@@ -10273,6 +10270,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirements(
             skip |= validate_struct_pnext("vkGetDeviceImageSparseMemoryRequirements", ParameterName("pSparseMemoryRequirements[%i].pNext", ParameterName::IndexVector{ pSparseMemoryRequirementIndex }), NULL, pSparseMemoryRequirements[pSparseMemoryRequirementIndex].pNext, 0, NULL, GeneratedVulkanHeaderVersion, "VUID-VkSparseImageMemoryRequirements2-pNext-pNext", kVUIDUndefined, false, false);
         }
     }
+    if (!skip) skip |= manual_PreCallValidateGetDeviceImageSparseMemoryRequirements(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
     return skip;
 }
 
@@ -14228,8 +14226,6 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirementsKHR(
 
             skip |= validate_ranged_enum("vkGetDeviceImageMemoryRequirementsKHR", "pInfo->pCreateInfo->initialLayout", "VkImageLayout", AllVkImageLayoutEnums, pInfo->pCreateInfo->initialLayout, "VUID-VkImageCreateInfo-initialLayout-parameter");
         }
-
-        skip |= validate_flags("vkGetDeviceImageMemoryRequirementsKHR", "pInfo->planeAspect", "VkImageAspectFlagBits", AllVkImageAspectFlagBits, pInfo->planeAspect, kRequiredSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter", "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
     skip |= validate_struct_type("vkGetDeviceImageMemoryRequirementsKHR", "pMemoryRequirements", "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true, "VUID-vkGetDeviceImageMemoryRequirements-pMemoryRequirements-parameter", "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != NULL)
@@ -14238,6 +14234,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirementsKHR(
 
         skip |= validate_struct_pnext("vkGetDeviceImageMemoryRequirementsKHR", "pMemoryRequirements->pNext", "VkMemoryDedicatedRequirements", pMemoryRequirements->pNext, ARRAY_SIZE(allowed_structs_VkMemoryRequirements2), allowed_structs_VkMemoryRequirements2, GeneratedVulkanHeaderVersion, "VUID-VkMemoryRequirements2-pNext-pNext", "VUID-VkMemoryRequirements2-sType-unique", false, false);
     }
+    if (!skip) skip |= manual_PreCallValidateGetDeviceImageMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
     return skip;
 }
 
@@ -14279,8 +14276,6 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirementsK
 
             skip |= validate_ranged_enum("vkGetDeviceImageSparseMemoryRequirementsKHR", "pInfo->pCreateInfo->initialLayout", "VkImageLayout", AllVkImageLayoutEnums, pInfo->pCreateInfo->initialLayout, "VUID-VkImageCreateInfo-initialLayout-parameter");
         }
-
-        skip |= validate_flags("vkGetDeviceImageSparseMemoryRequirementsKHR", "pInfo->planeAspect", "VkImageAspectFlagBits", AllVkImageAspectFlagBits, pInfo->planeAspect, kRequiredSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter", "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
     skip |= validate_struct_type_array("vkGetDeviceImageSparseMemoryRequirementsKHR", "pSparseMemoryRequirementCount", "pSparseMemoryRequirements", "VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2", pSparseMemoryRequirementCount, pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false, false, "VUID-VkSparseImageMemoryRequirements2-sType-sType", "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirements-parameter", kVUIDUndefined);
     if (pSparseMemoryRequirements != NULL)
@@ -14290,6 +14285,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirementsK
             skip |= validate_struct_pnext("vkGetDeviceImageSparseMemoryRequirementsKHR", ParameterName("pSparseMemoryRequirements[%i].pNext", ParameterName::IndexVector{ pSparseMemoryRequirementIndex }), NULL, pSparseMemoryRequirements[pSparseMemoryRequirementIndex].pNext, 0, NULL, GeneratedVulkanHeaderVersion, "VUID-VkSparseImageMemoryRequirements2-pNext-pNext", kVUIDUndefined, false, false);
         }
     }
+    if (!skip) skip |= manual_PreCallValidateGetDeviceImageSparseMemoryRequirementsKHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
     return skip;
 }
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -8286,3 +8286,39 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceSurfacePresentM
     return skip;
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+
+// VkDeviceImageMemoryRequirements::planeAspect should have been listed as optional to account for VK_IMAGE_ASPECT_NONE
+bool StatelessValidation::manual_PreCallValidateGetDeviceImageMemoryRequirementsKHR(
+    VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, VkMemoryRequirements2 *pMemoryRequirements) const {
+    return validate_flags("vkGetDeviceImageMemoryRequirementsKHR", "pInfo->planeAspect", "VkImageAspectFlagBits",
+                          AllVkImageAspectFlagBits, pInfo->planeAspect, kOptionalSingleBit,
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter",
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
+}
+
+bool StatelessValidation::manual_PreCallValidateGetDeviceImageMemoryRequirements(VkDevice device,
+                                                                                 const VkDeviceImageMemoryRequirements *pInfo,
+                                                                                 VkMemoryRequirements2 *pMemoryRequirements) const {
+    return validate_flags("vkGetDeviceImageMemoryRequirements", "pInfo->planeAspect", "VkImageAspectFlagBits",
+                          AllVkImageAspectFlagBits, pInfo->planeAspect, kOptionalSingleBit,
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter",
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
+}
+
+bool StatelessValidation::manual_PreCallValidateGetDeviceImageSparseMemoryRequirementsKHR(
+    VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, uint32_t *pSparseMemoryRequirementCount,
+    VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements) const {
+    return validate_flags("vkGetDeviceImageSparseMemoryRequirementsKHR", "pInfo->planeAspect", "VkImageAspectFlagBits",
+                          AllVkImageAspectFlagBits, pInfo->planeAspect, kOptionalSingleBit,
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter",
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
+}
+
+bool StatelessValidation::manual_PreCallValidateGetDeviceImageSparseMemoryRequirements(
+    VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, uint32_t *pSparseMemoryRequirementCount,
+    VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements) const {
+    return validate_flags("vkGetDeviceImageSparseMemoryRequirements", "pInfo->planeAspect", "VkImageAspectFlagBits",
+                          AllVkImageAspectFlagBits, pInfo->planeAspect, kOptionalSingleBit,
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter",
+                          "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
+}

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -59,6 +59,7 @@ extern const VkBuildAccelerationStructureFlagsNV AllVkBuildAccelerationStructure
 extern const VkGeometryFlagsKHR AllVkGeometryFlagBitsKHR;
 extern const VkPipelineColorBlendStateCreateFlags AllVkPipelineColorBlendStateCreateFlagBits;
 extern const VkPipelineDepthStencilStateCreateFlags AllVkPipelineDepthStencilStateCreateFlagBits;
+extern const VkImageAspectFlags AllVkImageAspectFlagBits;
 
 extern const std::vector<VkGeometryTypeKHR> AllVkGeometryTypeKHREnums;
 extern const std::vector<VkCompareOp> AllVkCompareOpEnums;
@@ -1832,6 +1833,19 @@ class StatelessValidation : public ValidationObject {
                                                                         uint32_t *pPresentModeCount,
                                                                         VkPresentModeKHR *pPresentModes) const;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+    bool manual_PreCallValidateGetDeviceImageMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements *pInfo,
+                                                                   VkMemoryRequirements2 *pMemoryRequirements) const;
+
+    bool manual_PreCallValidateGetDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements *pInfo,
+                                                                VkMemoryRequirements2 *pMemoryRequirements) const;
+
+    bool manual_PreCallValidateGetDeviceImageSparseMemoryRequirementsKHR(
+        VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, uint32_t *pSparseMemoryRequirementCount,
+        VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements) const;
+
+    bool manual_PreCallValidateGetDeviceImageSparseMemoryRequirements(
+        VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, uint32_t *pSparseMemoryRequirementCount,
+        VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements) const;
 
 #include "parameter_validation.h"
 };  // Class StatelessValidation

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -275,6 +275,10 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkGetPhysicalDeviceSurfaceCapabilities2KHR',
             'vkGetPhysicalDeviceSurfaceFormats2KHR',
             'vkGetPhysicalDeviceSurfacePresentModes2EXT',
+            'vkGetDeviceImageMemoryRequirementsKHR',
+            'vkGetDeviceImageMemoryRequirements',
+            'vkGetDeviceImageSparseMemoryRequirementsKHR',
+            'vkGetDeviceImageSparseMemoryRequirements',
             ]
 
         # Commands to ignore
@@ -290,7 +294,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             ]
 
         # Structure fields to ignore
-        self.structMemberBlacklist = { 'VkWriteDescriptorSet' : ['dstSet'], 'VkAccelerationStructureGeometryKHR' :['geometry'] }
+        self.structMemberBlacklist = { 'VkWriteDescriptorSet' : ['dstSet'], 'VkAccelerationStructureGeometryKHR' :['geometry'], 'VkDeviceImageMemoryRequirements' :['planeAspect'] }
         # Validation conditions for some special case struct members that are conditionally validated
         self.structMemberValidationConditions = { 'VkPipelineColorBlendStateCreateInfo' : { 'logicOp' : '{}logicOpEnable == VK_TRUE' } }
         # Header version

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -2573,3 +2573,31 @@ TEST_F(VkPositiveLayerTest, ValidExtendedUsageWithDifferentFormatViews) {
 
     m_errorMonitor->VerifyNotFound();
 }
+
+TEST_F(VkPositiveLayerTest, PlaneAspectNone) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
+        printf("%s This test requires Vulkan 1.3+, skipping test\n", kSkipPrefix);
+        return;
+    }
+    m_errorMonitor->ExpectSuccess();
+    auto image_createinfo = LvlInitStruct<VkImageCreateInfo>();
+    image_createinfo.imageType = VK_IMAGE_TYPE_2D;
+    image_createinfo.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
+    image_createinfo.extent = {128, 128, 1};
+    image_createinfo.mipLevels = 1;
+    image_createinfo.arrayLayers = 1;
+    image_createinfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_createinfo.tiling = VK_IMAGE_TILING_LINEAR;
+    image_createinfo.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    image_createinfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_createinfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    auto image_mem_reqs = LvlInitStruct<VkDeviceImageMemoryRequirements>();
+    image_mem_reqs.pCreateInfo = &image_createinfo;
+    image_mem_reqs.planeAspect = VK_IMAGE_ASPECT_NONE;
+    auto  mem_reqs_2 = LvlInitStruct<VkMemoryRequirements2>();
+    vk::GetDeviceImageMemoryRequirements(device(), &image_mem_reqs, &mem_reqs_2);
+    m_errorMonitor->VerifyNotFound();
+}


### PR DESCRIPTION
Addresses #3763 
The planeAspect field needs to be able to be set to VK_IMAGE_ASPECT_NONE, which is 0, but parameter validation will flag it as invalid because the field is not marked as optional.  There is an xml MR to correct this, and this is a workaround until it lands, at which time I plan to undo this.