### PR TITLE
layers: Add ValidationStateTracker::CreateDevice

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -202,13 +202,6 @@ bool BestPractices::ValidateSpecialUseExtensions(const char* api_name, const cha
     return skip;
 }
 
-void BestPractices::InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj) {
-    if (add_obj) {
-        ValidationStateTracker::InitDeviceValidationObject(add_obj, inst_obj, dev_obj);
-    }
-}
-
-
 bool BestPractices::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                                   VkInstance* pInstance) const {
     bool skip = false;

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -273,8 +273,6 @@ class BestPractices : public ValidationStateTracker {
 
     std::string GetAPIVersionName(uint32_t version) const;
 
-    void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj) override;
-
     bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* caller) const;
 
     void RecordCmdDrawType(VkCommandBuffer cmd_buffer, uint32_t draw_count, const char* caller);
@@ -596,9 +594,6 @@ class BestPractices : public ValidationStateTracker {
 
     void ManualPostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                                    VkImage* pSwapchainImages, VkResult result);
-
-    void ManualPostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                          const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result);
 
     void ManualPostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                          VkResult result);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -178,9 +178,6 @@ class CoreChecks : public ValidationStateTracker {
     ReadLockGuard ReadLock() override;
     WriteLockGuard WriteLock() override;
 
-    // Override base class, we have some extra work to do here
-    void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj) override;
-
     struct SimpleErrorLocation {
         const char* func_name;
         const char* vuid;
@@ -1043,8 +1040,7 @@ class CoreChecks : public ValidationStateTracker {
                                                 VkDeviceAddress indirectDeviceAddress) const override;
     bool PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) const override;
-    void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result) override;
+    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo) override;
     bool PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                         VkDeviceSize dataSize, const void* pData) const override;
     bool PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex,

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -89,8 +89,7 @@ class DebugPrintf : public ValidationStateTracker {
     void ReportSetupProblem(T object, const char* const specific_message) const;
     void PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void* modified_create_info) override;
-    void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result) override;
+    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo) override;
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) override;
     void PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -147,8 +147,7 @@ class GpuAssisted : public ValidationStateTracker {
     bool CheckForDescriptorIndexing(DeviceFeatures enabled_features) const;
     void PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, void* modified_create_info) override;
-    void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
-                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result) override;
+    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo) override;
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) override;
     void PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                          const VkBindAccelerationStructureMemoryInfoNV* pBindInfos,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -39,14 +39,6 @@
 #include "cmd_buffer_state.h"
 #include "render_pass_state.h"
 
-void ValidationStateTracker::InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
-    if (add_obj) {
-        instance_state = reinterpret_cast<ValidationStateTracker *>(GetValidationObject(inst_obj->object_dispatch, container_type));
-        // Call base class
-        ValidationObject::InitDeviceValidationObject(add_obj, inst_obj, dev_obj);
-    }
-}
-
 // NOTE:  Beware the lifespan of the rp_begin when holding  the return.  If the rp_begin isn't a "safe" copy, "IMAGELESS"
 //        attachments won't persist past the API entry point exit.
 static std::pair<uint32_t, const VkImageView *> GetFramebufferAttachments(const VkRenderPassBeginInfo &rp_begin,
@@ -575,10 +567,19 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
                                                         VkResult result) {
     if (VK_SUCCESS != result) return;
 
+    // The current object represents the VkInstance, look up / create the object for the device.
     ValidationObject *device_object = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
     ValidationObject *validation_data = GetValidationObject(device_object->object_dispatch, this->container_type);
-    ValidationStateTracker *state_tracker = static_cast<ValidationStateTracker *>(validation_data);
+    ValidationStateTracker *device_state = static_cast<ValidationStateTracker *>(validation_data);
 
+    device_state->instance_state = this;
+    // Save local link to this device's physical device state
+    device_state->physical_device_state = Get<PHYSICAL_DEVICE_STATE>(gpu).get();
+    // finish setup in the object representing the device
+    device_state->CreateDevice(pCreateInfo);
+}
+
+void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     const VkPhysicalDeviceFeatures *enabled_features_found = pCreateInfo->pEnabledFeatures;
     if (nullptr == enabled_features_found) {
         const auto *features2 = LvlFindInChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
@@ -588,617 +589,599 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     }
 
     if (nullptr == enabled_features_found) {
-        state_tracker->enabled_features.core = {};
+        enabled_features.core = {};
     } else {
-        state_tracker->enabled_features.core = *enabled_features_found;
+        enabled_features.core = *enabled_features_found;
     }
