### PR TITLE
Imagination best practices

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -250,4 +250,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SyncObjects_HighNumberOfS
 static const char DECORATE_UNUSED *kVUID_BestPractices_DynamicRendering_NotSupported =
     "UNASSIGNED-BestPractices-DynamicRendering-NotSupported";
 
+// Imagination Technologies best practices
+static const char DECORATE_UNUSED *kVUID_BestPractices_Texture_Format_PVRTC_Outdated =
+    "UNASSIGNED-BestPractices-Texture-Format-PVRTC-Outdated";
 #endif

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -327,14 +327,15 @@ bool BestPractices::PreCallValidateCreateImage(VkDevice device, const VkImageCre
                 VendorSpecificTag(kBPVendorArm), static_cast<uint32_t>(pCreateInfo->samples), kMaxEfficientSamplesArm);
         }
 
+    if (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) {
         if (pCreateInfo->samples > VK_SAMPLE_COUNT_1_BIT && !(pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
             skip |= LogPerformanceWarning(
                 device, kVUID_BestPractices_CreateImage_NonTransientMSImage,
-                "%s vkCreateImage(): Trying to create a multisampled image, but createInfo.usage did not have "
+                "%s %s vkCreateImage(): Trying to create a multisampled image, but createInfo.usage did not have "
                 "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT set. Multisampled images may be resolved on-chip, "
                 "and do not need to be backed by physical storage. "
                 "TRANSIENT_ATTACHMENT allows tiled GPUs to not back the multisampled image with physical memory.",
-                VendorSpecificTag(kBPVendorArm));
+                VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG));
         }
     }
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -37,10 +37,9 @@ struct VendorSpecificInfo {
     std::string name;
 };
 
-const std::map<BPVendorFlagBits, VendorSpecificInfo> kVendorInfo = {
-    {kBPVendorArm, {vendor_specific_arm, "Arm"}},
-    {kBPVendorAMD, {vendor_specific_amd, "AMD"}},
-};
+const std::map<BPVendorFlagBits, VendorSpecificInfo> kVendorInfo = {{kBPVendorArm, {vendor_specific_arm, "Arm"}},
+                                                                    {kBPVendorAMD, {vendor_specific_amd, "AMD"}},
+                                                                    {kBPVendorIMG, {vendor_specific_img, "IMG"}}};
 
 const SpecialUseVUIDs kSpecialUseInstanceVUIDs {
     kVUID_BestPractices_CreateInstance_SpecialUseExtension_CADSupport,

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -347,6 +347,20 @@ bool BestPractices::PreCallValidateCreateImage(VkDevice device, const VkImageCre
             VendorSpecificTag(kBPVendorIMG), static_cast<uint32_t>(pCreateInfo->samples), kMaxEfficientSamplesImg);
     }
 
