### PR TITLE
  syncval: QueueSubmit validation -- partial implementation -- default disabled

### DIFF
--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3475,6 +3475,7 @@ typedef enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
+    VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
 } ValidationCheckEnables;
 
 typedef enum VkValidationFeatureEnable {
@@ -3509,6 +3510,7 @@ typedef enum EnableFlags {
     vendor_specific_img,
     debug_printf,
     sync_validation,
+    sync_validation_queue_submit,
     // Insert new enables above this line
     kMaxEnableFlags,
 } EnableFlags;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -92,6 +92,8 @@ void SetValidationEnable(CHECK_ENABLED &enable_data, const ValidationCheckEnable
             enable_data[vendor_specific_amd] = true;
             enable_data[vendor_specific_img] = true;
             break;
+        case VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT:
+            enable_data[sync_validation_queue_submit] = true;
         default:
             assert(true);
     }

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -72,6 +72,8 @@ static const layer_data::unordered_map<std::string, ValidationCheckEnables> Vali
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL},
+    {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
+     VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT},
 };
 
 // This should mirror the 'DisableFlags' enumerated type
@@ -98,7 +100,8 @@ static const std::vector<std::string> EnableFlagNameHelper = {
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD",                         // vendor_specific_amd,
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG",                         // vendor_specific_img,
     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
-    "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION"              // sync_validation,
+    "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION",             // sync_validation,
+    "VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",     // queuesubmit time sync_validation,
 };
 
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -342,6 +342,22 @@ class ValidationStateTracker : public ValidationObject {
         return GetStateMap<State>().size();
     }
 
+    template <typename State, typename Fn>
+    void ForEachShared(Fn&& fn) const {
+        const auto& map = GetStateMap<State>();
+        for (const auto& entry : map.snapshot()) {
+            fn(entry.second);
+        }
+    }
+
+    template <typename State, typename Fn>
+    void ForEachShared(Fn&& fn) {
+        auto& map = GetStateMap<State>();
+        for (const auto& entry : map.snapshot()) {
+            fn(entry.second);
+        }
+    }
+
     template <typename State>
     void ForEach(std::function<void(const State& s)> fn) const {
         const auto& map = GetStateMap<State>();

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -894,5 +894,72 @@ template <typename BaseType>
 using base_type =
     typename std::remove_reference<typename std::remove_const<typename std::remove_pointer<BaseType>::type>::type>::type;
 
+// Helper for thread local Validate -> Record phase data
+// Define T unique to each entrypoint which will persist data
+// Use only in with singleton (leaf) validation objects
+// State machine transition state changes of payload relative to TlsGuard object lifecycle:
+//  State INIT: bool(payload_) 
+//  State RESET: NOT bool(payload_) 
+//    * PreCallValidate* phase
+//        * Initialized with skip (in PreCallValidate*)
+//            * RESET -> INIT
+//        * Destruct with skip == true
+//           * INIT -> RESET
+//    * PreCallRecord* phase (optional IF PostCallRecord present)
+//        * Initialized w/o skip (set "persist_" IFF PostCallRecord present)
+//           * Must be in state INIT
+//        * Destruct with NOT persist_
+//           * INIT -> RESET
+//    * PreCallRecord* phase (optional IF PreCallRecord present)
+//        * Initialized w/o skip ("persist_" *must be false)
+//           * Must be in state INIT
+//        * Destruct
+//           * INIT -> RESET
+
+struct TlsGuardPersist {};
+template <typename T>
+class TlsGuard {
+  public:
+    // For use on inital references -- Validate phase
+    template <typename... Args>
+    TlsGuard(bool *skip, Args &&...args) : skip_(skip), persist_(false) {
+        // Record phase calls are required to clean up payload
+        assert(!payload_);
+        payload_.emplace(std::forward<Args>(args)...);
+    }
+    // For use on non-terminal persistent references (PreRecord phase IFF PostRecord is also present.
+    TlsGuard(const TlsGuardPersist &) : skip_(nullptr), persist_(true) { assert(payload_); }
+    // For use on terminal persistent references
+    // Validate phase calls are required to setup payload
+    // PreCallRecord calls are required to preserve (persist_) payload, if PostCallRecord calls will use
+    TlsGuard() : skip_(nullptr), persist_(false) { assert(payload_); }
+    ~TlsGuard() {
+        assert(payload_);
+        if (!persist_ && (!skip_ || *skip_)) payload_.reset();
+    }
+
+    T &operator*() & {
+        assert(payload_);
+        return *payload_;
+    }
+    const T &operator*() const & {
+        assert(payload_);
+        return *payload_;
+    }
+    T &&operator*() && {
+        assert(payload_);
+        return std::move(*payload_);
+    }
+    T *operator->() { return &(*payload_); }
+
+  private:
+    thread_local static optional<T> payload_;
+    bool *skip_;
+    bool persist_;
+};
+
+template <typename T>
+thread_local optional<T> TlsGuard<T>::payload_;
+
 }  // namespace layer_data
 #endif  // LAYER_DATA_H

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -307,6 +307,7 @@ typedef enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
+    VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
 } ValidationCheckEnables;
 
 typedef enum VkValidationFeatureEnable {
@@ -341,6 +342,7 @@ typedef enum EnableFlags {
     vendor_specific_img,
     debug_printf,
     sync_validation,
+    sync_validation_queue_submit,
     // Insert new enables above this line
     kMaxEnableFlags,
 } EnableFlags;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3580,8 +3580,22 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     }
 }
 
