### PR TITLE
layers: Rename GPUAV and DebugPrintf derived command buffer state

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -654,7 +654,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
 
 bool DebugPrintf::CommandBufferNeedsProcessing(VkCommandBuffer command_buffer) {
     bool buffers_present = false;
-    auto cb_node = Get<CMD_BUFFER_STATE_PRINTF>(command_buffer);
+    auto cb_node = Get<debug_printf_state::CommandBuffer>(command_buffer);
     if (GetBufferInfo(cb_node.get()).size()) {
         buffers_present = true;
     }
@@ -667,7 +667,7 @@ bool DebugPrintf::CommandBufferNeedsProcessing(VkCommandBuffer command_buffer) {
 }
 
 void DebugPrintf::ProcessCommandBuffer(VkQueue queue, VkCommandBuffer command_buffer) {
-    auto cb_node = Get<CMD_BUFFER_STATE_PRINTF>(command_buffer);
+    auto cb_node = Get<debug_printf_state::CommandBuffer>(command_buffer);
     UtilProcessInstrumentationBuffer(queue, cb_node.get(), this);
     for (auto *secondary_cmd_buffer : cb_node->linkedCommandBuffers) {
         UtilProcessInstrumentationBuffer(queue, secondary_cmd_buffer, this);
@@ -874,7 +874,7 @@ void DebugPrintf::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
                                                VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                                VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                                uint32_t width, uint32_t height, uint32_t depth) {
-    auto cb_state = Get<CMD_BUFFER_STATE_PRINTF>(commandBuffer);
+    auto cb_state = Get<debug_printf_state::CommandBuffer>(commandBuffer);
     cb_state->hasTraceRaysCmd = true;
 }
 
@@ -893,7 +893,7 @@ void DebugPrintf::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                                 const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
                                                 const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
                                                 uint32_t height, uint32_t depth) {
-    auto cb_state = Get<CMD_BUFFER_STATE_PRINTF>(commandBuffer);
+    auto cb_state = Get<debug_printf_state::CommandBuffer>(commandBuffer);
     cb_state->hasTraceRaysCmd = true;
 }
 
@@ -912,7 +912,7 @@ void DebugPrintf::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandB
                                                         const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
                                                         const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
                                                         VkDeviceAddress indirectDeviceAddress) {
-    auto cb_state = Get<CMD_BUFFER_STATE_PRINTF>(commandBuffer);
+    auto cb_state = Get<debug_printf_state::CommandBuffer>(commandBuffer);
     cb_state->hasTraceRaysCmd = true;
 }
 
@@ -938,7 +938,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     VkDescriptorBufferInfo output_desc_buffer_info = {};
     output_desc_buffer_info.range = output_buffer_size;
 
-    auto cb_node = Get<CMD_BUFFER_STATE_PRINTF>(cmd_buffer);
+    auto cb_node = Get<debug_printf_state::CommandBuffer>(cmd_buffer);
     if (!cb_node) {
         ReportSetupProblem(device, "Unrecognized command buffer");
         aborted = true;
@@ -1001,14 +1001,15 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
 std::shared_ptr<CMD_BUFFER_STATE> DebugPrintf::CreateCmdBufferState(VkCommandBuffer cb,
                                                                     const VkCommandBufferAllocateInfo *pCreateInfo,
                                                                     const COMMAND_POOL_STATE *pool) {
-    return std::static_pointer_cast<CMD_BUFFER_STATE>(std::make_shared<CMD_BUFFER_STATE_PRINTF>(this, cb, pCreateInfo, pool));
+    return std::static_pointer_cast<CMD_BUFFER_STATE>(
+        std::make_shared<debug_printf_state::CommandBuffer>(this, cb, pCreateInfo, pool));
 }
 
-CMD_BUFFER_STATE_PRINTF::CMD_BUFFER_STATE_PRINTF(DebugPrintf *dp, VkCommandBuffer cb,
+debug_printf_state::CommandBuffer::CommandBuffer(DebugPrintf *dp, VkCommandBuffer cb,
                                                  const VkCommandBufferAllocateInfo *pCreateInfo, const COMMAND_POOL_STATE *pool)
     : CMD_BUFFER_STATE(dp, cb, pCreateInfo, pool) {}
 
-void CMD_BUFFER_STATE_PRINTF::Reset() {
+void debug_printf_state::CommandBuffer::Reset() {
     CMD_BUFFER_STATE::Reset();
     auto debug_printf = static_cast<DebugPrintf *>(dev_data);
     // Free the device memory and descriptor set(s) associated with a command buffer.

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -67,17 +67,19 @@ struct DPFOutputRecord {
     uint32_t values;
 };
 
-class CMD_BUFFER_STATE_PRINTF : public CMD_BUFFER_STATE {
+namespace debug_printf_state {
+class CommandBuffer : public CMD_BUFFER_STATE {
   public:
     std::vector<DPFBufferInfo> buffer_infos;
 
-    CMD_BUFFER_STATE_PRINTF(DebugPrintf* dp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
-                            const COMMAND_POOL_STATE* pool);
+    CommandBuffer(DebugPrintf* dp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
+                  const COMMAND_POOL_STATE* pool);
 
     void Reset() final;
 };
+};  // namespace debug_printf_state
 
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, CMD_BUFFER_STATE_PRINTF, CMD_BUFFER_STATE);
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, debug_printf_state::CommandBuffer, CMD_BUFFER_STATE);
 
 class DebugPrintf : public ValidationStateTracker {
   public:
@@ -250,12 +252,12 @@ class DebugPrintf : public ValidationStateTracker {
 
     const std::vector<DPFBufferInfo>& GetBufferInfo(const CMD_BUFFER_STATE* cb_node) const {
         assert(cb_node);
-        return static_cast<const CMD_BUFFER_STATE_PRINTF*>(cb_node)->buffer_infos;
+        return static_cast<const debug_printf_state::CommandBuffer*>(cb_node)->buffer_infos;
     }
 
     std::vector<DPFBufferInfo>& GetBufferInfo(CMD_BUFFER_STATE* cb_node) {
         assert(cb_node);
-        return static_cast<CMD_BUFFER_STATE_PRINTF*>(cb_node)->buffer_infos;
+        return static_cast<debug_printf_state::CommandBuffer*>(cb_node)->buffer_infos;
     }
 
     std::shared_ptr<CMD_BUFFER_STATE> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,


### PR DESCRIPTION
Update to using the new namespace naming scheme.