+    if (VendorCheckEnabled(kBPVendorIMG) && (pCreateInfo->format == VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG ||
+                                             pCreateInfo->format == VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG)) {
+        skip |= LogPerformanceWarning(device, kVUID_BestPractices_Texture_Format_PVRTC_Outdated,
+                                      "%s vkCreateImage(): Trying to create an image with a PVRTC format. Both PVRTC1 and PVRTC2 "
+                                      "are slower than standard image formats on PowerVR GPUs, prefer ETC, BC, ASTC, etc.",
+                                      VendorSpecificTag(kBPVendorIMG));
+    }
+
     if (VendorCheckEnabled(kBPVendorAMD)) {
         std::stringstream image_hex;
         image_hex << "0x" << std::hex << HandleToUint64(pImage);

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2104,12 +2104,13 @@ bool BestPractices::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer,
     const auto cmd_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
     if ((indexCount * instanceCount) <= kSmallIndexedDrawcallIndices &&
         (cmd_state->small_indexed_draw_call_count == kMaxSmallIndexedDrawcalls - 1) &&
-        VendorCheckEnabled(kBPVendorArm)) {
+        (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG))) {
         skip |= LogPerformanceWarning(device, kVUID_BestPractices_CmdDrawIndexed_ManySmallIndexedDrawcalls,
-                                      "%s: The command buffer contains many small indexed drawcalls "
+                                      "%s %s: The command buffer contains many small indexed drawcalls "
                                       "(at least %u drawcalls with less than %u indices each). This may cause pipeline bubbles. "
                                       "You can try batching drawcalls or instancing when applicable.",
-                                      VendorSpecificTag(kBPVendorArm), kMaxSmallIndexedDrawcalls, kSmallIndexedDrawcallIndices);
+                                      VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), kMaxSmallIndexedDrawcalls,
+                                      kSmallIndexedDrawcallIndices);
     }
 
     if (VendorCheckEnabled(kBPVendorArm)) {

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2641,7 +2641,7 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
     // Only send the warning when the vendor is enabled and a depth prepass is detected
     bool uses_depth =
         (render_pass_state.depthAttachment || render_pass_state.colorAttachment) &&
-        ((depth_only_arm && VendorCheckEnabled(kBPVendorAMD)) || (depth_only_img && VendorCheckEnabled(kBPVendorIMG)));
+        ((depth_only_arm && VendorCheckEnabled(kBPVendorArm)) || (depth_only_img && VendorCheckEnabled(kBPVendorIMG)));
 
     if (uses_depth) {
         skip |= LogPerformanceWarning(

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2639,8 +2639,9 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
                           render_pass_state.numDrawCallsDepthOnly >= kDepthPrePassNumDrawCallsIMG;
 
     // Only send the warning when the vendor is enabled and a depth prepass is detected
-    bool uses_depth = (render_pass_state.depthAttachment || render_pass_state.colorAttachment) &&
-                      (depth_only_arm && VendorCheckEnabled(kBPVendorAMD) || depth_only_img && VendorCheckEnabled(kBPVendorIMG));
+    bool uses_depth =
+        (render_pass_state.depthAttachment || render_pass_state.colorAttachment) &&
+        ((depth_only_arm && VendorCheckEnabled(kBPVendorAMD)) || (depth_only_img && VendorCheckEnabled(kBPVendorIMG)));
 
     if (uses_depth) {
         skip |= LogPerformanceWarning(

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2057,7 +2057,14 @@ void BestPractices::RecordCmdDrawType(VkCommandBuffer cmd_buffer, uint32_t draw_
 
 void BestPractices::RecordCmdDrawTypeArm(bp_state::CommandBuffer& cb_node, uint32_t draw_count, const char* caller) {
     auto& render_pass_state = cb_node.render_pass_state;
-    if (draw_count >= kDepthPrePassMinDrawCountArm) {
+    // Each TBDR vendor requires a depth pre-pass draw call to have a minimum number of vertices/indices before it counts towards
+    // depth prepass warnings First find the lowest enabled draw count
+    uint32_t lowestEnabledMinDrawCount = 0;
+    lowestEnabledMinDrawCount = VendorCheckEnabled(kBPVendorArm) * kDepthPrePassMinDrawCountArm;
+    if (VendorCheckEnabled(kBPVendorIMG) && kDepthPrePassMinDrawCountIMG < lowestEnabledMinDrawCount)
+        lowestEnabledMinDrawCount = kDepthPrePassMinDrawCountIMG;
+
+    if (draw_count >= lowestEnabledMinDrawCount) {
         if (render_pass_state.depthOnly) render_pass_state.numDrawCallsDepthOnly++;
         if (render_pass_state.depthEqualComparison) render_pass_state.numDrawCallsDepthEqualCompare++;
     }
@@ -2610,16 +2617,24 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
     if (cmd == nullptr) return skip;
     auto &render_pass_state = cmd->render_pass_state;
 
+    // Does the number of draw calls classified as depth only surpass the vendor limit for a specified vendor
+    bool depth_only_arm = render_pass_state.numDrawCallsDepthEqualCompare >= kDepthPrePassNumDrawCallsArm &&
+                          render_pass_state.numDrawCallsDepthOnly >= kDepthPrePassNumDrawCallsArm;
+    bool depth_only_img = render_pass_state.numDrawCallsDepthEqualCompare >= kDepthPrePassNumDrawCallsIMG &&
+                          render_pass_state.numDrawCallsDepthOnly >= kDepthPrePassNumDrawCallsIMG;
+
+    // Only send the warning when the vendor is enabled and a depth prepass is detected
     bool uses_depth = (render_pass_state.depthAttachment || render_pass_state.colorAttachment) &&
-                      render_pass_state.numDrawCallsDepthEqualCompare >= kDepthPrePassNumDrawCallsArm &&
-                      render_pass_state.numDrawCallsDepthOnly >= kDepthPrePassNumDrawCallsArm;
+                      (depth_only_arm && VendorCheckEnabled(kBPVendorAMD) || depth_only_img && VendorCheckEnabled(kBPVendorIMG));
+
     if (uses_depth) {
         skip |= LogPerformanceWarning(
             device, kVUID_BestPractices_EndRenderPass_DepthPrePassUsage,
-            "%s Depth pre-passes may be in use. In general, this is not recommended, as in Arm Mali GPUs since "
-            "Mali-T620, Forward Pixel Killing (FPK) can already perform automatic hidden surface removal; in which "
-            "case, using depth pre-passes for hidden surface removal may worsen performance.",
-            VendorSpecificTag(kBPVendorArm));
+            "%s %s Depth pre-passes may be in use. In general, this is not recommended in tile-based deferred "
+            "renderering architectures; such as those in Arm Mali or PowerVR GPUs. Since they can remove geometry "
+            "hidden by other opaque geometry. Mali has Forward Pixel Killing (FPK), PowerVR has Hiden Surface "
+            "Remover (HSR) in which case, using depth pre-passes for hidden surface removal may worsen performance.",
+            VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG));
     }
 
     RENDER_PASS_STATE* rp = cmd->activeRenderPass.get();

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -318,15 +318,6 @@ bool BestPractices::PreCallValidateCreateImage(VkDevice device, const VkImageCre
                            "same format and VK_IMAGE_CREATE_EXTENDED_USAGE_BIT will not have any effect.");
     }
 
-    if (VendorCheckEnabled(kBPVendorArm)) {
-        if (pCreateInfo->samples > kMaxEfficientSamplesArm) {
-            skip |= LogPerformanceWarning(
-                device, kVUID_BestPractices_CreateImage_TooLargeSampleCount,
-                "%s vkCreateImage(): Trying to create an image with %u samples. "
-                "The hardware revision may not have full throughput for framebuffers with more than %u samples.",
-                VendorSpecificTag(kBPVendorArm), static_cast<uint32_t>(pCreateInfo->samples), kMaxEfficientSamplesArm);
-        }
-
     if (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) {
         if (pCreateInfo->samples > VK_SAMPLE_COUNT_1_BIT && !(pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
             skip |= LogPerformanceWarning(
@@ -337,6 +328,23 @@ bool BestPractices::PreCallValidateCreateImage(VkDevice device, const VkImageCre
                 "TRANSIENT_ATTACHMENT allows tiled GPUs to not back the multisampled image with physical memory.",
                 VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG));
         }
+    }
+
+    if (VendorCheckEnabled(kBPVendorArm) && pCreateInfo->samples > kMaxEfficientSamplesArm) {
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreateImage_TooLargeSampleCount,
+            "%s vkCreateImage(): Trying to create an image with %u samples. "
+            "The hardware revision may not have full throughput for framebuffers with more than %u samples.",
+            VendorSpecificTag(kBPVendorArm), static_cast<uint32_t>(pCreateInfo->samples), kMaxEfficientSamplesArm);
+    }
+
+    if (VendorCheckEnabled(kBPVendorIMG) && pCreateInfo->samples > kMaxEfficientSamplesImg) {
+        skip |= LogPerformanceWarning(
+            device, kVUID_BestPractices_CreateImage_TooLargeSampleCount,
+            "%s vkCreateImage(): Trying to create an image with %u samples. "
+            "The device may not have full support for true multisampling for images with more than %u samples. "
+            "XT devices support up to 8 samples, XE up to 4 samples.",
+            VendorSpecificTag(kBPVendorIMG), static_cast<uint32_t>(pCreateInfo->samples), kMaxEfficientSamplesImg);
     }
 
     if (VendorCheckEnabled(kBPVendorAMD)) {

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1720,7 +1720,7 @@ void BestPractices::QueueValidateImage(QueueCallbacks &funcs, const char* functi
     }
 }
 
-void BestPractices::ValidateImageInQueueArm(const char* function_name, const bp_state::Image& image,
+void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const bp_state::Image& image,
                                             IMAGE_SUBRESOURCE_USAGE_BP last_usage, IMAGE_SUBRESOURCE_USAGE_BP usage,
                                             uint32_t array_layer, uint32_t mip_level) {
     // Swapchain images are implicitly read so clear after store is expected.
@@ -1728,20 +1728,19 @@ void BestPractices::ValidateImageInQueueArm(const char* function_name, const bp_
         !image.IsSwapchainImage()) {
         LogPerformanceWarning(
             device, kVUID_BestPractices_RenderPass_RedundantStore,
-            "%s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
             "image was used, it was written to with STORE_OP_STORE. "
             "Storing to the image is probably redundant in this case, and wastes bandwidth on tile-based "
             "architectures.",
-            function_name, VendorSpecificTag(kBPVendorArm), array_layer, mip_level);
+            function_name, VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), array_layer, mip_level);
     } else if (usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_CLEARED && last_usage == IMAGE_SUBRESOURCE_USAGE_BP::CLEARED) {
         LogPerformanceWarning(
             device, kVUID_BestPractices_RenderPass_RedundantClear,
-            "%s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
             "image was used, it was written to with vkCmdClear*Image(). "
             "Clearing the image with vkCmdClear*Image() is probably redundant in this case, and wastes bandwidth on "
-            "tile-based architectures."
-            "architectures.",
-            function_name, VendorSpecificTag(kBPVendorArm), array_layer, mip_level);
+            "tile-based architectures.",
+            function_name, VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), array_layer, mip_level);
     } else if (usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_READ_TO_TILE &&
                (last_usage == IMAGE_SUBRESOURCE_USAGE_BP::BLIT_WRITE || last_usage == IMAGE_SUBRESOURCE_USAGE_BP::CLEARED ||
                 last_usage == IMAGE_SUBRESOURCE_USAGE_BP::COPY_WRITE || last_usage == IMAGE_SUBRESOURCE_USAGE_BP::RESOLVE_WRITE)) {
@@ -1788,17 +1787,18 @@ void BestPractices::ValidateImageInQueueArm(const char* function_name, const bp_
 
         LogPerformanceWarning(
             device, vuid,
-            "%s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was loaded to tile as part of LOAD_OP_LOAD, but last "
+            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was loaded to tile as part of LOAD_OP_LOAD, but last "
             "time image was used, it was written to with %s. %s",
-            function_name, VendorSpecificTag(kBPVendorArm), array_layer, mip_level, last_cmd, suggestion);
+            function_name, VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), array_layer, mip_level, last_cmd,
+            suggestion);
     }
 }
 
 void BestPractices::ValidateImageInQueue(const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
                                          uint32_t array_layer, uint32_t mip_level) {
     auto last_usage = state.UpdateUsage(array_layer, mip_level, usage);
-    if (VendorCheckEnabled(kBPVendorArm)) {
-        ValidateImageInQueueArm(function_name, state, last_usage, usage, array_layer, mip_level);
+    if (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) {
+        ValidateImageInQueueArmImg(function_name, state, last_usage, usage, array_layer, mip_level);
     }
 }
 

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2639,8 +2639,7 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
 
     RENDER_PASS_STATE* rp = cmd->activeRenderPass.get();
 
-    if (VendorCheckEnabled(kBPVendorArm) && rp) {
-
+    if ((VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) && rp) {
         // If we use an attachment on-tile, we should access it in some way. Otherwise,
         // it is redundant to have it be part of the render pass.
         // Only consider it redundant if it will actually consume bandwidth, i.e.
@@ -2691,11 +2690,12 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
             if (untouched_aspects) {
                 skip |= LogPerformanceWarning(
                     device, kVUID_BestPractices_EndRenderPass_RedundantAttachmentOnTile,
-                    "%s Render pass was ended, but attachment #%u (format: %u, untouched aspects 0x%x) "
+                    "%s %s Render pass was ended, but attachment #%u (format: %u, untouched aspects 0x%x) "
                     "was never accessed by a pipeline or clear command. "
-                    "On tile-based architectures, LOAD_OP_LOAD and STORE_OP_STORE consume bandwidth and should not be part of the render pass "
+                    "On tile-based architectures, LOAD_OP_LOAD and STORE_OP_STORE consume bandwidth and should not be part of the "
+                    "render pass "
                     "if the attachments are not intended to be accessed.",
-                    VendorSpecificTag(kBPVendorArm), i, attachment.format, untouched_aspects);
+                    VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), i, attachment.format, untouched_aspects);
             }
         }
     }

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1653,17 +1653,17 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
             }
 
             // Using LOAD_OP_LOAD is expensive on tiled GPUs, so flag it as a potential improvement
