### PR TITLE
Check subresource overlap in blit operations

### DIFF
--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -10756,9 +10756,9 @@ TEST_F(VkLayerTest, CopyCommands2V13) {
     blit_region.dstSubresource.layerCount = 1;
     blit_region.dstSubresource.mipLevel = 0;
     blit_region.srcOffsets[0] = {0, 0, 0};
-    blit_region.srcOffsets[1] = {64, 64, 1};
-    blit_region.dstOffsets[0] = {0, 0, 0};
-    blit_region.dstOffsets[1] = {32, 32, 1};
+    blit_region.srcOffsets[1] = {31, 31, 1};
+    blit_region.dstOffsets[0] = {32, 32, 0};
+    blit_region.dstOffsets[1] = {64, 64, 1};
     auto blit_image_info = LvlInitStruct<VkBlitImageInfo2>();
     blit_image_info.srcImage = image.handle();
     blit_image_info.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;


### PR DESCRIPTION
Adds check for subresource overlap in blit operations, same approach as the one used in `vkCmdCopyImage`. There's an issue that we may want to tackle at some point, but since there has not been any complain on how the check is done in `vkCmdCopyImage` we can keep as things are for now.

The issue I found is the following: We currently only check for overlap if the same `VkImage` is used, and we only check against the subresource dimensions. What happens if we have 2 images that bind to the same memory and we use as src (the first one for example) and dst (the second one) with same subresource dimensions such that the memory is overlapped.

Ideally we would need to compute all memory locations and check that none overlap. Let me know what you think and how we should try to tackle the mentioned issue or if we care at all about this.