### PR TITLE
Update command buffer index buffer status at unbind

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -1370,6 +1370,7 @@ void CMD_BUFFER_STATE::UnbindResources() {
 
     // Vertex and index buffers
     index_buffer_binding.reset();
+    status &= ~CBSTATUS_INDEX_BUFFER_BOUND;
     vertex_buffer_used = false;
     current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
 


### PR DESCRIPTION
Fixes crash in dEQP-VK.multiview.draw_indexed.1_2_4_8
Tests are coming as stated in #3774 