### PR TITLE
Avoid creating an std::string from nullptr in LogError call

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -832,7 +832,7 @@ bool CoreChecks::ValidateBarriersToImages(const Location &outer_loc, const CMD_B
             if (image_state->layout_locked) {
                 // TODO: Add unique id for error when available
                 skip |= LogError(
-                    img_barrier.image, 0,
+                    img_barrier.image, "VUID-Undefined",
                     "%s Attempting to transition shared presentable %s"
                     " from layout %s to layout %s, but image has already been presented and cannot have its layout transitioned.",
                     loc.Message().c_str(), report_data->FormatHandle(img_barrier.image).c_str(),


### PR DESCRIPTION
Calling LogError(..., 0, ...) is undefined because the second
argument is an std::string (and this generally crashes). Use an
empty string instead. Discovered while experimenting with a
(partial) C++23 build, where constructing a string from nullptr
doesn't compile.