-            if (attachment_needs_readback && VendorCheckEnabled(kBPVendorArm)) {
-                skip |= LogPerformanceWarning(
-                    device, kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback,
-                    "%s Attachment #%u in render pass has begun with VK_ATTACHMENT_LOAD_OP_LOAD.\n"
-                    "Submitting this renderpass will cause the driver to inject a readback of the attachment "
+            if (attachment_needs_readback && (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG))) {
+                skip |=
+                    LogPerformanceWarning(device, kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback,
+                                          "%s %s Attachment #%u in render pass has begun with VK_ATTACHMENT_LOAD_OP_LOAD.\n"
+                                          "Submitting this renderpass will cause the driver to inject a readback of the attachment "
                                           "which will copy in total %u pixels (renderArea = "
-                    "{ %" PRId32 ", %" PRId32 ", %" PRIu32", %" PRIu32 " }) to the tile buffer.",
-                    VendorSpecificTag(kBPVendorArm), att,
-                    pRenderPassBegin->renderArea.extent.width * pRenderPassBegin->renderArea.extent.height,
-                    pRenderPassBegin->renderArea.offset.x, pRenderPassBegin->renderArea.offset.y,
-                    pRenderPassBegin->renderArea.extent.width, pRenderPassBegin->renderArea.extent.height);
+                                          "{ %" PRId32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 " }) to the tile buffer.",
+                                          VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), att,
+                                          pRenderPassBegin->renderArea.extent.width * pRenderPassBegin->renderArea.extent.height,
+                                          pRenderPassBegin->renderArea.offset.x, pRenderPassBegin->renderArea.offset.y,
+                                          pRenderPassBegin->renderArea.extent.width, pRenderPassBegin->renderArea.extent.height);
             }
         }
     }

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -264,15 +264,15 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
                            "vkCreateDevice() called before getting physical device features from vkGetPhysicalDeviceFeatures().");
     }
 
