### PR TITLE
layers: Add VK_KHR_dynamic_rendering VUs and Tests

### DIFF
--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -680,22 +680,6 @@ TEST_F(VkLayerTest, NoBeginCommandBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SecondaryCommandBufferNullRenderpass) {
-    ASSERT_NO_FATAL_FAILURE(Init());
-
-    VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-
-    // Force the failure by not setting the Renderpass and Framebuffer fields
-    VkCommandBufferInheritanceInfo cmd_buf_hinfo = LvlInitStruct<VkCommandBufferInheritanceInfo>();
-    VkCommandBufferBeginInfo cmd_buf_info = LvlInitStruct<VkCommandBufferBeginInfo>();
-    cmd_buf_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    cmd_buf_info.pInheritanceInfo = &cmd_buf_hinfo;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferBeginInfo-flags-06002");
-    vk::BeginCommandBuffer(cb.handle(), &cmd_buf_info);
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(VkLayerTest, SecondaryCommandBufferRerecordedExplicitReset) {
     ASSERT_NO_FATAL_FAILURE(Init());
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -15277,7 +15277,7 @@ TEST_F(VkLayerTest, CreateGraphicsPipelineNullRenderPass) {
 
     m_errorMonitor->VerifyNotFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-dynamicRendering-06052");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06051");
     pipe.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
VUs Added:
VUID-VkCommandBufferBeginInfo-flags-00053
VUID-VkGraphicsPipelineCreateInfo-flags-06482
VUID-VkGraphicsPipelineCreateInfo-flags-06483
VUID-VkGraphicsPipelineCreateInfo-renderPass-06051
VUID-VkGraphicsPipelineCreateInfo-renderPass-06063

Tests Added:
VUID-VkCommandBufferBeginInfo-flags-00053
VUID-VkCommandBufferBeginInfo-flags-00054
VUID-VkCommandBufferBeginInfo-flags-06000
VUID-VkCommandBufferBeginInfo-flags-06001
VUID-VkCommandBufferBeginInfo-flags-06002
VUID-VkGraphicsPipelineCreateInfo-flags-06482
VUID-VkGraphicsPipelineCreateInfo-flags-06483
VUID-VkGraphicsPipelineCreateInfo-renderPass-06051
VUID-VkGraphicsPipelineCreateInfo-renderPass-06063