-
-    // Save local link to this device's physical device state
-    state_tracker->physical_device_state = Get<PHYSICAL_DEVICE_STATE>(gpu).get();
 
     const auto *vulkan_13_features = LvlFindInChain<VkPhysicalDeviceVulkan13Features>(pCreateInfo->pNext);
     if (vulkan_13_features) {
-        state_tracker->enabled_features.core13 = *vulkan_13_features;
+        enabled_features.core13 = *vulkan_13_features;
     } else {
-        state_tracker->enabled_features.core13 = {};
+        enabled_features.core13 = {};
         const auto *image_robustness_features = LvlFindInChain<VkPhysicalDeviceImageRobustnessFeatures>(pCreateInfo->pNext);
         if (image_robustness_features) {
-            state_tracker->enabled_features.core13.robustImageAccess = image_robustness_features->robustImageAccess;
+            enabled_features.core13.robustImageAccess = image_robustness_features->robustImageAccess;
         }
 
         const auto *inline_uniform_block_features = LvlFindInChain<VkPhysicalDeviceInlineUniformBlockFeatures>(pCreateInfo->pNext);
         if (inline_uniform_block_features) {
-            state_tracker->enabled_features.core13.inlineUniformBlock = inline_uniform_block_features->inlineUniformBlock;
-            state_tracker->enabled_features.core13.descriptorBindingInlineUniformBlockUpdateAfterBind =
+            enabled_features.core13.inlineUniformBlock = inline_uniform_block_features->inlineUniformBlock;
+            enabled_features.core13.descriptorBindingInlineUniformBlockUpdateAfterBind =
                 inline_uniform_block_features->descriptorBindingInlineUniformBlockUpdateAfterBind;
         }
 
         const auto *pipeline_creation_cache_control_features =
             LvlFindInChain<VkPhysicalDevicePipelineCreationCacheControlFeatures>(pCreateInfo->pNext);
         if (pipeline_creation_cache_control_features) {
-            state_tracker->enabled_features.core13.pipelineCreationCacheControl =
+            enabled_features.core13.pipelineCreationCacheControl =
                 pipeline_creation_cache_control_features->pipelineCreationCacheControl;
         }
 
         const auto *private_data_features = LvlFindInChain<VkPhysicalDevicePrivateDataFeatures>(pCreateInfo->pNext);
         if (private_data_features) {
-            state_tracker->enabled_features.core13.privateData = private_data_features->privateData;
+            enabled_features.core13.privateData = private_data_features->privateData;
         }
 
         const auto *demote_to_helper_invocation_features =
             LvlFindInChain<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures>(pCreateInfo->pNext);
         if (demote_to_helper_invocation_features) {
-            state_tracker->enabled_features.core13.shaderDemoteToHelperInvocation =
+            enabled_features.core13.shaderDemoteToHelperInvocation =
                 demote_to_helper_invocation_features->shaderDemoteToHelperInvocation;
         }
 
         const auto *terminate_invocation_features =
             LvlFindInChain<VkPhysicalDeviceShaderTerminateInvocationFeatures>(pCreateInfo->pNext);
         if (terminate_invocation_features) {
-            state_tracker->enabled_features.core13.shaderTerminateInvocation =
-                terminate_invocation_features->shaderTerminateInvocation;
+            enabled_features.core13.shaderTerminateInvocation = terminate_invocation_features->shaderTerminateInvocation;
         }
 
         const auto *subgroup_size_control_features =
             LvlFindInChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(pCreateInfo->pNext);
         if (subgroup_size_control_features) {
-            state_tracker->enabled_features.core13.subgroupSizeControl = subgroup_size_control_features->subgroupSizeControl;
-            state_tracker->enabled_features.core13.computeFullSubgroups = subgroup_size_control_features->computeFullSubgroups;
+            enabled_features.core13.subgroupSizeControl = subgroup_size_control_features->subgroupSizeControl;
+            enabled_features.core13.computeFullSubgroups = subgroup_size_control_features->computeFullSubgroups;
         }
 
         const auto *synchronization2_features = LvlFindInChain<VkPhysicalDeviceSynchronization2Features>(pCreateInfo->pNext);
         if (synchronization2_features) {
-            state_tracker->enabled_features.core13.synchronization2 = synchronization2_features->synchronization2;
+            enabled_features.core13.synchronization2 = synchronization2_features->synchronization2;
         }
 
         const auto *texture_compression_astchdr_features =
             LvlFindInChain<VkPhysicalDeviceTextureCompressionASTCHDRFeatures>(pCreateInfo->pNext);
         if (texture_compression_astchdr_features) {
-            state_tracker->enabled_features.core13.textureCompressionASTC_HDR =
-                texture_compression_astchdr_features->textureCompressionASTC_HDR;
+            enabled_features.core13.textureCompressionASTC_HDR = texture_compression_astchdr_features->textureCompressionASTC_HDR;
         }
 
         const auto *initialize_workgroup_memory_features =
             LvlFindInChain<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>(pCreateInfo->pNext);
         if (initialize_workgroup_memory_features) {
-            state_tracker->enabled_features.core13.shaderZeroInitializeWorkgroupMemory =
+            enabled_features.core13.shaderZeroInitializeWorkgroupMemory =
                 initialize_workgroup_memory_features->shaderZeroInitializeWorkgroupMemory;
         }
 
         const auto *dynamic_rendering_features = LvlFindInChain<VkPhysicalDeviceDynamicRenderingFeatures>(pCreateInfo->pNext);
         if (dynamic_rendering_features) {
-            state_tracker->enabled_features.core13.dynamicRendering = dynamic_rendering_features->dynamicRendering;
+            enabled_features.core13.dynamicRendering = dynamic_rendering_features->dynamicRendering;
         }
 
         const auto *shader_integer_dot_product_features =
             LvlFindInChain<VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR>(pCreateInfo->pNext);
         if (shader_integer_dot_product_features) {
-            state_tracker->enabled_features.core13.shaderIntegerDotProduct =
-                shader_integer_dot_product_features->shaderIntegerDotProduct;
+            enabled_features.core13.shaderIntegerDotProduct = shader_integer_dot_product_features->shaderIntegerDotProduct;
         }
 
         const auto *maintenance4_features = LvlFindInChain<VkPhysicalDeviceMaintenance4FeaturesKHR>(pCreateInfo->pNext);
         if (maintenance4_features) {
-            state_tracker->enabled_features.core13.maintenance4 = maintenance4_features->maintenance4;
+            enabled_features.core13.maintenance4 = maintenance4_features->maintenance4;
         }
     }
 
     const auto *vulkan_12_features = LvlFindInChain<VkPhysicalDeviceVulkan12Features>(pCreateInfo->pNext);
     if (vulkan_12_features) {
-        state_tracker->enabled_features.core12 = *vulkan_12_features;
+        enabled_features.core12 = *vulkan_12_features;
     } else {
         // Set Extension Feature Aliases to false as there is no struct to check
-        state_tracker->enabled_features.core12.drawIndirectCount = VK_FALSE;
-        state_tracker->enabled_features.core12.samplerMirrorClampToEdge = VK_FALSE;
-        state_tracker->enabled_features.core12.descriptorIndexing = VK_FALSE;
-        state_tracker->enabled_features.core12.samplerFilterMinmax = VK_FALSE;
-        state_tracker->enabled_features.core12.shaderOutputLayer = VK_FALSE;
-        state_tracker->enabled_features.core12.shaderOutputViewportIndex = VK_FALSE;
-        state_tracker->enabled_features.core12.subgroupBroadcastDynamicId = VK_FALSE;
+        enabled_features.core12.drawIndirectCount = VK_FALSE;
+        enabled_features.core12.samplerMirrorClampToEdge = VK_FALSE;
+        enabled_features.core12.descriptorIndexing = VK_FALSE;
+        enabled_features.core12.samplerFilterMinmax = VK_FALSE;
+        enabled_features.core12.shaderOutputLayer = VK_FALSE;
+        enabled_features.core12.shaderOutputViewportIndex = VK_FALSE;
+        enabled_features.core12.subgroupBroadcastDynamicId = VK_FALSE;
 
         // These structs are only allowed in pNext chain if there is no VkPhysicalDeviceVulkan12Features
 
         const auto *eight_bit_storage_features = LvlFindInChain<VkPhysicalDevice8BitStorageFeatures>(pCreateInfo->pNext);
         if (eight_bit_storage_features) {
-            state_tracker->enabled_features.core12.storageBuffer8BitAccess = eight_bit_storage_features->storageBuffer8BitAccess;
-            state_tracker->enabled_features.core12.uniformAndStorageBuffer8BitAccess =
+            enabled_features.core12.storageBuffer8BitAccess = eight_bit_storage_features->storageBuffer8BitAccess;
+            enabled_features.core12.uniformAndStorageBuffer8BitAccess =
                 eight_bit_storage_features->uniformAndStorageBuffer8BitAccess;
-            state_tracker->enabled_features.core12.storagePushConstant8 = eight_bit_storage_features->storagePushConstant8;
+            enabled_features.core12.storagePushConstant8 = eight_bit_storage_features->storagePushConstant8;
         }
 
         const auto *float16_int8_features = LvlFindInChain<VkPhysicalDeviceShaderFloat16Int8Features>(pCreateInfo->pNext);
         if (float16_int8_features) {
-            state_tracker->enabled_features.core12.shaderFloat16 = float16_int8_features->shaderFloat16;
-            state_tracker->enabled_features.core12.shaderInt8 = float16_int8_features->shaderInt8;
+            enabled_features.core12.shaderFloat16 = float16_int8_features->shaderFloat16;
+            enabled_features.core12.shaderInt8 = float16_int8_features->shaderInt8;
         }
 
         const auto *descriptor_indexing_features = LvlFindInChain<VkPhysicalDeviceDescriptorIndexingFeatures>(pCreateInfo->pNext);
         if (descriptor_indexing_features) {
-            state_tracker->enabled_features.core12.shaderInputAttachmentArrayDynamicIndexing =
+            enabled_features.core12.shaderInputAttachmentArrayDynamicIndexing =
                 descriptor_indexing_features->shaderInputAttachmentArrayDynamicIndexing;
-            state_tracker->enabled_features.core12.shaderUniformTexelBufferArrayDynamicIndexing =
+            enabled_features.core12.shaderUniformTexelBufferArrayDynamicIndexing =
                 descriptor_indexing_features->shaderUniformTexelBufferArrayDynamicIndexing;
-            state_tracker->enabled_features.core12.shaderStorageTexelBufferArrayDynamicIndexing =
+            enabled_features.core12.shaderStorageTexelBufferArrayDynamicIndexing =
                 descriptor_indexing_features->shaderStorageTexelBufferArrayDynamicIndexing;
-            state_tracker->enabled_features.core12.shaderUniformBufferArrayNonUniformIndexing =
+            enabled_features.core12.shaderUniformBufferArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderUniformBufferArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderSampledImageArrayNonUniformIndexing =
+            enabled_features.core12.shaderSampledImageArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderSampledImageArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderStorageBufferArrayNonUniformIndexing =
+            enabled_features.core12.shaderStorageBufferArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderStorageBufferArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderStorageImageArrayNonUniformIndexing =
+            enabled_features.core12.shaderStorageImageArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderStorageImageArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderInputAttachmentArrayNonUniformIndexing =
+            enabled_features.core12.shaderInputAttachmentArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderInputAttachmentArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderUniformTexelBufferArrayNonUniformIndexing =
+            enabled_features.core12.shaderUniformTexelBufferArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderUniformTexelBufferArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.shaderStorageTexelBufferArrayNonUniformIndexing =
+            enabled_features.core12.shaderStorageTexelBufferArrayNonUniformIndexing =
                 descriptor_indexing_features->shaderStorageTexelBufferArrayNonUniformIndexing;
-            state_tracker->enabled_features.core12.descriptorBindingUniformBufferUpdateAfterBind =
+            enabled_features.core12.descriptorBindingUniformBufferUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingUniformBufferUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingSampledImageUpdateAfterBind =
+            enabled_features.core12.descriptorBindingSampledImageUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingSampledImageUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingStorageImageUpdateAfterBind =
+            enabled_features.core12.descriptorBindingStorageImageUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingStorageImageUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingStorageBufferUpdateAfterBind =
+            enabled_features.core12.descriptorBindingStorageBufferUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingStorageBufferUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingUniformTexelBufferUpdateAfterBind =
+            enabled_features.core12.descriptorBindingUniformTexelBufferUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingUniformTexelBufferUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingStorageTexelBufferUpdateAfterBind =
+            enabled_features.core12.descriptorBindingStorageTexelBufferUpdateAfterBind =
                 descriptor_indexing_features->descriptorBindingStorageTexelBufferUpdateAfterBind;
-            state_tracker->enabled_features.core12.descriptorBindingUpdateUnusedWhilePending =
+            enabled_features.core12.descriptorBindingUpdateUnusedWhilePending =
                 descriptor_indexing_features->descriptorBindingUpdateUnusedWhilePending;
-            state_tracker->enabled_features.core12.descriptorBindingPartiallyBound =
-                descriptor_indexing_features->descriptorBindingPartiallyBound;
-            state_tracker->enabled_features.core12.descriptorBindingVariableDescriptorCount =
+            enabled_features.core12.descriptorBindingPartiallyBound = descriptor_indexing_features->descriptorBindingPartiallyBound;
+            enabled_features.core12.descriptorBindingVariableDescriptorCount =
                 descriptor_indexing_features->descriptorBindingVariableDescriptorCount;
-            state_tracker->enabled_features.core12.runtimeDescriptorArray = descriptor_indexing_features->runtimeDescriptorArray;
+            enabled_features.core12.runtimeDescriptorArray = descriptor_indexing_features->runtimeDescriptorArray;
         }
 
         const auto *scalar_block_layout_features = LvlFindInChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(pCreateInfo->pNext);
         if (scalar_block_layout_features) {
-            state_tracker->enabled_features.core12.scalarBlockLayout = scalar_block_layout_features->scalarBlockLayout;
+            enabled_features.core12.scalarBlockLayout = scalar_block_layout_features->scalarBlockLayout;
         }
 
         const auto *imageless_framebuffer_features =
             LvlFindInChain<VkPhysicalDeviceImagelessFramebufferFeatures>(pCreateInfo->pNext);
         if (imageless_framebuffer_features) {
-            state_tracker->enabled_features.core12.imagelessFramebuffer = imageless_framebuffer_features->imagelessFramebuffer;
+            enabled_features.core12.imagelessFramebuffer = imageless_framebuffer_features->imagelessFramebuffer;
         }
 
         const auto *uniform_buffer_standard_layout_features =
             LvlFindInChain<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>(pCreateInfo->pNext);
         if (uniform_buffer_standard_layout_features) {
-            state_tracker->enabled_features.core12.uniformBufferStandardLayout =
+            enabled_features.core12.uniformBufferStandardLayout =
                 uniform_buffer_standard_layout_features->uniformBufferStandardLayout;
         }
 
         const auto *subgroup_extended_types_features =
             LvlFindInChain<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>(pCreateInfo->pNext);
         if (subgroup_extended_types_features) {
-            state_tracker->enabled_features.core12.shaderSubgroupExtendedTypes =
-                subgroup_extended_types_features->shaderSubgroupExtendedTypes;
+            enabled_features.core12.shaderSubgroupExtendedTypes = subgroup_extended_types_features->shaderSubgroupExtendedTypes;
         }
 
         const auto *separate_depth_stencil_layouts_features =
             LvlFindInChain<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>(pCreateInfo->pNext);
         if (separate_depth_stencil_layouts_features) {
-            state_tracker->enabled_features.core12.separateDepthStencilLayouts =
+            enabled_features.core12.separateDepthStencilLayouts =
                 separate_depth_stencil_layouts_features->separateDepthStencilLayouts;
         }
 
         const auto *host_query_reset_features = LvlFindInChain<VkPhysicalDeviceHostQueryResetFeatures>(pCreateInfo->pNext);
         if (host_query_reset_features) {
-            state_tracker->enabled_features.core12.hostQueryReset = host_query_reset_features->hostQueryReset;
+            enabled_features.core12.hostQueryReset = host_query_reset_features->hostQueryReset;
         }
 
         const auto *timeline_semaphore_features = LvlFindInChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(pCreateInfo->pNext);
         if (timeline_semaphore_features) {
-            state_tracker->enabled_features.core12.timelineSemaphore = timeline_semaphore_features->timelineSemaphore;
+            enabled_features.core12.timelineSemaphore = timeline_semaphore_features->timelineSemaphore;
         }
 
         const auto *buffer_device_address = LvlFindInChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(pCreateInfo->pNext);
         if (buffer_device_address) {
-            state_tracker->enabled_features.core12.bufferDeviceAddress = buffer_device_address->bufferDeviceAddress;
-            state_tracker->enabled_features.core12.bufferDeviceAddressCaptureReplay =
-                buffer_device_address->bufferDeviceAddressCaptureReplay;
-            state_tracker->enabled_features.core12.bufferDeviceAddressMultiDevice =
-                buffer_device_address->bufferDeviceAddressMultiDevice;
+            enabled_features.core12.bufferDeviceAddress = buffer_device_address->bufferDeviceAddress;
+            enabled_features.core12.bufferDeviceAddressCaptureReplay = buffer_device_address->bufferDeviceAddressCaptureReplay;
+            enabled_features.core12.bufferDeviceAddressMultiDevice = buffer_device_address->bufferDeviceAddressMultiDevice;
         }
 
         const auto *atomic_int64_features = LvlFindInChain<VkPhysicalDeviceShaderAtomicInt64Features>(pCreateInfo->pNext);
         if (atomic_int64_features) {
-            state_tracker->enabled_features.core12.shaderBufferInt64Atomics = atomic_int64_features->shaderBufferInt64Atomics;
-            state_tracker->enabled_features.core12.shaderSharedInt64Atomics = atomic_int64_features->shaderSharedInt64Atomics;
+            enabled_features.core12.shaderBufferInt64Atomics = atomic_int64_features->shaderBufferInt64Atomics;
+            enabled_features.core12.shaderSharedInt64Atomics = atomic_int64_features->shaderSharedInt64Atomics;
         }
 
         const auto *memory_model_features = LvlFindInChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(pCreateInfo->pNext);
         if (memory_model_features) {
-            state_tracker->enabled_features.core12.vulkanMemoryModel = memory_model_features->vulkanMemoryModel;
-            state_tracker->enabled_features.core12.vulkanMemoryModelDeviceScope =
-                memory_model_features->vulkanMemoryModelDeviceScope;
-            state_tracker->enabled_features.core12.vulkanMemoryModelAvailabilityVisibilityChains =
+            enabled_features.core12.vulkanMemoryModel = memory_model_features->vulkanMemoryModel;
+            enabled_features.core12.vulkanMemoryModelDeviceScope = memory_model_features->vulkanMemoryModelDeviceScope;
+            enabled_features.core12.vulkanMemoryModelAvailabilityVisibilityChains =
                 memory_model_features->vulkanMemoryModelAvailabilityVisibilityChains;
         }
     }
 
     const auto *vulkan_11_features = LvlFindInChain<VkPhysicalDeviceVulkan11Features>(pCreateInfo->pNext);
     if (vulkan_11_features) {
-        state_tracker->enabled_features.core11 = *vulkan_11_features;
+        enabled_features.core11 = *vulkan_11_features;
     } else {
         // These structs are only allowed in pNext chain if there is no vkPhysicalDeviceVulkan11Features
 
         const auto *sixteen_bit_storage_features = LvlFindInChain<VkPhysicalDevice16BitStorageFeatures>(pCreateInfo->pNext);
         if (sixteen_bit_storage_features) {
-            state_tracker->enabled_features.core11.storageBuffer16BitAccess =
-                sixteen_bit_storage_features->storageBuffer16BitAccess;
-            state_tracker->enabled_features.core11.uniformAndStorageBuffer16BitAccess =
+            enabled_features.core11.storageBuffer16BitAccess = sixteen_bit_storage_features->storageBuffer16BitAccess;
+            enabled_features.core11.uniformAndStorageBuffer16BitAccess =
                 sixteen_bit_storage_features->uniformAndStorageBuffer16BitAccess;
-            state_tracker->enabled_features.core11.storagePushConstant16 = sixteen_bit_storage_features->storagePushConstant16;
-            state_tracker->enabled_features.core11.storageInputOutput16 = sixteen_bit_storage_features->storageInputOutput16;
+            enabled_features.core11.storagePushConstant16 = sixteen_bit_storage_features->storagePushConstant16;
+            enabled_features.core11.storageInputOutput16 = sixteen_bit_storage_features->storageInputOutput16;
         }
 
         const auto *multiview_features = LvlFindInChain<VkPhysicalDeviceMultiviewFeatures>(pCreateInfo->pNext);
         if (multiview_features) {
-            state_tracker->enabled_features.core11.multiview = multiview_features->multiview;
-            state_tracker->enabled_features.core11.multiviewGeometryShader = multiview_features->multiviewGeometryShader;
-            state_tracker->enabled_features.core11.multiviewTessellationShader = multiview_features->multiviewTessellationShader;
+            enabled_features.core11.multiview = multiview_features->multiview;
+            enabled_features.core11.multiviewGeometryShader = multiview_features->multiviewGeometryShader;
+            enabled_features.core11.multiviewTessellationShader = multiview_features->multiviewTessellationShader;
         }
 
         const auto *variable_pointers_features = LvlFindInChain<VkPhysicalDeviceVariablePointersFeatures>(pCreateInfo->pNext);
         if (variable_pointers_features) {
-            state_tracker->enabled_features.core11.variablePointersStorageBuffer =
-                variable_pointers_features->variablePointersStorageBuffer;
-            state_tracker->enabled_features.core11.variablePointers = variable_pointers_features->variablePointers;
+            enabled_features.core11.variablePointersStorageBuffer = variable_pointers_features->variablePointersStorageBuffer;
+            enabled_features.core11.variablePointers = variable_pointers_features->variablePointers;
         }
 
         const auto *protected_memory_features = LvlFindInChain<VkPhysicalDeviceProtectedMemoryFeatures>(pCreateInfo->pNext);
         if (protected_memory_features) {
-            state_tracker->enabled_features.core11.protectedMemory = protected_memory_features->protectedMemory;
+            enabled_features.core11.protectedMemory = protected_memory_features->protectedMemory;
         }
 
         const auto *ycbcr_conversion_features = LvlFindInChain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(pCreateInfo->pNext);
         if (ycbcr_conversion_features) {
-            state_tracker->enabled_features.core11.samplerYcbcrConversion = ycbcr_conversion_features->samplerYcbcrConversion;
+            enabled_features.core11.samplerYcbcrConversion = ycbcr_conversion_features->samplerYcbcrConversion;
         }
 
         const auto *shader_draw_parameters_features =
             LvlFindInChain<VkPhysicalDeviceShaderDrawParametersFeatures>(pCreateInfo->pNext);
         if (shader_draw_parameters_features) {
-            state_tracker->enabled_features.core11.shaderDrawParameters = shader_draw_parameters_features->shaderDrawParameters;
+            enabled_features.core11.shaderDrawParameters = shader_draw_parameters_features->shaderDrawParameters;
         }
     }
 
     const auto *device_group_ci = LvlFindInChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);
     if (device_group_ci) {
-        state_tracker->physical_device_count = device_group_ci->physicalDeviceCount;
-        state_tracker->device_group_create_info = *device_group_ci;
+        physical_device_count = device_group_ci->physicalDeviceCount;
+        device_group_create_info = *device_group_ci;
     } else {
-        state_tracker->physical_device_count = 1;
+        physical_device_count = 1;
     }
 
     // Features from other extensions passesd in create info
     {
         const auto *exclusive_scissor_features = LvlFindInChain<VkPhysicalDeviceExclusiveScissorFeaturesNV>(pCreateInfo->pNext);
         if (exclusive_scissor_features) {
-            state_tracker->enabled_features.exclusive_scissor_features = *exclusive_scissor_features;
+            enabled_features.exclusive_scissor_features = *exclusive_scissor_features;
         }
 
         const auto *shading_rate_image_features = LvlFindInChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(pCreateInfo->pNext);
         if (shading_rate_image_features) {
-            state_tracker->enabled_features.shading_rate_image_features = *shading_rate_image_features;
+            enabled_features.shading_rate_image_features = *shading_rate_image_features;
         }
 
         const auto *mesh_shader_features = LvlFindInChain<VkPhysicalDeviceMeshShaderFeaturesNV>(pCreateInfo->pNext);
         if (mesh_shader_features) {
-            state_tracker->enabled_features.mesh_shader_features = *mesh_shader_features;
+            enabled_features.mesh_shader_features = *mesh_shader_features;
         }
 
         const auto *transform_feedback_features = LvlFindInChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(pCreateInfo->pNext);
         if (transform_feedback_features) {
-            state_tracker->enabled_features.transform_feedback_features = *transform_feedback_features;
+            enabled_features.transform_feedback_features = *transform_feedback_features;
         }
 
         const auto *vtx_attrib_div_features = LvlFindInChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>(pCreateInfo->pNext);
         if (vtx_attrib_div_features) {
-            state_tracker->enabled_features.vtx_attrib_divisor_features = *vtx_attrib_div_features;
+            enabled_features.vtx_attrib_divisor_features = *vtx_attrib_div_features;
         }
 
         const auto *buffer_device_address_ext_features =
             LvlFindInChain<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT>(pCreateInfo->pNext);
         if (buffer_device_address_ext_features) {
-            state_tracker->enabled_features.buffer_device_address_ext_features = *buffer_device_address_ext_features;
+            enabled_features.buffer_device_address_ext_features = *buffer_device_address_ext_features;
         }
 
         const auto *cooperative_matrix_features = LvlFindInChain<VkPhysicalDeviceCooperativeMatrixFeaturesNV>(pCreateInfo->pNext);
         if (cooperative_matrix_features) {
-            state_tracker->enabled_features.cooperative_matrix_features = *cooperative_matrix_features;
+            enabled_features.cooperative_matrix_features = *cooperative_matrix_features;
         }
 
         const auto *compute_shader_derivatives_features =
             LvlFindInChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>(pCreateInfo->pNext);
         if (compute_shader_derivatives_features) {
-            state_tracker->enabled_features.compute_shader_derivatives_features = *compute_shader_derivatives_features;
+            enabled_features.compute_shader_derivatives_features = *compute_shader_derivatives_features;
         }
 
         const auto *fragment_shader_barycentric_features =
             LvlFindInChain<VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV>(pCreateInfo->pNext);
         if (fragment_shader_barycentric_features) {
-            state_tracker->enabled_features.fragment_shader_barycentric_features = *fragment_shader_barycentric_features;
+            enabled_features.fragment_shader_barycentric_features = *fragment_shader_barycentric_features;
         }
 
         const auto *shader_image_footprint_features =
             LvlFindInChain<VkPhysicalDeviceShaderImageFootprintFeaturesNV>(pCreateInfo->pNext);
         if (shader_image_footprint_features) {
-            state_tracker->enabled_features.shader_image_footprint_features = *shader_image_footprint_features;
+            enabled_features.shader_image_footprint_features = *shader_image_footprint_features;
         }
 
         const auto *fragment_shader_interlock_features =
             LvlFindInChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(pCreateInfo->pNext);
         if (fragment_shader_interlock_features) {
-            state_tracker->enabled_features.fragment_shader_interlock_features = *fragment_shader_interlock_features;
+            enabled_features.fragment_shader_interlock_features = *fragment_shader_interlock_features;
         }
 
         const auto *texel_buffer_alignment_features =
             LvlFindInChain<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>(pCreateInfo->pNext);
         if (texel_buffer_alignment_features) {
-            state_tracker->enabled_features.texel_buffer_alignment_features = *texel_buffer_alignment_features;
+            enabled_features.texel_buffer_alignment_features = *texel_buffer_alignment_features;
         }
 
         const auto *pipeline_exe_props_features =
             LvlFindInChain<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>(pCreateInfo->pNext);
         if (pipeline_exe_props_features) {
-            state_tracker->enabled_features.pipeline_exe_props_features = *pipeline_exe_props_features;
+            enabled_features.pipeline_exe_props_features = *pipeline_exe_props_features;
         }
 
         const auto *dedicated_allocation_image_aliasing_features =
             LvlFindInChain<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>(pCreateInfo->pNext);
         if (dedicated_allocation_image_aliasing_features) {
-            state_tracker->enabled_features.dedicated_allocation_image_aliasing_features =
-                *dedicated_allocation_image_aliasing_features;
+            enabled_features.dedicated_allocation_image_aliasing_features = *dedicated_allocation_image_aliasing_features;
         }
 
         const auto *performance_query_features = LvlFindInChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(pCreateInfo->pNext);
         if (performance_query_features) {
-            state_tracker->enabled_features.performance_query_features = *performance_query_features;
+            enabled_features.performance_query_features = *performance_query_features;
         }
 
         const auto *device_coherent_memory_features = LvlFindInChain<VkPhysicalDeviceCoherentMemoryFeaturesAMD>(pCreateInfo->pNext);
         if (device_coherent_memory_features) {
-            state_tracker->enabled_features.device_coherent_memory_features = *device_coherent_memory_features;
+            enabled_features.device_coherent_memory_features = *device_coherent_memory_features;
         }
 
         const auto *ycbcr_image_array_features = LvlFindInChain<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>(pCreateInfo->pNext);
         if (ycbcr_image_array_features) {
-            state_tracker->enabled_features.ycbcr_image_array_features = *ycbcr_image_array_features;
+            enabled_features.ycbcr_image_array_features = *ycbcr_image_array_features;
         }
 
         const auto *ray_query_features = LvlFindInChain<VkPhysicalDeviceRayQueryFeaturesKHR>(pCreateInfo->pNext);
         if (ray_query_features) {
-            state_tracker->enabled_features.ray_query_features = *ray_query_features;
+            enabled_features.ray_query_features = *ray_query_features;
         }
 
         const auto *ray_tracing_pipeline_features =
             LvlFindInChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(pCreateInfo->pNext);
         if (ray_tracing_pipeline_features) {
-            state_tracker->enabled_features.ray_tracing_pipeline_features = *ray_tracing_pipeline_features;
+            enabled_features.ray_tracing_pipeline_features = *ray_tracing_pipeline_features;
         }
 
         const auto *ray_tracing_acceleration_structure_features =
             LvlFindInChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(pCreateInfo->pNext);
         if (ray_tracing_acceleration_structure_features) {
-            state_tracker->enabled_features.ray_tracing_acceleration_structure_features =
-                *ray_tracing_acceleration_structure_features;
+            enabled_features.ray_tracing_acceleration_structure_features = *ray_tracing_acceleration_structure_features;
         }
 
         const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(pCreateInfo->pNext);
         if (robustness2_features) {
-            state_tracker->enabled_features.robustness2_features = *robustness2_features;
+            enabled_features.robustness2_features = *robustness2_features;
         }
 
         const auto *fragment_density_map_features =
             LvlFindInChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(pCreateInfo->pNext);
         if (fragment_density_map_features) {
-            state_tracker->enabled_features.fragment_density_map_features = *fragment_density_map_features;
+            enabled_features.fragment_density_map_features = *fragment_density_map_features;
         }
 
         const auto *fragment_density_map_features2 =
             LvlFindInChain<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>(pCreateInfo->pNext);
         if (fragment_density_map_features2) {
-            state_tracker->enabled_features.fragment_density_map2_features = *fragment_density_map_features2;
+            enabled_features.fragment_density_map2_features = *fragment_density_map_features2;
         }
 
         const auto *fragment_density_map_offset_features =
             LvlFindInChain<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM>(pCreateInfo->pNext);
         if (fragment_density_map_offset_features) {
-            state_tracker->enabled_features.fragment_density_map_offset_features = *fragment_density_map_offset_features;
+            enabled_features.fragment_density_map_offset_features = *fragment_density_map_offset_features;
         }
 
         const auto *astc_decode_features = LvlFindInChain<VkPhysicalDeviceASTCDecodeFeaturesEXT>(pCreateInfo->pNext);
         if (astc_decode_features) {
-            state_tracker->enabled_features.astc_decode_features = *astc_decode_features;
+            enabled_features.astc_decode_features = *astc_decode_features;
         }
 
         const auto *custom_border_color_features = LvlFindInChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(pCreateInfo->pNext);
         if (custom_border_color_features) {
-            state_tracker->enabled_features.custom_border_color_features = *custom_border_color_features;
+            enabled_features.custom_border_color_features = *custom_border_color_features;
         }
 
         const auto *fragment_shading_rate_features =
             LvlFindInChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(pCreateInfo->pNext);
         if (fragment_shading_rate_features) {
-            state_tracker->enabled_features.fragment_shading_rate_features = *fragment_shading_rate_features;
+            enabled_features.fragment_shading_rate_features = *fragment_shading_rate_features;
         }
 
         const auto *extended_dynamic_state_features =
             LvlFindInChain<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(pCreateInfo->pNext);
         if (extended_dynamic_state_features) {
-            state_tracker->enabled_features.extended_dynamic_state_features = *extended_dynamic_state_features;
+            enabled_features.extended_dynamic_state_features = *extended_dynamic_state_features;
         }
 
         const auto *extended_dynamic_state2_features =
             LvlFindInChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(pCreateInfo->pNext);
         if (extended_dynamic_state2_features) {
-            state_tracker->enabled_features.extended_dynamic_state2_features = *extended_dynamic_state2_features;
+            enabled_features.extended_dynamic_state2_features = *extended_dynamic_state2_features;
         }
 
         const auto *multiview_features = LvlFindInChain<VkPhysicalDeviceMultiviewFeatures>(pCreateInfo->pNext);
         if (multiview_features) {
-            state_tracker->enabled_features.multiview_features = *multiview_features;
+            enabled_features.multiview_features = *multiview_features;
         }
 
         const auto *portability_features = LvlFindInChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(pCreateInfo->pNext);
         if (portability_features) {
-            state_tracker->enabled_features.portability_subset_features = *portability_features;
+            enabled_features.portability_subset_features = *portability_features;
         }
 
         const auto *shader_integer_functions2_features =
             LvlFindInChain<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>(pCreateInfo->pNext);
         if (shader_integer_functions2_features) {
-            state_tracker->enabled_features.shader_integer_functions2_features = *shader_integer_functions2_features;
+            enabled_features.shader_integer_functions2_features = *shader_integer_functions2_features;
         }
 
         const auto *shader_sm_builtins_features = LvlFindInChain<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>(pCreateInfo->pNext);
         if (shader_sm_builtins_features) {
-            state_tracker->enabled_features.shader_sm_builtins_features = *shader_sm_builtins_features;
+            enabled_features.shader_sm_builtins_features = *shader_sm_builtins_features;
         }
 
         const auto *shader_atomic_float_features = LvlFindInChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(pCreateInfo->pNext);
         if (shader_atomic_float_features) {
-            state_tracker->enabled_features.shader_atomic_float_features = *shader_atomic_float_features;
+            enabled_features.shader_atomic_float_features = *shader_atomic_float_features;
         }
 
         const auto *shader_image_atomic_int64_features =
             LvlFindInChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(pCreateInfo->pNext);
         if (shader_image_atomic_int64_features) {
-            state_tracker->enabled_features.shader_image_atomic_int64_features = *shader_image_atomic_int64_features;
+            enabled_features.shader_image_atomic_int64_features = *shader_image_atomic_int64_features;
         }
 
         const auto *shader_clock_features = LvlFindInChain<VkPhysicalDeviceShaderClockFeaturesKHR>(pCreateInfo->pNext);
         if (shader_clock_features) {
-            state_tracker->enabled_features.shader_clock_features = *shader_clock_features;
+            enabled_features.shader_clock_features = *shader_clock_features;
         }
 
         const auto *conditional_rendering_features =
             LvlFindInChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(pCreateInfo->pNext);
         if (conditional_rendering_features) {
-            state_tracker->enabled_features.conditional_rendering_features = *conditional_rendering_features;
+            enabled_features.conditional_rendering_features = *conditional_rendering_features;
         }
 
         const auto *workgroup_memory_explicit_layout_features =
             LvlFindInChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(pCreateInfo->pNext);
         if (workgroup_memory_explicit_layout_features) {
-            state_tracker->enabled_features.workgroup_memory_explicit_layout_features = *workgroup_memory_explicit_layout_features;
+            enabled_features.workgroup_memory_explicit_layout_features = *workgroup_memory_explicit_layout_features;
         }
 
         const auto *provoking_vertex_features = lvl_find_in_chain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(pCreateInfo->pNext);
         if (provoking_vertex_features) {
-            state_tracker->enabled_features.provoking_vertex_features = *provoking_vertex_features;
+            enabled_features.provoking_vertex_features = *provoking_vertex_features;
         }
 
         const auto *vertex_input_dynamic_state_features =
             LvlFindInChain<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(pCreateInfo->pNext);
         if (vertex_input_dynamic_state_features) {
-            state_tracker->enabled_features.vertex_input_dynamic_state_features = *vertex_input_dynamic_state_features;
+            enabled_features.vertex_input_dynamic_state_features = *vertex_input_dynamic_state_features;
         }
 
         const auto *inherited_viewport_scissor_features =
             LvlFindInChain<VkPhysicalDeviceInheritedViewportScissorFeaturesNV>(pCreateInfo->pNext);
         if (inherited_viewport_scissor_features) {
-            state_tracker->enabled_features.inherited_viewport_scissor_features = *inherited_viewport_scissor_features;
+            enabled_features.inherited_viewport_scissor_features = *inherited_viewport_scissor_features;
         }
 
         const auto *multi_draw_features = LvlFindInChain<VkPhysicalDeviceMultiDrawFeaturesEXT>(pCreateInfo->pNext);
         if (multi_draw_features) {
-            state_tracker->enabled_features.multi_draw_features = *multi_draw_features;
+            enabled_features.multi_draw_features = *multi_draw_features;
         }
 
         const auto *color_write_features = LvlFindInChain<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(pCreateInfo->pNext);
         if (color_write_features) {
-            state_tracker->enabled_features.color_write_features = *color_write_features;
+            enabled_features.color_write_features = *color_write_features;
         }
 
         const auto *shader_atomic_float2_features =
             LvlFindInChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(pCreateInfo->pNext);
         if (shader_atomic_float2_features) {
-            state_tracker->enabled_features.shader_atomic_float2_features = *shader_atomic_float2_features;
+            enabled_features.shader_atomic_float2_features = *shader_atomic_float2_features;
         }
 
         const auto *present_id_features = LvlFindInChain<VkPhysicalDevicePresentIdFeaturesKHR>(pCreateInfo->pNext);
         if (present_id_features) {
-            state_tracker->enabled_features.present_id_features = *present_id_features;
+            enabled_features.present_id_features = *present_id_features;
         }
 
         const auto *present_wait_features = LvlFindInChain<VkPhysicalDevicePresentWaitFeaturesKHR>(pCreateInfo->pNext);
         if (present_wait_features) {
-            state_tracker->enabled_features.present_wait_features = *present_wait_features;
+            enabled_features.present_wait_features = *present_wait_features;
         }
 
         const auto *ray_tracing_motion_blur_features =
             LvlFindInChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(pCreateInfo->pNext);
         if (ray_tracing_motion_blur_features) {
-            state_tracker->enabled_features.ray_tracing_motion_blur_features = *ray_tracing_motion_blur_features;
+            enabled_features.ray_tracing_motion_blur_features = *ray_tracing_motion_blur_features;
         }
 
         const auto *primitive_topology_list_restart_features =
             LvlFindInChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(pCreateInfo->pNext);
         if (primitive_topology_list_restart_features) {
-            state_tracker->enabled_features.primitive_topology_list_restart_features = *primitive_topology_list_restart_features;
+            enabled_features.primitive_topology_list_restart_features = *primitive_topology_list_restart_features;
         }
 
         const auto *zero_initialize_work_group_memory_features =
             LvlFindInChain<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR>(pCreateInfo->pNext);
         if (zero_initialize_work_group_memory_features) {
-            state_tracker->enabled_features.zero_initialize_work_group_memory_features =
-                *zero_initialize_work_group_memory_features;
+            enabled_features.zero_initialize_work_group_memory_features = *zero_initialize_work_group_memory_features;
         }
 
         const auto *rgba10x6_formats_features = LvlFindInChain<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT>(pCreateInfo->pNext);
         if (rgba10x6_formats_features) {
-            state_tracker->enabled_features.rgba10x6_formats_features = *rgba10x6_formats_features;
+            enabled_features.rgba10x6_formats_features = *rgba10x6_formats_features;
         }
 
         const auto *image_view_min_lod_features = LvlFindInChain<VkPhysicalDeviceImageViewMinLodFeaturesEXT>(pCreateInfo->pNext);
         if (image_view_min_lod_features) {
-            state_tracker->enabled_features.image_view_min_lod_features = *image_view_min_lod_features;
+            enabled_features.image_view_min_lod_features = *image_view_min_lod_features;
         }
     }
 
     // Store physical device properties and physical device mem limits into CoreChecks structs
