### PR TITLE
layers: Validation for new separate DS layouts

### DIFF
--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1094,6 +1094,26 @@ class StatelessValidation : public ValidationObject {
                                          func_name);
                         }
                     }
+                    if (attachment_description_stencil_layout && separate_depth_stencil_layouts) {
+                        if (initial_layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL ||
+                            initial_layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL) {
+                            skip |=
+                                LogError(device, "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06556",
+                                         "%s: pCreateInfo->pAttachments[%d].initialLayout must not be "
+                                         "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL or "
+                                         "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL",
+                                         func_name, i);
+                        }
+                        if (final_layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL ||
+                            final_layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL) {
+                            skip |=
+                                LogError(device, "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06557",
+                                         "%s: pCreateInfo->pAttachments[%d].initialLayout must not be "
+                                         "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL or "
+                                         "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL",
+                                         func_name, i);
+                        }
+                    }
                 } else {
                     if (initial_layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL ||
                         initial_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL ||

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -1299,6 +1299,26 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
                                          "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318");
             }
 
+            attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+
+            auto attachment_description_stencil_layout = LvlInitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
+            attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+            attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+
+            rpci2.pAttachments[1].pNext = &attachment_description_stencil_layout;
+
+            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
+                                     "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06556");
+
+            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
+                                     "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06557");
+
+            rpci2.pAttachments[1].pNext = nullptr;
+
             rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = nullptr;
         } else {
             rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;


### PR DESCRIPTION
This change adds validation for 2 new VUs :

   * VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06556
   * VUID-VkAttachmentDescription2-separateDepthStencilLayouts-06557

They restrict the layout used in VkAttachmentDescription2 for separate
depth/stencil attachments with depth/stencil aspects.