### PR TITLE
Add vuid 03737 03738 03727 03728, validate memory in acceleration structure copies

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -396,6 +396,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                  const void* pData) const;
     bool ValidateMemoryIsBoundToBuffer(const BUFFER_STATE*, const char*, const char*) const;
+    bool ValidateHostVisibleMemoryIsBoundToBuffer(const BUFFER_STATE*, const char*, const char*) const;
     bool ValidateMemoryIsBoundToImage(const IMAGE_STATE*, const char*, const char*) const;
     bool ValidateMemoryIsBoundToImage(const IMAGE_STATE*, const Location&) const;
     template <typename Location>


### PR DESCRIPTION
Add VUIDs to validate memory for buffers used in acceleration structures copies. 

Part of #3792 