-    DispatchGetPhysicalDeviceMemoryProperties(gpu, &state_tracker->phys_dev_mem_props);
-    DispatchGetPhysicalDeviceProperties(gpu, &state_tracker->phys_dev_props);
+    DispatchGetPhysicalDeviceMemoryProperties(physical_device, &phys_dev_mem_props);
+    DispatchGetPhysicalDeviceProperties(physical_device, &phys_dev_props);
 
     {
         uint32_t n_props = 0;
         std::vector<VkExtensionProperties> props;
-        instance_dispatch_table.EnumerateDeviceExtensionProperties(gpu, NULL, &n_props, NULL);
+        instance_dispatch_table.EnumerateDeviceExtensionProperties(physical_device, NULL, &n_props, NULL);
         props.resize(n_props);
-        instance_dispatch_table.EnumerateDeviceExtensionProperties(gpu, NULL, &n_props, props.data());
+        instance_dispatch_table.EnumerateDeviceExtensionProperties(physical_device, NULL, &n_props, props.data());
 
         for (const auto &ext_prop : props) {
-            state_tracker->phys_dev_extensions.insert(ext_prop.extensionName);
+            phys_dev_extensions.insert(ext_prop.extensionName);
         }
 
         // Even if VK_KHR_format_feature_flags2 is available, we need to have
         // a path to grab that information from the physical device. This
         // requires to have VK_KHR_get_physical_device_properties2 enabled or
         // Vulkan 1.1 (which made this core).
-        state_tracker->has_format_feature2 =
-            (state_tracker->api_version >= VK_API_VERSION_1_1 ||
-             IsExtEnabled(state_tracker->instance_extensions.vk_khr_get_physical_device_properties2)) &&
-            state_tracker->phys_dev_extensions.find(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME) !=
-            state_tracker->phys_dev_extensions.end();
+        has_format_feature2 =
+            (api_version >= VK_API_VERSION_1_1 || IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) &&
+            phys_dev_extensions.find(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME) != phys_dev_extensions.end();
     }
 
