### PR TITLE
Prevent safe struct pNext leak in initialize()

### DIFF
--- a/layers/generated/vk_safe_struct.cpp
+++ b/layers/generated/vk_safe_struct.cpp
@@ -109,6 +109,8 @@ safe_VkBufferMemoryBarrier::~safe_VkBufferMemoryBarrier()
 
 void safe_VkBufferMemoryBarrier::initialize(const VkBufferMemoryBarrier* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcAccessMask = in_struct->srcAccessMask;
     dstAccessMask = in_struct->dstAccessMask;
@@ -203,6 +205,8 @@ safe_VkImageMemoryBarrier::~safe_VkImageMemoryBarrier()
 
 void safe_VkImageMemoryBarrier::initialize(const VkImageMemoryBarrier* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcAccessMask = in_struct->srcAccessMask;
     dstAccessMask = in_struct->dstAccessMask;
@@ -275,6 +279,8 @@ safe_VkMemoryBarrier::~safe_VkMemoryBarrier()
 
 void safe_VkMemoryBarrier::initialize(const VkMemoryBarrier* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcAccessMask = in_struct->srcAccessMask;
     dstAccessMask = in_struct->dstAccessMask;
@@ -419,6 +425,10 @@ safe_VkApplicationInfo::~safe_VkApplicationInfo()
 
 void safe_VkApplicationInfo::initialize(const VkApplicationInfo* in_struct)
 {
+    if (pApplicationName) delete [] pApplicationName;
+    if (pEngineName) delete [] pEngineName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     applicationVersion = in_struct->applicationVersion;
     engineVersion = in_struct->engineVersion;
@@ -559,6 +569,22 @@ safe_VkInstanceCreateInfo::~safe_VkInstanceCreateInfo()
 
 void safe_VkInstanceCreateInfo::initialize(const VkInstanceCreateInfo* in_struct)
 {
+    if (pApplicationInfo)
+        delete pApplicationInfo;
+    if (ppEnabledLayerNames) {
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            delete [] ppEnabledLayerNames[i];
+        }
+        delete [] ppEnabledLayerNames;
+    }
+    if (ppEnabledExtensionNames) {
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            delete [] ppEnabledExtensionNames[i];
+        }
+        delete [] ppEnabledExtensionNames;
+    }
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pApplicationInfo = nullptr;
@@ -671,6 +697,10 @@ safe_VkDeviceQueueCreateInfo::~safe_VkDeviceQueueCreateInfo()
 
 void safe_VkDeviceQueueCreateInfo::initialize(const VkDeviceQueueCreateInfo* in_struct)
 {
+    if (pQueuePriorities)
+        delete[] pQueuePriorities;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     queueFamilyIndex = in_struct->queueFamilyIndex;
@@ -850,6 +880,24 @@ safe_VkDeviceCreateInfo::~safe_VkDeviceCreateInfo()
 
 void safe_VkDeviceCreateInfo::initialize(const VkDeviceCreateInfo* in_struct)
 {
+    if (pQueueCreateInfos)
+        delete[] pQueueCreateInfos;
+    if (ppEnabledLayerNames) {
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            delete [] ppEnabledLayerNames[i];
+        }
+        delete [] ppEnabledLayerNames;
+    }
+    if (ppEnabledExtensionNames) {
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            delete [] ppEnabledExtensionNames[i];
+        }
+        delete [] ppEnabledExtensionNames;
+    }
+    if (pEnabledFeatures)
+        delete pEnabledFeatures;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     queueCreateInfoCount = in_struct->queueCreateInfoCount;
@@ -1052,6 +1100,16 @@ safe_VkSubmitInfo::~safe_VkSubmitInfo()
 
 void safe_VkSubmitInfo::initialize(const VkSubmitInfo* in_struct)
 {
+    if (pWaitSemaphores)
+        delete[] pWaitSemaphores;
+    if (pWaitDstStageMask)
+        delete[] pWaitDstStageMask;
+    if (pCommandBuffers)
+        delete[] pCommandBuffers;
+    if (pSignalSemaphores)
+        delete[] pSignalSemaphores;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreCount = in_struct->waitSemaphoreCount;
     pWaitSemaphores = nullptr;
@@ -1166,6 +1224,8 @@ safe_VkMappedMemoryRange::~safe_VkMappedMemoryRange()
 
 void safe_VkMappedMemoryRange::initialize(const VkMappedMemoryRange* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     offset = in_struct->offset;
@@ -1228,6 +1288,8 @@ safe_VkMemoryAllocateInfo::~safe_VkMemoryAllocateInfo()
 
 void safe_VkMemoryAllocateInfo::initialize(const VkMemoryAllocateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     allocationSize = in_struct->allocationSize;
     memoryTypeIndex = in_struct->memoryTypeIndex;
@@ -1302,6 +1364,8 @@ safe_VkSparseBufferMemoryBindInfo::~safe_VkSparseBufferMemoryBindInfo()
 
 void safe_VkSparseBufferMemoryBindInfo::initialize(const VkSparseBufferMemoryBindInfo* in_struct)
 {
+    if (pBinds)
+        delete[] pBinds;
     buffer = in_struct->buffer;
     bindCount = in_struct->bindCount;
     pBinds = nullptr;
@@ -1386,6 +1450,8 @@ safe_VkSparseImageOpaqueMemoryBindInfo::~safe_VkSparseImageOpaqueMemoryBindInfo(
 
 void safe_VkSparseImageOpaqueMemoryBindInfo::initialize(const VkSparseImageOpaqueMemoryBindInfo* in_struct)
 {
+    if (pBinds)
+        delete[] pBinds;
     image = in_struct->image;
     bindCount = in_struct->bindCount;
     pBinds = nullptr;
@@ -1470,6 +1536,8 @@ safe_VkSparseImageMemoryBindInfo::~safe_VkSparseImageMemoryBindInfo()
 
 void safe_VkSparseImageMemoryBindInfo::initialize(const VkSparseImageMemoryBindInfo* in_struct)
 {
+    if (pBinds)
+        delete[] pBinds;
     image = in_struct->image;
     bindCount = in_struct->bindCount;
     pBinds = nullptr;
@@ -1682,6 +1750,18 @@ safe_VkBindSparseInfo::~safe_VkBindSparseInfo()
 
 void safe_VkBindSparseInfo::initialize(const VkBindSparseInfo* in_struct)
 {
+    if (pWaitSemaphores)
+        delete[] pWaitSemaphores;
+    if (pBufferBinds)
+        delete[] pBufferBinds;
+    if (pImageOpaqueBinds)
+        delete[] pImageOpaqueBinds;
+    if (pImageBinds)
+        delete[] pImageBinds;
+    if (pSignalSemaphores)
+        delete[] pSignalSemaphores;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreCount = in_struct->waitSemaphoreCount;
     pWaitSemaphores = nullptr;
@@ -1814,6 +1894,8 @@ safe_VkFenceCreateInfo::~safe_VkFenceCreateInfo()
 
 void safe_VkFenceCreateInfo::initialize(const VkFenceCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -1868,6 +1950,8 @@ safe_VkSemaphoreCreateInfo::~safe_VkSemaphoreCreateInfo()
 
 void safe_VkSemaphoreCreateInfo::initialize(const VkSemaphoreCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -1922,6 +2006,8 @@ safe_VkEventCreateInfo::~safe_VkEventCreateInfo()
 
 void safe_VkEventCreateInfo::initialize(const VkEventCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -1988,6 +2074,8 @@ safe_VkQueryPoolCreateInfo::~safe_VkQueryPoolCreateInfo()
 
 void safe_VkQueryPoolCreateInfo::initialize(const VkQueryPoolCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     queryType = in_struct->queryType;
@@ -2091,6 +2179,10 @@ safe_VkBufferCreateInfo::~safe_VkBufferCreateInfo()
 
 void safe_VkBufferCreateInfo::initialize(const VkBufferCreateInfo* in_struct)
 {
+    if (pQueueFamilyIndices)
+        delete[] pQueueFamilyIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     size = in_struct->size;
@@ -2183,6 +2275,8 @@ safe_VkBufferViewCreateInfo::~safe_VkBufferViewCreateInfo()
 
 void safe_VkBufferViewCreateInfo::initialize(const VkBufferViewCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     buffer = in_struct->buffer;
@@ -2316,6 +2410,10 @@ safe_VkImageCreateInfo::~safe_VkImageCreateInfo()
 
 void safe_VkImageCreateInfo::initialize(const VkImageCreateInfo* in_struct)
 {
+    if (pQueueFamilyIndices)
+        delete[] pQueueFamilyIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     imageType = in_struct->imageType;
@@ -2426,6 +2524,8 @@ safe_VkImageViewCreateInfo::~safe_VkImageViewCreateInfo()
 
 void safe_VkImageViewCreateInfo::initialize(const VkImageViewCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     image = in_struct->image;
@@ -2514,6 +2614,10 @@ safe_VkShaderModuleCreateInfo::~safe_VkShaderModuleCreateInfo()
 
 void safe_VkShaderModuleCreateInfo::initialize(const VkShaderModuleCreateInfo* in_struct)
 {
+    if (pCode)
+        delete[] reinterpret_cast<const uint8_t *>(pCode);
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     codeSize = in_struct->codeSize;
@@ -2588,6 +2692,8 @@ safe_VkPipelineCacheCreateInfo::~safe_VkPipelineCacheCreateInfo()
 
 void safe_VkPipelineCacheCreateInfo::initialize(const VkPipelineCacheCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     initialDataSize = in_struct->initialDataSize;
@@ -2662,6 +2768,8 @@ safe_VkSpecializationInfo::~safe_VkSpecializationInfo()
 
 void safe_VkSpecializationInfo::initialize(const VkSpecializationInfo* in_struct)
 {
+    if (pMapEntries)
+        delete[] pMapEntries;
     mapEntryCount = in_struct->mapEntryCount;
     pMapEntries = nullptr;
     dataSize = in_struct->dataSize;
@@ -2754,6 +2862,11 @@ safe_VkPipelineShaderStageCreateInfo::~safe_VkPipelineShaderStageCreateInfo()
 
 void safe_VkPipelineShaderStageCreateInfo::initialize(const VkPipelineShaderStageCreateInfo* in_struct)
 {
+    if (pName) delete [] pName;
+    if (pSpecializationInfo)
+        delete pSpecializationInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     stage = in_struct->stage;
@@ -2835,6 +2948,8 @@ safe_VkComputePipelineCreateInfo::~safe_VkComputePipelineCreateInfo()
 
 void safe_VkComputePipelineCreateInfo::initialize(const VkComputePipelineCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     stage.initialize(&in_struct->stage);
@@ -2945,6 +3060,12 @@ safe_VkPipelineVertexInputStateCreateInfo::~safe_VkPipelineVertexInputStateCreat
 
 void safe_VkPipelineVertexInputStateCreateInfo::initialize(const VkPipelineVertexInputStateCreateInfo* in_struct)
 {
+    if (pVertexBindingDescriptions)
+        delete[] pVertexBindingDescriptions;
+    if (pVertexAttributeDescriptions)
+        delete[] pVertexAttributeDescriptions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     vertexBindingDescriptionCount = in_struct->vertexBindingDescriptionCount;
@@ -3031,6 +3152,8 @@ safe_VkPipelineInputAssemblyStateCreateInfo::~safe_VkPipelineInputAssemblyStateC
 
 void safe_VkPipelineInputAssemblyStateCreateInfo::initialize(const VkPipelineInputAssemblyStateCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     topology = in_struct->topology;
@@ -3093,6 +3216,8 @@ safe_VkPipelineTessellationStateCreateInfo::~safe_VkPipelineTessellationStateCre
 
 void safe_VkPipelineTessellationStateCreateInfo::initialize(const VkPipelineTessellationStateCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     patchControlPoints = in_struct->patchControlPoints;
@@ -3209,6 +3334,12 @@ safe_VkPipelineViewportStateCreateInfo::~safe_VkPipelineViewportStateCreateInfo(
 
 void safe_VkPipelineViewportStateCreateInfo::initialize(const VkPipelineViewportStateCreateInfo* in_struct, const bool is_dynamic_viewports, const bool is_dynamic_scissors)
 {
+    if (pViewports)
+        delete[] pViewports;
+    if (pScissors)
+        delete[] pScissors;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     viewportCount = in_struct->viewportCount;
@@ -3335,6 +3466,8 @@ safe_VkPipelineRasterizationStateCreateInfo::~safe_VkPipelineRasterizationStateC
 
 void safe_VkPipelineRasterizationStateCreateInfo::initialize(const VkPipelineRasterizationStateCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     depthClampEnable = in_struct->depthClampEnable;
@@ -3446,6 +3579,10 @@ safe_VkPipelineMultisampleStateCreateInfo::~safe_VkPipelineMultisampleStateCreat
 
 void safe_VkPipelineMultisampleStateCreateInfo::initialize(const VkPipelineMultisampleStateCreateInfo* in_struct)
 {
+    if (pSampleMask)
+        delete pSampleMask;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     rasterizationSamples = in_struct->rasterizationSamples;
@@ -3554,6 +3691,8 @@ safe_VkPipelineDepthStencilStateCreateInfo::~safe_VkPipelineDepthStencilStateCre
 
 void safe_VkPipelineDepthStencilStateCreateInfo::initialize(const VkPipelineDepthStencilStateCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     depthTestEnable = in_struct->depthTestEnable;
@@ -3667,6 +3806,10 @@ safe_VkPipelineColorBlendStateCreateInfo::~safe_VkPipelineColorBlendStateCreateI
 
 void safe_VkPipelineColorBlendStateCreateInfo::initialize(const VkPipelineColorBlendStateCreateInfo* in_struct)
 {
+    if (pAttachments)
+        delete[] pAttachments;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     logicOpEnable = in_struct->logicOpEnable;
@@ -3767,6 +3910,10 @@ safe_VkPipelineDynamicStateCreateInfo::~safe_VkPipelineDynamicStateCreateInfo()
 
 void safe_VkPipelineDynamicStateCreateInfo::initialize(const VkPipelineDynamicStateCreateInfo* in_struct)
 {
+    if (pDynamicStates)
+        delete[] pDynamicStates;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     dynamicStateCount = in_struct->dynamicStateCount;
@@ -4111,6 +4258,28 @@ safe_VkGraphicsPipelineCreateInfo::~safe_VkGraphicsPipelineCreateInfo()
 
 void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreateInfo* in_struct, const bool uses_color_attachment, const bool uses_depthstencil_attachment)
 {
+    if (pStages)
+        delete[] pStages;
+    if (pVertexInputState)
+        delete pVertexInputState;
+    if (pInputAssemblyState)
+        delete pInputAssemblyState;
+    if (pTessellationState)
+        delete pTessellationState;
+    if (pViewportState)
+        delete pViewportState;
+    if (pRasterizationState)
+        delete pRasterizationState;
+    if (pMultisampleState)
+        delete pMultisampleState;
+    if (pDepthStencilState)
+        delete pDepthStencilState;
+    if (pColorBlendState)
+        delete pColorBlendState;
+    if (pDynamicState)
+        delete pDynamicState;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     stageCount = in_struct->stageCount;
@@ -4371,6 +4540,12 @@ safe_VkPipelineLayoutCreateInfo::~safe_VkPipelineLayoutCreateInfo()
 
 void safe_VkPipelineLayoutCreateInfo::initialize(const VkPipelineLayoutCreateInfo* in_struct)
 {
+    if (pSetLayouts)
+        delete[] pSetLayouts;
+    if (pPushConstantRanges)
+        delete[] pPushConstantRanges;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     setLayoutCount = in_struct->setLayoutCount;
@@ -4513,6 +4688,8 @@ safe_VkSamplerCreateInfo::~safe_VkSamplerCreateInfo()
 
 void safe_VkSamplerCreateInfo::initialize(const VkSamplerCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     magFilter = in_struct->magFilter;
@@ -4621,6 +4798,8 @@ safe_VkCopyDescriptorSet::~safe_VkCopyDescriptorSet()
 
 void safe_VkCopyDescriptorSet::initialize(const VkCopyDescriptorSet* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcSet = in_struct->srcSet;
     srcBinding = in_struct->srcBinding;
@@ -4715,6 +4894,10 @@ safe_VkDescriptorPoolCreateInfo::~safe_VkDescriptorPoolCreateInfo()
 
 void safe_VkDescriptorPoolCreateInfo::initialize(const VkDescriptorPoolCreateInfo* in_struct)
 {
+    if (pPoolSizes)
+        delete[] pPoolSizes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     maxSets = in_struct->maxSets;
@@ -4813,6 +4996,10 @@ safe_VkDescriptorSetAllocateInfo::~safe_VkDescriptorSetAllocateInfo()
 
 void safe_VkDescriptorSetAllocateInfo::initialize(const VkDescriptorSetAllocateInfo* in_struct)
 {
+    if (pSetLayouts)
+        delete[] pSetLayouts;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     descriptorPool = in_struct->descriptorPool;
     descriptorSetCount = in_struct->descriptorSetCount;
@@ -4912,6 +5099,8 @@ safe_VkDescriptorSetLayoutBinding::~safe_VkDescriptorSetLayoutBinding()
 
 void safe_VkDescriptorSetLayoutBinding::initialize(const VkDescriptorSetLayoutBinding* in_struct)
 {
+    if (pImmutableSamplers)
+        delete[] pImmutableSamplers;
     binding = in_struct->binding;
     descriptorType = in_struct->descriptorType;
     descriptorCount = in_struct->descriptorCount;
@@ -5014,6 +5203,10 @@ safe_VkDescriptorSetLayoutCreateInfo::~safe_VkDescriptorSetLayoutCreateInfo()
 
 void safe_VkDescriptorSetLayoutCreateInfo::initialize(const VkDescriptorSetLayoutCreateInfo* in_struct)
 {
+    if (pBindings)
+        delete[] pBindings;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     bindingCount = in_struct->bindingCount;
@@ -5232,6 +5425,14 @@ safe_VkWriteDescriptorSet::~safe_VkWriteDescriptorSet()
 
 void safe_VkWriteDescriptorSet::initialize(const VkWriteDescriptorSet* in_struct)
 {
+    if (pImageInfo)
+        delete[] pImageInfo;
+    if (pBufferInfo)
+        delete[] pBufferInfo;
+    if (pTexelBufferView)
+        delete[] pTexelBufferView;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dstSet = in_struct->dstSet;
     dstBinding = in_struct->dstBinding;
@@ -5418,6 +5619,10 @@ safe_VkFramebufferCreateInfo::~safe_VkFramebufferCreateInfo()
 
 void safe_VkFramebufferCreateInfo::initialize(const VkFramebufferCreateInfo* in_struct)
 {
+    if (pAttachments)
+        delete[] pAttachments;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     renderPass = in_struct->renderPass;
@@ -5597,6 +5802,16 @@ safe_VkSubpassDescription::~safe_VkSubpassDescription()
 
 void safe_VkSubpassDescription::initialize(const VkSubpassDescription* in_struct)
 {
+    if (pInputAttachments)
+        delete[] pInputAttachments;
+    if (pColorAttachments)
+        delete[] pColorAttachments;
+    if (pResolveAttachments)
+        delete[] pResolveAttachments;
+    if (pDepthStencilAttachment)
+        delete pDepthStencilAttachment;
+    if (pPreserveAttachments)
+        delete[] pPreserveAttachments;
     flags = in_struct->flags;
     pipelineBindPoint = in_struct->pipelineBindPoint;
     inputAttachmentCount = in_struct->inputAttachmentCount;
@@ -5781,6 +5996,14 @@ safe_VkRenderPassCreateInfo::~safe_VkRenderPassCreateInfo()
 
 void safe_VkRenderPassCreateInfo::initialize(const VkRenderPassCreateInfo* in_struct)
 {
+    if (pAttachments)
+        delete[] pAttachments;
+    if (pSubpasses)
+        delete[] pSubpasses;
+    if (pDependencies)
+        delete[] pDependencies;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     attachmentCount = in_struct->attachmentCount;
@@ -5879,6 +6102,8 @@ safe_VkCommandPoolCreateInfo::~safe_VkCommandPoolCreateInfo()
 
 void safe_VkCommandPoolCreateInfo::initialize(const VkCommandPoolCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     queueFamilyIndex = in_struct->queueFamilyIndex;
@@ -5943,6 +6168,8 @@ safe_VkCommandBufferAllocateInfo::~safe_VkCommandBufferAllocateInfo()
 
 void safe_VkCommandBufferAllocateInfo::initialize(const VkCommandBufferAllocateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     commandPool = in_struct->commandPool;
     level = in_struct->level;
@@ -6021,6 +6248,8 @@ safe_VkCommandBufferInheritanceInfo::~safe_VkCommandBufferInheritanceInfo()
 
 void safe_VkCommandBufferInheritanceInfo::initialize(const VkCommandBufferInheritanceInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     renderPass = in_struct->renderPass;
     subpass = in_struct->subpass;
@@ -6099,6 +6328,10 @@ safe_VkCommandBufferBeginInfo::~safe_VkCommandBufferBeginInfo()
 
 void safe_VkCommandBufferBeginInfo::initialize(const VkCommandBufferBeginInfo* in_struct)
 {
+    if (pInheritanceInfo)
+        delete pInheritanceInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pInheritanceInfo = nullptr;
@@ -6191,6 +6424,10 @@ safe_VkRenderPassBeginInfo::~safe_VkRenderPassBeginInfo()
 
 void safe_VkRenderPassBeginInfo::initialize(const VkRenderPassBeginInfo* in_struct)
 {
+    if (pClearValues)
+        delete[] pClearValues;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     renderPass = in_struct->renderPass;
     framebuffer = in_struct->framebuffer;
@@ -6273,6 +6510,8 @@ safe_VkPhysicalDeviceSubgroupProperties::~safe_VkPhysicalDeviceSubgroupPropertie
 
 void safe_VkPhysicalDeviceSubgroupProperties::initialize(const VkPhysicalDeviceSubgroupProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     subgroupSize = in_struct->subgroupSize;
     supportedStages = in_struct->supportedStages;
@@ -6341,6 +6580,8 @@ safe_VkBindBufferMemoryInfo::~safe_VkBindBufferMemoryInfo()
 
 void safe_VkBindBufferMemoryInfo::initialize(const VkBindBufferMemoryInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     buffer = in_struct->buffer;
     memory = in_struct->memory;
@@ -6407,6 +6648,8 @@ safe_VkBindImageMemoryInfo::~safe_VkBindImageMemoryInfo()
 
 void safe_VkBindImageMemoryInfo::initialize(const VkBindImageMemoryInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image = in_struct->image;
     memory = in_struct->memory;
@@ -6477,6 +6720,8 @@ safe_VkPhysicalDevice16BitStorageFeatures::~safe_VkPhysicalDevice16BitStorageFea
 
 void safe_VkPhysicalDevice16BitStorageFeatures::initialize(const VkPhysicalDevice16BitStorageFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     storageBuffer16BitAccess = in_struct->storageBuffer16BitAccess;
     uniformAndStorageBuffer16BitAccess = in_struct->uniformAndStorageBuffer16BitAccess;
@@ -6541,6 +6786,8 @@ safe_VkMemoryDedicatedRequirements::~safe_VkMemoryDedicatedRequirements()
 
 void safe_VkMemoryDedicatedRequirements::initialize(const VkMemoryDedicatedRequirements* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     prefersDedicatedAllocation = in_struct->prefersDedicatedAllocation;
     requiresDedicatedAllocation = in_struct->requiresDedicatedAllocation;
@@ -6601,6 +6848,8 @@ safe_VkMemoryDedicatedAllocateInfo::~safe_VkMemoryDedicatedAllocateInfo()
 
 void safe_VkMemoryDedicatedAllocateInfo::initialize(const VkMemoryDedicatedAllocateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image = in_struct->image;
     buffer = in_struct->buffer;
@@ -6661,6 +6910,8 @@ safe_VkMemoryAllocateFlagsInfo::~safe_VkMemoryAllocateFlagsInfo()
 
 void safe_VkMemoryAllocateFlagsInfo::initialize(const VkMemoryAllocateFlagsInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     deviceMask = in_struct->deviceMask;
@@ -6741,6 +6992,10 @@ safe_VkDeviceGroupRenderPassBeginInfo::~safe_VkDeviceGroupRenderPassBeginInfo()
 
 void safe_VkDeviceGroupRenderPassBeginInfo::initialize(const VkDeviceGroupRenderPassBeginInfo* in_struct)
 {
+    if (pDeviceRenderAreas)
+        delete[] pDeviceRenderAreas;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceMask = in_struct->deviceMask;
     deviceRenderAreaCount = in_struct->deviceRenderAreaCount;
@@ -6807,6 +7062,8 @@ safe_VkDeviceGroupCommandBufferBeginInfo::~safe_VkDeviceGroupCommandBufferBeginI
 
 void safe_VkDeviceGroupCommandBufferBeginInfo::initialize(const VkDeviceGroupCommandBufferBeginInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceMask = in_struct->deviceMask;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -6929,6 +7186,14 @@ safe_VkDeviceGroupSubmitInfo::~safe_VkDeviceGroupSubmitInfo()
 
 void safe_VkDeviceGroupSubmitInfo::initialize(const VkDeviceGroupSubmitInfo* in_struct)
 {
+    if (pWaitSemaphoreDeviceIndices)
+        delete[] pWaitSemaphoreDeviceIndices;
+    if (pCommandBufferDeviceMasks)
+        delete[] pCommandBufferDeviceMasks;
+    if (pSignalSemaphoreDeviceIndices)
+        delete[] pSignalSemaphoreDeviceIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreCount = in_struct->waitSemaphoreCount;
     pWaitSemaphoreDeviceIndices = nullptr;
@@ -7021,6 +7286,8 @@ safe_VkDeviceGroupBindSparseInfo::~safe_VkDeviceGroupBindSparseInfo()
 
 void safe_VkDeviceGroupBindSparseInfo::initialize(const VkDeviceGroupBindSparseInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     resourceDeviceIndex = in_struct->resourceDeviceIndex;
     memoryDeviceIndex = in_struct->memoryDeviceIndex;
@@ -7097,6 +7364,10 @@ safe_VkBindBufferMemoryDeviceGroupInfo::~safe_VkBindBufferMemoryDeviceGroupInfo(
 
 void safe_VkBindBufferMemoryDeviceGroupInfo::initialize(const VkBindBufferMemoryDeviceGroupInfo* in_struct)
 {
+    if (pDeviceIndices)
+        delete[] pDeviceIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceIndexCount = in_struct->deviceIndexCount;
     pDeviceIndices = nullptr;
@@ -7205,6 +7476,12 @@ safe_VkBindImageMemoryDeviceGroupInfo::~safe_VkBindImageMemoryDeviceGroupInfo()
 
 void safe_VkBindImageMemoryDeviceGroupInfo::initialize(const VkBindImageMemoryDeviceGroupInfo* in_struct)
 {
+    if (pDeviceIndices)
+        delete[] pDeviceIndices;
+    if (pSplitInstanceBindRegions)
+        delete[] pSplitInstanceBindRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceIndexCount = in_struct->deviceIndexCount;
     pDeviceIndices = nullptr;
@@ -7294,6 +7571,8 @@ safe_VkPhysicalDeviceGroupProperties::~safe_VkPhysicalDeviceGroupProperties()
 
 void safe_VkPhysicalDeviceGroupProperties::initialize(const VkPhysicalDeviceGroupProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     physicalDeviceCount = in_struct->physicalDeviceCount;
     subsetAllocation = in_struct->subsetAllocation;
@@ -7376,6 +7655,10 @@ safe_VkDeviceGroupDeviceCreateInfo::~safe_VkDeviceGroupDeviceCreateInfo()
 
 void safe_VkDeviceGroupDeviceCreateInfo::initialize(const VkDeviceGroupDeviceCreateInfo* in_struct)
 {
+    if (pPhysicalDevices)
+        delete[] pPhysicalDevices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     physicalDeviceCount = in_struct->physicalDeviceCount;
     pPhysicalDevices = nullptr;
@@ -7440,6 +7723,8 @@ safe_VkBufferMemoryRequirementsInfo2::~safe_VkBufferMemoryRequirementsInfo2()
 
 void safe_VkBufferMemoryRequirementsInfo2::initialize(const VkBufferMemoryRequirementsInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     buffer = in_struct->buffer;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7494,6 +7779,8 @@ safe_VkImageMemoryRequirementsInfo2::~safe_VkImageMemoryRequirementsInfo2()
 
 void safe_VkImageMemoryRequirementsInfo2::initialize(const VkImageMemoryRequirementsInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image = in_struct->image;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7548,6 +7835,8 @@ safe_VkImageSparseMemoryRequirementsInfo2::~safe_VkImageSparseMemoryRequirements
 
 void safe_VkImageSparseMemoryRequirementsInfo2::initialize(const VkImageSparseMemoryRequirementsInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image = in_struct->image;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7602,6 +7891,8 @@ safe_VkMemoryRequirements2::~safe_VkMemoryRequirements2()
 
 void safe_VkMemoryRequirements2::initialize(const VkMemoryRequirements2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryRequirements = in_struct->memoryRequirements;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7656,6 +7947,8 @@ safe_VkSparseImageMemoryRequirements2::~safe_VkSparseImageMemoryRequirements2()
 
 void safe_VkSparseImageMemoryRequirements2::initialize(const VkSparseImageMemoryRequirements2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryRequirements = in_struct->memoryRequirements;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7710,6 +8003,8 @@ safe_VkPhysicalDeviceFeatures2::~safe_VkPhysicalDeviceFeatures2()
 
 void safe_VkPhysicalDeviceFeatures2::initialize(const VkPhysicalDeviceFeatures2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     features = in_struct->features;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7764,6 +8059,8 @@ safe_VkPhysicalDeviceProperties2::~safe_VkPhysicalDeviceProperties2()
 
 void safe_VkPhysicalDeviceProperties2::initialize(const VkPhysicalDeviceProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     properties = in_struct->properties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7818,6 +8115,8 @@ safe_VkFormatProperties2::~safe_VkFormatProperties2()
 
 void safe_VkFormatProperties2::initialize(const VkFormatProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     formatProperties = in_struct->formatProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7872,6 +8171,8 @@ safe_VkImageFormatProperties2::~safe_VkImageFormatProperties2()
 
 void safe_VkImageFormatProperties2::initialize(const VkImageFormatProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageFormatProperties = in_struct->imageFormatProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -7942,6 +8243,8 @@ safe_VkPhysicalDeviceImageFormatInfo2::~safe_VkPhysicalDeviceImageFormatInfo2()
 
 void safe_VkPhysicalDeviceImageFormatInfo2::initialize(const VkPhysicalDeviceImageFormatInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     type = in_struct->type;
@@ -8004,6 +8307,8 @@ safe_VkQueueFamilyProperties2::~safe_VkQueueFamilyProperties2()
 
 void safe_VkQueueFamilyProperties2::initialize(const VkQueueFamilyProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     queueFamilyProperties = in_struct->queueFamilyProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8058,6 +8363,8 @@ safe_VkPhysicalDeviceMemoryProperties2::~safe_VkPhysicalDeviceMemoryProperties2(
 
 void safe_VkPhysicalDeviceMemoryProperties2::initialize(const VkPhysicalDeviceMemoryProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryProperties = in_struct->memoryProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8112,6 +8419,8 @@ safe_VkSparseImageFormatProperties2::~safe_VkSparseImageFormatProperties2()
 
 void safe_VkSparseImageFormatProperties2::initialize(const VkSparseImageFormatProperties2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     properties = in_struct->properties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8182,6 +8491,8 @@ safe_VkPhysicalDeviceSparseImageFormatInfo2::~safe_VkPhysicalDeviceSparseImageFo
 
 void safe_VkPhysicalDeviceSparseImageFormatInfo2::initialize(const VkPhysicalDeviceSparseImageFormatInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     type = in_struct->type;
@@ -8244,6 +8555,8 @@ safe_VkPhysicalDevicePointClippingProperties::~safe_VkPhysicalDevicePointClippin
 
 void safe_VkPhysicalDevicePointClippingProperties::initialize(const VkPhysicalDevicePointClippingProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pointClippingBehavior = in_struct->pointClippingBehavior;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8318,6 +8631,10 @@ safe_VkRenderPassInputAttachmentAspectCreateInfo::~safe_VkRenderPassInputAttachm
 
 void safe_VkRenderPassInputAttachmentAspectCreateInfo::initialize(const VkRenderPassInputAttachmentAspectCreateInfo* in_struct)
 {
+    if (pAspectReferences)
+        delete[] pAspectReferences;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     aspectReferenceCount = in_struct->aspectReferenceCount;
     pAspectReferences = nullptr;
@@ -8382,6 +8699,8 @@ safe_VkImageViewUsageCreateInfo::~safe_VkImageViewUsageCreateInfo()
 
 void safe_VkImageViewUsageCreateInfo::initialize(const VkImageViewUsageCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     usage = in_struct->usage;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8436,6 +8755,8 @@ safe_VkPipelineTessellationDomainOriginStateCreateInfo::~safe_VkPipelineTessella
 
 void safe_VkPipelineTessellationDomainOriginStateCreateInfo::initialize(const VkPipelineTessellationDomainOriginStateCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     domainOrigin = in_struct->domainOrigin;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8558,6 +8879,14 @@ safe_VkRenderPassMultiviewCreateInfo::~safe_VkRenderPassMultiviewCreateInfo()
 
 void safe_VkRenderPassMultiviewCreateInfo::initialize(const VkRenderPassMultiviewCreateInfo* in_struct)
 {
+    if (pViewMasks)
+        delete[] pViewMasks;
+    if (pViewOffsets)
+        delete[] pViewOffsets;
+    if (pCorrelationMasks)
+        delete[] pCorrelationMasks;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     subpassCount = in_struct->subpassCount;
     pViewMasks = nullptr;
@@ -8654,6 +8983,8 @@ safe_VkPhysicalDeviceMultiviewFeatures::~safe_VkPhysicalDeviceMultiviewFeatures(
 
 void safe_VkPhysicalDeviceMultiviewFeatures::initialize(const VkPhysicalDeviceMultiviewFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     multiview = in_struct->multiview;
     multiviewGeometryShader = in_struct->multiviewGeometryShader;
@@ -8716,6 +9047,8 @@ safe_VkPhysicalDeviceMultiviewProperties::~safe_VkPhysicalDeviceMultiviewPropert
 
 void safe_VkPhysicalDeviceMultiviewProperties::initialize(const VkPhysicalDeviceMultiviewProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxMultiviewViewCount = in_struct->maxMultiviewViewCount;
     maxMultiviewInstanceIndex = in_struct->maxMultiviewInstanceIndex;
@@ -8776,6 +9109,8 @@ safe_VkPhysicalDeviceVariablePointersFeatures::~safe_VkPhysicalDeviceVariablePoi
 
 void safe_VkPhysicalDeviceVariablePointersFeatures::initialize(const VkPhysicalDeviceVariablePointersFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     variablePointersStorageBuffer = in_struct->variablePointersStorageBuffer;
     variablePointers = in_struct->variablePointers;
@@ -8832,6 +9167,8 @@ safe_VkPhysicalDeviceProtectedMemoryFeatures::~safe_VkPhysicalDeviceProtectedMem
 
 void safe_VkPhysicalDeviceProtectedMemoryFeatures::initialize(const VkPhysicalDeviceProtectedMemoryFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     protectedMemory = in_struct->protectedMemory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8886,6 +9223,8 @@ safe_VkPhysicalDeviceProtectedMemoryProperties::~safe_VkPhysicalDeviceProtectedM
 
 void safe_VkPhysicalDeviceProtectedMemoryProperties::initialize(const VkPhysicalDeviceProtectedMemoryProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     protectedNoFault = in_struct->protectedNoFault;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -8948,6 +9287,8 @@ safe_VkDeviceQueueInfo2::~safe_VkDeviceQueueInfo2()
 
 void safe_VkDeviceQueueInfo2::initialize(const VkDeviceQueueInfo2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     queueFamilyIndex = in_struct->queueFamilyIndex;
@@ -9006,6 +9347,8 @@ safe_VkProtectedSubmitInfo::~safe_VkProtectedSubmitInfo()
 
 void safe_VkProtectedSubmitInfo::initialize(const VkProtectedSubmitInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     protectedSubmit = in_struct->protectedSubmit;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9088,6 +9431,8 @@ safe_VkSamplerYcbcrConversionCreateInfo::~safe_VkSamplerYcbcrConversionCreateInf
 
 void safe_VkSamplerYcbcrConversionCreateInfo::initialize(const VkSamplerYcbcrConversionCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     ycbcrModel = in_struct->ycbcrModel;
@@ -9156,6 +9501,8 @@ safe_VkSamplerYcbcrConversionInfo::~safe_VkSamplerYcbcrConversionInfo()
 
 void safe_VkSamplerYcbcrConversionInfo::initialize(const VkSamplerYcbcrConversionInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     conversion = in_struct->conversion;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9210,6 +9557,8 @@ safe_VkBindImagePlaneMemoryInfo::~safe_VkBindImagePlaneMemoryInfo()
 
 void safe_VkBindImagePlaneMemoryInfo::initialize(const VkBindImagePlaneMemoryInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     planeAspect = in_struct->planeAspect;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9264,6 +9613,8 @@ safe_VkImagePlaneMemoryRequirementsInfo::~safe_VkImagePlaneMemoryRequirementsInf
 
 void safe_VkImagePlaneMemoryRequirementsInfo::initialize(const VkImagePlaneMemoryRequirementsInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     planeAspect = in_struct->planeAspect;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9318,6 +9669,8 @@ safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures::~safe_VkPhysicalDeviceSampl
 
 void safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures::initialize(const VkPhysicalDeviceSamplerYcbcrConversionFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     samplerYcbcrConversion = in_struct->samplerYcbcrConversion;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9372,6 +9725,8 @@ safe_VkSamplerYcbcrConversionImageFormatProperties::~safe_VkSamplerYcbcrConversi
 
 void safe_VkSamplerYcbcrConversionImageFormatProperties::initialize(const VkSamplerYcbcrConversionImageFormatProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     combinedImageSamplerDescriptorCount = in_struct->combinedImageSamplerDescriptorCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9470,6 +9825,10 @@ safe_VkDescriptorUpdateTemplateCreateInfo::~safe_VkDescriptorUpdateTemplateCreat
 
 void safe_VkDescriptorUpdateTemplateCreateInfo::initialize(const VkDescriptorUpdateTemplateCreateInfo* in_struct)
 {
+    if (pDescriptorUpdateEntries)
+        delete[] pDescriptorUpdateEntries;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     descriptorUpdateEntryCount = in_struct->descriptorUpdateEntryCount;
@@ -9546,6 +9905,8 @@ safe_VkPhysicalDeviceExternalImageFormatInfo::~safe_VkPhysicalDeviceExternalImag
 
 void safe_VkPhysicalDeviceExternalImageFormatInfo::initialize(const VkPhysicalDeviceExternalImageFormatInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9600,6 +9961,8 @@ safe_VkExternalImageFormatProperties::~safe_VkExternalImageFormatProperties()
 
 void safe_VkExternalImageFormatProperties::initialize(const VkExternalImageFormatProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     externalMemoryProperties = in_struct->externalMemoryProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9662,6 +10025,8 @@ safe_VkPhysicalDeviceExternalBufferInfo::~safe_VkPhysicalDeviceExternalBufferInf
 
 void safe_VkPhysicalDeviceExternalBufferInfo::initialize(const VkPhysicalDeviceExternalBufferInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     usage = in_struct->usage;
@@ -9720,6 +10085,8 @@ safe_VkExternalBufferProperties::~safe_VkExternalBufferProperties()
 
 void safe_VkExternalBufferProperties::initialize(const VkExternalBufferProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     externalMemoryProperties = in_struct->externalMemoryProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9805,6 +10172,8 @@ safe_VkPhysicalDeviceIDProperties::~safe_VkPhysicalDeviceIDProperties()
 
 void safe_VkPhysicalDeviceIDProperties::initialize(const VkPhysicalDeviceIDProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceNodeMask = in_struct->deviceNodeMask;
     deviceLUIDValid = in_struct->deviceLUIDValid;
@@ -9879,6 +10248,8 @@ safe_VkExternalMemoryImageCreateInfo::~safe_VkExternalMemoryImageCreateInfo()
 
 void safe_VkExternalMemoryImageCreateInfo::initialize(const VkExternalMemoryImageCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9933,6 +10304,8 @@ safe_VkExternalMemoryBufferCreateInfo::~safe_VkExternalMemoryBufferCreateInfo()
 
 void safe_VkExternalMemoryBufferCreateInfo::initialize(const VkExternalMemoryBufferCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -9987,6 +10360,8 @@ safe_VkExportMemoryAllocateInfo::~safe_VkExportMemoryAllocateInfo()
 
 void safe_VkExportMemoryAllocateInfo::initialize(const VkExportMemoryAllocateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10041,6 +10416,8 @@ safe_VkPhysicalDeviceExternalFenceInfo::~safe_VkPhysicalDeviceExternalFenceInfo(
 
 void safe_VkPhysicalDeviceExternalFenceInfo::initialize(const VkPhysicalDeviceExternalFenceInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10103,6 +10480,8 @@ safe_VkExternalFenceProperties::~safe_VkExternalFenceProperties()
 
 void safe_VkExternalFenceProperties::initialize(const VkExternalFenceProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     exportFromImportedHandleTypes = in_struct->exportFromImportedHandleTypes;
     compatibleHandleTypes = in_struct->compatibleHandleTypes;
@@ -10161,6 +10540,8 @@ safe_VkExportFenceCreateInfo::~safe_VkExportFenceCreateInfo()
 
 void safe_VkExportFenceCreateInfo::initialize(const VkExportFenceCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10215,6 +10596,8 @@ safe_VkExportSemaphoreCreateInfo::~safe_VkExportSemaphoreCreateInfo()
 
 void safe_VkExportSemaphoreCreateInfo::initialize(const VkExportSemaphoreCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10269,6 +10652,8 @@ safe_VkPhysicalDeviceExternalSemaphoreInfo::~safe_VkPhysicalDeviceExternalSemaph
 
 void safe_VkPhysicalDeviceExternalSemaphoreInfo::initialize(const VkPhysicalDeviceExternalSemaphoreInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10331,6 +10716,8 @@ safe_VkExternalSemaphoreProperties::~safe_VkExternalSemaphoreProperties()
 
 void safe_VkExternalSemaphoreProperties::initialize(const VkExternalSemaphoreProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     exportFromImportedHandleTypes = in_struct->exportFromImportedHandleTypes;
     compatibleHandleTypes = in_struct->compatibleHandleTypes;
@@ -10393,6 +10780,8 @@ safe_VkPhysicalDeviceMaintenance3Properties::~safe_VkPhysicalDeviceMaintenance3P
 
 void safe_VkPhysicalDeviceMaintenance3Properties::initialize(const VkPhysicalDeviceMaintenance3Properties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxPerSetDescriptors = in_struct->maxPerSetDescriptors;
     maxMemoryAllocationSize = in_struct->maxMemoryAllocationSize;
@@ -10449,6 +10838,8 @@ safe_VkDescriptorSetLayoutSupport::~safe_VkDescriptorSetLayoutSupport()
 
 void safe_VkDescriptorSetLayoutSupport::initialize(const VkDescriptorSetLayoutSupport* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     supported = in_struct->supported;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10503,6 +10894,8 @@ safe_VkPhysicalDeviceShaderDrawParametersFeatures::~safe_VkPhysicalDeviceShaderD
 
 void safe_VkPhysicalDeviceShaderDrawParametersFeatures::initialize(const VkPhysicalDeviceShaderDrawParametersFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderDrawParameters = in_struct->shaderDrawParameters;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -10601,6 +10994,8 @@ safe_VkPhysicalDeviceVulkan11Features::~safe_VkPhysicalDeviceVulkan11Features()
 
 void safe_VkPhysicalDeviceVulkan11Features::initialize(const VkPhysicalDeviceVulkan11Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     storageBuffer16BitAccess = in_struct->storageBuffer16BitAccess;
     uniformAndStorageBuffer16BitAccess = in_struct->uniformAndStorageBuffer16BitAccess;
@@ -10748,6 +11143,8 @@ safe_VkPhysicalDeviceVulkan11Properties::~safe_VkPhysicalDeviceVulkan11Propertie
 
 void safe_VkPhysicalDeviceVulkan11Properties::initialize(const VkPhysicalDeviceVulkan11Properties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceNodeMask = in_struct->deviceNodeMask;
     deviceLUIDValid = in_struct->deviceLUIDValid;
@@ -11026,6 +11423,8 @@ safe_VkPhysicalDeviceVulkan12Features::~safe_VkPhysicalDeviceVulkan12Features()
 
 void safe_VkPhysicalDeviceVulkan12Features::initialize(const VkPhysicalDeviceVulkan12Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     samplerMirrorClampToEdge = in_struct->samplerMirrorClampToEdge;
     drawIndirectCount = in_struct->drawIndirectCount;
@@ -11386,6 +11785,8 @@ safe_VkPhysicalDeviceVulkan12Properties::~safe_VkPhysicalDeviceVulkan12Propertie
 
 void safe_VkPhysicalDeviceVulkan12Properties::initialize(const VkPhysicalDeviceVulkan12Properties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     driverID = in_struct->driverID;
     conformanceVersion = in_struct->conformanceVersion;
@@ -11570,6 +11971,10 @@ safe_VkImageFormatListCreateInfo::~safe_VkImageFormatListCreateInfo()
 
 void safe_VkImageFormatListCreateInfo::initialize(const VkImageFormatListCreateInfo* in_struct)
 {
+    if (pViewFormats)
+        delete[] pViewFormats;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     viewFormatCount = in_struct->viewFormatCount;
     pViewFormats = nullptr;
@@ -11666,6 +12071,8 @@ safe_VkAttachmentDescription2::~safe_VkAttachmentDescription2()
 
 void safe_VkAttachmentDescription2::initialize(const VkAttachmentDescription2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     format = in_struct->format;
@@ -11744,6 +12151,8 @@ safe_VkAttachmentReference2::~safe_VkAttachmentReference2()
 
 void safe_VkAttachmentReference2::initialize(const VkAttachmentReference2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     attachment = in_struct->attachment;
     layout = in_struct->layout;
@@ -11934,6 +12343,18 @@ safe_VkSubpassDescription2::~safe_VkSubpassDescription2()
 
 void safe_VkSubpassDescription2::initialize(const VkSubpassDescription2* in_struct)
 {
+    if (pInputAttachments)
+        delete[] pInputAttachments;
+    if (pColorAttachments)
+        delete[] pColorAttachments;
+    if (pResolveAttachments)
+        delete[] pResolveAttachments;
+    if (pDepthStencilAttachment)
+        delete pDepthStencilAttachment;
+    if (pPreserveAttachments)
+        delete[] pPreserveAttachments;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pipelineBindPoint = in_struct->pipelineBindPoint;
@@ -12084,6 +12505,8 @@ safe_VkSubpassDependency2::~safe_VkSubpassDependency2()
 
 void safe_VkSubpassDependency2::initialize(const VkSubpassDependency2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcSubpass = in_struct->srcSubpass;
     dstSubpass = in_struct->dstSubpass;
@@ -12266,6 +12689,16 @@ safe_VkRenderPassCreateInfo2::~safe_VkRenderPassCreateInfo2()
 
 void safe_VkRenderPassCreateInfo2::initialize(const VkRenderPassCreateInfo2* in_struct)
 {
+    if (pAttachments)
+        delete[] pAttachments;
+    if (pSubpasses)
+        delete[] pSubpasses;
+    if (pDependencies)
+        delete[] pDependencies;
+    if (pCorrelatedViewMasks)
+        delete[] pCorrelatedViewMasks;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     attachmentCount = in_struct->attachmentCount;
@@ -12380,6 +12813,8 @@ safe_VkSubpassBeginInfo::~safe_VkSubpassBeginInfo()
 
 void safe_VkSubpassBeginInfo::initialize(const VkSubpassBeginInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     contents = in_struct->contents;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -12430,6 +12865,8 @@ safe_VkSubpassEndInfo::~safe_VkSubpassEndInfo()
 
 void safe_VkSubpassEndInfo::initialize(const VkSubpassEndInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pNext = SafePnextCopy(in_struct->pNext);
 }
@@ -12490,6 +12927,8 @@ safe_VkPhysicalDevice8BitStorageFeatures::~safe_VkPhysicalDevice8BitStorageFeatu
 
 void safe_VkPhysicalDevice8BitStorageFeatures::initialize(const VkPhysicalDevice8BitStorageFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     storageBuffer8BitAccess = in_struct->storageBuffer8BitAccess;
     uniformAndStorageBuffer8BitAccess = in_struct->uniformAndStorageBuffer8BitAccess;
@@ -12570,6 +13009,8 @@ safe_VkPhysicalDeviceDriverProperties::~safe_VkPhysicalDeviceDriverProperties()
 
 void safe_VkPhysicalDeviceDriverProperties::initialize(const VkPhysicalDeviceDriverProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     driverID = in_struct->driverID;
     conformanceVersion = in_struct->conformanceVersion;
@@ -12642,6 +13083,8 @@ safe_VkPhysicalDeviceShaderAtomicInt64Features::~safe_VkPhysicalDeviceShaderAtom
 
 void safe_VkPhysicalDeviceShaderAtomicInt64Features::initialize(const VkPhysicalDeviceShaderAtomicInt64Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderBufferInt64Atomics = in_struct->shaderBufferInt64Atomics;
     shaderSharedInt64Atomics = in_struct->shaderSharedInt64Atomics;
@@ -12702,6 +13145,8 @@ safe_VkPhysicalDeviceShaderFloat16Int8Features::~safe_VkPhysicalDeviceShaderFloa
 
 void safe_VkPhysicalDeviceShaderFloat16Int8Features::initialize(const VkPhysicalDeviceShaderFloat16Int8Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderFloat16 = in_struct->shaderFloat16;
     shaderInt8 = in_struct->shaderInt8;
@@ -12822,6 +13267,8 @@ safe_VkPhysicalDeviceFloatControlsProperties::~safe_VkPhysicalDeviceFloatControl
 
 void safe_VkPhysicalDeviceFloatControlsProperties::initialize(const VkPhysicalDeviceFloatControlsProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     denormBehaviorIndependence = in_struct->denormBehaviorIndependence;
     roundingModeIndependence = in_struct->roundingModeIndependence;
@@ -12928,6 +13375,10 @@ safe_VkDescriptorSetLayoutBindingFlagsCreateInfo::~safe_VkDescriptorSetLayoutBin
 
 void safe_VkDescriptorSetLayoutBindingFlagsCreateInfo::initialize(const VkDescriptorSetLayoutBindingFlagsCreateInfo* in_struct)
 {
+    if (pBindingFlags)
+        delete[] pBindingFlags;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     bindingCount = in_struct->bindingCount;
     pBindingFlags = nullptr;
@@ -13068,6 +13519,8 @@ safe_VkPhysicalDeviceDescriptorIndexingFeatures::~safe_VkPhysicalDeviceDescripto
 
 void safe_VkPhysicalDeviceDescriptorIndexingFeatures::initialize(const VkPhysicalDeviceDescriptorIndexingFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderInputAttachmentArrayDynamicIndexing = in_struct->shaderInputAttachmentArrayDynamicIndexing;
     shaderUniformTexelBufferArrayDynamicIndexing = in_struct->shaderUniformTexelBufferArrayDynamicIndexing;
@@ -13248,6 +13701,8 @@ safe_VkPhysicalDeviceDescriptorIndexingProperties::~safe_VkPhysicalDeviceDescrip
 
 void safe_VkPhysicalDeviceDescriptorIndexingProperties::initialize(const VkPhysicalDeviceDescriptorIndexingProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxUpdateAfterBindDescriptorsInAllPools = in_struct->maxUpdateAfterBindDescriptorsInAllPools;
     shaderUniformBufferArrayNonUniformIndexingNative = in_struct->shaderUniformBufferArrayNonUniformIndexingNative;
@@ -13366,6 +13821,10 @@ safe_VkDescriptorSetVariableDescriptorCountAllocateInfo::~safe_VkDescriptorSetVa
 
 void safe_VkDescriptorSetVariableDescriptorCountAllocateInfo::initialize(const VkDescriptorSetVariableDescriptorCountAllocateInfo* in_struct)
 {
+    if (pDescriptorCounts)
+        delete[] pDescriptorCounts;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     descriptorSetCount = in_struct->descriptorSetCount;
     pDescriptorCounts = nullptr;
@@ -13430,6 +13889,8 @@ safe_VkDescriptorSetVariableDescriptorCountLayoutSupport::~safe_VkDescriptorSetV
 
 void safe_VkDescriptorSetVariableDescriptorCountLayoutSupport::initialize(const VkDescriptorSetVariableDescriptorCountLayoutSupport* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxVariableDescriptorCount = in_struct->maxVariableDescriptorCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -13502,6 +13963,10 @@ safe_VkSubpassDescriptionDepthStencilResolve::~safe_VkSubpassDescriptionDepthSte
 
 void safe_VkSubpassDescriptionDepthStencilResolve::initialize(const VkSubpassDescriptionDepthStencilResolve* in_struct)
 {
+    if (pDepthStencilResolveAttachment)
+        delete pDepthStencilResolveAttachment;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     depthResolveMode = in_struct->depthResolveMode;
     stencilResolveMode = in_struct->stencilResolveMode;
@@ -13576,6 +14041,8 @@ safe_VkPhysicalDeviceDepthStencilResolveProperties::~safe_VkPhysicalDeviceDepthS
 
 void safe_VkPhysicalDeviceDepthStencilResolveProperties::initialize(const VkPhysicalDeviceDepthStencilResolveProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     supportedDepthResolveModes = in_struct->supportedDepthResolveModes;
     supportedStencilResolveModes = in_struct->supportedStencilResolveModes;
@@ -13636,6 +14103,8 @@ safe_VkPhysicalDeviceScalarBlockLayoutFeatures::~safe_VkPhysicalDeviceScalarBloc
 
 void safe_VkPhysicalDeviceScalarBlockLayoutFeatures::initialize(const VkPhysicalDeviceScalarBlockLayoutFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     scalarBlockLayout = in_struct->scalarBlockLayout;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -13690,6 +14159,8 @@ safe_VkImageStencilUsageCreateInfo::~safe_VkImageStencilUsageCreateInfo()
 
 void safe_VkImageStencilUsageCreateInfo::initialize(const VkImageStencilUsageCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stencilUsage = in_struct->stencilUsage;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -13744,6 +14215,8 @@ safe_VkSamplerReductionModeCreateInfo::~safe_VkSamplerReductionModeCreateInfo()
 
 void safe_VkSamplerReductionModeCreateInfo::initialize(const VkSamplerReductionModeCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     reductionMode = in_struct->reductionMode;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -13802,6 +14275,8 @@ safe_VkPhysicalDeviceSamplerFilterMinmaxProperties::~safe_VkPhysicalDeviceSample
 
 void safe_VkPhysicalDeviceSamplerFilterMinmaxProperties::initialize(const VkPhysicalDeviceSamplerFilterMinmaxProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     filterMinmaxSingleComponentFormats = in_struct->filterMinmaxSingleComponentFormats;
     filterMinmaxImageComponentMapping = in_struct->filterMinmaxImageComponentMapping;
@@ -13866,6 +14341,8 @@ safe_VkPhysicalDeviceVulkanMemoryModelFeatures::~safe_VkPhysicalDeviceVulkanMemo
 
 void safe_VkPhysicalDeviceVulkanMemoryModelFeatures::initialize(const VkPhysicalDeviceVulkanMemoryModelFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vulkanMemoryModel = in_struct->vulkanMemoryModel;
     vulkanMemoryModelDeviceScope = in_struct->vulkanMemoryModelDeviceScope;
@@ -13924,6 +14401,8 @@ safe_VkPhysicalDeviceImagelessFramebufferFeatures::~safe_VkPhysicalDeviceImagele
 
 void safe_VkPhysicalDeviceImagelessFramebufferFeatures::initialize(const VkPhysicalDeviceImagelessFramebufferFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imagelessFramebuffer = in_struct->imagelessFramebuffer;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14018,6 +14497,10 @@ safe_VkFramebufferAttachmentImageInfo::~safe_VkFramebufferAttachmentImageInfo()
 
 void safe_VkFramebufferAttachmentImageInfo::initialize(const VkFramebufferAttachmentImageInfo* in_struct)
 {
+    if (pViewFormats)
+        delete[] pViewFormats;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     usage = in_struct->usage;
@@ -14118,6 +14601,10 @@ safe_VkFramebufferAttachmentsCreateInfo::~safe_VkFramebufferAttachmentsCreateInf
 
 void safe_VkFramebufferAttachmentsCreateInfo::initialize(const VkFramebufferAttachmentsCreateInfo* in_struct)
 {
+    if (pAttachmentImageInfos)
+        delete[] pAttachmentImageInfos;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     attachmentImageInfoCount = in_struct->attachmentImageInfoCount;
     pAttachmentImageInfos = nullptr;
@@ -14212,6 +14699,10 @@ safe_VkRenderPassAttachmentBeginInfo::~safe_VkRenderPassAttachmentBeginInfo()
 
 void safe_VkRenderPassAttachmentBeginInfo::initialize(const VkRenderPassAttachmentBeginInfo* in_struct)
 {
+    if (pAttachments)
+        delete[] pAttachments;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     attachmentCount = in_struct->attachmentCount;
     pAttachments = nullptr;
@@ -14280,6 +14771,8 @@ safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures::initialize(const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     uniformBufferStandardLayout = in_struct->uniformBufferStandardLayout;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14334,6 +14827,8 @@ safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::initialize(const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderSubgroupExtendedTypes = in_struct->shaderSubgroupExtendedTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14388,6 +14883,8 @@ safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::initialize(const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     separateDepthStencilLayouts = in_struct->separateDepthStencilLayouts;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14442,6 +14939,8 @@ safe_VkAttachmentReferenceStencilLayout::~safe_VkAttachmentReferenceStencilLayou
 
 void safe_VkAttachmentReferenceStencilLayout::initialize(const VkAttachmentReferenceStencilLayout* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stencilLayout = in_struct->stencilLayout;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14500,6 +14999,8 @@ safe_VkAttachmentDescriptionStencilLayout::~safe_VkAttachmentDescriptionStencilL
 
 void safe_VkAttachmentDescriptionStencilLayout::initialize(const VkAttachmentDescriptionStencilLayout* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stencilInitialLayout = in_struct->stencilInitialLayout;
     stencilFinalLayout = in_struct->stencilFinalLayout;
@@ -14556,6 +15057,8 @@ safe_VkPhysicalDeviceHostQueryResetFeatures::~safe_VkPhysicalDeviceHostQueryRese
 
 void safe_VkPhysicalDeviceHostQueryResetFeatures::initialize(const VkPhysicalDeviceHostQueryResetFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     hostQueryReset = in_struct->hostQueryReset;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14610,6 +15113,8 @@ safe_VkPhysicalDeviceTimelineSemaphoreFeatures::~safe_VkPhysicalDeviceTimelineSe
 
 void safe_VkPhysicalDeviceTimelineSemaphoreFeatures::initialize(const VkPhysicalDeviceTimelineSemaphoreFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     timelineSemaphore = in_struct->timelineSemaphore;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14664,6 +15169,8 @@ safe_VkPhysicalDeviceTimelineSemaphoreProperties::~safe_VkPhysicalDeviceTimeline
 
 void safe_VkPhysicalDeviceTimelineSemaphoreProperties::initialize(const VkPhysicalDeviceTimelineSemaphoreProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxTimelineSemaphoreValueDifference = in_struct->maxTimelineSemaphoreValueDifference;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -14722,6 +15229,8 @@ safe_VkSemaphoreTypeCreateInfo::~safe_VkSemaphoreTypeCreateInfo()
 
 void safe_VkSemaphoreTypeCreateInfo::initialize(const VkSemaphoreTypeCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphoreType = in_struct->semaphoreType;
     initialValue = in_struct->initialValue;
@@ -14822,6 +15331,12 @@ safe_VkTimelineSemaphoreSubmitInfo::~safe_VkTimelineSemaphoreSubmitInfo()
 
 void safe_VkTimelineSemaphoreSubmitInfo::initialize(const VkTimelineSemaphoreSubmitInfo* in_struct)
 {
+    if (pWaitSemaphoreValues)
+        delete[] pWaitSemaphoreValues;
+    if (pSignalSemaphoreValues)
+        delete[] pSignalSemaphoreValues;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreValueCount = in_struct->waitSemaphoreValueCount;
     pWaitSemaphoreValues = nullptr;
@@ -14948,6 +15463,12 @@ safe_VkSemaphoreWaitInfo::~safe_VkSemaphoreWaitInfo()
 
 void safe_VkSemaphoreWaitInfo::initialize(const VkSemaphoreWaitInfo* in_struct)
 {
+    if (pSemaphores)
+        delete[] pSemaphores;
+    if (pValues)
+        delete[] pValues;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     semaphoreCount = in_struct->semaphoreCount;
@@ -15032,6 +15553,8 @@ safe_VkSemaphoreSignalInfo::~safe_VkSemaphoreSignalInfo()
 
 void safe_VkSemaphoreSignalInfo::initialize(const VkSemaphoreSignalInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     value = in_struct->value;
@@ -15096,6 +15619,8 @@ safe_VkPhysicalDeviceBufferDeviceAddressFeatures::~safe_VkPhysicalDeviceBufferDe
 
 void safe_VkPhysicalDeviceBufferDeviceAddressFeatures::initialize(const VkPhysicalDeviceBufferDeviceAddressFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     bufferDeviceAddress = in_struct->bufferDeviceAddress;
     bufferDeviceAddressCaptureReplay = in_struct->bufferDeviceAddressCaptureReplay;
@@ -15154,6 +15679,8 @@ safe_VkBufferDeviceAddressInfo::~safe_VkBufferDeviceAddressInfo()
 
 void safe_VkBufferDeviceAddressInfo::initialize(const VkBufferDeviceAddressInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     buffer = in_struct->buffer;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -15208,6 +15735,8 @@ safe_VkBufferOpaqueCaptureAddressCreateInfo::~safe_VkBufferOpaqueCaptureAddressC
 
 void safe_VkBufferOpaqueCaptureAddressCreateInfo::initialize(const VkBufferOpaqueCaptureAddressCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     opaqueCaptureAddress = in_struct->opaqueCaptureAddress;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -15262,6 +15791,8 @@ safe_VkMemoryOpaqueCaptureAddressAllocateInfo::~safe_VkMemoryOpaqueCaptureAddres
 
 void safe_VkMemoryOpaqueCaptureAddressAllocateInfo::initialize(const VkMemoryOpaqueCaptureAddressAllocateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     opaqueCaptureAddress = in_struct->opaqueCaptureAddress;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -15316,6 +15847,8 @@ safe_VkDeviceMemoryOpaqueCaptureAddressInfo::~safe_VkDeviceMemoryOpaqueCaptureAd
 
 void safe_VkDeviceMemoryOpaqueCaptureAddressInfo::initialize(const VkDeviceMemoryOpaqueCaptureAddressInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -15426,6 +15959,8 @@ safe_VkPhysicalDeviceVulkan13Features::~safe_VkPhysicalDeviceVulkan13Features()
 
 void safe_VkPhysicalDeviceVulkan13Features::initialize(const VkPhysicalDeviceVulkan13Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     robustImageAccess = in_struct->robustImageAccess;
     inlineUniformBlock = in_struct->inlineUniformBlock;
@@ -15684,6 +16219,8 @@ safe_VkPhysicalDeviceVulkan13Properties::~safe_VkPhysicalDeviceVulkan13Propertie
 
 void safe_VkPhysicalDeviceVulkan13Properties::initialize(const VkPhysicalDeviceVulkan13Properties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minSubgroupSize = in_struct->minSubgroupSize;
     maxSubgroupSize = in_struct->maxSubgroupSize;
@@ -15863,6 +16400,12 @@ safe_VkPipelineCreationFeedbackCreateInfo::~safe_VkPipelineCreationFeedbackCreat
 
 void safe_VkPipelineCreationFeedbackCreateInfo::initialize(const VkPipelineCreationFeedbackCreateInfo* in_struct)
 {
+    if (pPipelineCreationFeedback)
+        delete pPipelineCreationFeedback;
+    if (pPipelineStageCreationFeedbacks)
+        delete[] pPipelineStageCreationFeedbacks;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pPipelineCreationFeedback = nullptr;
     pipelineStageCreationFeedbackCount = in_struct->pipelineStageCreationFeedbackCount;
@@ -15935,6 +16478,8 @@ safe_VkPhysicalDeviceShaderTerminateInvocationFeatures::~safe_VkPhysicalDeviceSh
 
 void safe_VkPhysicalDeviceShaderTerminateInvocationFeatures::initialize(const VkPhysicalDeviceShaderTerminateInvocationFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderTerminateInvocation = in_struct->shaderTerminateInvocation;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16025,6 +16570,8 @@ safe_VkPhysicalDeviceToolProperties::~safe_VkPhysicalDeviceToolProperties()
 
 void safe_VkPhysicalDeviceToolProperties::initialize(const VkPhysicalDeviceToolProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     purposes = in_struct->purposes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16103,6 +16650,8 @@ safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures::~safe_VkPhysicalDev
 
 void safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures::initialize(const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderDemoteToHelperInvocation = in_struct->shaderDemoteToHelperInvocation;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16157,6 +16706,8 @@ safe_VkPhysicalDevicePrivateDataFeatures::~safe_VkPhysicalDevicePrivateDataFeatu
 
 void safe_VkPhysicalDevicePrivateDataFeatures::initialize(const VkPhysicalDevicePrivateDataFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     privateData = in_struct->privateData;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16211,6 +16762,8 @@ safe_VkDevicePrivateDataCreateInfo::~safe_VkDevicePrivateDataCreateInfo()
 
 void safe_VkDevicePrivateDataCreateInfo::initialize(const VkDevicePrivateDataCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     privateDataSlotRequestCount = in_struct->privateDataSlotRequestCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16265,6 +16818,8 @@ safe_VkPrivateDataSlotCreateInfo::~safe_VkPrivateDataSlotCreateInfo()
 
 void safe_VkPrivateDataSlotCreateInfo::initialize(const VkPrivateDataSlotCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16319,6 +16874,8 @@ safe_VkPhysicalDevicePipelineCreationCacheControlFeatures::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDevicePipelineCreationCacheControlFeatures::initialize(const VkPhysicalDevicePipelineCreationCacheControlFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipelineCreationCacheControl = in_struct->pipelineCreationCacheControl;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -16385,6 +16942,8 @@ safe_VkMemoryBarrier2::~safe_VkMemoryBarrier2()
 
 void safe_VkMemoryBarrier2::initialize(const VkMemoryBarrier2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcStageMask = in_struct->srcStageMask;
     srcAccessMask = in_struct->srcAccessMask;
@@ -16477,6 +17036,8 @@ safe_VkBufferMemoryBarrier2::~safe_VkBufferMemoryBarrier2()
 
 void safe_VkBufferMemoryBarrier2::initialize(const VkBufferMemoryBarrier2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcStageMask = in_struct->srcStageMask;
     srcAccessMask = in_struct->srcAccessMask;
@@ -16583,6 +17144,8 @@ safe_VkImageMemoryBarrier2::~safe_VkImageMemoryBarrier2()
 
 void safe_VkImageMemoryBarrier2::initialize(const VkImageMemoryBarrier2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcStageMask = in_struct->srcStageMask;
     srcAccessMask = in_struct->srcAccessMask;
@@ -16745,6 +17308,14 @@ safe_VkDependencyInfo::~safe_VkDependencyInfo()
 
 void safe_VkDependencyInfo::initialize(const VkDependencyInfo* in_struct)
 {
+    if (pMemoryBarriers)
+        delete[] pMemoryBarriers;
+    if (pBufferMemoryBarriers)
+        delete[] pBufferMemoryBarriers;
+    if (pImageMemoryBarriers)
+        delete[] pImageMemoryBarriers;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dependencyFlags = in_struct->dependencyFlags;
     memoryBarrierCount = in_struct->memoryBarrierCount;
@@ -16859,6 +17430,8 @@ safe_VkSemaphoreSubmitInfo::~safe_VkSemaphoreSubmitInfo()
 
 void safe_VkSemaphoreSubmitInfo::initialize(const VkSemaphoreSubmitInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     value = in_struct->value;
@@ -16923,6 +17496,8 @@ safe_VkCommandBufferSubmitInfo::~safe_VkCommandBufferSubmitInfo()
 
 void safe_VkCommandBufferSubmitInfo::initialize(const VkCommandBufferSubmitInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     commandBuffer = in_struct->commandBuffer;
     deviceMask = in_struct->deviceMask;
@@ -17069,6 +17644,14 @@ safe_VkSubmitInfo2::~safe_VkSubmitInfo2()
 
 void safe_VkSubmitInfo2::initialize(const VkSubmitInfo2* in_struct)
 {
+    if (pWaitSemaphoreInfos)
+        delete[] pWaitSemaphoreInfos;
+    if (pCommandBufferInfos)
+        delete[] pCommandBufferInfos;
+    if (pSignalSemaphoreInfos)
+        delete[] pSignalSemaphoreInfos;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     waitSemaphoreInfoCount = in_struct->waitSemaphoreInfoCount;
@@ -17171,6 +17754,8 @@ safe_VkPhysicalDeviceSynchronization2Features::~safe_VkPhysicalDeviceSynchroniza
 
 void safe_VkPhysicalDeviceSynchronization2Features::initialize(const VkPhysicalDeviceSynchronization2Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     synchronization2 = in_struct->synchronization2;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -17225,6 +17810,8 @@ safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::~safe_VkPhysicalDevi
 
 void safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::initialize(const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderZeroInitializeWorkgroupMemory = in_struct->shaderZeroInitializeWorkgroupMemory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -17279,6 +17866,8 @@ safe_VkPhysicalDeviceImageRobustnessFeatures::~safe_VkPhysicalDeviceImageRobustn
 
 void safe_VkPhysicalDeviceImageRobustnessFeatures::initialize(const VkPhysicalDeviceImageRobustnessFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     robustImageAccess = in_struct->robustImageAccess;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -17341,6 +17930,8 @@ safe_VkBufferCopy2::~safe_VkBufferCopy2()
 
 void safe_VkBufferCopy2::initialize(const VkBufferCopy2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcOffset = in_struct->srcOffset;
     dstOffset = in_struct->dstOffset;
@@ -17433,6 +18024,10 @@ safe_VkCopyBufferInfo2::~safe_VkCopyBufferInfo2()
 
 void safe_VkCopyBufferInfo2::initialize(const VkCopyBufferInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcBuffer = in_struct->srcBuffer;
     dstBuffer = in_struct->dstBuffer;
@@ -17521,6 +18116,8 @@ safe_VkImageCopy2::~safe_VkImageCopy2()
 
 void safe_VkImageCopy2::initialize(const VkImageCopy2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcSubresource = in_struct->srcSubresource;
     srcOffset = in_struct->srcOffset;
@@ -17625,6 +18222,10 @@ safe_VkCopyImageInfo2::~safe_VkCopyImageInfo2()
 
 void safe_VkCopyImageInfo2::initialize(const VkCopyImageInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcImage = in_struct->srcImage;
     srcImageLayout = in_struct->srcImageLayout;
@@ -17721,6 +18322,8 @@ safe_VkBufferImageCopy2::~safe_VkBufferImageCopy2()
 
 void safe_VkBufferImageCopy2::initialize(const VkBufferImageCopy2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     bufferOffset = in_struct->bufferOffset;
     bufferRowLength = in_struct->bufferRowLength;
@@ -17823,6 +18426,10 @@ safe_VkCopyBufferToImageInfo2::~safe_VkCopyBufferToImageInfo2()
 
 void safe_VkCopyBufferToImageInfo2::initialize(const VkCopyBufferToImageInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcBuffer = in_struct->srcBuffer;
     dstImage = in_struct->dstImage;
@@ -17935,6 +18542,10 @@ safe_VkCopyImageToBufferInfo2::~safe_VkCopyImageToBufferInfo2()
 
 void safe_VkCopyImageToBufferInfo2::initialize(const VkCopyImageToBufferInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcImage = in_struct->srcImage;
     srcImageLayout = in_struct->srcImageLayout;
@@ -18031,6 +18642,8 @@ safe_VkImageBlit2::~safe_VkImageBlit2()
 
 void safe_VkImageBlit2::initialize(const VkImageBlit2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcSubresource = in_struct->srcSubresource;
     dstSubresource = in_struct->dstSubresource;
@@ -18145,6 +18758,10 @@ safe_VkBlitImageInfo2::~safe_VkBlitImageInfo2()
 
 void safe_VkBlitImageInfo2::initialize(const VkBlitImageInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcImage = in_struct->srcImage;
     srcImageLayout = in_struct->srcImageLayout;
@@ -18239,6 +18856,8 @@ safe_VkImageResolve2::~safe_VkImageResolve2()
 
 void safe_VkImageResolve2::initialize(const VkImageResolve2* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcSubresource = in_struct->srcSubresource;
     srcOffset = in_struct->srcOffset;
@@ -18343,6 +18962,10 @@ safe_VkResolveImageInfo2::~safe_VkResolveImageInfo2()
 
 void safe_VkResolveImageInfo2::initialize(const VkResolveImageInfo2* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcImage = in_struct->srcImage;
     srcImageLayout = in_struct->srcImageLayout;
@@ -18423,6 +19046,8 @@ safe_VkPhysicalDeviceSubgroupSizeControlFeatures::~safe_VkPhysicalDeviceSubgroup
 
 void safe_VkPhysicalDeviceSubgroupSizeControlFeatures::initialize(const VkPhysicalDeviceSubgroupSizeControlFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     subgroupSizeControl = in_struct->subgroupSizeControl;
     computeFullSubgroups = in_struct->computeFullSubgroups;
@@ -18491,6 +19116,8 @@ safe_VkPhysicalDeviceSubgroupSizeControlProperties::~safe_VkPhysicalDeviceSubgro
 
 void safe_VkPhysicalDeviceSubgroupSizeControlProperties::initialize(const VkPhysicalDeviceSubgroupSizeControlProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minSubgroupSize = in_struct->minSubgroupSize;
     maxSubgroupSize = in_struct->maxSubgroupSize;
@@ -18551,6 +19178,8 @@ safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo::~safe_VkPipelineShader
 
 void safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo::initialize(const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     requiredSubgroupSize = in_struct->requiredSubgroupSize;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -18609,6 +19238,8 @@ safe_VkPhysicalDeviceInlineUniformBlockFeatures::~safe_VkPhysicalDeviceInlineUni
 
 void safe_VkPhysicalDeviceInlineUniformBlockFeatures::initialize(const VkPhysicalDeviceInlineUniformBlockFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     inlineUniformBlock = in_struct->inlineUniformBlock;
     descriptorBindingInlineUniformBlockUpdateAfterBind = in_struct->descriptorBindingInlineUniformBlockUpdateAfterBind;
@@ -18681,6 +19312,8 @@ safe_VkPhysicalDeviceInlineUniformBlockProperties::~safe_VkPhysicalDeviceInlineU
 
 void safe_VkPhysicalDeviceInlineUniformBlockProperties::initialize(const VkPhysicalDeviceInlineUniformBlockProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxInlineUniformBlockSize = in_struct->maxInlineUniformBlockSize;
     maxPerStageDescriptorInlineUniformBlocks = in_struct->maxPerStageDescriptorInlineUniformBlocks;
@@ -18747,6 +19380,8 @@ safe_VkWriteDescriptorSetInlineUniformBlock::~safe_VkWriteDescriptorSetInlineUni
 
 void safe_VkWriteDescriptorSetInlineUniformBlock::initialize(const VkWriteDescriptorSetInlineUniformBlock* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dataSize = in_struct->dataSize;
     pData = in_struct->pData;
@@ -18803,6 +19438,8 @@ safe_VkDescriptorPoolInlineUniformBlockCreateInfo::~safe_VkDescriptorPoolInlineU
 
 void safe_VkDescriptorPoolInlineUniformBlockCreateInfo::initialize(const VkDescriptorPoolInlineUniformBlockCreateInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxInlineUniformBlockBindings = in_struct->maxInlineUniformBlockBindings;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -18857,6 +19494,8 @@ safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures::~safe_VkPhysicalDeviceTe
 
 void safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures::initialize(const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     textureCompressionASTC_HDR = in_struct->textureCompressionASTC_HDR;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -18939,6 +19578,8 @@ safe_VkRenderingAttachmentInfo::~safe_VkRenderingAttachmentInfo()
 
 void safe_VkRenderingAttachmentInfo::initialize(const VkRenderingAttachmentInfo* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageView = in_struct->imageView;
     imageLayout = in_struct->imageLayout;
@@ -19077,6 +19718,14 @@ safe_VkRenderingInfo::~safe_VkRenderingInfo()
 
 void safe_VkRenderingInfo::initialize(const VkRenderingInfo* in_struct)
 {
+    if (pColorAttachments)
+        delete[] pColorAttachments;
+    if (pDepthAttachment)
+        delete pDepthAttachment;
+    if (pStencilAttachment)
+        delete pStencilAttachment;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     renderArea = in_struct->renderArea;
@@ -19197,6 +19846,10 @@ safe_VkPipelineRenderingCreateInfo::~safe_VkPipelineRenderingCreateInfo()
 
 void safe_VkPipelineRenderingCreateInfo::initialize(const VkPipelineRenderingCreateInfo* in_struct)
 {
+    if (pColorAttachmentFormats)
+        delete[] pColorAttachmentFormats;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     viewMask = in_struct->viewMask;
     colorAttachmentCount = in_struct->colorAttachmentCount;
@@ -19267,6 +19920,8 @@ safe_VkPhysicalDeviceDynamicRenderingFeatures::~safe_VkPhysicalDeviceDynamicRend
 
 void safe_VkPhysicalDeviceDynamicRenderingFeatures::initialize(const VkPhysicalDeviceDynamicRenderingFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dynamicRendering = in_struct->dynamicRendering;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -19361,6 +20016,10 @@ safe_VkCommandBufferInheritanceRenderingInfo::~safe_VkCommandBufferInheritanceRe
 
 void safe_VkCommandBufferInheritanceRenderingInfo::initialize(const VkCommandBufferInheritanceRenderingInfo* in_struct)
 {
+    if (pColorAttachmentFormats)
+        delete[] pColorAttachmentFormats;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     viewMask = in_struct->viewMask;
@@ -19435,6 +20094,8 @@ safe_VkPhysicalDeviceShaderIntegerDotProductFeatures::~safe_VkPhysicalDeviceShad
 
 void safe_VkPhysicalDeviceShaderIntegerDotProductFeatures::initialize(const VkPhysicalDeviceShaderIntegerDotProductFeatures* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderIntegerDotProduct = in_struct->shaderIntegerDotProduct;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -19605,6 +20266,8 @@ safe_VkPhysicalDeviceShaderIntegerDotProductProperties::~safe_VkPhysicalDeviceSh
 
 void safe_VkPhysicalDeviceShaderIntegerDotProductProperties::initialize(const VkPhysicalDeviceShaderIntegerDotProductProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     integerDotProduct8BitUnsignedAccelerated = in_struct->integerDotProduct8BitUnsignedAccelerated;
     integerDotProduct8BitSignedAccelerated = in_struct->integerDotProduct8BitSignedAccelerated;
@@ -19729,6 +20392,8 @@ safe_VkPhysicalDeviceTexelBufferAlignmentProperties::~safe_VkPhysicalDeviceTexel
 
 void safe_VkPhysicalDeviceTexelBufferAlignmentProperties::initialize(const VkPhysicalDeviceTexelBufferAlignmentProperties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     storageTexelBufferOffsetAlignmentBytes = in_struct->storageTexelBufferOffsetAlignmentBytes;
     storageTexelBufferOffsetSingleTexelAlignment = in_struct->storageTexelBufferOffsetSingleTexelAlignment;
@@ -19797,6 +20462,8 @@ safe_VkFormatProperties3::~safe_VkFormatProperties3()
 
 void safe_VkFormatProperties3::initialize(const VkFormatProperties3* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     linearTilingFeatures = in_struct->linearTilingFeatures;
     optimalTilingFeatures = in_struct->optimalTilingFeatures;
@@ -19855,6 +20522,8 @@ safe_VkPhysicalDeviceMaintenance4Features::~safe_VkPhysicalDeviceMaintenance4Fea
 
 void safe_VkPhysicalDeviceMaintenance4Features::initialize(const VkPhysicalDeviceMaintenance4Features* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maintenance4 = in_struct->maintenance4;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -19909,6 +20578,8 @@ safe_VkPhysicalDeviceMaintenance4Properties::~safe_VkPhysicalDeviceMaintenance4P
 
 void safe_VkPhysicalDeviceMaintenance4Properties::initialize(const VkPhysicalDeviceMaintenance4Properties* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxBufferSize = in_struct->maxBufferSize;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -19973,6 +20644,10 @@ safe_VkDeviceBufferMemoryRequirements::~safe_VkDeviceBufferMemoryRequirements()
 
 void safe_VkDeviceBufferMemoryRequirements::initialize(const VkDeviceBufferMemoryRequirements* in_struct)
 {
+    if (pCreateInfo)
+        delete pCreateInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pCreateInfo = nullptr;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -20045,6 +20720,10 @@ safe_VkDeviceImageMemoryRequirements::~safe_VkDeviceImageMemoryRequirements()
 
 void safe_VkDeviceImageMemoryRequirements::initialize(const VkDeviceImageMemoryRequirements* in_struct)
 {
+    if (pCreateInfo)
+        delete pCreateInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pCreateInfo = nullptr;
     planeAspect = in_struct->planeAspect;
@@ -20188,6 +20867,10 @@ safe_VkSwapchainCreateInfoKHR::~safe_VkSwapchainCreateInfoKHR()
 
 void safe_VkSwapchainCreateInfoKHR::initialize(const VkSwapchainCreateInfoKHR* in_struct)
 {
+    if (pQueueFamilyIndices)
+        delete[] pQueueFamilyIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     surface = in_struct->surface;
@@ -20380,6 +21063,16 @@ safe_VkPresentInfoKHR::~safe_VkPresentInfoKHR()
 
 void safe_VkPresentInfoKHR::initialize(const VkPresentInfoKHR* in_struct)
 {
+    if (pWaitSemaphores)
+        delete[] pWaitSemaphores;
+    if (pSwapchains)
+        delete[] pSwapchains;
+    if (pImageIndices)
+        delete[] pImageIndices;
+    if (pResults)
+        delete[] pResults;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreCount = in_struct->waitSemaphoreCount;
     pWaitSemaphores = nullptr;
@@ -20484,6 +21177,8 @@ safe_VkImageSwapchainCreateInfoKHR::~safe_VkImageSwapchainCreateInfoKHR()
 
 void safe_VkImageSwapchainCreateInfoKHR::initialize(const VkImageSwapchainCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchain = in_struct->swapchain;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -20542,6 +21237,8 @@ safe_VkBindImageMemorySwapchainInfoKHR::~safe_VkBindImageMemorySwapchainInfoKHR(
 
 void safe_VkBindImageMemorySwapchainInfoKHR::initialize(const VkBindImageMemorySwapchainInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchain = in_struct->swapchain;
     imageIndex = in_struct->imageIndex;
@@ -20614,6 +21311,8 @@ safe_VkAcquireNextImageInfoKHR::~safe_VkAcquireNextImageInfoKHR()
 
 void safe_VkAcquireNextImageInfoKHR::initialize(const VkAcquireNextImageInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchain = in_struct->swapchain;
     timeout = in_struct->timeout;
@@ -20685,6 +21384,8 @@ safe_VkDeviceGroupPresentCapabilitiesKHR::~safe_VkDeviceGroupPresentCapabilities
 
 void safe_VkDeviceGroupPresentCapabilitiesKHR::initialize(const VkDeviceGroupPresentCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     modes = in_struct->modes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -20769,6 +21470,10 @@ safe_VkDeviceGroupPresentInfoKHR::~safe_VkDeviceGroupPresentInfoKHR()
 
 void safe_VkDeviceGroupPresentInfoKHR::initialize(const VkDeviceGroupPresentInfoKHR* in_struct)
 {
+    if (pDeviceMasks)
+        delete[] pDeviceMasks;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchainCount = in_struct->swapchainCount;
     pDeviceMasks = nullptr;
@@ -20835,6 +21540,8 @@ safe_VkDeviceGroupSwapchainCreateInfoKHR::~safe_VkDeviceGroupSwapchainCreateInfo
 
 void safe_VkDeviceGroupSwapchainCreateInfoKHR::initialize(const VkDeviceGroupSwapchainCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     modes = in_struct->modes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -20893,6 +21600,8 @@ safe_VkDisplayModeCreateInfoKHR::~safe_VkDisplayModeCreateInfoKHR()
 
 void safe_VkDisplayModeCreateInfoKHR::initialize(const VkDisplayModeCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     parameters = in_struct->parameters;
@@ -20963,6 +21672,7 @@ safe_VkDisplayPropertiesKHR::~safe_VkDisplayPropertiesKHR()
 
 void safe_VkDisplayPropertiesKHR::initialize(const VkDisplayPropertiesKHR* in_struct)
 {
+    if (displayName) delete [] displayName;
     display = in_struct->display;
     physicalDimensions = in_struct->physicalDimensions;
     physicalResolution = in_struct->physicalResolution;
@@ -21053,6 +21763,8 @@ safe_VkDisplaySurfaceCreateInfoKHR::~safe_VkDisplaySurfaceCreateInfoKHR()
 
 void safe_VkDisplaySurfaceCreateInfoKHR::initialize(const VkDisplaySurfaceCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     displayMode = in_struct->displayMode;
@@ -21129,6 +21841,8 @@ safe_VkDisplayPresentInfoKHR::~safe_VkDisplayPresentInfoKHR()
 
 void safe_VkDisplayPresentInfoKHR::initialize(const VkDisplayPresentInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcRect = in_struct->srcRect;
     dstRect = in_struct->dstRect;
@@ -21189,6 +21903,8 @@ safe_VkQueueFamilyQueryResultStatusProperties2KHR::~safe_VkQueueFamilyQueryResul
 
 void safe_VkQueueFamilyQueryResultStatusProperties2KHR::initialize(const VkQueueFamilyQueryResultStatusProperties2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     supported = in_struct->supported;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -21247,6 +21963,8 @@ safe_VkVideoQueueFamilyProperties2KHR::~safe_VkVideoQueueFamilyProperties2KHR()
 
 void safe_VkVideoQueueFamilyProperties2KHR::initialize(const VkVideoQueueFamilyProperties2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     videoCodecOperations = in_struct->videoCodecOperations;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -21317,6 +22035,8 @@ safe_VkVideoProfileKHR::~safe_VkVideoProfileKHR()
 
 void safe_VkVideoProfileKHR::initialize(const VkVideoProfileKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     videoCodecOperation = in_struct->videoCodecOperation;
     chromaSubsampling = in_struct->chromaSubsampling;
@@ -21407,6 +22127,10 @@ safe_VkVideoProfilesKHR::~safe_VkVideoProfilesKHR()
 
 void safe_VkVideoProfilesKHR::initialize(const VkVideoProfilesKHR* in_struct)
 {
+    if (pProfiles)
+        delete[] pProfiles;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     profileCount = in_struct->profileCount;
     pProfiles = nullptr;
@@ -21511,6 +22235,8 @@ safe_VkVideoCapabilitiesKHR::~safe_VkVideoCapabilitiesKHR()
 
 void safe_VkVideoCapabilitiesKHR::initialize(const VkVideoCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     capabilityFlags = in_struct->capabilityFlags;
     minBitstreamBufferOffsetAlignment = in_struct->minBitstreamBufferOffsetAlignment;
@@ -21599,6 +22325,10 @@ safe_VkPhysicalDeviceVideoFormatInfoKHR::~safe_VkPhysicalDeviceVideoFormatInfoKH
 
 void safe_VkPhysicalDeviceVideoFormatInfoKHR::initialize(const VkPhysicalDeviceVideoFormatInfoKHR* in_struct)
 {
+    if (pVideoProfiles)
+        delete pVideoProfiles;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageUsage = in_struct->imageUsage;
     pVideoProfiles = nullptr;
@@ -21663,6 +22393,8 @@ safe_VkVideoFormatPropertiesKHR::~safe_VkVideoFormatPropertiesKHR()
 
 void safe_VkVideoFormatPropertiesKHR::initialize(const VkVideoFormatPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -21733,6 +22465,8 @@ safe_VkVideoPictureResourceKHR::~safe_VkVideoPictureResourceKHR()
 
 void safe_VkVideoPictureResourceKHR::initialize(const VkVideoPictureResourceKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     codedOffset = in_struct->codedOffset;
     codedExtent = in_struct->codedExtent;
@@ -21811,6 +22545,10 @@ safe_VkVideoReferenceSlotKHR::~safe_VkVideoReferenceSlotKHR()
 
 void safe_VkVideoReferenceSlotKHR::initialize(const VkVideoReferenceSlotKHR* in_struct)
 {
+    if (pPictureResource)
+        delete pPictureResource;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     slotIndex = in_struct->slotIndex;
     pPictureResource = nullptr;
@@ -21889,6 +22627,10 @@ safe_VkVideoGetMemoryPropertiesKHR::~safe_VkVideoGetMemoryPropertiesKHR()
 
 void safe_VkVideoGetMemoryPropertiesKHR::initialize(const VkVideoGetMemoryPropertiesKHR* in_struct)
 {
+    if (pMemoryRequirements)
+        delete pMemoryRequirements;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryBindIndex = in_struct->memoryBindIndex;
     pMemoryRequirements = nullptr;
@@ -21965,6 +22707,8 @@ safe_VkVideoBindMemoryKHR::~safe_VkVideoBindMemoryKHR()
 
 void safe_VkVideoBindMemoryKHR::initialize(const VkVideoBindMemoryKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryBindIndex = in_struct->memoryBindIndex;
     memory = in_struct->memory;
@@ -22084,6 +22828,12 @@ safe_VkVideoSessionCreateInfoKHR::~safe_VkVideoSessionCreateInfoKHR()
 
 void safe_VkVideoSessionCreateInfoKHR::initialize(const VkVideoSessionCreateInfoKHR* in_struct)
 {
+    if (pVideoProfile)
+        delete pVideoProfile;
+    if (pStdHeaderVersion)
+        delete pStdHeaderVersion;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     queueFamilyIndex = in_struct->queueFamilyIndex;
     flags = in_struct->flags;
@@ -22172,6 +22922,8 @@ safe_VkVideoSessionParametersCreateInfoKHR::~safe_VkVideoSessionParametersCreate
 
 void safe_VkVideoSessionParametersCreateInfoKHR::initialize(const VkVideoSessionParametersCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     videoSessionParametersTemplate = in_struct->videoSessionParametersTemplate;
     videoSession = in_struct->videoSession;
@@ -22232,6 +22984,8 @@ safe_VkVideoSessionParametersUpdateInfoKHR::~safe_VkVideoSessionParametersUpdate
 
 void safe_VkVideoSessionParametersUpdateInfoKHR::initialize(const VkVideoSessionParametersUpdateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     updateSequenceCount = in_struct->updateSequenceCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -22332,6 +23086,10 @@ safe_VkVideoBeginCodingInfoKHR::~safe_VkVideoBeginCodingInfoKHR()
 
 void safe_VkVideoBeginCodingInfoKHR::initialize(const VkVideoBeginCodingInfoKHR* in_struct)
 {
+    if (pReferenceSlots)
+        delete[] pReferenceSlots;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     codecQualityPreset = in_struct->codecQualityPreset;
@@ -22412,6 +23170,8 @@ safe_VkVideoEndCodingInfoKHR::~safe_VkVideoEndCodingInfoKHR()
 
 void safe_VkVideoEndCodingInfoKHR::initialize(const VkVideoEndCodingInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -22470,6 +23230,8 @@ safe_VkVideoCodingControlInfoKHR::~safe_VkVideoCodingControlInfoKHR()
 
 void safe_VkVideoCodingControlInfoKHR::initialize(const VkVideoCodingControlInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -22528,6 +23290,8 @@ safe_VkVideoDecodeCapabilitiesKHR::~safe_VkVideoDecodeCapabilitiesKHR()
 
 void safe_VkVideoDecodeCapabilitiesKHR::initialize(const VkVideoDecodeCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -22645,6 +23409,12 @@ safe_VkVideoDecodeInfoKHR::~safe_VkVideoDecodeInfoKHR()
 
 void safe_VkVideoDecodeInfoKHR::initialize(const VkVideoDecodeInfoKHR* in_struct)
 {
+    if (pSetupReferenceSlot)
+        delete pSetupReferenceSlot;
+    if (pReferenceSlots)
+        delete[] pReferenceSlots;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     srcBuffer = in_struct->srcBuffer;
@@ -22739,6 +23509,8 @@ safe_VkRenderingFragmentShadingRateAttachmentInfoKHR::~safe_VkRenderingFragmentS
 
 void safe_VkRenderingFragmentShadingRateAttachmentInfoKHR::initialize(const VkRenderingFragmentShadingRateAttachmentInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageView = in_struct->imageView;
     imageLayout = in_struct->imageLayout;
@@ -22801,6 +23573,8 @@ safe_VkRenderingFragmentDensityMapAttachmentInfoEXT::~safe_VkRenderingFragmentDe
 
 void safe_VkRenderingFragmentDensityMapAttachmentInfoEXT::initialize(const VkRenderingFragmentDensityMapAttachmentInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageView = in_struct->imageView;
     imageLayout = in_struct->imageLayout;
@@ -22881,6 +23655,10 @@ safe_VkAttachmentSampleCountInfoAMD::~safe_VkAttachmentSampleCountInfoAMD()
 
 void safe_VkAttachmentSampleCountInfoAMD::initialize(const VkAttachmentSampleCountInfoAMD* in_struct)
 {
+    if (pColorAttachmentSamples)
+        delete[] pColorAttachmentSamples;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     colorAttachmentCount = in_struct->colorAttachmentCount;
     pColorAttachmentSamples = nullptr;
@@ -22951,6 +23729,8 @@ safe_VkMultiviewPerViewAttributesInfoNVX::~safe_VkMultiviewPerViewAttributesInfo
 
 void safe_VkMultiviewPerViewAttributesInfoNVX::initialize(const VkMultiviewPerViewAttributesInfoNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     perViewAttributes = in_struct->perViewAttributes;
     perViewAttributesPositionXOnly = in_struct->perViewAttributesPositionXOnly;
@@ -23017,6 +23797,8 @@ safe_VkImportMemoryWin32HandleInfoKHR::~safe_VkImportMemoryWin32HandleInfoKHR()
 
 void safe_VkImportMemoryWin32HandleInfoKHR::initialize(const VkImportMemoryWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     handle = in_struct->handle;
@@ -23100,6 +23882,10 @@ safe_VkExportMemoryWin32HandleInfoKHR::~safe_VkExportMemoryWin32HandleInfoKHR()
 
 void safe_VkExportMemoryWin32HandleInfoKHR::initialize(const VkExportMemoryWin32HandleInfoKHR* in_struct)
 {
+    if (pAttributes)
+        delete pAttributes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pAttributes = nullptr;
     dwAccess = in_struct->dwAccess;
@@ -23168,6 +23954,8 @@ safe_VkMemoryWin32HandlePropertiesKHR::~safe_VkMemoryWin32HandlePropertiesKHR()
 
 void safe_VkMemoryWin32HandlePropertiesKHR::initialize(const VkMemoryWin32HandlePropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryTypeBits = in_struct->memoryTypeBits;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -23230,6 +24018,8 @@ safe_VkMemoryGetWin32HandleInfoKHR::~safe_VkMemoryGetWin32HandleInfoKHR()
 
 void safe_VkMemoryGetWin32HandleInfoKHR::initialize(const VkMemoryGetWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     handleType = in_struct->handleType;
@@ -23292,6 +24082,8 @@ safe_VkImportMemoryFdInfoKHR::~safe_VkImportMemoryFdInfoKHR()
 
 void safe_VkImportMemoryFdInfoKHR::initialize(const VkImportMemoryFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     fd = in_struct->fd;
@@ -23348,6 +24140,8 @@ safe_VkMemoryFdPropertiesKHR::~safe_VkMemoryFdPropertiesKHR()
 
 void safe_VkMemoryFdPropertiesKHR::initialize(const VkMemoryFdPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryTypeBits = in_struct->memoryTypeBits;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -23406,6 +24200,8 @@ safe_VkMemoryGetFdInfoKHR::~safe_VkMemoryGetFdInfoKHR()
 
 void safe_VkMemoryGetFdInfoKHR::initialize(const VkMemoryGetFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     handleType = in_struct->handleType;
@@ -23580,6 +24376,18 @@ safe_VkWin32KeyedMutexAcquireReleaseInfoKHR::~safe_VkWin32KeyedMutexAcquireRelea
 
 void safe_VkWin32KeyedMutexAcquireReleaseInfoKHR::initialize(const VkWin32KeyedMutexAcquireReleaseInfoKHR* in_struct)
 {
+    if (pAcquireSyncs)
+        delete[] pAcquireSyncs;
+    if (pAcquireKeys)
+        delete[] pAcquireKeys;
+    if (pAcquireTimeouts)
+        delete[] pAcquireTimeouts;
+    if (pReleaseSyncs)
+        delete[] pReleaseSyncs;
+    if (pReleaseKeys)
+        delete[] pReleaseKeys;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     acquireCount = in_struct->acquireCount;
     pAcquireSyncs = nullptr;
@@ -23714,6 +24522,8 @@ safe_VkImportSemaphoreWin32HandleInfoKHR::~safe_VkImportSemaphoreWin32HandleInfo
 
 void safe_VkImportSemaphoreWin32HandleInfoKHR::initialize(const VkImportSemaphoreWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     flags = in_struct->flags;
@@ -23801,6 +24611,10 @@ safe_VkExportSemaphoreWin32HandleInfoKHR::~safe_VkExportSemaphoreWin32HandleInfo
 
 void safe_VkExportSemaphoreWin32HandleInfoKHR::initialize(const VkExportSemaphoreWin32HandleInfoKHR* in_struct)
 {
+    if (pAttributes)
+        delete pAttributes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pAttributes = nullptr;
     dwAccess = in_struct->dwAccess;
@@ -23913,6 +24727,12 @@ safe_VkD3D12FenceSubmitInfoKHR::~safe_VkD3D12FenceSubmitInfoKHR()
 
 void safe_VkD3D12FenceSubmitInfoKHR::initialize(const VkD3D12FenceSubmitInfoKHR* in_struct)
 {
+    if (pWaitSemaphoreValues)
+        delete[] pWaitSemaphoreValues;
+    if (pSignalSemaphoreValues)
+        delete[] pSignalSemaphoreValues;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     waitSemaphoreValuesCount = in_struct->waitSemaphoreValuesCount;
     pWaitSemaphoreValues = nullptr;
@@ -23997,6 +24817,8 @@ safe_VkSemaphoreGetWin32HandleInfoKHR::~safe_VkSemaphoreGetWin32HandleInfoKHR()
 
 void safe_VkSemaphoreGetWin32HandleInfoKHR::initialize(const VkSemaphoreGetWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     handleType = in_struct->handleType;
@@ -24067,6 +24889,8 @@ safe_VkImportSemaphoreFdInfoKHR::~safe_VkImportSemaphoreFdInfoKHR()
 
 void safe_VkImportSemaphoreFdInfoKHR::initialize(const VkImportSemaphoreFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     flags = in_struct->flags;
@@ -24131,6 +24955,8 @@ safe_VkSemaphoreGetFdInfoKHR::~safe_VkSemaphoreGetFdInfoKHR()
 
 void safe_VkSemaphoreGetFdInfoKHR::initialize(const VkSemaphoreGetFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     handleType = in_struct->handleType;
@@ -24187,6 +25013,8 @@ safe_VkPhysicalDevicePushDescriptorPropertiesKHR::~safe_VkPhysicalDevicePushDesc
 
 void safe_VkPhysicalDevicePushDescriptorPropertiesKHR::initialize(const VkPhysicalDevicePushDescriptorPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxPushDescriptors = in_struct->maxPushDescriptors;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -24249,6 +25077,8 @@ safe_VkPresentRegionKHR::~safe_VkPresentRegionKHR()
 
 void safe_VkPresentRegionKHR::initialize(const VkPresentRegionKHR* in_struct)
 {
+    if (pRectangles)
+        delete[] pRectangles;
     rectangleCount = in_struct->rectangleCount;
     pRectangles = nullptr;
     if (in_struct->pRectangles) {
@@ -24335,6 +25165,10 @@ safe_VkPresentRegionsKHR::~safe_VkPresentRegionsKHR()
 
 void safe_VkPresentRegionsKHR::initialize(const VkPresentRegionsKHR* in_struct)
 {
+    if (pRegions)
+        delete[] pRegions;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchainCount = in_struct->swapchainCount;
     pRegions = nullptr;
@@ -24403,6 +25237,8 @@ safe_VkSharedPresentSurfaceCapabilitiesKHR::~safe_VkSharedPresentSurfaceCapabili
 
 void safe_VkSharedPresentSurfaceCapabilitiesKHR::initialize(const VkSharedPresentSurfaceCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sharedPresentSupportedUsageFlags = in_struct->sharedPresentSupportedUsageFlags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -24475,6 +25311,8 @@ safe_VkImportFenceWin32HandleInfoKHR::~safe_VkImportFenceWin32HandleInfoKHR()
 
 void safe_VkImportFenceWin32HandleInfoKHR::initialize(const VkImportFenceWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fence = in_struct->fence;
     flags = in_struct->flags;
@@ -24562,6 +25400,10 @@ safe_VkExportFenceWin32HandleInfoKHR::~safe_VkExportFenceWin32HandleInfoKHR()
 
 void safe_VkExportFenceWin32HandleInfoKHR::initialize(const VkExportFenceWin32HandleInfoKHR* in_struct)
 {
+    if (pAttributes)
+        delete pAttributes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pAttributes = nullptr;
     dwAccess = in_struct->dwAccess;
@@ -24634,6 +25476,8 @@ safe_VkFenceGetWin32HandleInfoKHR::~safe_VkFenceGetWin32HandleInfoKHR()
 
 void safe_VkFenceGetWin32HandleInfoKHR::initialize(const VkFenceGetWin32HandleInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fence = in_struct->fence;
     handleType = in_struct->handleType;
@@ -24704,6 +25548,8 @@ safe_VkImportFenceFdInfoKHR::~safe_VkImportFenceFdInfoKHR()
 
 void safe_VkImportFenceFdInfoKHR::initialize(const VkImportFenceFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fence = in_struct->fence;
     flags = in_struct->flags;
@@ -24768,6 +25614,8 @@ safe_VkFenceGetFdInfoKHR::~safe_VkFenceGetFdInfoKHR()
 
 void safe_VkFenceGetFdInfoKHR::initialize(const VkFenceGetFdInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fence = in_struct->fence;
     handleType = in_struct->handleType;
@@ -24828,6 +25676,8 @@ safe_VkPhysicalDevicePerformanceQueryFeaturesKHR::~safe_VkPhysicalDevicePerforma
 
 void safe_VkPhysicalDevicePerformanceQueryFeaturesKHR::initialize(const VkPhysicalDevicePerformanceQueryFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     performanceCounterQueryPools = in_struct->performanceCounterQueryPools;
     performanceCounterMultipleQueryPools = in_struct->performanceCounterMultipleQueryPools;
@@ -24884,6 +25734,8 @@ safe_VkPhysicalDevicePerformanceQueryPropertiesKHR::~safe_VkPhysicalDevicePerfor
 
 void safe_VkPhysicalDevicePerformanceQueryPropertiesKHR::initialize(const VkPhysicalDevicePerformanceQueryPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     allowCommandBufferQueryCopies = in_struct->allowCommandBufferQueryCopies;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -24955,6 +25807,8 @@ safe_VkPerformanceCounterKHR::~safe_VkPerformanceCounterKHR()
 
 void safe_VkPerformanceCounterKHR::initialize(const VkPerformanceCounterKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     unit = in_struct->unit;
     scope = in_struct->scope;
@@ -25046,6 +25900,8 @@ safe_VkPerformanceCounterDescriptionKHR::~safe_VkPerformanceCounterDescriptionKH
 
 void safe_VkPerformanceCounterDescriptionKHR::initialize(const VkPerformanceCounterDescriptionKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25142,6 +25998,10 @@ safe_VkQueryPoolPerformanceCreateInfoKHR::~safe_VkQueryPoolPerformanceCreateInfo
 
 void safe_VkQueryPoolPerformanceCreateInfoKHR::initialize(const VkQueryPoolPerformanceCreateInfoKHR* in_struct)
 {
+    if (pCounterIndices)
+        delete[] pCounterIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     queueFamilyIndex = in_struct->queueFamilyIndex;
     counterIndexCount = in_struct->counterIndexCount;
@@ -25212,6 +26072,8 @@ safe_VkAcquireProfilingLockInfoKHR::~safe_VkAcquireProfilingLockInfoKHR()
 
 void safe_VkAcquireProfilingLockInfoKHR::initialize(const VkAcquireProfilingLockInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     timeout = in_struct->timeout;
@@ -25268,6 +26130,8 @@ safe_VkPerformanceQuerySubmitInfoKHR::~safe_VkPerformanceQuerySubmitInfoKHR()
 
 void safe_VkPerformanceQuerySubmitInfoKHR::initialize(const VkPerformanceQuerySubmitInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     counterPassIndex = in_struct->counterPassIndex;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25322,6 +26186,8 @@ safe_VkPhysicalDeviceSurfaceInfo2KHR::~safe_VkPhysicalDeviceSurfaceInfo2KHR()
 
 void safe_VkPhysicalDeviceSurfaceInfo2KHR::initialize(const VkPhysicalDeviceSurfaceInfo2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     surface = in_struct->surface;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25376,6 +26242,8 @@ safe_VkSurfaceCapabilities2KHR::~safe_VkSurfaceCapabilities2KHR()
 
 void safe_VkSurfaceCapabilities2KHR::initialize(const VkSurfaceCapabilities2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     surfaceCapabilities = in_struct->surfaceCapabilities;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25430,6 +26298,8 @@ safe_VkSurfaceFormat2KHR::~safe_VkSurfaceFormat2KHR()
 
 void safe_VkSurfaceFormat2KHR::initialize(const VkSurfaceFormat2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     surfaceFormat = in_struct->surfaceFormat;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25483,6 +26353,8 @@ safe_VkDisplayProperties2KHR::~safe_VkDisplayProperties2KHR()
 
 void safe_VkDisplayProperties2KHR::initialize(const VkDisplayProperties2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     displayProperties.initialize(&in_struct->displayProperties);
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25537,6 +26409,8 @@ safe_VkDisplayPlaneProperties2KHR::~safe_VkDisplayPlaneProperties2KHR()
 
 void safe_VkDisplayPlaneProperties2KHR::initialize(const VkDisplayPlaneProperties2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     displayPlaneProperties = in_struct->displayPlaneProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25591,6 +26465,8 @@ safe_VkDisplayModeProperties2KHR::~safe_VkDisplayModeProperties2KHR()
 
 void safe_VkDisplayModeProperties2KHR::initialize(const VkDisplayModeProperties2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     displayModeProperties = in_struct->displayModeProperties;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25649,6 +26525,8 @@ safe_VkDisplayPlaneInfo2KHR::~safe_VkDisplayPlaneInfo2KHR()
 
 void safe_VkDisplayPlaneInfo2KHR::initialize(const VkDisplayPlaneInfo2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     mode = in_struct->mode;
     planeIndex = in_struct->planeIndex;
@@ -25705,6 +26583,8 @@ safe_VkDisplayPlaneCapabilities2KHR::~safe_VkDisplayPlaneCapabilities2KHR()
 
 void safe_VkDisplayPlaneCapabilities2KHR::initialize(const VkDisplayPlaneCapabilities2KHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     capabilities = in_struct->capabilities;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25817,6 +26697,8 @@ safe_VkPhysicalDevicePortabilitySubsetFeaturesKHR::~safe_VkPhysicalDevicePortabi
 
 void safe_VkPhysicalDevicePortabilitySubsetFeaturesKHR::initialize(const VkPhysicalDevicePortabilitySubsetFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     constantAlphaColorBlendFactors = in_struct->constantAlphaColorBlendFactors;
     events = in_struct->events;
@@ -25903,6 +26785,8 @@ safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR::~safe_VkPhysicalDevicePorta
 
 void safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR::initialize(const VkPhysicalDevicePortabilitySubsetPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minVertexInputBindingStrideAlignment = in_struct->minVertexInputBindingStrideAlignment;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -25963,6 +26847,8 @@ safe_VkPhysicalDeviceShaderClockFeaturesKHR::~safe_VkPhysicalDeviceShaderClockFe
 
 void safe_VkPhysicalDeviceShaderClockFeaturesKHR::initialize(const VkPhysicalDeviceShaderClockFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderSubgroupClock = in_struct->shaderSubgroupClock;
     shaderDeviceClock = in_struct->shaderDeviceClock;
@@ -26019,6 +26905,8 @@ safe_VkDeviceQueueGlobalPriorityCreateInfoKHR::~safe_VkDeviceQueueGlobalPriority
 
 void safe_VkDeviceQueueGlobalPriorityCreateInfoKHR::initialize(const VkDeviceQueueGlobalPriorityCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     globalPriority = in_struct->globalPriority;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26073,6 +26961,8 @@ safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR::~safe_VkPhysicalDeviceGloba
 
 void safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR::initialize(const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     globalPriorityQuery = in_struct->globalPriorityQuery;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26136,6 +27026,8 @@ safe_VkQueueFamilyGlobalPriorityPropertiesKHR::~safe_VkQueueFamilyGlobalPriority
 
 void safe_VkQueueFamilyGlobalPriorityPropertiesKHR::initialize(const VkQueueFamilyGlobalPriorityPropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     priorityCount = in_struct->priorityCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26210,6 +27102,10 @@ safe_VkFragmentShadingRateAttachmentInfoKHR::~safe_VkFragmentShadingRateAttachme
 
 void safe_VkFragmentShadingRateAttachmentInfoKHR::initialize(const VkFragmentShadingRateAttachmentInfoKHR* in_struct)
 {
+    if (pFragmentShadingRateAttachment)
+        delete pFragmentShadingRateAttachment;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pFragmentShadingRateAttachment = nullptr;
     shadingRateAttachmentTexelSize = in_struct->shadingRateAttachmentTexelSize;
@@ -26279,6 +27175,8 @@ safe_VkPipelineFragmentShadingRateStateCreateInfoKHR::~safe_VkPipelineFragmentSh
 
 void safe_VkPipelineFragmentShadingRateStateCreateInfoKHR::initialize(const VkPipelineFragmentShadingRateStateCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentSize = in_struct->fragmentSize;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26347,6 +27245,8 @@ safe_VkPhysicalDeviceFragmentShadingRateFeaturesKHR::~safe_VkPhysicalDeviceFragm
 
 void safe_VkPhysicalDeviceFragmentShadingRateFeaturesKHR::initialize(const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipelineFragmentShadingRate = in_struct->pipelineFragmentShadingRate;
     primitiveFragmentShadingRate = in_struct->primitiveFragmentShadingRate;
@@ -26469,6 +27369,8 @@ safe_VkPhysicalDeviceFragmentShadingRatePropertiesKHR::~safe_VkPhysicalDeviceFra
 
 void safe_VkPhysicalDeviceFragmentShadingRatePropertiesKHR::initialize(const VkPhysicalDeviceFragmentShadingRatePropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minFragmentShadingRateAttachmentTexelSize = in_struct->minFragmentShadingRateAttachmentTexelSize;
     maxFragmentShadingRateAttachmentTexelSize = in_struct->maxFragmentShadingRateAttachmentTexelSize;
@@ -26559,6 +27461,8 @@ safe_VkPhysicalDeviceFragmentShadingRateKHR::~safe_VkPhysicalDeviceFragmentShadi
 
 void safe_VkPhysicalDeviceFragmentShadingRateKHR::initialize(const VkPhysicalDeviceFragmentShadingRateKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sampleCounts = in_struct->sampleCounts;
     fragmentSize = in_struct->fragmentSize;
@@ -26615,6 +27519,8 @@ safe_VkSurfaceProtectedCapabilitiesKHR::~safe_VkSurfaceProtectedCapabilitiesKHR(
 
 void safe_VkSurfaceProtectedCapabilitiesKHR::initialize(const VkSurfaceProtectedCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     supportsProtected = in_struct->supportsProtected;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26669,6 +27575,8 @@ safe_VkPhysicalDevicePresentWaitFeaturesKHR::~safe_VkPhysicalDevicePresentWaitFe
 
 void safe_VkPhysicalDevicePresentWaitFeaturesKHR::initialize(const VkPhysicalDevicePresentWaitFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     presentWait = in_struct->presentWait;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26723,6 +27631,8 @@ safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR::~safe_VkPhysicalDe
 
 void safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR::initialize(const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipelineExecutableInfo = in_struct->pipelineExecutableInfo;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26777,6 +27687,8 @@ safe_VkPipelineInfoKHR::~safe_VkPipelineInfoKHR()
 
 void safe_VkPipelineInfoKHR::initialize(const VkPipelineInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipeline = in_struct->pipeline;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -26853,6 +27765,8 @@ safe_VkPipelineExecutablePropertiesKHR::~safe_VkPipelineExecutablePropertiesKHR(
 
 void safe_VkPipelineExecutablePropertiesKHR::initialize(const VkPipelineExecutablePropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stages = in_struct->stages;
     subgroupSize = in_struct->subgroupSize;
@@ -26925,6 +27839,8 @@ safe_VkPipelineExecutableInfoKHR::~safe_VkPipelineExecutableInfoKHR()
 
 void safe_VkPipelineExecutableInfoKHR::initialize(const VkPipelineExecutableInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipeline = in_struct->pipeline;
     executableIndex = in_struct->executableIndex;
@@ -27003,6 +27919,8 @@ safe_VkPipelineExecutableStatisticKHR::~safe_VkPipelineExecutableStatisticKHR()
 
 void safe_VkPipelineExecutableStatisticKHR::initialize(const VkPipelineExecutableStatisticKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     value = in_struct->value;
@@ -27097,6 +28015,8 @@ safe_VkPipelineExecutableInternalRepresentationKHR::~safe_VkPipelineExecutableIn
 
 void safe_VkPipelineExecutableInternalRepresentationKHR::initialize(const VkPipelineExecutableInternalRepresentationKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     isText = in_struct->isText;
     dataSize = in_struct->dataSize;
@@ -27193,6 +28113,10 @@ safe_VkPipelineLibraryCreateInfoKHR::~safe_VkPipelineLibraryCreateInfoKHR()
 
 void safe_VkPipelineLibraryCreateInfoKHR::initialize(const VkPipelineLibraryCreateInfoKHR* in_struct)
 {
+    if (pLibraries)
+        delete[] pLibraries;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     libraryCount = in_struct->libraryCount;
     pLibraries = nullptr;
@@ -27281,6 +28205,10 @@ safe_VkPresentIdKHR::~safe_VkPresentIdKHR()
 
 void safe_VkPresentIdKHR::initialize(const VkPresentIdKHR* in_struct)
 {
+    if (pPresentIds)
+        delete[] pPresentIds;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchainCount = in_struct->swapchainCount;
     pPresentIds = nullptr;
@@ -27345,6 +28273,8 @@ safe_VkPhysicalDevicePresentIdFeaturesKHR::~safe_VkPhysicalDevicePresentIdFeatur
 
 void safe_VkPhysicalDevicePresentIdFeaturesKHR::initialize(const VkPhysicalDevicePresentIdFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     presentId = in_struct->presentId;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -27468,6 +28398,12 @@ safe_VkVideoEncodeInfoKHR::~safe_VkVideoEncodeInfoKHR()
 
 void safe_VkVideoEncodeInfoKHR::initialize(const VkVideoEncodeInfoKHR* in_struct)
 {
+    if (pSetupReferenceSlot)
+        delete pSetupReferenceSlot;
+    if (pReferenceSlots)
+        delete[] pReferenceSlots;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     qualityLevel = in_struct->qualityLevel;
@@ -27576,6 +28512,8 @@ safe_VkVideoEncodeCapabilitiesKHR::~safe_VkVideoEncodeCapabilitiesKHR()
 
 void safe_VkVideoEncodeCapabilitiesKHR::initialize(const VkVideoEncodeCapabilitiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     rateControlModes = in_struct->rateControlModes;
@@ -27662,6 +28600,8 @@ safe_VkVideoEncodeRateControlLayerInfoKHR::~safe_VkVideoEncodeRateControlLayerIn
 
 void safe_VkVideoEncodeRateControlLayerInfoKHR::initialize(const VkVideoEncodeRateControlLayerInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     averageBitrate = in_struct->averageBitrate;
     maxBitrate = in_struct->maxBitrate;
@@ -27764,6 +28704,10 @@ safe_VkVideoEncodeRateControlInfoKHR::~safe_VkVideoEncodeRateControlInfoKHR()
 
 void safe_VkVideoEncodeRateControlInfoKHR::initialize(const VkVideoEncodeRateControlInfoKHR* in_struct)
 {
+    if (pLayerConfigs)
+        delete[] pLayerConfigs;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     rateControlMode = in_struct->rateControlMode;
@@ -27838,6 +28782,8 @@ safe_VkQueueFamilyCheckpointProperties2NV::~safe_VkQueueFamilyCheckpointProperti
 
 void safe_VkQueueFamilyCheckpointProperties2NV::initialize(const VkQueueFamilyCheckpointProperties2NV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     checkpointExecutionStageMask = in_struct->checkpointExecutionStageMask;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -27896,6 +28842,8 @@ safe_VkCheckpointData2NV::~safe_VkCheckpointData2NV()
 
 void safe_VkCheckpointData2NV::initialize(const VkCheckpointData2NV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stage = in_struct->stage;
     pCheckpointMarker = in_struct->pCheckpointMarker;
@@ -27952,6 +28900,8 @@ safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR::~safe_VkPhysic
 
 void safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR::initialize(const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderSubgroupUniformControlFlow = in_struct->shaderSubgroupUniformControlFlow;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -28018,6 +28968,8 @@ safe_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::~safe_VkPhysicalD
 
 void safe_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::initialize(const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     workgroupMemoryExplicitLayout = in_struct->workgroupMemoryExplicitLayout;
     workgroupMemoryExplicitLayoutScalarBlockLayout = in_struct->workgroupMemoryExplicitLayoutScalarBlockLayout;
@@ -28086,6 +29038,8 @@ safe_VkDebugReportCallbackCreateInfoEXT::~safe_VkDebugReportCallbackCreateInfoEX
 
 void safe_VkDebugReportCallbackCreateInfoEXT::initialize(const VkDebugReportCallbackCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pfnCallback = in_struct->pfnCallback;
@@ -28144,6 +29098,8 @@ safe_VkPipelineRasterizationStateRasterizationOrderAMD::~safe_VkPipelineRasteriz
 
 void safe_VkPipelineRasterizationStateRasterizationOrderAMD::initialize(const VkPipelineRasterizationStateRasterizationOrderAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rasterizationOrder = in_struct->rasterizationOrder;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -28208,6 +29164,9 @@ safe_VkDebugMarkerObjectNameInfoEXT::~safe_VkDebugMarkerObjectNameInfoEXT()
 
 void safe_VkDebugMarkerObjectNameInfoEXT::initialize(const VkDebugMarkerObjectNameInfoEXT* in_struct)
 {
+    if (pObjectName) delete [] pObjectName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     objectType = in_struct->objectType;
     object = in_struct->object;
@@ -28282,6 +29241,8 @@ safe_VkDebugMarkerObjectTagInfoEXT::~safe_VkDebugMarkerObjectTagInfoEXT()
 
 void safe_VkDebugMarkerObjectTagInfoEXT::initialize(const VkDebugMarkerObjectTagInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     objectType = in_struct->objectType;
     object = in_struct->object;
@@ -28355,6 +29316,9 @@ safe_VkDebugMarkerMarkerInfoEXT::~safe_VkDebugMarkerMarkerInfoEXT()
 
 void safe_VkDebugMarkerMarkerInfoEXT::initialize(const VkDebugMarkerMarkerInfoEXT* in_struct)
 {
+    if (pMarkerName) delete [] pMarkerName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pNext = SafePnextCopy(in_struct->pNext);
     pMarkerName = SafeStringCopy(in_struct->pMarkerName);
@@ -28415,6 +29379,8 @@ safe_VkDedicatedAllocationImageCreateInfoNV::~safe_VkDedicatedAllocationImageCre
 
 void safe_VkDedicatedAllocationImageCreateInfoNV::initialize(const VkDedicatedAllocationImageCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dedicatedAllocation = in_struct->dedicatedAllocation;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -28469,6 +29435,8 @@ safe_VkDedicatedAllocationBufferCreateInfoNV::~safe_VkDedicatedAllocationBufferC
 
 void safe_VkDedicatedAllocationBufferCreateInfoNV::initialize(const VkDedicatedAllocationBufferCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dedicatedAllocation = in_struct->dedicatedAllocation;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -28527,6 +29495,8 @@ safe_VkDedicatedAllocationMemoryAllocateInfoNV::~safe_VkDedicatedAllocationMemor
 
 void safe_VkDedicatedAllocationMemoryAllocateInfoNV::initialize(const VkDedicatedAllocationMemoryAllocateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image = in_struct->image;
     buffer = in_struct->buffer;
@@ -28587,6 +29557,8 @@ safe_VkPhysicalDeviceTransformFeedbackFeaturesEXT::~safe_VkPhysicalDeviceTransfo
 
 void safe_VkPhysicalDeviceTransformFeedbackFeaturesEXT::initialize(const VkPhysicalDeviceTransformFeedbackFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     transformFeedback = in_struct->transformFeedback;
     geometryStreams = in_struct->geometryStreams;
@@ -28679,6 +29651,8 @@ safe_VkPhysicalDeviceTransformFeedbackPropertiesEXT::~safe_VkPhysicalDeviceTrans
 
 void safe_VkPhysicalDeviceTransformFeedbackPropertiesEXT::initialize(const VkPhysicalDeviceTransformFeedbackPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxTransformFeedbackStreams = in_struct->maxTransformFeedbackStreams;
     maxTransformFeedbackBuffers = in_struct->maxTransformFeedbackBuffers;
@@ -28755,6 +29729,8 @@ safe_VkPipelineRasterizationStateStreamCreateInfoEXT::~safe_VkPipelineRasterizat
 
 void safe_VkPipelineRasterizationStateStreamCreateInfoEXT::initialize(const VkPipelineRasterizationStateStreamCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     rasterizationStream = in_struct->rasterizationStream;
@@ -28815,6 +29791,8 @@ safe_VkCuModuleCreateInfoNVX::~safe_VkCuModuleCreateInfoNVX()
 
 void safe_VkCuModuleCreateInfoNVX::initialize(const VkCuModuleCreateInfoNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dataSize = in_struct->dataSize;
     pData = in_struct->pData;
@@ -28877,6 +29855,9 @@ safe_VkCuFunctionCreateInfoNVX::~safe_VkCuFunctionCreateInfoNVX()
 
 void safe_VkCuFunctionCreateInfoNVX::initialize(const VkCuFunctionCreateInfoNVX* in_struct)
 {
+    if (pName) delete [] pName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     module = in_struct->module;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -28977,6 +29958,8 @@ safe_VkCuLaunchInfoNVX::~safe_VkCuLaunchInfoNVX()
 
 void safe_VkCuLaunchInfoNVX::initialize(const VkCuLaunchInfoNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     function = in_struct->function;
     gridDimX = in_struct->gridDimX;
@@ -29061,6 +30044,8 @@ safe_VkImageViewHandleInfoNVX::~safe_VkImageViewHandleInfoNVX()
 
 void safe_VkImageViewHandleInfoNVX::initialize(const VkImageViewHandleInfoNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageView = in_struct->imageView;
     descriptorType = in_struct->descriptorType;
@@ -29123,6 +30108,8 @@ safe_VkImageViewAddressPropertiesNVX::~safe_VkImageViewAddressPropertiesNVX()
 
 void safe_VkImageViewAddressPropertiesNVX::initialize(const VkImageViewAddressPropertiesNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceAddress = in_struct->deviceAddress;
     size = in_struct->size;
@@ -29221,6 +30208,8 @@ safe_VkVideoEncodeH264CapabilitiesEXT::~safe_VkVideoEncodeH264CapabilitiesEXT()
 
 void safe_VkVideoEncodeH264CapabilitiesEXT::initialize(const VkVideoEncodeH264CapabilitiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     inputModeFlags = in_struct->inputModeFlags;
@@ -29343,6 +30332,12 @@ safe_VkVideoEncodeH264SessionParametersAddInfoEXT::~safe_VkVideoEncodeH264Sessio
 
 void safe_VkVideoEncodeH264SessionParametersAddInfoEXT::initialize(const VkVideoEncodeH264SessionParametersAddInfoEXT* in_struct)
 {
+    if (pSpsStd)
+        delete[] pSpsStd;
+    if (pPpsStd)
+        delete[] pPpsStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     spsStdCount = in_struct->spsStdCount;
     pSpsStd = nullptr;
@@ -29441,6 +30436,10 @@ safe_VkVideoEncodeH264SessionParametersCreateInfoEXT::~safe_VkVideoEncodeH264Ses
 
 void safe_VkVideoEncodeH264SessionParametersCreateInfoEXT::initialize(const VkVideoEncodeH264SessionParametersCreateInfoEXT* in_struct)
 {
+    if (pParametersAddInfo)
+        delete pParametersAddInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxSpsStdCount = in_struct->maxSpsStdCount;
     maxPpsStdCount = in_struct->maxPpsStdCount;
@@ -29524,6 +30523,10 @@ safe_VkVideoEncodeH264DpbSlotInfoEXT::~safe_VkVideoEncodeH264DpbSlotInfoEXT()
 
 void safe_VkVideoEncodeH264DpbSlotInfoEXT::initialize(const VkVideoEncodeH264DpbSlotInfoEXT* in_struct)
 {
+    if (pStdReferenceInfo)
+        delete pStdReferenceInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     slotIndex = in_struct->slotIndex;
     pStdReferenceInfo = nullptr;
@@ -29663,6 +30666,14 @@ safe_VkVideoEncodeH264ReferenceListsEXT::~safe_VkVideoEncodeH264ReferenceListsEX
 
 void safe_VkVideoEncodeH264ReferenceListsEXT::initialize(const VkVideoEncodeH264ReferenceListsEXT* in_struct)
 {
+    if (pReferenceList0Entries)
+        delete[] pReferenceList0Entries;
+    if (pReferenceList1Entries)
+        delete[] pReferenceList1Entries;
+    if (pMemMgmtCtrlOperations)
+        delete pMemMgmtCtrlOperations;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     referenceList0EntryCount = in_struct->referenceList0EntryCount;
     pReferenceList0Entries = nullptr;
@@ -29790,6 +30801,12 @@ safe_VkVideoEncodeH264NaluSliceEXT::~safe_VkVideoEncodeH264NaluSliceEXT()
 
 void safe_VkVideoEncodeH264NaluSliceEXT::initialize(const VkVideoEncodeH264NaluSliceEXT* in_struct)
 {
+    if (pReferenceFinalLists)
+        delete pReferenceFinalLists;
+    if (pSliceHeaderStd)
+        delete pSliceHeaderStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     mbCount = in_struct->mbCount;
     pReferenceFinalLists = nullptr;
@@ -29919,6 +30936,14 @@ safe_VkVideoEncodeH264VclFrameInfoEXT::~safe_VkVideoEncodeH264VclFrameInfoEXT()
 
 void safe_VkVideoEncodeH264VclFrameInfoEXT::initialize(const VkVideoEncodeH264VclFrameInfoEXT* in_struct)
 {
+    if (pReferenceFinalLists)
+        delete pReferenceFinalLists;
+    if (pNaluSliceEntries)
+        delete[] pNaluSliceEntries;
+    if (pCurrentPictureInfo)
+        delete pCurrentPictureInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pReferenceFinalLists = nullptr;
     naluSliceEntryCount = in_struct->naluSliceEntryCount;
@@ -30033,6 +31058,10 @@ safe_VkVideoEncodeH264EmitPictureParametersEXT::~safe_VkVideoEncodeH264EmitPictu
 
 void safe_VkVideoEncodeH264EmitPictureParametersEXT::initialize(const VkVideoEncodeH264EmitPictureParametersEXT* in_struct)
 {
+    if (ppsIdEntries)
+        delete[] ppsIdEntries;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     spsId = in_struct->spsId;
     emitSpsEnable = in_struct->emitSpsEnable;
@@ -30105,6 +31134,8 @@ safe_VkVideoEncodeH264ProfileEXT::~safe_VkVideoEncodeH264ProfileEXT()
 
 void safe_VkVideoEncodeH264ProfileEXT::initialize(const VkVideoEncodeH264ProfileEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stdProfileIdc = in_struct->stdProfileIdc;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -30179,6 +31210,8 @@ safe_VkVideoEncodeH264RateControlInfoEXT::~safe_VkVideoEncodeH264RateControlInfo
 
 void safe_VkVideoEncodeH264RateControlInfoEXT::initialize(const VkVideoEncodeH264RateControlInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     gopFrameCount = in_struct->gopFrameCount;
     idrPeriod = in_struct->idrPeriod;
@@ -30277,6 +31310,8 @@ safe_VkVideoEncodeH264RateControlLayerInfoEXT::~safe_VkVideoEncodeH264RateContro
 
 void safe_VkVideoEncodeH264RateControlLayerInfoEXT::initialize(const VkVideoEncodeH264RateControlLayerInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     temporalLayerId = in_struct->temporalLayerId;
     useInitialRcQp = in_struct->useInitialRcQp;
@@ -30427,6 +31462,8 @@ safe_VkVideoEncodeH265CapabilitiesEXT::~safe_VkVideoEncodeH265CapabilitiesEXT()
 
 void safe_VkVideoEncodeH265CapabilitiesEXT::initialize(const VkVideoEncodeH265CapabilitiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     inputModeFlags = in_struct->inputModeFlags;
@@ -30591,6 +31628,14 @@ safe_VkVideoEncodeH265SessionParametersAddInfoEXT::~safe_VkVideoEncodeH265Sessio
 
 void safe_VkVideoEncodeH265SessionParametersAddInfoEXT::initialize(const VkVideoEncodeH265SessionParametersAddInfoEXT* in_struct)
 {
+    if (pVpsStd)
+        delete[] pVpsStd;
+    if (pSpsStd)
+        delete[] pSpsStd;
+    if (pPpsStd)
+        delete[] pPpsStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vpsStdCount = in_struct->vpsStdCount;
     pVpsStd = nullptr;
@@ -30705,6 +31750,10 @@ safe_VkVideoEncodeH265SessionParametersCreateInfoEXT::~safe_VkVideoEncodeH265Ses
 
 void safe_VkVideoEncodeH265SessionParametersCreateInfoEXT::initialize(const VkVideoEncodeH265SessionParametersCreateInfoEXT* in_struct)
 {
+    if (pParametersAddInfo)
+        delete pParametersAddInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxVpsStdCount = in_struct->maxVpsStdCount;
     maxSpsStdCount = in_struct->maxSpsStdCount;
@@ -30790,6 +31839,10 @@ safe_VkVideoEncodeH265DpbSlotInfoEXT::~safe_VkVideoEncodeH265DpbSlotInfoEXT()
 
 void safe_VkVideoEncodeH265DpbSlotInfoEXT::initialize(const VkVideoEncodeH265DpbSlotInfoEXT* in_struct)
 {
+    if (pStdReferenceInfo)
+        delete pStdReferenceInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     slotIndex = in_struct->slotIndex;
     pStdReferenceInfo = nullptr;
@@ -30929,6 +31982,14 @@ safe_VkVideoEncodeH265ReferenceListsEXT::~safe_VkVideoEncodeH265ReferenceListsEX
 
 void safe_VkVideoEncodeH265ReferenceListsEXT::initialize(const VkVideoEncodeH265ReferenceListsEXT* in_struct)
 {
+    if (pReferenceList0Entries)
+        delete[] pReferenceList0Entries;
+    if (pReferenceList1Entries)
+        delete[] pReferenceList1Entries;
+    if (pReferenceModifications)
+        delete pReferenceModifications;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     referenceList0EntryCount = in_struct->referenceList0EntryCount;
     pReferenceList0Entries = nullptr;
@@ -31056,6 +32117,12 @@ safe_VkVideoEncodeH265NaluSliceSegmentEXT::~safe_VkVideoEncodeH265NaluSliceSegme
 
 void safe_VkVideoEncodeH265NaluSliceSegmentEXT::initialize(const VkVideoEncodeH265NaluSliceSegmentEXT* in_struct)
 {
+    if (pReferenceFinalLists)
+        delete pReferenceFinalLists;
+    if (pSliceSegmentHeaderStd)
+        delete pSliceSegmentHeaderStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     ctbCount = in_struct->ctbCount;
     pReferenceFinalLists = nullptr;
@@ -31185,6 +32252,14 @@ safe_VkVideoEncodeH265VclFrameInfoEXT::~safe_VkVideoEncodeH265VclFrameInfoEXT()
 
 void safe_VkVideoEncodeH265VclFrameInfoEXT::initialize(const VkVideoEncodeH265VclFrameInfoEXT* in_struct)
 {
+    if (pReferenceFinalLists)
+        delete pReferenceFinalLists;
+    if (pNaluSliceSegmentEntries)
+        delete[] pNaluSliceSegmentEntries;
+    if (pCurrentPictureInfo)
+        delete pCurrentPictureInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pReferenceFinalLists = nullptr;
     naluSliceSegmentEntryCount = in_struct->naluSliceSegmentEntryCount;
@@ -31307,6 +32382,10 @@ safe_VkVideoEncodeH265EmitPictureParametersEXT::~safe_VkVideoEncodeH265EmitPictu
 
 void safe_VkVideoEncodeH265EmitPictureParametersEXT::initialize(const VkVideoEncodeH265EmitPictureParametersEXT* in_struct)
 {
+    if (ppsIdEntries)
+        delete[] ppsIdEntries;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vpsId = in_struct->vpsId;
     spsId = in_struct->spsId;
@@ -31383,6 +32462,8 @@ safe_VkVideoEncodeH265ProfileEXT::~safe_VkVideoEncodeH265ProfileEXT()
 
 void safe_VkVideoEncodeH265ProfileEXT::initialize(const VkVideoEncodeH265ProfileEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stdProfileIdc = in_struct->stdProfileIdc;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -31457,6 +32538,8 @@ safe_VkVideoEncodeH265RateControlInfoEXT::~safe_VkVideoEncodeH265RateControlInfo
 
 void safe_VkVideoEncodeH265RateControlInfoEXT::initialize(const VkVideoEncodeH265RateControlInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     gopFrameCount = in_struct->gopFrameCount;
     idrPeriod = in_struct->idrPeriod;
@@ -31555,6 +32638,8 @@ safe_VkVideoEncodeH265RateControlLayerInfoEXT::~safe_VkVideoEncodeH265RateContro
 
 void safe_VkVideoEncodeH265RateControlLayerInfoEXT::initialize(const VkVideoEncodeH265RateControlLayerInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     temporalId = in_struct->temporalId;
     useInitialRcQp = in_struct->useInitialRcQp;
@@ -31633,6 +32718,8 @@ safe_VkVideoDecodeH264ProfileEXT::~safe_VkVideoDecodeH264ProfileEXT()
 
 void safe_VkVideoDecodeH264ProfileEXT::initialize(const VkVideoDecodeH264ProfileEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stdProfileIdc = in_struct->stdProfileIdc;
     pictureLayout = in_struct->pictureLayout;
@@ -31697,6 +32784,8 @@ safe_VkVideoDecodeH264CapabilitiesEXT::~safe_VkVideoDecodeH264CapabilitiesEXT()
 
 void safe_VkVideoDecodeH264CapabilitiesEXT::initialize(const VkVideoDecodeH264CapabilitiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxLevel = in_struct->maxLevel;
     fieldOffsetGranularity = in_struct->fieldOffsetGranularity;
@@ -31801,6 +32890,12 @@ safe_VkVideoDecodeH264SessionParametersAddInfoEXT::~safe_VkVideoDecodeH264Sessio
 
 void safe_VkVideoDecodeH264SessionParametersAddInfoEXT::initialize(const VkVideoDecodeH264SessionParametersAddInfoEXT* in_struct)
 {
+    if (pSpsStd)
+        delete[] pSpsStd;
+    if (pPpsStd)
+        delete[] pPpsStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     spsStdCount = in_struct->spsStdCount;
     pSpsStd = nullptr;
@@ -31899,6 +32994,10 @@ safe_VkVideoDecodeH264SessionParametersCreateInfoEXT::~safe_VkVideoDecodeH264Ses
 
 void safe_VkVideoDecodeH264SessionParametersCreateInfoEXT::initialize(const VkVideoDecodeH264SessionParametersCreateInfoEXT* in_struct)
 {
+    if (pParametersAddInfo)
+        delete pParametersAddInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxSpsStdCount = in_struct->maxSpsStdCount;
     maxPpsStdCount = in_struct->maxPpsStdCount;
@@ -32002,6 +33101,12 @@ safe_VkVideoDecodeH264PictureInfoEXT::~safe_VkVideoDecodeH264PictureInfoEXT()
 
 void safe_VkVideoDecodeH264PictureInfoEXT::initialize(const VkVideoDecodeH264PictureInfoEXT* in_struct)
 {
+    if (pStdPictureInfo)
+        delete pStdPictureInfo;
+    if (pSlicesDataOffsets)
+        delete[] pSlicesDataOffsets;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pStdPictureInfo = nullptr;
     slicesCount = in_struct->slicesCount;
@@ -32091,6 +33196,10 @@ safe_VkVideoDecodeH264MvcEXT::~safe_VkVideoDecodeH264MvcEXT()
 
 void safe_VkVideoDecodeH264MvcEXT::initialize(const VkVideoDecodeH264MvcEXT* in_struct)
 {
+    if (pStdMvc)
+        delete pStdMvc;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pStdMvc = nullptr;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32168,6 +33277,10 @@ safe_VkVideoDecodeH264DpbSlotInfoEXT::~safe_VkVideoDecodeH264DpbSlotInfoEXT()
 
 void safe_VkVideoDecodeH264DpbSlotInfoEXT::initialize(const VkVideoDecodeH264DpbSlotInfoEXT* in_struct)
 {
+    if (pStdReferenceInfo)
+        delete pStdReferenceInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pStdReferenceInfo = nullptr;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32230,6 +33343,8 @@ safe_VkTextureLODGatherFormatPropertiesAMD::~safe_VkTextureLODGatherFormatProper
 
 void safe_VkTextureLODGatherFormatPropertiesAMD::initialize(const VkTextureLODGatherFormatPropertiesAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     supportsTextureGatherLODBiasAMD = in_struct->supportsTextureGatherLODBiasAMD;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32290,6 +33405,8 @@ safe_VkStreamDescriptorSurfaceCreateInfoGGP::~safe_VkStreamDescriptorSurfaceCrea
 
 void safe_VkStreamDescriptorSurfaceCreateInfoGGP::initialize(const VkStreamDescriptorSurfaceCreateInfoGGP* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     streamDescriptor = in_struct->streamDescriptor;
@@ -32348,6 +33465,8 @@ safe_VkPhysicalDeviceCornerSampledImageFeaturesNV::~safe_VkPhysicalDeviceCornerS
 
 void safe_VkPhysicalDeviceCornerSampledImageFeaturesNV::initialize(const VkPhysicalDeviceCornerSampledImageFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     cornerSampledImage = in_struct->cornerSampledImage;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32402,6 +33521,8 @@ safe_VkExternalMemoryImageCreateInfoNV::~safe_VkExternalMemoryImageCreateInfoNV(
 
 void safe_VkExternalMemoryImageCreateInfoNV::initialize(const VkExternalMemoryImageCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32456,6 +33577,8 @@ safe_VkExportMemoryAllocateInfoNV::~safe_VkExportMemoryAllocateInfoNV()
 
 void safe_VkExportMemoryAllocateInfoNV::initialize(const VkExportMemoryAllocateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleTypes = in_struct->handleTypes;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -32516,6 +33639,8 @@ safe_VkImportMemoryWin32HandleInfoNV::~safe_VkImportMemoryWin32HandleInfoNV()
 
 void safe_VkImportMemoryWin32HandleInfoNV::initialize(const VkImportMemoryWin32HandleInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     handle = in_struct->handle;
@@ -32593,6 +33718,10 @@ safe_VkExportMemoryWin32HandleInfoNV::~safe_VkExportMemoryWin32HandleInfoNV()
 
 void safe_VkExportMemoryWin32HandleInfoNV::initialize(const VkExportMemoryWin32HandleInfoNV* in_struct)
 {
+    if (pAttributes)
+        delete pAttributes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pAttributes = nullptr;
     dwAccess = in_struct->dwAccess;
@@ -32775,6 +33904,18 @@ safe_VkWin32KeyedMutexAcquireReleaseInfoNV::~safe_VkWin32KeyedMutexAcquireReleas
 
 void safe_VkWin32KeyedMutexAcquireReleaseInfoNV::initialize(const VkWin32KeyedMutexAcquireReleaseInfoNV* in_struct)
 {
+    if (pAcquireSyncs)
+        delete[] pAcquireSyncs;
+    if (pAcquireKeys)
+        delete[] pAcquireKeys;
+    if (pAcquireTimeoutMilliseconds)
+        delete[] pAcquireTimeoutMilliseconds;
+    if (pReleaseSyncs)
+        delete[] pReleaseSyncs;
+    if (pReleaseKeys)
+        delete[] pReleaseKeys;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     acquireCount = in_struct->acquireCount;
     pAcquireSyncs = nullptr;
@@ -32911,6 +34052,10 @@ safe_VkValidationFlagsEXT::~safe_VkValidationFlagsEXT()
 
 void safe_VkValidationFlagsEXT::initialize(const VkValidationFlagsEXT* in_struct)
 {
+    if (pDisabledValidationChecks)
+        delete[] pDisabledValidationChecks;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     disabledValidationCheckCount = in_struct->disabledValidationCheckCount;
     pDisabledValidationChecks = nullptr;
@@ -32981,6 +34126,8 @@ safe_VkViSurfaceCreateInfoNN::~safe_VkViSurfaceCreateInfoNN()
 
 void safe_VkViSurfaceCreateInfoNN::initialize(const VkViSurfaceCreateInfoNN* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     window = in_struct->window;
@@ -33039,6 +34186,8 @@ safe_VkImageViewASTCDecodeModeEXT::~safe_VkImageViewASTCDecodeModeEXT()
 
 void safe_VkImageViewASTCDecodeModeEXT::initialize(const VkImageViewASTCDecodeModeEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     decodeMode = in_struct->decodeMode;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33093,6 +34242,8 @@ safe_VkPhysicalDeviceASTCDecodeFeaturesEXT::~safe_VkPhysicalDeviceASTCDecodeFeat
 
 void safe_VkPhysicalDeviceASTCDecodeFeaturesEXT::initialize(const VkPhysicalDeviceASTCDecodeFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     decodeModeSharedExponent = in_struct->decodeModeSharedExponent;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33155,6 +34306,8 @@ safe_VkConditionalRenderingBeginInfoEXT::~safe_VkConditionalRenderingBeginInfoEX
 
 void safe_VkConditionalRenderingBeginInfoEXT::initialize(const VkConditionalRenderingBeginInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     buffer = in_struct->buffer;
     offset = in_struct->offset;
@@ -33217,6 +34370,8 @@ safe_VkPhysicalDeviceConditionalRenderingFeaturesEXT::~safe_VkPhysicalDeviceCond
 
 void safe_VkPhysicalDeviceConditionalRenderingFeaturesEXT::initialize(const VkPhysicalDeviceConditionalRenderingFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     conditionalRendering = in_struct->conditionalRendering;
     inheritedConditionalRendering = in_struct->inheritedConditionalRendering;
@@ -33273,6 +34428,8 @@ safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT::~safe_VkCommandBuffe
 
 void safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT::initialize(const VkCommandBufferInheritanceConditionalRenderingInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     conditionalRenderingEnable = in_struct->conditionalRenderingEnable;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33351,6 +34508,10 @@ safe_VkPipelineViewportWScalingStateCreateInfoNV::~safe_VkPipelineViewportWScali
 
 void safe_VkPipelineViewportWScalingStateCreateInfoNV::initialize(const VkPipelineViewportWScalingStateCreateInfoNV* in_struct)
 {
+    if (pViewportWScalings)
+        delete[] pViewportWScalings;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     viewportWScalingEnable = in_struct->viewportWScalingEnable;
     viewportCount = in_struct->viewportCount;
@@ -33457,6 +34618,8 @@ safe_VkSurfaceCapabilities2EXT::~safe_VkSurfaceCapabilities2EXT()
 
 void safe_VkSurfaceCapabilities2EXT::initialize(const VkSurfaceCapabilities2EXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minImageCount = in_struct->minImageCount;
     maxImageCount = in_struct->maxImageCount;
@@ -33531,6 +34694,8 @@ safe_VkDisplayPowerInfoEXT::~safe_VkDisplayPowerInfoEXT()
 
 void safe_VkDisplayPowerInfoEXT::initialize(const VkDisplayPowerInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     powerState = in_struct->powerState;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33585,6 +34750,8 @@ safe_VkDeviceEventInfoEXT::~safe_VkDeviceEventInfoEXT()
 
 void safe_VkDeviceEventInfoEXT::initialize(const VkDeviceEventInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceEvent = in_struct->deviceEvent;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33639,6 +34806,8 @@ safe_VkDisplayEventInfoEXT::~safe_VkDisplayEventInfoEXT()
 
 void safe_VkDisplayEventInfoEXT::initialize(const VkDisplayEventInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     displayEvent = in_struct->displayEvent;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33693,6 +34862,8 @@ safe_VkSwapchainCounterCreateInfoEXT::~safe_VkSwapchainCounterCreateInfoEXT()
 
 void safe_VkSwapchainCounterCreateInfoEXT::initialize(const VkSwapchainCounterCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     surfaceCounters = in_struct->surfaceCounters;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33767,6 +34938,10 @@ safe_VkPresentTimesInfoGOOGLE::~safe_VkPresentTimesInfoGOOGLE()
 
 void safe_VkPresentTimesInfoGOOGLE::initialize(const VkPresentTimesInfoGOOGLE* in_struct)
 {
+    if (pTimes)
+        delete[] pTimes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     swapchainCount = in_struct->swapchainCount;
     pTimes = nullptr;
@@ -33831,6 +35006,8 @@ safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX::~safe_VkPhysicalDe
 
 void safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX::initialize(const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     perViewPositionAllComponents = in_struct->perViewPositionAllComponents;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -33909,6 +35086,10 @@ safe_VkPipelineViewportSwizzleStateCreateInfoNV::~safe_VkPipelineViewportSwizzle
 
 void safe_VkPipelineViewportSwizzleStateCreateInfoNV::initialize(const VkPipelineViewportSwizzleStateCreateInfoNV* in_struct)
 {
+    if (pViewportSwizzles)
+        delete[] pViewportSwizzles;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     viewportCount = in_struct->viewportCount;
@@ -33975,6 +35156,8 @@ safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT::~safe_VkPhysicalDeviceDiscar
 
 void safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT::initialize(const VkPhysicalDeviceDiscardRectanglePropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxDiscardRectangles = in_struct->maxDiscardRectangles;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -34057,6 +35240,10 @@ safe_VkPipelineDiscardRectangleStateCreateInfoEXT::~safe_VkPipelineDiscardRectan
 
 void safe_VkPipelineDiscardRectangleStateCreateInfoEXT::initialize(const VkPipelineDiscardRectangleStateCreateInfoEXT* in_struct)
 {
+    if (pDiscardRectangles)
+        delete[] pDiscardRectangles;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     discardRectangleMode = in_struct->discardRectangleMode;
@@ -34157,6 +35344,8 @@ safe_VkPhysicalDeviceConservativeRasterizationPropertiesEXT::~safe_VkPhysicalDev
 
 void safe_VkPhysicalDeviceConservativeRasterizationPropertiesEXT::initialize(const VkPhysicalDeviceConservativeRasterizationPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     primitiveOverestimationSize = in_struct->primitiveOverestimationSize;
     maxExtraPrimitiveOverestimationSize = in_struct->maxExtraPrimitiveOverestimationSize;
@@ -34235,6 +35424,8 @@ safe_VkPipelineRasterizationConservativeStateCreateInfoEXT::~safe_VkPipelineRast
 
 void safe_VkPipelineRasterizationConservativeStateCreateInfoEXT::initialize(const VkPipelineRasterizationConservativeStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     conservativeRasterizationMode = in_struct->conservativeRasterizationMode;
@@ -34293,6 +35484,8 @@ safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT::~safe_VkPhysicalDeviceDepthClip
 
 void safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT::initialize(const VkPhysicalDeviceDepthClipEnableFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     depthClipEnable = in_struct->depthClipEnable;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -34351,6 +35544,8 @@ safe_VkPipelineRasterizationDepthClipStateCreateInfoEXT::~safe_VkPipelineRasteri
 
 void safe_VkPipelineRasterizationDepthClipStateCreateInfoEXT::initialize(const VkPipelineRasterizationDepthClipStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     depthClipEnable = in_struct->depthClipEnable;
@@ -34435,6 +35630,8 @@ safe_VkHdrMetadataEXT::~safe_VkHdrMetadataEXT()
 
 void safe_VkHdrMetadataEXT::initialize(const VkHdrMetadataEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     displayPrimaryRed = in_struct->displayPrimaryRed;
     displayPrimaryGreen = in_struct->displayPrimaryGreen;
@@ -34514,6 +35711,9 @@ safe_VkDebugUtilsLabelEXT::~safe_VkDebugUtilsLabelEXT()
 
 void safe_VkDebugUtilsLabelEXT::initialize(const VkDebugUtilsLabelEXT* in_struct)
 {
+    if (pLabelName) delete [] pLabelName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pNext = SafePnextCopy(in_struct->pNext);
     pLabelName = SafeStringCopy(in_struct->pLabelName);
@@ -34584,6 +35784,9 @@ safe_VkDebugUtilsObjectNameInfoEXT::~safe_VkDebugUtilsObjectNameInfoEXT()
 
 void safe_VkDebugUtilsObjectNameInfoEXT::initialize(const VkDebugUtilsObjectNameInfoEXT* in_struct)
 {
+    if (pObjectName) delete [] pObjectName;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     objectType = in_struct->objectType;
     objectHandle = in_struct->objectHandle;
@@ -34748,6 +35951,16 @@ safe_VkDebugUtilsMessengerCallbackDataEXT::~safe_VkDebugUtilsMessengerCallbackDa
 
 void safe_VkDebugUtilsMessengerCallbackDataEXT::initialize(const VkDebugUtilsMessengerCallbackDataEXT* in_struct)
 {
+    if (pMessageIdName) delete [] pMessageIdName;
+    if (pMessage) delete [] pMessage;
+    if (pQueueLabels)
+        delete[] pQueueLabels;
+    if (pCmdBufLabels)
+        delete[] pCmdBufLabels;
+    if (pObjects)
+        delete[] pObjects;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     messageIdNumber = in_struct->messageIdNumber;
@@ -34872,6 +36085,8 @@ safe_VkDebugUtilsMessengerCreateInfoEXT::~safe_VkDebugUtilsMessengerCreateInfoEX
 
 void safe_VkDebugUtilsMessengerCreateInfoEXT::initialize(const VkDebugUtilsMessengerCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     messageSeverity = in_struct->messageSeverity;
@@ -34950,6 +36165,8 @@ safe_VkDebugUtilsObjectTagInfoEXT::~safe_VkDebugUtilsObjectTagInfoEXT()
 
 void safe_VkDebugUtilsObjectTagInfoEXT::initialize(const VkDebugUtilsObjectTagInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     objectType = in_struct->objectType;
     objectHandle = in_struct->objectHandle;
@@ -35014,6 +36231,8 @@ safe_VkAndroidHardwareBufferUsageANDROID::~safe_VkAndroidHardwareBufferUsageANDR
 
 void safe_VkAndroidHardwareBufferUsageANDROID::initialize(const VkAndroidHardwareBufferUsageANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     androidHardwareBufferUsage = in_struct->androidHardwareBufferUsage;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -35076,6 +36295,8 @@ safe_VkAndroidHardwareBufferPropertiesANDROID::~safe_VkAndroidHardwareBufferProp
 
 void safe_VkAndroidHardwareBufferPropertiesANDROID::initialize(const VkAndroidHardwareBufferPropertiesANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     allocationSize = in_struct->allocationSize;
     memoryTypeBits = in_struct->memoryTypeBits;
@@ -35164,6 +36385,8 @@ safe_VkAndroidHardwareBufferFormatPropertiesANDROID::~safe_VkAndroidHardwareBuff
 
 void safe_VkAndroidHardwareBufferFormatPropertiesANDROID::initialize(const VkAndroidHardwareBufferFormatPropertiesANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     externalFormat = in_struct->externalFormat;
@@ -35237,6 +36460,8 @@ safe_VkImportAndroidHardwareBufferInfoANDROID::~safe_VkImportAndroidHardwareBuff
 
 void safe_VkImportAndroidHardwareBufferInfoANDROID::initialize(const VkImportAndroidHardwareBufferInfoANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pNext = SafePnextCopy(in_struct->pNext);
     buffer = in_struct->buffer;
@@ -35295,6 +36520,8 @@ safe_VkMemoryGetAndroidHardwareBufferInfoANDROID::~safe_VkMemoryGetAndroidHardwa
 
 void safe_VkMemoryGetAndroidHardwareBufferInfoANDROID::initialize(const VkMemoryGetAndroidHardwareBufferInfoANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -35353,6 +36580,8 @@ safe_VkExternalFormatANDROID::~safe_VkExternalFormatANDROID()
 
 void safe_VkExternalFormatANDROID::initialize(const VkExternalFormatANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     externalFormat = in_struct->externalFormat;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -35439,6 +36668,8 @@ safe_VkAndroidHardwareBufferFormatProperties2ANDROID::~safe_VkAndroidHardwareBuf
 
 void safe_VkAndroidHardwareBufferFormatProperties2ANDROID::initialize(const VkAndroidHardwareBufferFormatProperties2ANDROID* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     format = in_struct->format;
     externalFormat = in_struct->externalFormat;
@@ -35537,6 +36768,10 @@ safe_VkSampleLocationsInfoEXT::~safe_VkSampleLocationsInfoEXT()
 
 void safe_VkSampleLocationsInfoEXT::initialize(const VkSampleLocationsInfoEXT* in_struct)
 {
+    if (pSampleLocations)
+        delete[] pSampleLocations;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sampleLocationsPerPixel = in_struct->sampleLocationsPerPixel;
     sampleLocationGridSize = in_struct->sampleLocationGridSize;
@@ -35649,6 +36884,12 @@ safe_VkRenderPassSampleLocationsBeginInfoEXT::~safe_VkRenderPassSampleLocationsB
 
 void safe_VkRenderPassSampleLocationsBeginInfoEXT::initialize(const VkRenderPassSampleLocationsBeginInfoEXT* in_struct)
 {
+    if (pAttachmentInitialSampleLocations)
+        delete[] pAttachmentInitialSampleLocations;
+    if (pPostSubpassSampleLocations)
+        delete[] pPostSubpassSampleLocations;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     attachmentInitialSampleLocationsCount = in_struct->attachmentInitialSampleLocationsCount;
     pAttachmentInitialSampleLocations = nullptr;
@@ -35728,6 +36969,8 @@ safe_VkPipelineSampleLocationsStateCreateInfoEXT::~safe_VkPipelineSampleLocation
 
 void safe_VkPipelineSampleLocationsStateCreateInfoEXT::initialize(const VkPipelineSampleLocationsStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sampleLocationsEnable = in_struct->sampleLocationsEnable;
     sampleLocationsInfo.initialize(&in_struct->sampleLocationsInfo);
@@ -35805,6 +37048,8 @@ safe_VkPhysicalDeviceSampleLocationsPropertiesEXT::~safe_VkPhysicalDeviceSampleL
 
 void safe_VkPhysicalDeviceSampleLocationsPropertiesEXT::initialize(const VkPhysicalDeviceSampleLocationsPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sampleLocationSampleCounts = in_struct->sampleLocationSampleCounts;
     maxSampleLocationGridSize = in_struct->maxSampleLocationGridSize;
@@ -35871,6 +37116,8 @@ safe_VkMultisamplePropertiesEXT::~safe_VkMultisamplePropertiesEXT()
 
 void safe_VkMultisamplePropertiesEXT::initialize(const VkMultisamplePropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxSampleLocationGridSize = in_struct->maxSampleLocationGridSize;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -35925,6 +37172,8 @@ safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT::~safe_VkPhysicalDeviceBl
 
 void safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT::initialize(const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     advancedBlendCoherentOperations = in_struct->advancedBlendCoherentOperations;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -35999,6 +37248,8 @@ safe_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT::initialize(const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     advancedBlendMaxColorAttachments = in_struct->advancedBlendMaxColorAttachments;
     advancedBlendIndependentBlend = in_struct->advancedBlendIndependentBlend;
@@ -36071,6 +37322,8 @@ safe_VkPipelineColorBlendAdvancedStateCreateInfoEXT::~safe_VkPipelineColorBlendA
 
 void safe_VkPipelineColorBlendAdvancedStateCreateInfoEXT::initialize(const VkPipelineColorBlendAdvancedStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     srcPremultiplied = in_struct->srcPremultiplied;
     dstPremultiplied = in_struct->dstPremultiplied;
@@ -36137,6 +37390,8 @@ safe_VkPipelineCoverageToColorStateCreateInfoNV::~safe_VkPipelineCoverageToColor
 
 void safe_VkPipelineCoverageToColorStateCreateInfoNV::initialize(const VkPipelineCoverageToColorStateCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     coverageToColorEnable = in_struct->coverageToColorEnable;
@@ -36227,6 +37482,10 @@ safe_VkPipelineCoverageModulationStateCreateInfoNV::~safe_VkPipelineCoverageModu
 
 void safe_VkPipelineCoverageModulationStateCreateInfoNV::initialize(const VkPipelineCoverageModulationStateCreateInfoNV* in_struct)
 {
+    if (pCoverageModulationTable)
+        delete[] pCoverageModulationTable;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     coverageModulationMode = in_struct->coverageModulationMode;
@@ -36301,6 +37560,8 @@ safe_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV::~safe_VkPhysicalDeviceShaderS
 
 void safe_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV::initialize(const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderSMCount = in_struct->shaderSMCount;
     shaderWarpsPerSM = in_struct->shaderWarpsPerSM;
@@ -36357,6 +37618,8 @@ safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::~safe_VkPhysicalDeviceShaderSMB
 
 void safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::initialize(const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderSMBuiltins = in_struct->shaderSMBuiltins;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -36431,6 +37694,10 @@ safe_VkDrmFormatModifierPropertiesListEXT::~safe_VkDrmFormatModifierPropertiesLi
 
 void safe_VkDrmFormatModifierPropertiesListEXT::initialize(const VkDrmFormatModifierPropertiesListEXT* in_struct)
 {
+    if (pDrmFormatModifierProperties)
+        delete[] pDrmFormatModifierProperties;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifierCount = in_struct->drmFormatModifierCount;
     pDrmFormatModifierProperties = nullptr;
@@ -36530,6 +37797,10 @@ safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT::~safe_VkPhysicalDeviceImageD
 
 void safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT::initialize(const VkPhysicalDeviceImageDrmFormatModifierInfoEXT* in_struct)
 {
+    if (pQueueFamilyIndices)
+        delete[] pQueueFamilyIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifier = in_struct->drmFormatModifier;
     sharingMode = in_struct->sharingMode;
@@ -36622,6 +37893,10 @@ safe_VkImageDrmFormatModifierListCreateInfoEXT::~safe_VkImageDrmFormatModifierLi
 
 void safe_VkImageDrmFormatModifierListCreateInfoEXT::initialize(const VkImageDrmFormatModifierListCreateInfoEXT* in_struct)
 {
+    if (pDrmFormatModifiers)
+        delete[] pDrmFormatModifiers;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifierCount = in_struct->drmFormatModifierCount;
     pDrmFormatModifiers = nullptr;
@@ -36710,6 +37985,10 @@ safe_VkImageDrmFormatModifierExplicitCreateInfoEXT::~safe_VkImageDrmFormatModifi
 
 void safe_VkImageDrmFormatModifierExplicitCreateInfoEXT::initialize(const VkImageDrmFormatModifierExplicitCreateInfoEXT* in_struct)
 {
+    if (pPlaneLayouts)
+        delete[] pPlaneLayouts;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifier = in_struct->drmFormatModifier;
     drmFormatModifierPlaneCount = in_struct->drmFormatModifierPlaneCount;
@@ -36776,6 +38055,8 @@ safe_VkImageDrmFormatModifierPropertiesEXT::~safe_VkImageDrmFormatModifierProper
 
 void safe_VkImageDrmFormatModifierPropertiesEXT::initialize(const VkImageDrmFormatModifierPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifier = in_struct->drmFormatModifier;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -36850,6 +38131,10 @@ safe_VkDrmFormatModifierPropertiesList2EXT::~safe_VkDrmFormatModifierPropertiesL
 
 void safe_VkDrmFormatModifierPropertiesList2EXT::initialize(const VkDrmFormatModifierPropertiesList2EXT* in_struct)
 {
+    if (pDrmFormatModifierProperties)
+        delete[] pDrmFormatModifierProperties;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     drmFormatModifierCount = in_struct->drmFormatModifierCount;
     pDrmFormatModifierProperties = nullptr;
@@ -36922,6 +38207,8 @@ safe_VkValidationCacheCreateInfoEXT::~safe_VkValidationCacheCreateInfoEXT()
 
 void safe_VkValidationCacheCreateInfoEXT::initialize(const VkValidationCacheCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     initialDataSize = in_struct->initialDataSize;
@@ -36980,6 +38267,8 @@ safe_VkShaderModuleValidationCacheCreateInfoEXT::~safe_VkShaderModuleValidationC
 
 void safe_VkShaderModuleValidationCacheCreateInfoEXT::initialize(const VkShaderModuleValidationCacheCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     validationCache = in_struct->validationCache;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -37042,6 +38331,8 @@ safe_VkShadingRatePaletteNV::~safe_VkShadingRatePaletteNV()
 
 void safe_VkShadingRatePaletteNV::initialize(const VkShadingRatePaletteNV* in_struct)
 {
+    if (pShadingRatePaletteEntries)
+        delete[] pShadingRatePaletteEntries;
     shadingRatePaletteEntryCount = in_struct->shadingRatePaletteEntryCount;
     pShadingRatePaletteEntries = nullptr;
     if (in_struct->pShadingRatePaletteEntries) {
@@ -37132,6 +38423,10 @@ safe_VkPipelineViewportShadingRateImageStateCreateInfoNV::~safe_VkPipelineViewpo
 
 void safe_VkPipelineViewportShadingRateImageStateCreateInfoNV::initialize(const VkPipelineViewportShadingRateImageStateCreateInfoNV* in_struct)
 {
+    if (pShadingRatePalettes)
+        delete[] pShadingRatePalettes;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shadingRateImageEnable = in_struct->shadingRateImageEnable;
     viewportCount = in_struct->viewportCount;
@@ -37206,6 +38501,8 @@ safe_VkPhysicalDeviceShadingRateImageFeaturesNV::~safe_VkPhysicalDeviceShadingRa
 
 void safe_VkPhysicalDeviceShadingRateImageFeaturesNV::initialize(const VkPhysicalDeviceShadingRateImageFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shadingRateImage = in_struct->shadingRateImage;
     shadingRateCoarseSampleOrder = in_struct->shadingRateCoarseSampleOrder;
@@ -37270,6 +38567,8 @@ safe_VkPhysicalDeviceShadingRateImagePropertiesNV::~safe_VkPhysicalDeviceShading
 
 void safe_VkPhysicalDeviceShadingRateImagePropertiesNV::initialize(const VkPhysicalDeviceShadingRateImagePropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shadingRateTexelSize = in_struct->shadingRateTexelSize;
     shadingRatePaletteSize = in_struct->shadingRatePaletteSize;
@@ -37344,6 +38643,8 @@ safe_VkCoarseSampleOrderCustomNV::~safe_VkCoarseSampleOrderCustomNV()
 
 void safe_VkCoarseSampleOrderCustomNV::initialize(const VkCoarseSampleOrderCustomNV* in_struct)
 {
+    if (pSampleLocations)
+        delete[] pSampleLocations;
     shadingRate = in_struct->shadingRate;
     sampleCount = in_struct->sampleCount;
     sampleLocationCount = in_struct->sampleLocationCount;
@@ -37438,6 +38739,10 @@ safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV::~safe_VkPipelineViewp
 
 void safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV::initialize(const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* in_struct)
 {
+    if (pCustomSampleOrders)
+        delete[] pCustomSampleOrders;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     sampleOrderType = in_struct->sampleOrderType;
     customSampleOrderCount = in_struct->customSampleOrderCount;
@@ -37524,6 +38829,8 @@ safe_VkRayTracingShaderGroupCreateInfoNV::~safe_VkRayTracingShaderGroupCreateInf
 
 void safe_VkRayTracingShaderGroupCreateInfoNV::initialize(const VkRayTracingShaderGroupCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     generalShader = in_struct->generalShader;
@@ -37662,6 +38969,12 @@ safe_VkRayTracingPipelineCreateInfoNV::~safe_VkRayTracingPipelineCreateInfoNV()
 
 void safe_VkRayTracingPipelineCreateInfoNV::initialize(const VkRayTracingPipelineCreateInfoNV* in_struct)
 {
+    if (pStages)
+        delete[] pStages;
+    if (pGroups)
+        delete[] pGroups;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     stageCount = in_struct->stageCount;
@@ -37796,6 +39109,8 @@ safe_VkGeometryTrianglesNV::~safe_VkGeometryTrianglesNV()
 
 void safe_VkGeometryTrianglesNV::initialize(const VkGeometryTrianglesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexData = in_struct->vertexData;
     vertexOffset = in_struct->vertexOffset;
@@ -37882,6 +39197,8 @@ safe_VkGeometryAABBNV::~safe_VkGeometryAABBNV()
 
 void safe_VkGeometryAABBNV::initialize(const VkGeometryAABBNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     aabbData = in_struct->aabbData;
     numAABBs = in_struct->numAABBs;
@@ -37950,6 +39267,8 @@ safe_VkGeometryNV::~safe_VkGeometryNV()
 
 void safe_VkGeometryNV::initialize(const VkGeometryNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     geometryType = in_struct->geometryType;
     geometry = in_struct->geometry;
@@ -38046,6 +39365,10 @@ safe_VkAccelerationStructureInfoNV::~safe_VkAccelerationStructureInfoNV()
 
 void safe_VkAccelerationStructureInfoNV::initialize(const VkAccelerationStructureInfoNV* in_struct)
 {
+    if (pGeometries)
+        delete[] pGeometries;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     flags = in_struct->flags;
@@ -38123,6 +39446,8 @@ safe_VkAccelerationStructureCreateInfoNV::~safe_VkAccelerationStructureCreateInf
 
 void safe_VkAccelerationStructureCreateInfoNV::initialize(const VkAccelerationStructureCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     compactedSize = in_struct->compactedSize;
     info.initialize(&in_struct->info);
@@ -38211,6 +39536,10 @@ safe_VkBindAccelerationStructureMemoryInfoNV::~safe_VkBindAccelerationStructureM
 
 void safe_VkBindAccelerationStructureMemoryInfoNV::initialize(const VkBindAccelerationStructureMemoryInfoNV* in_struct)
 {
+    if (pDeviceIndices)
+        delete[] pDeviceIndices;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructure = in_struct->accelerationStructure;
     memory = in_struct->memory;
@@ -38307,6 +39636,10 @@ safe_VkWriteDescriptorSetAccelerationStructureNV::~safe_VkWriteDescriptorSetAcce
 
 void safe_VkWriteDescriptorSetAccelerationStructureNV::initialize(const VkWriteDescriptorSetAccelerationStructureNV* in_struct)
 {
+    if (pAccelerationStructures)
+        delete[] pAccelerationStructures;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructureCount = in_struct->accelerationStructureCount;
     pAccelerationStructures = nullptr;
@@ -38379,6 +39712,8 @@ safe_VkAccelerationStructureMemoryRequirementsInfoNV::~safe_VkAccelerationStruct
 
 void safe_VkAccelerationStructureMemoryRequirementsInfoNV::initialize(const VkAccelerationStructureMemoryRequirementsInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     accelerationStructure = in_struct->accelerationStructure;
@@ -38463,6 +39798,8 @@ safe_VkPhysicalDeviceRayTracingPropertiesNV::~safe_VkPhysicalDeviceRayTracingPro
 
 void safe_VkPhysicalDeviceRayTracingPropertiesNV::initialize(const VkPhysicalDeviceRayTracingPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderGroupHandleSize = in_struct->shaderGroupHandleSize;
     maxRecursionDepth = in_struct->maxRecursionDepth;
@@ -38531,6 +39868,8 @@ safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV::initialize(const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     representativeFragmentTest = in_struct->representativeFragmentTest;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38585,6 +39924,8 @@ safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV::~safe_VkPipelineRepr
 
 void safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV::initialize(const VkPipelineRepresentativeFragmentTestStateCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     representativeFragmentTestEnable = in_struct->representativeFragmentTestEnable;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38639,6 +39980,8 @@ safe_VkPhysicalDeviceImageViewImageFormatInfoEXT::~safe_VkPhysicalDeviceImageVie
 
 void safe_VkPhysicalDeviceImageViewImageFormatInfoEXT::initialize(const VkPhysicalDeviceImageViewImageFormatInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageViewType = in_struct->imageViewType;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38697,6 +40040,8 @@ safe_VkFilterCubicImageViewImageFormatPropertiesEXT::~safe_VkFilterCubicImageVie
 
 void safe_VkFilterCubicImageViewImageFormatPropertiesEXT::initialize(const VkFilterCubicImageViewImageFormatPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     filterCubic = in_struct->filterCubic;
     filterCubicMinmax = in_struct->filterCubicMinmax;
@@ -38757,6 +40102,8 @@ safe_VkImportMemoryHostPointerInfoEXT::~safe_VkImportMemoryHostPointerInfoEXT()
 
 void safe_VkImportMemoryHostPointerInfoEXT::initialize(const VkImportMemoryHostPointerInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     pHostPointer = in_struct->pHostPointer;
@@ -38813,6 +40160,8 @@ safe_VkMemoryHostPointerPropertiesEXT::~safe_VkMemoryHostPointerPropertiesEXT()
 
 void safe_VkMemoryHostPointerPropertiesEXT::initialize(const VkMemoryHostPointerPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryTypeBits = in_struct->memoryTypeBits;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38867,6 +40216,8 @@ safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT::~safe_VkPhysicalDeviceExte
 
 void safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT::initialize(const VkPhysicalDeviceExternalMemoryHostPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minImportedHostPointerAlignment = in_struct->minImportedHostPointerAlignment;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38921,6 +40272,8 @@ safe_VkPipelineCompilerControlCreateInfoAMD::~safe_VkPipelineCompilerControlCrea
 
 void safe_VkPipelineCompilerControlCreateInfoAMD::initialize(const VkPipelineCompilerControlCreateInfoAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     compilerControlFlags = in_struct->compilerControlFlags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -38975,6 +40328,8 @@ safe_VkCalibratedTimestampInfoEXT::~safe_VkCalibratedTimestampInfoEXT()
 
 void safe_VkCalibratedTimestampInfoEXT::initialize(const VkCalibratedTimestampInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     timeDomain = in_struct->timeDomain;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39081,6 +40436,8 @@ safe_VkPhysicalDeviceShaderCorePropertiesAMD::~safe_VkPhysicalDeviceShaderCorePr
 
 void safe_VkPhysicalDeviceShaderCorePropertiesAMD::initialize(const VkPhysicalDeviceShaderCorePropertiesAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderEngineCount = in_struct->shaderEngineCount;
     shaderArraysPerEngineCount = in_struct->shaderArraysPerEngineCount;
@@ -39163,6 +40520,8 @@ safe_VkVideoDecodeH265ProfileEXT::~safe_VkVideoDecodeH265ProfileEXT()
 
 void safe_VkVideoDecodeH265ProfileEXT::initialize(const VkVideoDecodeH265ProfileEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stdProfileIdc = in_struct->stdProfileIdc;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39221,6 +40580,8 @@ safe_VkVideoDecodeH265CapabilitiesEXT::~safe_VkVideoDecodeH265CapabilitiesEXT()
 
 void safe_VkVideoDecodeH265CapabilitiesEXT::initialize(const VkVideoDecodeH265CapabilitiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxLevel = in_struct->maxLevel;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39347,6 +40708,14 @@ safe_VkVideoDecodeH265SessionParametersAddInfoEXT::~safe_VkVideoDecodeH265Sessio
 
 void safe_VkVideoDecodeH265SessionParametersAddInfoEXT::initialize(const VkVideoDecodeH265SessionParametersAddInfoEXT* in_struct)
 {
+    if (pVpsStd)
+        delete[] pVpsStd;
+    if (pSpsStd)
+        delete[] pSpsStd;
+    if (pPpsStd)
+        delete[] pPpsStd;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vpsStdCount = in_struct->vpsStdCount;
     pVpsStd = nullptr;
@@ -39461,6 +40830,10 @@ safe_VkVideoDecodeH265SessionParametersCreateInfoEXT::~safe_VkVideoDecodeH265Ses
 
 void safe_VkVideoDecodeH265SessionParametersCreateInfoEXT::initialize(const VkVideoDecodeH265SessionParametersCreateInfoEXT* in_struct)
 {
+    if (pParametersAddInfo)
+        delete pParametersAddInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxVpsStdCount = in_struct->maxVpsStdCount;
     maxSpsStdCount = in_struct->maxSpsStdCount;
@@ -39566,6 +40939,12 @@ safe_VkVideoDecodeH265PictureInfoEXT::~safe_VkVideoDecodeH265PictureInfoEXT()
 
 void safe_VkVideoDecodeH265PictureInfoEXT::initialize(const VkVideoDecodeH265PictureInfoEXT* in_struct)
 {
+    if (pStdPictureInfo)
+        delete pStdPictureInfo;
+    if (pSlicesDataOffsets)
+        delete[] pSlicesDataOffsets;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pStdPictureInfo = nullptr;
     slicesCount = in_struct->slicesCount;
@@ -39655,6 +41034,10 @@ safe_VkVideoDecodeH265DpbSlotInfoEXT::~safe_VkVideoDecodeH265DpbSlotInfoEXT()
 
 void safe_VkVideoDecodeH265DpbSlotInfoEXT::initialize(const VkVideoDecodeH265DpbSlotInfoEXT* in_struct)
 {
+    if (pStdReferenceInfo)
+        delete pStdReferenceInfo;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pStdReferenceInfo = nullptr;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39717,6 +41100,8 @@ safe_VkDeviceMemoryOverallocationCreateInfoAMD::~safe_VkDeviceMemoryOverallocati
 
 void safe_VkDeviceMemoryOverallocationCreateInfoAMD::initialize(const VkDeviceMemoryOverallocationCreateInfoAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     overallocationBehavior = in_struct->overallocationBehavior;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39771,6 +41156,8 @@ safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT::initialize(const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxVertexAttribDivisor = in_struct->maxVertexAttribDivisor;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -39845,6 +41232,10 @@ safe_VkPipelineVertexInputDivisorStateCreateInfoEXT::~safe_VkPipelineVertexInput
 
 void safe_VkPipelineVertexInputDivisorStateCreateInfoEXT::initialize(const VkPipelineVertexInputDivisorStateCreateInfoEXT* in_struct)
 {
+    if (pVertexBindingDivisors)
+        delete[] pVertexBindingDivisors;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexBindingDivisorCount = in_struct->vertexBindingDivisorCount;
     pVertexBindingDivisors = nullptr;
@@ -39913,6 +41304,8 @@ safe_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT::~safe_VkPhysicalDeviceVe
 
 void safe_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT::initialize(const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexAttributeInstanceRateDivisor = in_struct->vertexAttributeInstanceRateDivisor;
     vertexAttributeInstanceRateZeroDivisor = in_struct->vertexAttributeInstanceRateZeroDivisor;
@@ -39971,6 +41364,8 @@ safe_VkPresentFrameTokenGGP::~safe_VkPresentFrameTokenGGP()
 
 void safe_VkPresentFrameTokenGGP::initialize(const VkPresentFrameTokenGGP* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     frameToken = in_struct->frameToken;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40031,6 +41426,8 @@ safe_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::~safe_VkPhysicalDeviceC
 
 void safe_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::initialize(const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     computeDerivativeGroupQuads = in_struct->computeDerivativeGroupQuads;
     computeDerivativeGroupLinear = in_struct->computeDerivativeGroupLinear;
@@ -40091,6 +41488,8 @@ safe_VkPhysicalDeviceMeshShaderFeaturesNV::~safe_VkPhysicalDeviceMeshShaderFeatu
 
 void safe_VkPhysicalDeviceMeshShaderFeaturesNV::initialize(const VkPhysicalDeviceMeshShaderFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     taskShader = in_struct->taskShader;
     meshShader = in_struct->meshShader;
@@ -40205,6 +41604,8 @@ safe_VkPhysicalDeviceMeshShaderPropertiesNV::~safe_VkPhysicalDeviceMeshShaderPro
 
 void safe_VkPhysicalDeviceMeshShaderPropertiesNV::initialize(const VkPhysicalDeviceMeshShaderPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxDrawMeshTasksCount = in_struct->maxDrawMeshTasksCount;
     maxTaskWorkGroupInvocations = in_struct->maxTaskWorkGroupInvocations;
@@ -40291,6 +41692,8 @@ safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV::initialize(const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentShaderBarycentric = in_struct->fragmentShaderBarycentric;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40345,6 +41748,8 @@ safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV::~safe_VkPhysicalDeviceShade
 
 void safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV::initialize(const VkPhysicalDeviceShaderImageFootprintFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageFootprint = in_struct->imageFootprint;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40419,6 +41824,10 @@ safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV::~safe_VkPipelineViewpo
 
 void safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV::initialize(const VkPipelineViewportExclusiveScissorStateCreateInfoNV* in_struct)
 {
+    if (pExclusiveScissors)
+        delete[] pExclusiveScissors;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     exclusiveScissorCount = in_struct->exclusiveScissorCount;
     pExclusiveScissors = nullptr;
@@ -40483,6 +41892,8 @@ safe_VkPhysicalDeviceExclusiveScissorFeaturesNV::~safe_VkPhysicalDeviceExclusive
 
 void safe_VkPhysicalDeviceExclusiveScissorFeaturesNV::initialize(const VkPhysicalDeviceExclusiveScissorFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     exclusiveScissor = in_struct->exclusiveScissor;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40537,6 +41948,8 @@ safe_VkQueueFamilyCheckpointPropertiesNV::~safe_VkQueueFamilyCheckpointPropertie
 
 void safe_VkQueueFamilyCheckpointPropertiesNV::initialize(const VkQueueFamilyCheckpointPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     checkpointExecutionStageMask = in_struct->checkpointExecutionStageMask;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40595,6 +42008,8 @@ safe_VkCheckpointDataNV::~safe_VkCheckpointDataNV()
 
 void safe_VkCheckpointDataNV::initialize(const VkCheckpointDataNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stage = in_struct->stage;
     pCheckpointMarker = in_struct->pCheckpointMarker;
@@ -40651,6 +42066,8 @@ safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::initialize(const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderIntegerFunctions2 = in_struct->shaderIntegerFunctions2;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40703,6 +42120,7 @@ safe_VkPerformanceValueDataINTEL::~safe_VkPerformanceValueDataINTEL()
 
 void safe_VkPerformanceValueDataINTEL::initialize(const VkPerformanceValueDataINTEL* in_struct)
 {
+    if (valueString) delete [] valueString;
     value32 = in_struct->value32;
     value64 = in_struct->value64;
     valueFloat = in_struct->valueFloat;
@@ -40761,6 +42179,8 @@ safe_VkInitializePerformanceApiInfoINTEL::~safe_VkInitializePerformanceApiInfoIN
 
 void safe_VkInitializePerformanceApiInfoINTEL::initialize(const VkInitializePerformanceApiInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pUserData = in_struct->pUserData;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40815,6 +42235,8 @@ safe_VkQueryPoolPerformanceQueryCreateInfoINTEL::~safe_VkQueryPoolPerformanceQue
 
 void safe_VkQueryPoolPerformanceQueryCreateInfoINTEL::initialize(const VkQueryPoolPerformanceQueryCreateInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     performanceCountersSampling = in_struct->performanceCountersSampling;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40869,6 +42291,8 @@ safe_VkPerformanceMarkerInfoINTEL::~safe_VkPerformanceMarkerInfoINTEL()
 
 void safe_VkPerformanceMarkerInfoINTEL::initialize(const VkPerformanceMarkerInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     marker = in_struct->marker;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40923,6 +42347,8 @@ safe_VkPerformanceStreamMarkerInfoINTEL::~safe_VkPerformanceStreamMarkerInfoINTE
 
 void safe_VkPerformanceStreamMarkerInfoINTEL::initialize(const VkPerformanceStreamMarkerInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     marker = in_struct->marker;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -40985,6 +42411,8 @@ safe_VkPerformanceOverrideInfoINTEL::~safe_VkPerformanceOverrideInfoINTEL()
 
 void safe_VkPerformanceOverrideInfoINTEL::initialize(const VkPerformanceOverrideInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     enable = in_struct->enable;
@@ -41043,6 +42471,8 @@ safe_VkPerformanceConfigurationAcquireInfoINTEL::~safe_VkPerformanceConfiguratio
 
 void safe_VkPerformanceConfigurationAcquireInfoINTEL::initialize(const VkPerformanceConfigurationAcquireInfoINTEL* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41109,6 +42539,8 @@ safe_VkPhysicalDevicePCIBusInfoPropertiesEXT::~safe_VkPhysicalDevicePCIBusInfoPr
 
 void safe_VkPhysicalDevicePCIBusInfoPropertiesEXT::initialize(const VkPhysicalDevicePCIBusInfoPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pciDomain = in_struct->pciDomain;
     pciBus = in_struct->pciBus;
@@ -41169,6 +42601,8 @@ safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD::~safe_VkDisplayNativeHdrSurfaceCa
 
 void safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD::initialize(const VkDisplayNativeHdrSurfaceCapabilitiesAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     localDimmingSupport = in_struct->localDimmingSupport;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41223,6 +42657,8 @@ safe_VkSwapchainDisplayNativeHdrCreateInfoAMD::~safe_VkSwapchainDisplayNativeHdr
 
 void safe_VkSwapchainDisplayNativeHdrCreateInfoAMD::initialize(const VkSwapchainDisplayNativeHdrCreateInfoAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     localDimmingEnable = in_struct->localDimmingEnable;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41283,6 +42719,8 @@ safe_VkImagePipeSurfaceCreateInfoFUCHSIA::~safe_VkImagePipeSurfaceCreateInfoFUCH
 
 void safe_VkImagePipeSurfaceCreateInfoFUCHSIA::initialize(const VkImagePipeSurfaceCreateInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     imagePipeHandle = in_struct->imagePipeHandle;
@@ -41349,6 +42787,8 @@ safe_VkPhysicalDeviceFragmentDensityMapFeaturesEXT::~safe_VkPhysicalDeviceFragme
 
 void safe_VkPhysicalDeviceFragmentDensityMapFeaturesEXT::initialize(const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityMap = in_struct->fragmentDensityMap;
     fragmentDensityMapDynamic = in_struct->fragmentDensityMapDynamic;
@@ -41415,6 +42855,8 @@ safe_VkPhysicalDeviceFragmentDensityMapPropertiesEXT::~safe_VkPhysicalDeviceFrag
 
 void safe_VkPhysicalDeviceFragmentDensityMapPropertiesEXT::initialize(const VkPhysicalDeviceFragmentDensityMapPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minFragmentDensityTexelSize = in_struct->minFragmentDensityTexelSize;
     maxFragmentDensityTexelSize = in_struct->maxFragmentDensityTexelSize;
@@ -41473,6 +42915,8 @@ safe_VkRenderPassFragmentDensityMapCreateInfoEXT::~safe_VkRenderPassFragmentDens
 
 void safe_VkRenderPassFragmentDensityMapCreateInfoEXT::initialize(const VkRenderPassFragmentDensityMapCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityMapAttachment = in_struct->fragmentDensityMapAttachment;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41531,6 +42975,8 @@ safe_VkPhysicalDeviceShaderCoreProperties2AMD::~safe_VkPhysicalDeviceShaderCoreP
 
 void safe_VkPhysicalDeviceShaderCoreProperties2AMD::initialize(const VkPhysicalDeviceShaderCoreProperties2AMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderCoreFeatures = in_struct->shaderCoreFeatures;
     activeComputeUnitCount = in_struct->activeComputeUnitCount;
@@ -41587,6 +43033,8 @@ safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD::~safe_VkPhysicalDeviceCoherentMe
 
 void safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD::initialize(const VkPhysicalDeviceCoherentMemoryFeaturesAMD* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceCoherentMemory = in_struct->deviceCoherentMemory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41645,6 +43093,8 @@ safe_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::~safe_VkPhysicalDeviceSh
 
 void safe_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::initialize(const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderImageInt64Atomics = in_struct->shaderImageInt64Atomics;
     sparseImageInt64Atomics = in_struct->sparseImageInt64Atomics;
@@ -41715,6 +43165,8 @@ safe_VkPhysicalDeviceMemoryBudgetPropertiesEXT::~safe_VkPhysicalDeviceMemoryBudg
 
 void safe_VkPhysicalDeviceMemoryBudgetPropertiesEXT::initialize(const VkPhysicalDeviceMemoryBudgetPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pNext = SafePnextCopy(in_struct->pNext);
     for (uint32_t i = 0; i < VK_MAX_MEMORY_HEAPS; ++i) {
@@ -41779,6 +43231,8 @@ safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT::~safe_VkPhysicalDeviceMemoryPrio
 
 void safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT::initialize(const VkPhysicalDeviceMemoryPriorityFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryPriority = in_struct->memoryPriority;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41833,6 +43287,8 @@ safe_VkMemoryPriorityAllocateInfoEXT::~safe_VkMemoryPriorityAllocateInfoEXT()
 
 void safe_VkMemoryPriorityAllocateInfoEXT::initialize(const VkMemoryPriorityAllocateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     priority = in_struct->priority;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41887,6 +43343,8 @@ safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV::~safe_VkPhysica
 
 void safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV::initialize(const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     dedicatedAllocationImageAliasing = in_struct->dedicatedAllocationImageAliasing;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -41949,6 +43407,8 @@ safe_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::~safe_VkPhysicalDeviceBuffe
 
 void safe_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::initialize(const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     bufferDeviceAddress = in_struct->bufferDeviceAddress;
     bufferDeviceAddressCaptureReplay = in_struct->bufferDeviceAddressCaptureReplay;
@@ -42007,6 +43467,8 @@ safe_VkBufferDeviceAddressCreateInfoEXT::~safe_VkBufferDeviceAddressCreateInfoEX
 
 void safe_VkBufferDeviceAddressCreateInfoEXT::initialize(const VkBufferDeviceAddressCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceAddress = in_struct->deviceAddress;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42105,6 +43567,12 @@ safe_VkValidationFeaturesEXT::~safe_VkValidationFeaturesEXT()
 
 void safe_VkValidationFeaturesEXT::initialize(const VkValidationFeaturesEXT* in_struct)
 {
+    if (pEnabledValidationFeatures)
+        delete[] pEnabledValidationFeatures;
+    if (pDisabledValidationFeatures)
+        delete[] pDisabledValidationFeatures;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     enabledValidationFeatureCount = in_struct->enabledValidationFeatureCount;
     pEnabledValidationFeatures = nullptr;
@@ -42209,6 +43677,8 @@ safe_VkCooperativeMatrixPropertiesNV::~safe_VkCooperativeMatrixPropertiesNV()
 
 void safe_VkCooperativeMatrixPropertiesNV::initialize(const VkCooperativeMatrixPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     MSize = in_struct->MSize;
     NSize = in_struct->NSize;
@@ -42281,6 +43751,8 @@ safe_VkPhysicalDeviceCooperativeMatrixFeaturesNV::~safe_VkPhysicalDeviceCooperat
 
 void safe_VkPhysicalDeviceCooperativeMatrixFeaturesNV::initialize(const VkPhysicalDeviceCooperativeMatrixFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     cooperativeMatrix = in_struct->cooperativeMatrix;
     cooperativeMatrixRobustBufferAccess = in_struct->cooperativeMatrixRobustBufferAccess;
@@ -42337,6 +43809,8 @@ safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV::~safe_VkPhysicalDeviceCooper
 
 void safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV::initialize(const VkPhysicalDeviceCooperativeMatrixPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     cooperativeMatrixSupportedStages = in_struct->cooperativeMatrixSupportedStages;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42391,6 +43865,8 @@ safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV::~safe_VkPhysicalDeviceCove
 
 void safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV::initialize(const VkPhysicalDeviceCoverageReductionModeFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     coverageReductionMode = in_struct->coverageReductionMode;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42449,6 +43925,8 @@ safe_VkPipelineCoverageReductionStateCreateInfoNV::~safe_VkPipelineCoverageReduc
 
 void safe_VkPipelineCoverageReductionStateCreateInfoNV::initialize(const VkPipelineCoverageReductionStateCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     coverageReductionMode = in_struct->coverageReductionMode;
@@ -42517,6 +43995,8 @@ safe_VkFramebufferMixedSamplesCombinationNV::~safe_VkFramebufferMixedSamplesComb
 
 void safe_VkFramebufferMixedSamplesCombinationNV::initialize(const VkFramebufferMixedSamplesCombinationNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     coverageReductionMode = in_struct->coverageReductionMode;
     rasterizationSamples = in_struct->rasterizationSamples;
@@ -42585,6 +44065,8 @@ safe_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::~safe_VkPhysicalDeviceF
 
 void safe_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::initialize(const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentShaderSampleInterlock = in_struct->fragmentShaderSampleInterlock;
     fragmentShaderPixelInterlock = in_struct->fragmentShaderPixelInterlock;
@@ -42643,6 +44125,8 @@ safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT::~safe_VkPhysicalDeviceYcbcrIma
 
 void safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT::initialize(const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     ycbcrImageArrays = in_struct->ycbcrImageArrays;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42701,6 +44185,8 @@ safe_VkPhysicalDeviceProvokingVertexFeaturesEXT::~safe_VkPhysicalDeviceProvoking
 
 void safe_VkPhysicalDeviceProvokingVertexFeaturesEXT::initialize(const VkPhysicalDeviceProvokingVertexFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     provokingVertexLast = in_struct->provokingVertexLast;
     transformFeedbackPreservesProvokingVertex = in_struct->transformFeedbackPreservesProvokingVertex;
@@ -42761,6 +44247,8 @@ safe_VkPhysicalDeviceProvokingVertexPropertiesEXT::~safe_VkPhysicalDeviceProvoki
 
 void safe_VkPhysicalDeviceProvokingVertexPropertiesEXT::initialize(const VkPhysicalDeviceProvokingVertexPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     provokingVertexModePerPipeline = in_struct->provokingVertexModePerPipeline;
     transformFeedbackPreservesTriangleFanProvokingVertex = in_struct->transformFeedbackPreservesTriangleFanProvokingVertex;
@@ -42817,6 +44305,8 @@ safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT::~safe_VkPipelineR
 
 void safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT::initialize(const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     provokingVertexMode = in_struct->provokingVertexMode;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42873,6 +44363,8 @@ safe_VkSurfaceFullScreenExclusiveInfoEXT::~safe_VkSurfaceFullScreenExclusiveInfo
 
 void safe_VkSurfaceFullScreenExclusiveInfoEXT::initialize(const VkSurfaceFullScreenExclusiveInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fullScreenExclusive = in_struct->fullScreenExclusive;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42931,6 +44423,8 @@ safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT::~safe_VkSurfaceCapabilitiesFul
 
 void safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT::initialize(const VkSurfaceCapabilitiesFullScreenExclusiveEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fullScreenExclusiveSupported = in_struct->fullScreenExclusiveSupported;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -42989,6 +44483,8 @@ safe_VkSurfaceFullScreenExclusiveWin32InfoEXT::~safe_VkSurfaceFullScreenExclusiv
 
 void safe_VkSurfaceFullScreenExclusiveWin32InfoEXT::initialize(const VkSurfaceFullScreenExclusiveWin32InfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     hmonitor = in_struct->hmonitor;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43045,6 +44541,8 @@ safe_VkHeadlessSurfaceCreateInfoEXT::~safe_VkHeadlessSurfaceCreateInfoEXT()
 
 void safe_VkHeadlessSurfaceCreateInfoEXT::initialize(const VkHeadlessSurfaceCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43119,6 +44617,8 @@ safe_VkPhysicalDeviceLineRasterizationFeaturesEXT::~safe_VkPhysicalDeviceLineRas
 
 void safe_VkPhysicalDeviceLineRasterizationFeaturesEXT::initialize(const VkPhysicalDeviceLineRasterizationFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rectangularLines = in_struct->rectangularLines;
     bresenhamLines = in_struct->bresenhamLines;
@@ -43183,6 +44683,8 @@ safe_VkPhysicalDeviceLineRasterizationPropertiesEXT::~safe_VkPhysicalDeviceLineR
 
 void safe_VkPhysicalDeviceLineRasterizationPropertiesEXT::initialize(const VkPhysicalDeviceLineRasterizationPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     lineSubPixelPrecisionBits = in_struct->lineSubPixelPrecisionBits;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43249,6 +44751,8 @@ safe_VkPipelineRasterizationLineStateCreateInfoEXT::~safe_VkPipelineRasterizatio
 
 void safe_VkPipelineRasterizationLineStateCreateInfoEXT::initialize(const VkPipelineRasterizationLineStateCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     lineRasterizationMode = in_struct->lineRasterizationMode;
     stippledLineEnable = in_struct->stippledLineEnable;
@@ -43353,6 +44857,8 @@ safe_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::~safe_VkPhysicalDeviceShaderA
 
 void safe_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::initialize(const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderBufferFloat32Atomics = in_struct->shaderBufferFloat32Atomics;
     shaderBufferFloat32AtomicAdd = in_struct->shaderBufferFloat32AtomicAdd;
@@ -43429,6 +44935,8 @@ safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT::~safe_VkPhysicalDeviceIndexTypeU
 
 void safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT::initialize(const VkPhysicalDeviceIndexTypeUint8FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     indexTypeUint8 = in_struct->indexTypeUint8;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43483,6 +44991,8 @@ safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT::~safe_VkPhysicalDeviceExte
 
 void safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT::initialize(const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     extendedDynamicState = in_struct->extendedDynamicState;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43581,6 +45091,8 @@ safe_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::~safe_VkPhysicalDeviceShader
 
 void safe_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::initialize(const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderBufferFloat16Atomics = in_struct->shaderBufferFloat16Atomics;
     shaderBufferFloat16AtomicAdd = in_struct->shaderBufferFloat16AtomicAdd;
@@ -43689,6 +45201,8 @@ safe_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::initialize(const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxGraphicsShaderGroupCount = in_struct->maxGraphicsShaderGroupCount;
     maxIndirectSequenceCount = in_struct->maxIndirectSequenceCount;
@@ -43759,6 +45273,8 @@ safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV::~safe_VkPhysicalDeviceDe
 
 void safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV::initialize(const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceGeneratedCommands = in_struct->deviceGeneratedCommands;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -43867,6 +45383,14 @@ safe_VkGraphicsShaderGroupCreateInfoNV::~safe_VkGraphicsShaderGroupCreateInfoNV(
 
 void safe_VkGraphicsShaderGroupCreateInfoNV::initialize(const VkGraphicsShaderGroupCreateInfoNV* in_struct)
 {
+    if (pStages)
+        delete[] pStages;
+    if (pVertexInputState)
+        delete pVertexInputState;
+    if (pTessellationState)
+        delete pTessellationState;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     stageCount = in_struct->stageCount;
     pStages = nullptr;
@@ -44003,6 +45527,12 @@ safe_VkGraphicsPipelineShaderGroupsCreateInfoNV::~safe_VkGraphicsPipelineShaderG
 
 void safe_VkGraphicsPipelineShaderGroupsCreateInfoNV::initialize(const VkGraphicsPipelineShaderGroupsCreateInfoNV* in_struct)
 {
+    if (pGroups)
+        delete[] pGroups;
+    if (pPipelines)
+        delete[] pPipelines;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     groupCount = in_struct->groupCount;
     pGroups = nullptr;
@@ -44167,6 +45697,12 @@ safe_VkIndirectCommandsLayoutTokenNV::~safe_VkIndirectCommandsLayoutTokenNV()
 
 void safe_VkIndirectCommandsLayoutTokenNV::initialize(const VkIndirectCommandsLayoutTokenNV* in_struct)
 {
+    if (pIndexTypes)
+        delete[] pIndexTypes;
+    if (pIndexTypeValues)
+        delete[] pIndexTypeValues;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     tokenType = in_struct->tokenType;
     stream = in_struct->stream;
@@ -44319,6 +45855,12 @@ safe_VkIndirectCommandsLayoutCreateInfoNV::~safe_VkIndirectCommandsLayoutCreateI
 
 void safe_VkIndirectCommandsLayoutCreateInfoNV::initialize(const VkIndirectCommandsLayoutCreateInfoNV* in_struct)
 {
+    if (pTokens)
+        delete[] pTokens;
+    if (pStreamStrides)
+        delete[] pStreamStrides;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pipelineBindPoint = in_struct->pipelineBindPoint;
@@ -44473,6 +46015,10 @@ safe_VkGeneratedCommandsInfoNV::~safe_VkGeneratedCommandsInfoNV()
 
 void safe_VkGeneratedCommandsInfoNV::initialize(const VkGeneratedCommandsInfoNV* in_struct)
 {
+    if (pStreams)
+        delete[] pStreams;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipelineBindPoint = in_struct->pipelineBindPoint;
     pipeline = in_struct->pipeline;
@@ -44575,6 +46121,8 @@ safe_VkGeneratedCommandsMemoryRequirementsInfoNV::~safe_VkGeneratedCommandsMemor
 
 void safe_VkGeneratedCommandsMemoryRequirementsInfoNV::initialize(const VkGeneratedCommandsMemoryRequirementsInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pipelineBindPoint = in_struct->pipelineBindPoint;
     pipeline = in_struct->pipeline;
@@ -44635,6 +46183,8 @@ safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV::~safe_VkPhysicalDeviceI
 
 void safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV::initialize(const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     inheritedViewportScissor2D = in_struct->inheritedViewportScissor2D;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -44710,6 +46260,10 @@ safe_VkCommandBufferInheritanceViewportScissorInfoNV::~safe_VkCommandBufferInher
 
 void safe_VkCommandBufferInheritanceViewportScissorInfoNV::initialize(const VkCommandBufferInheritanceViewportScissorInfoNV* in_struct)
 {
+    if (pViewportDepths)
+        delete pViewportDepths;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     viewportScissor2D = in_struct->viewportScissor2D;
     viewportDepthCount = in_struct->viewportDepthCount;
@@ -44774,6 +46328,8 @@ safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT::~safe_VkPhysicalDeviceTexe
 
 void safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT::initialize(const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     texelBufferAlignment = in_struct->texelBufferAlignment;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -44828,6 +46384,8 @@ safe_VkRenderPassTransformBeginInfoQCOM::~safe_VkRenderPassTransformBeginInfoQCO
 
 void safe_VkRenderPassTransformBeginInfoQCOM::initialize(const VkRenderPassTransformBeginInfoQCOM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     transform = in_struct->transform;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -44886,6 +46444,8 @@ safe_VkCommandBufferInheritanceRenderPassTransformInfoQCOM::~safe_VkCommandBuffe
 
 void safe_VkCommandBufferInheritanceRenderPassTransformInfoQCOM::initialize(const VkCommandBufferInheritanceRenderPassTransformInfoQCOM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     transform = in_struct->transform;
     renderArea = in_struct->renderArea;
@@ -44942,6 +46502,8 @@ safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT::~safe_VkPhysicalDeviceDevice
 
 void safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT::initialize(const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     deviceMemoryReport = in_struct->deviceMemoryReport;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45020,6 +46582,8 @@ safe_VkDeviceMemoryReportCallbackDataEXT::~safe_VkDeviceMemoryReportCallbackData
 
 void safe_VkDeviceMemoryReportCallbackDataEXT::initialize(const VkDeviceMemoryReportCallbackDataEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     type = in_struct->type;
@@ -45094,6 +46658,8 @@ safe_VkDeviceDeviceMemoryReportCreateInfoEXT::~safe_VkDeviceDeviceMemoryReportCr
 
 void safe_VkDeviceDeviceMemoryReportCreateInfoEXT::initialize(const VkDeviceDeviceMemoryReportCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pfnUserCallback = in_struct->pfnUserCallback;
@@ -45160,6 +46726,8 @@ safe_VkPhysicalDeviceRobustness2FeaturesEXT::~safe_VkPhysicalDeviceRobustness2Fe
 
 void safe_VkPhysicalDeviceRobustness2FeaturesEXT::initialize(const VkPhysicalDeviceRobustness2FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     robustBufferAccess2 = in_struct->robustBufferAccess2;
     robustImageAccess2 = in_struct->robustImageAccess2;
@@ -45222,6 +46790,8 @@ safe_VkPhysicalDeviceRobustness2PropertiesEXT::~safe_VkPhysicalDeviceRobustness2
 
 void safe_VkPhysicalDeviceRobustness2PropertiesEXT::initialize(const VkPhysicalDeviceRobustness2PropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     robustStorageBufferAccessSizeAlignment = in_struct->robustStorageBufferAccessSizeAlignment;
     robustUniformBufferAccessSizeAlignment = in_struct->robustUniformBufferAccessSizeAlignment;
@@ -45282,6 +46852,8 @@ safe_VkSamplerCustomBorderColorCreateInfoEXT::~safe_VkSamplerCustomBorderColorCr
 
 void safe_VkSamplerCustomBorderColorCreateInfoEXT::initialize(const VkSamplerCustomBorderColorCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     customBorderColor = in_struct->customBorderColor;
     format = in_struct->format;
@@ -45338,6 +46910,8 @@ safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT::~safe_VkPhysicalDeviceCusto
 
 void safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT::initialize(const VkPhysicalDeviceCustomBorderColorPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxCustomBorderColorSamplers = in_struct->maxCustomBorderColorSamplers;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45396,6 +46970,8 @@ safe_VkPhysicalDeviceCustomBorderColorFeaturesEXT::~safe_VkPhysicalDeviceCustomB
 
 void safe_VkPhysicalDeviceCustomBorderColorFeaturesEXT::initialize(const VkPhysicalDeviceCustomBorderColorFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     customBorderColors = in_struct->customBorderColors;
     customBorderColorWithoutFormat = in_struct->customBorderColorWithoutFormat;
@@ -45452,6 +47028,8 @@ safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV::~safe_VkPhysicalDeviceDiagnost
 
 void safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV::initialize(const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     diagnosticsConfig = in_struct->diagnosticsConfig;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45506,6 +47084,8 @@ safe_VkDeviceDiagnosticsConfigCreateInfoNV::~safe_VkDeviceDiagnosticsConfigCreat
 
 void safe_VkDeviceDiagnosticsConfigCreateInfoNV::initialize(const VkDeviceDiagnosticsConfigCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45560,6 +47140,8 @@ safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::~safe_VkPhysicalDeviceG
 
 void safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::initialize(const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     graphicsPipelineLibrary = in_struct->graphicsPipelineLibrary;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45618,6 +47200,8 @@ safe_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT::initialize(const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     graphicsPipelineLibraryFastLinking = in_struct->graphicsPipelineLibraryFastLinking;
     graphicsPipelineLibraryIndependentInterpolationDecoration = in_struct->graphicsPipelineLibraryIndependentInterpolationDecoration;
@@ -45674,6 +47258,8 @@ safe_VkGraphicsPipelineLibraryCreateInfoEXT::~safe_VkGraphicsPipelineLibraryCrea
 
 void safe_VkGraphicsPipelineLibraryCreateInfoEXT::initialize(const VkGraphicsPipelineLibraryCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45736,6 +47322,8 @@ safe_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::~safe_VkPhysicalDeviceF
 
 void safe_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::initialize(const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentShadingRateEnums = in_struct->fragmentShadingRateEnums;
     supersampleFragmentShadingRates = in_struct->supersampleFragmentShadingRates;
@@ -45794,6 +47382,8 @@ safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV::initialize(const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxFragmentShadingRateInvocationCount = in_struct->maxFragmentShadingRateInvocationCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -45861,6 +47451,8 @@ safe_VkPipelineFragmentShadingRateEnumStateCreateInfoNV::~safe_VkPipelineFragmen
 
 void safe_VkPipelineFragmentShadingRateEnumStateCreateInfoNV::initialize(const VkPipelineFragmentShadingRateEnumStateCreateInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shadingRateType = in_struct->shadingRateType;
     shadingRate = in_struct->shadingRate;
@@ -45964,6 +47556,8 @@ safe_VkAccelerationStructureGeometryMotionTrianglesDataNV::~safe_VkAccelerationS
 
 void safe_VkAccelerationStructureGeometryMotionTrianglesDataNV::initialize(const VkAccelerationStructureGeometryMotionTrianglesDataNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexData.initialize(&in_struct->vertexData);
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46022,6 +47616,8 @@ safe_VkAccelerationStructureMotionInfoNV::~safe_VkAccelerationStructureMotionInf
 
 void safe_VkAccelerationStructureMotionInfoNV::initialize(const VkAccelerationStructureMotionInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxInstances = in_struct->maxInstances;
     flags = in_struct->flags;
@@ -46082,6 +47678,8 @@ safe_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::~safe_VkPhysicalDeviceRayTr
 
 void safe_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::initialize(const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rayTracingMotionBlur = in_struct->rayTracingMotionBlur;
     rayTracingMotionBlurPipelineTraceRaysIndirect = in_struct->rayTracingMotionBlurPipelineTraceRaysIndirect;
@@ -46138,6 +47736,8 @@ safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT::~safe_VkPhysicalDeviceYcb
 
 void safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT::initialize(const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     ycbcr2plane444Formats = in_struct->ycbcr2plane444Formats;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46192,6 +47792,8 @@ safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT::~safe_VkPhysicalDeviceFragm
 
 void safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT::initialize(const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityMapDeferred = in_struct->fragmentDensityMapDeferred;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46258,6 +47860,8 @@ safe_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT::~safe_VkPhysicalDeviceFra
 
 void safe_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT::initialize(const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     subsampledLoads = in_struct->subsampledLoads;
     subsampledCoarseReconstructionEarlyAccess = in_struct->subsampledCoarseReconstructionEarlyAccess;
@@ -46318,6 +47922,8 @@ safe_VkCopyCommandTransformInfoQCOM::~safe_VkCopyCommandTransformInfoQCOM()
 
 void safe_VkCopyCommandTransformInfoQCOM::initialize(const VkCopyCommandTransformInfoQCOM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     transform = in_struct->transform;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46376,6 +47982,8 @@ safe_VkPhysicalDevice4444FormatsFeaturesEXT::~safe_VkPhysicalDevice4444FormatsFe
 
 void safe_VkPhysicalDevice4444FormatsFeaturesEXT::initialize(const VkPhysicalDevice4444FormatsFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     formatA4R4G4B4 = in_struct->formatA4R4G4B4;
     formatA4B4G4R4 = in_struct->formatA4B4G4R4;
@@ -46440,6 +48048,8 @@ safe_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM::~safe_VkPhys
 
 void safe_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM::initialize(const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rasterizationOrderColorAttachmentAccess = in_struct->rasterizationOrderColorAttachmentAccess;
     rasterizationOrderDepthAttachmentAccess = in_struct->rasterizationOrderDepthAttachmentAccess;
@@ -46498,6 +48108,8 @@ safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT::~safe_VkPhysicalDeviceRGBA10X6F
 
 void safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT::initialize(const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     formatRgba10x6WithoutYCbCrSampler = in_struct->formatRgba10x6WithoutYCbCrSampler;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46588,6 +48200,12 @@ safe_VkDirectFBSurfaceCreateInfoEXT::~safe_VkDirectFBSurfaceCreateInfoEXT()
 
 void safe_VkDirectFBSurfaceCreateInfoEXT::initialize(const VkDirectFBSurfaceCreateInfoEXT* in_struct)
 {
+    if (dfb)
+        delete dfb;
+    if (surface)
+        delete surface;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     dfb = nullptr;
@@ -46660,6 +48278,8 @@ safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE::~safe_VkPhysicalDeviceM
 
 void safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE::initialize(const VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     mutableDescriptorType = in_struct->mutableDescriptorType;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46722,6 +48342,8 @@ safe_VkMutableDescriptorTypeListVALVE::~safe_VkMutableDescriptorTypeListVALVE()
 
 void safe_VkMutableDescriptorTypeListVALVE::initialize(const VkMutableDescriptorTypeListVALVE* in_struct)
 {
+    if (pDescriptorTypes)
+        delete[] pDescriptorTypes;
     descriptorTypeCount = in_struct->descriptorTypeCount;
     pDescriptorTypes = nullptr;
     if (in_struct->pDescriptorTypes) {
@@ -46808,6 +48430,10 @@ safe_VkMutableDescriptorTypeCreateInfoVALVE::~safe_VkMutableDescriptorTypeCreate
 
 void safe_VkMutableDescriptorTypeCreateInfoVALVE::initialize(const VkMutableDescriptorTypeCreateInfoVALVE* in_struct)
 {
+    if (pMutableDescriptorTypeLists)
+        delete[] pMutableDescriptorTypeLists;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     mutableDescriptorTypeListCount = in_struct->mutableDescriptorTypeListCount;
     pMutableDescriptorTypeLists = nullptr;
@@ -46876,6 +48502,8 @@ safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT::~safe_VkPhysicalDeviceV
 
 void safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT::initialize(const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexInputDynamicState = in_struct->vertexInputDynamicState;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -46942,6 +48570,8 @@ safe_VkVertexInputBindingDescription2EXT::~safe_VkVertexInputBindingDescription2
 
 void safe_VkVertexInputBindingDescription2EXT::initialize(const VkVertexInputBindingDescription2EXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     binding = in_struct->binding;
     stride = in_struct->stride;
@@ -47014,6 +48644,8 @@ safe_VkVertexInputAttributeDescription2EXT::~safe_VkVertexInputAttributeDescript
 
 void safe_VkVertexInputAttributeDescription2EXT::initialize(const VkVertexInputAttributeDescription2EXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     location = in_struct->location;
     binding = in_struct->binding;
@@ -47094,6 +48726,8 @@ safe_VkPhysicalDeviceDrmPropertiesEXT::~safe_VkPhysicalDeviceDrmPropertiesEXT()
 
 void safe_VkPhysicalDeviceDrmPropertiesEXT::initialize(const VkPhysicalDeviceDrmPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     hasPrimary = in_struct->hasPrimary;
     hasRender = in_struct->hasRender;
@@ -47158,6 +48792,8 @@ safe_VkPhysicalDeviceDepthClipControlFeaturesEXT::~safe_VkPhysicalDeviceDepthCli
 
 void safe_VkPhysicalDeviceDepthClipControlFeaturesEXT::initialize(const VkPhysicalDeviceDepthClipControlFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     depthClipControl = in_struct->depthClipControl;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -47212,6 +48848,8 @@ safe_VkPipelineViewportDepthClipControlCreateInfoEXT::~safe_VkPipelineViewportDe
 
 void safe_VkPipelineViewportDepthClipControlCreateInfoEXT::initialize(const VkPipelineViewportDepthClipControlCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     negativeOneToOne = in_struct->negativeOneToOne;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -47270,6 +48908,8 @@ safe_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::~safe_VkPhysicalDe
 
 void safe_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::initialize(const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     primitiveTopologyListRestart = in_struct->primitiveTopologyListRestart;
     primitiveTopologyPatchListRestart = in_struct->primitiveTopologyPatchListRestart;
@@ -47332,6 +48972,8 @@ safe_VkImportMemoryZirconHandleInfoFUCHSIA::~safe_VkImportMemoryZirconHandleInfo
 
 void safe_VkImportMemoryZirconHandleInfoFUCHSIA::initialize(const VkImportMemoryZirconHandleInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     handleType = in_struct->handleType;
     handle = in_struct->handle;
@@ -47392,6 +49034,8 @@ safe_VkMemoryZirconHandlePropertiesFUCHSIA::~safe_VkMemoryZirconHandleProperties
 
 void safe_VkMemoryZirconHandlePropertiesFUCHSIA::initialize(const VkMemoryZirconHandlePropertiesFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryTypeBits = in_struct->memoryTypeBits;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -47454,6 +49098,8 @@ safe_VkMemoryGetZirconHandleInfoFUCHSIA::~safe_VkMemoryGetZirconHandleInfoFUCHSI
 
 void safe_VkMemoryGetZirconHandleInfoFUCHSIA::initialize(const VkMemoryGetZirconHandleInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     handleType = in_struct->handleType;
@@ -47526,6 +49172,8 @@ safe_VkImportSemaphoreZirconHandleInfoFUCHSIA::~safe_VkImportSemaphoreZirconHand
 
 void safe_VkImportSemaphoreZirconHandleInfoFUCHSIA::initialize(const VkImportSemaphoreZirconHandleInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     flags = in_struct->flags;
@@ -47594,6 +49242,8 @@ safe_VkSemaphoreGetZirconHandleInfoFUCHSIA::~safe_VkSemaphoreGetZirconHandleInfo
 
 void safe_VkSemaphoreGetZirconHandleInfoFUCHSIA::initialize(const VkSemaphoreGetZirconHandleInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     semaphore = in_struct->semaphore;
     handleType = in_struct->handleType;
@@ -47654,6 +49304,8 @@ safe_VkBufferCollectionCreateInfoFUCHSIA::~safe_VkBufferCollectionCreateInfoFUCH
 
 void safe_VkBufferCollectionCreateInfoFUCHSIA::initialize(const VkBufferCollectionCreateInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     collectionToken = in_struct->collectionToken;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -47716,6 +49368,8 @@ safe_VkImportMemoryBufferCollectionFUCHSIA::~safe_VkImportMemoryBufferCollection
 
 void safe_VkImportMemoryBufferCollectionFUCHSIA::initialize(const VkImportMemoryBufferCollectionFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     collection = in_struct->collection;
     index = in_struct->index;
@@ -47780,6 +49434,8 @@ safe_VkBufferCollectionImageCreateInfoFUCHSIA::~safe_VkBufferCollectionImageCrea
 
 void safe_VkBufferCollectionImageCreateInfoFUCHSIA::initialize(const VkBufferCollectionImageCreateInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     collection = in_struct->collection;
     index = in_struct->index;
@@ -47856,6 +49512,8 @@ safe_VkBufferCollectionConstraintsInfoFUCHSIA::~safe_VkBufferCollectionConstrain
 
 void safe_VkBufferCollectionConstraintsInfoFUCHSIA::initialize(const VkBufferCollectionConstraintsInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minBufferCount = in_struct->minBufferCount;
     maxBufferCount = in_struct->maxBufferCount;
@@ -47928,6 +49586,8 @@ safe_VkBufferConstraintsInfoFUCHSIA::~safe_VkBufferConstraintsInfoFUCHSIA()
 
 void safe_VkBufferConstraintsInfoFUCHSIA::initialize(const VkBufferConstraintsInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     createInfo.initialize(&in_struct->createInfo);
     requiredFormatFeatures = in_struct->requiredFormatFeatures;
@@ -47994,6 +49654,8 @@ safe_VkBufferCollectionBufferCreateInfoFUCHSIA::~safe_VkBufferCollectionBufferCr
 
 void safe_VkBufferCollectionBufferCreateInfoFUCHSIA::initialize(const VkBufferCollectionBufferCreateInfoFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     collection = in_struct->collection;
     index = in_struct->index;
@@ -48054,6 +49716,8 @@ safe_VkSysmemColorSpaceFUCHSIA::~safe_VkSysmemColorSpaceFUCHSIA()
 
 void safe_VkSysmemColorSpaceFUCHSIA::initialize(const VkSysmemColorSpaceFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     colorSpace = in_struct->colorSpace;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -48151,6 +49815,8 @@ safe_VkBufferCollectionPropertiesFUCHSIA::~safe_VkBufferCollectionPropertiesFUCH
 
 void safe_VkBufferCollectionPropertiesFUCHSIA::initialize(const VkBufferCollectionPropertiesFUCHSIA* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memoryTypeBits = in_struct->memoryTypeBits;
     bufferCount = in_struct->bufferCount;
@@ -48270,6 +49936,10 @@ safe_VkImageFormatConstraintsInfoFUCHSIA::~safe_VkImageFormatConstraintsInfoFUCH
 
 void safe_VkImageFormatConstraintsInfoFUCHSIA::initialize(const VkImageFormatConstraintsInfoFUCHSIA* in_struct)
 {
+    if (pColorSpaces)
+        delete[] pColorSpaces;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     imageCreateInfo.initialize(&in_struct->imageCreateInfo);
     requiredFormatFeatures = in_struct->requiredFormatFeatures;
@@ -48383,6 +50053,10 @@ safe_VkImageConstraintsInfoFUCHSIA::~safe_VkImageConstraintsInfoFUCHSIA()
 
 void safe_VkImageConstraintsInfoFUCHSIA::initialize(const VkImageConstraintsInfoFUCHSIA* in_struct)
 {
+    if (pFormatConstraints)
+        delete[] pFormatConstraints;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     formatConstraintsCount = in_struct->formatConstraintsCount;
     pFormatConstraints = nullptr;
@@ -48461,6 +50135,8 @@ safe_VkSubpassShadingPipelineCreateInfoHUAWEI::~safe_VkSubpassShadingPipelineCre
 
 void safe_VkSubpassShadingPipelineCreateInfoHUAWEI::initialize(const VkSubpassShadingPipelineCreateInfoHUAWEI* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     renderPass = in_struct->renderPass;
     subpass = in_struct->subpass;
@@ -48517,6 +50193,8 @@ safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI::~safe_VkPhysicalDeviceSubpass
 
 void safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI::initialize(const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     subpassShading = in_struct->subpassShading;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -48571,6 +50249,8 @@ safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI::~safe_VkPhysicalDeviceSubpa
 
 void safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI::initialize(const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxSubpassShadingWorkgroupSizeAspectRatio = in_struct->maxSubpassShadingWorkgroupSizeAspectRatio;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -48625,6 +50305,8 @@ safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI::~safe_VkPhysicalDeviceInvocat
 
 void safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI::initialize(const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     invocationMask = in_struct->invocationMask;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -48683,6 +50365,8 @@ safe_VkMemoryGetRemoteAddressInfoNV::~safe_VkMemoryGetRemoteAddressInfoNV()
 
 void safe_VkMemoryGetRemoteAddressInfoNV::initialize(const VkMemoryGetRemoteAddressInfoNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     memory = in_struct->memory;
     handleType = in_struct->handleType;
@@ -48739,6 +50423,8 @@ safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV::~safe_VkPhysicalDeviceExterna
 
 void safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV::initialize(const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     externalMemoryRDMA = in_struct->externalMemoryRDMA;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -48801,6 +50487,8 @@ safe_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::~safe_VkPhysicalDeviceExt
 
 void safe_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::initialize(const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     extendedDynamicState2 = in_struct->extendedDynamicState2;
     extendedDynamicState2LogicOp = in_struct->extendedDynamicState2LogicOp;
@@ -48895,6 +50583,12 @@ safe_VkScreenSurfaceCreateInfoQNX::~safe_VkScreenSurfaceCreateInfoQNX()
 
 void safe_VkScreenSurfaceCreateInfoQNX::initialize(const VkScreenSurfaceCreateInfoQNX* in_struct)
 {
+    if (context)
+        delete context;
+    if (window)
+        delete window;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     context = nullptr;
@@ -48967,6 +50661,8 @@ safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT::~safe_VkPhysicalDeviceColorWri
 
 void safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT::initialize(const VkPhysicalDeviceColorWriteEnableFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     colorWriteEnable = in_struct->colorWriteEnable;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49041,6 +50737,10 @@ safe_VkPipelineColorWriteCreateInfoEXT::~safe_VkPipelineColorWriteCreateInfoEXT(
 
 void safe_VkPipelineColorWriteCreateInfoEXT::initialize(const VkPipelineColorWriteCreateInfoEXT* in_struct)
 {
+    if (pColorWriteEnables)
+        delete[] pColorWriteEnables;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     attachmentCount = in_struct->attachmentCount;
     pColorWriteEnables = nullptr;
@@ -49113,6 +50813,8 @@ safe_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::~safe_VkPhysicalDevice
 
 void safe_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::initialize(const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     primitivesGeneratedQuery = in_struct->primitivesGeneratedQuery;
     primitivesGeneratedQueryWithRasterizerDiscard = in_struct->primitivesGeneratedQueryWithRasterizerDiscard;
@@ -49171,6 +50873,8 @@ safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT::~safe_VkPhysicalDeviceImageView
 
 void safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT::initialize(const VkPhysicalDeviceImageViewMinLodFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minLod = in_struct->minLod;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49225,6 +50929,8 @@ safe_VkImageViewMinLodCreateInfoEXT::~safe_VkImageViewMinLodCreateInfoEXT()
 
 void safe_VkImageViewMinLodCreateInfoEXT::initialize(const VkImageViewMinLodCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     minLod = in_struct->minLod;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49279,6 +50985,8 @@ safe_VkPhysicalDeviceMultiDrawFeaturesEXT::~safe_VkPhysicalDeviceMultiDrawFeatur
 
 void safe_VkPhysicalDeviceMultiDrawFeaturesEXT::initialize(const VkPhysicalDeviceMultiDrawFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     multiDraw = in_struct->multiDraw;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49333,6 +51041,8 @@ safe_VkPhysicalDeviceMultiDrawPropertiesEXT::~safe_VkPhysicalDeviceMultiDrawProp
 
 void safe_VkPhysicalDeviceMultiDrawPropertiesEXT::initialize(const VkPhysicalDeviceMultiDrawPropertiesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxMultiDrawCount = in_struct->maxMultiDrawCount;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49391,6 +51101,8 @@ safe_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::~safe_VkPhysicalDeviceImage2DVi
 
 void safe_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::initialize(const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     image2DViewOf3D = in_struct->image2DViewOf3D;
     sampler2DViewOf3D = in_struct->sampler2DViewOf3D;
@@ -49451,6 +51163,8 @@ safe_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::~safe_VkPhysicalDeviceBorder
 
 void safe_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::initialize(const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     borderColorSwizzle = in_struct->borderColorSwizzle;
     borderColorSwizzleFromImage = in_struct->borderColorSwizzleFromImage;
@@ -49511,6 +51225,8 @@ safe_VkSamplerBorderColorComponentMappingCreateInfoEXT::~safe_VkSamplerBorderCol
 
 void safe_VkSamplerBorderColorComponentMappingCreateInfoEXT::initialize(const VkSamplerBorderColorComponentMappingCreateInfoEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     components = in_struct->components;
     srgb = in_struct->srgb;
@@ -49567,6 +51283,8 @@ safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT::initialize(const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pageableDeviceLocalMemory = in_struct->pageableDeviceLocalMemory;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49621,6 +51339,8 @@ safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE::~safe_VkPhysicalDevi
 
 void safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE::initialize(const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     descriptorSetHostMapping = in_struct->descriptorSetHostMapping;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49679,6 +51399,8 @@ safe_VkDescriptorSetBindingReferenceVALVE::~safe_VkDescriptorSetBindingReference
 
 void safe_VkDescriptorSetBindingReferenceVALVE::initialize(const VkDescriptorSetBindingReferenceVALVE* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     descriptorSetLayout = in_struct->descriptorSetLayout;
     binding = in_struct->binding;
@@ -49739,6 +51461,8 @@ safe_VkDescriptorSetLayoutHostMappingInfoVALVE::~safe_VkDescriptorSetLayoutHostM
 
 void safe_VkDescriptorSetLayoutHostMappingInfoVALVE::initialize(const VkDescriptorSetLayoutHostMappingInfoVALVE* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     descriptorOffset = in_struct->descriptorOffset;
     descriptorSize = in_struct->descriptorSize;
@@ -49795,6 +51519,8 @@ safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM::~safe_VkPhysicalDevic
 
 void safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM::initialize(const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityMapOffset = in_struct->fragmentDensityMapOffset;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49849,6 +51575,8 @@ safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM::~safe_VkPhysicalDev
 
 void safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM::initialize(const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityOffsetGranularity = in_struct->fragmentDensityOffsetGranularity;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -49923,6 +51651,10 @@ safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM::~safe_VkSubpassFragmentDensit
 
 void safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM::initialize(const VkSubpassFragmentDensityMapOffsetEndInfoQCOM* in_struct)
 {
+    if (pFragmentDensityOffsets)
+        delete[] pFragmentDensityOffsets;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     fragmentDensityOffsetCount = in_struct->fragmentDensityOffsetCount;
     pFragmentDensityOffsets = nullptr;
@@ -49987,6 +51719,8 @@ safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV::~safe_VkPhysicalDeviceLine
 
 void safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV::initialize(const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     linearColorAttachment = in_struct->linearColorAttachment;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -50104,6 +51838,8 @@ safe_VkAccelerationStructureGeometryTrianglesDataKHR::~safe_VkAccelerationStruct
 
 void safe_VkAccelerationStructureGeometryTrianglesDataKHR::initialize(const VkAccelerationStructureGeometryTrianglesDataKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     vertexFormat = in_struct->vertexFormat;
     vertexData.initialize(&in_struct->vertexData);
@@ -50173,6 +51909,8 @@ safe_VkAccelerationStructureGeometryAabbsDataKHR::~safe_VkAccelerationStructureG
 
 void safe_VkAccelerationStructureGeometryAabbsDataKHR::initialize(const VkAccelerationStructureGeometryAabbsDataKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     data.initialize(&in_struct->data);
     stride = in_struct->stride;
@@ -50232,6 +51970,8 @@ safe_VkAccelerationStructureGeometryInstancesDataKHR::~safe_VkAccelerationStruct
 
 void safe_VkAccelerationStructureGeometryInstancesDataKHR::initialize(const VkAccelerationStructureGeometryInstancesDataKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     arrayOfPointers = in_struct->arrayOfPointers;
     data.initialize(&in_struct->data);
@@ -50296,6 +52036,8 @@ safe_VkAccelerationStructureGeometryKHR::~safe_VkAccelerationStructureGeometryKH
 
 void safe_VkAccelerationStructureGeometryKHR::initialize(const VkAccelerationStructureGeometryKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     geometryType = in_struct->geometryType;
     geometry = in_struct->geometry;
@@ -50438,6 +52180,16 @@ safe_VkAccelerationStructureBuildGeometryInfoKHR::~safe_VkAccelerationStructureB
 
 void safe_VkAccelerationStructureBuildGeometryInfoKHR::initialize(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct)
 {
+    if (ppGeometries) {
+        for (uint32_t i = 0; i < geometryCount; ++i) {
+             delete ppGeometries[i];
+        }
+        delete[] ppGeometries;
+    } else if(pGeometries) {
+        delete[] pGeometries;
+    }
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     flags = in_struct->flags;
@@ -50553,6 +52305,8 @@ safe_VkAccelerationStructureCreateInfoKHR::~safe_VkAccelerationStructureCreateIn
 
 void safe_VkAccelerationStructureCreateInfoKHR::initialize(const VkAccelerationStructureCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     createFlags = in_struct->createFlags;
     buffer = in_struct->buffer;
@@ -50643,6 +52397,10 @@ safe_VkWriteDescriptorSetAccelerationStructureKHR::~safe_VkWriteDescriptorSetAcc
 
 void safe_VkWriteDescriptorSetAccelerationStructureKHR::initialize(const VkWriteDescriptorSetAccelerationStructureKHR* in_struct)
 {
+    if (pAccelerationStructures)
+        delete[] pAccelerationStructures;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructureCount = in_struct->accelerationStructureCount;
     pAccelerationStructures = nullptr;
@@ -50727,6 +52485,8 @@ safe_VkPhysicalDeviceAccelerationStructureFeaturesKHR::~safe_VkPhysicalDeviceAcc
 
 void safe_VkPhysicalDeviceAccelerationStructureFeaturesKHR::initialize(const VkPhysicalDeviceAccelerationStructureFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructure = in_struct->accelerationStructure;
     accelerationStructureCaptureReplay = in_struct->accelerationStructureCaptureReplay;
@@ -50817,6 +52577,8 @@ safe_VkPhysicalDeviceAccelerationStructurePropertiesKHR::~safe_VkPhysicalDeviceA
 
 void safe_VkPhysicalDeviceAccelerationStructurePropertiesKHR::initialize(const VkPhysicalDeviceAccelerationStructurePropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxGeometryCount = in_struct->maxGeometryCount;
     maxInstanceCount = in_struct->maxInstanceCount;
@@ -50885,6 +52647,8 @@ safe_VkAccelerationStructureDeviceAddressInfoKHR::~safe_VkAccelerationStructureD
 
 void safe_VkAccelerationStructureDeviceAddressInfoKHR::initialize(const VkAccelerationStructureDeviceAddressInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructure = in_struct->accelerationStructure;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -50955,6 +52719,10 @@ safe_VkAccelerationStructureVersionInfoKHR::~safe_VkAccelerationStructureVersion
 
 void safe_VkAccelerationStructureVersionInfoKHR::initialize(const VkAccelerationStructureVersionInfoKHR* in_struct)
 {
+    if (pVersionData)
+        delete[] pVersionData;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     pVersionData = nullptr;
     pNext = SafePnextCopy(in_struct->pNext);
@@ -51024,6 +52792,8 @@ safe_VkCopyAccelerationStructureToMemoryInfoKHR::~safe_VkCopyAccelerationStructu
 
 void safe_VkCopyAccelerationStructureToMemoryInfoKHR::initialize(const VkCopyAccelerationStructureToMemoryInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     src = in_struct->src;
     dst.initialize(&in_struct->dst);
@@ -51089,6 +52859,8 @@ safe_VkCopyMemoryToAccelerationStructureInfoKHR::~safe_VkCopyMemoryToAcceleratio
 
 void safe_VkCopyMemoryToAccelerationStructureInfoKHR::initialize(const VkCopyMemoryToAccelerationStructureInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     src.initialize(&in_struct->src);
     dst = in_struct->dst;
@@ -51155,6 +52927,8 @@ safe_VkCopyAccelerationStructureInfoKHR::~safe_VkCopyAccelerationStructureInfoKH
 
 void safe_VkCopyAccelerationStructureInfoKHR::initialize(const VkCopyAccelerationStructureInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     src = in_struct->src;
     dst = in_struct->dst;
@@ -51221,6 +52995,8 @@ safe_VkAccelerationStructureBuildSizesInfoKHR::~safe_VkAccelerationStructureBuil
 
 void safe_VkAccelerationStructureBuildSizesInfoKHR::initialize(const VkAccelerationStructureBuildSizesInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     accelerationStructureSize = in_struct->accelerationStructureSize;
     updateScratchSize = in_struct->updateScratchSize;
@@ -51299,6 +53075,8 @@ safe_VkRayTracingShaderGroupCreateInfoKHR::~safe_VkRayTracingShaderGroupCreateIn
 
 void safe_VkRayTracingShaderGroupCreateInfoKHR::initialize(const VkRayTracingShaderGroupCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
     generalShader = in_struct->generalShader;
@@ -51367,6 +53145,8 @@ safe_VkRayTracingPipelineInterfaceCreateInfoKHR::~safe_VkRayTracingPipelineInter
 
 void safe_VkRayTracingPipelineInterfaceCreateInfoKHR::initialize(const VkRayTracingPipelineInterfaceCreateInfoKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     maxPipelineRayPayloadSize = in_struct->maxPipelineRayPayloadSize;
     maxPipelineRayHitAttributeSize = in_struct->maxPipelineRayHitAttributeSize;
@@ -51541,6 +53321,18 @@ safe_VkRayTracingPipelineCreateInfoKHR::~safe_VkRayTracingPipelineCreateInfoKHR(
 
 void safe_VkRayTracingPipelineCreateInfoKHR::initialize(const VkRayTracingPipelineCreateInfoKHR* in_struct)
 {
+    if (pStages)
+        delete[] pStages;
+    if (pGroups)
+        delete[] pGroups;
+    if (pLibraryInfo)
+        delete pLibraryInfo;
+    if (pLibraryInterface)
+        delete pLibraryInterface;
+    if (pDynamicState)
+        delete pDynamicState;
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     flags = in_struct->flags;
     stageCount = in_struct->stageCount;
@@ -51669,6 +53461,8 @@ safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR::~safe_VkPhysicalDeviceRayTra
 
 void safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR::initialize(const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rayTracingPipeline = in_struct->rayTracingPipeline;
     rayTracingPipelineShaderGroupHandleCaptureReplay = in_struct->rayTracingPipelineShaderGroupHandleCaptureReplay;
@@ -51759,6 +53553,8 @@ safe_VkPhysicalDeviceRayTracingPipelinePropertiesKHR::~safe_VkPhysicalDeviceRayT
 
 void safe_VkPhysicalDeviceRayTracingPipelinePropertiesKHR::initialize(const VkPhysicalDeviceRayTracingPipelinePropertiesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     shaderGroupHandleSize = in_struct->shaderGroupHandleSize;
     maxRayRecursionDepth = in_struct->maxRayRecursionDepth;
@@ -51827,6 +53623,8 @@ safe_VkPhysicalDeviceRayQueryFeaturesKHR::~safe_VkPhysicalDeviceRayQueryFeatures
 
 void safe_VkPhysicalDeviceRayQueryFeaturesKHR::initialize(const VkPhysicalDeviceRayQueryFeaturesKHR* in_struct)
 {
+    if (pNext)
+        FreePnextChain(pNext);
     sType = in_struct->sType;
     rayQuery = in_struct->rayQuery;
     pNext = SafePnextCopy(in_struct->pNext);

--- a/layers/generated/vk_safe_struct.h
+++ b/layers/generated/vk_safe_struct.h
@@ -42,7 +42,7 @@ char *SafeStringCopy(const char *in_string);
 
 struct safe_VkBufferMemoryBarrier {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccessFlags srcAccessMask;
     VkAccessFlags dstAccessMask;
     uint32_t srcQueueFamilyIndex;
@@ -63,7 +63,7 @@ struct safe_VkBufferMemoryBarrier {
 
 struct safe_VkImageMemoryBarrier {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccessFlags srcAccessMask;
     VkAccessFlags dstAccessMask;
     VkImageLayout oldLayout;
@@ -85,7 +85,7 @@ struct safe_VkImageMemoryBarrier {
 
 struct safe_VkMemoryBarrier {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccessFlags srcAccessMask;
     VkAccessFlags dstAccessMask;
     safe_VkMemoryBarrier(const VkMemoryBarrier* in_struct);
@@ -100,7 +100,7 @@ struct safe_VkMemoryBarrier {
 };
 
 struct safe_VkAllocationCallbacks {
-    void* pUserData;
+    void* pUserData{};
     PFN_vkAllocationFunction pfnAllocation;
     PFN_vkReallocationFunction pfnReallocation;
     PFN_vkFreeFunction pfnFree;
@@ -119,10 +119,10 @@ struct safe_VkAllocationCallbacks {
 
 struct safe_VkApplicationInfo {
     VkStructureType sType;
-    const void* pNext;
-    const char* pApplicationName;
+    const void* pNext{};
+    const char* pApplicationName{};
     uint32_t applicationVersion;
-    const char* pEngineName;
+    const char* pEngineName{};
     uint32_t engineVersion;
     uint32_t apiVersion;
     safe_VkApplicationInfo(const VkApplicationInfo* in_struct);
@@ -138,13 +138,13 @@ struct safe_VkApplicationInfo {
 
 struct safe_VkInstanceCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkInstanceCreateFlags flags;
-    safe_VkApplicationInfo* pApplicationInfo;
+    safe_VkApplicationInfo* pApplicationInfo{};
     uint32_t enabledLayerCount;
-    const char* const* ppEnabledLayerNames;
+    const char* const* ppEnabledLayerNames{};
     uint32_t enabledExtensionCount;
-    const char* const* ppEnabledExtensionNames;
+    const char* const* ppEnabledExtensionNames{};
     safe_VkInstanceCreateInfo(const VkInstanceCreateInfo* in_struct);
     safe_VkInstanceCreateInfo(const safe_VkInstanceCreateInfo& copy_src);
     safe_VkInstanceCreateInfo& operator=(const safe_VkInstanceCreateInfo& copy_src);
@@ -158,11 +158,11 @@ struct safe_VkInstanceCreateInfo {
 
 struct safe_VkDeviceQueueCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceQueueCreateFlags flags;
     uint32_t queueFamilyIndex;
     uint32_t queueCount;
-    const float* pQueuePriorities;
+    const float* pQueuePriorities{};
     safe_VkDeviceQueueCreateInfo(const VkDeviceQueueCreateInfo* in_struct);
     safe_VkDeviceQueueCreateInfo(const safe_VkDeviceQueueCreateInfo& copy_src);
     safe_VkDeviceQueueCreateInfo& operator=(const safe_VkDeviceQueueCreateInfo& copy_src);
@@ -176,15 +176,15 @@ struct safe_VkDeviceQueueCreateInfo {
 
 struct safe_VkDeviceCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceCreateFlags flags;
     uint32_t queueCreateInfoCount;
-    safe_VkDeviceQueueCreateInfo* pQueueCreateInfos;
+    safe_VkDeviceQueueCreateInfo* pQueueCreateInfos{};
     uint32_t enabledLayerCount;
-    const char* const* ppEnabledLayerNames;
+    const char* const* ppEnabledLayerNames{};
     uint32_t enabledExtensionCount;
-    const char* const* ppEnabledExtensionNames;
-    const VkPhysicalDeviceFeatures* pEnabledFeatures;
+    const char* const* ppEnabledExtensionNames{};
+    const VkPhysicalDeviceFeatures* pEnabledFeatures{};
     safe_VkDeviceCreateInfo(const VkDeviceCreateInfo* in_struct);
     safe_VkDeviceCreateInfo(const safe_VkDeviceCreateInfo& copy_src);
     safe_VkDeviceCreateInfo& operator=(const safe_VkDeviceCreateInfo& copy_src);
@@ -198,14 +198,14 @@ struct safe_VkDeviceCreateInfo {
 
 struct safe_VkSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreCount;
-    VkSemaphore* pWaitSemaphores;
-    const VkPipelineStageFlags* pWaitDstStageMask;
+    VkSemaphore* pWaitSemaphores{};
+    const VkPipelineStageFlags* pWaitDstStageMask{};
     uint32_t commandBufferCount;
-    VkCommandBuffer* pCommandBuffers;
+    VkCommandBuffer* pCommandBuffers{};
     uint32_t signalSemaphoreCount;
-    VkSemaphore* pSignalSemaphores;
+    VkSemaphore* pSignalSemaphores{};
     safe_VkSubmitInfo(const VkSubmitInfo* in_struct);
     safe_VkSubmitInfo(const safe_VkSubmitInfo& copy_src);
     safe_VkSubmitInfo& operator=(const safe_VkSubmitInfo& copy_src);
@@ -219,7 +219,7 @@ struct safe_VkSubmitInfo {
 
 struct safe_VkMappedMemoryRange {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     VkDeviceSize offset;
     VkDeviceSize size;
@@ -236,7 +236,7 @@ struct safe_VkMappedMemoryRange {
 
 struct safe_VkMemoryAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceSize allocationSize;
     uint32_t memoryTypeIndex;
     safe_VkMemoryAllocateInfo(const VkMemoryAllocateInfo* in_struct);
@@ -253,7 +253,7 @@ struct safe_VkMemoryAllocateInfo {
 struct safe_VkSparseBufferMemoryBindInfo {
     VkBuffer buffer;
     uint32_t bindCount;
-    VkSparseMemoryBind* pBinds;
+    VkSparseMemoryBind* pBinds{};
     safe_VkSparseBufferMemoryBindInfo(const VkSparseBufferMemoryBindInfo* in_struct);
     safe_VkSparseBufferMemoryBindInfo(const safe_VkSparseBufferMemoryBindInfo& copy_src);
     safe_VkSparseBufferMemoryBindInfo& operator=(const safe_VkSparseBufferMemoryBindInfo& copy_src);
@@ -268,7 +268,7 @@ struct safe_VkSparseBufferMemoryBindInfo {
 struct safe_VkSparseImageOpaqueMemoryBindInfo {
     VkImage image;
     uint32_t bindCount;
-    VkSparseMemoryBind* pBinds;
+    VkSparseMemoryBind* pBinds{};
     safe_VkSparseImageOpaqueMemoryBindInfo(const VkSparseImageOpaqueMemoryBindInfo* in_struct);
     safe_VkSparseImageOpaqueMemoryBindInfo(const safe_VkSparseImageOpaqueMemoryBindInfo& copy_src);
     safe_VkSparseImageOpaqueMemoryBindInfo& operator=(const safe_VkSparseImageOpaqueMemoryBindInfo& copy_src);
@@ -283,7 +283,7 @@ struct safe_VkSparseImageOpaqueMemoryBindInfo {
 struct safe_VkSparseImageMemoryBindInfo {
     VkImage image;
     uint32_t bindCount;
-    VkSparseImageMemoryBind* pBinds;
+    VkSparseImageMemoryBind* pBinds{};
     safe_VkSparseImageMemoryBindInfo(const VkSparseImageMemoryBindInfo* in_struct);
     safe_VkSparseImageMemoryBindInfo(const safe_VkSparseImageMemoryBindInfo& copy_src);
     safe_VkSparseImageMemoryBindInfo& operator=(const safe_VkSparseImageMemoryBindInfo& copy_src);
@@ -297,17 +297,17 @@ struct safe_VkSparseImageMemoryBindInfo {
 
 struct safe_VkBindSparseInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreCount;
-    VkSemaphore* pWaitSemaphores;
+    VkSemaphore* pWaitSemaphores{};
     uint32_t bufferBindCount;
-    safe_VkSparseBufferMemoryBindInfo* pBufferBinds;
+    safe_VkSparseBufferMemoryBindInfo* pBufferBinds{};
     uint32_t imageOpaqueBindCount;
-    safe_VkSparseImageOpaqueMemoryBindInfo* pImageOpaqueBinds;
+    safe_VkSparseImageOpaqueMemoryBindInfo* pImageOpaqueBinds{};
     uint32_t imageBindCount;
-    safe_VkSparseImageMemoryBindInfo* pImageBinds;
+    safe_VkSparseImageMemoryBindInfo* pImageBinds{};
     uint32_t signalSemaphoreCount;
-    VkSemaphore* pSignalSemaphores;
+    VkSemaphore* pSignalSemaphores{};
     safe_VkBindSparseInfo(const VkBindSparseInfo* in_struct);
     safe_VkBindSparseInfo(const safe_VkBindSparseInfo& copy_src);
     safe_VkBindSparseInfo& operator=(const safe_VkBindSparseInfo& copy_src);
@@ -321,7 +321,7 @@ struct safe_VkBindSparseInfo {
 
 struct safe_VkFenceCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFenceCreateFlags flags;
     safe_VkFenceCreateInfo(const VkFenceCreateInfo* in_struct);
     safe_VkFenceCreateInfo(const safe_VkFenceCreateInfo& copy_src);
@@ -336,7 +336,7 @@ struct safe_VkFenceCreateInfo {
 
 struct safe_VkSemaphoreCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphoreCreateFlags flags;
     safe_VkSemaphoreCreateInfo(const VkSemaphoreCreateInfo* in_struct);
     safe_VkSemaphoreCreateInfo(const safe_VkSemaphoreCreateInfo& copy_src);
@@ -351,7 +351,7 @@ struct safe_VkSemaphoreCreateInfo {
 
 struct safe_VkEventCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkEventCreateFlags flags;
     safe_VkEventCreateInfo(const VkEventCreateInfo* in_struct);
     safe_VkEventCreateInfo(const safe_VkEventCreateInfo& copy_src);
@@ -366,7 +366,7 @@ struct safe_VkEventCreateInfo {
 
 struct safe_VkQueryPoolCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkQueryPoolCreateFlags flags;
     VkQueryType queryType;
     uint32_t queryCount;
@@ -384,13 +384,13 @@ struct safe_VkQueryPoolCreateInfo {
 
 struct safe_VkBufferCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferCreateFlags flags;
     VkDeviceSize size;
     VkBufferUsageFlags usage;
     VkSharingMode sharingMode;
     uint32_t queueFamilyIndexCount;
-    const uint32_t* pQueueFamilyIndices;
+    const uint32_t* pQueueFamilyIndices{};
     safe_VkBufferCreateInfo(const VkBufferCreateInfo* in_struct);
     safe_VkBufferCreateInfo(const safe_VkBufferCreateInfo& copy_src);
     safe_VkBufferCreateInfo& operator=(const safe_VkBufferCreateInfo& copy_src);
@@ -404,7 +404,7 @@ struct safe_VkBufferCreateInfo {
 
 struct safe_VkBufferViewCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferViewCreateFlags flags;
     VkBuffer buffer;
     VkFormat format;
@@ -423,7 +423,7 @@ struct safe_VkBufferViewCreateInfo {
 
 struct safe_VkImageCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageCreateFlags flags;
     VkImageType imageType;
     VkFormat format;
@@ -435,7 +435,7 @@ struct safe_VkImageCreateInfo {
     VkImageUsageFlags usage;
     VkSharingMode sharingMode;
     uint32_t queueFamilyIndexCount;
-    const uint32_t* pQueueFamilyIndices;
+    const uint32_t* pQueueFamilyIndices{};
     VkImageLayout initialLayout;
     safe_VkImageCreateInfo(const VkImageCreateInfo* in_struct);
     safe_VkImageCreateInfo(const safe_VkImageCreateInfo& copy_src);
@@ -450,7 +450,7 @@ struct safe_VkImageCreateInfo {
 
 struct safe_VkImageViewCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageViewCreateFlags flags;
     VkImage image;
     VkImageViewType viewType;
@@ -470,10 +470,10 @@ struct safe_VkImageViewCreateInfo {
 
 struct safe_VkShaderModuleCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkShaderModuleCreateFlags flags;
     size_t codeSize;
-    const uint32_t* pCode;
+    const uint32_t* pCode{};
     safe_VkShaderModuleCreateInfo(const VkShaderModuleCreateInfo* in_struct);
     safe_VkShaderModuleCreateInfo(const safe_VkShaderModuleCreateInfo& copy_src);
     safe_VkShaderModuleCreateInfo& operator=(const safe_VkShaderModuleCreateInfo& copy_src);
@@ -487,10 +487,10 @@ struct safe_VkShaderModuleCreateInfo {
 
 struct safe_VkPipelineCacheCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCacheCreateFlags flags;
     size_t initialDataSize;
-    const void* pInitialData;
+    const void* pInitialData{};
     safe_VkPipelineCacheCreateInfo(const VkPipelineCacheCreateInfo* in_struct);
     safe_VkPipelineCacheCreateInfo(const safe_VkPipelineCacheCreateInfo& copy_src);
     safe_VkPipelineCacheCreateInfo& operator=(const safe_VkPipelineCacheCreateInfo& copy_src);
@@ -504,9 +504,9 @@ struct safe_VkPipelineCacheCreateInfo {
 
 struct safe_VkSpecializationInfo {
     uint32_t mapEntryCount;
-    const VkSpecializationMapEntry* pMapEntries;
+    const VkSpecializationMapEntry* pMapEntries{};
     size_t dataSize;
-    const void* pData;
+    const void* pData{};
     safe_VkSpecializationInfo(const VkSpecializationInfo* in_struct);
     safe_VkSpecializationInfo(const safe_VkSpecializationInfo& copy_src);
     safe_VkSpecializationInfo& operator=(const safe_VkSpecializationInfo& copy_src);
@@ -520,12 +520,12 @@ struct safe_VkSpecializationInfo {
 
 struct safe_VkPipelineShaderStageCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineShaderStageCreateFlags flags;
     VkShaderStageFlagBits stage;
     VkShaderModule module;
-    const char* pName;
-    safe_VkSpecializationInfo* pSpecializationInfo;
+    const char* pName{};
+    safe_VkSpecializationInfo* pSpecializationInfo{};
     safe_VkPipelineShaderStageCreateInfo(const VkPipelineShaderStageCreateInfo* in_struct);
     safe_VkPipelineShaderStageCreateInfo(const safe_VkPipelineShaderStageCreateInfo& copy_src);
     safe_VkPipelineShaderStageCreateInfo& operator=(const safe_VkPipelineShaderStageCreateInfo& copy_src);
@@ -539,7 +539,7 @@ struct safe_VkPipelineShaderStageCreateInfo {
 
 struct safe_VkComputePipelineCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCreateFlags flags;
     safe_VkPipelineShaderStageCreateInfo stage;
     VkPipelineLayout layout;
@@ -558,12 +558,12 @@ struct safe_VkComputePipelineCreateInfo {
 
 struct safe_VkPipelineVertexInputStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineVertexInputStateCreateFlags flags;
     uint32_t vertexBindingDescriptionCount;
-    const VkVertexInputBindingDescription* pVertexBindingDescriptions;
+    const VkVertexInputBindingDescription* pVertexBindingDescriptions{};
     uint32_t vertexAttributeDescriptionCount;
-    const VkVertexInputAttributeDescription* pVertexAttributeDescriptions;
+    const VkVertexInputAttributeDescription* pVertexAttributeDescriptions{};
     safe_VkPipelineVertexInputStateCreateInfo(const VkPipelineVertexInputStateCreateInfo* in_struct);
     safe_VkPipelineVertexInputStateCreateInfo(const safe_VkPipelineVertexInputStateCreateInfo& copy_src);
     safe_VkPipelineVertexInputStateCreateInfo& operator=(const safe_VkPipelineVertexInputStateCreateInfo& copy_src);
@@ -577,7 +577,7 @@ struct safe_VkPipelineVertexInputStateCreateInfo {
 
 struct safe_VkPipelineInputAssemblyStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineInputAssemblyStateCreateFlags flags;
     VkPrimitiveTopology topology;
     VkBool32 primitiveRestartEnable;
@@ -594,7 +594,7 @@ struct safe_VkPipelineInputAssemblyStateCreateInfo {
 
 struct safe_VkPipelineTessellationStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineTessellationStateCreateFlags flags;
     uint32_t patchControlPoints;
     safe_VkPipelineTessellationStateCreateInfo(const VkPipelineTessellationStateCreateInfo* in_struct);
@@ -610,12 +610,12 @@ struct safe_VkPipelineTessellationStateCreateInfo {
 
 struct safe_VkPipelineViewportStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineViewportStateCreateFlags flags;
     uint32_t viewportCount;
-    const VkViewport* pViewports;
+    const VkViewport* pViewports{};
     uint32_t scissorCount;
-    const VkRect2D* pScissors;
+    const VkRect2D* pScissors{};
     safe_VkPipelineViewportStateCreateInfo(const VkPipelineViewportStateCreateInfo* in_struct, const bool is_dynamic_viewports, const bool is_dynamic_scissors);
     safe_VkPipelineViewportStateCreateInfo(const safe_VkPipelineViewportStateCreateInfo& copy_src);
     safe_VkPipelineViewportStateCreateInfo& operator=(const safe_VkPipelineViewportStateCreateInfo& copy_src);
@@ -629,7 +629,7 @@ struct safe_VkPipelineViewportStateCreateInfo {
 
 struct safe_VkPipelineRasterizationStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineRasterizationStateCreateFlags flags;
     VkBool32 depthClampEnable;
     VkBool32 rasterizerDiscardEnable;
@@ -654,12 +654,12 @@ struct safe_VkPipelineRasterizationStateCreateInfo {
 
 struct safe_VkPipelineMultisampleStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineMultisampleStateCreateFlags flags;
     VkSampleCountFlagBits rasterizationSamples;
     VkBool32 sampleShadingEnable;
     float minSampleShading;
-    const VkSampleMask* pSampleMask;
+    const VkSampleMask* pSampleMask{};
     VkBool32 alphaToCoverageEnable;
     VkBool32 alphaToOneEnable;
     safe_VkPipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateCreateInfo* in_struct);
@@ -675,7 +675,7 @@ struct safe_VkPipelineMultisampleStateCreateInfo {
 
 struct safe_VkPipelineDepthStencilStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineDepthStencilStateCreateFlags flags;
     VkBool32 depthTestEnable;
     VkBool32 depthWriteEnable;
@@ -699,12 +699,12 @@ struct safe_VkPipelineDepthStencilStateCreateInfo {
 
 struct safe_VkPipelineColorBlendStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineColorBlendStateCreateFlags flags;
     VkBool32 logicOpEnable;
     VkLogicOp logicOp;
     uint32_t attachmentCount;
-    const VkPipelineColorBlendAttachmentState* pAttachments;
+    const VkPipelineColorBlendAttachmentState* pAttachments{};
     float blendConstants[4];
     safe_VkPipelineColorBlendStateCreateInfo(const VkPipelineColorBlendStateCreateInfo* in_struct);
     safe_VkPipelineColorBlendStateCreateInfo(const safe_VkPipelineColorBlendStateCreateInfo& copy_src);
@@ -719,10 +719,10 @@ struct safe_VkPipelineColorBlendStateCreateInfo {
 
 struct safe_VkPipelineDynamicStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineDynamicStateCreateFlags flags;
     uint32_t dynamicStateCount;
-    const VkDynamicState* pDynamicStates;
+    const VkDynamicState* pDynamicStates{};
     safe_VkPipelineDynamicStateCreateInfo(const VkPipelineDynamicStateCreateInfo* in_struct);
     safe_VkPipelineDynamicStateCreateInfo(const safe_VkPipelineDynamicStateCreateInfo& copy_src);
     safe_VkPipelineDynamicStateCreateInfo& operator=(const safe_VkPipelineDynamicStateCreateInfo& copy_src);
@@ -736,19 +736,19 @@ struct safe_VkPipelineDynamicStateCreateInfo {
 
 struct safe_VkGraphicsPipelineCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCreateFlags flags;
     uint32_t stageCount;
-    safe_VkPipelineShaderStageCreateInfo* pStages;
-    safe_VkPipelineVertexInputStateCreateInfo* pVertexInputState;
-    safe_VkPipelineInputAssemblyStateCreateInfo* pInputAssemblyState;
-    safe_VkPipelineTessellationStateCreateInfo* pTessellationState;
-    safe_VkPipelineViewportStateCreateInfo* pViewportState;
-    safe_VkPipelineRasterizationStateCreateInfo* pRasterizationState;
-    safe_VkPipelineMultisampleStateCreateInfo* pMultisampleState;
-    safe_VkPipelineDepthStencilStateCreateInfo* pDepthStencilState;
-    safe_VkPipelineColorBlendStateCreateInfo* pColorBlendState;
-    safe_VkPipelineDynamicStateCreateInfo* pDynamicState;
+    safe_VkPipelineShaderStageCreateInfo* pStages{};
+    safe_VkPipelineVertexInputStateCreateInfo* pVertexInputState{};
+    safe_VkPipelineInputAssemblyStateCreateInfo* pInputAssemblyState{};
+    safe_VkPipelineTessellationStateCreateInfo* pTessellationState{};
+    safe_VkPipelineViewportStateCreateInfo* pViewportState{};
+    safe_VkPipelineRasterizationStateCreateInfo* pRasterizationState{};
+    safe_VkPipelineMultisampleStateCreateInfo* pMultisampleState{};
+    safe_VkPipelineDepthStencilStateCreateInfo* pDepthStencilState{};
+    safe_VkPipelineColorBlendStateCreateInfo* pColorBlendState{};
+    safe_VkPipelineDynamicStateCreateInfo* pDynamicState{};
     VkPipelineLayout layout;
     VkRenderPass renderPass;
     uint32_t subpass;
@@ -767,12 +767,12 @@ struct safe_VkGraphicsPipelineCreateInfo {
 
 struct safe_VkPipelineLayoutCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineLayoutCreateFlags flags;
     uint32_t setLayoutCount;
-    VkDescriptorSetLayout* pSetLayouts;
+    VkDescriptorSetLayout* pSetLayouts{};
     uint32_t pushConstantRangeCount;
-    const VkPushConstantRange* pPushConstantRanges;
+    const VkPushConstantRange* pPushConstantRanges{};
     safe_VkPipelineLayoutCreateInfo(const VkPipelineLayoutCreateInfo* in_struct);
     safe_VkPipelineLayoutCreateInfo(const safe_VkPipelineLayoutCreateInfo& copy_src);
     safe_VkPipelineLayoutCreateInfo& operator=(const safe_VkPipelineLayoutCreateInfo& copy_src);
@@ -786,7 +786,7 @@ struct safe_VkPipelineLayoutCreateInfo {
 
 struct safe_VkSamplerCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSamplerCreateFlags flags;
     VkFilter magFilter;
     VkFilter minFilter;
@@ -816,7 +816,7 @@ struct safe_VkSamplerCreateInfo {
 
 struct safe_VkCopyDescriptorSet {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorSet srcSet;
     uint32_t srcBinding;
     uint32_t srcArrayElement;
@@ -837,11 +837,11 @@ struct safe_VkCopyDescriptorSet {
 
 struct safe_VkDescriptorPoolCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorPoolCreateFlags flags;
     uint32_t maxSets;
     uint32_t poolSizeCount;
-    const VkDescriptorPoolSize* pPoolSizes;
+    const VkDescriptorPoolSize* pPoolSizes{};
     safe_VkDescriptorPoolCreateInfo(const VkDescriptorPoolCreateInfo* in_struct);
     safe_VkDescriptorPoolCreateInfo(const safe_VkDescriptorPoolCreateInfo& copy_src);
     safe_VkDescriptorPoolCreateInfo& operator=(const safe_VkDescriptorPoolCreateInfo& copy_src);
@@ -855,10 +855,10 @@ struct safe_VkDescriptorPoolCreateInfo {
 
 struct safe_VkDescriptorSetAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorPool descriptorPool;
     uint32_t descriptorSetCount;
-    VkDescriptorSetLayout* pSetLayouts;
+    VkDescriptorSetLayout* pSetLayouts{};
     safe_VkDescriptorSetAllocateInfo(const VkDescriptorSetAllocateInfo* in_struct);
     safe_VkDescriptorSetAllocateInfo(const safe_VkDescriptorSetAllocateInfo& copy_src);
     safe_VkDescriptorSetAllocateInfo& operator=(const safe_VkDescriptorSetAllocateInfo& copy_src);
@@ -875,7 +875,7 @@ struct safe_VkDescriptorSetLayoutBinding {
     VkDescriptorType descriptorType;
     uint32_t descriptorCount;
     VkShaderStageFlags stageFlags;
-    VkSampler* pImmutableSamplers;
+    VkSampler* pImmutableSamplers{};
     safe_VkDescriptorSetLayoutBinding(const VkDescriptorSetLayoutBinding* in_struct);
     safe_VkDescriptorSetLayoutBinding(const safe_VkDescriptorSetLayoutBinding& copy_src);
     safe_VkDescriptorSetLayoutBinding& operator=(const safe_VkDescriptorSetLayoutBinding& copy_src);
@@ -889,10 +889,10 @@ struct safe_VkDescriptorSetLayoutBinding {
 
 struct safe_VkDescriptorSetLayoutCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorSetLayoutCreateFlags flags;
     uint32_t bindingCount;
-    safe_VkDescriptorSetLayoutBinding* pBindings;
+    safe_VkDescriptorSetLayoutBinding* pBindings{};
     safe_VkDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo* in_struct);
     safe_VkDescriptorSetLayoutCreateInfo(const safe_VkDescriptorSetLayoutCreateInfo& copy_src);
     safe_VkDescriptorSetLayoutCreateInfo& operator=(const safe_VkDescriptorSetLayoutCreateInfo& copy_src);
@@ -906,15 +906,15 @@ struct safe_VkDescriptorSetLayoutCreateInfo {
 
 struct safe_VkWriteDescriptorSet {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorSet dstSet;
     uint32_t dstBinding;
     uint32_t dstArrayElement;
     uint32_t descriptorCount;
     VkDescriptorType descriptorType;
-    VkDescriptorImageInfo* pImageInfo;
-    VkDescriptorBufferInfo* pBufferInfo;
-    VkBufferView* pTexelBufferView;
+    VkDescriptorImageInfo* pImageInfo{};
+    VkDescriptorBufferInfo* pBufferInfo{};
+    VkBufferView* pTexelBufferView{};
     safe_VkWriteDescriptorSet(const VkWriteDescriptorSet* in_struct);
     safe_VkWriteDescriptorSet(const safe_VkWriteDescriptorSet& copy_src);
     safe_VkWriteDescriptorSet& operator=(const safe_VkWriteDescriptorSet& copy_src);
@@ -928,11 +928,11 @@ struct safe_VkWriteDescriptorSet {
 
 struct safe_VkFramebufferCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFramebufferCreateFlags flags;
     VkRenderPass renderPass;
     uint32_t attachmentCount;
-    VkImageView* pAttachments;
+    VkImageView* pAttachments{};
     uint32_t width;
     uint32_t height;
     uint32_t layers;
@@ -951,13 +951,13 @@ struct safe_VkSubpassDescription {
     VkSubpassDescriptionFlags flags;
     VkPipelineBindPoint pipelineBindPoint;
     uint32_t inputAttachmentCount;
-    const VkAttachmentReference* pInputAttachments;
+    const VkAttachmentReference* pInputAttachments{};
     uint32_t colorAttachmentCount;
-    const VkAttachmentReference* pColorAttachments;
-    const VkAttachmentReference* pResolveAttachments;
-    const VkAttachmentReference* pDepthStencilAttachment;
+    const VkAttachmentReference* pColorAttachments{};
+    const VkAttachmentReference* pResolveAttachments{};
+    const VkAttachmentReference* pDepthStencilAttachment{};
     uint32_t preserveAttachmentCount;
-    const uint32_t* pPreserveAttachments;
+    const uint32_t* pPreserveAttachments{};
     safe_VkSubpassDescription(const VkSubpassDescription* in_struct);
     safe_VkSubpassDescription(const safe_VkSubpassDescription& copy_src);
     safe_VkSubpassDescription& operator=(const safe_VkSubpassDescription& copy_src);
@@ -971,14 +971,14 @@ struct safe_VkSubpassDescription {
 
 struct safe_VkRenderPassCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderPassCreateFlags flags;
     uint32_t attachmentCount;
-    const VkAttachmentDescription* pAttachments;
+    const VkAttachmentDescription* pAttachments{};
     uint32_t subpassCount;
-    safe_VkSubpassDescription* pSubpasses;
+    safe_VkSubpassDescription* pSubpasses{};
     uint32_t dependencyCount;
-    const VkSubpassDependency* pDependencies;
+    const VkSubpassDependency* pDependencies{};
     safe_VkRenderPassCreateInfo(const VkRenderPassCreateInfo* in_struct);
     safe_VkRenderPassCreateInfo(const safe_VkRenderPassCreateInfo& copy_src);
     safe_VkRenderPassCreateInfo& operator=(const safe_VkRenderPassCreateInfo& copy_src);
@@ -992,7 +992,7 @@ struct safe_VkRenderPassCreateInfo {
 
 struct safe_VkCommandPoolCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCommandPoolCreateFlags flags;
     uint32_t queueFamilyIndex;
     safe_VkCommandPoolCreateInfo(const VkCommandPoolCreateInfo* in_struct);
@@ -1008,7 +1008,7 @@ struct safe_VkCommandPoolCreateInfo {
 
 struct safe_VkCommandBufferAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCommandPool commandPool;
     VkCommandBufferLevel level;
     uint32_t commandBufferCount;
@@ -1025,7 +1025,7 @@ struct safe_VkCommandBufferAllocateInfo {
 
 struct safe_VkCommandBufferInheritanceInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderPass renderPass;
     uint32_t subpass;
     VkFramebuffer framebuffer;
@@ -1045,9 +1045,9 @@ struct safe_VkCommandBufferInheritanceInfo {
 
 struct safe_VkCommandBufferBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCommandBufferUsageFlags flags;
-    safe_VkCommandBufferInheritanceInfo* pInheritanceInfo;
+    safe_VkCommandBufferInheritanceInfo* pInheritanceInfo{};
     safe_VkCommandBufferBeginInfo(const VkCommandBufferBeginInfo* in_struct);
     safe_VkCommandBufferBeginInfo(const safe_VkCommandBufferBeginInfo& copy_src);
     safe_VkCommandBufferBeginInfo& operator=(const safe_VkCommandBufferBeginInfo& copy_src);
@@ -1061,12 +1061,12 @@ struct safe_VkCommandBufferBeginInfo {
 
 struct safe_VkRenderPassBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderPass renderPass;
     VkFramebuffer framebuffer;
     VkRect2D renderArea;
     uint32_t clearValueCount;
-    const VkClearValue* pClearValues;
+    const VkClearValue* pClearValues{};
     safe_VkRenderPassBeginInfo(const VkRenderPassBeginInfo* in_struct);
     safe_VkRenderPassBeginInfo(const safe_VkRenderPassBeginInfo& copy_src);
     safe_VkRenderPassBeginInfo& operator=(const safe_VkRenderPassBeginInfo& copy_src);
@@ -1080,7 +1080,7 @@ struct safe_VkRenderPassBeginInfo {
 
 struct safe_VkPhysicalDeviceSubgroupProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t subgroupSize;
     VkShaderStageFlags supportedStages;
     VkSubgroupFeatureFlags supportedOperations;
@@ -1098,7 +1098,7 @@ struct safe_VkPhysicalDeviceSubgroupProperties {
 
 struct safe_VkBindBufferMemoryInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer buffer;
     VkDeviceMemory memory;
     VkDeviceSize memoryOffset;
@@ -1115,7 +1115,7 @@ struct safe_VkBindBufferMemoryInfo {
 
 struct safe_VkBindImageMemoryInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage image;
     VkDeviceMemory memory;
     VkDeviceSize memoryOffset;
@@ -1132,7 +1132,7 @@ struct safe_VkBindImageMemoryInfo {
 
 struct safe_VkPhysicalDevice16BitStorageFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 storageBuffer16BitAccess;
     VkBool32 uniformAndStorageBuffer16BitAccess;
     VkBool32 storagePushConstant16;
@@ -1150,7 +1150,7 @@ struct safe_VkPhysicalDevice16BitStorageFeatures {
 
 struct safe_VkMemoryDedicatedRequirements {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 prefersDedicatedAllocation;
     VkBool32 requiresDedicatedAllocation;
     safe_VkMemoryDedicatedRequirements(const VkMemoryDedicatedRequirements* in_struct);
@@ -1166,7 +1166,7 @@ struct safe_VkMemoryDedicatedRequirements {
 
 struct safe_VkMemoryDedicatedAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage image;
     VkBuffer buffer;
     safe_VkMemoryDedicatedAllocateInfo(const VkMemoryDedicatedAllocateInfo* in_struct);
@@ -1182,7 +1182,7 @@ struct safe_VkMemoryDedicatedAllocateInfo {
 
 struct safe_VkMemoryAllocateFlagsInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkMemoryAllocateFlags flags;
     uint32_t deviceMask;
     safe_VkMemoryAllocateFlagsInfo(const VkMemoryAllocateFlagsInfo* in_struct);
@@ -1198,10 +1198,10 @@ struct safe_VkMemoryAllocateFlagsInfo {
 
 struct safe_VkDeviceGroupRenderPassBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t deviceMask;
     uint32_t deviceRenderAreaCount;
-    const VkRect2D* pDeviceRenderAreas;
+    const VkRect2D* pDeviceRenderAreas{};
     safe_VkDeviceGroupRenderPassBeginInfo(const VkDeviceGroupRenderPassBeginInfo* in_struct);
     safe_VkDeviceGroupRenderPassBeginInfo(const safe_VkDeviceGroupRenderPassBeginInfo& copy_src);
     safe_VkDeviceGroupRenderPassBeginInfo& operator=(const safe_VkDeviceGroupRenderPassBeginInfo& copy_src);
@@ -1215,7 +1215,7 @@ struct safe_VkDeviceGroupRenderPassBeginInfo {
 
 struct safe_VkDeviceGroupCommandBufferBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t deviceMask;
     safe_VkDeviceGroupCommandBufferBeginInfo(const VkDeviceGroupCommandBufferBeginInfo* in_struct);
     safe_VkDeviceGroupCommandBufferBeginInfo(const safe_VkDeviceGroupCommandBufferBeginInfo& copy_src);
@@ -1230,13 +1230,13 @@ struct safe_VkDeviceGroupCommandBufferBeginInfo {
 
 struct safe_VkDeviceGroupSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreCount;
-    const uint32_t* pWaitSemaphoreDeviceIndices;
+    const uint32_t* pWaitSemaphoreDeviceIndices{};
     uint32_t commandBufferCount;
-    const uint32_t* pCommandBufferDeviceMasks;
+    const uint32_t* pCommandBufferDeviceMasks{};
     uint32_t signalSemaphoreCount;
-    const uint32_t* pSignalSemaphoreDeviceIndices;
+    const uint32_t* pSignalSemaphoreDeviceIndices{};
     safe_VkDeviceGroupSubmitInfo(const VkDeviceGroupSubmitInfo* in_struct);
     safe_VkDeviceGroupSubmitInfo(const safe_VkDeviceGroupSubmitInfo& copy_src);
     safe_VkDeviceGroupSubmitInfo& operator=(const safe_VkDeviceGroupSubmitInfo& copy_src);
@@ -1250,7 +1250,7 @@ struct safe_VkDeviceGroupSubmitInfo {
 
 struct safe_VkDeviceGroupBindSparseInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t resourceDeviceIndex;
     uint32_t memoryDeviceIndex;
     safe_VkDeviceGroupBindSparseInfo(const VkDeviceGroupBindSparseInfo* in_struct);
@@ -1266,9 +1266,9 @@ struct safe_VkDeviceGroupBindSparseInfo {
 
 struct safe_VkBindBufferMemoryDeviceGroupInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t deviceIndexCount;
-    const uint32_t* pDeviceIndices;
+    const uint32_t* pDeviceIndices{};
     safe_VkBindBufferMemoryDeviceGroupInfo(const VkBindBufferMemoryDeviceGroupInfo* in_struct);
     safe_VkBindBufferMemoryDeviceGroupInfo(const safe_VkBindBufferMemoryDeviceGroupInfo& copy_src);
     safe_VkBindBufferMemoryDeviceGroupInfo& operator=(const safe_VkBindBufferMemoryDeviceGroupInfo& copy_src);
@@ -1282,11 +1282,11 @@ struct safe_VkBindBufferMemoryDeviceGroupInfo {
 
 struct safe_VkBindImageMemoryDeviceGroupInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t deviceIndexCount;
-    const uint32_t* pDeviceIndices;
+    const uint32_t* pDeviceIndices{};
     uint32_t splitInstanceBindRegionCount;
-    const VkRect2D* pSplitInstanceBindRegions;
+    const VkRect2D* pSplitInstanceBindRegions{};
     safe_VkBindImageMemoryDeviceGroupInfo(const VkBindImageMemoryDeviceGroupInfo* in_struct);
     safe_VkBindImageMemoryDeviceGroupInfo(const safe_VkBindImageMemoryDeviceGroupInfo& copy_src);
     safe_VkBindImageMemoryDeviceGroupInfo& operator=(const safe_VkBindImageMemoryDeviceGroupInfo& copy_src);
@@ -1300,7 +1300,7 @@ struct safe_VkBindImageMemoryDeviceGroupInfo {
 
 struct safe_VkPhysicalDeviceGroupProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t physicalDeviceCount;
     VkPhysicalDevice physicalDevices[VK_MAX_DEVICE_GROUP_SIZE];
     VkBool32 subsetAllocation;
@@ -1317,9 +1317,9 @@ struct safe_VkPhysicalDeviceGroupProperties {
 
 struct safe_VkDeviceGroupDeviceCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t physicalDeviceCount;
-    VkPhysicalDevice* pPhysicalDevices;
+    VkPhysicalDevice* pPhysicalDevices{};
     safe_VkDeviceGroupDeviceCreateInfo(const VkDeviceGroupDeviceCreateInfo* in_struct);
     safe_VkDeviceGroupDeviceCreateInfo(const safe_VkDeviceGroupDeviceCreateInfo& copy_src);
     safe_VkDeviceGroupDeviceCreateInfo& operator=(const safe_VkDeviceGroupDeviceCreateInfo& copy_src);
@@ -1333,7 +1333,7 @@ struct safe_VkDeviceGroupDeviceCreateInfo {
 
 struct safe_VkBufferMemoryRequirementsInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer buffer;
     safe_VkBufferMemoryRequirementsInfo2(const VkBufferMemoryRequirementsInfo2* in_struct);
     safe_VkBufferMemoryRequirementsInfo2(const safe_VkBufferMemoryRequirementsInfo2& copy_src);
@@ -1348,7 +1348,7 @@ struct safe_VkBufferMemoryRequirementsInfo2 {
 
 struct safe_VkImageMemoryRequirementsInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage image;
     safe_VkImageMemoryRequirementsInfo2(const VkImageMemoryRequirementsInfo2* in_struct);
     safe_VkImageMemoryRequirementsInfo2(const safe_VkImageMemoryRequirementsInfo2& copy_src);
@@ -1363,7 +1363,7 @@ struct safe_VkImageMemoryRequirementsInfo2 {
 
 struct safe_VkImageSparseMemoryRequirementsInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage image;
     safe_VkImageSparseMemoryRequirementsInfo2(const VkImageSparseMemoryRequirementsInfo2* in_struct);
     safe_VkImageSparseMemoryRequirementsInfo2(const safe_VkImageSparseMemoryRequirementsInfo2& copy_src);
@@ -1378,7 +1378,7 @@ struct safe_VkImageSparseMemoryRequirementsInfo2 {
 
 struct safe_VkMemoryRequirements2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkMemoryRequirements memoryRequirements;
     safe_VkMemoryRequirements2(const VkMemoryRequirements2* in_struct);
     safe_VkMemoryRequirements2(const safe_VkMemoryRequirements2& copy_src);
@@ -1393,7 +1393,7 @@ struct safe_VkMemoryRequirements2 {
 
 struct safe_VkSparseImageMemoryRequirements2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSparseImageMemoryRequirements memoryRequirements;
     safe_VkSparseImageMemoryRequirements2(const VkSparseImageMemoryRequirements2* in_struct);
     safe_VkSparseImageMemoryRequirements2(const safe_VkSparseImageMemoryRequirements2& copy_src);
@@ -1408,7 +1408,7 @@ struct safe_VkSparseImageMemoryRequirements2 {
 
 struct safe_VkPhysicalDeviceFeatures2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPhysicalDeviceFeatures features;
     safe_VkPhysicalDeviceFeatures2(const VkPhysicalDeviceFeatures2* in_struct);
     safe_VkPhysicalDeviceFeatures2(const safe_VkPhysicalDeviceFeatures2& copy_src);
@@ -1423,7 +1423,7 @@ struct safe_VkPhysicalDeviceFeatures2 {
 
 struct safe_VkPhysicalDeviceProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPhysicalDeviceProperties properties;
     safe_VkPhysicalDeviceProperties2(const VkPhysicalDeviceProperties2* in_struct);
     safe_VkPhysicalDeviceProperties2(const safe_VkPhysicalDeviceProperties2& copy_src);
@@ -1438,7 +1438,7 @@ struct safe_VkPhysicalDeviceProperties2 {
 
 struct safe_VkFormatProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFormatProperties formatProperties;
     safe_VkFormatProperties2(const VkFormatProperties2* in_struct);
     safe_VkFormatProperties2(const safe_VkFormatProperties2& copy_src);
@@ -1453,7 +1453,7 @@ struct safe_VkFormatProperties2 {
 
 struct safe_VkImageFormatProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageFormatProperties imageFormatProperties;
     safe_VkImageFormatProperties2(const VkImageFormatProperties2* in_struct);
     safe_VkImageFormatProperties2(const safe_VkImageFormatProperties2& copy_src);
@@ -1468,7 +1468,7 @@ struct safe_VkImageFormatProperties2 {
 
 struct safe_VkPhysicalDeviceImageFormatInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFormat format;
     VkImageType type;
     VkImageTiling tiling;
@@ -1487,7 +1487,7 @@ struct safe_VkPhysicalDeviceImageFormatInfo2 {
 
 struct safe_VkQueueFamilyProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkQueueFamilyProperties queueFamilyProperties;
     safe_VkQueueFamilyProperties2(const VkQueueFamilyProperties2* in_struct);
     safe_VkQueueFamilyProperties2(const safe_VkQueueFamilyProperties2& copy_src);
@@ -1502,7 +1502,7 @@ struct safe_VkQueueFamilyProperties2 {
 
 struct safe_VkPhysicalDeviceMemoryProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPhysicalDeviceMemoryProperties memoryProperties;
     safe_VkPhysicalDeviceMemoryProperties2(const VkPhysicalDeviceMemoryProperties2* in_struct);
     safe_VkPhysicalDeviceMemoryProperties2(const safe_VkPhysicalDeviceMemoryProperties2& copy_src);
@@ -1517,7 +1517,7 @@ struct safe_VkPhysicalDeviceMemoryProperties2 {
 
 struct safe_VkSparseImageFormatProperties2 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSparseImageFormatProperties properties;
     safe_VkSparseImageFormatProperties2(const VkSparseImageFormatProperties2* in_struct);
     safe_VkSparseImageFormatProperties2(const safe_VkSparseImageFormatProperties2& copy_src);
@@ -1532,7 +1532,7 @@ struct safe_VkSparseImageFormatProperties2 {
 
 struct safe_VkPhysicalDeviceSparseImageFormatInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFormat format;
     VkImageType type;
     VkSampleCountFlagBits samples;
@@ -1551,7 +1551,7 @@ struct safe_VkPhysicalDeviceSparseImageFormatInfo2 {
 
 struct safe_VkPhysicalDevicePointClippingProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPointClippingBehavior pointClippingBehavior;
     safe_VkPhysicalDevicePointClippingProperties(const VkPhysicalDevicePointClippingProperties* in_struct);
     safe_VkPhysicalDevicePointClippingProperties(const safe_VkPhysicalDevicePointClippingProperties& copy_src);
@@ -1566,9 +1566,9 @@ struct safe_VkPhysicalDevicePointClippingProperties {
 
 struct safe_VkRenderPassInputAttachmentAspectCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t aspectReferenceCount;
-    const VkInputAttachmentAspectReference* pAspectReferences;
+    const VkInputAttachmentAspectReference* pAspectReferences{};
     safe_VkRenderPassInputAttachmentAspectCreateInfo(const VkRenderPassInputAttachmentAspectCreateInfo* in_struct);
     safe_VkRenderPassInputAttachmentAspectCreateInfo(const safe_VkRenderPassInputAttachmentAspectCreateInfo& copy_src);
     safe_VkRenderPassInputAttachmentAspectCreateInfo& operator=(const safe_VkRenderPassInputAttachmentAspectCreateInfo& copy_src);
@@ -1582,7 +1582,7 @@ struct safe_VkRenderPassInputAttachmentAspectCreateInfo {
 
 struct safe_VkImageViewUsageCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageUsageFlags usage;
     safe_VkImageViewUsageCreateInfo(const VkImageViewUsageCreateInfo* in_struct);
     safe_VkImageViewUsageCreateInfo(const safe_VkImageViewUsageCreateInfo& copy_src);
@@ -1597,7 +1597,7 @@ struct safe_VkImageViewUsageCreateInfo {
 
 struct safe_VkPipelineTessellationDomainOriginStateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkTessellationDomainOrigin domainOrigin;
     safe_VkPipelineTessellationDomainOriginStateCreateInfo(const VkPipelineTessellationDomainOriginStateCreateInfo* in_struct);
     safe_VkPipelineTessellationDomainOriginStateCreateInfo(const safe_VkPipelineTessellationDomainOriginStateCreateInfo& copy_src);
@@ -1612,13 +1612,13 @@ struct safe_VkPipelineTessellationDomainOriginStateCreateInfo {
 
 struct safe_VkRenderPassMultiviewCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t subpassCount;
-    const uint32_t* pViewMasks;
+    const uint32_t* pViewMasks{};
     uint32_t dependencyCount;
-    const int32_t* pViewOffsets;
+    const int32_t* pViewOffsets{};
     uint32_t correlationMaskCount;
-    const uint32_t* pCorrelationMasks;
+    const uint32_t* pCorrelationMasks{};
     safe_VkRenderPassMultiviewCreateInfo(const VkRenderPassMultiviewCreateInfo* in_struct);
     safe_VkRenderPassMultiviewCreateInfo(const safe_VkRenderPassMultiviewCreateInfo& copy_src);
     safe_VkRenderPassMultiviewCreateInfo& operator=(const safe_VkRenderPassMultiviewCreateInfo& copy_src);
@@ -1632,7 +1632,7 @@ struct safe_VkRenderPassMultiviewCreateInfo {
 
 struct safe_VkPhysicalDeviceMultiviewFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 multiview;
     VkBool32 multiviewGeometryShader;
     VkBool32 multiviewTessellationShader;
@@ -1649,7 +1649,7 @@ struct safe_VkPhysicalDeviceMultiviewFeatures {
 
 struct safe_VkPhysicalDeviceMultiviewProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxMultiviewViewCount;
     uint32_t maxMultiviewInstanceIndex;
     safe_VkPhysicalDeviceMultiviewProperties(const VkPhysicalDeviceMultiviewProperties* in_struct);
@@ -1665,7 +1665,7 @@ struct safe_VkPhysicalDeviceMultiviewProperties {
 
 struct safe_VkPhysicalDeviceVariablePointersFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 variablePointersStorageBuffer;
     VkBool32 variablePointers;
     safe_VkPhysicalDeviceVariablePointersFeatures(const VkPhysicalDeviceVariablePointersFeatures* in_struct);
@@ -1681,7 +1681,7 @@ struct safe_VkPhysicalDeviceVariablePointersFeatures {
 
 struct safe_VkPhysicalDeviceProtectedMemoryFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 protectedMemory;
     safe_VkPhysicalDeviceProtectedMemoryFeatures(const VkPhysicalDeviceProtectedMemoryFeatures* in_struct);
     safe_VkPhysicalDeviceProtectedMemoryFeatures(const safe_VkPhysicalDeviceProtectedMemoryFeatures& copy_src);
@@ -1696,7 +1696,7 @@ struct safe_VkPhysicalDeviceProtectedMemoryFeatures {
 
 struct safe_VkPhysicalDeviceProtectedMemoryProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 protectedNoFault;
     safe_VkPhysicalDeviceProtectedMemoryProperties(const VkPhysicalDeviceProtectedMemoryProperties* in_struct);
     safe_VkPhysicalDeviceProtectedMemoryProperties(const safe_VkPhysicalDeviceProtectedMemoryProperties& copy_src);
@@ -1711,7 +1711,7 @@ struct safe_VkPhysicalDeviceProtectedMemoryProperties {
 
 struct safe_VkDeviceQueueInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceQueueCreateFlags flags;
     uint32_t queueFamilyIndex;
     uint32_t queueIndex;
@@ -1728,7 +1728,7 @@ struct safe_VkDeviceQueueInfo2 {
 
 struct safe_VkProtectedSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 protectedSubmit;
     safe_VkProtectedSubmitInfo(const VkProtectedSubmitInfo* in_struct);
     safe_VkProtectedSubmitInfo(const safe_VkProtectedSubmitInfo& copy_src);
@@ -1743,7 +1743,7 @@ struct safe_VkProtectedSubmitInfo {
 
 struct safe_VkSamplerYcbcrConversionCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFormat format;
     VkSamplerYcbcrModelConversion ycbcrModel;
     VkSamplerYcbcrRange ycbcrRange;
@@ -1765,7 +1765,7 @@ struct safe_VkSamplerYcbcrConversionCreateInfo {
 
 struct safe_VkSamplerYcbcrConversionInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSamplerYcbcrConversion conversion;
     safe_VkSamplerYcbcrConversionInfo(const VkSamplerYcbcrConversionInfo* in_struct);
     safe_VkSamplerYcbcrConversionInfo(const safe_VkSamplerYcbcrConversionInfo& copy_src);
@@ -1780,7 +1780,7 @@ struct safe_VkSamplerYcbcrConversionInfo {
 
 struct safe_VkBindImagePlaneMemoryInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageAspectFlagBits planeAspect;
     safe_VkBindImagePlaneMemoryInfo(const VkBindImagePlaneMemoryInfo* in_struct);
     safe_VkBindImagePlaneMemoryInfo(const safe_VkBindImagePlaneMemoryInfo& copy_src);
@@ -1795,7 +1795,7 @@ struct safe_VkBindImagePlaneMemoryInfo {
 
 struct safe_VkImagePlaneMemoryRequirementsInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageAspectFlagBits planeAspect;
     safe_VkImagePlaneMemoryRequirementsInfo(const VkImagePlaneMemoryRequirementsInfo* in_struct);
     safe_VkImagePlaneMemoryRequirementsInfo(const safe_VkImagePlaneMemoryRequirementsInfo& copy_src);
@@ -1810,7 +1810,7 @@ struct safe_VkImagePlaneMemoryRequirementsInfo {
 
 struct safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 samplerYcbcrConversion;
     safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures(const VkPhysicalDeviceSamplerYcbcrConversionFeatures* in_struct);
     safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures(const safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures& copy_src);
@@ -1825,7 +1825,7 @@ struct safe_VkPhysicalDeviceSamplerYcbcrConversionFeatures {
 
 struct safe_VkSamplerYcbcrConversionImageFormatProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t combinedImageSamplerDescriptorCount;
     safe_VkSamplerYcbcrConversionImageFormatProperties(const VkSamplerYcbcrConversionImageFormatProperties* in_struct);
     safe_VkSamplerYcbcrConversionImageFormatProperties(const safe_VkSamplerYcbcrConversionImageFormatProperties& copy_src);
@@ -1840,10 +1840,10 @@ struct safe_VkSamplerYcbcrConversionImageFormatProperties {
 
 struct safe_VkDescriptorUpdateTemplateCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorUpdateTemplateCreateFlags flags;
     uint32_t descriptorUpdateEntryCount;
-    const VkDescriptorUpdateTemplateEntry* pDescriptorUpdateEntries;
+    const VkDescriptorUpdateTemplateEntry* pDescriptorUpdateEntries{};
     VkDescriptorUpdateTemplateType templateType;
     VkDescriptorSetLayout descriptorSetLayout;
     VkPipelineBindPoint pipelineBindPoint;
@@ -1862,7 +1862,7 @@ struct safe_VkDescriptorUpdateTemplateCreateInfo {
 
 struct safe_VkPhysicalDeviceExternalImageFormatInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagBits handleType;
     safe_VkPhysicalDeviceExternalImageFormatInfo(const VkPhysicalDeviceExternalImageFormatInfo* in_struct);
     safe_VkPhysicalDeviceExternalImageFormatInfo(const safe_VkPhysicalDeviceExternalImageFormatInfo& copy_src);
@@ -1877,7 +1877,7 @@ struct safe_VkPhysicalDeviceExternalImageFormatInfo {
 
 struct safe_VkExternalImageFormatProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExternalMemoryProperties externalMemoryProperties;
     safe_VkExternalImageFormatProperties(const VkExternalImageFormatProperties* in_struct);
     safe_VkExternalImageFormatProperties(const safe_VkExternalImageFormatProperties& copy_src);
@@ -1892,7 +1892,7 @@ struct safe_VkExternalImageFormatProperties {
 
 struct safe_VkPhysicalDeviceExternalBufferInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferCreateFlags flags;
     VkBufferUsageFlags usage;
     VkExternalMemoryHandleTypeFlagBits handleType;
@@ -1909,7 +1909,7 @@ struct safe_VkPhysicalDeviceExternalBufferInfo {
 
 struct safe_VkExternalBufferProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExternalMemoryProperties externalMemoryProperties;
     safe_VkExternalBufferProperties(const VkExternalBufferProperties* in_struct);
     safe_VkExternalBufferProperties(const safe_VkExternalBufferProperties& copy_src);
@@ -1924,7 +1924,7 @@ struct safe_VkExternalBufferProperties {
 
 struct safe_VkPhysicalDeviceIDProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint8_t deviceUUID[VK_UUID_SIZE];
     uint8_t driverUUID[VK_UUID_SIZE];
     uint8_t deviceLUID[VK_LUID_SIZE];
@@ -1943,7 +1943,7 @@ struct safe_VkPhysicalDeviceIDProperties {
 
 struct safe_VkExternalMemoryImageCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlags handleTypes;
     safe_VkExternalMemoryImageCreateInfo(const VkExternalMemoryImageCreateInfo* in_struct);
     safe_VkExternalMemoryImageCreateInfo(const safe_VkExternalMemoryImageCreateInfo& copy_src);
@@ -1958,7 +1958,7 @@ struct safe_VkExternalMemoryImageCreateInfo {
 
 struct safe_VkExternalMemoryBufferCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlags handleTypes;
     safe_VkExternalMemoryBufferCreateInfo(const VkExternalMemoryBufferCreateInfo* in_struct);
     safe_VkExternalMemoryBufferCreateInfo(const safe_VkExternalMemoryBufferCreateInfo& copy_src);
@@ -1973,7 +1973,7 @@ struct safe_VkExternalMemoryBufferCreateInfo {
 
 struct safe_VkExportMemoryAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlags handleTypes;
     safe_VkExportMemoryAllocateInfo(const VkExportMemoryAllocateInfo* in_struct);
     safe_VkExportMemoryAllocateInfo(const safe_VkExportMemoryAllocateInfo& copy_src);
@@ -1988,7 +1988,7 @@ struct safe_VkExportMemoryAllocateInfo {
 
 struct safe_VkPhysicalDeviceExternalFenceInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalFenceHandleTypeFlagBits handleType;
     safe_VkPhysicalDeviceExternalFenceInfo(const VkPhysicalDeviceExternalFenceInfo* in_struct);
     safe_VkPhysicalDeviceExternalFenceInfo(const safe_VkPhysicalDeviceExternalFenceInfo& copy_src);
@@ -2003,7 +2003,7 @@ struct safe_VkPhysicalDeviceExternalFenceInfo {
 
 struct safe_VkExternalFenceProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExternalFenceHandleTypeFlags exportFromImportedHandleTypes;
     VkExternalFenceHandleTypeFlags compatibleHandleTypes;
     VkExternalFenceFeatureFlags externalFenceFeatures;
@@ -2020,7 +2020,7 @@ struct safe_VkExternalFenceProperties {
 
 struct safe_VkExportFenceCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalFenceHandleTypeFlags handleTypes;
     safe_VkExportFenceCreateInfo(const VkExportFenceCreateInfo* in_struct);
     safe_VkExportFenceCreateInfo(const safe_VkExportFenceCreateInfo& copy_src);
@@ -2035,7 +2035,7 @@ struct safe_VkExportFenceCreateInfo {
 
 struct safe_VkExportSemaphoreCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalSemaphoreHandleTypeFlags handleTypes;
     safe_VkExportSemaphoreCreateInfo(const VkExportSemaphoreCreateInfo* in_struct);
     safe_VkExportSemaphoreCreateInfo(const safe_VkExportSemaphoreCreateInfo& copy_src);
@@ -2050,7 +2050,7 @@ struct safe_VkExportSemaphoreCreateInfo {
 
 struct safe_VkPhysicalDeviceExternalSemaphoreInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalSemaphoreHandleTypeFlagBits handleType;
     safe_VkPhysicalDeviceExternalSemaphoreInfo(const VkPhysicalDeviceExternalSemaphoreInfo* in_struct);
     safe_VkPhysicalDeviceExternalSemaphoreInfo(const safe_VkPhysicalDeviceExternalSemaphoreInfo& copy_src);
@@ -2065,7 +2065,7 @@ struct safe_VkPhysicalDeviceExternalSemaphoreInfo {
 
 struct safe_VkExternalSemaphoreProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExternalSemaphoreHandleTypeFlags exportFromImportedHandleTypes;
     VkExternalSemaphoreHandleTypeFlags compatibleHandleTypes;
     VkExternalSemaphoreFeatureFlags externalSemaphoreFeatures;
@@ -2082,7 +2082,7 @@ struct safe_VkExternalSemaphoreProperties {
 
 struct safe_VkPhysicalDeviceMaintenance3Properties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxPerSetDescriptors;
     VkDeviceSize maxMemoryAllocationSize;
     safe_VkPhysicalDeviceMaintenance3Properties(const VkPhysicalDeviceMaintenance3Properties* in_struct);
@@ -2098,7 +2098,7 @@ struct safe_VkPhysicalDeviceMaintenance3Properties {
 
 struct safe_VkDescriptorSetLayoutSupport {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 supported;
     safe_VkDescriptorSetLayoutSupport(const VkDescriptorSetLayoutSupport* in_struct);
     safe_VkDescriptorSetLayoutSupport(const safe_VkDescriptorSetLayoutSupport& copy_src);
@@ -2113,7 +2113,7 @@ struct safe_VkDescriptorSetLayoutSupport {
 
 struct safe_VkPhysicalDeviceShaderDrawParametersFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderDrawParameters;
     safe_VkPhysicalDeviceShaderDrawParametersFeatures(const VkPhysicalDeviceShaderDrawParametersFeatures* in_struct);
     safe_VkPhysicalDeviceShaderDrawParametersFeatures(const safe_VkPhysicalDeviceShaderDrawParametersFeatures& copy_src);
@@ -2128,7 +2128,7 @@ struct safe_VkPhysicalDeviceShaderDrawParametersFeatures {
 
 struct safe_VkPhysicalDeviceVulkan11Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 storageBuffer16BitAccess;
     VkBool32 uniformAndStorageBuffer16BitAccess;
     VkBool32 storagePushConstant16;
@@ -2154,7 +2154,7 @@ struct safe_VkPhysicalDeviceVulkan11Features {
 
 struct safe_VkPhysicalDeviceVulkan11Properties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint8_t deviceUUID[VK_UUID_SIZE];
     uint8_t driverUUID[VK_UUID_SIZE];
     uint8_t deviceLUID[VK_LUID_SIZE];
@@ -2183,7 +2183,7 @@ struct safe_VkPhysicalDeviceVulkan11Properties {
 
 struct safe_VkPhysicalDeviceVulkan12Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 samplerMirrorClampToEdge;
     VkBool32 drawIndirectCount;
     VkBool32 storageBuffer8BitAccess;
@@ -2244,7 +2244,7 @@ struct safe_VkPhysicalDeviceVulkan12Features {
 
 struct safe_VkPhysicalDeviceVulkan12Properties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDriverId driverID;
     char driverName[VK_MAX_DRIVER_NAME_SIZE];
     char driverInfo[VK_MAX_DRIVER_INFO_SIZE];
@@ -2310,9 +2310,9 @@ struct safe_VkPhysicalDeviceVulkan12Properties {
 
 struct safe_VkImageFormatListCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t viewFormatCount;
-    const VkFormat* pViewFormats;
+    const VkFormat* pViewFormats{};
     safe_VkImageFormatListCreateInfo(const VkImageFormatListCreateInfo* in_struct);
     safe_VkImageFormatListCreateInfo(const safe_VkImageFormatListCreateInfo& copy_src);
     safe_VkImageFormatListCreateInfo& operator=(const safe_VkImageFormatListCreateInfo& copy_src);
@@ -2326,7 +2326,7 @@ struct safe_VkImageFormatListCreateInfo {
 
 struct safe_VkAttachmentDescription2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAttachmentDescriptionFlags flags;
     VkFormat format;
     VkSampleCountFlagBits samples;
@@ -2349,7 +2349,7 @@ struct safe_VkAttachmentDescription2 {
 
 struct safe_VkAttachmentReference2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t attachment;
     VkImageLayout layout;
     VkImageAspectFlags aspectMask;
@@ -2366,18 +2366,18 @@ struct safe_VkAttachmentReference2 {
 
 struct safe_VkSubpassDescription2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSubpassDescriptionFlags flags;
     VkPipelineBindPoint pipelineBindPoint;
     uint32_t viewMask;
     uint32_t inputAttachmentCount;
-    safe_VkAttachmentReference2* pInputAttachments;
+    safe_VkAttachmentReference2* pInputAttachments{};
     uint32_t colorAttachmentCount;
-    safe_VkAttachmentReference2* pColorAttachments;
-    safe_VkAttachmentReference2* pResolveAttachments;
-    safe_VkAttachmentReference2* pDepthStencilAttachment;
+    safe_VkAttachmentReference2* pColorAttachments{};
+    safe_VkAttachmentReference2* pResolveAttachments{};
+    safe_VkAttachmentReference2* pDepthStencilAttachment{};
     uint32_t preserveAttachmentCount;
-    const uint32_t* pPreserveAttachments;
+    const uint32_t* pPreserveAttachments{};
     safe_VkSubpassDescription2(const VkSubpassDescription2* in_struct);
     safe_VkSubpassDescription2(const safe_VkSubpassDescription2& copy_src);
     safe_VkSubpassDescription2& operator=(const safe_VkSubpassDescription2& copy_src);
@@ -2391,7 +2391,7 @@ struct safe_VkSubpassDescription2 {
 
 struct safe_VkSubpassDependency2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t srcSubpass;
     uint32_t dstSubpass;
     VkPipelineStageFlags srcStageMask;
@@ -2413,16 +2413,16 @@ struct safe_VkSubpassDependency2 {
 
 struct safe_VkRenderPassCreateInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderPassCreateFlags flags;
     uint32_t attachmentCount;
-    safe_VkAttachmentDescription2* pAttachments;
+    safe_VkAttachmentDescription2* pAttachments{};
     uint32_t subpassCount;
-    safe_VkSubpassDescription2* pSubpasses;
+    safe_VkSubpassDescription2* pSubpasses{};
     uint32_t dependencyCount;
-    safe_VkSubpassDependency2* pDependencies;
+    safe_VkSubpassDependency2* pDependencies{};
     uint32_t correlatedViewMaskCount;
-    const uint32_t* pCorrelatedViewMasks;
+    const uint32_t* pCorrelatedViewMasks{};
     safe_VkRenderPassCreateInfo2(const VkRenderPassCreateInfo2* in_struct);
     safe_VkRenderPassCreateInfo2(const safe_VkRenderPassCreateInfo2& copy_src);
     safe_VkRenderPassCreateInfo2& operator=(const safe_VkRenderPassCreateInfo2& copy_src);
@@ -2436,7 +2436,7 @@ struct safe_VkRenderPassCreateInfo2 {
 
 struct safe_VkSubpassBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSubpassContents contents;
     safe_VkSubpassBeginInfo(const VkSubpassBeginInfo* in_struct);
     safe_VkSubpassBeginInfo(const safe_VkSubpassBeginInfo& copy_src);
@@ -2451,7 +2451,7 @@ struct safe_VkSubpassBeginInfo {
 
 struct safe_VkSubpassEndInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkSubpassEndInfo(const VkSubpassEndInfo* in_struct);
     safe_VkSubpassEndInfo(const safe_VkSubpassEndInfo& copy_src);
     safe_VkSubpassEndInfo& operator=(const safe_VkSubpassEndInfo& copy_src);
@@ -2465,7 +2465,7 @@ struct safe_VkSubpassEndInfo {
 
 struct safe_VkPhysicalDevice8BitStorageFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 storageBuffer8BitAccess;
     VkBool32 uniformAndStorageBuffer8BitAccess;
     VkBool32 storagePushConstant8;
@@ -2482,7 +2482,7 @@ struct safe_VkPhysicalDevice8BitStorageFeatures {
 
 struct safe_VkPhysicalDeviceDriverProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDriverId driverID;
     char driverName[VK_MAX_DRIVER_NAME_SIZE];
     char driverInfo[VK_MAX_DRIVER_INFO_SIZE];
@@ -2500,7 +2500,7 @@ struct safe_VkPhysicalDeviceDriverProperties {
 
 struct safe_VkPhysicalDeviceShaderAtomicInt64Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderBufferInt64Atomics;
     VkBool32 shaderSharedInt64Atomics;
     safe_VkPhysicalDeviceShaderAtomicInt64Features(const VkPhysicalDeviceShaderAtomicInt64Features* in_struct);
@@ -2516,7 +2516,7 @@ struct safe_VkPhysicalDeviceShaderAtomicInt64Features {
 
 struct safe_VkPhysicalDeviceShaderFloat16Int8Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderFloat16;
     VkBool32 shaderInt8;
     safe_VkPhysicalDeviceShaderFloat16Int8Features(const VkPhysicalDeviceShaderFloat16Int8Features* in_struct);
@@ -2532,7 +2532,7 @@ struct safe_VkPhysicalDeviceShaderFloat16Int8Features {
 
 struct safe_VkPhysicalDeviceFloatControlsProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkShaderFloatControlsIndependence denormBehaviorIndependence;
     VkShaderFloatControlsIndependence roundingModeIndependence;
     VkBool32 shaderSignedZeroInfNanPreserveFloat16;
@@ -2563,9 +2563,9 @@ struct safe_VkPhysicalDeviceFloatControlsProperties {
 
 struct safe_VkDescriptorSetLayoutBindingFlagsCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t bindingCount;
-    const VkDescriptorBindingFlags* pBindingFlags;
+    const VkDescriptorBindingFlags* pBindingFlags{};
     safe_VkDescriptorSetLayoutBindingFlagsCreateInfo(const VkDescriptorSetLayoutBindingFlagsCreateInfo* in_struct);
     safe_VkDescriptorSetLayoutBindingFlagsCreateInfo(const safe_VkDescriptorSetLayoutBindingFlagsCreateInfo& copy_src);
     safe_VkDescriptorSetLayoutBindingFlagsCreateInfo& operator=(const safe_VkDescriptorSetLayoutBindingFlagsCreateInfo& copy_src);
@@ -2579,7 +2579,7 @@ struct safe_VkDescriptorSetLayoutBindingFlagsCreateInfo {
 
 struct safe_VkPhysicalDeviceDescriptorIndexingFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderInputAttachmentArrayDynamicIndexing;
     VkBool32 shaderUniformTexelBufferArrayDynamicIndexing;
     VkBool32 shaderStorageTexelBufferArrayDynamicIndexing;
@@ -2613,7 +2613,7 @@ struct safe_VkPhysicalDeviceDescriptorIndexingFeatures {
 
 struct safe_VkPhysicalDeviceDescriptorIndexingProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxUpdateAfterBindDescriptorsInAllPools;
     VkBool32 shaderUniformBufferArrayNonUniformIndexingNative;
     VkBool32 shaderSampledImageArrayNonUniformIndexingNative;
@@ -2650,9 +2650,9 @@ struct safe_VkPhysicalDeviceDescriptorIndexingProperties {
 
 struct safe_VkDescriptorSetVariableDescriptorCountAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t descriptorSetCount;
-    const uint32_t* pDescriptorCounts;
+    const uint32_t* pDescriptorCounts{};
     safe_VkDescriptorSetVariableDescriptorCountAllocateInfo(const VkDescriptorSetVariableDescriptorCountAllocateInfo* in_struct);
     safe_VkDescriptorSetVariableDescriptorCountAllocateInfo(const safe_VkDescriptorSetVariableDescriptorCountAllocateInfo& copy_src);
     safe_VkDescriptorSetVariableDescriptorCountAllocateInfo& operator=(const safe_VkDescriptorSetVariableDescriptorCountAllocateInfo& copy_src);
@@ -2666,7 +2666,7 @@ struct safe_VkDescriptorSetVariableDescriptorCountAllocateInfo {
 
 struct safe_VkDescriptorSetVariableDescriptorCountLayoutSupport {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxVariableDescriptorCount;
     safe_VkDescriptorSetVariableDescriptorCountLayoutSupport(const VkDescriptorSetVariableDescriptorCountLayoutSupport* in_struct);
     safe_VkDescriptorSetVariableDescriptorCountLayoutSupport(const safe_VkDescriptorSetVariableDescriptorCountLayoutSupport& copy_src);
@@ -2681,10 +2681,10 @@ struct safe_VkDescriptorSetVariableDescriptorCountLayoutSupport {
 
 struct safe_VkSubpassDescriptionDepthStencilResolve {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkResolveModeFlagBits depthResolveMode;
     VkResolveModeFlagBits stencilResolveMode;
-    safe_VkAttachmentReference2* pDepthStencilResolveAttachment;
+    safe_VkAttachmentReference2* pDepthStencilResolveAttachment{};
     safe_VkSubpassDescriptionDepthStencilResolve(const VkSubpassDescriptionDepthStencilResolve* in_struct);
     safe_VkSubpassDescriptionDepthStencilResolve(const safe_VkSubpassDescriptionDepthStencilResolve& copy_src);
     safe_VkSubpassDescriptionDepthStencilResolve& operator=(const safe_VkSubpassDescriptionDepthStencilResolve& copy_src);
@@ -2698,7 +2698,7 @@ struct safe_VkSubpassDescriptionDepthStencilResolve {
 
 struct safe_VkPhysicalDeviceDepthStencilResolveProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkResolveModeFlags supportedDepthResolveModes;
     VkResolveModeFlags supportedStencilResolveModes;
     VkBool32 independentResolveNone;
@@ -2716,7 +2716,7 @@ struct safe_VkPhysicalDeviceDepthStencilResolveProperties {
 
 struct safe_VkPhysicalDeviceScalarBlockLayoutFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 scalarBlockLayout;
     safe_VkPhysicalDeviceScalarBlockLayoutFeatures(const VkPhysicalDeviceScalarBlockLayoutFeatures* in_struct);
     safe_VkPhysicalDeviceScalarBlockLayoutFeatures(const safe_VkPhysicalDeviceScalarBlockLayoutFeatures& copy_src);
@@ -2731,7 +2731,7 @@ struct safe_VkPhysicalDeviceScalarBlockLayoutFeatures {
 
 struct safe_VkImageStencilUsageCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageUsageFlags stencilUsage;
     safe_VkImageStencilUsageCreateInfo(const VkImageStencilUsageCreateInfo* in_struct);
     safe_VkImageStencilUsageCreateInfo(const safe_VkImageStencilUsageCreateInfo& copy_src);
@@ -2746,7 +2746,7 @@ struct safe_VkImageStencilUsageCreateInfo {
 
 struct safe_VkSamplerReductionModeCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSamplerReductionMode reductionMode;
     safe_VkSamplerReductionModeCreateInfo(const VkSamplerReductionModeCreateInfo* in_struct);
     safe_VkSamplerReductionModeCreateInfo(const safe_VkSamplerReductionModeCreateInfo& copy_src);
@@ -2761,7 +2761,7 @@ struct safe_VkSamplerReductionModeCreateInfo {
 
 struct safe_VkPhysicalDeviceSamplerFilterMinmaxProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 filterMinmaxSingleComponentFormats;
     VkBool32 filterMinmaxImageComponentMapping;
     safe_VkPhysicalDeviceSamplerFilterMinmaxProperties(const VkPhysicalDeviceSamplerFilterMinmaxProperties* in_struct);
@@ -2777,7 +2777,7 @@ struct safe_VkPhysicalDeviceSamplerFilterMinmaxProperties {
 
 struct safe_VkPhysicalDeviceVulkanMemoryModelFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 vulkanMemoryModel;
     VkBool32 vulkanMemoryModelDeviceScope;
     VkBool32 vulkanMemoryModelAvailabilityVisibilityChains;
@@ -2794,7 +2794,7 @@ struct safe_VkPhysicalDeviceVulkanMemoryModelFeatures {
 
 struct safe_VkPhysicalDeviceImagelessFramebufferFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 imagelessFramebuffer;
     safe_VkPhysicalDeviceImagelessFramebufferFeatures(const VkPhysicalDeviceImagelessFramebufferFeatures* in_struct);
     safe_VkPhysicalDeviceImagelessFramebufferFeatures(const safe_VkPhysicalDeviceImagelessFramebufferFeatures& copy_src);
@@ -2809,14 +2809,14 @@ struct safe_VkPhysicalDeviceImagelessFramebufferFeatures {
 
 struct safe_VkFramebufferAttachmentImageInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageCreateFlags flags;
     VkImageUsageFlags usage;
     uint32_t width;
     uint32_t height;
     uint32_t layerCount;
     uint32_t viewFormatCount;
-    const VkFormat* pViewFormats;
+    const VkFormat* pViewFormats{};
     safe_VkFramebufferAttachmentImageInfo(const VkFramebufferAttachmentImageInfo* in_struct);
     safe_VkFramebufferAttachmentImageInfo(const safe_VkFramebufferAttachmentImageInfo& copy_src);
     safe_VkFramebufferAttachmentImageInfo& operator=(const safe_VkFramebufferAttachmentImageInfo& copy_src);
@@ -2830,9 +2830,9 @@ struct safe_VkFramebufferAttachmentImageInfo {
 
 struct safe_VkFramebufferAttachmentsCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t attachmentImageInfoCount;
-    safe_VkFramebufferAttachmentImageInfo* pAttachmentImageInfos;
+    safe_VkFramebufferAttachmentImageInfo* pAttachmentImageInfos{};
     safe_VkFramebufferAttachmentsCreateInfo(const VkFramebufferAttachmentsCreateInfo* in_struct);
     safe_VkFramebufferAttachmentsCreateInfo(const safe_VkFramebufferAttachmentsCreateInfo& copy_src);
     safe_VkFramebufferAttachmentsCreateInfo& operator=(const safe_VkFramebufferAttachmentsCreateInfo& copy_src);
@@ -2846,9 +2846,9 @@ struct safe_VkFramebufferAttachmentsCreateInfo {
 
 struct safe_VkRenderPassAttachmentBeginInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t attachmentCount;
-    VkImageView* pAttachments;
+    VkImageView* pAttachments{};
     safe_VkRenderPassAttachmentBeginInfo(const VkRenderPassAttachmentBeginInfo* in_struct);
     safe_VkRenderPassAttachmentBeginInfo(const safe_VkRenderPassAttachmentBeginInfo& copy_src);
     safe_VkRenderPassAttachmentBeginInfo& operator=(const safe_VkRenderPassAttachmentBeginInfo& copy_src);
@@ -2862,7 +2862,7 @@ struct safe_VkRenderPassAttachmentBeginInfo {
 
 struct safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 uniformBufferStandardLayout;
     safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures(const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* in_struct);
     safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures(const safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures& copy_src);
@@ -2877,7 +2877,7 @@ struct safe_VkPhysicalDeviceUniformBufferStandardLayoutFeatures {
 
 struct safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderSubgroupExtendedTypes;
     safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures(const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* in_struct);
     safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures(const safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures& copy_src);
@@ -2892,7 +2892,7 @@ struct safe_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures {
 
 struct safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 separateDepthStencilLayouts;
     safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures(const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* in_struct);
     safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures(const safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures& copy_src);
@@ -2907,7 +2907,7 @@ struct safe_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures {
 
 struct safe_VkAttachmentReferenceStencilLayout {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageLayout stencilLayout;
     safe_VkAttachmentReferenceStencilLayout(const VkAttachmentReferenceStencilLayout* in_struct);
     safe_VkAttachmentReferenceStencilLayout(const safe_VkAttachmentReferenceStencilLayout& copy_src);
@@ -2922,7 +2922,7 @@ struct safe_VkAttachmentReferenceStencilLayout {
 
 struct safe_VkAttachmentDescriptionStencilLayout {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageLayout stencilInitialLayout;
     VkImageLayout stencilFinalLayout;
     safe_VkAttachmentDescriptionStencilLayout(const VkAttachmentDescriptionStencilLayout* in_struct);
@@ -2938,7 +2938,7 @@ struct safe_VkAttachmentDescriptionStencilLayout {
 
 struct safe_VkPhysicalDeviceHostQueryResetFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 hostQueryReset;
     safe_VkPhysicalDeviceHostQueryResetFeatures(const VkPhysicalDeviceHostQueryResetFeatures* in_struct);
     safe_VkPhysicalDeviceHostQueryResetFeatures(const safe_VkPhysicalDeviceHostQueryResetFeatures& copy_src);
@@ -2953,7 +2953,7 @@ struct safe_VkPhysicalDeviceHostQueryResetFeatures {
 
 struct safe_VkPhysicalDeviceTimelineSemaphoreFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 timelineSemaphore;
     safe_VkPhysicalDeviceTimelineSemaphoreFeatures(const VkPhysicalDeviceTimelineSemaphoreFeatures* in_struct);
     safe_VkPhysicalDeviceTimelineSemaphoreFeatures(const safe_VkPhysicalDeviceTimelineSemaphoreFeatures& copy_src);
@@ -2968,7 +2968,7 @@ struct safe_VkPhysicalDeviceTimelineSemaphoreFeatures {
 
 struct safe_VkPhysicalDeviceTimelineSemaphoreProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint64_t maxTimelineSemaphoreValueDifference;
     safe_VkPhysicalDeviceTimelineSemaphoreProperties(const VkPhysicalDeviceTimelineSemaphoreProperties* in_struct);
     safe_VkPhysicalDeviceTimelineSemaphoreProperties(const safe_VkPhysicalDeviceTimelineSemaphoreProperties& copy_src);
@@ -2983,7 +2983,7 @@ struct safe_VkPhysicalDeviceTimelineSemaphoreProperties {
 
 struct safe_VkSemaphoreTypeCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphoreType semaphoreType;
     uint64_t initialValue;
     safe_VkSemaphoreTypeCreateInfo(const VkSemaphoreTypeCreateInfo* in_struct);
@@ -2999,11 +2999,11 @@ struct safe_VkSemaphoreTypeCreateInfo {
 
 struct safe_VkTimelineSemaphoreSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreValueCount;
-    const uint64_t* pWaitSemaphoreValues;
+    const uint64_t* pWaitSemaphoreValues{};
     uint32_t signalSemaphoreValueCount;
-    const uint64_t* pSignalSemaphoreValues;
+    const uint64_t* pSignalSemaphoreValues{};
     safe_VkTimelineSemaphoreSubmitInfo(const VkTimelineSemaphoreSubmitInfo* in_struct);
     safe_VkTimelineSemaphoreSubmitInfo(const safe_VkTimelineSemaphoreSubmitInfo& copy_src);
     safe_VkTimelineSemaphoreSubmitInfo& operator=(const safe_VkTimelineSemaphoreSubmitInfo& copy_src);
@@ -3017,11 +3017,11 @@ struct safe_VkTimelineSemaphoreSubmitInfo {
 
 struct safe_VkSemaphoreWaitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphoreWaitFlags flags;
     uint32_t semaphoreCount;
-    VkSemaphore* pSemaphores;
-    const uint64_t* pValues;
+    VkSemaphore* pSemaphores{};
+    const uint64_t* pValues{};
     safe_VkSemaphoreWaitInfo(const VkSemaphoreWaitInfo* in_struct);
     safe_VkSemaphoreWaitInfo(const safe_VkSemaphoreWaitInfo& copy_src);
     safe_VkSemaphoreWaitInfo& operator=(const safe_VkSemaphoreWaitInfo& copy_src);
@@ -3035,7 +3035,7 @@ struct safe_VkSemaphoreWaitInfo {
 
 struct safe_VkSemaphoreSignalInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     uint64_t value;
     safe_VkSemaphoreSignalInfo(const VkSemaphoreSignalInfo* in_struct);
@@ -3051,7 +3051,7 @@ struct safe_VkSemaphoreSignalInfo {
 
 struct safe_VkPhysicalDeviceBufferDeviceAddressFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 bufferDeviceAddress;
     VkBool32 bufferDeviceAddressCaptureReplay;
     VkBool32 bufferDeviceAddressMultiDevice;
@@ -3068,7 +3068,7 @@ struct safe_VkPhysicalDeviceBufferDeviceAddressFeatures {
 
 struct safe_VkBufferDeviceAddressInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer buffer;
     safe_VkBufferDeviceAddressInfo(const VkBufferDeviceAddressInfo* in_struct);
     safe_VkBufferDeviceAddressInfo(const safe_VkBufferDeviceAddressInfo& copy_src);
@@ -3083,7 +3083,7 @@ struct safe_VkBufferDeviceAddressInfo {
 
 struct safe_VkBufferOpaqueCaptureAddressCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint64_t opaqueCaptureAddress;
     safe_VkBufferOpaqueCaptureAddressCreateInfo(const VkBufferOpaqueCaptureAddressCreateInfo* in_struct);
     safe_VkBufferOpaqueCaptureAddressCreateInfo(const safe_VkBufferOpaqueCaptureAddressCreateInfo& copy_src);
@@ -3098,7 +3098,7 @@ struct safe_VkBufferOpaqueCaptureAddressCreateInfo {
 
 struct safe_VkMemoryOpaqueCaptureAddressAllocateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint64_t opaqueCaptureAddress;
     safe_VkMemoryOpaqueCaptureAddressAllocateInfo(const VkMemoryOpaqueCaptureAddressAllocateInfo* in_struct);
     safe_VkMemoryOpaqueCaptureAddressAllocateInfo(const safe_VkMemoryOpaqueCaptureAddressAllocateInfo& copy_src);
@@ -3113,7 +3113,7 @@ struct safe_VkMemoryOpaqueCaptureAddressAllocateInfo {
 
 struct safe_VkDeviceMemoryOpaqueCaptureAddressInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     safe_VkDeviceMemoryOpaqueCaptureAddressInfo(const VkDeviceMemoryOpaqueCaptureAddressInfo* in_struct);
     safe_VkDeviceMemoryOpaqueCaptureAddressInfo(const safe_VkDeviceMemoryOpaqueCaptureAddressInfo& copy_src);
@@ -3128,7 +3128,7 @@ struct safe_VkDeviceMemoryOpaqueCaptureAddressInfo {
 
 struct safe_VkPhysicalDeviceVulkan13Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 robustImageAccess;
     VkBool32 inlineUniformBlock;
     VkBool32 descriptorBindingInlineUniformBlockUpdateAfterBind;
@@ -3157,7 +3157,7 @@ struct safe_VkPhysicalDeviceVulkan13Features {
 
 struct safe_VkPhysicalDeviceVulkan13Properties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t minSubgroupSize;
     uint32_t maxSubgroupSize;
     uint32_t maxComputeWorkgroupSubgroups;
@@ -3216,10 +3216,10 @@ struct safe_VkPhysicalDeviceVulkan13Properties {
 
 struct safe_VkPipelineCreationFeedbackCreateInfo {
     VkStructureType sType;
-    const void* pNext;
-    VkPipelineCreationFeedback* pPipelineCreationFeedback;
+    const void* pNext{};
+    VkPipelineCreationFeedback* pPipelineCreationFeedback{};
     uint32_t pipelineStageCreationFeedbackCount;
-    VkPipelineCreationFeedback* pPipelineStageCreationFeedbacks;
+    VkPipelineCreationFeedback* pPipelineStageCreationFeedbacks{};
     safe_VkPipelineCreationFeedbackCreateInfo(const VkPipelineCreationFeedbackCreateInfo* in_struct);
     safe_VkPipelineCreationFeedbackCreateInfo(const safe_VkPipelineCreationFeedbackCreateInfo& copy_src);
     safe_VkPipelineCreationFeedbackCreateInfo& operator=(const safe_VkPipelineCreationFeedbackCreateInfo& copy_src);
@@ -3233,7 +3233,7 @@ struct safe_VkPipelineCreationFeedbackCreateInfo {
 
 struct safe_VkPhysicalDeviceShaderTerminateInvocationFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderTerminateInvocation;
     safe_VkPhysicalDeviceShaderTerminateInvocationFeatures(const VkPhysicalDeviceShaderTerminateInvocationFeatures* in_struct);
     safe_VkPhysicalDeviceShaderTerminateInvocationFeatures(const safe_VkPhysicalDeviceShaderTerminateInvocationFeatures& copy_src);
@@ -3248,7 +3248,7 @@ struct safe_VkPhysicalDeviceShaderTerminateInvocationFeatures {
 
 struct safe_VkPhysicalDeviceToolProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     char name[VK_MAX_EXTENSION_NAME_SIZE];
     char version[VK_MAX_EXTENSION_NAME_SIZE];
     VkToolPurposeFlags purposes;
@@ -3267,7 +3267,7 @@ struct safe_VkPhysicalDeviceToolProperties {
 
 struct safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderDemoteToHelperInvocation;
     safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures(const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* in_struct);
     safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures(const safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures& copy_src);
@@ -3282,7 +3282,7 @@ struct safe_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures {
 
 struct safe_VkPhysicalDevicePrivateDataFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 privateData;
     safe_VkPhysicalDevicePrivateDataFeatures(const VkPhysicalDevicePrivateDataFeatures* in_struct);
     safe_VkPhysicalDevicePrivateDataFeatures(const safe_VkPhysicalDevicePrivateDataFeatures& copy_src);
@@ -3297,7 +3297,7 @@ struct safe_VkPhysicalDevicePrivateDataFeatures {
 
 struct safe_VkDevicePrivateDataCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t privateDataSlotRequestCount;
     safe_VkDevicePrivateDataCreateInfo(const VkDevicePrivateDataCreateInfo* in_struct);
     safe_VkDevicePrivateDataCreateInfo(const safe_VkDevicePrivateDataCreateInfo& copy_src);
@@ -3312,7 +3312,7 @@ struct safe_VkDevicePrivateDataCreateInfo {
 
 struct safe_VkPrivateDataSlotCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPrivateDataSlotCreateFlags flags;
     safe_VkPrivateDataSlotCreateInfo(const VkPrivateDataSlotCreateInfo* in_struct);
     safe_VkPrivateDataSlotCreateInfo(const safe_VkPrivateDataSlotCreateInfo& copy_src);
@@ -3327,7 +3327,7 @@ struct safe_VkPrivateDataSlotCreateInfo {
 
 struct safe_VkPhysicalDevicePipelineCreationCacheControlFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 pipelineCreationCacheControl;
     safe_VkPhysicalDevicePipelineCreationCacheControlFeatures(const VkPhysicalDevicePipelineCreationCacheControlFeatures* in_struct);
     safe_VkPhysicalDevicePipelineCreationCacheControlFeatures(const safe_VkPhysicalDevicePipelineCreationCacheControlFeatures& copy_src);
@@ -3342,7 +3342,7 @@ struct safe_VkPhysicalDevicePipelineCreationCacheControlFeatures {
 
 struct safe_VkMemoryBarrier2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineStageFlags2 srcStageMask;
     VkAccessFlags2 srcAccessMask;
     VkPipelineStageFlags2 dstStageMask;
@@ -3360,7 +3360,7 @@ struct safe_VkMemoryBarrier2 {
 
 struct safe_VkBufferMemoryBarrier2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineStageFlags2 srcStageMask;
     VkAccessFlags2 srcAccessMask;
     VkPipelineStageFlags2 dstStageMask;
@@ -3383,7 +3383,7 @@ struct safe_VkBufferMemoryBarrier2 {
 
 struct safe_VkImageMemoryBarrier2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineStageFlags2 srcStageMask;
     VkAccessFlags2 srcAccessMask;
     VkPipelineStageFlags2 dstStageMask;
@@ -3407,14 +3407,14 @@ struct safe_VkImageMemoryBarrier2 {
 
 struct safe_VkDependencyInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDependencyFlags dependencyFlags;
     uint32_t memoryBarrierCount;
-    safe_VkMemoryBarrier2* pMemoryBarriers;
+    safe_VkMemoryBarrier2* pMemoryBarriers{};
     uint32_t bufferMemoryBarrierCount;
-    safe_VkBufferMemoryBarrier2* pBufferMemoryBarriers;
+    safe_VkBufferMemoryBarrier2* pBufferMemoryBarriers{};
     uint32_t imageMemoryBarrierCount;
-    safe_VkImageMemoryBarrier2* pImageMemoryBarriers;
+    safe_VkImageMemoryBarrier2* pImageMemoryBarriers{};
     safe_VkDependencyInfo(const VkDependencyInfo* in_struct);
     safe_VkDependencyInfo(const safe_VkDependencyInfo& copy_src);
     safe_VkDependencyInfo& operator=(const safe_VkDependencyInfo& copy_src);
@@ -3428,7 +3428,7 @@ struct safe_VkDependencyInfo {
 
 struct safe_VkSemaphoreSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     uint64_t value;
     VkPipelineStageFlags2 stageMask;
@@ -3446,7 +3446,7 @@ struct safe_VkSemaphoreSubmitInfo {
 
 struct safe_VkCommandBufferSubmitInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCommandBuffer commandBuffer;
     uint32_t deviceMask;
     safe_VkCommandBufferSubmitInfo(const VkCommandBufferSubmitInfo* in_struct);
@@ -3462,14 +3462,14 @@ struct safe_VkCommandBufferSubmitInfo {
 
 struct safe_VkSubmitInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSubmitFlags flags;
     uint32_t waitSemaphoreInfoCount;
-    safe_VkSemaphoreSubmitInfo* pWaitSemaphoreInfos;
+    safe_VkSemaphoreSubmitInfo* pWaitSemaphoreInfos{};
     uint32_t commandBufferInfoCount;
-    safe_VkCommandBufferSubmitInfo* pCommandBufferInfos;
+    safe_VkCommandBufferSubmitInfo* pCommandBufferInfos{};
     uint32_t signalSemaphoreInfoCount;
-    safe_VkSemaphoreSubmitInfo* pSignalSemaphoreInfos;
+    safe_VkSemaphoreSubmitInfo* pSignalSemaphoreInfos{};
     safe_VkSubmitInfo2(const VkSubmitInfo2* in_struct);
     safe_VkSubmitInfo2(const safe_VkSubmitInfo2& copy_src);
     safe_VkSubmitInfo2& operator=(const safe_VkSubmitInfo2& copy_src);
@@ -3483,7 +3483,7 @@ struct safe_VkSubmitInfo2 {
 
 struct safe_VkPhysicalDeviceSynchronization2Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 synchronization2;
     safe_VkPhysicalDeviceSynchronization2Features(const VkPhysicalDeviceSynchronization2Features* in_struct);
     safe_VkPhysicalDeviceSynchronization2Features(const safe_VkPhysicalDeviceSynchronization2Features& copy_src);
@@ -3498,7 +3498,7 @@ struct safe_VkPhysicalDeviceSynchronization2Features {
 
 struct safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderZeroInitializeWorkgroupMemory;
     safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures(const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* in_struct);
     safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures(const safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures& copy_src);
@@ -3513,7 +3513,7 @@ struct safe_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
 
 struct safe_VkPhysicalDeviceImageRobustnessFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 robustImageAccess;
     safe_VkPhysicalDeviceImageRobustnessFeatures(const VkPhysicalDeviceImageRobustnessFeatures* in_struct);
     safe_VkPhysicalDeviceImageRobustnessFeatures(const safe_VkPhysicalDeviceImageRobustnessFeatures& copy_src);
@@ -3528,7 +3528,7 @@ struct safe_VkPhysicalDeviceImageRobustnessFeatures {
 
 struct safe_VkBufferCopy2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceSize srcOffset;
     VkDeviceSize dstOffset;
     VkDeviceSize size;
@@ -3545,11 +3545,11 @@ struct safe_VkBufferCopy2 {
 
 struct safe_VkCopyBufferInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer srcBuffer;
     VkBuffer dstBuffer;
     uint32_t regionCount;
-    safe_VkBufferCopy2* pRegions;
+    safe_VkBufferCopy2* pRegions{};
     safe_VkCopyBufferInfo2(const VkCopyBufferInfo2* in_struct);
     safe_VkCopyBufferInfo2(const safe_VkCopyBufferInfo2& copy_src);
     safe_VkCopyBufferInfo2& operator=(const safe_VkCopyBufferInfo2& copy_src);
@@ -3563,7 +3563,7 @@ struct safe_VkCopyBufferInfo2 {
 
 struct safe_VkImageCopy2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageSubresourceLayers srcSubresource;
     VkOffset3D srcOffset;
     VkImageSubresourceLayers dstSubresource;
@@ -3582,13 +3582,13 @@ struct safe_VkImageCopy2 {
 
 struct safe_VkCopyImageInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage srcImage;
     VkImageLayout srcImageLayout;
     VkImage dstImage;
     VkImageLayout dstImageLayout;
     uint32_t regionCount;
-    safe_VkImageCopy2* pRegions;
+    safe_VkImageCopy2* pRegions{};
     safe_VkCopyImageInfo2(const VkCopyImageInfo2* in_struct);
     safe_VkCopyImageInfo2(const safe_VkCopyImageInfo2& copy_src);
     safe_VkCopyImageInfo2& operator=(const safe_VkCopyImageInfo2& copy_src);
@@ -3602,7 +3602,7 @@ struct safe_VkCopyImageInfo2 {
 
 struct safe_VkBufferImageCopy2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceSize bufferOffset;
     uint32_t bufferRowLength;
     uint32_t bufferImageHeight;
@@ -3622,12 +3622,12 @@ struct safe_VkBufferImageCopy2 {
 
 struct safe_VkCopyBufferToImageInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer srcBuffer;
     VkImage dstImage;
     VkImageLayout dstImageLayout;
     uint32_t regionCount;
-    safe_VkBufferImageCopy2* pRegions;
+    safe_VkBufferImageCopy2* pRegions{};
     safe_VkCopyBufferToImageInfo2(const VkCopyBufferToImageInfo2* in_struct);
     safe_VkCopyBufferToImageInfo2(const safe_VkCopyBufferToImageInfo2& copy_src);
     safe_VkCopyBufferToImageInfo2& operator=(const safe_VkCopyBufferToImageInfo2& copy_src);
@@ -3641,12 +3641,12 @@ struct safe_VkCopyBufferToImageInfo2 {
 
 struct safe_VkCopyImageToBufferInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage srcImage;
     VkImageLayout srcImageLayout;
     VkBuffer dstBuffer;
     uint32_t regionCount;
-    safe_VkBufferImageCopy2* pRegions;
+    safe_VkBufferImageCopy2* pRegions{};
     safe_VkCopyImageToBufferInfo2(const VkCopyImageToBufferInfo2* in_struct);
     safe_VkCopyImageToBufferInfo2(const safe_VkCopyImageToBufferInfo2& copy_src);
     safe_VkCopyImageToBufferInfo2& operator=(const safe_VkCopyImageToBufferInfo2& copy_src);
@@ -3660,7 +3660,7 @@ struct safe_VkCopyImageToBufferInfo2 {
 
 struct safe_VkImageBlit2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageSubresourceLayers srcSubresource;
     VkOffset3D srcOffsets[2];
     VkImageSubresourceLayers dstSubresource;
@@ -3678,13 +3678,13 @@ struct safe_VkImageBlit2 {
 
 struct safe_VkBlitImageInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage srcImage;
     VkImageLayout srcImageLayout;
     VkImage dstImage;
     VkImageLayout dstImageLayout;
     uint32_t regionCount;
-    safe_VkImageBlit2* pRegions;
+    safe_VkImageBlit2* pRegions{};
     VkFilter filter;
     safe_VkBlitImageInfo2(const VkBlitImageInfo2* in_struct);
     safe_VkBlitImageInfo2(const safe_VkBlitImageInfo2& copy_src);
@@ -3699,7 +3699,7 @@ struct safe_VkBlitImageInfo2 {
 
 struct safe_VkImageResolve2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageSubresourceLayers srcSubresource;
     VkOffset3D srcOffset;
     VkImageSubresourceLayers dstSubresource;
@@ -3718,13 +3718,13 @@ struct safe_VkImageResolve2 {
 
 struct safe_VkResolveImageInfo2 {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage srcImage;
     VkImageLayout srcImageLayout;
     VkImage dstImage;
     VkImageLayout dstImageLayout;
     uint32_t regionCount;
-    safe_VkImageResolve2* pRegions;
+    safe_VkImageResolve2* pRegions{};
     safe_VkResolveImageInfo2(const VkResolveImageInfo2* in_struct);
     safe_VkResolveImageInfo2(const safe_VkResolveImageInfo2& copy_src);
     safe_VkResolveImageInfo2& operator=(const safe_VkResolveImageInfo2& copy_src);
@@ -3738,7 +3738,7 @@ struct safe_VkResolveImageInfo2 {
 
 struct safe_VkPhysicalDeviceSubgroupSizeControlFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 subgroupSizeControl;
     VkBool32 computeFullSubgroups;
     safe_VkPhysicalDeviceSubgroupSizeControlFeatures(const VkPhysicalDeviceSubgroupSizeControlFeatures* in_struct);
@@ -3754,7 +3754,7 @@ struct safe_VkPhysicalDeviceSubgroupSizeControlFeatures {
 
 struct safe_VkPhysicalDeviceSubgroupSizeControlProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t minSubgroupSize;
     uint32_t maxSubgroupSize;
     uint32_t maxComputeWorkgroupSubgroups;
@@ -3772,7 +3772,7 @@ struct safe_VkPhysicalDeviceSubgroupSizeControlProperties {
 
 struct safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t requiredSubgroupSize;
     safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo(const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo* in_struct);
     safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo(const safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo& copy_src);
@@ -3787,7 +3787,7 @@ struct safe_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo {
 
 struct safe_VkPhysicalDeviceInlineUniformBlockFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 inlineUniformBlock;
     VkBool32 descriptorBindingInlineUniformBlockUpdateAfterBind;
     safe_VkPhysicalDeviceInlineUniformBlockFeatures(const VkPhysicalDeviceInlineUniformBlockFeatures* in_struct);
@@ -3803,7 +3803,7 @@ struct safe_VkPhysicalDeviceInlineUniformBlockFeatures {
 
 struct safe_VkPhysicalDeviceInlineUniformBlockProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxInlineUniformBlockSize;
     uint32_t maxPerStageDescriptorInlineUniformBlocks;
     uint32_t maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks;
@@ -3822,9 +3822,9 @@ struct safe_VkPhysicalDeviceInlineUniformBlockProperties {
 
 struct safe_VkWriteDescriptorSetInlineUniformBlock {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t dataSize;
-    const void* pData;
+    const void* pData{};
     safe_VkWriteDescriptorSetInlineUniformBlock(const VkWriteDescriptorSetInlineUniformBlock* in_struct);
     safe_VkWriteDescriptorSetInlineUniformBlock(const safe_VkWriteDescriptorSetInlineUniformBlock& copy_src);
     safe_VkWriteDescriptorSetInlineUniformBlock& operator=(const safe_VkWriteDescriptorSetInlineUniformBlock& copy_src);
@@ -3838,7 +3838,7 @@ struct safe_VkWriteDescriptorSetInlineUniformBlock {
 
 struct safe_VkDescriptorPoolInlineUniformBlockCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxInlineUniformBlockBindings;
     safe_VkDescriptorPoolInlineUniformBlockCreateInfo(const VkDescriptorPoolInlineUniformBlockCreateInfo* in_struct);
     safe_VkDescriptorPoolInlineUniformBlockCreateInfo(const safe_VkDescriptorPoolInlineUniformBlockCreateInfo& copy_src);
@@ -3853,7 +3853,7 @@ struct safe_VkDescriptorPoolInlineUniformBlockCreateInfo {
 
 struct safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 textureCompressionASTC_HDR;
     safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures(const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* in_struct);
     safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures(const safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures& copy_src);
@@ -3868,7 +3868,7 @@ struct safe_VkPhysicalDeviceTextureCompressionASTCHDRFeatures {
 
 struct safe_VkRenderingAttachmentInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageView imageView;
     VkImageLayout imageLayout;
     VkResolveModeFlagBits resolveMode;
@@ -3890,15 +3890,15 @@ struct safe_VkRenderingAttachmentInfo {
 
 struct safe_VkRenderingInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderingFlags flags;
     VkRect2D renderArea;
     uint32_t layerCount;
     uint32_t viewMask;
     uint32_t colorAttachmentCount;
-    safe_VkRenderingAttachmentInfo* pColorAttachments;
-    safe_VkRenderingAttachmentInfo* pDepthAttachment;
-    safe_VkRenderingAttachmentInfo* pStencilAttachment;
+    safe_VkRenderingAttachmentInfo* pColorAttachments{};
+    safe_VkRenderingAttachmentInfo* pDepthAttachment{};
+    safe_VkRenderingAttachmentInfo* pStencilAttachment{};
     safe_VkRenderingInfo(const VkRenderingInfo* in_struct);
     safe_VkRenderingInfo(const safe_VkRenderingInfo& copy_src);
     safe_VkRenderingInfo& operator=(const safe_VkRenderingInfo& copy_src);
@@ -3912,10 +3912,10 @@ struct safe_VkRenderingInfo {
 
 struct safe_VkPipelineRenderingCreateInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t viewMask;
     uint32_t colorAttachmentCount;
-    const VkFormat* pColorAttachmentFormats;
+    const VkFormat* pColorAttachmentFormats{};
     VkFormat depthAttachmentFormat;
     VkFormat stencilAttachmentFormat;
     safe_VkPipelineRenderingCreateInfo(const VkPipelineRenderingCreateInfo* in_struct);
@@ -3931,7 +3931,7 @@ struct safe_VkPipelineRenderingCreateInfo {
 
 struct safe_VkPhysicalDeviceDynamicRenderingFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 dynamicRendering;
     safe_VkPhysicalDeviceDynamicRenderingFeatures(const VkPhysicalDeviceDynamicRenderingFeatures* in_struct);
     safe_VkPhysicalDeviceDynamicRenderingFeatures(const safe_VkPhysicalDeviceDynamicRenderingFeatures& copy_src);
@@ -3946,11 +3946,11 @@ struct safe_VkPhysicalDeviceDynamicRenderingFeatures {
 
 struct safe_VkCommandBufferInheritanceRenderingInfo {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRenderingFlags flags;
     uint32_t viewMask;
     uint32_t colorAttachmentCount;
-    const VkFormat* pColorAttachmentFormats;
+    const VkFormat* pColorAttachmentFormats{};
     VkFormat depthAttachmentFormat;
     VkFormat stencilAttachmentFormat;
     VkSampleCountFlagBits rasterizationSamples;
@@ -3967,7 +3967,7 @@ struct safe_VkCommandBufferInheritanceRenderingInfo {
 
 struct safe_VkPhysicalDeviceShaderIntegerDotProductFeatures {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderIntegerDotProduct;
     safe_VkPhysicalDeviceShaderIntegerDotProductFeatures(const VkPhysicalDeviceShaderIntegerDotProductFeatures* in_struct);
     safe_VkPhysicalDeviceShaderIntegerDotProductFeatures(const safe_VkPhysicalDeviceShaderIntegerDotProductFeatures& copy_src);
@@ -3982,7 +3982,7 @@ struct safe_VkPhysicalDeviceShaderIntegerDotProductFeatures {
 
 struct safe_VkPhysicalDeviceShaderIntegerDotProductProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 integerDotProduct8BitUnsignedAccelerated;
     VkBool32 integerDotProduct8BitSignedAccelerated;
     VkBool32 integerDotProduct8BitMixedSignednessAccelerated;
@@ -4026,7 +4026,7 @@ struct safe_VkPhysicalDeviceShaderIntegerDotProductProperties {
 
 struct safe_VkPhysicalDeviceTexelBufferAlignmentProperties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize storageTexelBufferOffsetAlignmentBytes;
     VkBool32 storageTexelBufferOffsetSingleTexelAlignment;
     VkDeviceSize uniformTexelBufferOffsetAlignmentBytes;
@@ -4044,7 +4044,7 @@ struct safe_VkPhysicalDeviceTexelBufferAlignmentProperties {
 
 struct safe_VkFormatProperties3 {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFormatFeatureFlags2 linearTilingFeatures;
     VkFormatFeatureFlags2 optimalTilingFeatures;
     VkFormatFeatureFlags2 bufferFeatures;
@@ -4061,7 +4061,7 @@ struct safe_VkFormatProperties3 {
 
 struct safe_VkPhysicalDeviceMaintenance4Features {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 maintenance4;
     safe_VkPhysicalDeviceMaintenance4Features(const VkPhysicalDeviceMaintenance4Features* in_struct);
     safe_VkPhysicalDeviceMaintenance4Features(const safe_VkPhysicalDeviceMaintenance4Features& copy_src);
@@ -4076,7 +4076,7 @@ struct safe_VkPhysicalDeviceMaintenance4Features {
 
 struct safe_VkPhysicalDeviceMaintenance4Properties {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize maxBufferSize;
     safe_VkPhysicalDeviceMaintenance4Properties(const VkPhysicalDeviceMaintenance4Properties* in_struct);
     safe_VkPhysicalDeviceMaintenance4Properties(const safe_VkPhysicalDeviceMaintenance4Properties& copy_src);
@@ -4091,8 +4091,8 @@ struct safe_VkPhysicalDeviceMaintenance4Properties {
 
 struct safe_VkDeviceBufferMemoryRequirements {
     VkStructureType sType;
-    const void* pNext;
-    safe_VkBufferCreateInfo* pCreateInfo;
+    const void* pNext{};
+    safe_VkBufferCreateInfo* pCreateInfo{};
     safe_VkDeviceBufferMemoryRequirements(const VkDeviceBufferMemoryRequirements* in_struct);
     safe_VkDeviceBufferMemoryRequirements(const safe_VkDeviceBufferMemoryRequirements& copy_src);
     safe_VkDeviceBufferMemoryRequirements& operator=(const safe_VkDeviceBufferMemoryRequirements& copy_src);
@@ -4106,8 +4106,8 @@ struct safe_VkDeviceBufferMemoryRequirements {
 
 struct safe_VkDeviceImageMemoryRequirements {
     VkStructureType sType;
-    const void* pNext;
-    safe_VkImageCreateInfo* pCreateInfo;
+    const void* pNext{};
+    safe_VkImageCreateInfo* pCreateInfo{};
     VkImageAspectFlagBits planeAspect;
     safe_VkDeviceImageMemoryRequirements(const VkDeviceImageMemoryRequirements* in_struct);
     safe_VkDeviceImageMemoryRequirements(const safe_VkDeviceImageMemoryRequirements& copy_src);
@@ -4122,7 +4122,7 @@ struct safe_VkDeviceImageMemoryRequirements {
 
 struct safe_VkSwapchainCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSwapchainCreateFlagsKHR flags;
     VkSurfaceKHR surface;
     uint32_t minImageCount;
@@ -4133,7 +4133,7 @@ struct safe_VkSwapchainCreateInfoKHR {
     VkImageUsageFlags imageUsage;
     VkSharingMode imageSharingMode;
     uint32_t queueFamilyIndexCount;
-    const uint32_t* pQueueFamilyIndices;
+    const uint32_t* pQueueFamilyIndices{};
     VkSurfaceTransformFlagBitsKHR preTransform;
     VkCompositeAlphaFlagBitsKHR compositeAlpha;
     VkPresentModeKHR presentMode;
@@ -4152,13 +4152,13 @@ struct safe_VkSwapchainCreateInfoKHR {
 
 struct safe_VkPresentInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreCount;
-    VkSemaphore* pWaitSemaphores;
+    VkSemaphore* pWaitSemaphores{};
     uint32_t swapchainCount;
-    VkSwapchainKHR* pSwapchains;
-    const uint32_t* pImageIndices;
-    VkResult* pResults;
+    VkSwapchainKHR* pSwapchains{};
+    const uint32_t* pImageIndices{};
+    VkResult* pResults{};
     safe_VkPresentInfoKHR(const VkPresentInfoKHR* in_struct);
     safe_VkPresentInfoKHR(const safe_VkPresentInfoKHR& copy_src);
     safe_VkPresentInfoKHR& operator=(const safe_VkPresentInfoKHR& copy_src);
@@ -4172,7 +4172,7 @@ struct safe_VkPresentInfoKHR {
 
 struct safe_VkImageSwapchainCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSwapchainKHR swapchain;
     safe_VkImageSwapchainCreateInfoKHR(const VkImageSwapchainCreateInfoKHR* in_struct);
     safe_VkImageSwapchainCreateInfoKHR(const safe_VkImageSwapchainCreateInfoKHR& copy_src);
@@ -4187,7 +4187,7 @@ struct safe_VkImageSwapchainCreateInfoKHR {
 
 struct safe_VkBindImageMemorySwapchainInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSwapchainKHR swapchain;
     uint32_t imageIndex;
     safe_VkBindImageMemorySwapchainInfoKHR(const VkBindImageMemorySwapchainInfoKHR* in_struct);
@@ -4203,7 +4203,7 @@ struct safe_VkBindImageMemorySwapchainInfoKHR {
 
 struct safe_VkAcquireNextImageInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSwapchainKHR swapchain;
     uint64_t timeout;
     VkSemaphore semaphore;
@@ -4222,7 +4222,7 @@ struct safe_VkAcquireNextImageInfoKHR {
 
 struct safe_VkDeviceGroupPresentCapabilitiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t presentMask[VK_MAX_DEVICE_GROUP_SIZE];
     VkDeviceGroupPresentModeFlagsKHR modes;
     safe_VkDeviceGroupPresentCapabilitiesKHR(const VkDeviceGroupPresentCapabilitiesKHR* in_struct);
@@ -4238,9 +4238,9 @@ struct safe_VkDeviceGroupPresentCapabilitiesKHR {
 
 struct safe_VkDeviceGroupPresentInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t swapchainCount;
-    const uint32_t* pDeviceMasks;
+    const uint32_t* pDeviceMasks{};
     VkDeviceGroupPresentModeFlagBitsKHR mode;
     safe_VkDeviceGroupPresentInfoKHR(const VkDeviceGroupPresentInfoKHR* in_struct);
     safe_VkDeviceGroupPresentInfoKHR(const safe_VkDeviceGroupPresentInfoKHR& copy_src);
@@ -4255,7 +4255,7 @@ struct safe_VkDeviceGroupPresentInfoKHR {
 
 struct safe_VkDeviceGroupSwapchainCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceGroupPresentModeFlagsKHR modes;
     safe_VkDeviceGroupSwapchainCreateInfoKHR(const VkDeviceGroupSwapchainCreateInfoKHR* in_struct);
     safe_VkDeviceGroupSwapchainCreateInfoKHR(const safe_VkDeviceGroupSwapchainCreateInfoKHR& copy_src);
@@ -4270,7 +4270,7 @@ struct safe_VkDeviceGroupSwapchainCreateInfoKHR {
 
 struct safe_VkDisplayModeCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDisplayModeCreateFlagsKHR flags;
     VkDisplayModeParametersKHR parameters;
     safe_VkDisplayModeCreateInfoKHR(const VkDisplayModeCreateInfoKHR* in_struct);
@@ -4286,7 +4286,7 @@ struct safe_VkDisplayModeCreateInfoKHR {
 
 struct safe_VkDisplayPropertiesKHR {
     VkDisplayKHR display;
-    const char* displayName;
+    const char* displayName{};
     VkExtent2D physicalDimensions;
     VkExtent2D physicalResolution;
     VkSurfaceTransformFlagsKHR supportedTransforms;
@@ -4305,7 +4305,7 @@ struct safe_VkDisplayPropertiesKHR {
 
 struct safe_VkDisplaySurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDisplaySurfaceCreateFlagsKHR flags;
     VkDisplayModeKHR displayMode;
     uint32_t planeIndex;
@@ -4327,7 +4327,7 @@ struct safe_VkDisplaySurfaceCreateInfoKHR {
 
 struct safe_VkDisplayPresentInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRect2D srcRect;
     VkRect2D dstRect;
     VkBool32 persistent;
@@ -4345,9 +4345,9 @@ struct safe_VkDisplayPresentInfoKHR {
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 struct safe_VkXlibSurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkXlibSurfaceCreateFlagsKHR flags;
-    Display* dpy;
+    Display* dpy{};
     Window window;
     safe_VkXlibSurfaceCreateInfoKHR(const VkXlibSurfaceCreateInfoKHR* in_struct);
     safe_VkXlibSurfaceCreateInfoKHR(const safe_VkXlibSurfaceCreateInfoKHR& copy_src);
@@ -4364,9 +4364,9 @@ struct safe_VkXlibSurfaceCreateInfoKHR {
 #ifdef VK_USE_PLATFORM_XCB_KHR
 struct safe_VkXcbSurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkXcbSurfaceCreateFlagsKHR flags;
-    xcb_connection_t* connection;
+    xcb_connection_t* connection{};
     xcb_window_t window;
     safe_VkXcbSurfaceCreateInfoKHR(const VkXcbSurfaceCreateInfoKHR* in_struct);
     safe_VkXcbSurfaceCreateInfoKHR(const safe_VkXcbSurfaceCreateInfoKHR& copy_src);
@@ -4383,10 +4383,10 @@ struct safe_VkXcbSurfaceCreateInfoKHR {
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 struct safe_VkWaylandSurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkWaylandSurfaceCreateFlagsKHR flags;
-    struct wl_display* display;
-    struct wl_surface* surface;
+    struct wl_display* display{};
+    struct wl_surface* surface{};
     safe_VkWaylandSurfaceCreateInfoKHR(const VkWaylandSurfaceCreateInfoKHR* in_struct);
     safe_VkWaylandSurfaceCreateInfoKHR(const safe_VkWaylandSurfaceCreateInfoKHR& copy_src);
     safe_VkWaylandSurfaceCreateInfoKHR& operator=(const safe_VkWaylandSurfaceCreateInfoKHR& copy_src);
@@ -4402,9 +4402,9 @@ struct safe_VkWaylandSurfaceCreateInfoKHR {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkAndroidSurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAndroidSurfaceCreateFlagsKHR flags;
-    struct ANativeWindow* window;
+    struct ANativeWindow* window{};
     safe_VkAndroidSurfaceCreateInfoKHR(const VkAndroidSurfaceCreateInfoKHR* in_struct);
     safe_VkAndroidSurfaceCreateInfoKHR(const safe_VkAndroidSurfaceCreateInfoKHR& copy_src);
     safe_VkAndroidSurfaceCreateInfoKHR& operator=(const safe_VkAndroidSurfaceCreateInfoKHR& copy_src);
@@ -4420,7 +4420,7 @@ struct safe_VkAndroidSurfaceCreateInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkWin32SurfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkWin32SurfaceCreateFlagsKHR flags;
     HINSTANCE hinstance;
     HWND hwnd;
@@ -4439,7 +4439,7 @@ struct safe_VkWin32SurfaceCreateInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkQueueFamilyQueryResultStatusProperties2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 supported;
     safe_VkQueueFamilyQueryResultStatusProperties2KHR(const VkQueueFamilyQueryResultStatusProperties2KHR* in_struct);
     safe_VkQueueFamilyQueryResultStatusProperties2KHR(const safe_VkQueueFamilyQueryResultStatusProperties2KHR& copy_src);
@@ -4456,7 +4456,7 @@ struct safe_VkQueueFamilyQueryResultStatusProperties2KHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoQueueFamilyProperties2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoCodecOperationFlagsKHR videoCodecOperations;
     safe_VkVideoQueueFamilyProperties2KHR(const VkVideoQueueFamilyProperties2KHR* in_struct);
     safe_VkVideoQueueFamilyProperties2KHR(const safe_VkVideoQueueFamilyProperties2KHR& copy_src);
@@ -4473,7 +4473,7 @@ struct safe_VkVideoQueueFamilyProperties2KHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoProfileKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoCodecOperationFlagBitsKHR videoCodecOperation;
     VkVideoChromaSubsamplingFlagsKHR chromaSubsampling;
     VkVideoComponentBitDepthFlagsKHR lumaBitDepth;
@@ -4493,9 +4493,9 @@ struct safe_VkVideoProfileKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoProfilesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t profileCount;
-    safe_VkVideoProfileKHR* pProfiles;
+    safe_VkVideoProfileKHR* pProfiles{};
     safe_VkVideoProfilesKHR(const VkVideoProfilesKHR* in_struct);
     safe_VkVideoProfilesKHR(const safe_VkVideoProfilesKHR& copy_src);
     safe_VkVideoProfilesKHR& operator=(const safe_VkVideoProfilesKHR& copy_src);
@@ -4511,7 +4511,7 @@ struct safe_VkVideoProfilesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoCapabilitiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoCapabilityFlagsKHR capabilityFlags;
     VkDeviceSize minBitstreamBufferOffsetAlignment;
     VkDeviceSize minBitstreamBufferSizeAlignment;
@@ -4536,9 +4536,9 @@ struct safe_VkVideoCapabilitiesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkPhysicalDeviceVideoFormatInfoKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageUsageFlags imageUsage;
-    safe_VkVideoProfilesKHR* pVideoProfiles;
+    safe_VkVideoProfilesKHR* pVideoProfiles{};
     safe_VkPhysicalDeviceVideoFormatInfoKHR(const VkPhysicalDeviceVideoFormatInfoKHR* in_struct);
     safe_VkPhysicalDeviceVideoFormatInfoKHR(const safe_VkPhysicalDeviceVideoFormatInfoKHR& copy_src);
     safe_VkPhysicalDeviceVideoFormatInfoKHR& operator=(const safe_VkPhysicalDeviceVideoFormatInfoKHR& copy_src);
@@ -4554,7 +4554,7 @@ struct safe_VkPhysicalDeviceVideoFormatInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoFormatPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFormat format;
     safe_VkVideoFormatPropertiesKHR(const VkVideoFormatPropertiesKHR* in_struct);
     safe_VkVideoFormatPropertiesKHR(const safe_VkVideoFormatPropertiesKHR& copy_src);
@@ -4571,7 +4571,7 @@ struct safe_VkVideoFormatPropertiesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoPictureResourceKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkOffset2D codedOffset;
     VkExtent2D codedExtent;
     uint32_t baseArrayLayer;
@@ -4591,9 +4591,9 @@ struct safe_VkVideoPictureResourceKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoReferenceSlotKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     int8_t slotIndex;
-    safe_VkVideoPictureResourceKHR* pPictureResource;
+    safe_VkVideoPictureResourceKHR* pPictureResource{};
     safe_VkVideoReferenceSlotKHR(const VkVideoReferenceSlotKHR* in_struct);
     safe_VkVideoReferenceSlotKHR(const safe_VkVideoReferenceSlotKHR& copy_src);
     safe_VkVideoReferenceSlotKHR& operator=(const safe_VkVideoReferenceSlotKHR& copy_src);
@@ -4609,9 +4609,9 @@ struct safe_VkVideoReferenceSlotKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoGetMemoryPropertiesKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t memoryBindIndex;
-    safe_VkMemoryRequirements2* pMemoryRequirements;
+    safe_VkMemoryRequirements2* pMemoryRequirements{};
     safe_VkVideoGetMemoryPropertiesKHR(const VkVideoGetMemoryPropertiesKHR* in_struct);
     safe_VkVideoGetMemoryPropertiesKHR(const safe_VkVideoGetMemoryPropertiesKHR& copy_src);
     safe_VkVideoGetMemoryPropertiesKHR& operator=(const safe_VkVideoGetMemoryPropertiesKHR& copy_src);
@@ -4627,7 +4627,7 @@ struct safe_VkVideoGetMemoryPropertiesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoBindMemoryKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t memoryBindIndex;
     VkDeviceMemory memory;
     VkDeviceSize memoryOffset;
@@ -4647,16 +4647,16 @@ struct safe_VkVideoBindMemoryKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoSessionCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t queueFamilyIndex;
     VkVideoSessionCreateFlagsKHR flags;
-    safe_VkVideoProfileKHR* pVideoProfile;
+    safe_VkVideoProfileKHR* pVideoProfile{};
     VkFormat pictureFormat;
     VkExtent2D maxCodedExtent;
     VkFormat referencePicturesFormat;
     uint32_t maxReferencePicturesSlotsCount;
     uint32_t maxReferencePicturesActiveCount;
-    const VkExtensionProperties* pStdHeaderVersion;
+    const VkExtensionProperties* pStdHeaderVersion{};
     safe_VkVideoSessionCreateInfoKHR(const VkVideoSessionCreateInfoKHR* in_struct);
     safe_VkVideoSessionCreateInfoKHR(const safe_VkVideoSessionCreateInfoKHR& copy_src);
     safe_VkVideoSessionCreateInfoKHR& operator=(const safe_VkVideoSessionCreateInfoKHR& copy_src);
@@ -4672,7 +4672,7 @@ struct safe_VkVideoSessionCreateInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoSessionParametersCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoSessionParametersKHR videoSessionParametersTemplate;
     VkVideoSessionKHR videoSession;
     safe_VkVideoSessionParametersCreateInfoKHR(const VkVideoSessionParametersCreateInfoKHR* in_struct);
@@ -4690,7 +4690,7 @@ struct safe_VkVideoSessionParametersCreateInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoSessionParametersUpdateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t updateSequenceCount;
     safe_VkVideoSessionParametersUpdateInfoKHR(const VkVideoSessionParametersUpdateInfoKHR* in_struct);
     safe_VkVideoSessionParametersUpdateInfoKHR(const safe_VkVideoSessionParametersUpdateInfoKHR& copy_src);
@@ -4707,13 +4707,13 @@ struct safe_VkVideoSessionParametersUpdateInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoBeginCodingInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoBeginCodingFlagsKHR flags;
     VkVideoCodingQualityPresetFlagsKHR codecQualityPreset;
     VkVideoSessionKHR videoSession;
     VkVideoSessionParametersKHR videoSessionParameters;
     uint32_t referenceSlotCount;
-    safe_VkVideoReferenceSlotKHR* pReferenceSlots;
+    safe_VkVideoReferenceSlotKHR* pReferenceSlots{};
     safe_VkVideoBeginCodingInfoKHR(const VkVideoBeginCodingInfoKHR* in_struct);
     safe_VkVideoBeginCodingInfoKHR(const safe_VkVideoBeginCodingInfoKHR& copy_src);
     safe_VkVideoBeginCodingInfoKHR& operator=(const safe_VkVideoBeginCodingInfoKHR& copy_src);
@@ -4729,7 +4729,7 @@ struct safe_VkVideoBeginCodingInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEndCodingInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoEndCodingFlagsKHR flags;
     safe_VkVideoEndCodingInfoKHR(const VkVideoEndCodingInfoKHR* in_struct);
     safe_VkVideoEndCodingInfoKHR(const safe_VkVideoEndCodingInfoKHR& copy_src);
@@ -4746,7 +4746,7 @@ struct safe_VkVideoEndCodingInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoCodingControlInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoCodingControlFlagsKHR flags;
     safe_VkVideoCodingControlInfoKHR(const VkVideoCodingControlInfoKHR* in_struct);
     safe_VkVideoCodingControlInfoKHR(const safe_VkVideoCodingControlInfoKHR& copy_src);
@@ -4763,7 +4763,7 @@ struct safe_VkVideoCodingControlInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeCapabilitiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoDecodeCapabilityFlagsKHR flags;
     safe_VkVideoDecodeCapabilitiesKHR(const VkVideoDecodeCapabilitiesKHR* in_struct);
     safe_VkVideoDecodeCapabilitiesKHR(const safe_VkVideoDecodeCapabilitiesKHR& copy_src);
@@ -4780,15 +4780,15 @@ struct safe_VkVideoDecodeCapabilitiesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoDecodeFlagsKHR flags;
     VkBuffer srcBuffer;
     VkDeviceSize srcBufferOffset;
     VkDeviceSize srcBufferRange;
     safe_VkVideoPictureResourceKHR dstPictureResource;
-    safe_VkVideoReferenceSlotKHR* pSetupReferenceSlot;
+    safe_VkVideoReferenceSlotKHR* pSetupReferenceSlot{};
     uint32_t referenceSlotCount;
-    safe_VkVideoReferenceSlotKHR* pReferenceSlots;
+    safe_VkVideoReferenceSlotKHR* pReferenceSlots{};
     safe_VkVideoDecodeInfoKHR(const VkVideoDecodeInfoKHR* in_struct);
     safe_VkVideoDecodeInfoKHR(const safe_VkVideoDecodeInfoKHR& copy_src);
     safe_VkVideoDecodeInfoKHR& operator=(const safe_VkVideoDecodeInfoKHR& copy_src);
@@ -4803,7 +4803,7 @@ struct safe_VkVideoDecodeInfoKHR {
 
 struct safe_VkRenderingFragmentShadingRateAttachmentInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageView imageView;
     VkImageLayout imageLayout;
     VkExtent2D shadingRateAttachmentTexelSize;
@@ -4820,7 +4820,7 @@ struct safe_VkRenderingFragmentShadingRateAttachmentInfoKHR {
 
 struct safe_VkRenderingFragmentDensityMapAttachmentInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageView imageView;
     VkImageLayout imageLayout;
     safe_VkRenderingFragmentDensityMapAttachmentInfoEXT(const VkRenderingFragmentDensityMapAttachmentInfoEXT* in_struct);
@@ -4836,9 +4836,9 @@ struct safe_VkRenderingFragmentDensityMapAttachmentInfoEXT {
 
 struct safe_VkAttachmentSampleCountInfoAMD {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t colorAttachmentCount;
-    const VkSampleCountFlagBits* pColorAttachmentSamples;
+    const VkSampleCountFlagBits* pColorAttachmentSamples{};
     VkSampleCountFlagBits depthStencilAttachmentSamples;
     safe_VkAttachmentSampleCountInfoAMD(const VkAttachmentSampleCountInfoAMD* in_struct);
     safe_VkAttachmentSampleCountInfoAMD(const safe_VkAttachmentSampleCountInfoAMD& copy_src);
@@ -4853,7 +4853,7 @@ struct safe_VkAttachmentSampleCountInfoAMD {
 
 struct safe_VkMultiviewPerViewAttributesInfoNVX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 perViewAttributes;
     VkBool32 perViewAttributesPositionXOnly;
     safe_VkMultiviewPerViewAttributesInfoNVX(const VkMultiviewPerViewAttributesInfoNVX* in_struct);
@@ -4870,7 +4870,7 @@ struct safe_VkMultiviewPerViewAttributesInfoNVX {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkImportMemoryWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagBits handleType;
     HANDLE handle;
     LPCWSTR name;
@@ -4889,8 +4889,8 @@ struct safe_VkImportMemoryWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkExportMemoryWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
-    const SECURITY_ATTRIBUTES* pAttributes;
+    const void* pNext{};
+    const SECURITY_ATTRIBUTES* pAttributes{};
     DWORD dwAccess;
     LPCWSTR name;
     safe_VkExportMemoryWin32HandleInfoKHR(const VkExportMemoryWin32HandleInfoKHR* in_struct);
@@ -4908,7 +4908,7 @@ struct safe_VkExportMemoryWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkMemoryWin32HandlePropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t memoryTypeBits;
     safe_VkMemoryWin32HandlePropertiesKHR(const VkMemoryWin32HandlePropertiesKHR* in_struct);
     safe_VkMemoryWin32HandlePropertiesKHR(const safe_VkMemoryWin32HandlePropertiesKHR& copy_src);
@@ -4925,7 +4925,7 @@ struct safe_VkMemoryWin32HandlePropertiesKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkMemoryGetWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     VkExternalMemoryHandleTypeFlagBits handleType;
     safe_VkMemoryGetWin32HandleInfoKHR(const VkMemoryGetWin32HandleInfoKHR* in_struct);
@@ -4942,7 +4942,7 @@ struct safe_VkMemoryGetWin32HandleInfoKHR {
 
 struct safe_VkImportMemoryFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagBits handleType;
     int fd;
     safe_VkImportMemoryFdInfoKHR(const VkImportMemoryFdInfoKHR* in_struct);
@@ -4958,7 +4958,7 @@ struct safe_VkImportMemoryFdInfoKHR {
 
 struct safe_VkMemoryFdPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t memoryTypeBits;
     safe_VkMemoryFdPropertiesKHR(const VkMemoryFdPropertiesKHR* in_struct);
     safe_VkMemoryFdPropertiesKHR(const safe_VkMemoryFdPropertiesKHR& copy_src);
@@ -4973,7 +4973,7 @@ struct safe_VkMemoryFdPropertiesKHR {
 
 struct safe_VkMemoryGetFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     VkExternalMemoryHandleTypeFlagBits handleType;
     safe_VkMemoryGetFdInfoKHR(const VkMemoryGetFdInfoKHR* in_struct);
@@ -4990,14 +4990,14 @@ struct safe_VkMemoryGetFdInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkWin32KeyedMutexAcquireReleaseInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t acquireCount;
-    VkDeviceMemory* pAcquireSyncs;
-    const uint64_t* pAcquireKeys;
-    const uint32_t* pAcquireTimeouts;
+    VkDeviceMemory* pAcquireSyncs{};
+    const uint64_t* pAcquireKeys{};
+    const uint32_t* pAcquireTimeouts{};
     uint32_t releaseCount;
-    VkDeviceMemory* pReleaseSyncs;
-    const uint64_t* pReleaseKeys;
+    VkDeviceMemory* pReleaseSyncs{};
+    const uint64_t* pReleaseKeys{};
     safe_VkWin32KeyedMutexAcquireReleaseInfoKHR(const VkWin32KeyedMutexAcquireReleaseInfoKHR* in_struct);
     safe_VkWin32KeyedMutexAcquireReleaseInfoKHR(const safe_VkWin32KeyedMutexAcquireReleaseInfoKHR& copy_src);
     safe_VkWin32KeyedMutexAcquireReleaseInfoKHR& operator=(const safe_VkWin32KeyedMutexAcquireReleaseInfoKHR& copy_src);
@@ -5013,7 +5013,7 @@ struct safe_VkWin32KeyedMutexAcquireReleaseInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkImportSemaphoreWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkSemaphoreImportFlags flags;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
@@ -5034,8 +5034,8 @@ struct safe_VkImportSemaphoreWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkExportSemaphoreWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
-    const SECURITY_ATTRIBUTES* pAttributes;
+    const void* pNext{};
+    const SECURITY_ATTRIBUTES* pAttributes{};
     DWORD dwAccess;
     LPCWSTR name;
     safe_VkExportSemaphoreWin32HandleInfoKHR(const VkExportSemaphoreWin32HandleInfoKHR* in_struct);
@@ -5053,11 +5053,11 @@ struct safe_VkExportSemaphoreWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkD3D12FenceSubmitInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t waitSemaphoreValuesCount;
-    const uint64_t* pWaitSemaphoreValues;
+    const uint64_t* pWaitSemaphoreValues{};
     uint32_t signalSemaphoreValuesCount;
-    const uint64_t* pSignalSemaphoreValues;
+    const uint64_t* pSignalSemaphoreValues{};
     safe_VkD3D12FenceSubmitInfoKHR(const VkD3D12FenceSubmitInfoKHR* in_struct);
     safe_VkD3D12FenceSubmitInfoKHR(const safe_VkD3D12FenceSubmitInfoKHR& copy_src);
     safe_VkD3D12FenceSubmitInfoKHR& operator=(const safe_VkD3D12FenceSubmitInfoKHR& copy_src);
@@ -5073,7 +5073,7 @@ struct safe_VkD3D12FenceSubmitInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkSemaphoreGetWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
     safe_VkSemaphoreGetWin32HandleInfoKHR(const VkSemaphoreGetWin32HandleInfoKHR* in_struct);
@@ -5090,7 +5090,7 @@ struct safe_VkSemaphoreGetWin32HandleInfoKHR {
 
 struct safe_VkImportSemaphoreFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkSemaphoreImportFlags flags;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
@@ -5108,7 +5108,7 @@ struct safe_VkImportSemaphoreFdInfoKHR {
 
 struct safe_VkSemaphoreGetFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
     safe_VkSemaphoreGetFdInfoKHR(const VkSemaphoreGetFdInfoKHR* in_struct);
@@ -5124,7 +5124,7 @@ struct safe_VkSemaphoreGetFdInfoKHR {
 
 struct safe_VkPhysicalDevicePushDescriptorPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxPushDescriptors;
     safe_VkPhysicalDevicePushDescriptorPropertiesKHR(const VkPhysicalDevicePushDescriptorPropertiesKHR* in_struct);
     safe_VkPhysicalDevicePushDescriptorPropertiesKHR(const safe_VkPhysicalDevicePushDescriptorPropertiesKHR& copy_src);
@@ -5139,7 +5139,7 @@ struct safe_VkPhysicalDevicePushDescriptorPropertiesKHR {
 
 struct safe_VkPresentRegionKHR {
     uint32_t rectangleCount;
-    const VkRectLayerKHR* pRectangles;
+    const VkRectLayerKHR* pRectangles{};
     safe_VkPresentRegionKHR(const VkPresentRegionKHR* in_struct);
     safe_VkPresentRegionKHR(const safe_VkPresentRegionKHR& copy_src);
     safe_VkPresentRegionKHR& operator=(const safe_VkPresentRegionKHR& copy_src);
@@ -5153,9 +5153,9 @@ struct safe_VkPresentRegionKHR {
 
 struct safe_VkPresentRegionsKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t swapchainCount;
-    safe_VkPresentRegionKHR* pRegions;
+    safe_VkPresentRegionKHR* pRegions{};
     safe_VkPresentRegionsKHR(const VkPresentRegionsKHR* in_struct);
     safe_VkPresentRegionsKHR(const safe_VkPresentRegionsKHR& copy_src);
     safe_VkPresentRegionsKHR& operator=(const safe_VkPresentRegionsKHR& copy_src);
@@ -5169,7 +5169,7 @@ struct safe_VkPresentRegionsKHR {
 
 struct safe_VkSharedPresentSurfaceCapabilitiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageUsageFlags sharedPresentSupportedUsageFlags;
     safe_VkSharedPresentSurfaceCapabilitiesKHR(const VkSharedPresentSurfaceCapabilitiesKHR* in_struct);
     safe_VkSharedPresentSurfaceCapabilitiesKHR(const safe_VkSharedPresentSurfaceCapabilitiesKHR& copy_src);
@@ -5185,7 +5185,7 @@ struct safe_VkSharedPresentSurfaceCapabilitiesKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkImportFenceWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFence fence;
     VkFenceImportFlags flags;
     VkExternalFenceHandleTypeFlagBits handleType;
@@ -5206,8 +5206,8 @@ struct safe_VkImportFenceWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkExportFenceWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
-    const SECURITY_ATTRIBUTES* pAttributes;
+    const void* pNext{};
+    const SECURITY_ATTRIBUTES* pAttributes{};
     DWORD dwAccess;
     LPCWSTR name;
     safe_VkExportFenceWin32HandleInfoKHR(const VkExportFenceWin32HandleInfoKHR* in_struct);
@@ -5225,7 +5225,7 @@ struct safe_VkExportFenceWin32HandleInfoKHR {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkFenceGetWin32HandleInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFence fence;
     VkExternalFenceHandleTypeFlagBits handleType;
     safe_VkFenceGetWin32HandleInfoKHR(const VkFenceGetWin32HandleInfoKHR* in_struct);
@@ -5242,7 +5242,7 @@ struct safe_VkFenceGetWin32HandleInfoKHR {
 
 struct safe_VkImportFenceFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFence fence;
     VkFenceImportFlags flags;
     VkExternalFenceHandleTypeFlagBits handleType;
@@ -5260,7 +5260,7 @@ struct safe_VkImportFenceFdInfoKHR {
 
 struct safe_VkFenceGetFdInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFence fence;
     VkExternalFenceHandleTypeFlagBits handleType;
     safe_VkFenceGetFdInfoKHR(const VkFenceGetFdInfoKHR* in_struct);
@@ -5276,7 +5276,7 @@ struct safe_VkFenceGetFdInfoKHR {
 
 struct safe_VkPhysicalDevicePerformanceQueryFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 performanceCounterQueryPools;
     VkBool32 performanceCounterMultipleQueryPools;
     safe_VkPhysicalDevicePerformanceQueryFeaturesKHR(const VkPhysicalDevicePerformanceQueryFeaturesKHR* in_struct);
@@ -5292,7 +5292,7 @@ struct safe_VkPhysicalDevicePerformanceQueryFeaturesKHR {
 
 struct safe_VkPhysicalDevicePerformanceQueryPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 allowCommandBufferQueryCopies;
     safe_VkPhysicalDevicePerformanceQueryPropertiesKHR(const VkPhysicalDevicePerformanceQueryPropertiesKHR* in_struct);
     safe_VkPhysicalDevicePerformanceQueryPropertiesKHR(const safe_VkPhysicalDevicePerformanceQueryPropertiesKHR& copy_src);
@@ -5307,7 +5307,7 @@ struct safe_VkPhysicalDevicePerformanceQueryPropertiesKHR {
 
 struct safe_VkPerformanceCounterKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPerformanceCounterUnitKHR unit;
     VkPerformanceCounterScopeKHR scope;
     VkPerformanceCounterStorageKHR storage;
@@ -5325,7 +5325,7 @@ struct safe_VkPerformanceCounterKHR {
 
 struct safe_VkPerformanceCounterDescriptionKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPerformanceCounterDescriptionFlagsKHR flags;
     char name[VK_MAX_DESCRIPTION_SIZE];
     char category[VK_MAX_DESCRIPTION_SIZE];
@@ -5343,10 +5343,10 @@ struct safe_VkPerformanceCounterDescriptionKHR {
 
 struct safe_VkQueryPoolPerformanceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t queueFamilyIndex;
     uint32_t counterIndexCount;
-    const uint32_t* pCounterIndices;
+    const uint32_t* pCounterIndices{};
     safe_VkQueryPoolPerformanceCreateInfoKHR(const VkQueryPoolPerformanceCreateInfoKHR* in_struct);
     safe_VkQueryPoolPerformanceCreateInfoKHR(const safe_VkQueryPoolPerformanceCreateInfoKHR& copy_src);
     safe_VkQueryPoolPerformanceCreateInfoKHR& operator=(const safe_VkQueryPoolPerformanceCreateInfoKHR& copy_src);
@@ -5360,7 +5360,7 @@ struct safe_VkQueryPoolPerformanceCreateInfoKHR {
 
 struct safe_VkAcquireProfilingLockInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAcquireProfilingLockFlagsKHR flags;
     uint64_t timeout;
     safe_VkAcquireProfilingLockInfoKHR(const VkAcquireProfilingLockInfoKHR* in_struct);
@@ -5376,7 +5376,7 @@ struct safe_VkAcquireProfilingLockInfoKHR {
 
 struct safe_VkPerformanceQuerySubmitInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t counterPassIndex;
     safe_VkPerformanceQuerySubmitInfoKHR(const VkPerformanceQuerySubmitInfoKHR* in_struct);
     safe_VkPerformanceQuerySubmitInfoKHR(const safe_VkPerformanceQuerySubmitInfoKHR& copy_src);
@@ -5391,7 +5391,7 @@ struct safe_VkPerformanceQuerySubmitInfoKHR {
 
 struct safe_VkPhysicalDeviceSurfaceInfo2KHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSurfaceKHR surface;
     safe_VkPhysicalDeviceSurfaceInfo2KHR(const VkPhysicalDeviceSurfaceInfo2KHR* in_struct);
     safe_VkPhysicalDeviceSurfaceInfo2KHR(const safe_VkPhysicalDeviceSurfaceInfo2KHR& copy_src);
@@ -5406,7 +5406,7 @@ struct safe_VkPhysicalDeviceSurfaceInfo2KHR {
 
 struct safe_VkSurfaceCapabilities2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSurfaceCapabilitiesKHR surfaceCapabilities;
     safe_VkSurfaceCapabilities2KHR(const VkSurfaceCapabilities2KHR* in_struct);
     safe_VkSurfaceCapabilities2KHR(const safe_VkSurfaceCapabilities2KHR& copy_src);
@@ -5421,7 +5421,7 @@ struct safe_VkSurfaceCapabilities2KHR {
 
 struct safe_VkSurfaceFormat2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSurfaceFormatKHR surfaceFormat;
     safe_VkSurfaceFormat2KHR(const VkSurfaceFormat2KHR* in_struct);
     safe_VkSurfaceFormat2KHR(const safe_VkSurfaceFormat2KHR& copy_src);
@@ -5436,7 +5436,7 @@ struct safe_VkSurfaceFormat2KHR {
 
 struct safe_VkDisplayProperties2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     safe_VkDisplayPropertiesKHR displayProperties;
     safe_VkDisplayProperties2KHR(const VkDisplayProperties2KHR* in_struct);
     safe_VkDisplayProperties2KHR(const safe_VkDisplayProperties2KHR& copy_src);
@@ -5451,7 +5451,7 @@ struct safe_VkDisplayProperties2KHR {
 
 struct safe_VkDisplayPlaneProperties2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDisplayPlanePropertiesKHR displayPlaneProperties;
     safe_VkDisplayPlaneProperties2KHR(const VkDisplayPlaneProperties2KHR* in_struct);
     safe_VkDisplayPlaneProperties2KHR(const safe_VkDisplayPlaneProperties2KHR& copy_src);
@@ -5466,7 +5466,7 @@ struct safe_VkDisplayPlaneProperties2KHR {
 
 struct safe_VkDisplayModeProperties2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDisplayModePropertiesKHR displayModeProperties;
     safe_VkDisplayModeProperties2KHR(const VkDisplayModeProperties2KHR* in_struct);
     safe_VkDisplayModeProperties2KHR(const safe_VkDisplayModeProperties2KHR& copy_src);
@@ -5481,7 +5481,7 @@ struct safe_VkDisplayModeProperties2KHR {
 
 struct safe_VkDisplayPlaneInfo2KHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDisplayModeKHR mode;
     uint32_t planeIndex;
     safe_VkDisplayPlaneInfo2KHR(const VkDisplayPlaneInfo2KHR* in_struct);
@@ -5497,7 +5497,7 @@ struct safe_VkDisplayPlaneInfo2KHR {
 
 struct safe_VkDisplayPlaneCapabilities2KHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDisplayPlaneCapabilitiesKHR capabilities;
     safe_VkDisplayPlaneCapabilities2KHR(const VkDisplayPlaneCapabilities2KHR* in_struct);
     safe_VkDisplayPlaneCapabilities2KHR(const safe_VkDisplayPlaneCapabilities2KHR& copy_src);
@@ -5513,7 +5513,7 @@ struct safe_VkDisplayPlaneCapabilities2KHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkPhysicalDevicePortabilitySubsetFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 constantAlphaColorBlendFactors;
     VkBool32 events;
     VkBool32 imageViewFormatReinterpretation;
@@ -5544,7 +5544,7 @@ struct safe_VkPhysicalDevicePortabilitySubsetFeaturesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t minVertexInputBindingStrideAlignment;
     safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR(const VkPhysicalDevicePortabilitySubsetPropertiesKHR* in_struct);
     safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR(const safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR& copy_src);
@@ -5560,7 +5560,7 @@ struct safe_VkPhysicalDevicePortabilitySubsetPropertiesKHR {
 
 struct safe_VkPhysicalDeviceShaderClockFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderSubgroupClock;
     VkBool32 shaderDeviceClock;
     safe_VkPhysicalDeviceShaderClockFeaturesKHR(const VkPhysicalDeviceShaderClockFeaturesKHR* in_struct);
@@ -5576,7 +5576,7 @@ struct safe_VkPhysicalDeviceShaderClockFeaturesKHR {
 
 struct safe_VkDeviceQueueGlobalPriorityCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkQueueGlobalPriorityKHR globalPriority;
     safe_VkDeviceQueueGlobalPriorityCreateInfoKHR(const VkDeviceQueueGlobalPriorityCreateInfoKHR* in_struct);
     safe_VkDeviceQueueGlobalPriorityCreateInfoKHR(const safe_VkDeviceQueueGlobalPriorityCreateInfoKHR& copy_src);
@@ -5591,7 +5591,7 @@ struct safe_VkDeviceQueueGlobalPriorityCreateInfoKHR {
 
 struct safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 globalPriorityQuery;
     safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR(const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR* in_struct);
     safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR(const safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR& copy_src);
@@ -5606,7 +5606,7 @@ struct safe_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR {
 
 struct safe_VkQueueFamilyGlobalPriorityPropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t priorityCount;
     VkQueueGlobalPriorityKHR priorities[VK_MAX_GLOBAL_PRIORITY_SIZE_KHR];
     safe_VkQueueFamilyGlobalPriorityPropertiesKHR(const VkQueueFamilyGlobalPriorityPropertiesKHR* in_struct);
@@ -5622,8 +5622,8 @@ struct safe_VkQueueFamilyGlobalPriorityPropertiesKHR {
 
 struct safe_VkFragmentShadingRateAttachmentInfoKHR {
     VkStructureType sType;
-    const void* pNext;
-    safe_VkAttachmentReference2* pFragmentShadingRateAttachment;
+    const void* pNext{};
+    safe_VkAttachmentReference2* pFragmentShadingRateAttachment{};
     VkExtent2D shadingRateAttachmentTexelSize;
     safe_VkFragmentShadingRateAttachmentInfoKHR(const VkFragmentShadingRateAttachmentInfoKHR* in_struct);
     safe_VkFragmentShadingRateAttachmentInfoKHR(const safe_VkFragmentShadingRateAttachmentInfoKHR& copy_src);
@@ -5638,7 +5638,7 @@ struct safe_VkFragmentShadingRateAttachmentInfoKHR {
 
 struct safe_VkPipelineFragmentShadingRateStateCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExtent2D fragmentSize;
     VkFragmentShadingRateCombinerOpKHR combinerOps[2];
     safe_VkPipelineFragmentShadingRateStateCreateInfoKHR(const VkPipelineFragmentShadingRateStateCreateInfoKHR* in_struct);
@@ -5654,7 +5654,7 @@ struct safe_VkPipelineFragmentShadingRateStateCreateInfoKHR {
 
 struct safe_VkPhysicalDeviceFragmentShadingRateFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 pipelineFragmentShadingRate;
     VkBool32 primitiveFragmentShadingRate;
     VkBool32 attachmentFragmentShadingRate;
@@ -5671,7 +5671,7 @@ struct safe_VkPhysicalDeviceFragmentShadingRateFeaturesKHR {
 
 struct safe_VkPhysicalDeviceFragmentShadingRatePropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExtent2D minFragmentShadingRateAttachmentTexelSize;
     VkExtent2D maxFragmentShadingRateAttachmentTexelSize;
     uint32_t maxFragmentShadingRateAttachmentTexelSizeAspectRatio;
@@ -5702,7 +5702,7 @@ struct safe_VkPhysicalDeviceFragmentShadingRatePropertiesKHR {
 
 struct safe_VkPhysicalDeviceFragmentShadingRateKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSampleCountFlags sampleCounts;
     VkExtent2D fragmentSize;
     safe_VkPhysicalDeviceFragmentShadingRateKHR(const VkPhysicalDeviceFragmentShadingRateKHR* in_struct);
@@ -5718,7 +5718,7 @@ struct safe_VkPhysicalDeviceFragmentShadingRateKHR {
 
 struct safe_VkSurfaceProtectedCapabilitiesKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 supportsProtected;
     safe_VkSurfaceProtectedCapabilitiesKHR(const VkSurfaceProtectedCapabilitiesKHR* in_struct);
     safe_VkSurfaceProtectedCapabilitiesKHR(const safe_VkSurfaceProtectedCapabilitiesKHR& copy_src);
@@ -5733,7 +5733,7 @@ struct safe_VkSurfaceProtectedCapabilitiesKHR {
 
 struct safe_VkPhysicalDevicePresentWaitFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 presentWait;
     safe_VkPhysicalDevicePresentWaitFeaturesKHR(const VkPhysicalDevicePresentWaitFeaturesKHR* in_struct);
     safe_VkPhysicalDevicePresentWaitFeaturesKHR(const safe_VkPhysicalDevicePresentWaitFeaturesKHR& copy_src);
@@ -5748,7 +5748,7 @@ struct safe_VkPhysicalDevicePresentWaitFeaturesKHR {
 
 struct safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 pipelineExecutableInfo;
     safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR(const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* in_struct);
     safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR(const safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR& copy_src);
@@ -5763,7 +5763,7 @@ struct safe_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
 
 struct safe_VkPipelineInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipeline pipeline;
     safe_VkPipelineInfoKHR(const VkPipelineInfoKHR* in_struct);
     safe_VkPipelineInfoKHR(const safe_VkPipelineInfoKHR& copy_src);
@@ -5778,7 +5778,7 @@ struct safe_VkPipelineInfoKHR {
 
 struct safe_VkPipelineExecutablePropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkShaderStageFlags stages;
     char name[VK_MAX_DESCRIPTION_SIZE];
     char description[VK_MAX_DESCRIPTION_SIZE];
@@ -5796,7 +5796,7 @@ struct safe_VkPipelineExecutablePropertiesKHR {
 
 struct safe_VkPipelineExecutableInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipeline pipeline;
     uint32_t executableIndex;
     safe_VkPipelineExecutableInfoKHR(const VkPipelineExecutableInfoKHR* in_struct);
@@ -5812,7 +5812,7 @@ struct safe_VkPipelineExecutableInfoKHR {
 
 struct safe_VkPipelineExecutableStatisticKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     char name[VK_MAX_DESCRIPTION_SIZE];
     char description[VK_MAX_DESCRIPTION_SIZE];
     VkPipelineExecutableStatisticFormatKHR format;
@@ -5830,12 +5830,12 @@ struct safe_VkPipelineExecutableStatisticKHR {
 
 struct safe_VkPipelineExecutableInternalRepresentationKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     char name[VK_MAX_DESCRIPTION_SIZE];
     char description[VK_MAX_DESCRIPTION_SIZE];
     VkBool32 isText;
     size_t dataSize;
-    void* pData;
+    void* pData{};
     safe_VkPipelineExecutableInternalRepresentationKHR(const VkPipelineExecutableInternalRepresentationKHR* in_struct);
     safe_VkPipelineExecutableInternalRepresentationKHR(const safe_VkPipelineExecutableInternalRepresentationKHR& copy_src);
     safe_VkPipelineExecutableInternalRepresentationKHR& operator=(const safe_VkPipelineExecutableInternalRepresentationKHR& copy_src);
@@ -5849,9 +5849,9 @@ struct safe_VkPipelineExecutableInternalRepresentationKHR {
 
 struct safe_VkPipelineLibraryCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t libraryCount;
-    VkPipeline* pLibraries;
+    VkPipeline* pLibraries{};
     safe_VkPipelineLibraryCreateInfoKHR(const VkPipelineLibraryCreateInfoKHR* in_struct);
     safe_VkPipelineLibraryCreateInfoKHR(const safe_VkPipelineLibraryCreateInfoKHR& copy_src);
     safe_VkPipelineLibraryCreateInfoKHR& operator=(const safe_VkPipelineLibraryCreateInfoKHR& copy_src);
@@ -5865,9 +5865,9 @@ struct safe_VkPipelineLibraryCreateInfoKHR {
 
 struct safe_VkPresentIdKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t swapchainCount;
-    const uint64_t* pPresentIds;
+    const uint64_t* pPresentIds{};
     safe_VkPresentIdKHR(const VkPresentIdKHR* in_struct);
     safe_VkPresentIdKHR(const safe_VkPresentIdKHR& copy_src);
     safe_VkPresentIdKHR& operator=(const safe_VkPresentIdKHR& copy_src);
@@ -5881,7 +5881,7 @@ struct safe_VkPresentIdKHR {
 
 struct safe_VkPhysicalDevicePresentIdFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 presentId;
     safe_VkPhysicalDevicePresentIdFeaturesKHR(const VkPhysicalDevicePresentIdFeaturesKHR* in_struct);
     safe_VkPhysicalDevicePresentIdFeaturesKHR(const safe_VkPhysicalDevicePresentIdFeaturesKHR& copy_src);
@@ -5897,16 +5897,16 @@ struct safe_VkPhysicalDevicePresentIdFeaturesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoEncodeFlagsKHR flags;
     uint32_t qualityLevel;
     VkBuffer dstBitstreamBuffer;
     VkDeviceSize dstBitstreamBufferOffset;
     VkDeviceSize dstBitstreamBufferMaxRange;
     safe_VkVideoPictureResourceKHR srcPictureResource;
-    safe_VkVideoReferenceSlotKHR* pSetupReferenceSlot;
+    safe_VkVideoReferenceSlotKHR* pSetupReferenceSlot{};
     uint32_t referenceSlotCount;
-    safe_VkVideoReferenceSlotKHR* pReferenceSlots;
+    safe_VkVideoReferenceSlotKHR* pReferenceSlots{};
     uint32_t precedingExternallyEncodedBytes;
     safe_VkVideoEncodeInfoKHR(const VkVideoEncodeInfoKHR* in_struct);
     safe_VkVideoEncodeInfoKHR(const safe_VkVideoEncodeInfoKHR& copy_src);
@@ -5923,7 +5923,7 @@ struct safe_VkVideoEncodeInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeCapabilitiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoEncodeCapabilityFlagsKHR flags;
     VkVideoEncodeRateControlModeFlagsKHR rateControlModes;
     uint8_t rateControlLayerCount;
@@ -5944,7 +5944,7 @@ struct safe_VkVideoEncodeCapabilitiesKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeRateControlLayerInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t averageBitrate;
     uint32_t maxBitrate;
     uint32_t frameRateNumerator;
@@ -5966,11 +5966,11 @@ struct safe_VkVideoEncodeRateControlLayerInfoKHR {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeRateControlInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkVideoEncodeRateControlFlagsKHR flags;
     VkVideoEncodeRateControlModeFlagBitsKHR rateControlMode;
     uint8_t layerCount;
-    safe_VkVideoEncodeRateControlLayerInfoKHR* pLayerConfigs;
+    safe_VkVideoEncodeRateControlLayerInfoKHR* pLayerConfigs{};
     safe_VkVideoEncodeRateControlInfoKHR(const VkVideoEncodeRateControlInfoKHR* in_struct);
     safe_VkVideoEncodeRateControlInfoKHR(const safe_VkVideoEncodeRateControlInfoKHR& copy_src);
     safe_VkVideoEncodeRateControlInfoKHR& operator=(const safe_VkVideoEncodeRateControlInfoKHR& copy_src);
@@ -5985,7 +5985,7 @@ struct safe_VkVideoEncodeRateControlInfoKHR {
 
 struct safe_VkQueueFamilyCheckpointProperties2NV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPipelineStageFlags2 checkpointExecutionStageMask;
     safe_VkQueueFamilyCheckpointProperties2NV(const VkQueueFamilyCheckpointProperties2NV* in_struct);
     safe_VkQueueFamilyCheckpointProperties2NV(const safe_VkQueueFamilyCheckpointProperties2NV& copy_src);
@@ -6000,9 +6000,9 @@ struct safe_VkQueueFamilyCheckpointProperties2NV {
 
 struct safe_VkCheckpointData2NV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPipelineStageFlags2 stage;
-    void* pCheckpointMarker;
+    void* pCheckpointMarker{};
     safe_VkCheckpointData2NV(const VkCheckpointData2NV* in_struct);
     safe_VkCheckpointData2NV(const safe_VkCheckpointData2NV& copy_src);
     safe_VkCheckpointData2NV& operator=(const safe_VkCheckpointData2NV& copy_src);
@@ -6016,7 +6016,7 @@ struct safe_VkCheckpointData2NV {
 
 struct safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderSubgroupUniformControlFlow;
     safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR(const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* in_struct);
     safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR(const safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR& copy_src);
@@ -6031,7 +6031,7 @@ struct safe_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR {
 
 struct safe_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 workgroupMemoryExplicitLayout;
     VkBool32 workgroupMemoryExplicitLayoutScalarBlockLayout;
     VkBool32 workgroupMemoryExplicitLayout8BitAccess;
@@ -6049,10 +6049,10 @@ struct safe_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR {
 
 struct safe_VkDebugReportCallbackCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDebugReportFlagsEXT flags;
     PFN_vkDebugReportCallbackEXT pfnCallback;
-    void* pUserData;
+    void* pUserData{};
     safe_VkDebugReportCallbackCreateInfoEXT(const VkDebugReportCallbackCreateInfoEXT* in_struct);
     safe_VkDebugReportCallbackCreateInfoEXT(const safe_VkDebugReportCallbackCreateInfoEXT& copy_src);
     safe_VkDebugReportCallbackCreateInfoEXT& operator=(const safe_VkDebugReportCallbackCreateInfoEXT& copy_src);
@@ -6066,7 +6066,7 @@ struct safe_VkDebugReportCallbackCreateInfoEXT {
 
 struct safe_VkPipelineRasterizationStateRasterizationOrderAMD {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRasterizationOrderAMD rasterizationOrder;
     safe_VkPipelineRasterizationStateRasterizationOrderAMD(const VkPipelineRasterizationStateRasterizationOrderAMD* in_struct);
     safe_VkPipelineRasterizationStateRasterizationOrderAMD(const safe_VkPipelineRasterizationStateRasterizationOrderAMD& copy_src);
@@ -6081,10 +6081,10 @@ struct safe_VkPipelineRasterizationStateRasterizationOrderAMD {
 
 struct safe_VkDebugMarkerObjectNameInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDebugReportObjectTypeEXT objectType;
     uint64_t object;
-    const char* pObjectName;
+    const char* pObjectName{};
     safe_VkDebugMarkerObjectNameInfoEXT(const VkDebugMarkerObjectNameInfoEXT* in_struct);
     safe_VkDebugMarkerObjectNameInfoEXT(const safe_VkDebugMarkerObjectNameInfoEXT& copy_src);
     safe_VkDebugMarkerObjectNameInfoEXT& operator=(const safe_VkDebugMarkerObjectNameInfoEXT& copy_src);
@@ -6098,12 +6098,12 @@ struct safe_VkDebugMarkerObjectNameInfoEXT {
 
 struct safe_VkDebugMarkerObjectTagInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDebugReportObjectTypeEXT objectType;
     uint64_t object;
     uint64_t tagName;
     size_t tagSize;
-    const void* pTag;
+    const void* pTag{};
     safe_VkDebugMarkerObjectTagInfoEXT(const VkDebugMarkerObjectTagInfoEXT* in_struct);
     safe_VkDebugMarkerObjectTagInfoEXT(const safe_VkDebugMarkerObjectTagInfoEXT& copy_src);
     safe_VkDebugMarkerObjectTagInfoEXT& operator=(const safe_VkDebugMarkerObjectTagInfoEXT& copy_src);
@@ -6117,8 +6117,8 @@ struct safe_VkDebugMarkerObjectTagInfoEXT {
 
 struct safe_VkDebugMarkerMarkerInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    const char* pMarkerName;
+    const void* pNext{};
+    const char* pMarkerName{};
     float color[4];
     safe_VkDebugMarkerMarkerInfoEXT(const VkDebugMarkerMarkerInfoEXT* in_struct);
     safe_VkDebugMarkerMarkerInfoEXT(const safe_VkDebugMarkerMarkerInfoEXT& copy_src);
@@ -6133,7 +6133,7 @@ struct safe_VkDebugMarkerMarkerInfoEXT {
 
 struct safe_VkDedicatedAllocationImageCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 dedicatedAllocation;
     safe_VkDedicatedAllocationImageCreateInfoNV(const VkDedicatedAllocationImageCreateInfoNV* in_struct);
     safe_VkDedicatedAllocationImageCreateInfoNV(const safe_VkDedicatedAllocationImageCreateInfoNV& copy_src);
@@ -6148,7 +6148,7 @@ struct safe_VkDedicatedAllocationImageCreateInfoNV {
 
 struct safe_VkDedicatedAllocationBufferCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 dedicatedAllocation;
     safe_VkDedicatedAllocationBufferCreateInfoNV(const VkDedicatedAllocationBufferCreateInfoNV* in_struct);
     safe_VkDedicatedAllocationBufferCreateInfoNV(const safe_VkDedicatedAllocationBufferCreateInfoNV& copy_src);
@@ -6163,7 +6163,7 @@ struct safe_VkDedicatedAllocationBufferCreateInfoNV {
 
 struct safe_VkDedicatedAllocationMemoryAllocateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImage image;
     VkBuffer buffer;
     safe_VkDedicatedAllocationMemoryAllocateInfoNV(const VkDedicatedAllocationMemoryAllocateInfoNV* in_struct);
@@ -6179,7 +6179,7 @@ struct safe_VkDedicatedAllocationMemoryAllocateInfoNV {
 
 struct safe_VkPhysicalDeviceTransformFeedbackFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 transformFeedback;
     VkBool32 geometryStreams;
     safe_VkPhysicalDeviceTransformFeedbackFeaturesEXT(const VkPhysicalDeviceTransformFeedbackFeaturesEXT* in_struct);
@@ -6195,7 +6195,7 @@ struct safe_VkPhysicalDeviceTransformFeedbackFeaturesEXT {
 
 struct safe_VkPhysicalDeviceTransformFeedbackPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxTransformFeedbackStreams;
     uint32_t maxTransformFeedbackBuffers;
     VkDeviceSize maxTransformFeedbackBufferSize;
@@ -6219,7 +6219,7 @@ struct safe_VkPhysicalDeviceTransformFeedbackPropertiesEXT {
 
 struct safe_VkPipelineRasterizationStateStreamCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineRasterizationStateStreamCreateFlagsEXT flags;
     uint32_t rasterizationStream;
     safe_VkPipelineRasterizationStateStreamCreateInfoEXT(const VkPipelineRasterizationStateStreamCreateInfoEXT* in_struct);
@@ -6235,9 +6235,9 @@ struct safe_VkPipelineRasterizationStateStreamCreateInfoEXT {
 
 struct safe_VkCuModuleCreateInfoNVX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     size_t dataSize;
-    const void* pData;
+    const void* pData{};
     safe_VkCuModuleCreateInfoNVX(const VkCuModuleCreateInfoNVX* in_struct);
     safe_VkCuModuleCreateInfoNVX(const safe_VkCuModuleCreateInfoNVX& copy_src);
     safe_VkCuModuleCreateInfoNVX& operator=(const safe_VkCuModuleCreateInfoNVX& copy_src);
@@ -6251,9 +6251,9 @@ struct safe_VkCuModuleCreateInfoNVX {
 
 struct safe_VkCuFunctionCreateInfoNVX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCuModuleNVX module;
-    const char* pName;
+    const char* pName{};
     safe_VkCuFunctionCreateInfoNVX(const VkCuFunctionCreateInfoNVX* in_struct);
     safe_VkCuFunctionCreateInfoNVX(const safe_VkCuFunctionCreateInfoNVX& copy_src);
     safe_VkCuFunctionCreateInfoNVX& operator=(const safe_VkCuFunctionCreateInfoNVX& copy_src);
@@ -6267,7 +6267,7 @@ struct safe_VkCuFunctionCreateInfoNVX {
 
 struct safe_VkCuLaunchInfoNVX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCuFunctionNVX function;
     uint32_t gridDimX;
     uint32_t gridDimY;
@@ -6277,9 +6277,9 @@ struct safe_VkCuLaunchInfoNVX {
     uint32_t blockDimZ;
     uint32_t sharedMemBytes;
     size_t paramCount;
-    const void* const * pParams;
+    const void* const * pParams{};
     size_t extraCount;
-    const void* const * pExtras;
+    const void* const * pExtras{};
     safe_VkCuLaunchInfoNVX(const VkCuLaunchInfoNVX* in_struct);
     safe_VkCuLaunchInfoNVX(const safe_VkCuLaunchInfoNVX& copy_src);
     safe_VkCuLaunchInfoNVX& operator=(const safe_VkCuLaunchInfoNVX& copy_src);
@@ -6293,7 +6293,7 @@ struct safe_VkCuLaunchInfoNVX {
 
 struct safe_VkImageViewHandleInfoNVX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImageView imageView;
     VkDescriptorType descriptorType;
     VkSampler sampler;
@@ -6310,7 +6310,7 @@ struct safe_VkImageViewHandleInfoNVX {
 
 struct safe_VkImageViewAddressPropertiesNVX {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceAddress deviceAddress;
     VkDeviceSize size;
     safe_VkImageViewAddressPropertiesNVX(const VkImageViewAddressPropertiesNVX* in_struct);
@@ -6327,7 +6327,7 @@ struct safe_VkImageViewAddressPropertiesNVX {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264CapabilitiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoEncodeH264CapabilityFlagsEXT flags;
     VkVideoEncodeH264InputModeFlagsEXT inputModeFlags;
     VkVideoEncodeH264OutputModeFlagsEXT outputModeFlags;
@@ -6354,11 +6354,11 @@ struct safe_VkVideoEncodeH264CapabilitiesEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264SessionParametersAddInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t spsStdCount;
-    const StdVideoH264SequenceParameterSet* pSpsStd;
+    const StdVideoH264SequenceParameterSet* pSpsStd{};
     uint32_t ppsStdCount;
-    const StdVideoH264PictureParameterSet* pPpsStd;
+    const StdVideoH264PictureParameterSet* pPpsStd{};
     safe_VkVideoEncodeH264SessionParametersAddInfoEXT(const VkVideoEncodeH264SessionParametersAddInfoEXT* in_struct);
     safe_VkVideoEncodeH264SessionParametersAddInfoEXT(const safe_VkVideoEncodeH264SessionParametersAddInfoEXT& copy_src);
     safe_VkVideoEncodeH264SessionParametersAddInfoEXT& operator=(const safe_VkVideoEncodeH264SessionParametersAddInfoEXT& copy_src);
@@ -6374,10 +6374,10 @@ struct safe_VkVideoEncodeH264SessionParametersAddInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264SessionParametersCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxSpsStdCount;
     uint32_t maxPpsStdCount;
-    safe_VkVideoEncodeH264SessionParametersAddInfoEXT* pParametersAddInfo;
+    safe_VkVideoEncodeH264SessionParametersAddInfoEXT* pParametersAddInfo{};
     safe_VkVideoEncodeH264SessionParametersCreateInfoEXT(const VkVideoEncodeH264SessionParametersCreateInfoEXT* in_struct);
     safe_VkVideoEncodeH264SessionParametersCreateInfoEXT(const safe_VkVideoEncodeH264SessionParametersCreateInfoEXT& copy_src);
     safe_VkVideoEncodeH264SessionParametersCreateInfoEXT& operator=(const safe_VkVideoEncodeH264SessionParametersCreateInfoEXT& copy_src);
@@ -6393,9 +6393,9 @@ struct safe_VkVideoEncodeH264SessionParametersCreateInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264DpbSlotInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     int8_t slotIndex;
-    const StdVideoEncodeH264ReferenceInfo* pStdReferenceInfo;
+    const StdVideoEncodeH264ReferenceInfo* pStdReferenceInfo{};
     safe_VkVideoEncodeH264DpbSlotInfoEXT(const VkVideoEncodeH264DpbSlotInfoEXT* in_struct);
     safe_VkVideoEncodeH264DpbSlotInfoEXT(const safe_VkVideoEncodeH264DpbSlotInfoEXT& copy_src);
     safe_VkVideoEncodeH264DpbSlotInfoEXT& operator=(const safe_VkVideoEncodeH264DpbSlotInfoEXT& copy_src);
@@ -6411,12 +6411,12 @@ struct safe_VkVideoEncodeH264DpbSlotInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264ReferenceListsEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t referenceList0EntryCount;
-    safe_VkVideoEncodeH264DpbSlotInfoEXT* pReferenceList0Entries;
+    safe_VkVideoEncodeH264DpbSlotInfoEXT* pReferenceList0Entries{};
     uint8_t referenceList1EntryCount;
-    safe_VkVideoEncodeH264DpbSlotInfoEXT* pReferenceList1Entries;
-    const StdVideoEncodeH264RefMemMgmtCtrlOperations* pMemMgmtCtrlOperations;
+    safe_VkVideoEncodeH264DpbSlotInfoEXT* pReferenceList1Entries{};
+    const StdVideoEncodeH264RefMemMgmtCtrlOperations* pMemMgmtCtrlOperations{};
     safe_VkVideoEncodeH264ReferenceListsEXT(const VkVideoEncodeH264ReferenceListsEXT* in_struct);
     safe_VkVideoEncodeH264ReferenceListsEXT(const safe_VkVideoEncodeH264ReferenceListsEXT& copy_src);
     safe_VkVideoEncodeH264ReferenceListsEXT& operator=(const safe_VkVideoEncodeH264ReferenceListsEXT& copy_src);
@@ -6432,10 +6432,10 @@ struct safe_VkVideoEncodeH264ReferenceListsEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264NaluSliceEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t mbCount;
-    safe_VkVideoEncodeH264ReferenceListsEXT* pReferenceFinalLists;
-    const StdVideoEncodeH264SliceHeader* pSliceHeaderStd;
+    safe_VkVideoEncodeH264ReferenceListsEXT* pReferenceFinalLists{};
+    const StdVideoEncodeH264SliceHeader* pSliceHeaderStd{};
     safe_VkVideoEncodeH264NaluSliceEXT(const VkVideoEncodeH264NaluSliceEXT* in_struct);
     safe_VkVideoEncodeH264NaluSliceEXT(const safe_VkVideoEncodeH264NaluSliceEXT& copy_src);
     safe_VkVideoEncodeH264NaluSliceEXT& operator=(const safe_VkVideoEncodeH264NaluSliceEXT& copy_src);
@@ -6451,11 +6451,11 @@ struct safe_VkVideoEncodeH264NaluSliceEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264VclFrameInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    safe_VkVideoEncodeH264ReferenceListsEXT* pReferenceFinalLists;
+    const void* pNext{};
+    safe_VkVideoEncodeH264ReferenceListsEXT* pReferenceFinalLists{};
     uint32_t naluSliceEntryCount;
-    safe_VkVideoEncodeH264NaluSliceEXT* pNaluSliceEntries;
-    const StdVideoEncodeH264PictureInfo* pCurrentPictureInfo;
+    safe_VkVideoEncodeH264NaluSliceEXT* pNaluSliceEntries{};
+    const StdVideoEncodeH264PictureInfo* pCurrentPictureInfo{};
     safe_VkVideoEncodeH264VclFrameInfoEXT(const VkVideoEncodeH264VclFrameInfoEXT* in_struct);
     safe_VkVideoEncodeH264VclFrameInfoEXT(const safe_VkVideoEncodeH264VclFrameInfoEXT& copy_src);
     safe_VkVideoEncodeH264VclFrameInfoEXT& operator=(const safe_VkVideoEncodeH264VclFrameInfoEXT& copy_src);
@@ -6471,11 +6471,11 @@ struct safe_VkVideoEncodeH264VclFrameInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264EmitPictureParametersEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t spsId;
     VkBool32 emitSpsEnable;
     uint32_t ppsIdEntryCount;
-    const uint8_t* ppsIdEntries;
+    const uint8_t* ppsIdEntries{};
     safe_VkVideoEncodeH264EmitPictureParametersEXT(const VkVideoEncodeH264EmitPictureParametersEXT* in_struct);
     safe_VkVideoEncodeH264EmitPictureParametersEXT(const safe_VkVideoEncodeH264EmitPictureParametersEXT& copy_src);
     safe_VkVideoEncodeH264EmitPictureParametersEXT& operator=(const safe_VkVideoEncodeH264EmitPictureParametersEXT& copy_src);
@@ -6491,7 +6491,7 @@ struct safe_VkVideoEncodeH264EmitPictureParametersEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264ProfileEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     StdVideoH264ProfileIdc stdProfileIdc;
     safe_VkVideoEncodeH264ProfileEXT(const VkVideoEncodeH264ProfileEXT* in_struct);
     safe_VkVideoEncodeH264ProfileEXT(const safe_VkVideoEncodeH264ProfileEXT& copy_src);
@@ -6508,7 +6508,7 @@ struct safe_VkVideoEncodeH264ProfileEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264RateControlInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t gopFrameCount;
     uint32_t idrPeriod;
     uint32_t consecutiveBFrameCount;
@@ -6529,7 +6529,7 @@ struct safe_VkVideoEncodeH264RateControlInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH264RateControlLayerInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t temporalLayerId;
     VkBool32 useInitialRcQp;
     VkVideoEncodeH264QpEXT initialRcQp;
@@ -6554,7 +6554,7 @@ struct safe_VkVideoEncodeH264RateControlLayerInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265CapabilitiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkVideoEncodeH265CapabilityFlagsEXT flags;
     VkVideoEncodeH265InputModeFlagsEXT inputModeFlags;
     VkVideoEncodeH265OutputModeFlagsEXT outputModeFlags;
@@ -6590,13 +6590,13 @@ struct safe_VkVideoEncodeH265CapabilitiesEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265SessionParametersAddInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t vpsStdCount;
-    const StdVideoH265VideoParameterSet* pVpsStd;
+    const StdVideoH265VideoParameterSet* pVpsStd{};
     uint32_t spsStdCount;
-    const StdVideoH265SequenceParameterSet* pSpsStd;
+    const StdVideoH265SequenceParameterSet* pSpsStd{};
     uint32_t ppsStdCount;
-    const StdVideoH265PictureParameterSet* pPpsStd;
+    const StdVideoH265PictureParameterSet* pPpsStd{};
     safe_VkVideoEncodeH265SessionParametersAddInfoEXT(const VkVideoEncodeH265SessionParametersAddInfoEXT* in_struct);
     safe_VkVideoEncodeH265SessionParametersAddInfoEXT(const safe_VkVideoEncodeH265SessionParametersAddInfoEXT& copy_src);
     safe_VkVideoEncodeH265SessionParametersAddInfoEXT& operator=(const safe_VkVideoEncodeH265SessionParametersAddInfoEXT& copy_src);
@@ -6612,11 +6612,11 @@ struct safe_VkVideoEncodeH265SessionParametersAddInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265SessionParametersCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxVpsStdCount;
     uint32_t maxSpsStdCount;
     uint32_t maxPpsStdCount;
-    safe_VkVideoEncodeH265SessionParametersAddInfoEXT* pParametersAddInfo;
+    safe_VkVideoEncodeH265SessionParametersAddInfoEXT* pParametersAddInfo{};
     safe_VkVideoEncodeH265SessionParametersCreateInfoEXT(const VkVideoEncodeH265SessionParametersCreateInfoEXT* in_struct);
     safe_VkVideoEncodeH265SessionParametersCreateInfoEXT(const safe_VkVideoEncodeH265SessionParametersCreateInfoEXT& copy_src);
     safe_VkVideoEncodeH265SessionParametersCreateInfoEXT& operator=(const safe_VkVideoEncodeH265SessionParametersCreateInfoEXT& copy_src);
@@ -6632,9 +6632,9 @@ struct safe_VkVideoEncodeH265SessionParametersCreateInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265DpbSlotInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     int8_t slotIndex;
-    const StdVideoEncodeH265ReferenceInfo* pStdReferenceInfo;
+    const StdVideoEncodeH265ReferenceInfo* pStdReferenceInfo{};
     safe_VkVideoEncodeH265DpbSlotInfoEXT(const VkVideoEncodeH265DpbSlotInfoEXT* in_struct);
     safe_VkVideoEncodeH265DpbSlotInfoEXT(const safe_VkVideoEncodeH265DpbSlotInfoEXT& copy_src);
     safe_VkVideoEncodeH265DpbSlotInfoEXT& operator=(const safe_VkVideoEncodeH265DpbSlotInfoEXT& copy_src);
@@ -6650,12 +6650,12 @@ struct safe_VkVideoEncodeH265DpbSlotInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265ReferenceListsEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t referenceList0EntryCount;
-    safe_VkVideoEncodeH265DpbSlotInfoEXT* pReferenceList0Entries;
+    safe_VkVideoEncodeH265DpbSlotInfoEXT* pReferenceList0Entries{};
     uint8_t referenceList1EntryCount;
-    safe_VkVideoEncodeH265DpbSlotInfoEXT* pReferenceList1Entries;
-    const StdVideoEncodeH265ReferenceModifications* pReferenceModifications;
+    safe_VkVideoEncodeH265DpbSlotInfoEXT* pReferenceList1Entries{};
+    const StdVideoEncodeH265ReferenceModifications* pReferenceModifications{};
     safe_VkVideoEncodeH265ReferenceListsEXT(const VkVideoEncodeH265ReferenceListsEXT* in_struct);
     safe_VkVideoEncodeH265ReferenceListsEXT(const safe_VkVideoEncodeH265ReferenceListsEXT& copy_src);
     safe_VkVideoEncodeH265ReferenceListsEXT& operator=(const safe_VkVideoEncodeH265ReferenceListsEXT& copy_src);
@@ -6671,10 +6671,10 @@ struct safe_VkVideoEncodeH265ReferenceListsEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265NaluSliceSegmentEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t ctbCount;
-    safe_VkVideoEncodeH265ReferenceListsEXT* pReferenceFinalLists;
-    const StdVideoEncodeH265SliceSegmentHeader* pSliceSegmentHeaderStd;
+    safe_VkVideoEncodeH265ReferenceListsEXT* pReferenceFinalLists{};
+    const StdVideoEncodeH265SliceSegmentHeader* pSliceSegmentHeaderStd{};
     safe_VkVideoEncodeH265NaluSliceSegmentEXT(const VkVideoEncodeH265NaluSliceSegmentEXT* in_struct);
     safe_VkVideoEncodeH265NaluSliceSegmentEXT(const safe_VkVideoEncodeH265NaluSliceSegmentEXT& copy_src);
     safe_VkVideoEncodeH265NaluSliceSegmentEXT& operator=(const safe_VkVideoEncodeH265NaluSliceSegmentEXT& copy_src);
@@ -6690,11 +6690,11 @@ struct safe_VkVideoEncodeH265NaluSliceSegmentEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265VclFrameInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    safe_VkVideoEncodeH265ReferenceListsEXT* pReferenceFinalLists;
+    const void* pNext{};
+    safe_VkVideoEncodeH265ReferenceListsEXT* pReferenceFinalLists{};
     uint32_t naluSliceSegmentEntryCount;
-    safe_VkVideoEncodeH265NaluSliceSegmentEXT* pNaluSliceSegmentEntries;
-    const StdVideoEncodeH265PictureInfo* pCurrentPictureInfo;
+    safe_VkVideoEncodeH265NaluSliceSegmentEXT* pNaluSliceSegmentEntries{};
+    const StdVideoEncodeH265PictureInfo* pCurrentPictureInfo{};
     safe_VkVideoEncodeH265VclFrameInfoEXT(const VkVideoEncodeH265VclFrameInfoEXT* in_struct);
     safe_VkVideoEncodeH265VclFrameInfoEXT(const safe_VkVideoEncodeH265VclFrameInfoEXT& copy_src);
     safe_VkVideoEncodeH265VclFrameInfoEXT& operator=(const safe_VkVideoEncodeH265VclFrameInfoEXT& copy_src);
@@ -6710,13 +6710,13 @@ struct safe_VkVideoEncodeH265VclFrameInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265EmitPictureParametersEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t vpsId;
     uint8_t spsId;
     VkBool32 emitVpsEnable;
     VkBool32 emitSpsEnable;
     uint32_t ppsIdEntryCount;
-    const uint8_t* ppsIdEntries;
+    const uint8_t* ppsIdEntries{};
     safe_VkVideoEncodeH265EmitPictureParametersEXT(const VkVideoEncodeH265EmitPictureParametersEXT* in_struct);
     safe_VkVideoEncodeH265EmitPictureParametersEXT(const safe_VkVideoEncodeH265EmitPictureParametersEXT& copy_src);
     safe_VkVideoEncodeH265EmitPictureParametersEXT& operator=(const safe_VkVideoEncodeH265EmitPictureParametersEXT& copy_src);
@@ -6732,7 +6732,7 @@ struct safe_VkVideoEncodeH265EmitPictureParametersEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265ProfileEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     StdVideoH265ProfileIdc stdProfileIdc;
     safe_VkVideoEncodeH265ProfileEXT(const VkVideoEncodeH265ProfileEXT* in_struct);
     safe_VkVideoEncodeH265ProfileEXT(const safe_VkVideoEncodeH265ProfileEXT& copy_src);
@@ -6749,7 +6749,7 @@ struct safe_VkVideoEncodeH265ProfileEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265RateControlInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t gopFrameCount;
     uint32_t idrPeriod;
     uint32_t consecutiveBFrameCount;
@@ -6770,7 +6770,7 @@ struct safe_VkVideoEncodeH265RateControlInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoEncodeH265RateControlLayerInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint8_t temporalId;
     VkBool32 useInitialRcQp;
     VkVideoEncodeH265QpEXT initialRcQp;
@@ -6795,7 +6795,7 @@ struct safe_VkVideoEncodeH265RateControlLayerInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264ProfileEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     StdVideoH264ProfileIdc stdProfileIdc;
     VkVideoDecodeH264PictureLayoutFlagsEXT pictureLayout;
     safe_VkVideoDecodeH264ProfileEXT(const VkVideoDecodeH264ProfileEXT* in_struct);
@@ -6813,7 +6813,7 @@ struct safe_VkVideoDecodeH264ProfileEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264CapabilitiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     StdVideoH264Level maxLevel;
     VkOffset2D fieldOffsetGranularity;
     safe_VkVideoDecodeH264CapabilitiesEXT(const VkVideoDecodeH264CapabilitiesEXT* in_struct);
@@ -6831,11 +6831,11 @@ struct safe_VkVideoDecodeH264CapabilitiesEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264SessionParametersAddInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t spsStdCount;
-    const StdVideoH264SequenceParameterSet* pSpsStd;
+    const StdVideoH264SequenceParameterSet* pSpsStd{};
     uint32_t ppsStdCount;
-    const StdVideoH264PictureParameterSet* pPpsStd;
+    const StdVideoH264PictureParameterSet* pPpsStd{};
     safe_VkVideoDecodeH264SessionParametersAddInfoEXT(const VkVideoDecodeH264SessionParametersAddInfoEXT* in_struct);
     safe_VkVideoDecodeH264SessionParametersAddInfoEXT(const safe_VkVideoDecodeH264SessionParametersAddInfoEXT& copy_src);
     safe_VkVideoDecodeH264SessionParametersAddInfoEXT& operator=(const safe_VkVideoDecodeH264SessionParametersAddInfoEXT& copy_src);
@@ -6851,10 +6851,10 @@ struct safe_VkVideoDecodeH264SessionParametersAddInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264SessionParametersCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxSpsStdCount;
     uint32_t maxPpsStdCount;
-    safe_VkVideoDecodeH264SessionParametersAddInfoEXT* pParametersAddInfo;
+    safe_VkVideoDecodeH264SessionParametersAddInfoEXT* pParametersAddInfo{};
     safe_VkVideoDecodeH264SessionParametersCreateInfoEXT(const VkVideoDecodeH264SessionParametersCreateInfoEXT* in_struct);
     safe_VkVideoDecodeH264SessionParametersCreateInfoEXT(const safe_VkVideoDecodeH264SessionParametersCreateInfoEXT& copy_src);
     safe_VkVideoDecodeH264SessionParametersCreateInfoEXT& operator=(const safe_VkVideoDecodeH264SessionParametersCreateInfoEXT& copy_src);
@@ -6870,10 +6870,10 @@ struct safe_VkVideoDecodeH264SessionParametersCreateInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264PictureInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    const StdVideoDecodeH264PictureInfo* pStdPictureInfo;
+    const void* pNext{};
+    const StdVideoDecodeH264PictureInfo* pStdPictureInfo{};
     uint32_t slicesCount;
-    const uint32_t* pSlicesDataOffsets;
+    const uint32_t* pSlicesDataOffsets{};
     safe_VkVideoDecodeH264PictureInfoEXT(const VkVideoDecodeH264PictureInfoEXT* in_struct);
     safe_VkVideoDecodeH264PictureInfoEXT(const safe_VkVideoDecodeH264PictureInfoEXT& copy_src);
     safe_VkVideoDecodeH264PictureInfoEXT& operator=(const safe_VkVideoDecodeH264PictureInfoEXT& copy_src);
@@ -6889,8 +6889,8 @@ struct safe_VkVideoDecodeH264PictureInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264MvcEXT {
     VkStructureType sType;
-    const void* pNext;
-    const StdVideoDecodeH264Mvc* pStdMvc;
+    const void* pNext{};
+    const StdVideoDecodeH264Mvc* pStdMvc{};
     safe_VkVideoDecodeH264MvcEXT(const VkVideoDecodeH264MvcEXT* in_struct);
     safe_VkVideoDecodeH264MvcEXT(const safe_VkVideoDecodeH264MvcEXT& copy_src);
     safe_VkVideoDecodeH264MvcEXT& operator=(const safe_VkVideoDecodeH264MvcEXT& copy_src);
@@ -6906,8 +6906,8 @@ struct safe_VkVideoDecodeH264MvcEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH264DpbSlotInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    const StdVideoDecodeH264ReferenceInfo* pStdReferenceInfo;
+    const void* pNext{};
+    const StdVideoDecodeH264ReferenceInfo* pStdReferenceInfo{};
     safe_VkVideoDecodeH264DpbSlotInfoEXT(const VkVideoDecodeH264DpbSlotInfoEXT* in_struct);
     safe_VkVideoDecodeH264DpbSlotInfoEXT(const safe_VkVideoDecodeH264DpbSlotInfoEXT& copy_src);
     safe_VkVideoDecodeH264DpbSlotInfoEXT& operator=(const safe_VkVideoDecodeH264DpbSlotInfoEXT& copy_src);
@@ -6922,7 +6922,7 @@ struct safe_VkVideoDecodeH264DpbSlotInfoEXT {
 
 struct safe_VkTextureLODGatherFormatPropertiesAMD {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 supportsTextureGatherLODBiasAMD;
     safe_VkTextureLODGatherFormatPropertiesAMD(const VkTextureLODGatherFormatPropertiesAMD* in_struct);
     safe_VkTextureLODGatherFormatPropertiesAMD(const safe_VkTextureLODGatherFormatPropertiesAMD& copy_src);
@@ -6938,7 +6938,7 @@ struct safe_VkTextureLODGatherFormatPropertiesAMD {
 #ifdef VK_USE_PLATFORM_GGP
 struct safe_VkStreamDescriptorSurfaceCreateInfoGGP {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkStreamDescriptorSurfaceCreateFlagsGGP flags;
     GgpStreamDescriptor streamDescriptor;
     safe_VkStreamDescriptorSurfaceCreateInfoGGP(const VkStreamDescriptorSurfaceCreateInfoGGP* in_struct);
@@ -6955,7 +6955,7 @@ struct safe_VkStreamDescriptorSurfaceCreateInfoGGP {
 
 struct safe_VkPhysicalDeviceCornerSampledImageFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 cornerSampledImage;
     safe_VkPhysicalDeviceCornerSampledImageFeaturesNV(const VkPhysicalDeviceCornerSampledImageFeaturesNV* in_struct);
     safe_VkPhysicalDeviceCornerSampledImageFeaturesNV(const safe_VkPhysicalDeviceCornerSampledImageFeaturesNV& copy_src);
@@ -6970,7 +6970,7 @@ struct safe_VkPhysicalDeviceCornerSampledImageFeaturesNV {
 
 struct safe_VkExternalMemoryImageCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagsNV handleTypes;
     safe_VkExternalMemoryImageCreateInfoNV(const VkExternalMemoryImageCreateInfoNV* in_struct);
     safe_VkExternalMemoryImageCreateInfoNV(const safe_VkExternalMemoryImageCreateInfoNV& copy_src);
@@ -6985,7 +6985,7 @@ struct safe_VkExternalMemoryImageCreateInfoNV {
 
 struct safe_VkExportMemoryAllocateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagsNV handleTypes;
     safe_VkExportMemoryAllocateInfoNV(const VkExportMemoryAllocateInfoNV* in_struct);
     safe_VkExportMemoryAllocateInfoNV(const safe_VkExportMemoryAllocateInfoNV& copy_src);
@@ -7001,7 +7001,7 @@ struct safe_VkExportMemoryAllocateInfoNV {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkImportMemoryWin32HandleInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagsNV handleType;
     HANDLE handle;
     safe_VkImportMemoryWin32HandleInfoNV(const VkImportMemoryWin32HandleInfoNV* in_struct);
@@ -7019,8 +7019,8 @@ struct safe_VkImportMemoryWin32HandleInfoNV {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkExportMemoryWin32HandleInfoNV {
     VkStructureType sType;
-    const void* pNext;
-    const SECURITY_ATTRIBUTES* pAttributes;
+    const void* pNext{};
+    const SECURITY_ATTRIBUTES* pAttributes{};
     DWORD dwAccess;
     safe_VkExportMemoryWin32HandleInfoNV(const VkExportMemoryWin32HandleInfoNV* in_struct);
     safe_VkExportMemoryWin32HandleInfoNV(const safe_VkExportMemoryWin32HandleInfoNV& copy_src);
@@ -7037,14 +7037,14 @@ struct safe_VkExportMemoryWin32HandleInfoNV {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkWin32KeyedMutexAcquireReleaseInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t acquireCount;
-    VkDeviceMemory* pAcquireSyncs;
-    const uint64_t* pAcquireKeys;
-    const uint32_t* pAcquireTimeoutMilliseconds;
+    VkDeviceMemory* pAcquireSyncs{};
+    const uint64_t* pAcquireKeys{};
+    const uint32_t* pAcquireTimeoutMilliseconds{};
     uint32_t releaseCount;
-    VkDeviceMemory* pReleaseSyncs;
-    const uint64_t* pReleaseKeys;
+    VkDeviceMemory* pReleaseSyncs{};
+    const uint64_t* pReleaseKeys{};
     safe_VkWin32KeyedMutexAcquireReleaseInfoNV(const VkWin32KeyedMutexAcquireReleaseInfoNV* in_struct);
     safe_VkWin32KeyedMutexAcquireReleaseInfoNV(const safe_VkWin32KeyedMutexAcquireReleaseInfoNV& copy_src);
     safe_VkWin32KeyedMutexAcquireReleaseInfoNV& operator=(const safe_VkWin32KeyedMutexAcquireReleaseInfoNV& copy_src);
@@ -7059,9 +7059,9 @@ struct safe_VkWin32KeyedMutexAcquireReleaseInfoNV {
 
 struct safe_VkValidationFlagsEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t disabledValidationCheckCount;
-    const VkValidationCheckEXT* pDisabledValidationChecks;
+    const VkValidationCheckEXT* pDisabledValidationChecks{};
     safe_VkValidationFlagsEXT(const VkValidationFlagsEXT* in_struct);
     safe_VkValidationFlagsEXT(const safe_VkValidationFlagsEXT& copy_src);
     safe_VkValidationFlagsEXT& operator=(const safe_VkValidationFlagsEXT& copy_src);
@@ -7076,9 +7076,9 @@ struct safe_VkValidationFlagsEXT {
 #ifdef VK_USE_PLATFORM_VI_NN
 struct safe_VkViSurfaceCreateInfoNN {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkViSurfaceCreateFlagsNN flags;
-    void* window;
+    void* window{};
     safe_VkViSurfaceCreateInfoNN(const VkViSurfaceCreateInfoNN* in_struct);
     safe_VkViSurfaceCreateInfoNN(const safe_VkViSurfaceCreateInfoNN& copy_src);
     safe_VkViSurfaceCreateInfoNN& operator=(const safe_VkViSurfaceCreateInfoNN& copy_src);
@@ -7093,7 +7093,7 @@ struct safe_VkViSurfaceCreateInfoNN {
 
 struct safe_VkImageViewASTCDecodeModeEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFormat decodeMode;
     safe_VkImageViewASTCDecodeModeEXT(const VkImageViewASTCDecodeModeEXT* in_struct);
     safe_VkImageViewASTCDecodeModeEXT(const safe_VkImageViewASTCDecodeModeEXT& copy_src);
@@ -7108,7 +7108,7 @@ struct safe_VkImageViewASTCDecodeModeEXT {
 
 struct safe_VkPhysicalDeviceASTCDecodeFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 decodeModeSharedExponent;
     safe_VkPhysicalDeviceASTCDecodeFeaturesEXT(const VkPhysicalDeviceASTCDecodeFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceASTCDecodeFeaturesEXT(const safe_VkPhysicalDeviceASTCDecodeFeaturesEXT& copy_src);
@@ -7123,7 +7123,7 @@ struct safe_VkPhysicalDeviceASTCDecodeFeaturesEXT {
 
 struct safe_VkConditionalRenderingBeginInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer buffer;
     VkDeviceSize offset;
     VkConditionalRenderingFlagsEXT flags;
@@ -7140,7 +7140,7 @@ struct safe_VkConditionalRenderingBeginInfoEXT {
 
 struct safe_VkPhysicalDeviceConditionalRenderingFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 conditionalRendering;
     VkBool32 inheritedConditionalRendering;
     safe_VkPhysicalDeviceConditionalRenderingFeaturesEXT(const VkPhysicalDeviceConditionalRenderingFeaturesEXT* in_struct);
@@ -7156,7 +7156,7 @@ struct safe_VkPhysicalDeviceConditionalRenderingFeaturesEXT {
 
 struct safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 conditionalRenderingEnable;
     safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT(const VkCommandBufferInheritanceConditionalRenderingInfoEXT* in_struct);
     safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT(const safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT& copy_src);
@@ -7171,10 +7171,10 @@ struct safe_VkCommandBufferInheritanceConditionalRenderingInfoEXT {
 
 struct safe_VkPipelineViewportWScalingStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 viewportWScalingEnable;
     uint32_t viewportCount;
-    const VkViewportWScalingNV* pViewportWScalings;
+    const VkViewportWScalingNV* pViewportWScalings{};
     safe_VkPipelineViewportWScalingStateCreateInfoNV(const VkPipelineViewportWScalingStateCreateInfoNV* in_struct);
     safe_VkPipelineViewportWScalingStateCreateInfoNV(const safe_VkPipelineViewportWScalingStateCreateInfoNV& copy_src);
     safe_VkPipelineViewportWScalingStateCreateInfoNV& operator=(const safe_VkPipelineViewportWScalingStateCreateInfoNV& copy_src);
@@ -7188,7 +7188,7 @@ struct safe_VkPipelineViewportWScalingStateCreateInfoNV {
 
 struct safe_VkSurfaceCapabilities2EXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t minImageCount;
     uint32_t maxImageCount;
     VkExtent2D currentExtent;
@@ -7213,7 +7213,7 @@ struct safe_VkSurfaceCapabilities2EXT {
 
 struct safe_VkDisplayPowerInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDisplayPowerStateEXT powerState;
     safe_VkDisplayPowerInfoEXT(const VkDisplayPowerInfoEXT* in_struct);
     safe_VkDisplayPowerInfoEXT(const safe_VkDisplayPowerInfoEXT& copy_src);
@@ -7228,7 +7228,7 @@ struct safe_VkDisplayPowerInfoEXT {
 
 struct safe_VkDeviceEventInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceEventTypeEXT deviceEvent;
     safe_VkDeviceEventInfoEXT(const VkDeviceEventInfoEXT* in_struct);
     safe_VkDeviceEventInfoEXT(const safe_VkDeviceEventInfoEXT& copy_src);
@@ -7243,7 +7243,7 @@ struct safe_VkDeviceEventInfoEXT {
 
 struct safe_VkDisplayEventInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDisplayEventTypeEXT displayEvent;
     safe_VkDisplayEventInfoEXT(const VkDisplayEventInfoEXT* in_struct);
     safe_VkDisplayEventInfoEXT(const safe_VkDisplayEventInfoEXT& copy_src);
@@ -7258,7 +7258,7 @@ struct safe_VkDisplayEventInfoEXT {
 
 struct safe_VkSwapchainCounterCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSurfaceCounterFlagsEXT surfaceCounters;
     safe_VkSwapchainCounterCreateInfoEXT(const VkSwapchainCounterCreateInfoEXT* in_struct);
     safe_VkSwapchainCounterCreateInfoEXT(const safe_VkSwapchainCounterCreateInfoEXT& copy_src);
@@ -7273,9 +7273,9 @@ struct safe_VkSwapchainCounterCreateInfoEXT {
 
 struct safe_VkPresentTimesInfoGOOGLE {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t swapchainCount;
-    const VkPresentTimeGOOGLE* pTimes;
+    const VkPresentTimeGOOGLE* pTimes{};
     safe_VkPresentTimesInfoGOOGLE(const VkPresentTimesInfoGOOGLE* in_struct);
     safe_VkPresentTimesInfoGOOGLE(const safe_VkPresentTimesInfoGOOGLE& copy_src);
     safe_VkPresentTimesInfoGOOGLE& operator=(const safe_VkPresentTimesInfoGOOGLE& copy_src);
@@ -7289,7 +7289,7 @@ struct safe_VkPresentTimesInfoGOOGLE {
 
 struct safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 perViewPositionAllComponents;
     safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX(const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* in_struct);
     safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX(const safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& copy_src);
@@ -7304,10 +7304,10 @@ struct safe_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX {
 
 struct safe_VkPipelineViewportSwizzleStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineViewportSwizzleStateCreateFlagsNV flags;
     uint32_t viewportCount;
-    const VkViewportSwizzleNV* pViewportSwizzles;
+    const VkViewportSwizzleNV* pViewportSwizzles{};
     safe_VkPipelineViewportSwizzleStateCreateInfoNV(const VkPipelineViewportSwizzleStateCreateInfoNV* in_struct);
     safe_VkPipelineViewportSwizzleStateCreateInfoNV(const safe_VkPipelineViewportSwizzleStateCreateInfoNV& copy_src);
     safe_VkPipelineViewportSwizzleStateCreateInfoNV& operator=(const safe_VkPipelineViewportSwizzleStateCreateInfoNV& copy_src);
@@ -7321,7 +7321,7 @@ struct safe_VkPipelineViewportSwizzleStateCreateInfoNV {
 
 struct safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxDiscardRectangles;
     safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT(const VkPhysicalDeviceDiscardRectanglePropertiesEXT* in_struct);
     safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT(const safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT& copy_src);
@@ -7336,11 +7336,11 @@ struct safe_VkPhysicalDeviceDiscardRectanglePropertiesEXT {
 
 struct safe_VkPipelineDiscardRectangleStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineDiscardRectangleStateCreateFlagsEXT flags;
     VkDiscardRectangleModeEXT discardRectangleMode;
     uint32_t discardRectangleCount;
-    const VkRect2D* pDiscardRectangles;
+    const VkRect2D* pDiscardRectangles{};
     safe_VkPipelineDiscardRectangleStateCreateInfoEXT(const VkPipelineDiscardRectangleStateCreateInfoEXT* in_struct);
     safe_VkPipelineDiscardRectangleStateCreateInfoEXT(const safe_VkPipelineDiscardRectangleStateCreateInfoEXT& copy_src);
     safe_VkPipelineDiscardRectangleStateCreateInfoEXT& operator=(const safe_VkPipelineDiscardRectangleStateCreateInfoEXT& copy_src);
@@ -7354,7 +7354,7 @@ struct safe_VkPipelineDiscardRectangleStateCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceConservativeRasterizationPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     float primitiveOverestimationSize;
     float maxExtraPrimitiveOverestimationSize;
     float extraPrimitiveOverestimationSizeGranularity;
@@ -7377,7 +7377,7 @@ struct safe_VkPhysicalDeviceConservativeRasterizationPropertiesEXT {
 
 struct safe_VkPipelineRasterizationConservativeStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineRasterizationConservativeStateCreateFlagsEXT flags;
     VkConservativeRasterizationModeEXT conservativeRasterizationMode;
     float extraPrimitiveOverestimationSize;
@@ -7394,7 +7394,7 @@ struct safe_VkPipelineRasterizationConservativeStateCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 depthClipEnable;
     safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT(const VkPhysicalDeviceDepthClipEnableFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT(const safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT& copy_src);
@@ -7409,7 +7409,7 @@ struct safe_VkPhysicalDeviceDepthClipEnableFeaturesEXT {
 
 struct safe_VkPipelineRasterizationDepthClipStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineRasterizationDepthClipStateCreateFlagsEXT flags;
     VkBool32 depthClipEnable;
     safe_VkPipelineRasterizationDepthClipStateCreateInfoEXT(const VkPipelineRasterizationDepthClipStateCreateInfoEXT* in_struct);
@@ -7425,7 +7425,7 @@ struct safe_VkPipelineRasterizationDepthClipStateCreateInfoEXT {
 
 struct safe_VkHdrMetadataEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkXYColorEXT displayPrimaryRed;
     VkXYColorEXT displayPrimaryGreen;
     VkXYColorEXT displayPrimaryBlue;
@@ -7448,9 +7448,9 @@ struct safe_VkHdrMetadataEXT {
 #ifdef VK_USE_PLATFORM_IOS_MVK
 struct safe_VkIOSSurfaceCreateInfoMVK {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkIOSSurfaceCreateFlagsMVK flags;
-    const void* pView;
+    const void* pView{};
     safe_VkIOSSurfaceCreateInfoMVK(const VkIOSSurfaceCreateInfoMVK* in_struct);
     safe_VkIOSSurfaceCreateInfoMVK(const safe_VkIOSSurfaceCreateInfoMVK& copy_src);
     safe_VkIOSSurfaceCreateInfoMVK& operator=(const safe_VkIOSSurfaceCreateInfoMVK& copy_src);
@@ -7466,9 +7466,9 @@ struct safe_VkIOSSurfaceCreateInfoMVK {
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 struct safe_VkMacOSSurfaceCreateInfoMVK {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkMacOSSurfaceCreateFlagsMVK flags;
-    const void* pView;
+    const void* pView{};
     safe_VkMacOSSurfaceCreateInfoMVK(const VkMacOSSurfaceCreateInfoMVK* in_struct);
     safe_VkMacOSSurfaceCreateInfoMVK(const safe_VkMacOSSurfaceCreateInfoMVK& copy_src);
     safe_VkMacOSSurfaceCreateInfoMVK& operator=(const safe_VkMacOSSurfaceCreateInfoMVK& copy_src);
@@ -7483,8 +7483,8 @@ struct safe_VkMacOSSurfaceCreateInfoMVK {
 
 struct safe_VkDebugUtilsLabelEXT {
     VkStructureType sType;
-    const void* pNext;
-    const char* pLabelName;
+    const void* pNext{};
+    const char* pLabelName{};
     float color[4];
     safe_VkDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* in_struct);
     safe_VkDebugUtilsLabelEXT(const safe_VkDebugUtilsLabelEXT& copy_src);
@@ -7499,10 +7499,10 @@ struct safe_VkDebugUtilsLabelEXT {
 
 struct safe_VkDebugUtilsObjectNameInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkObjectType objectType;
     uint64_t objectHandle;
-    const char* pObjectName;
+    const char* pObjectName{};
     safe_VkDebugUtilsObjectNameInfoEXT(const VkDebugUtilsObjectNameInfoEXT* in_struct);
     safe_VkDebugUtilsObjectNameInfoEXT(const safe_VkDebugUtilsObjectNameInfoEXT& copy_src);
     safe_VkDebugUtilsObjectNameInfoEXT& operator=(const safe_VkDebugUtilsObjectNameInfoEXT& copy_src);
@@ -7516,17 +7516,17 @@ struct safe_VkDebugUtilsObjectNameInfoEXT {
 
 struct safe_VkDebugUtilsMessengerCallbackDataEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDebugUtilsMessengerCallbackDataFlagsEXT flags;
-    const char* pMessageIdName;
+    const char* pMessageIdName{};
     int32_t messageIdNumber;
-    const char* pMessage;
+    const char* pMessage{};
     uint32_t queueLabelCount;
-    safe_VkDebugUtilsLabelEXT* pQueueLabels;
+    safe_VkDebugUtilsLabelEXT* pQueueLabels{};
     uint32_t cmdBufLabelCount;
-    safe_VkDebugUtilsLabelEXT* pCmdBufLabels;
+    safe_VkDebugUtilsLabelEXT* pCmdBufLabels{};
     uint32_t objectCount;
-    safe_VkDebugUtilsObjectNameInfoEXT* pObjects;
+    safe_VkDebugUtilsObjectNameInfoEXT* pObjects{};
     safe_VkDebugUtilsMessengerCallbackDataEXT(const VkDebugUtilsMessengerCallbackDataEXT* in_struct);
     safe_VkDebugUtilsMessengerCallbackDataEXT(const safe_VkDebugUtilsMessengerCallbackDataEXT& copy_src);
     safe_VkDebugUtilsMessengerCallbackDataEXT& operator=(const safe_VkDebugUtilsMessengerCallbackDataEXT& copy_src);
@@ -7540,12 +7540,12 @@ struct safe_VkDebugUtilsMessengerCallbackDataEXT {
 
 struct safe_VkDebugUtilsMessengerCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDebugUtilsMessengerCreateFlagsEXT flags;
     VkDebugUtilsMessageSeverityFlagsEXT messageSeverity;
     VkDebugUtilsMessageTypeFlagsEXT messageType;
     PFN_vkDebugUtilsMessengerCallbackEXT pfnUserCallback;
-    void* pUserData;
+    void* pUserData{};
     safe_VkDebugUtilsMessengerCreateInfoEXT(const VkDebugUtilsMessengerCreateInfoEXT* in_struct);
     safe_VkDebugUtilsMessengerCreateInfoEXT(const safe_VkDebugUtilsMessengerCreateInfoEXT& copy_src);
     safe_VkDebugUtilsMessengerCreateInfoEXT& operator=(const safe_VkDebugUtilsMessengerCreateInfoEXT& copy_src);
@@ -7559,12 +7559,12 @@ struct safe_VkDebugUtilsMessengerCreateInfoEXT {
 
 struct safe_VkDebugUtilsObjectTagInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkObjectType objectType;
     uint64_t objectHandle;
     uint64_t tagName;
     size_t tagSize;
-    const void* pTag;
+    const void* pTag{};
     safe_VkDebugUtilsObjectTagInfoEXT(const VkDebugUtilsObjectTagInfoEXT* in_struct);
     safe_VkDebugUtilsObjectTagInfoEXT(const safe_VkDebugUtilsObjectTagInfoEXT& copy_src);
     safe_VkDebugUtilsObjectTagInfoEXT& operator=(const safe_VkDebugUtilsObjectTagInfoEXT& copy_src);
@@ -7579,7 +7579,7 @@ struct safe_VkDebugUtilsObjectTagInfoEXT {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkAndroidHardwareBufferUsageANDROID {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint64_t androidHardwareBufferUsage;
     safe_VkAndroidHardwareBufferUsageANDROID(const VkAndroidHardwareBufferUsageANDROID* in_struct);
     safe_VkAndroidHardwareBufferUsageANDROID(const safe_VkAndroidHardwareBufferUsageANDROID& copy_src);
@@ -7596,7 +7596,7 @@ struct safe_VkAndroidHardwareBufferUsageANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkAndroidHardwareBufferPropertiesANDROID {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize allocationSize;
     uint32_t memoryTypeBits;
     safe_VkAndroidHardwareBufferPropertiesANDROID(const VkAndroidHardwareBufferPropertiesANDROID* in_struct);
@@ -7614,7 +7614,7 @@ struct safe_VkAndroidHardwareBufferPropertiesANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkAndroidHardwareBufferFormatPropertiesANDROID {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFormat format;
     uint64_t externalFormat;
     VkFormatFeatureFlags formatFeatures;
@@ -7638,8 +7638,8 @@ struct safe_VkAndroidHardwareBufferFormatPropertiesANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkImportAndroidHardwareBufferInfoANDROID {
     VkStructureType sType;
-    const void* pNext;
-    struct AHardwareBuffer* buffer;
+    const void* pNext{};
+    struct AHardwareBuffer* buffer{};
     safe_VkImportAndroidHardwareBufferInfoANDROID(const VkImportAndroidHardwareBufferInfoANDROID* in_struct);
     safe_VkImportAndroidHardwareBufferInfoANDROID(const safe_VkImportAndroidHardwareBufferInfoANDROID& copy_src);
     safe_VkImportAndroidHardwareBufferInfoANDROID& operator=(const safe_VkImportAndroidHardwareBufferInfoANDROID& copy_src);
@@ -7655,7 +7655,7 @@ struct safe_VkImportAndroidHardwareBufferInfoANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkMemoryGetAndroidHardwareBufferInfoANDROID {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     safe_VkMemoryGetAndroidHardwareBufferInfoANDROID(const VkMemoryGetAndroidHardwareBufferInfoANDROID* in_struct);
     safe_VkMemoryGetAndroidHardwareBufferInfoANDROID(const safe_VkMemoryGetAndroidHardwareBufferInfoANDROID& copy_src);
@@ -7672,7 +7672,7 @@ struct safe_VkMemoryGetAndroidHardwareBufferInfoANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkExternalFormatANDROID {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint64_t externalFormat;
     safe_VkExternalFormatANDROID(const VkExternalFormatANDROID* in_struct);
     safe_VkExternalFormatANDROID(const safe_VkExternalFormatANDROID& copy_src);
@@ -7689,7 +7689,7 @@ struct safe_VkExternalFormatANDROID {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 struct safe_VkAndroidHardwareBufferFormatProperties2ANDROID {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFormat format;
     uint64_t externalFormat;
     VkFormatFeatureFlags2 formatFeatures;
@@ -7712,11 +7712,11 @@ struct safe_VkAndroidHardwareBufferFormatProperties2ANDROID {
 
 struct safe_VkSampleLocationsInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSampleCountFlagBits sampleLocationsPerPixel;
     VkExtent2D sampleLocationGridSize;
     uint32_t sampleLocationsCount;
-    const VkSampleLocationEXT* pSampleLocations;
+    const VkSampleLocationEXT* pSampleLocations{};
     safe_VkSampleLocationsInfoEXT(const VkSampleLocationsInfoEXT* in_struct);
     safe_VkSampleLocationsInfoEXT(const safe_VkSampleLocationsInfoEXT& copy_src);
     safe_VkSampleLocationsInfoEXT& operator=(const safe_VkSampleLocationsInfoEXT& copy_src);
@@ -7730,11 +7730,11 @@ struct safe_VkSampleLocationsInfoEXT {
 
 struct safe_VkRenderPassSampleLocationsBeginInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t attachmentInitialSampleLocationsCount;
-    const VkAttachmentSampleLocationsEXT* pAttachmentInitialSampleLocations;
+    const VkAttachmentSampleLocationsEXT* pAttachmentInitialSampleLocations{};
     uint32_t postSubpassSampleLocationsCount;
-    const VkSubpassSampleLocationsEXT* pPostSubpassSampleLocations;
+    const VkSubpassSampleLocationsEXT* pPostSubpassSampleLocations{};
     safe_VkRenderPassSampleLocationsBeginInfoEXT(const VkRenderPassSampleLocationsBeginInfoEXT* in_struct);
     safe_VkRenderPassSampleLocationsBeginInfoEXT(const safe_VkRenderPassSampleLocationsBeginInfoEXT& copy_src);
     safe_VkRenderPassSampleLocationsBeginInfoEXT& operator=(const safe_VkRenderPassSampleLocationsBeginInfoEXT& copy_src);
@@ -7748,7 +7748,7 @@ struct safe_VkRenderPassSampleLocationsBeginInfoEXT {
 
 struct safe_VkPipelineSampleLocationsStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 sampleLocationsEnable;
     safe_VkSampleLocationsInfoEXT sampleLocationsInfo;
     safe_VkPipelineSampleLocationsStateCreateInfoEXT(const VkPipelineSampleLocationsStateCreateInfoEXT* in_struct);
@@ -7764,7 +7764,7 @@ struct safe_VkPipelineSampleLocationsStateCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceSampleLocationsPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSampleCountFlags sampleLocationSampleCounts;
     VkExtent2D maxSampleLocationGridSize;
     float sampleLocationCoordinateRange[2];
@@ -7783,7 +7783,7 @@ struct safe_VkPhysicalDeviceSampleLocationsPropertiesEXT {
 
 struct safe_VkMultisamplePropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExtent2D maxSampleLocationGridSize;
     safe_VkMultisamplePropertiesEXT(const VkMultisamplePropertiesEXT* in_struct);
     safe_VkMultisamplePropertiesEXT(const safe_VkMultisamplePropertiesEXT& copy_src);
@@ -7798,7 +7798,7 @@ struct safe_VkMultisamplePropertiesEXT {
 
 struct safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 advancedBlendCoherentOperations;
     safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT(const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT(const safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& copy_src);
@@ -7813,7 +7813,7 @@ struct safe_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT {
 
 struct safe_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t advancedBlendMaxColorAttachments;
     VkBool32 advancedBlendIndependentBlend;
     VkBool32 advancedBlendNonPremultipliedSrcColor;
@@ -7833,7 +7833,7 @@ struct safe_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT {
 
 struct safe_VkPipelineColorBlendAdvancedStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 srcPremultiplied;
     VkBool32 dstPremultiplied;
     VkBlendOverlapEXT blendOverlap;
@@ -7850,7 +7850,7 @@ struct safe_VkPipelineColorBlendAdvancedStateCreateInfoEXT {
 
 struct safe_VkPipelineCoverageToColorStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCoverageToColorStateCreateFlagsNV flags;
     VkBool32 coverageToColorEnable;
     uint32_t coverageToColorLocation;
@@ -7867,12 +7867,12 @@ struct safe_VkPipelineCoverageToColorStateCreateInfoNV {
 
 struct safe_VkPipelineCoverageModulationStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCoverageModulationStateCreateFlagsNV flags;
     VkCoverageModulationModeNV coverageModulationMode;
     VkBool32 coverageModulationTableEnable;
     uint32_t coverageModulationTableCount;
-    const float* pCoverageModulationTable;
+    const float* pCoverageModulationTable{};
     safe_VkPipelineCoverageModulationStateCreateInfoNV(const VkPipelineCoverageModulationStateCreateInfoNV* in_struct);
     safe_VkPipelineCoverageModulationStateCreateInfoNV(const safe_VkPipelineCoverageModulationStateCreateInfoNV& copy_src);
     safe_VkPipelineCoverageModulationStateCreateInfoNV& operator=(const safe_VkPipelineCoverageModulationStateCreateInfoNV& copy_src);
@@ -7886,7 +7886,7 @@ struct safe_VkPipelineCoverageModulationStateCreateInfoNV {
 
 struct safe_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t shaderSMCount;
     uint32_t shaderWarpsPerSM;
     safe_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV(const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV* in_struct);
@@ -7902,7 +7902,7 @@ struct safe_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV {
 
 struct safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderSMBuiltins;
     safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV(const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* in_struct);
     safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV(const safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV& copy_src);
@@ -7917,9 +7917,9 @@ struct safe_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV {
 
 struct safe_VkDrmFormatModifierPropertiesListEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t drmFormatModifierCount;
-    VkDrmFormatModifierPropertiesEXT* pDrmFormatModifierProperties;
+    VkDrmFormatModifierPropertiesEXT* pDrmFormatModifierProperties{};
     safe_VkDrmFormatModifierPropertiesListEXT(const VkDrmFormatModifierPropertiesListEXT* in_struct);
     safe_VkDrmFormatModifierPropertiesListEXT(const safe_VkDrmFormatModifierPropertiesListEXT& copy_src);
     safe_VkDrmFormatModifierPropertiesListEXT& operator=(const safe_VkDrmFormatModifierPropertiesListEXT& copy_src);
@@ -7933,11 +7933,11 @@ struct safe_VkDrmFormatModifierPropertiesListEXT {
 
 struct safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint64_t drmFormatModifier;
     VkSharingMode sharingMode;
     uint32_t queueFamilyIndexCount;
-    const uint32_t* pQueueFamilyIndices;
+    const uint32_t* pQueueFamilyIndices{};
     safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT(const VkPhysicalDeviceImageDrmFormatModifierInfoEXT* in_struct);
     safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT(const safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT& copy_src);
     safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT& operator=(const safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT& copy_src);
@@ -7951,9 +7951,9 @@ struct safe_VkPhysicalDeviceImageDrmFormatModifierInfoEXT {
 
 struct safe_VkImageDrmFormatModifierListCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t drmFormatModifierCount;
-    const uint64_t* pDrmFormatModifiers;
+    const uint64_t* pDrmFormatModifiers{};
     safe_VkImageDrmFormatModifierListCreateInfoEXT(const VkImageDrmFormatModifierListCreateInfoEXT* in_struct);
     safe_VkImageDrmFormatModifierListCreateInfoEXT(const safe_VkImageDrmFormatModifierListCreateInfoEXT& copy_src);
     safe_VkImageDrmFormatModifierListCreateInfoEXT& operator=(const safe_VkImageDrmFormatModifierListCreateInfoEXT& copy_src);
@@ -7967,10 +7967,10 @@ struct safe_VkImageDrmFormatModifierListCreateInfoEXT {
 
 struct safe_VkImageDrmFormatModifierExplicitCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint64_t drmFormatModifier;
     uint32_t drmFormatModifierPlaneCount;
-    const VkSubresourceLayout* pPlaneLayouts;
+    const VkSubresourceLayout* pPlaneLayouts{};
     safe_VkImageDrmFormatModifierExplicitCreateInfoEXT(const VkImageDrmFormatModifierExplicitCreateInfoEXT* in_struct);
     safe_VkImageDrmFormatModifierExplicitCreateInfoEXT(const safe_VkImageDrmFormatModifierExplicitCreateInfoEXT& copy_src);
     safe_VkImageDrmFormatModifierExplicitCreateInfoEXT& operator=(const safe_VkImageDrmFormatModifierExplicitCreateInfoEXT& copy_src);
@@ -7984,7 +7984,7 @@ struct safe_VkImageDrmFormatModifierExplicitCreateInfoEXT {
 
 struct safe_VkImageDrmFormatModifierPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint64_t drmFormatModifier;
     safe_VkImageDrmFormatModifierPropertiesEXT(const VkImageDrmFormatModifierPropertiesEXT* in_struct);
     safe_VkImageDrmFormatModifierPropertiesEXT(const safe_VkImageDrmFormatModifierPropertiesEXT& copy_src);
@@ -7999,9 +7999,9 @@ struct safe_VkImageDrmFormatModifierPropertiesEXT {
 
 struct safe_VkDrmFormatModifierPropertiesList2EXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t drmFormatModifierCount;
-    VkDrmFormatModifierProperties2EXT* pDrmFormatModifierProperties;
+    VkDrmFormatModifierProperties2EXT* pDrmFormatModifierProperties{};
     safe_VkDrmFormatModifierPropertiesList2EXT(const VkDrmFormatModifierPropertiesList2EXT* in_struct);
     safe_VkDrmFormatModifierPropertiesList2EXT(const safe_VkDrmFormatModifierPropertiesList2EXT& copy_src);
     safe_VkDrmFormatModifierPropertiesList2EXT& operator=(const safe_VkDrmFormatModifierPropertiesList2EXT& copy_src);
@@ -8015,10 +8015,10 @@ struct safe_VkDrmFormatModifierPropertiesList2EXT {
 
 struct safe_VkValidationCacheCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkValidationCacheCreateFlagsEXT flags;
     size_t initialDataSize;
-    const void* pInitialData;
+    const void* pInitialData{};
     safe_VkValidationCacheCreateInfoEXT(const VkValidationCacheCreateInfoEXT* in_struct);
     safe_VkValidationCacheCreateInfoEXT(const safe_VkValidationCacheCreateInfoEXT& copy_src);
     safe_VkValidationCacheCreateInfoEXT& operator=(const safe_VkValidationCacheCreateInfoEXT& copy_src);
@@ -8032,7 +8032,7 @@ struct safe_VkValidationCacheCreateInfoEXT {
 
 struct safe_VkShaderModuleValidationCacheCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkValidationCacheEXT validationCache;
     safe_VkShaderModuleValidationCacheCreateInfoEXT(const VkShaderModuleValidationCacheCreateInfoEXT* in_struct);
     safe_VkShaderModuleValidationCacheCreateInfoEXT(const safe_VkShaderModuleValidationCacheCreateInfoEXT& copy_src);
@@ -8047,7 +8047,7 @@ struct safe_VkShaderModuleValidationCacheCreateInfoEXT {
 
 struct safe_VkShadingRatePaletteNV {
     uint32_t shadingRatePaletteEntryCount;
-    const VkShadingRatePaletteEntryNV* pShadingRatePaletteEntries;
+    const VkShadingRatePaletteEntryNV* pShadingRatePaletteEntries{};
     safe_VkShadingRatePaletteNV(const VkShadingRatePaletteNV* in_struct);
     safe_VkShadingRatePaletteNV(const safe_VkShadingRatePaletteNV& copy_src);
     safe_VkShadingRatePaletteNV& operator=(const safe_VkShadingRatePaletteNV& copy_src);
@@ -8061,10 +8061,10 @@ struct safe_VkShadingRatePaletteNV {
 
 struct safe_VkPipelineViewportShadingRateImageStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 shadingRateImageEnable;
     uint32_t viewportCount;
-    safe_VkShadingRatePaletteNV* pShadingRatePalettes;
+    safe_VkShadingRatePaletteNV* pShadingRatePalettes{};
     safe_VkPipelineViewportShadingRateImageStateCreateInfoNV(const VkPipelineViewportShadingRateImageStateCreateInfoNV* in_struct);
     safe_VkPipelineViewportShadingRateImageStateCreateInfoNV(const safe_VkPipelineViewportShadingRateImageStateCreateInfoNV& copy_src);
     safe_VkPipelineViewportShadingRateImageStateCreateInfoNV& operator=(const safe_VkPipelineViewportShadingRateImageStateCreateInfoNV& copy_src);
@@ -8078,7 +8078,7 @@ struct safe_VkPipelineViewportShadingRateImageStateCreateInfoNV {
 
 struct safe_VkPhysicalDeviceShadingRateImageFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shadingRateImage;
     VkBool32 shadingRateCoarseSampleOrder;
     safe_VkPhysicalDeviceShadingRateImageFeaturesNV(const VkPhysicalDeviceShadingRateImageFeaturesNV* in_struct);
@@ -8094,7 +8094,7 @@ struct safe_VkPhysicalDeviceShadingRateImageFeaturesNV {
 
 struct safe_VkPhysicalDeviceShadingRateImagePropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExtent2D shadingRateTexelSize;
     uint32_t shadingRatePaletteSize;
     uint32_t shadingRateMaxCoarseSamples;
@@ -8113,7 +8113,7 @@ struct safe_VkCoarseSampleOrderCustomNV {
     VkShadingRatePaletteEntryNV shadingRate;
     uint32_t sampleCount;
     uint32_t sampleLocationCount;
-    const VkCoarseSampleLocationNV* pSampleLocations;
+    const VkCoarseSampleLocationNV* pSampleLocations{};
     safe_VkCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV* in_struct);
     safe_VkCoarseSampleOrderCustomNV(const safe_VkCoarseSampleOrderCustomNV& copy_src);
     safe_VkCoarseSampleOrderCustomNV& operator=(const safe_VkCoarseSampleOrderCustomNV& copy_src);
@@ -8127,10 +8127,10 @@ struct safe_VkCoarseSampleOrderCustomNV {
 
 struct safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkCoarseSampleOrderTypeNV sampleOrderType;
     uint32_t customSampleOrderCount;
-    safe_VkCoarseSampleOrderCustomNV* pCustomSampleOrders;
+    safe_VkCoarseSampleOrderCustomNV* pCustomSampleOrders{};
     safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV(const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* in_struct);
     safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV(const safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& copy_src);
     safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& operator=(const safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& copy_src);
@@ -8144,7 +8144,7 @@ struct safe_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV {
 
 struct safe_VkRayTracingShaderGroupCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRayTracingShaderGroupTypeKHR type;
     uint32_t generalShader;
     uint32_t closestHitShader;
@@ -8163,12 +8163,12 @@ struct safe_VkRayTracingShaderGroupCreateInfoNV {
 
 struct safe_VkRayTracingPipelineCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCreateFlags flags;
     uint32_t stageCount;
-    safe_VkPipelineShaderStageCreateInfo* pStages;
+    safe_VkPipelineShaderStageCreateInfo* pStages{};
     uint32_t groupCount;
-    safe_VkRayTracingShaderGroupCreateInfoNV* pGroups;
+    safe_VkRayTracingShaderGroupCreateInfoNV* pGroups{};
     uint32_t maxRecursionDepth;
     VkPipelineLayout layout;
     VkPipeline basePipelineHandle;
@@ -8186,7 +8186,7 @@ struct safe_VkRayTracingPipelineCreateInfoNV {
 
 struct safe_VkGeometryTrianglesNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer vertexData;
     VkDeviceSize vertexOffset;
     uint32_t vertexCount;
@@ -8211,7 +8211,7 @@ struct safe_VkGeometryTrianglesNV {
 
 struct safe_VkGeometryAABBNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBuffer aabbData;
     uint32_t numAABBs;
     uint32_t stride;
@@ -8229,7 +8229,7 @@ struct safe_VkGeometryAABBNV {
 
 struct safe_VkGeometryNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkGeometryTypeKHR geometryType;
     VkGeometryDataNV geometry;
     VkGeometryFlagsKHR flags;
@@ -8246,12 +8246,12 @@ struct safe_VkGeometryNV {
 
 struct safe_VkAccelerationStructureInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureTypeNV type;
     VkBuildAccelerationStructureFlagsNV flags;
     uint32_t instanceCount;
     uint32_t geometryCount;
-    safe_VkGeometryNV* pGeometries;
+    safe_VkGeometryNV* pGeometries{};
     safe_VkAccelerationStructureInfoNV(const VkAccelerationStructureInfoNV* in_struct);
     safe_VkAccelerationStructureInfoNV(const safe_VkAccelerationStructureInfoNV& copy_src);
     safe_VkAccelerationStructureInfoNV& operator=(const safe_VkAccelerationStructureInfoNV& copy_src);
@@ -8265,7 +8265,7 @@ struct safe_VkAccelerationStructureInfoNV {
 
 struct safe_VkAccelerationStructureCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceSize compactedSize;
     safe_VkAccelerationStructureInfoNV info;
     safe_VkAccelerationStructureCreateInfoNV(const VkAccelerationStructureCreateInfoNV* in_struct);
@@ -8281,12 +8281,12 @@ struct safe_VkAccelerationStructureCreateInfoNV {
 
 struct safe_VkBindAccelerationStructureMemoryInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureNV accelerationStructure;
     VkDeviceMemory memory;
     VkDeviceSize memoryOffset;
     uint32_t deviceIndexCount;
-    const uint32_t* pDeviceIndices;
+    const uint32_t* pDeviceIndices{};
     safe_VkBindAccelerationStructureMemoryInfoNV(const VkBindAccelerationStructureMemoryInfoNV* in_struct);
     safe_VkBindAccelerationStructureMemoryInfoNV(const safe_VkBindAccelerationStructureMemoryInfoNV& copy_src);
     safe_VkBindAccelerationStructureMemoryInfoNV& operator=(const safe_VkBindAccelerationStructureMemoryInfoNV& copy_src);
@@ -8300,9 +8300,9 @@ struct safe_VkBindAccelerationStructureMemoryInfoNV {
 
 struct safe_VkWriteDescriptorSetAccelerationStructureNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t accelerationStructureCount;
-    VkAccelerationStructureNV* pAccelerationStructures;
+    VkAccelerationStructureNV* pAccelerationStructures{};
     safe_VkWriteDescriptorSetAccelerationStructureNV(const VkWriteDescriptorSetAccelerationStructureNV* in_struct);
     safe_VkWriteDescriptorSetAccelerationStructureNV(const safe_VkWriteDescriptorSetAccelerationStructureNV& copy_src);
     safe_VkWriteDescriptorSetAccelerationStructureNV& operator=(const safe_VkWriteDescriptorSetAccelerationStructureNV& copy_src);
@@ -8316,7 +8316,7 @@ struct safe_VkWriteDescriptorSetAccelerationStructureNV {
 
 struct safe_VkAccelerationStructureMemoryRequirementsInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureMemoryRequirementsTypeNV type;
     VkAccelerationStructureNV accelerationStructure;
     safe_VkAccelerationStructureMemoryRequirementsInfoNV(const VkAccelerationStructureMemoryRequirementsInfoNV* in_struct);
@@ -8332,7 +8332,7 @@ struct safe_VkAccelerationStructureMemoryRequirementsInfoNV {
 
 struct safe_VkPhysicalDeviceRayTracingPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t shaderGroupHandleSize;
     uint32_t maxRecursionDepth;
     uint32_t maxShaderGroupStride;
@@ -8354,7 +8354,7 @@ struct safe_VkPhysicalDeviceRayTracingPropertiesNV {
 
 struct safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 representativeFragmentTest;
     safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV(const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* in_struct);
     safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV(const safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& copy_src);
@@ -8369,7 +8369,7 @@ struct safe_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV {
 
 struct safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 representativeFragmentTestEnable;
     safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV(const VkPipelineRepresentativeFragmentTestStateCreateInfoNV* in_struct);
     safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV(const safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV& copy_src);
@@ -8384,7 +8384,7 @@ struct safe_VkPipelineRepresentativeFragmentTestStateCreateInfoNV {
 
 struct safe_VkPhysicalDeviceImageViewImageFormatInfoEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkImageViewType imageViewType;
     safe_VkPhysicalDeviceImageViewImageFormatInfoEXT(const VkPhysicalDeviceImageViewImageFormatInfoEXT* in_struct);
     safe_VkPhysicalDeviceImageViewImageFormatInfoEXT(const safe_VkPhysicalDeviceImageViewImageFormatInfoEXT& copy_src);
@@ -8399,7 +8399,7 @@ struct safe_VkPhysicalDeviceImageViewImageFormatInfoEXT {
 
 struct safe_VkFilterCubicImageViewImageFormatPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 filterCubic;
     VkBool32 filterCubicMinmax;
     safe_VkFilterCubicImageViewImageFormatPropertiesEXT(const VkFilterCubicImageViewImageFormatPropertiesEXT* in_struct);
@@ -8415,9 +8415,9 @@ struct safe_VkFilterCubicImageViewImageFormatPropertiesEXT {
 
 struct safe_VkImportMemoryHostPointerInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagBits handleType;
-    void* pHostPointer;
+    void* pHostPointer{};
     safe_VkImportMemoryHostPointerInfoEXT(const VkImportMemoryHostPointerInfoEXT* in_struct);
     safe_VkImportMemoryHostPointerInfoEXT(const safe_VkImportMemoryHostPointerInfoEXT& copy_src);
     safe_VkImportMemoryHostPointerInfoEXT& operator=(const safe_VkImportMemoryHostPointerInfoEXT& copy_src);
@@ -8431,7 +8431,7 @@ struct safe_VkImportMemoryHostPointerInfoEXT {
 
 struct safe_VkMemoryHostPointerPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t memoryTypeBits;
     safe_VkMemoryHostPointerPropertiesEXT(const VkMemoryHostPointerPropertiesEXT* in_struct);
     safe_VkMemoryHostPointerPropertiesEXT(const safe_VkMemoryHostPointerPropertiesEXT& copy_src);
@@ -8446,7 +8446,7 @@ struct safe_VkMemoryHostPointerPropertiesEXT {
 
 struct safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize minImportedHostPointerAlignment;
     safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT(const VkPhysicalDeviceExternalMemoryHostPropertiesEXT* in_struct);
     safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT(const safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT& copy_src);
@@ -8461,7 +8461,7 @@ struct safe_VkPhysicalDeviceExternalMemoryHostPropertiesEXT {
 
 struct safe_VkPipelineCompilerControlCreateInfoAMD {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCompilerControlFlagsAMD compilerControlFlags;
     safe_VkPipelineCompilerControlCreateInfoAMD(const VkPipelineCompilerControlCreateInfoAMD* in_struct);
     safe_VkPipelineCompilerControlCreateInfoAMD(const safe_VkPipelineCompilerControlCreateInfoAMD& copy_src);
@@ -8476,7 +8476,7 @@ struct safe_VkPipelineCompilerControlCreateInfoAMD {
 
 struct safe_VkCalibratedTimestampInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkTimeDomainEXT timeDomain;
     safe_VkCalibratedTimestampInfoEXT(const VkCalibratedTimestampInfoEXT* in_struct);
     safe_VkCalibratedTimestampInfoEXT(const safe_VkCalibratedTimestampInfoEXT& copy_src);
@@ -8491,7 +8491,7 @@ struct safe_VkCalibratedTimestampInfoEXT {
 
 struct safe_VkPhysicalDeviceShaderCorePropertiesAMD {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t shaderEngineCount;
     uint32_t shaderArraysPerEngineCount;
     uint32_t computeUnitsPerShaderArray;
@@ -8520,7 +8520,7 @@ struct safe_VkPhysicalDeviceShaderCorePropertiesAMD {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265ProfileEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     StdVideoH265ProfileIdc stdProfileIdc;
     safe_VkVideoDecodeH265ProfileEXT(const VkVideoDecodeH265ProfileEXT* in_struct);
     safe_VkVideoDecodeH265ProfileEXT(const safe_VkVideoDecodeH265ProfileEXT& copy_src);
@@ -8537,7 +8537,7 @@ struct safe_VkVideoDecodeH265ProfileEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265CapabilitiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     StdVideoH265Level maxLevel;
     safe_VkVideoDecodeH265CapabilitiesEXT(const VkVideoDecodeH265CapabilitiesEXT* in_struct);
     safe_VkVideoDecodeH265CapabilitiesEXT(const safe_VkVideoDecodeH265CapabilitiesEXT& copy_src);
@@ -8554,13 +8554,13 @@ struct safe_VkVideoDecodeH265CapabilitiesEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265SessionParametersAddInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t vpsStdCount;
-    const StdVideoH265VideoParameterSet* pVpsStd;
+    const StdVideoH265VideoParameterSet* pVpsStd{};
     uint32_t spsStdCount;
-    const StdVideoH265SequenceParameterSet* pSpsStd;
+    const StdVideoH265SequenceParameterSet* pSpsStd{};
     uint32_t ppsStdCount;
-    const StdVideoH265PictureParameterSet* pPpsStd;
+    const StdVideoH265PictureParameterSet* pPpsStd{};
     safe_VkVideoDecodeH265SessionParametersAddInfoEXT(const VkVideoDecodeH265SessionParametersAddInfoEXT* in_struct);
     safe_VkVideoDecodeH265SessionParametersAddInfoEXT(const safe_VkVideoDecodeH265SessionParametersAddInfoEXT& copy_src);
     safe_VkVideoDecodeH265SessionParametersAddInfoEXT& operator=(const safe_VkVideoDecodeH265SessionParametersAddInfoEXT& copy_src);
@@ -8576,11 +8576,11 @@ struct safe_VkVideoDecodeH265SessionParametersAddInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265SessionParametersCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxVpsStdCount;
     uint32_t maxSpsStdCount;
     uint32_t maxPpsStdCount;
-    safe_VkVideoDecodeH265SessionParametersAddInfoEXT* pParametersAddInfo;
+    safe_VkVideoDecodeH265SessionParametersAddInfoEXT* pParametersAddInfo{};
     safe_VkVideoDecodeH265SessionParametersCreateInfoEXT(const VkVideoDecodeH265SessionParametersCreateInfoEXT* in_struct);
     safe_VkVideoDecodeH265SessionParametersCreateInfoEXT(const safe_VkVideoDecodeH265SessionParametersCreateInfoEXT& copy_src);
     safe_VkVideoDecodeH265SessionParametersCreateInfoEXT& operator=(const safe_VkVideoDecodeH265SessionParametersCreateInfoEXT& copy_src);
@@ -8596,10 +8596,10 @@ struct safe_VkVideoDecodeH265SessionParametersCreateInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265PictureInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    StdVideoDecodeH265PictureInfo* pStdPictureInfo;
+    const void* pNext{};
+    StdVideoDecodeH265PictureInfo* pStdPictureInfo{};
     uint32_t slicesCount;
-    const uint32_t* pSlicesDataOffsets;
+    const uint32_t* pSlicesDataOffsets{};
     safe_VkVideoDecodeH265PictureInfoEXT(const VkVideoDecodeH265PictureInfoEXT* in_struct);
     safe_VkVideoDecodeH265PictureInfoEXT(const safe_VkVideoDecodeH265PictureInfoEXT& copy_src);
     safe_VkVideoDecodeH265PictureInfoEXT& operator=(const safe_VkVideoDecodeH265PictureInfoEXT& copy_src);
@@ -8615,8 +8615,8 @@ struct safe_VkVideoDecodeH265PictureInfoEXT {
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 struct safe_VkVideoDecodeH265DpbSlotInfoEXT {
     VkStructureType sType;
-    const void* pNext;
-    const StdVideoDecodeH265ReferenceInfo* pStdReferenceInfo;
+    const void* pNext{};
+    const StdVideoDecodeH265ReferenceInfo* pStdReferenceInfo{};
     safe_VkVideoDecodeH265DpbSlotInfoEXT(const VkVideoDecodeH265DpbSlotInfoEXT* in_struct);
     safe_VkVideoDecodeH265DpbSlotInfoEXT(const safe_VkVideoDecodeH265DpbSlotInfoEXT& copy_src);
     safe_VkVideoDecodeH265DpbSlotInfoEXT& operator=(const safe_VkVideoDecodeH265DpbSlotInfoEXT& copy_src);
@@ -8631,7 +8631,7 @@ struct safe_VkVideoDecodeH265DpbSlotInfoEXT {
 
 struct safe_VkDeviceMemoryOverallocationCreateInfoAMD {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkMemoryOverallocationBehaviorAMD overallocationBehavior;
     safe_VkDeviceMemoryOverallocationCreateInfoAMD(const VkDeviceMemoryOverallocationCreateInfoAMD* in_struct);
     safe_VkDeviceMemoryOverallocationCreateInfoAMD(const safe_VkDeviceMemoryOverallocationCreateInfoAMD& copy_src);
@@ -8646,7 +8646,7 @@ struct safe_VkDeviceMemoryOverallocationCreateInfoAMD {
 
 struct safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxVertexAttribDivisor;
     safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT(const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* in_struct);
     safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT(const safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& copy_src);
@@ -8661,9 +8661,9 @@ struct safe_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT {
 
 struct safe_VkPipelineVertexInputDivisorStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t vertexBindingDivisorCount;
-    const VkVertexInputBindingDivisorDescriptionEXT* pVertexBindingDivisors;
+    const VkVertexInputBindingDivisorDescriptionEXT* pVertexBindingDivisors{};
     safe_VkPipelineVertexInputDivisorStateCreateInfoEXT(const VkPipelineVertexInputDivisorStateCreateInfoEXT* in_struct);
     safe_VkPipelineVertexInputDivisorStateCreateInfoEXT(const safe_VkPipelineVertexInputDivisorStateCreateInfoEXT& copy_src);
     safe_VkPipelineVertexInputDivisorStateCreateInfoEXT& operator=(const safe_VkPipelineVertexInputDivisorStateCreateInfoEXT& copy_src);
@@ -8677,7 +8677,7 @@ struct safe_VkPipelineVertexInputDivisorStateCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 vertexAttributeInstanceRateDivisor;
     VkBool32 vertexAttributeInstanceRateZeroDivisor;
     safe_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT(const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* in_struct);
@@ -8694,7 +8694,7 @@ struct safe_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT {
 #ifdef VK_USE_PLATFORM_GGP
 struct safe_VkPresentFrameTokenGGP {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     GgpFrameToken frameToken;
     safe_VkPresentFrameTokenGGP(const VkPresentFrameTokenGGP* in_struct);
     safe_VkPresentFrameTokenGGP(const safe_VkPresentFrameTokenGGP& copy_src);
@@ -8710,7 +8710,7 @@ struct safe_VkPresentFrameTokenGGP {
 
 struct safe_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 computeDerivativeGroupQuads;
     VkBool32 computeDerivativeGroupLinear;
     safe_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV(const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* in_struct);
@@ -8726,7 +8726,7 @@ struct safe_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV {
 
 struct safe_VkPhysicalDeviceMeshShaderFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 taskShader;
     VkBool32 meshShader;
     safe_VkPhysicalDeviceMeshShaderFeaturesNV(const VkPhysicalDeviceMeshShaderFeaturesNV* in_struct);
@@ -8742,7 +8742,7 @@ struct safe_VkPhysicalDeviceMeshShaderFeaturesNV {
 
 struct safe_VkPhysicalDeviceMeshShaderPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxDrawMeshTasksCount;
     uint32_t maxTaskWorkGroupInvocations;
     uint32_t maxTaskWorkGroupSize[3];
@@ -8769,7 +8769,7 @@ struct safe_VkPhysicalDeviceMeshShaderPropertiesNV {
 
 struct safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentShaderBarycentric;
     safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV(const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* in_struct);
     safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV(const safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV& copy_src);
@@ -8784,7 +8784,7 @@ struct safe_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV {
 
 struct safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 imageFootprint;
     safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV(const VkPhysicalDeviceShaderImageFootprintFeaturesNV* in_struct);
     safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV(const safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV& copy_src);
@@ -8799,9 +8799,9 @@ struct safe_VkPhysicalDeviceShaderImageFootprintFeaturesNV {
 
 struct safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t exclusiveScissorCount;
-    const VkRect2D* pExclusiveScissors;
+    const VkRect2D* pExclusiveScissors{};
     safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV(const VkPipelineViewportExclusiveScissorStateCreateInfoNV* in_struct);
     safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV(const safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV& copy_src);
     safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV& operator=(const safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV& copy_src);
@@ -8815,7 +8815,7 @@ struct safe_VkPipelineViewportExclusiveScissorStateCreateInfoNV {
 
 struct safe_VkPhysicalDeviceExclusiveScissorFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 exclusiveScissor;
     safe_VkPhysicalDeviceExclusiveScissorFeaturesNV(const VkPhysicalDeviceExclusiveScissorFeaturesNV* in_struct);
     safe_VkPhysicalDeviceExclusiveScissorFeaturesNV(const safe_VkPhysicalDeviceExclusiveScissorFeaturesNV& copy_src);
@@ -8830,7 +8830,7 @@ struct safe_VkPhysicalDeviceExclusiveScissorFeaturesNV {
 
 struct safe_VkQueueFamilyCheckpointPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPipelineStageFlags checkpointExecutionStageMask;
     safe_VkQueueFamilyCheckpointPropertiesNV(const VkQueueFamilyCheckpointPropertiesNV* in_struct);
     safe_VkQueueFamilyCheckpointPropertiesNV(const safe_VkQueueFamilyCheckpointPropertiesNV& copy_src);
@@ -8845,9 +8845,9 @@ struct safe_VkQueueFamilyCheckpointPropertiesNV {
 
 struct safe_VkCheckpointDataNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkPipelineStageFlagBits stage;
-    void* pCheckpointMarker;
+    void* pCheckpointMarker{};
     safe_VkCheckpointDataNV(const VkCheckpointDataNV* in_struct);
     safe_VkCheckpointDataNV(const safe_VkCheckpointDataNV& copy_src);
     safe_VkCheckpointDataNV& operator=(const safe_VkCheckpointDataNV& copy_src);
@@ -8861,7 +8861,7 @@ struct safe_VkCheckpointDataNV {
 
 struct safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderIntegerFunctions2;
     safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL(const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* in_struct);
     safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL(const safe_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL& copy_src);
@@ -8879,7 +8879,7 @@ union safe_VkPerformanceValueDataINTEL {
     uint64_t value64;
     float valueFloat;
     VkBool32 valueBool;
-    const char* valueString;
+    const char* valueString{};
     safe_VkPerformanceValueDataINTEL(const VkPerformanceValueDataINTEL* in_struct);
     safe_VkPerformanceValueDataINTEL(const safe_VkPerformanceValueDataINTEL& copy_src);
     safe_VkPerformanceValueDataINTEL& operator=(const safe_VkPerformanceValueDataINTEL& copy_src);
@@ -8893,8 +8893,8 @@ union safe_VkPerformanceValueDataINTEL {
 
 struct safe_VkInitializePerformanceApiInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
-    void* pUserData;
+    const void* pNext{};
+    void* pUserData{};
     safe_VkInitializePerformanceApiInfoINTEL(const VkInitializePerformanceApiInfoINTEL* in_struct);
     safe_VkInitializePerformanceApiInfoINTEL(const safe_VkInitializePerformanceApiInfoINTEL& copy_src);
     safe_VkInitializePerformanceApiInfoINTEL& operator=(const safe_VkInitializePerformanceApiInfoINTEL& copy_src);
@@ -8908,7 +8908,7 @@ struct safe_VkInitializePerformanceApiInfoINTEL {
 
 struct safe_VkQueryPoolPerformanceQueryCreateInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkQueryPoolSamplingModeINTEL performanceCountersSampling;
     safe_VkQueryPoolPerformanceQueryCreateInfoINTEL(const VkQueryPoolPerformanceQueryCreateInfoINTEL* in_struct);
     safe_VkQueryPoolPerformanceQueryCreateInfoINTEL(const safe_VkQueryPoolPerformanceQueryCreateInfoINTEL& copy_src);
@@ -8923,7 +8923,7 @@ struct safe_VkQueryPoolPerformanceQueryCreateInfoINTEL {
 
 struct safe_VkPerformanceMarkerInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint64_t marker;
     safe_VkPerformanceMarkerInfoINTEL(const VkPerformanceMarkerInfoINTEL* in_struct);
     safe_VkPerformanceMarkerInfoINTEL(const safe_VkPerformanceMarkerInfoINTEL& copy_src);
@@ -8938,7 +8938,7 @@ struct safe_VkPerformanceMarkerInfoINTEL {
 
 struct safe_VkPerformanceStreamMarkerInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t marker;
     safe_VkPerformanceStreamMarkerInfoINTEL(const VkPerformanceStreamMarkerInfoINTEL* in_struct);
     safe_VkPerformanceStreamMarkerInfoINTEL(const safe_VkPerformanceStreamMarkerInfoINTEL& copy_src);
@@ -8953,7 +8953,7 @@ struct safe_VkPerformanceStreamMarkerInfoINTEL {
 
 struct safe_VkPerformanceOverrideInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPerformanceOverrideTypeINTEL type;
     VkBool32 enable;
     uint64_t parameter;
@@ -8970,7 +8970,7 @@ struct safe_VkPerformanceOverrideInfoINTEL {
 
 struct safe_VkPerformanceConfigurationAcquireInfoINTEL {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPerformanceConfigurationTypeINTEL type;
     safe_VkPerformanceConfigurationAcquireInfoINTEL(const VkPerformanceConfigurationAcquireInfoINTEL* in_struct);
     safe_VkPerformanceConfigurationAcquireInfoINTEL(const safe_VkPerformanceConfigurationAcquireInfoINTEL& copy_src);
@@ -8985,7 +8985,7 @@ struct safe_VkPerformanceConfigurationAcquireInfoINTEL {
 
 struct safe_VkPhysicalDevicePCIBusInfoPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t pciDomain;
     uint32_t pciBus;
     uint32_t pciDevice;
@@ -9003,7 +9003,7 @@ struct safe_VkPhysicalDevicePCIBusInfoPropertiesEXT {
 
 struct safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 localDimmingSupport;
     safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD(const VkDisplayNativeHdrSurfaceCapabilitiesAMD* in_struct);
     safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD(const safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD& copy_src);
@@ -9018,7 +9018,7 @@ struct safe_VkDisplayNativeHdrSurfaceCapabilitiesAMD {
 
 struct safe_VkSwapchainDisplayNativeHdrCreateInfoAMD {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 localDimmingEnable;
     safe_VkSwapchainDisplayNativeHdrCreateInfoAMD(const VkSwapchainDisplayNativeHdrCreateInfoAMD* in_struct);
     safe_VkSwapchainDisplayNativeHdrCreateInfoAMD(const safe_VkSwapchainDisplayNativeHdrCreateInfoAMD& copy_src);
@@ -9034,7 +9034,7 @@ struct safe_VkSwapchainDisplayNativeHdrCreateInfoAMD {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImagePipeSurfaceCreateInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkImagePipeSurfaceCreateFlagsFUCHSIA flags;
     zx_handle_t imagePipeHandle;
     safe_VkImagePipeSurfaceCreateInfoFUCHSIA(const VkImagePipeSurfaceCreateInfoFUCHSIA* in_struct);
@@ -9052,9 +9052,9 @@ struct safe_VkImagePipeSurfaceCreateInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_METAL_EXT
 struct safe_VkMetalSurfaceCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkMetalSurfaceCreateFlagsEXT flags;
-    const CAMetalLayer* pLayer;
+    const CAMetalLayer* pLayer{};
     safe_VkMetalSurfaceCreateInfoEXT(const VkMetalSurfaceCreateInfoEXT* in_struct);
     safe_VkMetalSurfaceCreateInfoEXT(const safe_VkMetalSurfaceCreateInfoEXT& copy_src);
     safe_VkMetalSurfaceCreateInfoEXT& operator=(const safe_VkMetalSurfaceCreateInfoEXT& copy_src);
@@ -9069,7 +9069,7 @@ struct safe_VkMetalSurfaceCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceFragmentDensityMapFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentDensityMap;
     VkBool32 fragmentDensityMapDynamic;
     VkBool32 fragmentDensityMapNonSubsampledImages;
@@ -9086,7 +9086,7 @@ struct safe_VkPhysicalDeviceFragmentDensityMapFeaturesEXT {
 
 struct safe_VkPhysicalDeviceFragmentDensityMapPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExtent2D minFragmentDensityTexelSize;
     VkExtent2D maxFragmentDensityTexelSize;
     VkBool32 fragmentDensityInvocations;
@@ -9103,7 +9103,7 @@ struct safe_VkPhysicalDeviceFragmentDensityMapPropertiesEXT {
 
 struct safe_VkRenderPassFragmentDensityMapCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAttachmentReference fragmentDensityMapAttachment;
     safe_VkRenderPassFragmentDensityMapCreateInfoEXT(const VkRenderPassFragmentDensityMapCreateInfoEXT* in_struct);
     safe_VkRenderPassFragmentDensityMapCreateInfoEXT(const safe_VkRenderPassFragmentDensityMapCreateInfoEXT& copy_src);
@@ -9118,7 +9118,7 @@ struct safe_VkRenderPassFragmentDensityMapCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceShaderCoreProperties2AMD {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkShaderCorePropertiesFlagsAMD shaderCoreFeatures;
     uint32_t activeComputeUnitCount;
     safe_VkPhysicalDeviceShaderCoreProperties2AMD(const VkPhysicalDeviceShaderCoreProperties2AMD* in_struct);
@@ -9134,7 +9134,7 @@ struct safe_VkPhysicalDeviceShaderCoreProperties2AMD {
 
 struct safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 deviceCoherentMemory;
     safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD(const VkPhysicalDeviceCoherentMemoryFeaturesAMD* in_struct);
     safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD(const safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD& copy_src);
@@ -9149,7 +9149,7 @@ struct safe_VkPhysicalDeviceCoherentMemoryFeaturesAMD {
 
 struct safe_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderImageInt64Atomics;
     VkBool32 sparseImageInt64Atomics;
     safe_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT(const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* in_struct);
@@ -9165,7 +9165,7 @@ struct safe_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT {
 
 struct safe_VkPhysicalDeviceMemoryBudgetPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize heapBudget[VK_MAX_MEMORY_HEAPS];
     VkDeviceSize heapUsage[VK_MAX_MEMORY_HEAPS];
     safe_VkPhysicalDeviceMemoryBudgetPropertiesEXT(const VkPhysicalDeviceMemoryBudgetPropertiesEXT* in_struct);
@@ -9181,7 +9181,7 @@ struct safe_VkPhysicalDeviceMemoryBudgetPropertiesEXT {
 
 struct safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 memoryPriority;
     safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT(const VkPhysicalDeviceMemoryPriorityFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT(const safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT& copy_src);
@@ -9196,7 +9196,7 @@ struct safe_VkPhysicalDeviceMemoryPriorityFeaturesEXT {
 
 struct safe_VkMemoryPriorityAllocateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     float priority;
     safe_VkMemoryPriorityAllocateInfoEXT(const VkMemoryPriorityAllocateInfoEXT* in_struct);
     safe_VkMemoryPriorityAllocateInfoEXT(const safe_VkMemoryPriorityAllocateInfoEXT& copy_src);
@@ -9211,7 +9211,7 @@ struct safe_VkMemoryPriorityAllocateInfoEXT {
 
 struct safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 dedicatedAllocationImageAliasing;
     safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV(const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* in_struct);
     safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV(const safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV& copy_src);
@@ -9226,7 +9226,7 @@ struct safe_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV {
 
 struct safe_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 bufferDeviceAddress;
     VkBool32 bufferDeviceAddressCaptureReplay;
     VkBool32 bufferDeviceAddressMultiDevice;
@@ -9243,7 +9243,7 @@ struct safe_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT {
 
 struct safe_VkBufferDeviceAddressCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceAddress deviceAddress;
     safe_VkBufferDeviceAddressCreateInfoEXT(const VkBufferDeviceAddressCreateInfoEXT* in_struct);
     safe_VkBufferDeviceAddressCreateInfoEXT(const safe_VkBufferDeviceAddressCreateInfoEXT& copy_src);
@@ -9258,11 +9258,11 @@ struct safe_VkBufferDeviceAddressCreateInfoEXT {
 
 struct safe_VkValidationFeaturesEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t enabledValidationFeatureCount;
-    const VkValidationFeatureEnableEXT* pEnabledValidationFeatures;
+    const VkValidationFeatureEnableEXT* pEnabledValidationFeatures{};
     uint32_t disabledValidationFeatureCount;
-    const VkValidationFeatureDisableEXT* pDisabledValidationFeatures;
+    const VkValidationFeatureDisableEXT* pDisabledValidationFeatures{};
     safe_VkValidationFeaturesEXT(const VkValidationFeaturesEXT* in_struct);
     safe_VkValidationFeaturesEXT(const safe_VkValidationFeaturesEXT& copy_src);
     safe_VkValidationFeaturesEXT& operator=(const safe_VkValidationFeaturesEXT& copy_src);
@@ -9276,7 +9276,7 @@ struct safe_VkValidationFeaturesEXT {
 
 struct safe_VkCooperativeMatrixPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t MSize;
     uint32_t NSize;
     uint32_t KSize;
@@ -9298,7 +9298,7 @@ struct safe_VkCooperativeMatrixPropertiesNV {
 
 struct safe_VkPhysicalDeviceCooperativeMatrixFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 cooperativeMatrix;
     VkBool32 cooperativeMatrixRobustBufferAccess;
     safe_VkPhysicalDeviceCooperativeMatrixFeaturesNV(const VkPhysicalDeviceCooperativeMatrixFeaturesNV* in_struct);
@@ -9314,7 +9314,7 @@ struct safe_VkPhysicalDeviceCooperativeMatrixFeaturesNV {
 
 struct safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkShaderStageFlags cooperativeMatrixSupportedStages;
     safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV(const VkPhysicalDeviceCooperativeMatrixPropertiesNV* in_struct);
     safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV(const safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV& copy_src);
@@ -9329,7 +9329,7 @@ struct safe_VkPhysicalDeviceCooperativeMatrixPropertiesNV {
 
 struct safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 coverageReductionMode;
     safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV(const VkPhysicalDeviceCoverageReductionModeFeaturesNV* in_struct);
     safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV(const safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV& copy_src);
@@ -9344,7 +9344,7 @@ struct safe_VkPhysicalDeviceCoverageReductionModeFeaturesNV {
 
 struct safe_VkPipelineCoverageReductionStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCoverageReductionStateCreateFlagsNV flags;
     VkCoverageReductionModeNV coverageReductionMode;
     safe_VkPipelineCoverageReductionStateCreateInfoNV(const VkPipelineCoverageReductionStateCreateInfoNV* in_struct);
@@ -9360,7 +9360,7 @@ struct safe_VkPipelineCoverageReductionStateCreateInfoNV {
 
 struct safe_VkFramebufferMixedSamplesCombinationNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkCoverageReductionModeNV coverageReductionMode;
     VkSampleCountFlagBits rasterizationSamples;
     VkSampleCountFlags depthStencilSamples;
@@ -9378,7 +9378,7 @@ struct safe_VkFramebufferMixedSamplesCombinationNV {
 
 struct safe_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentShaderSampleInterlock;
     VkBool32 fragmentShaderPixelInterlock;
     VkBool32 fragmentShaderShadingRateInterlock;
@@ -9395,7 +9395,7 @@ struct safe_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT {
 
 struct safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 ycbcrImageArrays;
     safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT(const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT(const safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT& copy_src);
@@ -9410,7 +9410,7 @@ struct safe_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT {
 
 struct safe_VkPhysicalDeviceProvokingVertexFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 provokingVertexLast;
     VkBool32 transformFeedbackPreservesProvokingVertex;
     safe_VkPhysicalDeviceProvokingVertexFeaturesEXT(const VkPhysicalDeviceProvokingVertexFeaturesEXT* in_struct);
@@ -9426,7 +9426,7 @@ struct safe_VkPhysicalDeviceProvokingVertexFeaturesEXT {
 
 struct safe_VkPhysicalDeviceProvokingVertexPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 provokingVertexModePerPipeline;
     VkBool32 transformFeedbackPreservesTriangleFanProvokingVertex;
     safe_VkPhysicalDeviceProvokingVertexPropertiesEXT(const VkPhysicalDeviceProvokingVertexPropertiesEXT* in_struct);
@@ -9442,7 +9442,7 @@ struct safe_VkPhysicalDeviceProvokingVertexPropertiesEXT {
 
 struct safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkProvokingVertexModeEXT provokingVertexMode;
     safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT(const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT* in_struct);
     safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT(const safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT& copy_src);
@@ -9458,7 +9458,7 @@ struct safe_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkSurfaceFullScreenExclusiveInfoEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkFullScreenExclusiveEXT fullScreenExclusive;
     safe_VkSurfaceFullScreenExclusiveInfoEXT(const VkSurfaceFullScreenExclusiveInfoEXT* in_struct);
     safe_VkSurfaceFullScreenExclusiveInfoEXT(const safe_VkSurfaceFullScreenExclusiveInfoEXT& copy_src);
@@ -9475,7 +9475,7 @@ struct safe_VkSurfaceFullScreenExclusiveInfoEXT {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fullScreenExclusiveSupported;
     safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT(const VkSurfaceCapabilitiesFullScreenExclusiveEXT* in_struct);
     safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT(const safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT& copy_src);
@@ -9492,7 +9492,7 @@ struct safe_VkSurfaceCapabilitiesFullScreenExclusiveEXT {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 struct safe_VkSurfaceFullScreenExclusiveWin32InfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     HMONITOR hmonitor;
     safe_VkSurfaceFullScreenExclusiveWin32InfoEXT(const VkSurfaceFullScreenExclusiveWin32InfoEXT* in_struct);
     safe_VkSurfaceFullScreenExclusiveWin32InfoEXT(const safe_VkSurfaceFullScreenExclusiveWin32InfoEXT& copy_src);
@@ -9508,7 +9508,7 @@ struct safe_VkSurfaceFullScreenExclusiveWin32InfoEXT {
 
 struct safe_VkHeadlessSurfaceCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkHeadlessSurfaceCreateFlagsEXT flags;
     safe_VkHeadlessSurfaceCreateInfoEXT(const VkHeadlessSurfaceCreateInfoEXT* in_struct);
     safe_VkHeadlessSurfaceCreateInfoEXT(const safe_VkHeadlessSurfaceCreateInfoEXT& copy_src);
@@ -9523,7 +9523,7 @@ struct safe_VkHeadlessSurfaceCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceLineRasterizationFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 rectangularLines;
     VkBool32 bresenhamLines;
     VkBool32 smoothLines;
@@ -9543,7 +9543,7 @@ struct safe_VkPhysicalDeviceLineRasterizationFeaturesEXT {
 
 struct safe_VkPhysicalDeviceLineRasterizationPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t lineSubPixelPrecisionBits;
     safe_VkPhysicalDeviceLineRasterizationPropertiesEXT(const VkPhysicalDeviceLineRasterizationPropertiesEXT* in_struct);
     safe_VkPhysicalDeviceLineRasterizationPropertiesEXT(const safe_VkPhysicalDeviceLineRasterizationPropertiesEXT& copy_src);
@@ -9558,7 +9558,7 @@ struct safe_VkPhysicalDeviceLineRasterizationPropertiesEXT {
 
 struct safe_VkPipelineRasterizationLineStateCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkLineRasterizationModeEXT lineRasterizationMode;
     VkBool32 stippledLineEnable;
     uint32_t lineStippleFactor;
@@ -9576,7 +9576,7 @@ struct safe_VkPipelineRasterizationLineStateCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderBufferFloat32Atomics;
     VkBool32 shaderBufferFloat32AtomicAdd;
     VkBool32 shaderBufferFloat64Atomics;
@@ -9602,7 +9602,7 @@ struct safe_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT {
 
 struct safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 indexTypeUint8;
     safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT(const VkPhysicalDeviceIndexTypeUint8FeaturesEXT* in_struct);
     safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT(const safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT& copy_src);
@@ -9617,7 +9617,7 @@ struct safe_VkPhysicalDeviceIndexTypeUint8FeaturesEXT {
 
 struct safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 extendedDynamicState;
     safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT(const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT(const safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT& copy_src);
@@ -9632,7 +9632,7 @@ struct safe_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT {
 
 struct safe_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 shaderBufferFloat16Atomics;
     VkBool32 shaderBufferFloat16AtomicAdd;
     VkBool32 shaderBufferFloat16AtomicMinMax;
@@ -9658,7 +9658,7 @@ struct safe_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT {
 
 struct safe_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxGraphicsShaderGroupCount;
     uint32_t maxIndirectSequenceCount;
     uint32_t maxIndirectCommandsTokenCount;
@@ -9681,7 +9681,7 @@ struct safe_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV {
 
 struct safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 deviceGeneratedCommands;
     safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV(const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* in_struct);
     safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV(const safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV& copy_src);
@@ -9696,11 +9696,11 @@ struct safe_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV {
 
 struct safe_VkGraphicsShaderGroupCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t stageCount;
-    safe_VkPipelineShaderStageCreateInfo* pStages;
-    safe_VkPipelineVertexInputStateCreateInfo* pVertexInputState;
-    safe_VkPipelineTessellationStateCreateInfo* pTessellationState;
+    safe_VkPipelineShaderStageCreateInfo* pStages{};
+    safe_VkPipelineVertexInputStateCreateInfo* pVertexInputState{};
+    safe_VkPipelineTessellationStateCreateInfo* pTessellationState{};
     safe_VkGraphicsShaderGroupCreateInfoNV(const VkGraphicsShaderGroupCreateInfoNV* in_struct);
     safe_VkGraphicsShaderGroupCreateInfoNV(const safe_VkGraphicsShaderGroupCreateInfoNV& copy_src);
     safe_VkGraphicsShaderGroupCreateInfoNV& operator=(const safe_VkGraphicsShaderGroupCreateInfoNV& copy_src);
@@ -9714,11 +9714,11 @@ struct safe_VkGraphicsShaderGroupCreateInfoNV {
 
 struct safe_VkGraphicsPipelineShaderGroupsCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t groupCount;
-    safe_VkGraphicsShaderGroupCreateInfoNV* pGroups;
+    safe_VkGraphicsShaderGroupCreateInfoNV* pGroups{};
     uint32_t pipelineCount;
-    VkPipeline* pPipelines;
+    VkPipeline* pPipelines{};
     safe_VkGraphicsPipelineShaderGroupsCreateInfoNV(const VkGraphicsPipelineShaderGroupsCreateInfoNV* in_struct);
     safe_VkGraphicsPipelineShaderGroupsCreateInfoNV(const safe_VkGraphicsPipelineShaderGroupsCreateInfoNV& copy_src);
     safe_VkGraphicsPipelineShaderGroupsCreateInfoNV& operator=(const safe_VkGraphicsPipelineShaderGroupsCreateInfoNV& copy_src);
@@ -9732,7 +9732,7 @@ struct safe_VkGraphicsPipelineShaderGroupsCreateInfoNV {
 
 struct safe_VkIndirectCommandsLayoutTokenNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkIndirectCommandsTokenTypeNV tokenType;
     uint32_t stream;
     uint32_t offset;
@@ -9744,8 +9744,8 @@ struct safe_VkIndirectCommandsLayoutTokenNV {
     uint32_t pushconstantSize;
     VkIndirectStateFlagsNV indirectStateFlags;
     uint32_t indexTypeCount;
-    const VkIndexType* pIndexTypes;
-    const uint32_t* pIndexTypeValues;
+    const VkIndexType* pIndexTypes{};
+    const uint32_t* pIndexTypeValues{};
     safe_VkIndirectCommandsLayoutTokenNV(const VkIndirectCommandsLayoutTokenNV* in_struct);
     safe_VkIndirectCommandsLayoutTokenNV(const safe_VkIndirectCommandsLayoutTokenNV& copy_src);
     safe_VkIndirectCommandsLayoutTokenNV& operator=(const safe_VkIndirectCommandsLayoutTokenNV& copy_src);
@@ -9759,13 +9759,13 @@ struct safe_VkIndirectCommandsLayoutTokenNV {
 
 struct safe_VkIndirectCommandsLayoutCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkIndirectCommandsLayoutUsageFlagsNV flags;
     VkPipelineBindPoint pipelineBindPoint;
     uint32_t tokenCount;
-    safe_VkIndirectCommandsLayoutTokenNV* pTokens;
+    safe_VkIndirectCommandsLayoutTokenNV* pTokens{};
     uint32_t streamCount;
-    const uint32_t* pStreamStrides;
+    const uint32_t* pStreamStrides{};
     safe_VkIndirectCommandsLayoutCreateInfoNV(const VkIndirectCommandsLayoutCreateInfoNV* in_struct);
     safe_VkIndirectCommandsLayoutCreateInfoNV(const safe_VkIndirectCommandsLayoutCreateInfoNV& copy_src);
     safe_VkIndirectCommandsLayoutCreateInfoNV& operator=(const safe_VkIndirectCommandsLayoutCreateInfoNV& copy_src);
@@ -9779,12 +9779,12 @@ struct safe_VkIndirectCommandsLayoutCreateInfoNV {
 
 struct safe_VkGeneratedCommandsInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineBindPoint pipelineBindPoint;
     VkPipeline pipeline;
     VkIndirectCommandsLayoutNV indirectCommandsLayout;
     uint32_t streamCount;
-    VkIndirectCommandsStreamNV* pStreams;
+    VkIndirectCommandsStreamNV* pStreams{};
     uint32_t sequencesCount;
     VkBuffer preprocessBuffer;
     VkDeviceSize preprocessOffset;
@@ -9806,7 +9806,7 @@ struct safe_VkGeneratedCommandsInfoNV {
 
 struct safe_VkGeneratedCommandsMemoryRequirementsInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineBindPoint pipelineBindPoint;
     VkPipeline pipeline;
     VkIndirectCommandsLayoutNV indirectCommandsLayout;
@@ -9824,7 +9824,7 @@ struct safe_VkGeneratedCommandsMemoryRequirementsInfoNV {
 
 struct safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 inheritedViewportScissor2D;
     safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV(const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* in_struct);
     safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV(const safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV& copy_src);
@@ -9839,10 +9839,10 @@ struct safe_VkPhysicalDeviceInheritedViewportScissorFeaturesNV {
 
 struct safe_VkCommandBufferInheritanceViewportScissorInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 viewportScissor2D;
     uint32_t viewportDepthCount;
-    const VkViewport* pViewportDepths;
+    const VkViewport* pViewportDepths{};
     safe_VkCommandBufferInheritanceViewportScissorInfoNV(const VkCommandBufferInheritanceViewportScissorInfoNV* in_struct);
     safe_VkCommandBufferInheritanceViewportScissorInfoNV(const safe_VkCommandBufferInheritanceViewportScissorInfoNV& copy_src);
     safe_VkCommandBufferInheritanceViewportScissorInfoNV& operator=(const safe_VkCommandBufferInheritanceViewportScissorInfoNV& copy_src);
@@ -9856,7 +9856,7 @@ struct safe_VkCommandBufferInheritanceViewportScissorInfoNV {
 
 struct safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 texelBufferAlignment;
     safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT(const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT(const safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT& copy_src);
@@ -9871,7 +9871,7 @@ struct safe_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT {
 
 struct safe_VkRenderPassTransformBeginInfoQCOM {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSurfaceTransformFlagBitsKHR transform;
     safe_VkRenderPassTransformBeginInfoQCOM(const VkRenderPassTransformBeginInfoQCOM* in_struct);
     safe_VkRenderPassTransformBeginInfoQCOM(const safe_VkRenderPassTransformBeginInfoQCOM& copy_src);
@@ -9886,7 +9886,7 @@ struct safe_VkRenderPassTransformBeginInfoQCOM {
 
 struct safe_VkCommandBufferInheritanceRenderPassTransformInfoQCOM {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSurfaceTransformFlagBitsKHR transform;
     VkRect2D renderArea;
     safe_VkCommandBufferInheritanceRenderPassTransformInfoQCOM(const VkCommandBufferInheritanceRenderPassTransformInfoQCOM* in_struct);
@@ -9902,7 +9902,7 @@ struct safe_VkCommandBufferInheritanceRenderPassTransformInfoQCOM {
 
 struct safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 deviceMemoryReport;
     safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT(const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT(const safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& copy_src);
@@ -9917,7 +9917,7 @@ struct safe_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT {
 
 struct safe_VkDeviceMemoryReportCallbackDataEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceMemoryReportFlagsEXT flags;
     VkDeviceMemoryReportEventTypeEXT type;
     uint64_t memoryObjectId;
@@ -9938,10 +9938,10 @@ struct safe_VkDeviceMemoryReportCallbackDataEXT {
 
 struct safe_VkDeviceDeviceMemoryReportCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemoryReportFlagsEXT flags;
     PFN_vkDeviceMemoryReportCallbackEXT pfnUserCallback;
-    void* pUserData;
+    void* pUserData{};
     safe_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemoryReportCreateInfoEXT* in_struct);
     safe_VkDeviceDeviceMemoryReportCreateInfoEXT(const safe_VkDeviceDeviceMemoryReportCreateInfoEXT& copy_src);
     safe_VkDeviceDeviceMemoryReportCreateInfoEXT& operator=(const safe_VkDeviceDeviceMemoryReportCreateInfoEXT& copy_src);
@@ -9955,7 +9955,7 @@ struct safe_VkDeviceDeviceMemoryReportCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceRobustness2FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 robustBufferAccess2;
     VkBool32 robustImageAccess2;
     VkBool32 nullDescriptor;
@@ -9972,7 +9972,7 @@ struct safe_VkPhysicalDeviceRobustness2FeaturesEXT {
 
 struct safe_VkPhysicalDeviceRobustness2PropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkDeviceSize robustStorageBufferAccessSizeAlignment;
     VkDeviceSize robustUniformBufferAccessSizeAlignment;
     safe_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT* in_struct);
@@ -9988,7 +9988,7 @@ struct safe_VkPhysicalDeviceRobustness2PropertiesEXT {
 
 struct safe_VkSamplerCustomBorderColorCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkClearColorValue customBorderColor;
     VkFormat format;
     safe_VkSamplerCustomBorderColorCreateInfoEXT(const VkSamplerCustomBorderColorCreateInfoEXT* in_struct);
@@ -10004,7 +10004,7 @@ struct safe_VkSamplerCustomBorderColorCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxCustomBorderColorSamplers;
     safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT(const VkPhysicalDeviceCustomBorderColorPropertiesEXT* in_struct);
     safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT(const safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT& copy_src);
@@ -10019,7 +10019,7 @@ struct safe_VkPhysicalDeviceCustomBorderColorPropertiesEXT {
 
 struct safe_VkPhysicalDeviceCustomBorderColorFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 customBorderColors;
     VkBool32 customBorderColorWithoutFormat;
     safe_VkPhysicalDeviceCustomBorderColorFeaturesEXT(const VkPhysicalDeviceCustomBorderColorFeaturesEXT* in_struct);
@@ -10035,7 +10035,7 @@ struct safe_VkPhysicalDeviceCustomBorderColorFeaturesEXT {
 
 struct safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 diagnosticsConfig;
     safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV(const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* in_struct);
     safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV(const safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV& copy_src);
@@ -10050,7 +10050,7 @@ struct safe_VkPhysicalDeviceDiagnosticsConfigFeaturesNV {
 
 struct safe_VkDeviceDiagnosticsConfigCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceDiagnosticsConfigFlagsNV flags;
     safe_VkDeviceDiagnosticsConfigCreateInfoNV(const VkDeviceDiagnosticsConfigCreateInfoNV* in_struct);
     safe_VkDeviceDiagnosticsConfigCreateInfoNV(const safe_VkDeviceDiagnosticsConfigCreateInfoNV& copy_src);
@@ -10065,7 +10065,7 @@ struct safe_VkDeviceDiagnosticsConfigCreateInfoNV {
 
 struct safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 graphicsPipelineLibrary;
     safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT(const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT(const safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT& copy_src);
@@ -10080,7 +10080,7 @@ struct safe_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT {
 
 struct safe_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 graphicsPipelineLibraryFastLinking;
     VkBool32 graphicsPipelineLibraryIndependentInterpolationDecoration;
     safe_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT(const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT* in_struct);
@@ -10096,7 +10096,7 @@ struct safe_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT {
 
 struct safe_VkGraphicsPipelineLibraryCreateInfoEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkGraphicsPipelineLibraryFlagsEXT flags;
     safe_VkGraphicsPipelineLibraryCreateInfoEXT(const VkGraphicsPipelineLibraryCreateInfoEXT* in_struct);
     safe_VkGraphicsPipelineLibraryCreateInfoEXT(const safe_VkGraphicsPipelineLibraryCreateInfoEXT& copy_src);
@@ -10111,7 +10111,7 @@ struct safe_VkGraphicsPipelineLibraryCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentShadingRateEnums;
     VkBool32 supersampleFragmentShadingRates;
     VkBool32 noInvocationFragmentShadingRates;
@@ -10128,7 +10128,7 @@ struct safe_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV {
 
 struct safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkSampleCountFlagBits maxFragmentShadingRateInvocationCount;
     safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV(const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV* in_struct);
     safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV(const safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV& copy_src);
@@ -10143,7 +10143,7 @@ struct safe_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV {
 
 struct safe_VkPipelineFragmentShadingRateEnumStateCreateInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFragmentShadingRateTypeNV shadingRateType;
     VkFragmentShadingRateNV shadingRate;
     VkFragmentShadingRateCombinerOpKHR combinerOps[2];
@@ -10160,7 +10160,7 @@ struct safe_VkPipelineFragmentShadingRateEnumStateCreateInfoNV {
 
 union safe_VkDeviceOrHostAddressConstKHR {
     VkDeviceAddress deviceAddress;
-    const void* hostAddress;
+    const void* hostAddress{};
     safe_VkDeviceOrHostAddressConstKHR(const VkDeviceOrHostAddressConstKHR* in_struct);
     safe_VkDeviceOrHostAddressConstKHR(const safe_VkDeviceOrHostAddressConstKHR& copy_src);
     safe_VkDeviceOrHostAddressConstKHR& operator=(const safe_VkDeviceOrHostAddressConstKHR& copy_src);
@@ -10174,7 +10174,7 @@ union safe_VkDeviceOrHostAddressConstKHR {
 
 struct safe_VkAccelerationStructureGeometryMotionTrianglesDataNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkDeviceOrHostAddressConstKHR vertexData;
     safe_VkAccelerationStructureGeometryMotionTrianglesDataNV(const VkAccelerationStructureGeometryMotionTrianglesDataNV* in_struct);
     safe_VkAccelerationStructureGeometryMotionTrianglesDataNV(const safe_VkAccelerationStructureGeometryMotionTrianglesDataNV& copy_src);
@@ -10189,7 +10189,7 @@ struct safe_VkAccelerationStructureGeometryMotionTrianglesDataNV {
 
 struct safe_VkAccelerationStructureMotionInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxInstances;
     VkAccelerationStructureMotionInfoFlagsNV flags;
     safe_VkAccelerationStructureMotionInfoNV(const VkAccelerationStructureMotionInfoNV* in_struct);
@@ -10205,7 +10205,7 @@ struct safe_VkAccelerationStructureMotionInfoNV {
 
 struct safe_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 rayTracingMotionBlur;
     VkBool32 rayTracingMotionBlurPipelineTraceRaysIndirect;
     safe_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV(const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* in_struct);
@@ -10221,7 +10221,7 @@ struct safe_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV {
 
 struct safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 ycbcr2plane444Formats;
     safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT(const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT(const safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT& copy_src);
@@ -10236,7 +10236,7 @@ struct safe_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT {
 
 struct safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentDensityMapDeferred;
     safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT(const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* in_struct);
     safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT(const safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT& copy_src);
@@ -10251,7 +10251,7 @@ struct safe_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT {
 
 struct safe_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 subsampledLoads;
     VkBool32 subsampledCoarseReconstructionEarlyAccess;
     uint32_t maxSubsampledArrayLayers;
@@ -10269,7 +10269,7 @@ struct safe_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT {
 
 struct safe_VkCopyCommandTransformInfoQCOM {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSurfaceTransformFlagBitsKHR transform;
     safe_VkCopyCommandTransformInfoQCOM(const VkCopyCommandTransformInfoQCOM* in_struct);
     safe_VkCopyCommandTransformInfoQCOM(const safe_VkCopyCommandTransformInfoQCOM& copy_src);
@@ -10284,7 +10284,7 @@ struct safe_VkCopyCommandTransformInfoQCOM {
 
 struct safe_VkPhysicalDevice4444FormatsFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 formatA4R4G4B4;
     VkBool32 formatA4B4G4R4;
     safe_VkPhysicalDevice4444FormatsFeaturesEXT(const VkPhysicalDevice4444FormatsFeaturesEXT* in_struct);
@@ -10300,7 +10300,7 @@ struct safe_VkPhysicalDevice4444FormatsFeaturesEXT {
 
 struct safe_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 rasterizationOrderColorAttachmentAccess;
     VkBool32 rasterizationOrderDepthAttachmentAccess;
     VkBool32 rasterizationOrderStencilAttachmentAccess;
@@ -10317,7 +10317,7 @@ struct safe_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM {
 
 struct safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 formatRgba10x6WithoutYCbCrSampler;
     safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT(const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT(const safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT& copy_src);
@@ -10333,10 +10333,10 @@ struct safe_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT {
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
 struct safe_VkDirectFBSurfaceCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDirectFBSurfaceCreateFlagsEXT flags;
-    IDirectFB* dfb;
-    IDirectFBSurface* surface;
+    IDirectFB* dfb{};
+    IDirectFBSurface* surface{};
     safe_VkDirectFBSurfaceCreateInfoEXT(const VkDirectFBSurfaceCreateInfoEXT* in_struct);
     safe_VkDirectFBSurfaceCreateInfoEXT(const safe_VkDirectFBSurfaceCreateInfoEXT& copy_src);
     safe_VkDirectFBSurfaceCreateInfoEXT& operator=(const safe_VkDirectFBSurfaceCreateInfoEXT& copy_src);
@@ -10351,7 +10351,7 @@ struct safe_VkDirectFBSurfaceCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 mutableDescriptorType;
     safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE(const VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE* in_struct);
     safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE(const safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE& copy_src);
@@ -10366,7 +10366,7 @@ struct safe_VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE {
 
 struct safe_VkMutableDescriptorTypeListVALVE {
     uint32_t descriptorTypeCount;
-    const VkDescriptorType* pDescriptorTypes;
+    const VkDescriptorType* pDescriptorTypes{};
     safe_VkMutableDescriptorTypeListVALVE(const VkMutableDescriptorTypeListVALVE* in_struct);
     safe_VkMutableDescriptorTypeListVALVE(const safe_VkMutableDescriptorTypeListVALVE& copy_src);
     safe_VkMutableDescriptorTypeListVALVE& operator=(const safe_VkMutableDescriptorTypeListVALVE& copy_src);
@@ -10380,9 +10380,9 @@ struct safe_VkMutableDescriptorTypeListVALVE {
 
 struct safe_VkMutableDescriptorTypeCreateInfoVALVE {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t mutableDescriptorTypeListCount;
-    safe_VkMutableDescriptorTypeListVALVE* pMutableDescriptorTypeLists;
+    safe_VkMutableDescriptorTypeListVALVE* pMutableDescriptorTypeLists{};
     safe_VkMutableDescriptorTypeCreateInfoVALVE(const VkMutableDescriptorTypeCreateInfoVALVE* in_struct);
     safe_VkMutableDescriptorTypeCreateInfoVALVE(const safe_VkMutableDescriptorTypeCreateInfoVALVE& copy_src);
     safe_VkMutableDescriptorTypeCreateInfoVALVE& operator=(const safe_VkMutableDescriptorTypeCreateInfoVALVE& copy_src);
@@ -10396,7 +10396,7 @@ struct safe_VkMutableDescriptorTypeCreateInfoVALVE {
 
 struct safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 vertexInputDynamicState;
     safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT(const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT(const safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT& copy_src);
@@ -10411,7 +10411,7 @@ struct safe_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT {
 
 struct safe_VkVertexInputBindingDescription2EXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t binding;
     uint32_t stride;
     VkVertexInputRate inputRate;
@@ -10429,7 +10429,7 @@ struct safe_VkVertexInputBindingDescription2EXT {
 
 struct safe_VkVertexInputAttributeDescription2EXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t location;
     uint32_t binding;
     VkFormat format;
@@ -10447,7 +10447,7 @@ struct safe_VkVertexInputAttributeDescription2EXT {
 
 struct safe_VkPhysicalDeviceDrmPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 hasPrimary;
     VkBool32 hasRender;
     int64_t primaryMajor;
@@ -10467,7 +10467,7 @@ struct safe_VkPhysicalDeviceDrmPropertiesEXT {
 
 struct safe_VkPhysicalDeviceDepthClipControlFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 depthClipControl;
     safe_VkPhysicalDeviceDepthClipControlFeaturesEXT(const VkPhysicalDeviceDepthClipControlFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceDepthClipControlFeaturesEXT(const safe_VkPhysicalDeviceDepthClipControlFeaturesEXT& copy_src);
@@ -10482,7 +10482,7 @@ struct safe_VkPhysicalDeviceDepthClipControlFeaturesEXT {
 
 struct safe_VkPipelineViewportDepthClipControlCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 negativeOneToOne;
     safe_VkPipelineViewportDepthClipControlCreateInfoEXT(const VkPipelineViewportDepthClipControlCreateInfoEXT* in_struct);
     safe_VkPipelineViewportDepthClipControlCreateInfoEXT(const safe_VkPipelineViewportDepthClipControlCreateInfoEXT& copy_src);
@@ -10497,7 +10497,7 @@ struct safe_VkPipelineViewportDepthClipControlCreateInfoEXT {
 
 struct safe_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 primitiveTopologyListRestart;
     VkBool32 primitiveTopologyPatchListRestart;
     safe_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT(const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* in_struct);
@@ -10514,7 +10514,7 @@ struct safe_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImportMemoryZirconHandleInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkExternalMemoryHandleTypeFlagBits handleType;
     zx_handle_t handle;
     safe_VkImportMemoryZirconHandleInfoFUCHSIA(const VkImportMemoryZirconHandleInfoFUCHSIA* in_struct);
@@ -10532,7 +10532,7 @@ struct safe_VkImportMemoryZirconHandleInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkMemoryZirconHandlePropertiesFUCHSIA {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t memoryTypeBits;
     safe_VkMemoryZirconHandlePropertiesFUCHSIA(const VkMemoryZirconHandlePropertiesFUCHSIA* in_struct);
     safe_VkMemoryZirconHandlePropertiesFUCHSIA(const safe_VkMemoryZirconHandlePropertiesFUCHSIA& copy_src);
@@ -10549,7 +10549,7 @@ struct safe_VkMemoryZirconHandlePropertiesFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkMemoryGetZirconHandleInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     VkExternalMemoryHandleTypeFlagBits handleType;
     safe_VkMemoryGetZirconHandleInfoFUCHSIA(const VkMemoryGetZirconHandleInfoFUCHSIA* in_struct);
@@ -10567,7 +10567,7 @@ struct safe_VkMemoryGetZirconHandleInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImportSemaphoreZirconHandleInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkSemaphoreImportFlags flags;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
@@ -10587,7 +10587,7 @@ struct safe_VkImportSemaphoreZirconHandleInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkSemaphoreGetZirconHandleInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkSemaphore semaphore;
     VkExternalSemaphoreHandleTypeFlagBits handleType;
     safe_VkSemaphoreGetZirconHandleInfoFUCHSIA(const VkSemaphoreGetZirconHandleInfoFUCHSIA* in_struct);
@@ -10605,7 +10605,7 @@ struct safe_VkSemaphoreGetZirconHandleInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferCollectionCreateInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     zx_handle_t collectionToken;
     safe_VkBufferCollectionCreateInfoFUCHSIA(const VkBufferCollectionCreateInfoFUCHSIA* in_struct);
     safe_VkBufferCollectionCreateInfoFUCHSIA(const safe_VkBufferCollectionCreateInfoFUCHSIA& copy_src);
@@ -10622,7 +10622,7 @@ struct safe_VkBufferCollectionCreateInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImportMemoryBufferCollectionFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferCollectionFUCHSIA collection;
     uint32_t index;
     safe_VkImportMemoryBufferCollectionFUCHSIA(const VkImportMemoryBufferCollectionFUCHSIA* in_struct);
@@ -10640,7 +10640,7 @@ struct safe_VkImportMemoryBufferCollectionFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferCollectionImageCreateInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferCollectionFUCHSIA collection;
     uint32_t index;
     safe_VkBufferCollectionImageCreateInfoFUCHSIA(const VkBufferCollectionImageCreateInfoFUCHSIA* in_struct);
@@ -10658,7 +10658,7 @@ struct safe_VkBufferCollectionImageCreateInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferCollectionConstraintsInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t minBufferCount;
     uint32_t maxBufferCount;
     uint32_t minBufferCountForCamping;
@@ -10679,7 +10679,7 @@ struct safe_VkBufferCollectionConstraintsInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferConstraintsInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkBufferCreateInfo createInfo;
     VkFormatFeatureFlags requiredFormatFeatures;
     safe_VkBufferCollectionConstraintsInfoFUCHSIA bufferCollectionConstraints;
@@ -10698,7 +10698,7 @@ struct safe_VkBufferConstraintsInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferCollectionBufferCreateInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBufferCollectionFUCHSIA collection;
     uint32_t index;
     safe_VkBufferCollectionBufferCreateInfoFUCHSIA(const VkBufferCollectionBufferCreateInfoFUCHSIA* in_struct);
@@ -10716,7 +10716,7 @@ struct safe_VkBufferCollectionBufferCreateInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkSysmemColorSpaceFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t colorSpace;
     safe_VkSysmemColorSpaceFUCHSIA(const VkSysmemColorSpaceFUCHSIA* in_struct);
     safe_VkSysmemColorSpaceFUCHSIA(const safe_VkSysmemColorSpaceFUCHSIA& copy_src);
@@ -10733,7 +10733,7 @@ struct safe_VkSysmemColorSpaceFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkBufferCollectionPropertiesFUCHSIA {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t memoryTypeBits;
     uint32_t bufferCount;
     uint32_t createInfoIndex;
@@ -10760,13 +10760,13 @@ struct safe_VkBufferCollectionPropertiesFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImageFormatConstraintsInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkImageCreateInfo imageCreateInfo;
     VkFormatFeatureFlags requiredFormatFeatures;
     VkImageFormatConstraintsFlagsFUCHSIA flags;
     uint64_t sysmemPixelFormat;
     uint32_t colorSpaceCount;
-    safe_VkSysmemColorSpaceFUCHSIA* pColorSpaces;
+    safe_VkSysmemColorSpaceFUCHSIA* pColorSpaces{};
     safe_VkImageFormatConstraintsInfoFUCHSIA(const VkImageFormatConstraintsInfoFUCHSIA* in_struct);
     safe_VkImageFormatConstraintsInfoFUCHSIA(const safe_VkImageFormatConstraintsInfoFUCHSIA& copy_src);
     safe_VkImageFormatConstraintsInfoFUCHSIA& operator=(const safe_VkImageFormatConstraintsInfoFUCHSIA& copy_src);
@@ -10782,9 +10782,9 @@ struct safe_VkImageFormatConstraintsInfoFUCHSIA {
 #ifdef VK_USE_PLATFORM_FUCHSIA
 struct safe_VkImageConstraintsInfoFUCHSIA {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t formatConstraintsCount;
-    safe_VkImageFormatConstraintsInfoFUCHSIA* pFormatConstraints;
+    safe_VkImageFormatConstraintsInfoFUCHSIA* pFormatConstraints{};
     safe_VkBufferCollectionConstraintsInfoFUCHSIA bufferCollectionConstraints;
     VkImageConstraintsInfoFlagsFUCHSIA flags;
     safe_VkImageConstraintsInfoFUCHSIA(const VkImageConstraintsInfoFUCHSIA* in_struct);
@@ -10801,7 +10801,7 @@ struct safe_VkImageConstraintsInfoFUCHSIA {
 
 struct safe_VkSubpassShadingPipelineCreateInfoHUAWEI {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkRenderPass renderPass;
     uint32_t subpass;
     safe_VkSubpassShadingPipelineCreateInfoHUAWEI(const VkSubpassShadingPipelineCreateInfoHUAWEI* in_struct);
@@ -10817,7 +10817,7 @@ struct safe_VkSubpassShadingPipelineCreateInfoHUAWEI {
 
 struct safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 subpassShading;
     safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI(const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* in_struct);
     safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI(const safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI& copy_src);
@@ -10832,7 +10832,7 @@ struct safe_VkPhysicalDeviceSubpassShadingFeaturesHUAWEI {
 
 struct safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxSubpassShadingWorkgroupSizeAspectRatio;
     safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI(const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI* in_struct);
     safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI(const safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI& copy_src);
@@ -10847,7 +10847,7 @@ struct safe_VkPhysicalDeviceSubpassShadingPropertiesHUAWEI {
 
 struct safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 invocationMask;
     safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI(const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* in_struct);
     safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI(const safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI& copy_src);
@@ -10862,7 +10862,7 @@ struct safe_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI {
 
 struct safe_VkMemoryGetRemoteAddressInfoNV {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceMemory memory;
     VkExternalMemoryHandleTypeFlagBits handleType;
     safe_VkMemoryGetRemoteAddressInfoNV(const VkMemoryGetRemoteAddressInfoNV* in_struct);
@@ -10878,7 +10878,7 @@ struct safe_VkMemoryGetRemoteAddressInfoNV {
 
 struct safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 externalMemoryRDMA;
     safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV(const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* in_struct);
     safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV(const safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV& copy_src);
@@ -10893,7 +10893,7 @@ struct safe_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV {
 
 struct safe_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 extendedDynamicState2;
     VkBool32 extendedDynamicState2LogicOp;
     VkBool32 extendedDynamicState2PatchControlPoints;
@@ -10911,10 +10911,10 @@ struct safe_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT {
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
 struct safe_VkScreenSurfaceCreateInfoQNX {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkScreenSurfaceCreateFlagsQNX flags;
-    struct _screen_context* context;
-    struct _screen_window* window;
+    struct _screen_context* context{};
+    struct _screen_window* window{};
     safe_VkScreenSurfaceCreateInfoQNX(const VkScreenSurfaceCreateInfoQNX* in_struct);
     safe_VkScreenSurfaceCreateInfoQNX(const safe_VkScreenSurfaceCreateInfoQNX& copy_src);
     safe_VkScreenSurfaceCreateInfoQNX& operator=(const safe_VkScreenSurfaceCreateInfoQNX& copy_src);
@@ -10929,7 +10929,7 @@ struct safe_VkScreenSurfaceCreateInfoQNX {
 
 struct safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 colorWriteEnable;
     safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT(const VkPhysicalDeviceColorWriteEnableFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT(const safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT& copy_src);
@@ -10944,9 +10944,9 @@ struct safe_VkPhysicalDeviceColorWriteEnableFeaturesEXT {
 
 struct safe_VkPipelineColorWriteCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t attachmentCount;
-    const VkBool32* pColorWriteEnables;
+    const VkBool32* pColorWriteEnables{};
     safe_VkPipelineColorWriteCreateInfoEXT(const VkPipelineColorWriteCreateInfoEXT* in_struct);
     safe_VkPipelineColorWriteCreateInfoEXT(const safe_VkPipelineColorWriteCreateInfoEXT& copy_src);
     safe_VkPipelineColorWriteCreateInfoEXT& operator=(const safe_VkPipelineColorWriteCreateInfoEXT& copy_src);
@@ -10960,7 +10960,7 @@ struct safe_VkPipelineColorWriteCreateInfoEXT {
 
 struct safe_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 primitivesGeneratedQuery;
     VkBool32 primitivesGeneratedQueryWithRasterizerDiscard;
     VkBool32 primitivesGeneratedQueryWithNonZeroStreams;
@@ -10977,7 +10977,7 @@ struct safe_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT {
 
 struct safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 minLod;
     safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT(const VkPhysicalDeviceImageViewMinLodFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT(const safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT& copy_src);
@@ -10992,7 +10992,7 @@ struct safe_VkPhysicalDeviceImageViewMinLodFeaturesEXT {
 
 struct safe_VkImageViewMinLodCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     float minLod;
     safe_VkImageViewMinLodCreateInfoEXT(const VkImageViewMinLodCreateInfoEXT* in_struct);
     safe_VkImageViewMinLodCreateInfoEXT(const safe_VkImageViewMinLodCreateInfoEXT& copy_src);
@@ -11007,7 +11007,7 @@ struct safe_VkImageViewMinLodCreateInfoEXT {
 
 struct safe_VkPhysicalDeviceMultiDrawFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 multiDraw;
     safe_VkPhysicalDeviceMultiDrawFeaturesEXT(const VkPhysicalDeviceMultiDrawFeaturesEXT* in_struct);
     safe_VkPhysicalDeviceMultiDrawFeaturesEXT(const safe_VkPhysicalDeviceMultiDrawFeaturesEXT& copy_src);
@@ -11022,7 +11022,7 @@ struct safe_VkPhysicalDeviceMultiDrawFeaturesEXT {
 
 struct safe_VkPhysicalDeviceMultiDrawPropertiesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t maxMultiDrawCount;
     safe_VkPhysicalDeviceMultiDrawPropertiesEXT(const VkPhysicalDeviceMultiDrawPropertiesEXT* in_struct);
     safe_VkPhysicalDeviceMultiDrawPropertiesEXT(const safe_VkPhysicalDeviceMultiDrawPropertiesEXT& copy_src);
@@ -11037,7 +11037,7 @@ struct safe_VkPhysicalDeviceMultiDrawPropertiesEXT {
 
 struct safe_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 image2DViewOf3D;
     VkBool32 sampler2DViewOf3D;
     safe_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT(const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* in_struct);
@@ -11053,7 +11053,7 @@ struct safe_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT {
 
 struct safe_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 borderColorSwizzle;
     VkBool32 borderColorSwizzleFromImage;
     safe_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT(const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* in_struct);
@@ -11069,7 +11069,7 @@ struct safe_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT {
 
 struct safe_VkSamplerBorderColorComponentMappingCreateInfoEXT {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkComponentMapping components;
     VkBool32 srgb;
     safe_VkSamplerBorderColorComponentMappingCreateInfoEXT(const VkSamplerBorderColorComponentMappingCreateInfoEXT* in_struct);
@@ -11085,7 +11085,7 @@ struct safe_VkSamplerBorderColorComponentMappingCreateInfoEXT {
 
 struct safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 pageableDeviceLocalMemory;
     safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT(const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* in_struct);
     safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT(const safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT& copy_src);
@@ -11100,7 +11100,7 @@ struct safe_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT {
 
 struct safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 descriptorSetHostMapping;
     safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE(const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* in_struct);
     safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE(const safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE& copy_src);
@@ -11115,7 +11115,7 @@ struct safe_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE {
 
 struct safe_VkDescriptorSetBindingReferenceVALVE {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDescriptorSetLayout descriptorSetLayout;
     uint32_t binding;
     safe_VkDescriptorSetBindingReferenceVALVE(const VkDescriptorSetBindingReferenceVALVE* in_struct);
@@ -11131,7 +11131,7 @@ struct safe_VkDescriptorSetBindingReferenceVALVE {
 
 struct safe_VkDescriptorSetLayoutHostMappingInfoVALVE {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     size_t descriptorOffset;
     uint32_t descriptorSize;
     safe_VkDescriptorSetLayoutHostMappingInfoVALVE(const VkDescriptorSetLayoutHostMappingInfoVALVE* in_struct);
@@ -11147,7 +11147,7 @@ struct safe_VkDescriptorSetLayoutHostMappingInfoVALVE {
 
 struct safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 fragmentDensityMapOffset;
     safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM(const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM* in_struct);
     safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM(const safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM& copy_src);
@@ -11162,7 +11162,7 @@ struct safe_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM {
 
 struct safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkExtent2D fragmentDensityOffsetGranularity;
     safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM(const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM* in_struct);
     safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM(const safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM& copy_src);
@@ -11177,9 +11177,9 @@ struct safe_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM {
 
 struct safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t fragmentDensityOffsetCount;
-    const VkOffset2D* pFragmentDensityOffsets;
+    const VkOffset2D* pFragmentDensityOffsets{};
     safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM(const VkSubpassFragmentDensityMapOffsetEndInfoQCOM* in_struct);
     safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM(const safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM& copy_src);
     safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM& operator=(const safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM& copy_src);
@@ -11193,7 +11193,7 @@ struct safe_VkSubpassFragmentDensityMapOffsetEndInfoQCOM {
 
 struct safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 linearColorAttachment;
     safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV(const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* in_struct);
     safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV(const safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV& copy_src);
@@ -11208,7 +11208,7 @@ struct safe_VkPhysicalDeviceLinearColorAttachmentFeaturesNV {
 
 union safe_VkDeviceOrHostAddressKHR {
     VkDeviceAddress deviceAddress;
-    void* hostAddress;
+    void* hostAddress{};
     safe_VkDeviceOrHostAddressKHR(const VkDeviceOrHostAddressKHR* in_struct);
     safe_VkDeviceOrHostAddressKHR(const safe_VkDeviceOrHostAddressKHR& copy_src);
     safe_VkDeviceOrHostAddressKHR& operator=(const safe_VkDeviceOrHostAddressKHR& copy_src);
@@ -11222,7 +11222,7 @@ union safe_VkDeviceOrHostAddressKHR {
 
 struct safe_VkAccelerationStructureGeometryTrianglesDataKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkFormat vertexFormat;
     safe_VkDeviceOrHostAddressConstKHR vertexData;
     VkDeviceSize vertexStride;
@@ -11243,7 +11243,7 @@ struct safe_VkAccelerationStructureGeometryTrianglesDataKHR {
 
 struct safe_VkAccelerationStructureGeometryAabbsDataKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkDeviceOrHostAddressConstKHR data;
     VkDeviceSize stride;
     safe_VkAccelerationStructureGeometryAabbsDataKHR(const VkAccelerationStructureGeometryAabbsDataKHR* in_struct);
@@ -11259,7 +11259,7 @@ struct safe_VkAccelerationStructureGeometryAabbsDataKHR {
 
 struct safe_VkAccelerationStructureGeometryInstancesDataKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkBool32 arrayOfPointers;
     safe_VkDeviceOrHostAddressConstKHR data;
     safe_VkAccelerationStructureGeometryInstancesDataKHR(const VkAccelerationStructureGeometryInstancesDataKHR* in_struct);
@@ -11275,7 +11275,7 @@ struct safe_VkAccelerationStructureGeometryInstancesDataKHR {
 
 struct safe_VkAccelerationStructureGeometryKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkGeometryTypeKHR geometryType;
     VkAccelerationStructureGeometryDataKHR geometry;
     VkGeometryFlagsKHR flags;
@@ -11292,15 +11292,15 @@ struct safe_VkAccelerationStructureGeometryKHR {
 
 struct safe_VkAccelerationStructureBuildGeometryInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureTypeKHR type;
     VkBuildAccelerationStructureFlagsKHR flags;
     VkBuildAccelerationStructureModeKHR mode;
     VkAccelerationStructureKHR srcAccelerationStructure;
     VkAccelerationStructureKHR dstAccelerationStructure;
     uint32_t geometryCount;
-    safe_VkAccelerationStructureGeometryKHR* pGeometries;
-    safe_VkAccelerationStructureGeometryKHR** ppGeometries;
+    safe_VkAccelerationStructureGeometryKHR* pGeometries{};
+    safe_VkAccelerationStructureGeometryKHR** ppGeometries{};
     safe_VkDeviceOrHostAddressKHR scratchData;
     safe_VkAccelerationStructureBuildGeometryInfoKHR(const VkAccelerationStructureBuildGeometryInfoKHR* in_struct);
     safe_VkAccelerationStructureBuildGeometryInfoKHR(const safe_VkAccelerationStructureBuildGeometryInfoKHR& copy_src);
@@ -11315,7 +11315,7 @@ struct safe_VkAccelerationStructureBuildGeometryInfoKHR {
 
 struct safe_VkAccelerationStructureCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureCreateFlagsKHR createFlags;
     VkBuffer buffer;
     VkDeviceSize offset;
@@ -11335,9 +11335,9 @@ struct safe_VkAccelerationStructureCreateInfoKHR {
 
 struct safe_VkWriteDescriptorSetAccelerationStructureKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t accelerationStructureCount;
-    VkAccelerationStructureKHR* pAccelerationStructures;
+    VkAccelerationStructureKHR* pAccelerationStructures{};
     safe_VkWriteDescriptorSetAccelerationStructureKHR(const VkWriteDescriptorSetAccelerationStructureKHR* in_struct);
     safe_VkWriteDescriptorSetAccelerationStructureKHR(const safe_VkWriteDescriptorSetAccelerationStructureKHR& copy_src);
     safe_VkWriteDescriptorSetAccelerationStructureKHR& operator=(const safe_VkWriteDescriptorSetAccelerationStructureKHR& copy_src);
@@ -11351,7 +11351,7 @@ struct safe_VkWriteDescriptorSetAccelerationStructureKHR {
 
 struct safe_VkPhysicalDeviceAccelerationStructureFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 accelerationStructure;
     VkBool32 accelerationStructureCaptureReplay;
     VkBool32 accelerationStructureIndirectBuild;
@@ -11370,7 +11370,7 @@ struct safe_VkPhysicalDeviceAccelerationStructureFeaturesKHR {
 
 struct safe_VkPhysicalDeviceAccelerationStructurePropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint64_t maxGeometryCount;
     uint64_t maxInstanceCount;
     uint64_t maxPrimitiveCount;
@@ -11392,7 +11392,7 @@ struct safe_VkPhysicalDeviceAccelerationStructurePropertiesKHR {
 
 struct safe_VkAccelerationStructureDeviceAddressInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureKHR accelerationStructure;
     safe_VkAccelerationStructureDeviceAddressInfoKHR(const VkAccelerationStructureDeviceAddressInfoKHR* in_struct);
     safe_VkAccelerationStructureDeviceAddressInfoKHR(const safe_VkAccelerationStructureDeviceAddressInfoKHR& copy_src);
@@ -11407,8 +11407,8 @@ struct safe_VkAccelerationStructureDeviceAddressInfoKHR {
 
 struct safe_VkAccelerationStructureVersionInfoKHR {
     VkStructureType sType;
-    const void* pNext;
-    const uint8_t* pVersionData;
+    const void* pNext{};
+    const uint8_t* pVersionData{};
     safe_VkAccelerationStructureVersionInfoKHR(const VkAccelerationStructureVersionInfoKHR* in_struct);
     safe_VkAccelerationStructureVersionInfoKHR(const safe_VkAccelerationStructureVersionInfoKHR& copy_src);
     safe_VkAccelerationStructureVersionInfoKHR& operator=(const safe_VkAccelerationStructureVersionInfoKHR& copy_src);
@@ -11422,7 +11422,7 @@ struct safe_VkAccelerationStructureVersionInfoKHR {
 
 struct safe_VkCopyAccelerationStructureToMemoryInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureKHR src;
     safe_VkDeviceOrHostAddressKHR dst;
     VkCopyAccelerationStructureModeKHR mode;
@@ -11439,7 +11439,7 @@ struct safe_VkCopyAccelerationStructureToMemoryInfoKHR {
 
 struct safe_VkCopyMemoryToAccelerationStructureInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     safe_VkDeviceOrHostAddressConstKHR src;
     VkAccelerationStructureKHR dst;
     VkCopyAccelerationStructureModeKHR mode;
@@ -11456,7 +11456,7 @@ struct safe_VkCopyMemoryToAccelerationStructureInfoKHR {
 
 struct safe_VkCopyAccelerationStructureInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkAccelerationStructureKHR src;
     VkAccelerationStructureKHR dst;
     VkCopyAccelerationStructureModeKHR mode;
@@ -11473,7 +11473,7 @@ struct safe_VkCopyAccelerationStructureInfoKHR {
 
 struct safe_VkAccelerationStructureBuildSizesInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkDeviceSize accelerationStructureSize;
     VkDeviceSize updateScratchSize;
     VkDeviceSize buildScratchSize;
@@ -11490,13 +11490,13 @@ struct safe_VkAccelerationStructureBuildSizesInfoKHR {
 
 struct safe_VkRayTracingShaderGroupCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkRayTracingShaderGroupTypeKHR type;
     uint32_t generalShader;
     uint32_t closestHitShader;
     uint32_t anyHitShader;
     uint32_t intersectionShader;
-    const void* pShaderGroupCaptureReplayHandle;
+    const void* pShaderGroupCaptureReplayHandle{};
     safe_VkRayTracingShaderGroupCreateInfoKHR(const VkRayTracingShaderGroupCreateInfoKHR* in_struct);
     safe_VkRayTracingShaderGroupCreateInfoKHR(const safe_VkRayTracingShaderGroupCreateInfoKHR& copy_src);
     safe_VkRayTracingShaderGroupCreateInfoKHR& operator=(const safe_VkRayTracingShaderGroupCreateInfoKHR& copy_src);
@@ -11510,7 +11510,7 @@ struct safe_VkRayTracingShaderGroupCreateInfoKHR {
 
 struct safe_VkRayTracingPipelineInterfaceCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     uint32_t maxPipelineRayPayloadSize;
     uint32_t maxPipelineRayHitAttributeSize;
     safe_VkRayTracingPipelineInterfaceCreateInfoKHR(const VkRayTracingPipelineInterfaceCreateInfoKHR* in_struct);
@@ -11526,16 +11526,16 @@ struct safe_VkRayTracingPipelineInterfaceCreateInfoKHR {
 
 struct safe_VkRayTracingPipelineCreateInfoKHR {
     VkStructureType sType;
-    const void* pNext;
+    const void* pNext{};
     VkPipelineCreateFlags flags;
     uint32_t stageCount;
-    safe_VkPipelineShaderStageCreateInfo* pStages;
+    safe_VkPipelineShaderStageCreateInfo* pStages{};
     uint32_t groupCount;
-    safe_VkRayTracingShaderGroupCreateInfoKHR* pGroups;
+    safe_VkRayTracingShaderGroupCreateInfoKHR* pGroups{};
     uint32_t maxPipelineRayRecursionDepth;
-    safe_VkPipelineLibraryCreateInfoKHR* pLibraryInfo;
-    safe_VkRayTracingPipelineInterfaceCreateInfoKHR* pLibraryInterface;
-    safe_VkPipelineDynamicStateCreateInfo* pDynamicState;
+    safe_VkPipelineLibraryCreateInfoKHR* pLibraryInfo{};
+    safe_VkRayTracingPipelineInterfaceCreateInfoKHR* pLibraryInterface{};
+    safe_VkPipelineDynamicStateCreateInfo* pDynamicState{};
     VkPipelineLayout layout;
     VkPipeline basePipelineHandle;
     int32_t basePipelineIndex;
@@ -11552,7 +11552,7 @@ struct safe_VkRayTracingPipelineCreateInfoKHR {
 
 struct safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 rayTracingPipeline;
     VkBool32 rayTracingPipelineShaderGroupHandleCaptureReplay;
     VkBool32 rayTracingPipelineShaderGroupHandleCaptureReplayMixed;
@@ -11571,7 +11571,7 @@ struct safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR {
 
 struct safe_VkPhysicalDeviceRayTracingPipelinePropertiesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     uint32_t shaderGroupHandleSize;
     uint32_t maxRayRecursionDepth;
     uint32_t maxShaderGroupStride;
@@ -11593,7 +11593,7 @@ struct safe_VkPhysicalDeviceRayTracingPipelinePropertiesKHR {
 
 struct safe_VkPhysicalDeviceRayQueryFeaturesKHR {
     VkStructureType sType;
-    void* pNext;
+    void* pNext{};
     VkBool32 rayQuery;
     safe_VkPhysicalDeviceRayQueryFeaturesKHR(const VkPhysicalDeviceRayQueryFeaturesKHR* in_struct);
     safe_VkPhysicalDeviceRayQueryFeaturesKHR(const safe_VkPhysicalDeviceRayQueryFeaturesKHR& copy_src);

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -166,7 +166,7 @@ struct PipelineStageState {
 class PIPELINE_STATE : public BASE_NODE {
   public:
     union CreateInfo {
-        CreateInfo(const VkGraphicsPipelineCreateInfo *ci, std::shared_ptr<const RENDER_PASS_STATE> rpstate) {
+        CreateInfo(const VkGraphicsPipelineCreateInfo *ci, std::shared_ptr<const RENDER_PASS_STATE> rpstate) : graphics() {
             bool use_color = false;
             bool use_depth_stencil = false;
 


### PR DESCRIPTION
Fixes #3960