-    if ((VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorAMD)) && (pCreateInfo->pEnabledFeatures != nullptr) &&
-        (pCreateInfo->pEnabledFeatures->robustBufferAccess == VK_TRUE)) {
+    if ((VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorAMD) || VendorCheckEnabled(kBPVendorIMG)) &&
+        (pCreateInfo->pEnabledFeatures != nullptr) && (pCreateInfo->pEnabledFeatures->robustBufferAccess == VK_TRUE)) {
         skip |= LogPerformanceWarning(
             device, kVUID_BestPractices_CreateDevice_RobustBufferAccess,
-            "%s %s vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during "
+            "%s %s %s vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during "
             "development. Enabling it causes loss in performance for accesses to uniform buffers and shader storage "
             "buffers. Disable robustBufferAccess in release builds. Only leave it enabled if the application use-case "
             "requires the additional level of reliability due to the use of unverified user-supplied draw parameters.",
-            VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorAMD));
+            VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorAMD), VendorSpecificTag(kBPVendorIMG));
     }
 
     return skip;

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -268,7 +268,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
         (pCreateInfo->pEnabledFeatures != nullptr) && (pCreateInfo->pEnabledFeatures->robustBufferAccess == VK_TRUE)) {
         skip |= LogPerformanceWarning(
             device, kVUID_BestPractices_CreateDevice_RobustBufferAccess,
-            "%s %s %s vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during "
+            "%s %s %s: vkCreateDevice() called with enabled robustBufferAccess. Use robustBufferAccess as a debugging tool during "
             "development. Enabling it causes loss in performance for accesses to uniform buffers and shader storage "
             "buffers. Disable robustBufferAccess in release builds. Only leave it enabled if the application use-case "
             "requires the additional level of reliability due to the use of unverified user-supplied draw parameters.",
@@ -1656,7 +1656,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
             if (attachment_needs_readback && (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG))) {
                 skip |=
                     LogPerformanceWarning(device, kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback,
-                                          "%s %s Attachment #%u in render pass has begun with VK_ATTACHMENT_LOAD_OP_LOAD.\n"
+                                          "%s %s: Attachment #%u in render pass has begun with VK_ATTACHMENT_LOAD_OP_LOAD.\n"
                                           "Submitting this renderpass will cause the driver to inject a readback of the attachment "
                                           "which will copy in total %u pixels (renderArea = "
                                           "{ %" PRId32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 " }) to the tile buffer.",
@@ -1728,7 +1728,7 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
         !image.IsSwapchainImage()) {
         LogPerformanceWarning(
             device, kVUID_BestPractices_RenderPass_RedundantStore,
-            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+            "%s %s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
             "image was used, it was written to with STORE_OP_STORE. "
             "Storing to the image is probably redundant in this case, and wastes bandwidth on tile-based "
             "architectures.",
@@ -1736,7 +1736,7 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
     } else if (usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_CLEARED && last_usage == IMAGE_SUBRESOURCE_USAGE_BP::CLEARED) {
         LogPerformanceWarning(
             device, kVUID_BestPractices_RenderPass_RedundantClear,
-            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
+            "%s %s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was cleared as part of LOAD_OP_CLEAR, but last time "
             "image was used, it was written to with vkCmdClear*Image(). "
             "Clearing the image with vkCmdClear*Image() is probably redundant in this case, and wastes bandwidth on "
             "tile-based architectures.",
@@ -1787,7 +1787,7 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
 
         LogPerformanceWarning(
             device, vuid,
-            "%s: %s %s Subresource (arrayLayer: %u, mipLevel: %u) of image was loaded to tile as part of LOAD_OP_LOAD, but last "
+            "%s %s: %s Subresource (arrayLayer: %u, mipLevel: %u) of image was loaded to tile as part of LOAD_OP_LOAD, but last "
             "time image was used, it was written to with %s. %s",
             function_name, VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), array_layer, mip_level, last_cmd,
             suggestion);
@@ -2631,7 +2631,7 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
     if (uses_depth) {
         skip |= LogPerformanceWarning(
             device, kVUID_BestPractices_EndRenderPass_DepthPrePassUsage,
-            "%s %s Depth pre-passes may be in use. In general, this is not recommended in tile-based deferred "
+            "%s %s: Depth pre-passes may be in use. In general, this is not recommended in tile-based deferred "
             "renderering architectures; such as those in Arm Mali or PowerVR GPUs. Since they can remove geometry "
             "hidden by other opaque geometry. Mali has Forward Pixel Killing (FPK), PowerVR has Hiden Surface "
             "Remover (HSR) in which case, using depth pre-passes for hidden surface removal may worsen performance.",
@@ -2691,11 +2691,10 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) cons
             if (untouched_aspects) {
                 skip |= LogPerformanceWarning(
                     device, kVUID_BestPractices_EndRenderPass_RedundantAttachmentOnTile,
-                    "%s %s Render pass was ended, but attachment #%u (format: %u, untouched aspects 0x%x) "
+                    "%s %s: Render pass was ended, but attachment #%u (format: %u, untouched aspects 0x%x) "
                     "was never accessed by a pipeline or clear command. "
                     "On tile-based architectures, LOAD_OP_LOAD and STORE_OP_STORE consume bandwidth and should not be part of the "
-                    "render pass "
-                    "if the attachments are not intended to be accessed.",
+                    "render pass if the attachments are not intended to be accessed.",
                     VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), i, attachment.format, untouched_aspects);
             }
         }

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -290,7 +290,8 @@ class BestPractices : public ValidationStateTracker {
 
     bool ValidateDeprecatedExtensions(const char* api_name, const char* extension_name, uint32_t version, const char* vuid) const;
 
-    bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name, const SpecialUseVUIDs& special_use_vuids) const;
+    bool ValidateSpecialUseExtensions(const char* api_name, const char* extension_name,
+                                      const SpecialUseVUIDs& special_use_vuids) const;
 
     bool PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
@@ -412,12 +413,12 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          VkSubpassContents contents) override;
     void PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                          const VkSubpassBeginInfo *pSubpassBeginInfo) override;
+                                          const VkSubpassBeginInfo* pSubpassBeginInfo) override;
     void PreCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                             const VkSubpassBeginInfo *pSubpassBeginInfo) override;