-void VkSyncValTest::InitSyncValFramework() {
+void VkSyncValTest::InitSyncValFramework(bool enable_queue_submit_validation) {
     // Enable synchronization validation
+
+    // Optional feature definition, add if requested (but they can't be defined at the conditional scope)
+    const char *kEnableQueuSubmitSyncValidation = "VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT";
+    VkLayerSettingValueDataEXT qs_setting_string_value{};
+    qs_setting_string_value.arrayString.pCharArray = kEnableQueuSubmitSyncValidation;
+    qs_setting_string_value.arrayString.count = strlen(qs_setting_string_value.arrayString.pCharArray);
+    VkLayerSettingValueEXT qs_enable_setting_val = {"enables", VK_LAYER_SETTING_VALUE_TYPE_STRING_ARRAY_EXT,
+                                                    qs_setting_string_value};
+    VkLayerSettingsEXT qs_settings{static_cast<VkStructureType>(VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT), nullptr, 1,
+                                   &qs_enable_setting_val};
+
+    if (enable_queue_submit_validation) {
+        features_.pNext = &qs_settings;
+    }
     InitFramework(m_errorMonitor, &features_);
 }
 

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -335,7 +335,7 @@ class VkDebugPrintfTest : public VkLayerTest {
 
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework();
+    void InitSyncValFramework(bool enable_queue_submit_validation = false);
 
   protected:
     VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -4156,3 +4156,65 @@ TEST_F(VkSyncValTest, TestCopyingToCompressedImage) {
         m_commandBuffer->end();
     }
 }
+
+TEST_F(VkSyncValTest, SyncQSBufferCopyHazards) {
+    ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    VkBufferObj buffer_a;
+    VkBufferObj buffer_b;
+    VkBufferObj buffer_c;
+    VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    buffer_a.init_as_src_and_dst(*m_device, 256, mem_prop);
+    buffer_b.init_as_src_and_dst(*m_device, 256, mem_prop);
+    buffer_c.init_as_src_and_dst(*m_device, 256, mem_prop);
+
+    VkBufferCopy region = {0, 0, 256};
+
+    VkCommandBufferObj cba(m_device, m_commandPool);
+    VkCommandBufferObj cbb(m_device, m_commandPool);
+
+    cba.begin();
+    const VkCommandBuffer h_cba = cba.handle();
+    vk::CmdCopyBuffer(h_cba, buffer_a.handle(), buffer_b.handle(), 1, &region);
+    cba.end();
+
+    const VkCommandBuffer h_cbb = cbb.handle();
+    cbb.begin();
+    vk::CmdCopyBuffer(h_cbb, buffer_c.handle(), buffer_a.handle(), 1, &region);
+    cbb.end();
+
+    auto submit1 = lvl_init_struct<VkSubmitInfo>();
+    submit1.commandBufferCount = 2;
+    VkCommandBuffer two_cbs[2] = {h_cba, h_cbb};
+    submit1.pCommandBuffers = two_cbs;
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_READ");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    vk::DeviceWaitIdle(m_device->device());
+
+    VkSubmitInfo submit2[2] = {lvl_init_struct<VkSubmitInfo>(), lvl_init_struct<VkSubmitInfo>()};
+    submit2[0].commandBufferCount = 1;
+    submit2[0].pCommandBuffers = &h_cba;
+    submit2[1].commandBufferCount = 1;
+    submit2[1].pCommandBuffers = &h_cbb;
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_READ");
+    vk::QueueSubmit(m_device->m_queue, 2, submit2, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    // With the skip settings, the above QueueSubmit's didn't record, so we can treat the global queue contexts as empty
+    submit1.commandBufferCount = 1;
+    submit1.pCommandBuffers = &h_cba;
+    // Submit A
+    m_errorMonitor->ExpectSuccess();
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyNotFound();
+
+    submit1.pCommandBuffers = &h_cbb;
+    // Submit B -- which should conflict via the queue's "last batch"
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_READ");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -4218,3 +4218,64 @@ TEST_F(VkSyncValTest, SyncQSBufferCopyHazards) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 }
+TEST_F(VkSyncValTest, SyncQSBufferCopyVsIdle) {
+    ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    VkBufferObj buffer_a;
+    VkBufferObj buffer_b;
+    VkBufferObj buffer_c;
+    VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    buffer_a.init_as_src_and_dst(*m_device, 256, mem_prop);
+    buffer_b.init_as_src_and_dst(*m_device, 256, mem_prop);
+    buffer_c.init_as_src_and_dst(*m_device, 256, mem_prop);
+
+    VkBufferCopy region = {0, 0, 256};
+
+    m_errorMonitor->ExpectSuccess();
+    VkCommandBufferObj cba(m_device, m_commandPool);
+    VkCommandBufferObj cbb(m_device, m_commandPool);
+
+    cba.begin();
+    const VkCommandBuffer h_cba = cba.handle();
+    vk::CmdCopyBuffer(h_cba, buffer_a.handle(), buffer_b.handle(), 1, &region);
+    cba.end();
+
+    const VkCommandBuffer h_cbb = cbb.handle();
+    cbb.begin();
+    vk::CmdCopyBuffer(h_cbb, buffer_c.handle(), buffer_a.handle(), 1, &region);
+    cbb.end();
+
+    // Submit A
+    auto submit1 = lvl_init_struct<VkSubmitInfo>();
+    submit1.commandBufferCount = 1;
+    submit1.pCommandBuffers = &h_cba;
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyNotFound();
+
+    // Submit B which hazards vs. A
+    submit1.pCommandBuffers = &h_cbb;
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_READ");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    // With the skip settings, the above QueueSubmit's didn't record, so we can treat the previous submit as not
+    // having happened. So we'll try again with a device wait idle
+    // Submit B again, but after idling, which should remove the hazard
+    m_errorMonitor->ExpectSuccess();
+    vk::DeviceWaitIdle(m_device->device());
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyNotFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE_AFTER_WRITE");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    // With the skip settings, the above QueueSubmit's didn't record, so we can treat the previous submit as not
+    // having happened. So we'll try again with a queue wait idle
+    // Submit B again, but after idling, which should remove the hazard
+    m_errorMonitor->ExpectSuccess();
+    vk::QueueWaitIdle(m_device->m_queue);
+    vk::QueueSubmit(m_device->m_queue, 1, &submit1, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyNotFound();
+}

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -295,7 +295,7 @@ class Queue : public internal::Handle<VkQueue> {
     // vkQueueWaitIdle()
     VkResult wait();
 
-    uint32_t get_family_index() { return family_index_; }
+    uint32_t get_family_index() const { return family_index_; }
 
   private:
     uint32_t family_index_;


### PR DESCRIPTION
Mostly this is notes to myself, but this is the general shape, and should support multi-queue when complete.

- The analog to the CommandBufferAccessContext is the "QueueBatchAccessContext"
   - See updated documentation for full details
- Tagging is global with ranges assigned at queuesubmit time
- Queue submit order hazard detection (single queue) functional
- PipelineBarrier now correctly scopes for access outside queue submit order
- Trivial semaphore examples function

#### Missing/Incomplete
- Semaphore barrier modelling is incorrect
- SetEvent replay must be define and event scope creation must be rerun(and merged) at submit time
- Wait event chaining must look at the *set* time chaining info to be correct (will need additional state)
- Other submit types need support (including submit2
- Fence support is missing (though QueueWaitIdle model changes should be sufficient
