### PR TITLE
layers: Fixes memory leak in descriptor set validation

### DIFF
--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -155,8 +155,10 @@ void ThreadSafety::PostCallRecordFreeDescriptorSets(
         auto lock = WriteLockGuard(thread_safety_lock);
         auto &pool_descriptor_sets = pool_descriptor_sets_map[descriptorPool];
         for (uint32_t index0 = 0; index0 < descriptorSetCount; index0++) {
-            DestroyObject(pDescriptorSets[index0]);
-            pool_descriptor_sets.erase(pDescriptorSets[index0]);
+            auto descriptor_set = pDescriptorSets[index0];
+            DestroyObject(descriptor_set);
+            pool_descriptor_sets.erase(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
     }
 }
@@ -192,6 +194,7 @@ void ThreadSafety::PostCallRecordDestroyDescriptorPool(
         for(auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
             FinishWriteObject(descriptor_set, "vkDestroyDescriptorPool");
             DestroyObject(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
         pool_descriptor_sets_map[descriptorPool].clear();
         pool_descriptor_sets_map.erase(descriptorPool);
@@ -231,6 +234,7 @@ void ThreadSafety::PostCallRecordResetDescriptorPool(
         for(auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
             FinishWriteObject(descriptor_set, "vkResetDescriptorPool");
             DestroyObject(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
         pool_descriptor_sets_map[descriptorPool].clear();
     }

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -762,8 +762,10 @@ void ThreadSafety::PostCallRecordFreeDescriptorSets(
         auto lock = WriteLockGuard(thread_safety_lock);
         auto &pool_descriptor_sets = pool_descriptor_sets_map[descriptorPool];
         for (uint32_t index0 = 0; index0 < descriptorSetCount; index0++) {
-            DestroyObject(pDescriptorSets[index0]);
-            pool_descriptor_sets.erase(pDescriptorSets[index0]);
+            auto descriptor_set = pDescriptorSets[index0];
+            DestroyObject(descriptor_set);
+            pool_descriptor_sets.erase(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
     }
 }
@@ -799,6 +801,7 @@ void ThreadSafety::PostCallRecordDestroyDescriptorPool(
         for(auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
             FinishWriteObject(descriptor_set, "vkDestroyDescriptorPool");
             DestroyObject(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
         pool_descriptor_sets_map[descriptorPool].clear();
         pool_descriptor_sets_map.erase(descriptorPool);
@@ -838,6 +841,7 @@ void ThreadSafety::PostCallRecordResetDescriptorPool(
         for(auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
             FinishWriteObject(descriptor_set, "vkResetDescriptorPool");
             DestroyObject(descriptor_set);
+            ds_update_after_bind_map.erase(descriptor_set);
         }
         pool_descriptor_sets_map[descriptorPool].clear();
     }


### PR DESCRIPTION
Fixes memory leak in descriptor set validation. On allocation of new descriptor sets, the sets are added to a map that they are never removed from on pool reset, pool destruction, or set free.  This causes a memory leak to manifest itself when resetting the pool/freeing the descriptor sets and then reallocating the descriptor sets each frame.

Closes #236, #2512