+                                             const VkSubpassBeginInfo* pSubpassBeginInfo) override;
     void PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer) override;
-    void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) override;
-    void PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR *pSubpassEndInfo) override;
+    void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) override;
+    void PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassEndInfo) override;
     bool PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                            VkSubpassContents contents) const override;
     bool PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
@@ -456,8 +457,8 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) const override;
     bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const override;
-    bool PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) const override;
-    bool PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) const override;
+    bool PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const override;
+    bool PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) const override;
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                               uint32_t firstInstance) override;
     void PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
@@ -527,8 +528,7 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                       VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                       const VkImageResolve* pRegions) override;
-    void PreCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
-                                          const VkResolveImageInfo2KHR *pResolveImageInfo) override;
+    void PreCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR* pResolveImageInfo) override;
     void PreCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo) override;
     void PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                          const VkClearColorValue* pColor, uint32_t rangeCount,
@@ -539,7 +539,8 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
                                    VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy* pRegions) override;
     void PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                           VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy* pRegions) override;
+                                           VkImageLayout dstImageLayout, uint32_t regionCount,
+                                           const VkBufferImageCopy* pRegions) override;
     void PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                            VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions) override;
     void PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
@@ -624,7 +625,8 @@ class BestPractices : public ValidationStateTracker {
                                           VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
                                           uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
                                           uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
-                                          uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers) override;
+                                          uint32_t imageMemoryBarrierCount,
+                                          const VkImageMemoryBarrier* pImageMemoryBarriers) override;
 
     void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                               const VkGraphicsPipelineCreateInfo* pCreateInfos,
