### PR TITLE
layers: Let concurrent unordered map's insert use templated args

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -412,16 +412,18 @@ class LockedSharedPtr : public std::shared_ptr<T> {
 template <typename Key, typename T, int BUCKETSLOG2 = 2, typename Hash = layer_data::hash<Key>>
 class vl_concurrent_unordered_map {
   public:
-    void insert_or_assign(const Key &key, const T &value) {
+    template <typename... Args>
+    void insert_or_assign(const Key &key, Args &&...args) {
         uint32_t h = ConcurrentMapHashObject(key);
         WriteLockGuard lock(locks[h].lock);
-        maps[h][key] = value;
+        maps[h][key] = {std::forward<Args>(args)...};
     }
 
-    bool insert(const Key &key, const T &value) {
+    template <typename... Args>
+    bool insert(const Key &key, Args &&...args) {
         uint32_t h = ConcurrentMapHashObject(key);
         WriteLockGuard lock(locks[h].lock);
-        auto ret = maps[h].emplace(key, value);
+        auto ret = maps[h].emplace(key, std::forward<Args>(args)...);
         return ret.second;
     }
 


### PR DESCRIPTION
While working on a different PR I found we didn't use the best approach for the insert of the concurrent unordered map. This should allow for correct use of move constructors and extends it to allow multiple arguments for in place construction with correct forwarding if wanted.

The previous approach always did a copy due to the constant reference when assigning or constructing the inserted value.

Let me know what you think