### PR TITLE
Best practices validate image create flags

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -120,6 +120,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_Swapchain_InvalidCount = 
 static const char DECORATE_UNUSED *kVUID_BestPractices_DepthBiasNoAttachment = "UNASSIGNED-BestPractices-DepthBiasNoAttachment";
 static const char DECORATE_UNUSED *kVUID_BestPractices_SpirvDeprecated_WorkgroupSize =
     "UNASSIGNED-BestPractices-SpirvDeprecated_WorkgroupSize";
+static const char DECORATE_UNUSED *kVUID_BestPractices_ImageCreateFlags = "UNASSIGNED-BestPractices-ImageCreateFlags";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -296,6 +296,13 @@ bool BestPractices::PreCallValidateCreateImage(VkDevice device, const VkImageCre
                        image_hex.str().c_str(), pCreateInfo->queueFamilyIndexCount);
     }
 
+    if ((pCreateInfo->flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT) && !(pCreateInfo->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
+        skip |= LogWarning(device, kVUID_BestPractices_ImageCreateFlags,
+                           "vkCreateImage(): pCreateInfo->flags has VK_IMAGE_CREATE_EXTENDED_USAGE_BIT set, but not "
+                           "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, therefore image views created from this image will have to use the "
+                           "same format and VK_IMAGE_CREATE_EXTENDED_USAGE_BIT will not have any effect.");
+    }
+
     if (VendorCheckEnabled(kBPVendorArm)) {
         if (pCreateInfo->samples > kMaxEfficientSamplesArm) {
             skip |= LogPerformanceWarning(

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1277,3 +1277,29 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineWithoutRenderPass) {
 
     m_errorMonitor->VerifyNotFound();
 }
+
+TEST_F(VkBestPracticesLayerTest, ImageExtendedUsageWithoutMutableFormat) {
+    TEST_DESCRIPTION("Create image with extended usage bit but not mutable format bit.");
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    VkImageCreateInfo image_ci = LvlInitStruct<VkImageCreateInfo>();
+    image_ci.flags = VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
+    image_ci.extent.width = 256;
+    image_ci.extent.height = 256;
+    image_ci.extent.depth = 1;
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VkImage image;
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, kVUID_BestPractices_ImageCreateFlags);
+    vk::CreateImage(device(), &image_ci, nullptr, &image);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Closes #3859 

If VK_IMAGE_CREATE_EXTENDED_USAGE_BIT is set without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, it will have no effect. 