@@ -632,7 +634,7 @@ class BestPractices : public ValidationStateTracker {
                                               void* cgpl_state) override;
 
     bool PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
-                                            const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                             const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                              const VkCopyDescriptorSet* pDescriptorCopies) const override;
     bool PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator,
@@ -663,12 +665,11 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkFence* pFence) const override;
 
-
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;
 
     void PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                          const VkClearAttachment* pClearAttachments,
-                                          uint32_t rectCount, const VkClearRect *pRects) override;
+                                          const VkClearAttachment* pClearAttachments, uint32_t rectCount,
+                                          const VkClearRect* pRects) override;
 
     bool PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                            const VkCommandBuffer* pCommandBuffers) const override;
@@ -751,7 +752,7 @@ class BestPractices : public ValidationStateTracker {
                                  VkImageAspectFlags aspects, bool secondary) const;
 
     bool ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer) const;
-    void RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin);
+    void RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin);
 
     void PipelineUsedInFrame(VkPipeline pipeline) {
         WriteLockGuard guard(pipeline_lock_);
@@ -778,4 +779,3 @@ class BestPractices : public ValidationStateTracker {
     layer_data::unordered_set<VkPipeline> pipelines_used_in_frame_;
     mutable ReadWriteLock pipeline_lock_;
 };
-

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -515,7 +515,7 @@ class BestPractices : public ValidationStateTracker {
                             IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
     void ValidateImageInQueue(const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
                               uint32_t array_layer, uint32_t mip_level);
-    void ValidateImageInQueueArm(const char* function_name, const bp_state::Image& image, IMAGE_SUBRESOURCE_USAGE_BP last_usage,
+    void ValidateImageInQueueArmImg(const char* function_name, const bp_state::Image& image, IMAGE_SUBRESOURCE_USAGE_BP last_usage,
                                  IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
 
     void PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -102,8 +102,7 @@ struct DeprecationData {
     std::string target;
 };
 
-struct SpecialUseVUIDs
-{
+struct SpecialUseVUIDs {
     const char* cadsupport;
     const char* d3demulation;
     const char* devtools;
@@ -114,6 +113,7 @@ struct SpecialUseVUIDs
 typedef enum {
     kBPVendorArm = 0x00000001,
     kBPVendorAMD = 0x00000002,
+    kBPVendorIMG = 0x00000004,
 } BPVendorFlagBits;
 typedef VkFlags BPVendorFlags;
 

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -90,6 +90,9 @@ static const uint32_t kThreadGroupDispatchCountAlignmentArm = 4;
 // Maximum number of threads which can efficiently be part of a compute workgroup when using thread group barriers.
 static const uint32_t kMaxEfficientWorkGroupThreadCountArm = 64;
 
+// Maximum sample count on PowerVR before showing a warning
+static const VkSampleCountFlagBits kMaxEfficientSamplesImg = VK_SAMPLE_COUNT_4_BIT;
+
 
 enum ExtDeprecationReason {
     kExtPromoted,

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -90,6 +90,12 @@ static const uint32_t kThreadGroupDispatchCountAlignmentArm = 4;
 // Maximum number of threads which can efficiently be part of a compute workgroup when using thread group barriers.
 static const uint32_t kMaxEfficientWorkGroupThreadCountArm = 64;
 
+// Minimum number of vertices/indices a draw needs to have before considering it in depth prepass warnings on PowerVR
+static const int kDepthPrePassMinDrawCountIMG = 300;
+
+// Minimum, number of draw calls matching the above criteria before triggerring a depth prepass warning on PowerVR
+static const int kDepthPrePassNumDrawCallsIMG = 10;
+
 // Maximum sample count on PowerVR before showing a warning
 static const VkSampleCountFlagBits kMaxEfficientSamplesImg = VK_SAMPLE_COUNT_4_BIT;
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3448,6 +3448,7 @@ typedef enum ValidationCheckDisables {
 typedef enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
 } ValidationCheckEnables;
 
@@ -3480,6 +3481,7 @@ typedef enum EnableFlags {
     best_practices,
     vendor_specific_arm,
     vendor_specific_amd,
+    vendor_specific_img,
     debug_printf,
     sync_validation,
     // Insert new enables above this line

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -84,9 +84,13 @@ void SetValidationEnable(CHECK_ENABLED &enable_data, const ValidationCheckEnable
         case VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD:
             enable_data[vendor_specific_amd] = true;
             break;
+        case VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG:
+            enable_data[vendor_specific_img] = true;
+            break;
         case VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL:
             enable_data[vendor_specific_arm] = true;
             enable_data[vendor_specific_amd] = true;
+            enable_data[vendor_specific_img] = true;
             break;
         default:
             assert(true);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -70,6 +70,7 @@ static const layer_data::unordered_map<std::string, ValidationCheckDisables> Val
 static const layer_data::unordered_map<std::string, ValidationCheckEnables> ValidationEnableLookup = {
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD},
+    {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL},
 };
 
@@ -95,6 +96,7 @@ static const std::vector<std::string> EnableFlagNameHelper = {
     "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",                     // best_practices,
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM",                         // vendor_specific_arm,
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD",                         // vendor_specific_amd,
+    "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG",                         // vendor_specific_img,
     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
     "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION"              // sync_validation,
 };

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -305,6 +305,7 @@ typedef enum ValidationCheckDisables {
 typedef enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
 } ValidationCheckEnables;
 
@@ -337,6 +338,7 @@ typedef enum EnableFlags {
     best_practices,
     vendor_specific_arm,
     vendor_specific_amd,
+    vendor_specific_img,
     debug_printf,
     sync_validation,
     // Insert new enables above this line


### PR DESCRIPTION
Allow Imagination technologies best practices to be enabled through the VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG property.

From there, most validation checks are simply ports from ARM as there is a large overlap. Finally there is a new warning to advice users to stop using PVRTC