### PR TITLE
layers: Label warnings as new VUID

### DIFF
--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -1011,8 +1011,9 @@ class StatelessValidation : public ValidationObject {
             const VkImageLayout initial_layout = pCreateInfo->pAttachments[i].initialLayout;
             const VkImageLayout final_layout = pCreateInfo->pAttachments[i].finalLayout;
             if (attachment_format == VK_FORMAT_UNDEFINED) {
-                vuid = use_rp2 ? "VUID-VkAttachmentDescription2-format-parameter" : "VUID-VkAttachmentDescription-format-parameter";
-                skip |= LogWarning(device, vuid, "%s: pCreateInfo->pAttachments[%u].format is VK_FORMAT_UNDEFINED.", func_name, i);
+                vuid = use_rp2 ? "VUID-VkAttachmentDescription2-format-06701" : "VUID-VkAttachmentDescription-format-06698";
+                skip |= LogError(device, vuid, "%s: pCreateInfo->pAttachments[%" PRIu32 "].format is VK_FORMAT_UNDEFINED.",
+                                 func_name, i);
             }
             if (final_layout == VK_IMAGE_LAYOUT_UNDEFINED || final_layout == VK_IMAGE_LAYOUT_PREINITIALIZED) {
                 vuid =


### PR DESCRIPTION
Label what were warnings as proper new VUIDs in 1.3.210 spec

~~mikes-lunarg to roll in with header update~~ Honestly can just be rebased as not a compatible issue and pipeline library might be enough churn :smile: 