### PR TITLE
build: Handle different SPIRV-Tools targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,25 @@ if(BUILD_LAYERS OR BUILD_TESTS)
         endif()
 	set(SPIRV_HEADERS_INCLUDE_DIR "${SPIRV_HEADERS_INSTALL_DIR}/include")
     endif()
+    if (NOT TARGET SPIRV-Tools)
+        find_package(SPIRV-Tools REQUIRED CONFIG)
+	# See https://github.com/KhronosGroup/SPIRV-Tools/issues/3909 for background on this.
+	# The targets available from SPIRV-Tools change depending on how SPIRV_TOOLS_BUILD_STATIC is set.
+	# Try to handle all possible combinations so that we work with externally built packages.
+	if (TARGET SPIRV-Tools)
+	    set(SPIRV_TOOLS_TARGET "SPIRV-Tools")
+	elseif(TARGET SPIRV-Tools-static)
+	    set(SPIRV_TOOLS_TARGET "SPIRV-Tools-static")
+	elseif(TARGET SPIRV-Tools-shared)
+	    set(SPIRV_TOOLS_TARGET "SPIRV-Tools-shared")
+	else()
+	    message(FATAL_ERROR "Cannot determine SPIRV-Tools target name")
+	endif()
+    endif()
+    # Thankfully SPIRV-Tools-opt has only one target name.
+    if (NOT TARGET SPIRV-Tools-opt)
+        find_package(SPIRV-Tools-opt REQUIRED CONFIG)
+    endif()
 endif()
 
 if(BUILD_TESTS)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -270,12 +270,6 @@ if(INSTRUMENT_OPTICK)
 endif()
 
 if(BUILD_LAYERS)
-    if (NOT TARGET SPIRV-Tools)
-        find_package(SPIRV-Tools REQUIRED CONFIG)
-    endif()
-    if (NOT TARGET SPIRV-Tools-opt)
-        find_package(SPIRV-Tools-opt REQUIRED CONFIG)
-    endif()
     AddVkLayer(khronos_validation "${KHRONOS_LAYER_COMPILE_DEFINITIONS}"
         ${CHASSIS_LIBRARY_FILES}
         ${CORE_VALIDATION_LIBRARY_FILES}
@@ -310,7 +304,7 @@ if(BUILD_LAYERS)
         target_include_directories(VkLayer_khronos_validation PRIVATE ${ROBIN_HOOD_HASHING_INCLUDE_DIR})
     endif()
     target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
-    target_link_libraries(VkLayer_khronos_validation PRIVATE SPIRV-Tools-static SPIRV-Tools-opt)
+    target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_TARGET} SPIRV-Tools-opt)
 
 
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,9 +66,6 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-find_package(SPIRV-Tools REQUIRED CONFIG)
-find_package(SPIRV-Tools-opt REQUIRED CONFIG)
-
 set(LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
 
 set(COMMON_CPP
@@ -154,7 +151,7 @@ target_include_directories(vk_layer_validation_tests PRIVATE ${SPIRV_HEADERS_INC
 target_link_libraries(vk_layer_validation_tests
                       PRIVATE VkLayer_utils
                               ${GLSLANG_LIBRARIES}
-			      SPIRV-Tools-static SPIRV-Tools-opt
+			      ${SPIRV_TOOLS_TARGET} SPIRV-Tools-opt
 			      GTest::gtest GTest::gtest_main)
 
 if(NOT WIN32)


### PR DESCRIPTION
Depending on how SPIRV_TOOLS_BUILD_STATIC is set when building
SPIRV-Tools, the targets it provides may change. Handle all of them
so that we can work with externally built packages with either setting.

Fixes #3766