### PR TITLE
layers: fix framebuffer miplevel-based extents calculation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13551,7 +13551,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
                         }
                     }
 
-                    const auto view_width = image_create_info->extent.width >> subresource_range.baseMipLevel;
+                    const auto view_width = max(1u, image_create_info->extent.width >> subresource_range.baseMipLevel);
                     if (framebuffer_attachment_image_info->width != view_width) {
                         skip |= LogError(pRenderPassBeginInfo->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-03211",
                                          "%s: For VkRenderPassAttachmentBeginInfo::pAttachments[%" PRIu32
@@ -13563,7 +13563,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
 
                     const bool is_1d = (image_view_create_info->viewType == VK_IMAGE_VIEW_TYPE_1D) ||
                                        (image_view_create_info->viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY);
-                    const auto view_height = (!is_1d) ? image_create_info->extent.height >> subresource_range.baseMipLevel
+                    const auto view_height = (!is_1d) ? max(1u, image_create_info->extent.height >> subresource_range.baseMipLevel)
                                                       : image_create_info->extent.height;
                     if (framebuffer_attachment_image_info->height != view_height) {
                         skip |=


### PR DESCRIPTION
this needs to be clamped to 1 to avoid spurious validation errors