-    const auto &dev_ext = state_tracker->device_extensions;
-    auto *phys_dev_props = &state_tracker->phys_dev_ext_props;
+    const auto &dev_ext = device_extensions;
+    auto *phys_dev_props = &phys_dev_ext_props;
 
     // Vulkan 1.2 / 1.3 can get properties from single struct, otherwise need to add to it per extension
     if (dev_ext.vk_feature_version_1_2 || dev_ext.vk_feature_version_1_3) {
-        GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_feature_version_1_2, &state_tracker->phys_dev_props_core11);
-        GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_feature_version_1_2, &state_tracker->phys_dev_props_core12);
+        GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_2, &phys_dev_props_core11);
+        GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_2, &phys_dev_props_core12);
         if (dev_ext.vk_feature_version_1_3)
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_feature_version_1_3, &state_tracker->phys_dev_props_core13);
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_3, &phys_dev_props_core13);
     } else {
         // VkPhysicalDeviceVulkan11Properties
         //
@@ -1206,31 +1189,31 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
 
         if (dev_ext.vk_khr_multiview) {
             auto multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_multiview, &multiview_props);
-            state_tracker->phys_dev_props_core11.maxMultiviewViewCount = multiview_props.maxMultiviewViewCount;
-            state_tracker->phys_dev_props_core11.maxMultiviewInstanceIndex = multiview_props.maxMultiviewInstanceIndex;
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_multiview, &multiview_props);
+            phys_dev_props_core11.maxMultiviewViewCount = multiview_props.maxMultiviewViewCount;
+            phys_dev_props_core11.maxMultiviewInstanceIndex = multiview_props.maxMultiviewInstanceIndex;
         }
 
         if (dev_ext.vk_khr_maintenance3) {
             auto maintenance3_props = LvlInitStruct<VkPhysicalDeviceMaintenance3Properties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_maintenance3, &maintenance3_props);
