### PR TITLE
layers:  Make MostSignificantBit(0) yield -1

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -157,14 +157,22 @@ VK_LAYER_EXPORT VkLayerDeviceCreateInfo *get_chain_info(const VkDeviceCreateInfo
 
 static inline bool IsPowerOfTwo(unsigned x) { return x && !(x & (x - 1)); }
 
-static inline uint32_t MostSignificantBit(uint32_t mask) {
-    uint32_t highest_view_bit = 0;
-    for (uint32_t k = 0; k < 32; ++k) {
+// Returns the 0-based index of the MSB, like the x86 bit scan reverse (bsr) instruction
+// Note: an input mask of 0 yields -1
+static inline int MostSignificantBit(uint32_t mask) {
+#if defined __GNUC__
+    return mask ? __builtin_clz(mask) ^ 31 : -1;
+#elif defined _MSC_VER
+    unsigned long bit_pos;
+    return _BitScanReverse(&bit_pos, mask) ? int(bit_pos) : -1;
+#else
+    for (int k = 31; k >= 0; --k) {
         if (((mask >> k) & 1) != 0) {
-            highest_view_bit = k;
+            return k;
         }
     }
-    return highest_view_bit;
+    return -1;
+#endif
 }
 
 static inline uint32_t SampleCountSize(VkSampleCountFlagBits sample_count) {


### PR DESCRIPTION
For a Vulkan 1.0 application, `phys_dev_props_core11.maxMultiviewViewCount` seems to be 0. This can cause the following indirect validation error when the app tries to use dynamic rendering, also see issue #3796:

[ VUID-VkPipelineRenderingCreateInfo-viewMask-06067 ] Object 0: handle = 0x7fc6e0cbae40, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x66903323 | vkCreateGraphicsPipelines() pCreateInfos[0]: Most significant bit in VkPipelineRenderingCreateInfo->viewMask(0) must be less maxMultiviewViewCount(0) The Vulkan spec states: The index of the most significant bit in viewMask must be less than maxMultiviewViewCount (https://vulkan.lunarg.com/doc/view/1.3.204.0/linux/1.3-extensions/vkspec.html#VUID-VkPipelineRenderingCreateInfo-viewMask-06067)

This PR changes `MostSignificantBit(0)`'s behavior from yielding 0 to yielding -1 and changing unsigned types to signed as appropriate. -1 is a logical result for a zero input; it is the value of `k` after the loop terminates and makes `MostSignificantBit(x) == 31 - lzcnt(x)` for all `x`.

This is my first PR at the suggestion of @[AaronHaganAMD](https://github.com/AaronHaganAMD). I'll be happy to make any changes to it. I'm also fine to have someone else handle this if that's preferred.