### PR TITLE
layers: Fix build failure in ValidationStateTracker::CreateDevice()

### DIFF
--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1019,7 +1019,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         const auto *fragment_shading_rate_enums_features =
             LvlFindInChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(pCreateInfo->pNext);
         if (fragment_shading_rate_enums_features) {
-            state_tracker->enabled_features.fragment_shading_rate_enums_features = *fragment_shading_rate_enums_features;
+            enabled_features.fragment_shading_rate_enums_features = *fragment_shading_rate_enums_features;
         }
 
         const auto *extended_dynamic_state_features =


### PR DESCRIPTION
An extra state_tracker-> snuck in from the 1.3.210 header update.