-            state_tracker->phys_dev_props_core11.maxPerSetDescriptors = maintenance3_props.maxPerSetDescriptors;
-            state_tracker->phys_dev_props_core11.maxMemoryAllocationSize = maintenance3_props.maxMemoryAllocationSize;
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_maintenance3, &maintenance3_props);
+            phys_dev_props_core11.maxPerSetDescriptors = maintenance3_props.maxPerSetDescriptors;
+            phys_dev_props_core11.maxMemoryAllocationSize = maintenance3_props.maxMemoryAllocationSize;
         }
 
         // Some 1.1 properties were added to core without previous extensions
-        if (state_tracker->api_version >= VK_API_VERSION_1_1) {
+        if (api_version >= VK_API_VERSION_1_1) {
             auto subgroup_prop = LvlInitStruct<VkPhysicalDeviceSubgroupProperties>();
             auto protected_memory_prop = LvlInitStruct<VkPhysicalDeviceProtectedMemoryProperties>(&subgroup_prop);
             auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&protected_memory_prop);
-            instance_dispatch_table.GetPhysicalDeviceProperties2(gpu, &prop2);
+            instance_dispatch_table.GetPhysicalDeviceProperties2(physical_device, &prop2);
 
-            state_tracker->phys_dev_props_core11.subgroupSize = subgroup_prop.subgroupSize;
-            state_tracker->phys_dev_props_core11.subgroupSupportedStages = subgroup_prop.supportedStages;
-            state_tracker->phys_dev_props_core11.subgroupSupportedOperations = subgroup_prop.supportedOperations;
-            state_tracker->phys_dev_props_core11.subgroupQuadOperationsInAllStages = subgroup_prop.quadOperationsInAllStages;
+            phys_dev_props_core11.subgroupSize = subgroup_prop.subgroupSize;
+            phys_dev_props_core11.subgroupSupportedStages = subgroup_prop.supportedStages;
+            phys_dev_props_core11.subgroupSupportedOperations = subgroup_prop.supportedOperations;
+            phys_dev_props_core11.subgroupQuadOperationsInAllStages = subgroup_prop.quadOperationsInAllStages;
 
-            state_tracker->phys_dev_props_core11.protectedNoFault = protected_memory_prop.protectedNoFault;
+            phys_dev_props_core11.protectedNoFault = protected_memory_prop.protectedNoFault;
         }
 
         // VkPhysicalDeviceVulkan12Properties
