### PR TITLE
layers: Refactor and improve acceleration structure state tracking

### DIFF
--- a/layers/buffer_state.h
+++ b/layers/buffer_state.h
@@ -27,6 +27,7 @@
  */
 #pragma once
 #include "device_memory_state.h"
+#include "range_vector.h"
 
 class ValidationStateTracker;
 
@@ -44,6 +45,9 @@ class BUFFER_STATE : public BINDABLE {
 
     VkBuffer buffer() const { return handle_.Cast<VkBuffer>(); }
 
+    sparse_container::range<VkDeviceAddress> DeviceAddressRange() const {
+        return {deviceAddress, deviceAddress + createInfo.size};
+    }
 };
 
 class BUFFER_VIEW_STATE : public BASE_NODE {

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -6192,14 +6192,6 @@ bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, 
     return ValidateIdleBuffer(buffer);
 }
 
-void CoreChecks::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
-    auto buffer_state = Get<BUFFER_STATE>(buffer);
-    if (buffer_state) {
-        buffer_address_map_.erase(buffer_state->deviceAddress);
-    }
-    StateTracker::PreCallRecordDestroyBuffer(device, buffer, pAllocator);
-}
-
 bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView,
                                                   const VkAllocationCallbacks *pAllocator) const {
     auto buffer_view_state = Get<BUFFER_VIEW_STATE>(bufferView);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8584,7 +8584,7 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureNV(VkDevice device, 
     bool skip = false;
     if (as_state) {
         skip |= ValidateObjectNotInUse(as_state.get(), "vkDestroyAccelerationStructureNV",
-                                       "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442");
+                                       "VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03752");
     }
     return skip;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -213,7 +213,7 @@ bool CoreChecks::ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION
 // Check to see if memory was bound to this acceleration structure
 bool CoreChecks::ValidateMemoryIsBoundToAccelerationStructure(const ACCELERATION_STRUCTURE_STATE_KHR *as_state,
                                                               const char *api_name, const char *error_code) const {
-    return VerifyBoundMemoryIsValid(as_state->MemState(), as_state->acceleration_structure(), as_state->Handle(), api_name,
+    return VerifyBoundMemoryIsValid(as_state->buffer_state->MemState(), as_state->acceleration_structure(), as_state->Handle(), api_name,
                                     error_code);
 }
 
@@ -8128,33 +8128,32 @@ bool CoreChecks::ValidateBindAccelerationStructureMemory(VkDevice device,
     if (mem_info) {
         skip |= ValidateInsertAccelerationStructureMemoryRange(info.accelerationStructure, mem_info.get(), info.memoryOffset,
                                                                "vkBindAccelerationStructureMemoryNV()");
-        skip |= ValidateMemoryTypes(mem_info.get(), as_state->memory_requirements.memoryRequirements.memoryTypeBits,
+        skip |= ValidateMemoryTypes(mem_info.get(), as_state->memory_requirements.memoryTypeBits,
                                     "vkBindAccelerationStructureMemoryNV()",
                                     "VUID-VkBindAccelerationStructureMemoryInfoNV-memory-03622");
     }
 
     // Validate memory requirements alignment
-    if (SafeModulo(info.memoryOffset, as_state->memory_requirements.memoryRequirements.alignment) != 0) {
+    if (SafeModulo(info.memoryOffset, as_state->memory_requirements.alignment) != 0) {
         skip |= LogError(info.accelerationStructure, "VUID-VkBindAccelerationStructureMemoryInfoNV-memoryOffset-03623",
                          "vkBindAccelerationStructureMemoryNV(): memoryOffset  0x%" PRIxLEAST64
                          " must be an integer multiple of the alignment 0x%" PRIxLEAST64
                          " member of the VkMemoryRequirements structure returned from "
                          "a call to vkGetAccelerationStructureMemoryRequirementsNV with accelerationStructure and type of "
                          "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV",
-                         info.memoryOffset, as_state->memory_requirements.memoryRequirements.alignment);
+                         info.memoryOffset, as_state->memory_requirements.alignment);
     }
 
     if (mem_info) {
         // Validate memory requirements size
-        if (as_state->memory_requirements.memoryRequirements.size > (mem_info->alloc_info.allocationSize - info.memoryOffset)) {
+        if (as_state->memory_requirements.size > (mem_info->alloc_info.allocationSize - info.memoryOffset)) {
             skip |= LogError(info.accelerationStructure, "VUID-VkBindAccelerationStructureMemoryInfoNV-size-03624",
                              "vkBindAccelerationStructureMemoryNV(): The size 0x%" PRIxLEAST64
                              " member of the VkMemoryRequirements structure returned from a call to "
                              "vkGetAccelerationStructureMemoryRequirementsNV with accelerationStructure and type of "
                              "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV must be less than or equal to the size "
                              "of memory minus memoryOffset 0x%" PRIxLEAST64 ".",
-                             as_state->memory_requirements.memoryRequirements.size,
-                             mem_info->alloc_info.allocationSize - info.memoryOffset);
+                             as_state->memory_requirements.size, mem_info->alloc_info.allocationSize - info.memoryOffset);
         }
     }
 
@@ -8499,8 +8498,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
             // Use requirements fetched at create time
         }
         if (scratch_buffer_state != nullptr && dst_as_state != nullptr &&
-            dst_as_state->update_scratch_memory_requirements.memoryRequirements.size >
-                (scratch_buffer_state->createInfo.size - scratchOffset)) {
+            dst_as_state->update_scratch_memory_requirements.size > (scratch_buffer_state->createInfo.size - scratchOffset)) {
             skip |= LogError(commandBuffer, "VUID-vkCmdBuildAccelerationStructureNV-update-02492",
                              "vkCmdBuildAccelerationStructureNV(): If update is VK_TRUE, The size member of the "
                              "VkMemoryRequirements structure returned from a call to "
@@ -8519,8 +8517,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
             // Use requirements fetched at create time
         }
         if (scratch_buffer_state != nullptr && dst_as_state != nullptr &&
-            dst_as_state->build_scratch_memory_requirements.memoryRequirements.size >
-                (scratch_buffer_state->createInfo.size - scratchOffset)) {
+            dst_as_state->build_scratch_memory_requirements.size > (scratch_buffer_state->createInfo.size - scratchOffset)) {
             skip |= LogError(commandBuffer, "VUID-vkCmdBuildAccelerationStructureNV-update-02491",
                              "vkCmdBuildAccelerationStructureNV(): If update is VK_FALSE, The size member of the "
                              "VkMemoryRequirements structure returned from a call to "

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8265,11 +8265,12 @@ bool CoreChecks::ValidateAccelerationBuffers(uint32_t info_index, const VkAccele
 
     auto buffer_check = [this, info_index, func_name](uint32_t gi, const VkDeviceOrHostAddressConstKHR address,
                                                       const char *field) -> bool {
-        const auto itr = buffer_address_map_.find(address.deviceAddress);
-        if (itr != buffer_address_map_.end() &&
-            !(itr->second->createInfo.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR)) {
+        // being inside the lambda confuses the compiler about our constness
+        const auto buffer_state = const_cast<const CoreChecks *>(this)->GetBufferByAddress(address.deviceAddress);
+        if (buffer_state &&
+            !(buffer_state->createInfo.usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR)) {
             LogObjectList objlist(device);
-            objlist.add(itr->second->Handle());
+            objlist.add(buffer_state->Handle());
             return LogError(objlist, "VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673",
                             "%s(): The buffer associated with pInfos[%" PRIu32 "].pGeometries[%" PRIu32
                             "].%s was not created with VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR.",
@@ -8313,12 +8314,19 @@ bool CoreChecks::ValidateAccelerationBuffers(uint32_t info_index, const VkAccele
         }
     }
 
-    const auto itr = buffer_address_map_.find(info.scratchData.deviceAddress);
-    if (itr != buffer_address_map_.end() && !(itr->second->createInfo.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)) {
-        skip |= LogError(device, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674",
-                         "vkBuildAccelerationStructuresKHR(): The buffer associated with pInfos[%" PRIu32
-                         "].scratchData.deviceAddress was not created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT bit.",
-                         info_index);
+    const auto buffer_state = GetBufferByAddress(info.scratchData.deviceAddress);
+    if (!buffer_state) {
+        skip |= LogError(device, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03802",
+                "vkBuildAccelerationStructuresKHR(): The buffer associated with pInfos[%" PRIu32
+                "].scratchData.deviceAddress %" PRIx64 " is not a valid device address.",
+                info_index, info.scratchData.deviceAddress);
+    } else {
+        if (!(buffer_state->createInfo.usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)) {
+            skip |= LogError(device, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674",
+                    "vkBuildAccelerationStructuresKHR(): The buffer associated with pInfos[%" PRIu32
+                    "].scratchData.deviceAddress was not created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT bit.",
+                    info_index);
+        }
     }
 
     return skip;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -910,7 +910,6 @@ class CoreChecks : public ValidationStateTracker {
                                          const VkAllocationCallbacks* pAllocator) const override;
 
     bool PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator) const override;
-    void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator) override;
 
     bool PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView,
                                           const VkAllocationCallbacks* pAllocator) const override;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1715,7 +1715,7 @@ bool CoreChecks::ValidateAccelerationDescriptor(const char *caller, const DrawDi
                                 report_data->FormatHandle(acc).c_str());
             }
         } else {
-            for (const auto &item: acc_node->GetBoundMemory()) {
+            for (const auto &item: acc_node->buffer_state->GetBoundMemory()) {
                 auto &mem_binding = item.second;
                 if (mem_binding.mem_state->Destroyed()) {
                     auto set = descriptor_set->GetSet();

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2521,7 +2521,7 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructureNV(
     cb_state->RecordCmd(CMD_BUILDACCELERATIONSTRUCTURENV);
 
     auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE>(dst);
-    if (dst_as_state != nullptr) {
+    if (dst_as_state) {
         dst_as_state->Build(pInfo);
         if (!disabled[command_buffer_state]) {
             cb_state->AddChild(dst_as_state);
@@ -2529,9 +2529,40 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructureNV(
     }
     if (!disabled[command_buffer_state]) {
         auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE>(src);
-        if (src_as_state != nullptr) {
+        if (src_as_state) {
             cb_state->AddChild(src_as_state);
         }
+	auto instance_buffer = Get<BUFFER_STATE>(instanceData);
+        if (instance_buffer) {
+            cb_state->AddChild(instance_buffer);
+        }
+	auto scratch_buffer = Get<BUFFER_STATE>(scratch);
+        if (scratch_buffer) {
+            cb_state->AddChild(scratch_buffer);
+        }
+
+	for (uint32_t i = 0; i < pInfo->geometryCount; i++) {
+	   const auto& geom = pInfo->pGeometries[i];
+
+	   auto vertex_buffer = Get<BUFFER_STATE>(geom.geometry.triangles.vertexData);
+	   if (vertex_buffer) {
+              cb_state->AddChild(vertex_buffer);
+	   }
+	   auto index_buffer = Get<BUFFER_STATE>(geom.geometry.triangles.indexData);
+	   if (index_buffer) {
+              cb_state->AddChild(index_buffer);
+	   }
+	   auto transform_buffer = Get<BUFFER_STATE>(geom.geometry.triangles.transformData);
+	   if (transform_buffer) {
+              cb_state->AddChild(transform_buffer);
+	   }
+
+	   auto aabb_buffer = Get<BUFFER_STATE>(geom.geometry.aabbs.aabbData);
+	   if (aabb_buffer) {
+              cb_state->AddChild(aabb_buffer);
+	   }
+	}
+
     }
     cb_state->hasBuildAccelerationStructureCmd = true;
 }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1078,6 +1078,10 @@ class ValidationStateTracker : public ValidationObject {
                                                     const VkCopyAccelerationStructureInfoKHR* pInfo, VkResult result) override;
     void PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                        const VkCopyAccelerationStructureInfoKHR* pInfo) override;
+    void PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
+                                                               const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) override;
+    void PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
+                                                               const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) override;
     void PreCallRecordCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) override;
     void PreCallRecordCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) override;
     void PreCallRecordCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace) override;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2420,7 +2420,7 @@ bool InitFrameworkForRayTracingTest(VkRenderFramework *renderFramework, bool isK
 }
 
 void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, VkBufferObj *vbo, VkBufferObj *ibo,
-                                                    VkGeometryNV *geometry) {
+                                                    VkGeometryNV *geometry, VkDeviceSize offset) {
     vbo->init(device, 1024, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
               VK_BUFFER_USAGE_RAY_TRACING_BIT_NV | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR);
     ibo->init(device, 1024, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -2430,11 +2430,11 @@ void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, V
     const std::vector<uint32_t> indicies = {0, 1, 2};
 
     uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo->memory().map();
-    std::memcpy(mapped_vbo_buffer_data, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
+    std::memcpy(mapped_vbo_buffer_data + offset, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
     vbo->memory().unmap();
 
     uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo->memory().map();
-    std::memcpy(mapped_ibo_buffer_data, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
+    std::memcpy(mapped_ibo_buffer_data + offset, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
     ibo->memory().unmap();
 
     *geometry = {};

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -859,7 +859,7 @@ bool InitFrameworkForRayTracingTest(VkRenderFramework *renderFramework, bool isK
                                     bool deferred_state_init = false, VkPhysicalDeviceFeatures2KHR *features2 = nullptr);
 
 void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, VkBufferObj *vbo, VkBufferObj *ibo,
-                                                    VkGeometryNV *geometry);
+                                                    VkGeometryNV *geometry, VkDeviceSize offset = 0);
 
 void print_android(const char *c);
 #endif  // VKLAYERTEST_H

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -9712,8 +9712,7 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     valid_geometry_triangles.geometry.triangles.transformData.deviceAddress = 0;
     valid_geometry_triangles.geometry.triangles.maxVertex = 1;
     valid_geometry_triangles.flags = 0;
-    VkAccelerationStructureGeometryKHR *pGeometry = new VkAccelerationStructureGeometryKHR[1];
-    pGeometry[0] = valid_geometry_triangles;
+    VkAccelerationStructureGeometryKHR *pGeometry = &valid_geometry_triangles;
 
     VkAccelerationStructureBuildGeometryInfoKHR build_info_khr = LvlInitStruct<VkAccelerationStructureBuildGeometryInfoKHR>();
     PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
@@ -9744,11 +9743,12 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     build_info_ppGeometries_khr.pGeometries = NULL;
     build_info_ppGeometries_khr.ppGeometries = &pGeometry;
 
-    VkAccelerationStructureBuildRangeInfoKHR *pBuildRangeInfos = new VkAccelerationStructureBuildRangeInfoKHR[1];
-    pBuildRangeInfos[0].firstVertex = 0;
-    pBuildRangeInfos[0].primitiveCount = 1;
-    pBuildRangeInfos[0].primitiveOffset = 3;
-    pBuildRangeInfos[0].transformOffset = 0;
+    VkAccelerationStructureBuildRangeInfoKHR build_range_info;
+    build_range_info.firstVertex = 0;
+    build_range_info.primitiveCount = 1;
+    build_range_info.primitiveOffset = 3;
+    build_range_info.transformOffset = 0;
+    VkAccelerationStructureBuildRangeInfoKHR *pBuildRangeInfos = &build_range_info;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-recording");
     vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, &build_info_khr, &pBuildRangeInfos);
@@ -9906,8 +9906,13 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
         vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, &build_info_khr, &pBuildRangeInfos);
         m_errorMonitor->VerifyFound();
     }
-
-    delete[] pGeometry;
+    // Scratch data buffer is 0
+    {
+        build_info_khr.scratchData.deviceAddress = 0;
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03802");
+        vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, &build_info_khr, &pBuildRangeInfos);
+        m_errorMonitor->VerifyFound();
+    }
 }
 
 TEST_F(VkLayerTest, ObjInUseCmdBuildAccelerationStructureKHR) {


### PR DESCRIPTION
 Remove unneeded data members and make many others const.

The KHR state object shouldn't inherit from BINDABLE, because memory is never bound to it.

Add tracking for buffers used in the build acceleration structure commands, including those that are passed by VkDeviceAddress.

Fixes #3664 