### PR TITLE
layers: Find all shader variable ids, fix false positive wrong descriptor type

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1133,6 +1133,7 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
     VkImageLayout image_layout = image_descriptor.GetImageLayout();
     const auto binding = binding_info.first;
     const auto reqs = binding_info.second.reqs;
+    const auto all_reqs = binding_info.second.all_reqs;
 
     if (image_descriptor.GetClass() == cvdescriptorset::DescriptorClass::ImageSampler) {
         sampler_states.emplace_back(
@@ -1167,8 +1168,8 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
         const auto &image_view_ci = image_view_state->create_info;
         const auto *image_state = image_view_state->image_state.get();
 
-        if (reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
-            if (~reqs & (1 << image_view_ci.viewType)) {
+        if (all_reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
+            if (~all_reqs & (1 << image_view_ci.viewType)) {
                 auto set = descriptor_set->GetSet();
                 return LogError(set, vuids.descriptor_valid,
                                 "Descriptor set %s encountered the following validation error at %s time: Descriptor "
@@ -1176,7 +1177,8 @@ bool CoreChecks::ValidateImageDescriptor(const char *caller, const DrawDispatchV
                                 report_data->FormatHandle(set).c_str(), caller, binding, index,
                                 StringDescriptorReqViewType(reqs).c_str(), string_VkImageViewType(image_view_ci.viewType));
             }
-
+        }
+        if (reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
             if (!(reqs & image_view_state->descriptor_format_bits)) {
                 // bad component type
                 auto set = descriptor_set->GetSet();

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -273,7 +273,9 @@ PipelineStageState::PipelineStageState(const VkPipelineShaderStageCreateInfo *st
       stage_flag(stage->stage),
       entrypoint(module_state->FindEntrypoint(stage->pName, stage->stage)),
       accessible_ids(module_state->MarkAccessibleIds(entrypoint)),
+      variable_ids(module_state->MarkVariableIds()),
       descriptor_uses(module_state->CollectInterfaceByDescriptorSlot(accessible_ids)),
+      all_descriptor_uses(module_state->CollectInterfaceByDescriptorSlot(variable_ids)),
       has_writable_descriptor(HasWriteableDescriptor(descriptor_uses)),
       has_atomic_descriptor(HasAtomicDescriptor(descriptor_uses)),
       wrote_primitive_shading_rate(WrotePrimitiveShadingRate(stage_flag, entrypoint, module_state.get())) {}
@@ -327,6 +329,28 @@ static PIPELINE_STATE::ActiveSlotMap GetActiveSlots(const PIPELINE_STATE::StageS
                     ++image_index;
                 }
             }
+        }
+        for (const auto &use : stage.all_descriptor_uses) {
+            // Don't add new sets, only new bindings
+            bool set_exists = false;
+            for (const auto &set : active_slots) {
+                if (set.first == use.first.set) {
+                    set_exists = true;
+                    break;
+                }
+            }
+            if (!set_exists) {
+                continue;
+            }
+            auto &entry = active_slots[use.first.set][use.first.binding];
+            auto &reqs = entry.all_reqs;
+            reqs |= stage.module_state->DescriptorTypeToReqs(use.second.type_id);
+            if (use.second.is_atomic_operation) reqs |= DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION;
+            if (use.second.is_sampler_implicitLod_dref_proj) reqs |= DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ;
+            if (use.second.is_sampler_bias_offset) reqs |= DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET;
+            if (use.second.is_read_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT;
+            if (use.second.is_write_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT;
+            if (use.second.is_dref_operation) reqs |= DESCRIPTOR_REQ_IMAGE_DREF;
         }
     }
     return active_slots;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -83,10 +83,11 @@ extern DescriptorReqFlags DescriptorRequirementsBitsFromFormat(VkFormat fmt);
 
 struct DescriptorRequirement {
     DescriptorReqFlags reqs;
+    DescriptorReqFlags all_reqs;
     bool is_writable;
     // Copy from StageState.interface_var. It combines from plural shader stages. The index of array is index of image.
     std::vector<layer_data::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
-    DescriptorRequirement() : reqs(0), is_writable(false) {}
+    DescriptorRequirement() : reqs(0), all_reqs(0), is_writable(false) {}
 };
 
 inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) NOEXCEPT { return a.reqs == b.reqs; }
@@ -154,8 +155,10 @@ struct PipelineStageState {
     VkShaderStageFlagBits stage_flag;
     spirv_inst_iter entrypoint;
     layer_data::unordered_set<uint32_t> accessible_ids;
+    layer_data::unordered_set<uint32_t> variable_ids;
     using DescriptorUse = std::pair<DescriptorSlot, interface_var>;
     std::vector<DescriptorUse> descriptor_uses;
+    std::vector<DescriptorUse> all_descriptor_uses;
     bool has_writable_descriptor;
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -268,6 +268,16 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(spirv
     return ids;
 }
 
+layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkVariableIds() const {
+    layer_data::unordered_set<uint32_t> variable_ids;
+    for (const auto insn : *this) {
+        if (insn.opcode() == spv::OpVariable) {
+            variable_ids.insert(insn.word(2));
+        }
+    }
+    return variable_ids;
+}
+
 layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const spirv_inst_iter &entrypoint) const {
     layer_data::optional<VkPrimitiveTopology> result;
 
@@ -1515,11 +1525,11 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
 }
 
 std::vector<std::pair<DescriptorSlot, interface_var>> SHADER_MODULE_STATE::CollectInterfaceByDescriptorSlot(
-    layer_data::unordered_set<uint32_t> const &accessible_ids) const {
+    layer_data::unordered_set<uint32_t> const &ids) const {
     std::vector<std::pair<DescriptorSlot, interface_var>> out;
     shader_module_used_operators operators;
 
-    for (auto id : accessible_ids) {
+    for (auto id : ids) {
         auto insn = get_def(id);
         assert(insn != end());
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -338,6 +338,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::string DescribeInstruction(const spirv_inst_iter &insn) const;
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(spirv_inst_iter entrypoint) const;
+    layer_data::unordered_set<uint32_t> MarkVariableIds() const;
     layer_data::optional<VkPrimitiveTopology> GetTopology(const spirv_inst_iter &entrypoint) const;
 
     const EntryPoint *FindEntrypointStruct(char const *name, VkShaderStageFlagBits stageBits) const;
@@ -374,7 +375,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     void IsSpecificDescriptorType(const spirv_inst_iter &id_it, bool is_storage_buffer, bool is_check_writable,
                                   interface_var &out_interface_var, shader_module_used_operators &used_operators) const;
     std::vector<std::pair<DescriptorSlot, interface_var>> CollectInterfaceByDescriptorSlot(
-        layer_data::unordered_set<uint32_t> const &accessible_ids) const;
+        layer_data::unordered_set<uint32_t> const &ids) const;
     layer_data::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const spirv_inst_iter &entrypoint) const;
     bool CollectInterfaceBlockMembers(std::map<location_t, interface_var> *out, bool is_array_of_verts, uint32_t id,
                                       uint32_t type_id, bool is_patch, uint32_t first_location) const;


### PR DESCRIPTION
Closes #3971 

Before descriptor types were only checked against used variables, but we need to allow binding descriptor types from unused variables as well, to prevent false positives. 