@@ -1239,163 +1222,165 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
 
         if (dev_ext.vk_ext_descriptor_indexing) {
             auto descriptor_indexing_prop = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_descriptor_indexing, &descriptor_indexing_prop);
-            state_tracker->phys_dev_props_core12.maxUpdateAfterBindDescriptorsInAllPools =
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_descriptor_indexing, &descriptor_indexing_prop);
+            phys_dev_props_core12.maxUpdateAfterBindDescriptorsInAllPools =
                 descriptor_indexing_prop.maxUpdateAfterBindDescriptorsInAllPools;
-            state_tracker->phys_dev_props_core12.shaderUniformBufferArrayNonUniformIndexingNative =
+            phys_dev_props_core12.shaderUniformBufferArrayNonUniformIndexingNative =
                 descriptor_indexing_prop.shaderUniformBufferArrayNonUniformIndexingNative;
-            state_tracker->phys_dev_props_core12.shaderSampledImageArrayNonUniformIndexingNative =
+            phys_dev_props_core12.shaderSampledImageArrayNonUniformIndexingNative =
                 descriptor_indexing_prop.shaderSampledImageArrayNonUniformIndexingNative;
-            state_tracker->phys_dev_props_core12.shaderStorageBufferArrayNonUniformIndexingNative =
+            phys_dev_props_core12.shaderStorageBufferArrayNonUniformIndexingNative =
                 descriptor_indexing_prop.shaderStorageBufferArrayNonUniformIndexingNative;
-            state_tracker->phys_dev_props_core12.shaderStorageImageArrayNonUniformIndexingNative =
+            phys_dev_props_core12.shaderStorageImageArrayNonUniformIndexingNative =
                 descriptor_indexing_prop.shaderStorageImageArrayNonUniformIndexingNative;
-            state_tracker->phys_dev_props_core12.shaderInputAttachmentArrayNonUniformIndexingNative =
+            phys_dev_props_core12.shaderInputAttachmentArrayNonUniformIndexingNative =
                 descriptor_indexing_prop.shaderInputAttachmentArrayNonUniformIndexingNative;
-            state_tracker->phys_dev_props_core12.robustBufferAccessUpdateAfterBind =
-                descriptor_indexing_prop.robustBufferAccessUpdateAfterBind;
-            state_tracker->phys_dev_props_core12.quadDivergentImplicitLod = descriptor_indexing_prop.quadDivergentImplicitLod;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindSamplers =
+            phys_dev_props_core12.robustBufferAccessUpdateAfterBind = descriptor_indexing_prop.robustBufferAccessUpdateAfterBind;
+            phys_dev_props_core12.quadDivergentImplicitLod = descriptor_indexing_prop.quadDivergentImplicitLod;
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindSamplers =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindSamplers;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindUniformBuffers =
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindUniformBuffers =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindUniformBuffers;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindStorageBuffers =
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindStorageBuffers =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindStorageBuffers;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindSampledImages =
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindSampledImages =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindSampledImages;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindStorageImages =
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindStorageImages =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindStorageImages;
-            state_tracker->phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindInputAttachments =
+            phys_dev_props_core12.maxPerStageDescriptorUpdateAfterBindInputAttachments =
                 descriptor_indexing_prop.maxPerStageDescriptorUpdateAfterBindInputAttachments;
-            state_tracker->phys_dev_props_core12.maxPerStageUpdateAfterBindResources =
+            phys_dev_props_core12.maxPerStageUpdateAfterBindResources =
                 descriptor_indexing_prop.maxPerStageUpdateAfterBindResources;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindSamplers =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindSamplers =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindSamplers;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindUniformBuffers =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindUniformBuffers =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindUniformBuffers;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageBuffers =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageBuffers =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindStorageBuffers;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindSampledImages =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindSampledImages =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindSampledImages;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageImages =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindStorageImages =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindStorageImages;
-            state_tracker->phys_dev_props_core12.maxDescriptorSetUpdateAfterBindInputAttachments =
+            phys_dev_props_core12.maxDescriptorSetUpdateAfterBindInputAttachments =
                 descriptor_indexing_prop.maxDescriptorSetUpdateAfterBindInputAttachments;
         }
 
         if (dev_ext.vk_khr_depth_stencil_resolve) {
             auto depth_stencil_resolve_props = LvlInitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_depth_stencil_resolve, &depth_stencil_resolve_props);
-            state_tracker->phys_dev_props_core12.supportedDepthResolveModes =
-                depth_stencil_resolve_props.supportedDepthResolveModes;
-            state_tracker->phys_dev_props_core12.supportedStencilResolveModes =
-                depth_stencil_resolve_props.supportedStencilResolveModes;
-            state_tracker->phys_dev_props_core12.independentResolveNone = depth_stencil_resolve_props.independentResolveNone;
-            state_tracker->phys_dev_props_core12.independentResolve = depth_stencil_resolve_props.independentResolve;
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_depth_stencil_resolve, &depth_stencil_resolve_props);
+            phys_dev_props_core12.supportedDepthResolveModes = depth_stencil_resolve_props.supportedDepthResolveModes;
+            phys_dev_props_core12.supportedStencilResolveModes = depth_stencil_resolve_props.supportedStencilResolveModes;
+            phys_dev_props_core12.independentResolveNone = depth_stencil_resolve_props.independentResolveNone;
+            phys_dev_props_core12.independentResolve = depth_stencil_resolve_props.independentResolve;
         }
 
         if (dev_ext.vk_khr_timeline_semaphore) {
             auto timeline_semaphore_props = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_timeline_semaphore, &timeline_semaphore_props);
-            state_tracker->phys_dev_props_core12.maxTimelineSemaphoreValueDifference =
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_timeline_semaphore, &timeline_semaphore_props);
+            phys_dev_props_core12.maxTimelineSemaphoreValueDifference =
                 timeline_semaphore_props.maxTimelineSemaphoreValueDifference;
         }
 
         if (dev_ext.vk_ext_sampler_filter_minmax) {
             auto sampler_filter_minmax_props = LvlInitStruct<VkPhysicalDeviceSamplerFilterMinmaxProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_sampler_filter_minmax, &sampler_filter_minmax_props);
-            state_tracker->phys_dev_props_core12.filterMinmaxSingleComponentFormats =
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_sampler_filter_minmax, &sampler_filter_minmax_props);
+            phys_dev_props_core12.filterMinmaxSingleComponentFormats =
                 sampler_filter_minmax_props.filterMinmaxSingleComponentFormats;
-            state_tracker->phys_dev_props_core12.filterMinmaxImageComponentMapping =
-                sampler_filter_minmax_props.filterMinmaxImageComponentMapping;
+            phys_dev_props_core12.filterMinmaxImageComponentMapping = sampler_filter_minmax_props.filterMinmaxImageComponentMapping;
         }
 
         if (dev_ext.vk_khr_shader_float_controls) {
             auto float_controls_props = LvlInitStruct<VkPhysicalDeviceFloatControlsProperties>();
-            GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_shader_float_controls, &float_controls_props);
-            state_tracker->phys_dev_props_core12.denormBehaviorIndependence = float_controls_props.denormBehaviorIndependence;
-            state_tracker->phys_dev_props_core12.roundingModeIndependence = float_controls_props.roundingModeIndependence;
-            state_tracker->phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat16 =
+            GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_shader_float_controls, &float_controls_props);
+            phys_dev_props_core12.denormBehaviorIndependence = float_controls_props.denormBehaviorIndependence;
+            phys_dev_props_core12.roundingModeIndependence = float_controls_props.roundingModeIndependence;
+            phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat16 =
                 float_controls_props.shaderSignedZeroInfNanPreserveFloat16;
-            state_tracker->phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat32 =
+            phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat32 =
                 float_controls_props.shaderSignedZeroInfNanPreserveFloat32;
-            state_tracker->phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat64 =
+            phys_dev_props_core12.shaderSignedZeroInfNanPreserveFloat64 =
                 float_controls_props.shaderSignedZeroInfNanPreserveFloat64;
-            state_tracker->phys_dev_props_core12.shaderDenormPreserveFloat16 = float_controls_props.shaderDenormPreserveFloat16;
-            state_tracker->phys_dev_props_core12.shaderDenormPreserveFloat32 = float_controls_props.shaderDenormPreserveFloat32;
-            state_tracker->phys_dev_props_core12.shaderDenormPreserveFloat64 = float_controls_props.shaderDenormPreserveFloat64;
-            state_tracker->phys_dev_props_core12.shaderDenormFlushToZeroFloat16 =
-                float_controls_props.shaderDenormFlushToZeroFloat16;
-            state_tracker->phys_dev_props_core12.shaderDenormFlushToZeroFloat32 =
-                float_controls_props.shaderDenormFlushToZeroFloat32;
-            state_tracker->phys_dev_props_core12.shaderDenormFlushToZeroFloat64 =
-                float_controls_props.shaderDenormFlushToZeroFloat64;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTEFloat16 = float_controls_props.shaderRoundingModeRTEFloat16;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTEFloat32 = float_controls_props.shaderRoundingModeRTEFloat32;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTEFloat64 = float_controls_props.shaderRoundingModeRTEFloat64;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTZFloat16 = float_controls_props.shaderRoundingModeRTZFloat16;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTZFloat32 = float_controls_props.shaderRoundingModeRTZFloat32;
-            state_tracker->phys_dev_props_core12.shaderRoundingModeRTZFloat64 = float_controls_props.shaderRoundingModeRTZFloat64;
+            phys_dev_props_core12.shaderDenormPreserveFloat16 = float_controls_props.shaderDenormPreserveFloat16;
+            phys_dev_props_core12.shaderDenormPreserveFloat32 = float_controls_props.shaderDenormPreserveFloat32;
+            phys_dev_props_core12.shaderDenormPreserveFloat64 = float_controls_props.shaderDenormPreserveFloat64;
+            phys_dev_props_core12.shaderDenormFlushToZeroFloat16 = float_controls_props.shaderDenormFlushToZeroFloat16;
+            phys_dev_props_core12.shaderDenormFlushToZeroFloat32 = float_controls_props.shaderDenormFlushToZeroFloat32;
+            phys_dev_props_core12.shaderDenormFlushToZeroFloat64 = float_controls_props.shaderDenormFlushToZeroFloat64;
+            phys_dev_props_core12.shaderRoundingModeRTEFloat16 = float_controls_props.shaderRoundingModeRTEFloat16;
+            phys_dev_props_core12.shaderRoundingModeRTEFloat32 = float_controls_props.shaderRoundingModeRTEFloat32;
+            phys_dev_props_core12.shaderRoundingModeRTEFloat64 = float_controls_props.shaderRoundingModeRTEFloat64;
+            phys_dev_props_core12.shaderRoundingModeRTZFloat16 = float_controls_props.shaderRoundingModeRTZFloat16;
+            phys_dev_props_core12.shaderRoundingModeRTZFloat32 = float_controls_props.shaderRoundingModeRTZFloat32;
+            phys_dev_props_core12.shaderRoundingModeRTZFloat64 = float_controls_props.shaderRoundingModeRTZFloat64;
         }
     }
 
     // Extensions with properties to extract to DeviceExtensionProperties
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_push_descriptor, &phys_dev_props->push_descriptor_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_nv_shading_rate_image, &phys_dev_props->shading_rate_image_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_nv_mesh_shader, &phys_dev_props->mesh_shader_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_inline_uniform_block, &phys_dev_props->inline_uniform_block_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_vertex_attribute_divisor, &phys_dev_props->vtx_attrib_divisor_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_transform_feedback, &phys_dev_props->transform_feedback_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_nv_ray_tracing, &phys_dev_props->ray_tracing_propsNV);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_ray_tracing_pipeline, &phys_dev_props->ray_tracing_propsKHR);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_acceleration_structure, &phys_dev_props->acc_structure_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_texel_buffer_alignment, &phys_dev_props->texel_buffer_alignment_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_fragment_density_map, &phys_dev_props->fragment_density_map_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_fragment_density_map2, &phys_dev_props->fragment_density_map2_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_qcom_fragment_density_map_offset,
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_push_descriptor, &phys_dev_props->push_descriptor_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_nv_shading_rate_image, &phys_dev_props->shading_rate_image_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_nv_mesh_shader, &phys_dev_props->mesh_shader_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_inline_uniform_block,
+                                   &phys_dev_props->inline_uniform_block_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_vertex_attribute_divisor,
+                                   &phys_dev_props->vtx_attrib_divisor_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_transform_feedback, &phys_dev_props->transform_feedback_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_nv_ray_tracing, &phys_dev_props->ray_tracing_propsNV);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_ray_tracing_pipeline, &phys_dev_props->ray_tracing_propsKHR);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_acceleration_structure, &phys_dev_props->acc_structure_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_texel_buffer_alignment,
+                                   &phys_dev_props->texel_buffer_alignment_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_fragment_density_map,
+                                   &phys_dev_props->fragment_density_map_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_fragment_density_map2,
+                                   &phys_dev_props->fragment_density_map2_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_qcom_fragment_density_map_offset,
                                    &phys_dev_props->fragment_density_map_offset_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_performance_query, &phys_dev_props->performance_query_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_sample_locations, &phys_dev_props->sample_locations_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_custom_border_color, &phys_dev_props->custom_border_color_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_multiview, &phys_dev_props->multiview_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_portability_subset, &phys_dev_props->portability_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_khr_fragment_shading_rate, &phys_dev_props->fragment_shading_rate_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_provoking_vertex, &phys_dev_props->provoking_vertex_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_multi_draw, &phys_dev_props->multi_draw_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_discard_rectangles, &phys_dev_props->discard_rectangle_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_blend_operation_advanced, &phys_dev_props->blend_operation_advanced_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_conservative_rasterization, &phys_dev_props->conservative_rasterization_props);
-    GetPhysicalDeviceExtProperties(gpu, dev_ext.vk_ext_subgroup_size_control, &phys_dev_props->subgroup_size_control_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_performance_query, &phys_dev_props->performance_query_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_sample_locations, &phys_dev_props->sample_locations_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_custom_border_color, &phys_dev_props->custom_border_color_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_multiview, &phys_dev_props->multiview_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_portability_subset, &phys_dev_props->portability_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_fragment_shading_rate,
+                                   &phys_dev_props->fragment_shading_rate_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_provoking_vertex, &phys_dev_props->provoking_vertex_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_multi_draw, &phys_dev_props->multi_draw_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_discard_rectangles, &phys_dev_props->discard_rectangle_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_blend_operation_advanced,
+                                   &phys_dev_props->blend_operation_advanced_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_conservative_rasterization,
+                                   &phys_dev_props->conservative_rasterization_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_subgroup_size_control,
+                                   &phys_dev_props->subgroup_size_control_props);
 
     if (IsExtEnabled(dev_ext.vk_nv_cooperative_matrix)) {
         // Get the needed cooperative_matrix properties
         auto cooperative_matrix_props = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixPropertiesNV>();
         auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&cooperative_matrix_props);
-        instance_dispatch_table.GetPhysicalDeviceProperties2KHR(gpu, &prop2);
-        state_tracker->phys_dev_ext_props.cooperative_matrix_props = cooperative_matrix_props;
+        instance_dispatch_table.GetPhysicalDeviceProperties2KHR(physical_device, &prop2);
+        phys_dev_ext_props.cooperative_matrix_props = cooperative_matrix_props;
 
         uint32_t num_cooperative_matrix_properties = 0;
-        instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(gpu, &num_cooperative_matrix_properties, NULL);
-        state_tracker->cooperative_matrix_properties.resize(num_cooperative_matrix_properties,
-                                                            LvlInitStruct<VkCooperativeMatrixPropertiesNV>());
+        instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(physical_device, &num_cooperative_matrix_properties,
+                                                                               NULL);
+        cooperative_matrix_properties.resize(num_cooperative_matrix_properties, LvlInitStruct<VkCooperativeMatrixPropertiesNV>());
 
-        instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(gpu, &num_cooperative_matrix_properties,
-                                                                               state_tracker->cooperative_matrix_properties.data());
+        instance_dispatch_table.GetPhysicalDeviceCooperativeMatrixPropertiesNV(physical_device, &num_cooperative_matrix_properties,
+                                                                               cooperative_matrix_properties.data());
     }
 
     // Store queue family data
     if (pCreateInfo->pQueueCreateInfos != nullptr) {
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
-            state_tracker->queue_family_index_set.insert(queue_create_info.queueFamilyIndex);
-            state_tracker->device_queue_info_list.push_back(
+            queue_family_index_set.insert(queue_create_info.queueFamilyIndex);
+            device_queue_info_list.push_back(
                 {i, queue_create_info.queueFamilyIndex, queue_create_info.flags, queue_create_info.queueCount});
         }
-        for (const auto &queue_info : state_tracker->device_queue_info_list) {
+        for (const auto &queue_info : device_queue_info_list) {
             for (uint32_t i = 0; i < queue_info.queue_count; i++) {
                 VkQueue queue = VK_NULL_HANDLE;
                 // vkGetDeviceQueue2() was added in vulkan 1.1, and there was never a KHR version of it.
@@ -1404,12 +1389,12 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
                     get_info.flags = queue_info.flags;
                     get_info.queueFamilyIndex = queue_info.queue_family_index;
                     get_info.queueIndex = i;
-                    DispatchGetDeviceQueue2(*pDevice, &get_info, &queue);
+                    DispatchGetDeviceQueue2(device, &get_info, &queue);
                 } else {
-                    DispatchGetDeviceQueue(*pDevice, queue_info.queue_family_index, i, &queue);
+                    DispatchGetDeviceQueue(device, queue_info.queue_family_index, i, &queue);
                 }
                 assert(queue != VK_NULL_HANDLE);
-                state_tracker->Add(std::make_shared<QUEUE_STATE>(queue, queue_info.queue_family_index, queue_info.flags));
+                Add(std::make_shared<QUEUE_STATE>(queue, queue_info.queue_family_index, queue_info.flags));
             }
         }
     }

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -323,9 +323,6 @@ class ValidationStateTracker : public ValidationObject {
     }
 
   public:
-    // Override base class, we have some extra work to do here
-    void InitDeviceValidationObject(bool add_obj, ValidationObject* inst_obj, ValidationObject* dev_obj) override;
-
     template <typename State, typename HandleType = typename state_object::Traits<State>::HandleType>
     void Add(std::shared_ptr<State>&& state_object) {
         auto& map = GetStateMap<State>();
@@ -604,6 +601,8 @@ class ValidationStateTracker : public ValidationObject {
 
     void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result) override;
+    virtual void CreateDevice(const VkDeviceCreateInfo* pCreateInfo);
+
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) override;
 
     void PostCallRecordCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo,

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -1172,8 +1172,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     void RecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo, CMD_TYPE cmd);
     bool SupressedBoundDescriptorWAW(const HazardResult &hazard) const;
 
-    void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, VkResult result) override;
+    void CreateDevice(const VkDeviceCreateInfo *pCreateInfo) override;
 
     bool ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                  const VkSubpassBeginInfo *pSubpassBeginInfo, CMD_TYPE cmd) const;


### PR DESCRIPTION
This virtual method can be used to do device level setup.
PostCallRecordCreateDevice() gets called on the validation object
representing the VkInstance, making it awkward to set up the device
state object there.