### PR TITLE
Tests cleanup

### DIFF
--- a/layers/convert_to_renderpass2.cpp
+++ b/layers/convert_to_renderpass2.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2020 The Khronos Group Inc.
  * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2022 LunarG, Inc.
  * Copyright (C) 2015-2020 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -104,9 +104,9 @@ bool ImageFormatAndFeaturesSupported(const VkInstance inst, const VkPhysicalDevi
 
     // Verify again using version 2, if supported, which *can* return more property data than the original...
     // (It's not clear that this is any more definitive than using the original version - but no harm)
-    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR p_GetPDIFP2KHR =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(inst,
-                                                                                "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    auto p_GetPDIFP2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>(vk::GetInstanceProcAddr(inst,
+                                                                                "vkGetPhysicalDeviceImageFormatProperties2KHR"));
     if (nullptr != p_GetPDIFP2KHR) {
         VkPhysicalDeviceImageFormatInfo2KHR fmt_info = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2KHR>();
         fmt_info.format = info.format;
@@ -135,8 +135,8 @@ bool BufferFormatAndFeaturesSupported(VkPhysicalDevice phy, VkFormat format, VkF
 
 VkPhysicalDevicePushDescriptorPropertiesKHR GetPushDescriptorProperties(VkInstance instance, VkPhysicalDevice gpu) {
     // Find address of extension call and make the call -- assumes needed extensions are enabled.
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     // Get the push descriptor limits
@@ -250,8 +250,8 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, co
     }
 
     if (rp2_supported && rp2_vuid) {
-        PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-            (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
+        auto vkCreateRenderPass2KHR =
+            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR"));
         safe_VkRenderPassCreateInfo2 create_info2;
         ConvertVkRenderPassCreateInfoToV2KHR(*create_info, &create_info2);
 
@@ -264,7 +264,7 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, co
         error_monitor->VerifyFound();
 
         // For api version >= 1.2, try core entrypoint
-        PFN_vkCreateRenderPass2 vkCreateRenderPass2 = (PFN_vkCreateRenderPass2)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2");
+        auto vkCreateRenderPass2 = reinterpret_cast<PFN_vkCreateRenderPass2>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2"));
         if (vkCreateRenderPass2) {
             // Some tests mismatch attachment type with layout
             error_monitor->SetUnexpectedError("VUID-VkSubpassDescription2-None-04439");
@@ -288,8 +288,8 @@ void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice de
     error_monitor->VerifyNotFound();
 
     if (rp2_supported) {
-        PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-            (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
+        auto vkCreateRenderPass2KHR =
+            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR"));
         safe_VkRenderPassCreateInfo2 create_info2;
         ConvertVkRenderPassCreateInfoToV2KHR(*create_info, &create_info2);
 
@@ -304,8 +304,8 @@ void PositiveTestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevic
                                       const VkRenderPassCreateInfo2KHR *create_info) {
     VkRenderPass render_pass = VK_NULL_HANDLE;
     VkResult err;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR"));
 
     error_monitor->ExpectSuccess();
     err = vkCreateRenderPass2KHR(device, create_info, nullptr, &render_pass);
@@ -317,8 +317,8 @@ void TestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevice device
                               const char *rp2_vuid) {
     VkRenderPass render_pass = VK_NULL_HANDLE;
     VkResult err;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR"));
 
     error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
     err = vkCreateRenderPass2KHR(device, create_info, nullptr, &render_pass);
@@ -339,8 +339,8 @@ void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, con
         vk::ResetCommandBuffer(command_buffer, 0);
     }
     if (rp2Supported && rp2_vuid) {
-        PFN_vkCmdBeginRenderPass2KHR vkCmdBeginRenderPass2KHR =
-            (PFN_vkCmdBeginRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCmdBeginRenderPass2KHR");
+        auto vkCmdBeginRenderPass2KHR =
+            reinterpret_cast<PFN_vkCmdBeginRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCmdBeginRenderPass2KHR"));
         VkSubpassBeginInfoKHR subpass_begin_info = {VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO_KHR, nullptr, VK_SUBPASS_CONTENTS_INLINE};
         vk::BeginCommandBuffer(command_buffer, &cmd_begin_info);
         error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
@@ -349,8 +349,8 @@ void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, con
         vk::ResetCommandBuffer(command_buffer, 0);
 
         // For api version >= 1.2, try core entrypoint
-        PFN_vkCmdBeginRenderPass2KHR vkCmdBeginRenderPass2 =
-            (PFN_vkCmdBeginRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCmdBeginRenderPass2");
+        auto vkCmdBeginRenderPass2 =
+            reinterpret_cast<PFN_vkCmdBeginRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCmdBeginRenderPass2"));
         if (vkCmdBeginRenderPass2) {
             vk::BeginCommandBuffer(command_buffer, &cmd_begin_info);
             error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
@@ -768,9 +768,8 @@ bool CheckDescriptorIndexingSupportAndInitFramework(VkRenderFramework *renderFra
 }
 
 bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramework) {
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(renderFramework->instance(),
-                                                                     "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(renderFramework->instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&timeline_semaphore_features);
     vkGetPhysicalDeviceFeatures2KHR(renderFramework->gpu(), &features2);
@@ -778,9 +777,8 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
         return false;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(renderFramework->instance(),
-                                                                       "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(renderFramework->instance(), "vkGetPhysicalDeviceProperties2KHR"));
     VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props =
         LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&timeline_semaphore_props);
@@ -795,9 +793,8 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
 }
 
 bool CheckSynchronization2SupportAndInitState(VkRenderFramework *framework) {
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(framework->instance(),
-                                                                     "vkGetPhysicalDeviceFeatures2");
+    auto vkGetPhysicalDeviceFeatures2 = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(
+        vk::GetInstanceProcAddr(framework->instance(), "vkGetPhysicalDeviceFeatures2"));
     auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2>(&sync2_features);
     vkGetPhysicalDeviceFeatures2(framework->gpu(), &features2);
@@ -1058,7 +1055,8 @@ VkLayerTest::VkLayerTest() {
     app_info_.apiVersion = VK_API_VERSION_1_0;
 
     // Find out what version the instance supports and record the default target instance
-    auto enumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vk::GetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion");
+    auto enumerateInstanceVersion =
+        reinterpret_cast<PFN_vkEnumerateInstanceVersion>(vk::GetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion"));
     if (enumerateInstanceVersion) {
         enumerateInstanceVersion(&m_instance_api_version);
     } else {
@@ -1157,10 +1155,10 @@ bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
     PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {
     // Load required functions
-    fpvkSetPhysicalDeviceFormatPropertiesEXT =
-        (PFN_vkSetPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatPropertiesEXT");
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT = (PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(
-        instance(), "vkGetOriginalPhysicalDeviceFormatPropertiesEXT");
+    fpvkSetPhysicalDeviceFormatPropertiesEXT = reinterpret_cast<PFN_vkSetPhysicalDeviceFormatPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatPropertiesEXT"));
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFormatPropertiesEXT"));
 
     if (!(fpvkSetPhysicalDeviceFormatPropertiesEXT) || !(fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -1174,11 +1172,10 @@ bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatProperties2EXT &fpvkSetPhysicalDeviceFormatProperties2EXT,
     PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT &fpvkGetOriginalPhysicalDeviceFormatProperties2EXT) {
     // Load required functions
-    fpvkSetPhysicalDeviceFormatProperties2EXT =
-        (PFN_vkSetPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatProperties2EXT");
-    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT =
-        (PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(
-            instance(), "vkGetOriginalPhysicalDeviceFormatProperties2EXT");
+    fpvkSetPhysicalDeviceFormatProperties2EXT = reinterpret_cast<PFN_vkSetPhysicalDeviceFormatProperties2EXT>(
+        vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatProperties2EXT"));
+    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFormatProperties2EXT"));
 
     if (!(fpvkSetPhysicalDeviceFormatProperties2EXT) || !(fpvkGetOriginalPhysicalDeviceFormatProperties2EXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -1192,9 +1189,9 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkS
                                          PFN_vkGetOriginalPhysicalDeviceLimitsEXT &fpvkGetOriginalPhysicalDeviceLimitsEXT) {
     // Load required functions
     fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -2255,8 +2252,8 @@ VkResult CreateNVRayTracingPipelineHelper::CreateNVRayTracingPipeline(bool impli
         pipeline_ = VK_NULL_HANDLE;
     }
 
-    PFN_vkCreateRayTracingPipelinesNV vkCreateRayTracingPipelinesNV =
-        (PFN_vkCreateRayTracingPipelinesNV)vk::GetInstanceProcAddr(layer_test_.instance(), "vkCreateRayTracingPipelinesNV");
+    auto vkCreateRayTracingPipelinesNV = reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(
+        vk::GetInstanceProcAddr(layer_test_.instance(), "vkCreateRayTracingPipelinesNV"));
     err = vkCreateRayTracingPipelinesNV(layer_test_.device(), pipeline_cache_, 1, &rp_ci_, nullptr, &pipeline_);
     return err;
 }
@@ -2270,8 +2267,8 @@ VkResult CreateNVRayTracingPipelineHelper::CreateKHRRayTracingPipeline(bool impl
         vk::DestroyPipeline(layer_test_.device(), pipeline_, nullptr);
         pipeline_ = VK_NULL_HANDLE;
     }
-    PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR =
-        (PFN_vkCreateRayTracingPipelinesKHR)vk::GetInstanceProcAddr(layer_test_.instance(), "vkCreateRayTracingPipelinesKHR");
+    auto vkCreateRayTracingPipelinesKHR = reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(
+        vk::GetInstanceProcAddr(layer_test_.instance(), "vkCreateRayTracingPipelinesKHR"));
     err = vkCreateRayTracingPipelinesKHR(layer_test_.device(), 0, pipeline_cache_, 1, &rp_ci_KHR_, nullptr, &pipeline_);
     return err;
 }
@@ -2608,8 +2605,8 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
     if (descriptor_indexing) {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&indexing_features);
@@ -2625,8 +2622,8 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
@@ -3249,17 +3246,15 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
                          call_source_runtime, true, 0, 0, 0, 0, 0, 5, "Descriptor index 5 is uninitialized."});
     }
 
-    PFN_vkCreateRayTracingPipelinesNV vkCreateRayTracingPipelinesNV = reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(
+    auto vkCreateRayTracingPipelinesNV = reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateRayTracingPipelinesNV"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesNV != nullptr);
 
-    PFN_vkGetRayTracingShaderGroupHandlesNV vkGetRayTracingShaderGroupHandlesNV =
-        reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkGetRayTracingShaderGroupHandlesNV"));
+    auto vkGetRayTracingShaderGroupHandlesNV = reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkGetRayTracingShaderGroupHandlesNV"));
     ASSERT_TRUE(vkGetRayTracingShaderGroupHandlesNV != nullptr);
 
-    PFN_vkCmdTraceRaysNV vkCmdTraceRaysNV =
-        reinterpret_cast<PFN_vkCmdTraceRaysNV>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdTraceRaysNV"));
+    auto vkCmdTraceRaysNV = reinterpret_cast<PFN_vkCmdTraceRaysNV>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdTraceRaysNV"));
     ASSERT_TRUE(vkCmdTraceRaysNV != nullptr);
 
     // Iteration 0 tests with no descriptor set bound (to sanity test "draw" validation). Iteration 1

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -107,7 +107,7 @@ bool ImageFormatAndFeaturesSupported(const VkInstance inst, const VkPhysicalDevi
     PFN_vkGetPhysicalDeviceImageFormatProperties2KHR p_GetPDIFP2KHR =
         (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(inst,
                                                                                 "vkGetPhysicalDeviceImageFormatProperties2KHR");
-    if (NULL != p_GetPDIFP2KHR) {
+    if (nullptr != p_GetPDIFP2KHR) {
         VkPhysicalDeviceImageFormatInfo2KHR fmt_info = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2KHR>();
         fmt_info.format = info.format;
         fmt_info.type = info.imageType;
@@ -193,7 +193,7 @@ extern "C" void *AddToCommandBuffer(void *arg) {
             break;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 extern "C" void *UpdateDescriptor(void *arg) {
@@ -212,12 +212,12 @@ extern "C" void *UpdateDescriptor(void *arg) {
     descriptor_write.pBufferInfo = &buffer_info;
 
     for (int i = 0; i < 80000; i++) {
-        vk::UpdateDescriptorSets(data->device, 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(data->device, 1, &descriptor_write, 0, nullptr);
         if (*data->bailout) {
             break;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 #endif  // GTEST_IS_THREADSAFE
@@ -226,12 +226,12 @@ extern "C" void *ReleaseNullFence(void *arg) {
     struct thread_data_struct *data = (struct thread_data_struct *)arg;
 
     for (int i = 0; i < 40000; i++) {
-        vk::DestroyFence(data->device, VK_NULL_HANDLE, NULL);
+        vk::DestroyFence(data->device, VK_NULL_HANDLE, nullptr);
         if (*data->bailout) {
             break;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo *create_info,
@@ -559,7 +559,7 @@ void AllocateDisjointMemory(VkDeviceObj *device, PFN_vkGetImageMemoryRequirement
     VkMemoryAllocateInfo mp_image_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     mp_image_alloc_info.allocationSize = mp_image_mem_reqs2.memoryRequirements.size;
     ASSERT_TRUE(device->phy().set_memory_type(mp_image_mem_reqs2.memoryRequirements.memoryTypeBits, &mp_image_alloc_info, 0));
-    ASSERT_VK_SUCCESS(vk::AllocateMemory(device->device(), &mp_image_alloc_info, NULL, mp_image_mem));
+    ASSERT_VK_SUCCESS(vk::AllocateMemory(device->device(), &mp_image_alloc_info, nullptr, mp_image_mem));
 }
 
 void NegHeightViewportTests(VkDeviceObj *m_device, VkCommandBufferObj *m_commandBuffer, ErrorMonitor *m_errorMonitor) {
@@ -610,14 +610,14 @@ void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *pCreateInfo
     else
         test.Monitor().ExpectSuccess();
 
-    err = vk::CreateSampler(test.device(), pCreateInfo, NULL, &sampler);
+    err = vk::CreateSampler(test.device(), pCreateInfo, nullptr, &sampler);
     if (code.length())
         test.Monitor().VerifyFound();
     else
         test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
-        vk::DestroySampler(test.device(), sampler, NULL);
+        vk::DestroySampler(test.device(), sampler, nullptr);
     }
 }
 
@@ -629,14 +629,14 @@ void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, 
     else
         test.Monitor().ExpectSuccess();
 
-    err = vk::CreateBuffer(test.device(), pCreateInfo, NULL, &buffer);
+    err = vk::CreateBuffer(test.device(), pCreateInfo, nullptr, &buffer);
     if (code.length())
         test.Monitor().VerifyFound();
     else
         test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
-        vk::DestroyBuffer(test.device(), buffer, NULL);
+        vk::DestroyBuffer(test.device(), buffer, nullptr);
     }
 }
 
@@ -649,14 +649,14 @@ void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, st
         test.Monitor().ExpectSuccess();
     }
 
-    err = vk::CreateImage(test.device(), pCreateInfo, NULL, &image);
+    err = vk::CreateImage(test.device(), pCreateInfo, nullptr, &image);
     if (code.length())
         test.Monitor().VerifyFound();
     else
         test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
-        vk::DestroyImage(test.device(), image, NULL);
+        vk::DestroyImage(test.device(), image, nullptr);
     }
 }
 
@@ -668,14 +668,14 @@ void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCrea
     else
         test.Monitor().ExpectSuccess();
 
-    err = vk::CreateBufferView(test.device(), pCreateInfo, NULL, &view);
+    err = vk::CreateBufferView(test.device(), pCreateInfo, nullptr, &view);
     if (codes.size())
         test.Monitor().VerifyFound();
     else
         test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
-        vk::DestroyBufferView(test.device(), view, NULL);
+        vk::DestroyBufferView(test.device(), view, nullptr);
     }
 }
 
@@ -687,14 +687,14 @@ void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreate
     else
         test.Monitor().ExpectSuccess();
 
-    err = vk::CreateImageView(test.device(), pCreateInfo, NULL, &view);
+    err = vk::CreateImageView(test.device(), pCreateInfo, nullptr, &view);
     if (code.length())
         test.Monitor().VerifyFound();
     else
         test.Monitor().VerifyNotFound();
 
     if (VK_SUCCESS == err) {
-        vk::DestroyImageView(test.device(), view, NULL);
+        vk::DestroyImageView(test.device(), view, nullptr);
     }
 }
 
@@ -1050,7 +1050,7 @@ VkLayerTest::VkLayerTest() {
     }
 
     app_info_.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    app_info_.pNext = NULL;
+    app_info_.pNext = nullptr;
     app_info_.pApplicationName = "layer_tests";
     app_info_.applicationVersion = 1;
     app_info_.pEngineName = "unittest";
@@ -1099,7 +1099,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         printf("%s %s extension not supported\n", kSkipPrefix, VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
         return false;
     }
-    auto temp_dpy = XOpenDisplay(NULL);
+    auto temp_dpy = XOpenDisplay(nullptr);
     if (temp_dpy) {
         instance_extensions_.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
         bSupport = true;
@@ -1113,7 +1113,7 @@ bool VkLayerTest::AddSurfaceInstanceExtension() {
         return false;
     }
     if (!bSupport) {
-        auto temp_xcb = xcb_connect(NULL, NULL);
+        auto temp_xcb = xcb_connect(nullptr, nullptr);
         if (temp_xcb) {
             instance_extensions_.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
             bSupport = true;
@@ -1268,7 +1268,7 @@ VkBufferTest::VkBufferTest(VkDeviceObj *aVulkanDevice, VkBufferUsageFlags aBuffe
             return;
         }
 
-        vk::AllocateMemory(VulkanDevice, &memory_allocate_info, NULL, &VulkanMemory);
+        vk::AllocateMemory(VulkanDevice, &memory_allocate_info, nullptr, &VulkanMemory);
         // NB: 1 is intentionally an invalid offset value
         const bool offset_en = eInvalidDeviceOffset == aTestFlag || eInvalidMemoryOffset == aTestFlag;
         vk::BindBufferMemory(VulkanDevice, VulkanBuffer, VulkanMemory, offset_en ? eOffsetAlignment : 0);
@@ -1600,7 +1600,7 @@ void OneOffDescriptorSet::WriteDescriptorImageInfo(int binding, VkImageView imag
 }
 
 void OneOffDescriptorSet::UpdateDescriptorSets() {
-    vk::UpdateDescriptorSets(device_->handle(), descriptor_writes.size(), descriptor_writes.data(), 0, NULL);
+    vk::UpdateDescriptorSets(device_->handle(), descriptor_writes.size(), descriptor_writes.data(), 0, nullptr);
 }
 
 CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, uint32_t color_attachments_count)
@@ -1628,7 +1628,7 @@ void CreatePipelineHelper::InitMultisampleInfo() {
     pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci_.sampleShadingEnable = VK_FALSE;
     pipe_ms_state_ci_.minSampleShading = 1.0;
-    pipe_ms_state_ci_.pSampleMask = NULL;
+    pipe_ms_state_ci_.pSampleMask = nullptr;
 }
 
 void CreatePipelineHelper::InitPipelineLayoutInfo() {
@@ -1860,7 +1860,7 @@ void CreatePipelineHelper::InitState() {
     pipeline_layout_ =
         VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_}, push_ranges, pipeline_layout_ci_.flags);
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, nullptr, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 
@@ -1891,7 +1891,7 @@ VkResult CreatePipelineHelper::CreateGraphicsPipeline(bool implicit_destroy, boo
         vk::DestroyPipeline(layer_test_.device(), pipeline_, nullptr);
         pipeline_ = VK_NULL_HANDLE;
     }
-    err = vk::CreateGraphicsPipelines(layer_test_.device(), pipeline_cache_, 1, &gp_ci_, NULL, &pipeline_);
+    err = vk::CreateGraphicsPipelines(layer_test_.device(), pipeline_cache_, 1, &gp_ci_, nullptr, &pipeline_);
     return err;
 }
 
@@ -1948,7 +1948,7 @@ void CreateComputePipelineHelper::InitState() {
         pipeline_layout_ci_.pPushConstantRanges + pipeline_layout_ci_.pushConstantRangeCount);
     pipeline_layout_ = VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_}, push_ranges);
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, nullptr, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 
@@ -1967,7 +1967,7 @@ VkResult CreateComputePipelineHelper::CreateComputePipeline(bool implicit_destro
         vk::DestroyPipeline(layer_test_.device(), pipeline_, nullptr);
         pipeline_ = VK_NULL_HANDLE;
     }
-    err = vk::CreateComputePipelines(layer_test_.device(), pipeline_cache_, 1, &cp_ci_, NULL, &pipeline_);
+    err = vk::CreateComputePipelines(layer_test_.device(), pipeline_cache_, 1, &cp_ci_, nullptr, &pipeline_);
     return err;
 }
 
@@ -2228,7 +2228,7 @@ void CreateNVRayTracingPipelineHelper::InitState() {
 
     pipeline_layout_ = VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_});
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, nullptr, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 
@@ -2885,12 +2885,12 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     }
     descriptor_writes[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_writes[2].pImageInfo = descriptor_image_infos;
-    vk::UpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, nullptr);
     if (descriptor_indexing) {
         descriptor_writes[0].dstSet = ds_variable.set_;
         descriptor_writes[1].dstSet = ds_variable.set_;
         descriptor_writes[2].dstSet = ds_variable.set_;
-        vk::UpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 3, descriptor_writes, 0, nullptr);
     }
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {&ds.layout_});
@@ -3640,13 +3640,13 @@ void addFullTestCommentIfPresent(const ::testing::TestInfo &test_info, std::stri
     const char *const type_param = test_info.type_param();
     const char *const value_param = test_info.value_param();
 
-    if (type_param != NULL || value_param != NULL) {
+    if (type_param != nullptr || value_param != nullptr) {
         error_message.append(", where ");
-        if (type_param != NULL) {
+        if (type_param != nullptr) {
             error_message.append("TypeParam = ").append(type_param);
-            if (value_param != NULL) error_message.append(" and ");
+            if (value_param != nullptr) error_message.append(" and ");
         }
-        if (value_param != NULL) {
+        if (value_param != nullptr) {
             error_message.append("GetParam() = ").append(value_param);
         }
     }
@@ -3735,7 +3735,7 @@ void android_main(struct android_app *app) {
     while (1) {
         int events;
         struct android_poll_source *source;
-        while (ALooper_pollAll(active ? 0 : -1, NULL, &events, (void **)&source) >= 0) {
+        while (ALooper_pollAll(active ? 0 : -1, nullptr, &events, (void **)&source) >= 0) {
             if (source) {
                 source->process(app, source);
             }

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -218,7 +218,7 @@ TEST_F(VkPositiveLayerTest, BasicQuery) {
     query_pool_info.queryCount = 2;
     query_pool_info.pipelineStatistics = 0;
 
-    VkResult res = vk::CreateQueryPool(m_device->handle(), &query_pool_info, NULL, &query_pool);
+    VkResult res = vk::CreateQueryPool(m_device->handle(), &query_pool_info, nullptr, &query_pool);
     ASSERT_VK_SUCCESS(res);
 
     CreatePipelineHelper pipe(*this);
@@ -266,7 +266,7 @@ TEST_F(VkPositiveLayerTest, BasicQuery) {
     m_commandBuffer->QueueCommandBuffer();
     m_errorMonitor->VerifyNotFound();
     vk::QueueWaitIdle(m_device->m_queue);
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, ConfirmNoVLErrorWhenVkCmdClearAttachmentsCalledInSecondaryCB) {
@@ -322,7 +322,7 @@ TEST_F(VkPositiveLayerTest, CommandPoolDeleteWithReferences) {
     cmd_pool_info.flags = 0;
 
     VkCommandPool secondary_cmd_pool;
-    VkResult res = vk::CreateCommandPool(m_device->handle(), &cmd_pool_info, NULL, &secondary_cmd_pool);
+    VkResult res = vk::CreateCommandPool(m_device->handle(), &cmd_pool_info, nullptr, &secondary_cmd_pool);
     ASSERT_VK_SUCCESS(res);
 
     VkCommandBufferAllocateInfo cmdalloc = vk_testing::CommandBuffer::create_info(secondary_cmd_pool);
@@ -352,7 +352,7 @@ TEST_F(VkPositiveLayerTest, CommandPoolDeleteWithReferences) {
     m_commandBuffer->end();
 
     // DestroyCommandPool *implicitly* frees the command buffers allocated from it
-    vk::DestroyCommandPool(m_device->handle(), secondary_cmd_pool, NULL);
+    vk::DestroyCommandPool(m_device->handle(), secondary_cmd_pool, nullptr);
     // If bookkeeping has been lax, validating the reset will attempt to touch deleted data
     res = vk::ResetCommandPool(m_device->handle(), m_commandPool->handle(), 0);
     ASSERT_VK_SUCCESS(res);
@@ -790,7 +790,7 @@ TEST_F(VkPositiveLayerTest, FramebufferBindingDestroyCommandPool) {
     vk::CmdEndRenderPass(command_buffer);
     vk::EndCommandBuffer(command_buffer);
     // Destroy command pool to implicitly free command buffer
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
     vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     vk::DestroyRenderPass(m_device->device(), rp, nullptr);
     m_errorMonitor->VerifyNotFound();
@@ -894,7 +894,7 @@ TEST_F(VkPositiveLayerTest, QueryAndCopySecondaryCommandBuffers) {
         return;
     }
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -970,7 +970,7 @@ TEST_F(VkPositiveLayerTest, QueryAndCopyMultipleCommandBuffers) {
         return;
     }
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -1040,7 +1040,7 @@ TEST_F(VkPositiveLayerTest, QueryAndCopyMultipleCommandBuffers) {
 
     vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, command_buffer);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1053,7 +1053,7 @@ TEST_F(VkPositiveLayerTest, DestroyQueryPoolAfterGetQueryPoolResults) {
     m_errorMonitor->ExpectSuccess();
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -1217,7 +1217,7 @@ TEST_F(VkPositiveLayerTest, WriteTimestampNoneAndAll) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -488,10 +488,9 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
         return;
     }
@@ -548,6 +547,7 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature12) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
@@ -562,9 +562,7 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature12) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
         return;
     }

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -69,7 +69,7 @@ TEST_F(VkPositiveLayerTest, CopyNonupdatedDescriptors) {
         copy_ds_update[i].dstBinding = i;
         copy_ds_update[i].descriptorCount = 1;
     }
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, copy_size, copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, copy_size, copy_ds_update);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -93,7 +93,7 @@ TEST_F(VkPositiveLayerTest, DeleteDescriptorSetLayoutsBeforeDescriptorSets) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool_one;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool_one);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool_one);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -101,7 +101,7 @@ TEST_F(VkPositiveLayerTest, DeleteDescriptorSetLayoutsBeforeDescriptorSets) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     VkDescriptorSet descriptorSet;
     {
@@ -116,7 +116,7 @@ TEST_F(VkPositiveLayerTest, DeleteDescriptorSetLayoutsBeforeDescriptorSets) {
     }  // ds_layout destroyed
     err = vk::FreeDescriptorSets(m_device->device(), ds_pool_one, 1, &descriptorSet);
 
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool_one, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool_one, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -174,7 +174,7 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
         descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo *>(invalid_ptr);
         descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView *>(invalid_ptr);
 
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_errorMonitor->VerifyNotFound();
     }
@@ -218,7 +218,7 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
         descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo *>(invalid_ptr);
         descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView *>(invalid_ptr);
 
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_errorMonitor->VerifyNotFound();
     }
@@ -242,7 +242,7 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
         buff_view_ci.format = format_texel_case;
         buff_view_ci.range = VK_WHOLE_SIZE;
         VkBufferView buffer_view;
-        VkResult err = vk::CreateBufferView(m_device->device(), &buff_view_ci, NULL, &buffer_view);
+        VkResult err = vk::CreateBufferView(m_device->device(), &buff_view_ci, nullptr, &buffer_view);
         ASSERT_VK_SUCCESS(err);
         OneOffDescriptorSet descriptor_set(m_device,
                                            {
@@ -265,11 +265,11 @@ TEST_F(VkPositiveLayerTest, IgnoreUnrelatedDescriptor) {
         descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo *>(invalid_ptr);
         descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo *>(invalid_ptr);
 
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_errorMonitor->VerifyNotFound();
 
-        vk::DestroyBufferView(m_device->device(), buffer_view, NULL);
+        vk::DestroyBufferView(m_device->device(), buffer_view, nullptr);
     }
 }
 
@@ -285,7 +285,7 @@ TEST_F(VkPositiveLayerTest, ImmutableSamplerOnlyDescriptor) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
@@ -298,7 +298,7 @@ TEST_F(VkPositiveLayerTest, ImmutableSamplerOnlyDescriptor) {
                               &descriptor_set.set_, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
@@ -329,7 +329,7 @@ TEST_F(VkPositiveLayerTest, EmptyDescriptorUpdateTest) {
     buff_ci.size = 256;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     VkBuffer buffer;
-    err = vk::CreateBuffer(m_device->device(), &buff_ci, NULL, &buffer);
+    err = vk::CreateBuffer(m_device->device(), &buff_ci, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
     // Have to bind memory to buffer before descriptor update
     VkMemoryAllocateInfo mem_alloc = LvlInitStruct<VkMemoryAllocateInfo>();
@@ -341,7 +341,7 @@ TEST_F(VkPositiveLayerTest, EmptyDescriptorUpdateTest) {
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     if (!pass) {
         printf("%s Failed to allocate memory.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
     // Make sure allocation is sufficiently large to accommodate buffer requirements
@@ -350,7 +350,7 @@ TEST_F(VkPositiveLayerTest, EmptyDescriptorUpdateTest) {
     }
 
     VkDeviceMemory mem;
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
     err = vk::BindBufferMemory(m_device->device(), buffer, mem, 0);
     ASSERT_VK_SUCCESS(err);
@@ -369,12 +369,12 @@ TEST_F(VkPositiveLayerTest, EmptyDescriptorUpdateTest) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = ds.set_;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_errorMonitor->VerifyNotFound();
     // Cleanup
-    vk::FreeMemory(m_device->device(), mem, NULL);
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
 }
 
 // This is a positive test. No failures are expected.
@@ -412,7 +412,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
     // Create push descriptor set layout
@@ -491,7 +491,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     OneOffDescriptorSet descriptor_set(m_device, {dsl_binding}, 0, nullptr, VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
                                        nullptr);
@@ -538,7 +538,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               descriptor_set.descriptor_writes.data());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 1, 1,
-                              &descriptor_set.set_, 0, NULL);
+                              &descriptor_set.set_, 0, nullptr);
 
     // No errors should be generated.
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
@@ -641,7 +641,7 @@ TEST_F(VkPositiveLayerTest, BindingPartiallyBound) {
     descriptor_writes[0].descriptorCount = 1;
     descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_writes[0].pBufferInfo = buffer_info;
-    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
 
     char const *shader_source = R"glsl(
         #version 450
@@ -868,7 +868,7 @@ TEST_F(VkPositiveLayerTest, DynamicOffsetWithInactiveBinding) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     descriptor_write.pBufferInfo = buff_info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -387,11 +387,10 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
         printf("%s Did not find VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME; skipped.\n", kSkipPrefix);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
-        printf("%s Push Descriptors Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Extension %s not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -465,10 +464,9 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
         printf("%s Did not find VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME; skipped.\n", kSkipPrefix);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Push Descriptors Extension not supported, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -561,15 +559,11 @@ TEST_F(VkPositiveLayerTest, BindingPartiallyBound) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     InitFramework(m_errorMonitor);
 
-    bool descriptor_indexing = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
-    descriptor_indexing =
-        descriptor_indexing && DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-    if (descriptor_indexing) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s and/or %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_MAINTENANCE_3_EXTENSION_NAME,
                VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
         return;
@@ -691,10 +685,9 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
@@ -996,10 +989,9 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
@@ -1065,19 +1057,14 @@ TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
-        printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Required extensions not supported by device; skipped.\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
-
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)) {
-        printf("%s Extension %s is not supported; skipped.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-        return;
-    }
-    m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
 
     auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&robustness2_features);

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -442,8 +442,8 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
     // Find address of extension call and make the call
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
     assert(vkCmdPushDescriptorSetKHR != nullptr);
 
     m_commandBuffer->begin();
@@ -526,8 +526,8 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), 0, sizeof(bo_data));
     descriptor_set.UpdateDescriptorSets();
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
     assert(vkCmdPushDescriptorSetKHR != nullptr);
 
     m_commandBuffer->begin();
@@ -577,8 +577,8 @@ TEST_F(VkPositiveLayerTest, BindingPartiallyBound) {
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&indexing_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
@@ -718,8 +718,8 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
 
     VkDescriptorBufferInfo buffer_info = {buffer_obj.handle(), 0, VK_WHOLE_SIZE};
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
     ASSERT_TRUE(vkCmdPushDescriptorSetKHR != nullptr);
 
     const VkDescriptorSetLayoutBinding ds_binding_0 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -1023,7 +1023,7 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
     auto vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
 
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {
         {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, &sampler_handle}};
@@ -1082,8 +1082,8 @@ TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
     auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&robustness2_features);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
 
@@ -1092,8 +1092,8 @@ TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
         return;
     }
 
-    PFN_vkCmdBindVertexBuffers2EXT vkCmdBindVertexBuffers2EXT =
-        (PFN_vkCmdBindVertexBuffers2EXT)vk::GetInstanceProcAddr(instance(), "vkCmdBindVertexBuffers2EXT");
+    auto vkCmdBindVertexBuffers2EXT =
+        reinterpret_cast<PFN_vkCmdBindVertexBuffers2EXT>(vk::GetInstanceProcAddr(instance(), "vkCmdBindVertexBuffers2EXT"));
     ASSERT_TRUE(vkCmdBindVertexBuffers2EXT != nullptr);
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -1136,8 +1136,8 @@ TEST_F(VkPositiveLayerTest, CopyMutableDescriptors) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -223,10 +223,10 @@ TEST_F(VkPositiveLayerTest, TestBeginQueryInDynamicRendering) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkCmdBeginRendering vkCmdBeginRendering =
+    auto vkCmdBeginRendering =
         reinterpret_cast<PFN_vkCmdBeginRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRendering"));
     assert(vkCmdBeginRendering != nullptr);
-    PFN_vkCmdEndRendering vkCmdEndRendering =
+    auto vkCmdEndRendering =
         reinterpret_cast<PFN_vkCmdEndRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRendering"));
     assert(vkCmdEndRendering != nullptr);
 

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -87,7 +87,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneGetImageSubresourceLayout) {
     }
 
     VkImage image;
-    VkResult err = vk::CreateImage(device(), &ci, NULL, &image);
+    VkResult err = vk::CreateImage(device(), &ci, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     // Query layout of 3rd plane
@@ -101,7 +101,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneGetImageSubresourceLayout) {
     vk::GetImageSubresourceLayout(device(), image, &subres, &layout);
     m_errorMonitor->VerifyNotFound();
 
-    vk::DestroyImage(device(), image, NULL);
+    vk::DestroyImage(device(), image, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, OwnershipTranfersImage) {
@@ -337,7 +337,7 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithoutFeature) {
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     vk::DestroySampler(m_device->device(), sampler, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
@@ -366,7 +366,7 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithoutFeature12) {
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     vk::DestroySampler(m_device->device(), sampler, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
@@ -401,7 +401,7 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithFeature) {
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     vk::DestroySampler(m_device->device(), sampler, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
@@ -443,7 +443,7 @@ TEST_F(VkPositiveLayerTest, NonCoherentMemoryMapping) {
         }
     }
 
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     // Map/Flush/Invalidate using WHOLE_SIZE and zero offsets and entire mapped range
@@ -506,7 +506,7 @@ TEST_F(VkPositiveLayerTest, NonCoherentMemoryMapping) {
     m_errorMonitor->VerifyNotFound();
     vk::UnmapMemory(m_device->device(), mem);
 
-    vk::FreeMemory(m_device->device(), mem, NULL);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, CreateImageViewFollowsParameterCompatibilityRequirements) {
@@ -558,9 +558,9 @@ TEST_F(VkPositiveLayerTest, ValidUsage) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    vk::CreateImageView(m_device->device(), &ivci, NULL, &imageView);
+    vk::CreateImageView(m_device->device(), &ivci, nullptr, &imageView);
     m_errorMonitor->VerifyNotFound();
-    vk::DestroyImageView(m_device->device(), imageView, NULL);
+    vk::DestroyImageView(m_device->device(), imageView, nullptr);
 }
 
 // This is a positive test. No failures are expected.
@@ -594,7 +594,7 @@ TEST_F(VkPositiveLayerTest, BindSparse) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements memory_reqs;
@@ -621,9 +621,9 @@ TEST_F(VkPositiveLayerTest, BindSparse) {
     memory_info.allocationSize = memory_reqs.alignment;
     pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory_one);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &memory_one);
     ASSERT_VK_SUCCESS(err);
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory_two);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &memory_two);
     ASSERT_VK_SUCCESS(err);
     VkSparseMemoryBind binds[2];
     binds[0].flags = 0;
@@ -649,9 +649,9 @@ TEST_F(VkPositiveLayerTest, BindSparse) {
 
     vk::QueueBindSparse(m_device->m_queue, 1, &bindSparseInfo, fence);
     vk::QueueWaitIdle(m_device->m_queue);
-    vk::DestroyImage(m_device->device(), image, NULL);
-    vk::FreeMemory(m_device->device(), memory_one, NULL);
-    vk::FreeMemory(m_device->device(), memory_two, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
+    vk::FreeMemory(m_device->device(), memory_one, nullptr);
+    vk::FreeMemory(m_device->device(), memory_two, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -686,7 +686,7 @@ TEST_F(VkPositiveLayerTest, BindSparseFreeMemory) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements memory_reqs;
@@ -700,7 +700,7 @@ TEST_F(VkPositiveLayerTest, BindSparseFreeMemory) {
     bool pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
 
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &memory);
     ASSERT_VK_SUCCESS(err);
 
     VkSparseMemoryBind bind;
@@ -730,7 +730,7 @@ TEST_F(VkPositiveLayerTest, BindSparseFreeMemory) {
     vk::QueueWaitIdle(m_device->m_queue);
 
     // Free the memory, then use the image in a new command buffer
-    vk::FreeMemory(m_device->device(), memory, NULL);
+    vk::FreeMemory(m_device->device(), memory, nullptr);
 
     m_commandBuffer->begin();
 
@@ -761,7 +761,7 @@ TEST_F(VkPositiveLayerTest, BindSparseFreeMemory) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
 
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -796,7 +796,7 @@ TEST_F(VkPositiveLayerTest, BindSparseMetadata) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     // Query image memory requirements
@@ -825,7 +825,7 @@ TEST_F(VkPositiveLayerTest, BindSparseMetadata) {
         VkMemoryAllocateInfo metadata_memory_info = LvlInitStruct<VkMemoryAllocateInfo>();
         metadata_memory_info.allocationSize = metadata_reqs->imageMipTailSize;
         m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &metadata_memory_info, 0);
-        err = vk::AllocateMemory(m_device->device(), &metadata_memory_info, NULL, &metadata_memory);
+        err = vk::AllocateMemory(m_device->device(), &metadata_memory_info, nullptr, &metadata_memory);
         ASSERT_VK_SUCCESS(err);
 
         // Bind metadata
@@ -850,10 +850,10 @@ TEST_F(VkPositiveLayerTest, BindSparseMetadata) {
 
         // Cleanup
         vk::QueueWaitIdle(m_device->m_queue);
-        vk::FreeMemory(m_device->device(), metadata_memory, NULL);
+        vk::FreeMemory(m_device->device(), metadata_memory, nullptr);
     }
 
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
 }
 
 // This is a positive test.  No errors should be generated.
@@ -1505,7 +1505,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
     }
 
     VkImage image;
-    ASSERT_VK_SUCCESS(vk::CreateImage(device(), &ci, NULL, &image));
+    ASSERT_VK_SUCCESS(vk::CreateImage(device(), &ci, nullptr, &image));
 
     // Allocate & bind memory
     VkPhysicalDeviceMemoryProperties phys_mem_props;
@@ -1520,14 +1520,14 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
             VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
             alloc_info.allocationSize = mem_reqs.size;
             alloc_info.memoryTypeIndex = type;
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &mem_obj));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &mem_obj));
             break;
         }
     }
 
     if (VK_NULL_HANDLE == mem_obj) {
         printf("%s Unable to allocate image memory. Skipping test.\n", kSkipPrefix);
-        vk::DestroyImage(device(), image, NULL);
+        vk::DestroyImage(device(), image, nullptr);
         return;
     }
     ASSERT_VK_SUCCESS(vk::BindImageMemory(device(), image, mem_obj, 0));
@@ -1554,15 +1554,15 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
     m_commandBuffer->end();
     m_errorMonitor->VerifyNotFound();
 
-    vk::FreeMemory(device(), mem_obj, NULL);
-    vk::DestroyImage(device(), image, NULL);
+    vk::FreeMemory(device(), mem_obj, nullptr);
+    vk::DestroyImage(device(), image, nullptr);
 
     // Repeat bind test on a DISJOINT multi-planar image, with per-plane memory objects, using API2 variants
     //
     features |= VK_FORMAT_FEATURE_DISJOINT_BIT;
     ci.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
     if (ImageFormatAndFeaturesSupported(instance(), gpu(), ci, features)) {
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &ci, NULL, &image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &ci, nullptr, &image));
 
         // Allocate & bind memory
         VkPhysicalDeviceMemoryProperties2 phys_mem_props2 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
@@ -1589,18 +1589,18 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
             }
         }
         alloc_info.allocationSize = mem_reqs2.memoryRequirements.size;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &p0_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &p0_mem));
 
         // Plane 1 & 2 use same memory type
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
         vkGetImageMemoryRequirements2Function(device(), &mem_req_info2, &mem_reqs2);
         alloc_info.allocationSize = mem_reqs2.memoryRequirements.size;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &p1_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &p1_mem));
 
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
         vkGetImageMemoryRequirements2Function(device(), &mem_req_info2, &mem_reqs2);
         alloc_info.allocationSize = mem_reqs2.memoryRequirements.size;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &p2_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &p2_mem));
 
         // Set up 3-plane binding
         VkBindImageMemoryInfo bind_info[3];
@@ -1617,10 +1617,10 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
         vkBindImageMemory2Function(device(), 3, bind_info);
         m_errorMonitor->VerifyNotFound();
 
-        vk::FreeMemory(device(), p0_mem, NULL);
-        vk::FreeMemory(device(), p1_mem, NULL);
-        vk::FreeMemory(device(), p2_mem, NULL);
-        vk::DestroyImage(device(), image, NULL);
+        vk::FreeMemory(device(), p0_mem, nullptr);
+        vk::FreeMemory(device(), p1_mem, nullptr);
+        vk::FreeMemory(device(), p2_mem, nullptr);
+        vk::DestroyImage(device(), image, nullptr);
     }
 
     // Test that changing the layout of ASPECT_COLOR also changes the layout of the individual planes
@@ -1670,7 +1670,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
     VkSampler sampler;
 
     VkResult err;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
@@ -1722,7 +1722,7 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
     m_errorMonitor->VerifyNotFound();
 
     vk::QueueWaitIdle(m_device->m_queue);
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
     vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
@@ -1928,7 +1928,7 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
     image_create_info.pNext = &image_swapchain_create_info;
 
     VkImage image_from_swapchain;
-    vk::CreateImage(device(), &image_create_info, NULL, &image_from_swapchain);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image_from_swapchain);
 
     auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
     bind_swapchain_info.swapchain = m_swapchain;
@@ -1962,7 +1962,7 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyNotFound();
 
-    vk::DestroyImage(m_device->device(), image_from_swapchain, NULL);
+    vk::DestroyImage(m_device->device(), image_from_swapchain, nullptr);
     DestroySwapchain();
 }
 
@@ -2047,7 +2047,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     image_create_info.pNext = &image_swapchain_create_info;
 
     VkImage peer_image;
-    vk::CreateImage(device(), &image_create_info, NULL, &peer_image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &peer_image);
 
     auto bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
     bind_devicegroup_info.deviceIndexCount = 2;
@@ -2117,7 +2117,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     m_commandBuffer->QueueCommandBuffer();
     m_errorMonitor->VerifyNotFound();
 
-    vk::DestroyImage(m_device->device(), peer_image, NULL);
+    vk::DestroyImage(m_device->device(), peer_image, nullptr);
     DestroySwapchain();
 }
 
@@ -2139,7 +2139,7 @@ TEST_F(VkPositiveLayerTest, SwapchainImageLayout) {
     uint32_t image_index, image_count;
     PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR =
         (PFN_vkGetSwapchainImagesKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR");
-    fpGetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, NULL);
+    fpGetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, nullptr);
     VkImage *swapchainImages = (VkImage *)malloc(image_count * sizeof(VkImage));
     fpGetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, swapchainImages);
     VkFenceCreateInfo fenceci = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
@@ -2210,12 +2210,12 @@ TEST_F(VkPositiveLayerTest, SwapchainImageLayout) {
     m_commandBuffer->end();
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
     vk::WaitForFences(m_device->device(), 1, &fence, VK_TRUE, UINT64_MAX);
     vk::ResetFences(m_device->device(), 1, &fence);
     m_errorMonitor->ExpectSuccess();
@@ -2224,12 +2224,12 @@ TEST_F(VkPositiveLayerTest, SwapchainImageLayout) {
     vk::WaitForFences(m_device->device(), 1, &fence, VK_TRUE, UINT64_MAX);
 
     free(swapchainImages);
-    vk::DestroyFramebuffer(m_device->device(), fb1, NULL);
-    vk::DestroyRenderPass(m_device->device(), rp1, NULL);
-    vk::DestroyFramebuffer(m_device->device(), fb2, NULL);
-    vk::DestroyRenderPass(m_device->device(), rp2, NULL);
-    vk::DestroyFence(m_device->device(), fence, NULL);
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroyFramebuffer(m_device->device(), fb1, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp1, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), fb2, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp2, nullptr);
+    vk::DestroyFence(m_device->device(), fence, nullptr);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
     DestroySwapchain();
 }
 
@@ -2357,7 +2357,7 @@ TEST_F(VkPositiveLayerTest, ImagelessLayoutTracking) {
     VkRenderPassCreateInfo renderPassCreateInfo = {
         VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attachmentDescription, 1, subpasses, 0, nullptr};
     VkRenderPass renderPass;
-    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, NULL, &renderPass);
+    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     // Create an image to use in an imageless framebuffer.  Bind swapchain memory to it.
     auto image_swapchain_create_info = LvlInitStruct<VkImageSwapchainCreateInfoKHR>();

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1065,9 +1065,8 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
     VkPhysicalDeviceExternalBufferInfoKHR ebi = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR, nullptr, 0,
                                                  VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, handle_type};
     VkExternalBufferPropertiesKHR ebp = {VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR, nullptr, {0, 0, 0}};
-    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
+    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceExternalBufferPropertiesKHR != nullptr);
     vkGetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &ebi, &ebp);
     if (!(ebp.externalMemoryProperties.compatibleHandleTypes & handle_type) ||
@@ -1139,7 +1138,7 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
 #ifdef _WIN32
     // Export memory to handle
     auto vkGetMemoryWin32HandleKHR =
-        (PFN_vkGetMemoryWin32HandleKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR");
+        reinterpret_cast<PFN_vkGetMemoryWin32HandleKHR>(vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR"));
     ASSERT_TRUE(vkGetMemoryWin32HandleKHR != nullptr);
     VkMemoryGetWin32HandleInfoKHR mghi = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr, memory_export.handle(),
                                           handle_type};
@@ -1150,7 +1149,7 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
                                                     handle};
 #else
     // Export memory to fd
-    auto vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR");
+    auto vkGetMemoryFdKHR = reinterpret_cast<PFN_vkGetMemoryFdKHR>(vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR"));
     ASSERT_TRUE(vkGetMemoryFdKHR != nullptr);
     VkMemoryGetFdInfoKHR mgfi = {VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, nullptr, memory_export.handle(), handle_type};
     int fd;
@@ -1471,11 +1470,12 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
         vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
         vkGetPhysicalDeviceMemoryProperties2Function = vk::GetPhysicalDeviceMemoryProperties2;
     } else {
-        vkBindImageMemory2Function = (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
-        vkGetImageMemoryRequirements2Function =
-            (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
-        vkGetPhysicalDeviceMemoryProperties2Function = (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)vk::GetDeviceProcAddr(
-            m_device->handle(), "vkGetPhysicalDeviceMemoryProperties2KHR");
+        vkBindImageMemory2Function =
+            reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
+        vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
+        vkGetPhysicalDeviceMemoryProperties2Function = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties2KHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkGetPhysicalDeviceMemoryProperties2KHR"));
     }
 
     if (!vkBindImageMemory2Function || !vkGetImageMemoryRequirements2Function || !vkGetPhysicalDeviceMemoryProperties2Function) {
@@ -2137,8 +2137,8 @@ TEST_F(VkPositiveLayerTest, SwapchainImageLayout) {
         return;
     }
     uint32_t image_index, image_count;
-    PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR =
-        (PFN_vkGetSwapchainImagesKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR");
+    auto fpGetSwapchainImagesKHR =
+        reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR"));
     fpGetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, nullptr);
     VkImage *swapchainImages = (VkImage *)malloc(image_count * sizeof(VkImage));
     fpGetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, swapchainImages);

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -320,10 +320,9 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithoutFeature) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
         return;
     }
@@ -347,6 +346,7 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithoutFeature12) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
@@ -354,9 +354,7 @@ TEST_F(VkPositiveLayerTest, SamplerMirrorClampToEdgeWithoutFeature12) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
         return;
     }
@@ -1200,12 +1198,11 @@ TEST_F(VkPositiveLayerTest, GetMemoryRequirements2) {
         "Get memory requirements with VK_KHR_get_memory_requirements2 instead of core entry points and verify layers do not emit "
         "errors when objects are bound and used");
 
+    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check for VK_KHR_get_memory_requirementes2 extensions
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
         return;
     }
@@ -1284,12 +1281,11 @@ TEST_F(VkPositiveLayerTest, BindMemory2) {
         "Bind memory with VK_KHR_bind_memory2 instead of core entry points and verify layers do not emit errors when objects are "
         "used");
 
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check for VK_KHR_get_memory_requirementes2 extensions
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_BIND_MEMORY_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
         return;
     }
@@ -1729,10 +1725,9 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
 TEST_F(VkPositiveLayerTest, TestFormatCompatibility) {
     TEST_DESCRIPTION("Test format compatibility");
 
+    AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
         return;
     }
@@ -1766,10 +1761,9 @@ TEST_F(VkPositiveLayerTest, TestFormatCompatibility) {
 TEST_F(VkPositiveLayerTest, TestCreatingFramebufferFrom3DImage) {
     TEST_DESCRIPTION("Validate creating a framebuffer from a 3D image.");
 
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping tests\n", kSkipPrefix, VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
         return;
     }

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -79,8 +79,8 @@ TEST_F(VkPositiveLayerTest, NullFunctionPointer) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     m_errorMonitor->ExpectSuccess();
-    auto fpGetBufferMemoryRequirements =
-        (PFN_vkGetBufferMemoryRequirements2)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferMemoryRequirements2");
+    auto fpGetBufferMemoryRequirements = reinterpret_cast<PFN_vkGetBufferMemoryRequirements2>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferMemoryRequirements2"));
     if (fpGetBufferMemoryRequirements) {
         m_errorMonitor->SetError("Null was expected!");
     }

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -94,7 +94,7 @@ TEST_F(VkPositiveLayerTest, ValidationInstanceExtensions) {
     std::vector<std::string> extensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
                                            VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME};
     uint32_t property_count;
-    vk::EnumerateInstanceExtensionProperties(layer_name.c_str(), &property_count, NULL);
+    vk::EnumerateInstanceExtensionProperties(layer_name.c_str(), &property_count, nullptr);
     std::vector<VkExtensionProperties> properties(property_count);
     vk::EnumerateInstanceExtensionProperties(layer_name.c_str(), &property_count, properties.data());
     for (size_t i = 0; i < extensions.size(); i++) {

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -67,12 +67,12 @@ TEST_F(VkPositiveLayerTest, NullFunctionPointer) {
     TEST_DESCRIPTION("On 1_0 instance , call GetDeviceProcAddr on promoted 1_1 device-level entrypoint");
     SetTargetApiVersion(VK_API_VERSION_1_0);
 
+    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, "VK_KHR_get_memory_requirements2")) {
-        m_device_extension_names.push_back("VK_KHR_get_memory_requirements2");
-    } else {
-        printf("%s VK_KHR_get_memory_reqirements2 extension not supported, skipping NullFunctionPointer test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping NullFunctionPointer test\n", kSkipPrefix,
+               VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
         return;
     }
 

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -58,8 +58,8 @@ TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
     VkEvent event_handle = VK_NULL_HANDLE;
     VkEventCreateInfo event_info = LvlInitStruct<VkEventCreateInfo>();
     event_info.flags = 1;
-    vk::CreateEvent(device(), &event_info, NULL, &event_handle);
-    vk::DestroyEvent(device(), event_handle, NULL);
+    vk::CreateEvent(device(), &event_info, nullptr, &event_handle);
+    vk::DestroyEvent(device(), event_handle, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -72,26 +72,26 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
     m_errorMonitor->ExpectSuccess();
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    vk::DestroyBuffer(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyBufferView(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyCommandPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDescriptorPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDescriptorSetLayout(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDevice(VK_NULL_HANDLE, NULL);
-    vk::DestroyEvent(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyFramebuffer(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyImage(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyImageView(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyInstance(VK_NULL_HANDLE, NULL);
-    vk::DestroyPipeline(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyPipelineCache(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyPipelineLayout(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyQueryPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyRenderPass(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroySampler(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroySemaphore(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyShaderModule(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyBuffer(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyBufferView(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyCommandPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDescriptorPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDescriptorSetLayout(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDevice(VK_NULL_HANDLE, nullptr);
+    vk::DestroyEvent(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyImage(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyImageView(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyInstance(VK_NULL_HANDLE, nullptr);
+    vk::DestroyPipeline(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyPipelineCache(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyPipelineLayout(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyQueryPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyRenderPass(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroySampler(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroySemaphore(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyShaderModule(m_device->device(), VK_NULL_HANDLE, nullptr);
 
     VkCommandPool command_pool;
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
@@ -105,7 +105,7 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     vk::AllocateCommandBuffers(m_device->device(), &command_buffer_allocate_info, &command_buffers[1]);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 3, command_buffers);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -118,7 +118,7 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -126,7 +126,7 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
 
@@ -138,9 +138,9 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
     err = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_sets[1]);
     ASSERT_VK_SUCCESS(err);
     vk::FreeDescriptorSets(m_device->device(), ds_pool, 3, descriptor_sets);
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 
-    vk::FreeMemory(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::FreeMemory(m_device->device(), VK_NULL_HANDLE, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -195,7 +195,7 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
 
     VkBuffer buffer;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements memory_reqs;
@@ -213,14 +213,14 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     ASSERT_TRUE(pass);
 
     VkDeviceMemory buffer_memory;
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &buffer_memory);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &buffer_memory);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindBufferMemory(m_device->device(), buffer, buffer_memory, 0);
     ASSERT_VK_SUCCESS(err);
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
-    vk::FreeMemory(m_device->device(), buffer_memory, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
+    vk::FreeMemory(m_device->device(), buffer_memory, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -548,7 +548,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     device_ci.pQueueCreateInfos = &queue_ci;
 
     VkDevice device;
-    vk::CreateDevice(gpu(), &device_ci, NULL, &device);
+    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
 
     vkTrimCommandPoolKHR = vk::GetDeviceProcAddr(device, "vkTrimCommandPoolKHR");
     if (nullptr == vkTrimCommandPoolKHR) m_errorMonitor->SetError("Unexpected null pointer");
@@ -593,7 +593,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
     VkBuffer buffer;
-    vk::CreateBuffer(m_device->device(), &bci, NULL, &buffer);
+    vk::CreateBuffer(m_device->device(), &bci, nullptr, &buffer);
     VkMemoryRequirements buffer_mem_reqs = {};
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
@@ -603,7 +603,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     buffer_alloc_info.pNext = &alloc_flags;
     VkDeviceMemory buffer_mem;
-    VkResult err = vk::AllocateMemory(m_device->device(), &buffer_alloc_info, NULL, &buffer_mem);
+    VkResult err = vk::AllocateMemory(m_device->device(), &buffer_alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(m_device->device(), buffer, buffer_mem, 0);
 
@@ -620,8 +620,8 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
         (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR");
     if (nullptr != vkGetBufferDeviceAddressKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
     m_errorMonitor->VerifyNotFound();
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
-    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
+    vk::FreeMemory(m_device->device(), buffer_mem, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, QueueThreading) {

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -148,11 +148,10 @@ TEST_F(VkPositiveLayerTest, TestDestroyFreeNullHandles) {
 TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
     TEST_DESCRIPTION("Validate various special cases for the Maintenance1_KHR extension");
 
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
-    } else {
-        printf("%s Maintenance1 Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -173,11 +172,10 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     TEST_DESCRIPTION("Verify that a valid pNext value is handled correctly");
 
     // Positive test to check parameter_validation and unique_objects support for NV_dedicated_allocation
+    AddRequiredExtensions(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
-    } else {
-        printf("%s VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME Extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test.\n", kSkipPrefix, VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -442,14 +440,13 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
         LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -266,8 +266,8 @@ TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     VkResult err;
@@ -352,8 +352,8 @@ TEST_F(VkPositiveLayerTest, RayTracingPipelineNV) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     if (!CreateNVRayTracingPipelineHelper::InitDeviceExtensions(*this, m_device_extension_names)) {
@@ -458,7 +458,8 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     m_errorMonitor->ExpectSuccess();
 
@@ -511,7 +512,8 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrNullPtr) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     m_errorMonitor->ExpectSuccess();
-    auto fpDestroySurface = (PFN_vkCreateValidationCacheEXT)vk::GetDeviceProcAddr(m_device->device(), "vkDestroySurfaceKHR");
+    auto fpDestroySurface =
+        reinterpret_cast<PFN_vkCreateValidationCacheEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkDestroySurfaceKHR"));
     if (fpDestroySurface) {
         m_errorMonitor->SetError("Null was expected!");
     }
@@ -568,8 +570,8 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
 
     VkPhysicalDeviceFeatures2 features2 = {};
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2");
+    auto vkGetPhysicalDeviceFeatures2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2 != nullptr);
 
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&bda_features);
@@ -610,14 +612,14 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
     VkBufferDeviceAddressInfo bda_info = LvlInitStruct<VkBufferDeviceAddressInfo>();
     bda_info.buffer = buffer;
     auto vkGetBufferDeviceAddress =
-        (PFN_vkGetBufferDeviceAddress)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddress");
+        reinterpret_cast<PFN_vkGetBufferDeviceAddress>(vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddress"));
     ASSERT_TRUE(vkGetBufferDeviceAddress != nullptr);
     vkGetBufferDeviceAddress(m_device->device(), &bda_info);
     m_errorMonitor->VerifyNotFound();
 
     // Also verify that we don't get the KHR extension address without enabling the KHR extension
     auto vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR");
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR"));
     if (nullptr != vkGetBufferDeviceAddressKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
     m_errorMonitor->VerifyNotFound();
     vk::DestroyBuffer(m_device->device(), buffer, nullptr);

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -1830,8 +1830,8 @@ TEST_F(VkPositiveLayerTest, PipelineStageConditionalRendering) {
     }
     m_device_extension_names.push_back(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
 
-    auto vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME)) {
         printf("%s requires %s.\n", kSkipPrefix, VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -2419,8 +2419,8 @@ TEST_F(VkPositiveLayerTest, CreatePipelineSpecializeInt8) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto float16int8_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
@@ -2495,8 +2495,8 @@ TEST_F(VkPositiveLayerTest, CreatePipelineSpecializeInt16) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>();
@@ -2624,8 +2624,8 @@ TEST_F(VkPositiveLayerTest, CreatePipelineSpecializeInt64) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>();
@@ -2830,8 +2830,8 @@ TEST_F(VkPositiveLayerTest, SeparateDepthStencilSubresourceLayout) {
     VkRenderPass render_pass_combined{};
     VkFramebuffer framebuffer_combined{};
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR"));
 
     vkCreateRenderPass2KHR(device(), &rp2, nullptr, &render_pass_separate);
 
@@ -3098,8 +3098,8 @@ TEST_F(VkPositiveLayerTest, ProtectedAndUnprotectedQueue) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -3163,7 +3163,7 @@ TEST_F(VkPositiveLayerTest, ProtectedAndUnprotectedQueue) {
     VkQueue test_queue_protected = VK_NULL_HANDLE;
     VkQueue test_queue_unprotected = VK_NULL_HANDLE;
 
-    PFN_vkGetDeviceQueue2 vkGetDeviceQueue2 = (PFN_vkGetDeviceQueue2)vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2");
+    auto vkGetDeviceQueue2 = reinterpret_cast<PFN_vkGetDeviceQueue2>(vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2"));
     ASSERT_TRUE(vkGetDeviceQueue2 != nullptr);
 
     VkDeviceQueueInfo2 queue_info_2 = LvlInitStruct<VkDeviceQueueInfo2>();
@@ -3212,8 +3212,8 @@ TEST_F(VkPositiveLayerTest, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto shader_float_control = LvlInitStruct<VkPhysicalDeviceFloatControlsProperties>();
@@ -3367,8 +3367,8 @@ TEST_F(VkPositiveLayerTest, Storage8and16bit) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto storage_8_bit_features = LvlInitStruct<VkPhysicalDevice8BitStorageFeaturesKHR>();
@@ -3661,8 +3661,8 @@ TEST_F(VkPositiveLayerTest, ReadShaderClock) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto shader_clock_features = LvlInitStruct<VkPhysicalDeviceShaderClockFeaturesKHR>();
@@ -3746,9 +3746,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferMemoryRequirements) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // Allocate an AHardwareBuffer
@@ -3841,9 +3840,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferDepthStencil) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // Allocate an AHardwareBuffer
@@ -3951,9 +3949,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferBindBufferMemory) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // Allocate an AHardwareBuffer
@@ -4037,8 +4034,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportBuffer) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetMemoryAndroidHardwareBufferANDROID vkGetMemoryAndroidHardwareBufferANDROID =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID");
+    auto vkGetMemoryAndroidHardwareBufferANDROID = reinterpret_cast<PFN_vkGetMemoryAndroidHardwareBufferANDROID>(
+        vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID"));
     ASSERT_TRUE(vkGetMemoryAndroidHardwareBufferANDROID != nullptr);
 
     m_errorMonitor->ExpectSuccess();
@@ -4112,8 +4109,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportImage) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetMemoryAndroidHardwareBufferANDROID vkGetMemoryAndroidHardwareBufferANDROID =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID");
+    auto vkGetMemoryAndroidHardwareBufferANDROID = reinterpret_cast<PFN_vkGetMemoryAndroidHardwareBufferANDROID>(
+        vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID"));
     ASSERT_TRUE(vkGetMemoryAndroidHardwareBufferANDROID != nullptr);
 
     m_errorMonitor->ExpectSuccess();
@@ -4206,9 +4203,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExternalImage) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // FORMAT_Y8Cb8Cr8_420 is a known/public valid AHB Format but does not have a Vulkan mapping to it
@@ -4334,9 +4330,8 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExternalCameraFormat) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     m_errorMonitor->ExpectSuccess();
@@ -4717,8 +4712,8 @@ TEST_F(VkPositiveLayerTest, ProtectedSwapchainImageColorAttachment) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -4777,8 +4772,8 @@ TEST_F(VkPositiveLayerTest, ProtectedSwapchainImageColorAttachment) {
     ASSERT_VK_SUCCESS(vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain));
 
     // Get VkImage from swapchain which should be protected
-    PFN_vkGetSwapchainImagesKHR vkGetSwapchainImagesKHR =
-        (PFN_vkGetSwapchainImagesKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR");
+    auto vkGetSwapchainImagesKHR =
+        reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR"));
     ASSERT_TRUE(vkGetSwapchainImagesKHR != nullptr);
     uint32_t image_count;
     std::vector<VkImage> swapchain_images;
@@ -5045,8 +5040,8 @@ TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables mesh_shader
@@ -5754,8 +5749,8 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicInt64) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto atomic_int64_features = lvl_init_struct<VkPhysicalDeviceShaderAtomicInt64Features>();
@@ -6179,7 +6174,7 @@ TEST_F(VkPositiveLayerTest, RayTracingPipelineShaderGroupsKHR) {
 
     m_errorMonitor->ExpectSuccess();
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
         vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
@@ -6205,12 +6200,11 @@ TEST_F(VkPositiveLayerTest, RayTracingPipelineShaderGroupsKHR) {
     VkShaderObj rgen_shader(this, empty_shader, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2);
     VkShaderObj chit_shader(this, empty_shader, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2);
 
-    PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR =
+    auto vkCreateRayTracingPipelinesKHR =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesKHR"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
 
-    PFN_vkDestroyPipeline vkDestroyPipeline =
-        reinterpret_cast<PFN_vkDestroyPipeline>(vk::GetInstanceProcAddr(instance(), "vkDestroyPipeline"));
+    auto vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(vk::GetInstanceProcAddr(instance(), "vkDestroyPipeline"));
     ASSERT_TRUE(vkDestroyPipeline != nullptr);
 
     VkPipeline pipeline = VK_NULL_HANDLE;

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -286,7 +286,7 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribComponents) {
     rpci.pAttachments = attach_desc;
 
     VkRenderPass renderpass;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &renderpass);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &renderpass);
     pipe.AddShader(&vs);
     pipe.AddShader(&fs);
 
@@ -1604,7 +1604,7 @@ TEST_F(VkPositiveLayerTest, TestSamplerDataForCombinedImageSampler) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     m_errorMonitor->ExpectSuccess();
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
@@ -1612,7 +1612,7 @@ TEST_F(VkPositiveLayerTest, TestSamplerDataForCombinedImageSampler) {
 
     vk::CmdEndRenderPass(m_commandBuffer->handle());
     m_commandBuffer->end();
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, NotPointSizeGeometryShaderSuccess) {
@@ -4004,7 +4004,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferBindBufferMemory) {
     // Some drivers don't return exact size in getBufferMemory as getAHB
     m_errorMonitor->SetUnexpectedError("VUID-VkMemoryAllocateInfo-allocationSize-02383");
     VkDeviceMemory memory;
-    vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
+    vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &memory);
     vk::BindBufferMemory(m_device->device(), buffer, memory, mem_reqs.alignment);
 
     m_errorMonitor->VerifyNotFound();
@@ -4070,7 +4070,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportBuffer) {
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), &memory_info, NULL, &memory);
+    vk::AllocateMemory(device(), &memory_info, nullptr, &memory);
     vk::BindBufferMemory(device(), buffer, memory, 0);
 
     // Export memory to AHB
@@ -4084,7 +4084,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportBuffer) {
 
     // App in charge of releasing after exporting
     AHardwareBuffer_release(ahb);
-    vk::FreeMemory(device(), memory, NULL);
+    vk::FreeMemory(device(), memory, nullptr);
     vk::DestroyBuffer(device(), buffer, nullptr);
 }
 
@@ -4159,7 +4159,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportImage) {
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), &memory_info, NULL, &memory);
+    vk::AllocateMemory(device(), &memory_info, nullptr, &memory);
     vk::BindImageMemory(device(), image, memory, 0);
 
     // Export memory to AHB
@@ -4173,7 +4173,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportImage) {
 
     // App in charge of releasing after exporting
     AHardwareBuffer_release(ahb);
-    vk::FreeMemory(device(), memory, NULL);
+    vk::FreeMemory(device(), memory, nullptr);
     vk::DestroyImage(device(), image, nullptr);
 }
 
@@ -4667,7 +4667,7 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
 
     m_errorMonitor->ExpectSuccess();
     for (auto &image : images) {
-        vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+        vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
         auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
         bind_swapchain_info.swapchain = m_swapchain;
         bind_swapchain_info.imageIndex = 0;
@@ -5271,7 +5271,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptorSubresourceLayout) {
         // Set up the descriptor
         img_info.imageView = view->handle();
         img_info.imageLayout = descriptor_layout;
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         for (TestType test_type : test_list) {
             auto init_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
@@ -5316,7 +5316,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptorSubresourceLayout) {
             cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
             vk::CmdBindPipeline(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
             vk::CmdBindDescriptorSets(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                                      &descriptorSet, 0, NULL);
+                                      &descriptorSet, 0, nullptr);
             vk::CmdSetViewport(cmd_buf.handle(), 0, 1, &viewport);
             vk::CmdSetScissor(cmd_buf.handle(), 0, 1, &scissor);
 
@@ -5515,7 +5515,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
         // Set up the descriptor
         img_info.imageView = o_view->handle();
         img_info.imageLayout = descriptor_layout;
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         for (TestType test_type : test_list) {
             auto image_barrier = LvlInitStruct<VkImageMemoryBarrier>();
@@ -5560,7 +5560,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
             cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
             vk::CmdBindPipeline(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
             vk::CmdBindDescriptorSets(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                                      &descriptorSet, 0, NULL);
+                                      &descriptorSet, 0, nullptr);
             vk::CmdSetViewport(cmd_buf.handle(), 0, 1, &viewport);
             vk::CmdSetScissor(cmd_buf.handle(), 0, 1, &scissor);
 
@@ -6499,7 +6499,7 @@ TEST_F(VkPositiveLayerTest, MutableStorageImageFormatWriteForFormat) {
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
     descriptor_write.pImageInfo = &image_info;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_commandBuffer->reset();
     m_commandBuffer->begin();

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -50,10 +50,9 @@ TEST_F(VkPositiveLayerTest, ViewportWithCountNoMultiViewport) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -1157,6 +1156,7 @@ TEST_F(VkPositiveLayerTest, CreatePipeineWithTessellationDomainOrigin) {
 TEST_F(VkPositiveLayerTest, ViewportArray2NV) {
     TEST_DESCRIPTION("Test to validate VK_NV_viewport_array2");
 
+    AddRequiredExtensions(VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     VkPhysicalDeviceFeatures available_features = {};
@@ -1175,9 +1175,7 @@ TEST_F(VkPositiveLayerTest, ViewportArray2NV) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME);
         return;
     }
@@ -1389,11 +1387,10 @@ TEST_F(VkPositiveLayerTest, CreateSurface) {
 TEST_F(VkPositiveLayerTest, SampleMaskOverrideCoverageNV) {
     TEST_DESCRIPTION("Test to validate VK_NV_sample_mask_override_coverage");
 
+    AddRequiredExtensions(VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME);
         return;
     }
@@ -1716,6 +1713,7 @@ TEST_F(VkPositiveLayerTest, SubpassWithReadOnlyLayoutWithoutDependency) {
 TEST_F(VkPositiveLayerTest, GeometryShaderPassthroughNV) {
     TEST_DESCRIPTION("Test to validate VK_NV_geometry_shader_passthrough");
 
+    AddRequiredExtensions(VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     VkPhysicalDeviceFeatures available_features = {};
@@ -1726,9 +1724,7 @@ TEST_F(VkPositiveLayerTest, GeometryShaderPassthroughNV) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
         return;
     }
@@ -1822,13 +1818,13 @@ TEST_F(VkPositiveLayerTest, PipelineStageConditionalRendering) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Did not find required device extension %s; skipped.\n", kSkipPrefix,
                VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
 
     auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
         vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
@@ -2411,10 +2407,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineSpecializeInt8) {
                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
         return;
     }
@@ -2688,13 +2683,12 @@ TEST_F(VkPositiveLayerTest, CreatePipelineSpecializeInt64) {
 TEST_F(VkPositiveLayerTest, SeparateDepthStencilSubresourceLayout) {
     TEST_DESCRIPTION("Test that separate depth stencil layouts are tracked correctly.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix,
                VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
         return;
@@ -3195,6 +3189,7 @@ TEST_F(VkPositiveLayerTest, ShaderFloatControl) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
@@ -3202,9 +3197,7 @@ TEST_F(VkPositiveLayerTest, ShaderFloatControl) {
     }
 
     // The issue with revision 4 of this extension should not be an issue with the tests
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
         return;
     }
@@ -3652,11 +3645,10 @@ TEST_F(VkPositiveLayerTest, ReadShaderClock) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_CLOCK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
         return;
     }
@@ -4621,11 +4613,10 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     TEST_DESCRIPTION("Try destroying a swapchain which has multiple images");
 
     if (!AddSurfaceInstanceExtension()) return;
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     // Check for VK_KHR_get_memory_requirements2 extension
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_BIND_MEMORY_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
         return;
     }
@@ -4858,6 +4849,7 @@ TEST_F(VkPositiveLayerTest, ImageDrmFormatModifier) {
     TEST_DESCRIPTION("Create image and imageView using VK_EXT_image_drm_format_modifier");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);  // for extension dependencies
+    AddRequiredExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kMockICD)) {
@@ -4870,12 +4862,11 @@ TEST_F(VkPositiveLayerTest, ImageDrmFormatModifier) {
         return;
     }
 
-    if (!DeviceExtensionSupported(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME)) {
-        printf("%s VK_EXT_image_drm_format_modifier is not supported but required. Skipping\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s is not supported but required. Skipping\n", kSkipPrefix, VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
         return;
     }
 
-    m_device_extension_names.push_back(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // we just hope that one of these formats supports modifiers
@@ -5740,11 +5731,10 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicInt64) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
         return;
     }
@@ -5918,6 +5908,7 @@ TEST_F(VkPositiveLayerTest, TestDynamicVertexInput) {
     TEST_DESCRIPTION("Test using dynamic vertex input and not setting pVertexInputState in the graphics pipeline create info");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -5925,9 +5916,7 @@ TEST_F(VkPositiveLayerTest, TestDynamicVertexInput) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -5962,6 +5951,7 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXT) {
     TEST_DESCRIPTION("Test CmdSetVertexInputEXT");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -5969,9 +5959,7 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXT) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -6026,8 +6014,9 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXT) {
 
 TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXTStride) {
     TEST_DESCRIPTION("Test CmdSetVertexInputEXT");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -6035,9 +6024,7 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXTStride) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -178,10 +178,10 @@ TEST_F(VkPositiveLayerTest, RenderPassCreateAttachmentLayoutWithLoadOpThenReadOn
 
     // Now create RenderPass and verify no errors
     VkRenderPass rp;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyNotFound();
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, RenderPassBeginSubpassZeroTransitionsApplied) {
@@ -336,13 +336,13 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginStencilLoadOp) {
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
-    subpass.pInputAttachments = NULL;
+    subpass.pInputAttachments = nullptr;
     subpass.colorAttachmentCount = 0;
-    subpass.pColorAttachments = NULL;
-    subpass.pResolveAttachments = NULL;
+    subpass.pColorAttachments = nullptr;
+    subpass.pResolveAttachments = nullptr;
     subpass.pDepthStencilAttachment = &ref;
     subpass.preserveAttachmentCount = 0;
-    subpass.pPreserveAttachments = NULL;
+    subpass.pPreserveAttachments = nullptr;
 
     VkRenderPass rp;
     VkRenderPassCreateInfo rp_info = LvlInitStruct<VkRenderPassCreateInfo>();
@@ -350,7 +350,7 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginStencilLoadOp) {
     rp_info.pAttachments = &att;
     rp_info.subpassCount = 1;
     rp_info.pSubpasses = &subpass;
-    result = vk::CreateRenderPass(device(), &rp_info, NULL, &rp);
+    result = vk::CreateRenderPass(device(), &rp_info, nullptr, &rp);
     ASSERT_VK_SUCCESS(result);
 
     VkImageView *depthView = m_depthStencil->BindInfo();
@@ -362,7 +362,7 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginStencilLoadOp) {
     fb_info.height = 100;
     fb_info.layers = 1;
     VkFramebuffer fb;
-    result = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    result = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     ASSERT_VK_SUCCESS(result);
 
     VkRenderPassBeginInfo rpbinfo = LvlInitStruct<VkRenderPassBeginInfo>();
@@ -424,12 +424,12 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginStencilLoadOp) {
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &cmdbuf.handle();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
 
     m_errorMonitor->ExpectSuccess();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -536,9 +536,9 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginDepthStencilLayoutTransitionFromUndef
     m_errorMonitor->VerifyNotFound();
 
     // Cleanup
-    vk::DestroyImageView(m_device->device(), view, NULL);
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
-    vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, DestroyPipelineRenderPass) {
@@ -576,14 +576,14 @@ TEST_F(VkPositiveLayerTest, DestroyPipelineRenderPass) {
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
-    subpass.pInputAttachments = NULL;
+    subpass.pInputAttachments = nullptr;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &ref;
-    subpass.pResolveAttachments = NULL;
+    subpass.pResolveAttachments = nullptr;
 
-    subpass.pDepthStencilAttachment = NULL;
+    subpass.pDepthStencilAttachment = nullptr;
     subpass.preserveAttachmentCount = 0;
-    subpass.pPreserveAttachments = NULL;
+    subpass.pPreserveAttachments = nullptr;
 
     VkRenderPassCreateInfo rp_info = LvlInitStruct<VkRenderPassCreateInfo>();
     rp_info.attachmentCount = 1;
@@ -592,7 +592,7 @@ TEST_F(VkPositiveLayerTest, DestroyPipelineRenderPass) {
     rp_info.pSubpasses = &subpass;
 
     VkRenderPass rp;
-    err = vk::CreateRenderPass(device(), &rp_info, NULL, &rp);
+    err = vk::CreateRenderPass(device(), &rp_info, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
@@ -911,7 +911,7 @@ TEST_F(VkPositiveLayerTest, RenderPassSingleMipTransition) {
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     VkSampler sampler = VK_NULL_HANDLE;
-    err = vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     OneOffDescriptorSet::Bindings binding_defs = {{2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
@@ -962,7 +962,7 @@ TEST_F(VkPositiveLayerTest, RenderPassSingleMipTransition) {
     vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
 
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, NULL);
+                              &descriptor_set.set_, 0, nullptr);
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -46,15 +46,15 @@ TEST_F(VkPositiveLayerTest, ShaderRelaxedBlockLayout) {
     // Verifies the ability to relax block layout rules with a shader that requires them to be relaxed
     TEST_DESCRIPTION("Create a shader that requires relaxed block layout.");
 
+    AddRequiredExtensions(VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // The Relaxed Block Layout extension was promoted to core in 1.1.
     // Go ahead and check for it and turn it on in case a 1.0 device has it.
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix, VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -101,15 +101,15 @@ TEST_F(VkPositiveLayerTest, ShaderUboStd430Layout) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check for the UBO standard block layout extension and turn it on if it's available
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix,
                VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME);
 
     auto vkGetPhysicalDeviceFeatures2 =
         reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
@@ -171,14 +171,14 @@ TEST_F(VkPositiveLayerTest, ShaderScalarBlockLayout) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check for the Scalar Block Layout extension and turn it on if it's available
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix, VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
 
     auto vkGetPhysicalDeviceFeatures2 =
         reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
@@ -574,15 +574,15 @@ TEST_F(VkPositiveLayerTest, ShaderNonSemanticInfo) {
     // This is a positive test, no errors expected
     // Verifies the ability to use non-semantic extended instruction sets when the extension is enabled
     TEST_DESCRIPTION("Create a shader that uses SPV_KHR_non_semantic_info.");
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check for the extension and turn it on if it's available
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix,
                VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -744,13 +744,13 @@ TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension1of2) {
     // Verifies the ability to deal with a shader that declares a non-unique SPIRV capability ID
     TEST_DESCRIPTION("Create a shader in which uses a non-unique capability ID extension, 1 of 2");
 
+    AddRequiredExtensions(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix,
                VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // These tests require that the device support multiViewport
@@ -785,14 +785,14 @@ TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension2of2) {
     // Verifies the ability to deal with a shader that declares a non-unique SPIRV capability ID
     TEST_DESCRIPTION("Create a shader in which uses a non-unique capability ID extension, 2 of 2");
 
+    AddRequiredExtensions(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     // Need to use SPV_EXT_shader_viewport_index_layer
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported, skipping this pass. \n", kSkipPrefix,
                VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // These tests require that the device support multiViewport
@@ -1001,10 +1001,9 @@ TEST_F(VkPositiveLayerTest, ShaderDrawParametersWithoutFeature) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
+    AddRequiredExtensions(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
         return;
     }
@@ -1038,6 +1037,7 @@ TEST_F(VkPositiveLayerTest, ShaderDrawParametersWithoutFeature11) {
     m_errorMonitor->ExpectSuccess();
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -1045,9 +1045,7 @@ TEST_F(VkPositiveLayerTest, ShaderDrawParametersWithoutFeature11) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
         return;
     }
@@ -1139,10 +1137,9 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
         return;
     }
@@ -1236,10 +1233,9 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFloat) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
         return;
     }
@@ -1501,15 +1497,14 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFloat2) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
+    AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         printf("%s Test requires Vulkan >= 1.2.\n", kSkipPrefix);
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
         return;
     }

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -111,8 +111,8 @@ TEST_F(VkPositiveLayerTest, ShaderUboStd430Layout) {
     }
     m_device_extension_names.push_back(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME);
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
 
     auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>();
     uniform_buffer_standard_layout_features.uniformBufferStandardLayout = VK_TRUE;
@@ -180,8 +180,8 @@ TEST_F(VkPositiveLayerTest, ShaderScalarBlockLayout) {
     }
     m_device_extension_names.push_back(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
 
     auto scalar_block_features = LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>();
     auto query_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&scalar_block_features);
@@ -1147,8 +1147,8 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto image_atomic_int64_features = lvl_init_struct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
@@ -1244,8 +1244,8 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFloat) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto atomic_float_features = lvl_init_struct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>();
@@ -2036,8 +2036,8 @@ TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables mesh_shader
@@ -2154,8 +2154,8 @@ TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
 
     VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mesh_shader_features);
@@ -2167,8 +2167,8 @@ TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     VkPhysicalDeviceVulkan11Properties vulkan11_props = LvlInitStruct<VkPhysicalDeviceVulkan11Properties>();
@@ -2396,8 +2396,8 @@ TEST_F(VkPositiveLayerTest, Std430SpirvOptFlags10) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
 
     auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>();
     auto scalar_block_layout_features =
@@ -2530,8 +2530,8 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     if (!AreRequestedExtensionsEnabled()) {
@@ -2725,8 +2725,8 @@ TEST_F(VkPositiveLayerTest, WriteDescriptorSetAccelerationStructureNVNullDescrip
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -114,7 +114,7 @@ TEST_F(VkPositiveLayerTest, ShaderUboStd430Layout) {
     PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
         (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
 
-    auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>(NULL);
+    auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>();
     uniform_buffer_standard_layout_features.uniformBufferStandardLayout = VK_TRUE;
     auto query_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&uniform_buffer_standard_layout_features);
     vkGetPhysicalDeviceFeatures2(gpu(), &query_features2);
@@ -183,7 +183,7 @@ TEST_F(VkPositiveLayerTest, ShaderScalarBlockLayout) {
     PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
         (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
 
-    auto scalar_block_features = LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>(NULL);
+    auto scalar_block_features = LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>();
     auto query_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&scalar_block_features);
     vkGetPhysicalDeviceFeatures2(gpu(), &query_features2);
 
@@ -720,7 +720,7 @@ TEST_F(VkPositiveLayerTest, SpirvGroupDecorations) {
         dslb[i].binding = i;
         dslb[i].descriptorCount = 1;
         dslb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        dslb[i].pImmutableSamplers = NULL;
+        dslb[i].pImmutableSamplers = nullptr;
         dslb[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_ALL;
     }
     if (m_device->props.limits.maxPerStageDescriptorStorageBuffers < dslb_size) {

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -56,10 +56,10 @@ TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayObjects) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetPhysicalDeviceDisplayPropertiesKHR vkGetPhysicalDeviceDisplayPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
+    auto vkGetPhysicalDeviceDisplayPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPropertiesKHR"));
+    auto vkGetDisplayModePropertiesKHR =
+        reinterpret_cast<PFN_vkGetDisplayModePropertiesKHR>(vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceDisplayPropertiesKHR != nullptr);
     ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
 
@@ -92,11 +92,10 @@ TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayPlaneObjects) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
+    auto vkGetPhysicalDeviceDisplayPlanePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
+    auto vkGetDisplayModePropertiesKHR =
+        reinterpret_cast<PFN_vkGetDisplayModePropertiesKHR>(vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceDisplayPlanePropertiesKHR != nullptr);
     ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
 
@@ -1498,8 +1497,8 @@ TEST_F(VkPositiveLayerTest, ExternalSemaphore) {
                                                     handle_type};
     VkExternalSemaphorePropertiesKHR esp = {VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR, nullptr};
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        reinterpret_cast<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(vk::GetInstanceProcAddr(
+            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"));
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1530,30 +1529,32 @@ TEST_F(VkPositiveLayerTest, ExternalSemaphore) {
     HANDLE handle = nullptr;
     VkSemaphoreGetWin32HandleInfoKHR ghi = {VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR, nullptr, export_semaphore,
                                             handle_type};
-    auto vkGetSemaphoreWin32HandleKHR =
-        (PFN_vkGetSemaphoreWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreWin32HandleKHR");
+    auto vkGetSemaphoreWin32HandleKHR = reinterpret_cast<PFN_vkGetSemaphoreWin32HandleKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreWin32HandleKHR"));
     err = vkGetSemaphoreWin32HandleKHR(m_device->device(), &ghi, &handle);
     ASSERT_VK_SUCCESS(err);
 
     // Import opaque handle exported above
     VkImportSemaphoreWin32HandleInfoKHR ihi = {
         VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR, nullptr, import_semaphore, 0, handle_type, handle, nullptr};
-    auto vkImportSemaphoreWin32HandleKHR =
-        (PFN_vkImportSemaphoreWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreWin32HandleKHR");
+    auto vkImportSemaphoreWin32HandleKHR = reinterpret_cast<PFN_vkImportSemaphoreWin32HandleKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreWin32HandleKHR"));
     err = vkImportSemaphoreWin32HandleKHR(m_device->device(), &ihi);
     ASSERT_VK_SUCCESS(err);
 #else
     // Export semaphore payload to an opaque handle
     int fd = 0;
     VkSemaphoreGetFdInfoKHR ghi = {VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR, nullptr, export_semaphore, handle_type};
-    auto vkGetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreFdKHR");
+    auto vkGetSemaphoreFdKHR =
+        reinterpret_cast<PFN_vkGetSemaphoreFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreFdKHR"));
     err = vkGetSemaphoreFdKHR(m_device->device(), &ghi, &fd);
     ASSERT_VK_SUCCESS(err);
 
     // Import opaque handle exported above
     VkImportSemaphoreFdInfoKHR ihi = {
         VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR, nullptr, import_semaphore, 0, handle_type, fd};
-    auto vkImportSemaphoreFdKHR = (PFN_vkImportSemaphoreFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR");
+    auto vkImportSemaphoreFdKHR =
+        reinterpret_cast<PFN_vkImportSemaphoreFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR"));
     err = vkImportSemaphoreFdKHR(m_device->device(), &ihi);
     ASSERT_VK_SUCCESS(err);
 #endif
@@ -1621,8 +1622,8 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     // Check for external fence import and export capability
     VkPhysicalDeviceExternalFenceInfoKHR efi = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR, nullptr, handle_type};
     VkExternalFencePropertiesKHR efp = {VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR, nullptr};
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR"));
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1657,7 +1658,7 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     {
         VkFenceGetWin32HandleInfoKHR ghi = {VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR, nullptr, export_fence, handle_type};
         auto vkGetFenceWin32HandleKHR =
-            (PFN_vkGetFenceWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceWin32HandleKHR");
+            reinterpret_cast<PFN_vkGetFenceWin32HandleKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceWin32HandleKHR"));
         err = vkGetFenceWin32HandleKHR(m_device->device(), &ghi, &handle);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1666,8 +1667,8 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     {
         VkImportFenceWin32HandleInfoKHR ifi = {
             VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR, nullptr, import_fence, 0, handle_type, handle, nullptr};
-        auto vkImportFenceWin32HandleKHR =
-            (PFN_vkImportFenceWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceWin32HandleKHR");
+        auto vkImportFenceWin32HandleKHR = reinterpret_cast<PFN_vkImportFenceWin32HandleKHR>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceWin32HandleKHR"));
         err = vkImportFenceWin32HandleKHR(m_device->device(), &ifi);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1676,7 +1677,7 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     int fd = 0;
     {
         VkFenceGetFdInfoKHR gfi = {VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR, nullptr, export_fence, handle_type};
-        auto vkGetFenceFdKHR = (PFN_vkGetFenceFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceFdKHR");
+        auto vkGetFenceFdKHR = reinterpret_cast<PFN_vkGetFenceFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceFdKHR"));
         err = vkGetFenceFdKHR(m_device->device(), &gfi, &fd);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1684,7 +1685,8 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     // Import opaque handle exported above
     {
         VkImportFenceFdInfoKHR ifi = {VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR, nullptr, import_fence, 0, handle_type, fd};
-        auto vkImportFenceFdKHR = (PFN_vkImportFenceFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceFdKHR");
+        auto vkImportFenceFdKHR =
+            reinterpret_cast<PFN_vkImportFenceFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceFdKHR"));
         err = vkImportFenceFdKHR(m_device->device(), &ifi);
         ASSERT_VK_SUCCESS(err);
     }

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -118,11 +118,10 @@ TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayPlaneObjects) {
 TEST_F(VkPositiveLayerTest, Sync2OwnershipTranfersImage) {
     TEST_DESCRIPTION("Valid image ownership transfers that shouldn't create errors");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
 
@@ -173,11 +172,10 @@ TEST_F(VkPositiveLayerTest, Sync2OwnershipTranfersImage) {
 TEST_F(VkPositiveLayerTest, Sync2OwnershipTranfersBuffer) {
     TEST_DESCRIPTION("Valid buffer ownership transfers that shouldn't create errors");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
 
@@ -942,11 +940,10 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAn
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -1860,11 +1857,10 @@ TEST_F(VkPositiveLayerTest, QueueSubmitTimelineSemaphore2Queue) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -357,8 +357,8 @@ TEST_F(VkPositiveLayerTest, QueueSubmitSemaphoresAndLayoutTracking) {
     vk::QueueSubmit(m_device->m_queue, 3, submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
 
-    vk::DestroySemaphore(m_device->device(), semaphore1, NULL);
-    vk::DestroySemaphore(m_device->device(), semaphore2, NULL);
+    vk::DestroySemaphore(m_device->device(), semaphore1, nullptr);
+    vk::DestroySemaphore(m_device->device(), semaphore2, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -471,7 +471,7 @@ TEST_F(VkPositiveLayerTest, TwoFencesThreeFrames) {
         }
     }
     m_errorMonitor->VerifyNotFound();
-    vk::DestroyCommandPool(m_device->device(), cmd_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), cmd_pool, nullptr);
     for (uint32_t i = 0; i < NUM_OBJECTS; ++i) {
         vk::DestroyFence(m_device->device(), fences[i], nullptr);
     }
@@ -563,7 +563,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenc
 
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -661,7 +661,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenc
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -760,7 +760,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenc
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -925,7 +925,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFenc
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1144,7 +1144,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsOneQueueWithSemaphoreAndOneFence) {
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1225,14 +1225,14 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsOneQueueNullQueueSubmitWithFence) {
         vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     }
 
-    vk::QueueSubmit(m_device->m_queue, 0, NULL, fence);
+    vk::QueueSubmit(m_device->m_queue, 0, nullptr, fence);
 
     VkResult err = vk::WaitForFences(m_device->device(), 1, &fence, VK_TRUE, UINT64_MAX);
     ASSERT_VK_SUCCESS(err);
 
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1317,7 +1317,7 @@ TEST_F(VkPositiveLayerTest, TwoQueueSubmitsOneQueueOneFence) {
 
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1392,7 +1392,7 @@ TEST_F(VkPositiveLayerTest, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) 
         submit_info[0].signalSemaphoreCount = 1;
         submit_info[0].pSignalSemaphores = &semaphore;
         submit_info[0].waitSemaphoreCount = 0;
-        submit_info[0].pWaitSemaphores = NULL;
+        submit_info[0].pWaitSemaphores = nullptr;
         submit_info[0].pWaitDstStageMask = 0;
 
         submit_info[1] = LvlInitStruct<VkSubmitInfo>();
@@ -1402,7 +1402,7 @@ TEST_F(VkPositiveLayerTest, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) 
         submit_info[1].pWaitSemaphores = &semaphore;
         submit_info[1].pWaitDstStageMask = flags;
         submit_info[1].signalSemaphoreCount = 0;
-        submit_info[1].pSignalSemaphores = NULL;
+        submit_info[1].pSignalSemaphores = nullptr;
         vk::QueueSubmit(m_device->m_queue, 2, &submit_info[0], fence);
     }
 
@@ -1410,7 +1410,7 @@ TEST_F(VkPositiveLayerTest, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) 
 
     vk::DestroyFence(m_device->device(), fence, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 2, &command_buffer[0]);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
 
     m_errorMonitor->VerifyNotFound();
@@ -1732,11 +1732,11 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
     // There should be no validation error from collision of that non-object.
     test_platform_thread_create(&thread, ReleaseNullFence, (void *)&data);
     for (int i = 0; i < 40000; i++) {
-        vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
+        vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, nullptr);
     }
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
 
-    m_errorMonitor->SetBailout(NULL);
+    m_errorMonitor->SetBailout(nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1791,7 +1791,7 @@ TEST_F(VkPositiveLayerTest, WaitEventThenSet) {
 
     vk::DestroyEvent(m_device->device(), event, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 1, &command_buffer);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -2017,7 +2017,7 @@ TEST_F(VkPositiveLayerTest, ResetQueryPoolFromDifferentCBWithFenceAfter) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -53,8 +53,8 @@ TEST_F(VkPositiveLayerTest, ToolingExtension) {
     }
 
     m_errorMonitor->ExpectSuccess();
-    auto fpGetPhysicalDeviceToolPropertiesEXT =
-        (PFN_vkGetPhysicalDeviceToolPropertiesEXT)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceToolPropertiesEXT");
+    auto fpGetPhysicalDeviceToolPropertiesEXT = reinterpret_cast<PFN_vkGetPhysicalDeviceToolPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceToolPropertiesEXT"));
 
     uint32_t tool_count = 0;
     auto result = fpGetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, nullptr);

--- a/tests/test_environment.cpp
+++ b/tests/test_environment.cpp
@@ -39,7 +39,7 @@ Environment::Environment() : default_dev_(0) {
     app_.pEngineName = "vk_testing";
     app_.engineVersion = 1;
     app_.apiVersion = VK_API_VERSION_1_0;
-    app_.pNext = NULL;
+    app_.pNext = nullptr;
 }
 
 bool Environment::parse_args(int argc, char **argv) {
@@ -101,18 +101,18 @@ void Environment::SetUp() {
     }
     VkInstanceCreateInfo inst_info = {};
     inst_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    inst_info.pNext = NULL;
+    inst_info.pNext = nullptr;
     inst_info.pApplicationInfo = &app_;
     inst_info.enabledExtensionCount = instance_extension_names.size();
-    inst_info.ppEnabledExtensionNames = (instance_extension_names.size()) ? &instance_extension_names[0] : NULL;
+    inst_info.ppEnabledExtensionNames = (instance_extension_names.size()) ? &instance_extension_names[0] : nullptr;
     inst_info.enabledLayerCount = 0;
-    inst_info.ppEnabledLayerNames = NULL;
+    inst_info.ppEnabledLayerNames = nullptr;
 
     VkResult err;
     uint32_t count;
-    err = vk::CreateInstance(&inst_info, NULL, &inst);
+    err = vk::CreateInstance(&inst_info, nullptr, &inst);
     ASSERT_EQ(VK_SUCCESS, err);
-    err = vk::EnumeratePhysicalDevices(inst, &count, NULL);
+    err = vk::EnumeratePhysicalDevices(inst, &count, nullptr);
     ASSERT_EQ(VK_SUCCESS, err);
     ASSERT_LE(count, ARRAY_SIZE(gpus));
     err = vk::EnumeratePhysicalDevices(inst, &count, gpus);
@@ -148,6 +148,6 @@ void Environment::TearDown() {
     for (std::vector<Device *>::iterator it = devs_.begin(); it != devs_.end(); it++) delete *it;
     devs_.clear();
 
-    if (inst) vk::DestroyInstance(inst, NULL);
+    if (inst) vk::DestroyInstance(inst, nullptr);
 }
 }  // namespace vk_testing

--- a/tests/test_environment.cpp
+++ b/tests/test_environment.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2019 The Khronos Group Inc.
  * Copyright (c) 2015-2019 Valve Corporation
- * Copyright (c) 2015-2019 LunarG, Inc.
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -336,21 +336,21 @@ TEST_F(VkAmdBestPracticesLayerTest, CopyingDescriptors) {
 
     VkDescriptorPoolCreateInfo ds_pool_ci = {};
     ds_pool_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    ds_pool_ci.pNext = NULL;
+    ds_pool_ci.pNext = nullptr;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 2;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
 
@@ -664,7 +664,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
     present_info.swapchainCount = 1;
     present_info.pSwapchains = &m_swapchain;
     present_info.pImageIndices = 0;
-    present_info.pResults = NULL;
+    present_info.pResults = nullptr;
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
                                          "UNASSIGNED-BestPractices-Submission-ReduceNumberOfSubmissions");
@@ -711,11 +711,11 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
 
     VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = {};
     pipe_ms_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    pipe_ms_state_ci.pNext = NULL;
+    pipe_ms_state_ci.pNext = nullptr;
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     const float vbo_data[3] = {1.f, 0.f, 1.f};
     VkVerticesObj vertex_buffer(m_device, 1, 1, sizeof(vbo_data), 1, vbo_data);

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2021 The Khronos Group Inc.
  * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 LunarG, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -215,11 +215,11 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
 
     VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = {};
     pipe_ms_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    pipe_ms_state_ci.pNext = NULL;
+    pipe_ms_state_ci.pNext = nullptr;
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
@@ -254,14 +254,14 @@ TEST_F(VkArmBestPracticesLayerTest, SuboptimalDescriptorReuseTest) {
 
     VkDescriptorPoolCreateInfo ds_pool_ci = {};
     ds_pool_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    ds_pool_ci.pNext = NULL;
+    ds_pool_ci.pNext = nullptr;
     ds_pool_ci.maxSets = 6;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    VkResult err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    VkResult err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding ds_binding = {};

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1081,7 +1081,7 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     vk::GetPhysicalDeviceQueueFamilyProperties2(phys_device_obj.handle(), &queue_count, queue_family_props2.data());
 
     // And for GetPhysicalDeviceQueueFamilyProperties2KHR
-    PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR vkGetPhysicalDeviceQueueFamilyProperties2KHR =
+    auto vkGetPhysicalDeviceQueueFamilyProperties2KHR =
         reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR>(
             vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceQueueFamilyProperties2KHR"));
     if (vkGetPhysicalDeviceQueueFamilyProperties2KHR) {
@@ -1336,8 +1336,8 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables descriptorBindingStorageBufferUpdateAfterBind

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -89,7 +89,7 @@ TEST_F(VkBestPracticesLayerTest, ValidateReturnCodes) {
     // Force a non-success success code by only asking for a subset of query results
     uint32_t format_count;
     std::vector<VkSurfaceFormatKHR> formats;
-    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, NULL);
+    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, nullptr);
     if (result != VK_SUCCESS || format_count <= 1) {
         printf("%s test requires 2 or more extensions available, skipping test.\n", kSkipPrefix);
         return;
@@ -180,7 +180,7 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     VkDeviceCreateInfo dev_info = {};
     VkDeviceQueueCreateInfo queue_info = {};
     queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queue_info.pNext = NULL;
+    queue_info.pNext = nullptr;
     queue_info.queueFamilyIndex = 0;
     queue_info.queueCount = 1;
     queue_info.pQueuePriorities = nullptr;
@@ -189,12 +189,12 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     dev_info.queueCreateInfoCount = 1;
     dev_info.pQueueCreateInfos = &queue_info;
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
-    vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
+    vk::CreateDevice(this->gpu(), &dev_info, nullptr, &local_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -214,7 +214,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
     VkDeviceCreateInfo dev_info = {};
     VkDeviceQueueCreateInfo queue_info = {};
     queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    queue_info.pNext = NULL;
+    queue_info.pNext = nullptr;
     queue_info.queueFamilyIndex = 0;
     queue_info.queueCount = 1;
     queue_info.pQueuePriorities = nullptr;
@@ -223,12 +223,12 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
     dev_info.queueCreateInfoCount = 1;
     dev_info.pQueueCreateInfos = &queue_info;
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-d3demulation");
-    vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
+    vk::CreateDevice(this->gpu(), &dev_info, nullptr, &local_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -372,11 +372,11 @@ TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
 
     VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = {};
     pipe_ms_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    pipe_ms_state_ci.pNext = NULL;
+    pipe_ms_state_ci.pNext = nullptr;
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
@@ -413,26 +413,26 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
 
     m_errorMonitor->ExpectSuccess();
 
-    vk::DestroyBuffer(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyBufferView(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyCommandPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDescriptorPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDescriptorSetLayout(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyDevice(VK_NULL_HANDLE, NULL);
-    vk::DestroyEvent(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyFramebuffer(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyImage(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyImageView(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyInstance(VK_NULL_HANDLE, NULL);
-    vk::DestroyPipeline(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyPipelineCache(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyBuffer(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyBufferView(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyCommandPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDescriptorPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDescriptorSetLayout(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyDevice(VK_NULL_HANDLE, nullptr);
+    vk::DestroyEvent(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyImage(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyImageView(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyInstance(VK_NULL_HANDLE, nullptr);
+    vk::DestroyPipeline(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyPipelineCache(m_device->device(), VK_NULL_HANDLE, nullptr);
     vk::DestroyPipelineLayout(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyQueryPool(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyRenderPass(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroySampler(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroySemaphore(m_device->device(), VK_NULL_HANDLE, NULL);
-    vk::DestroyShaderModule(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::DestroyQueryPool(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyRenderPass(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroySampler(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroySemaphore(m_device->device(), VK_NULL_HANDLE, nullptr);
+    vk::DestroyShaderModule(m_device->device(), VK_NULL_HANDLE, nullptr);
 
     VkCommandPool command_pool;
     VkCommandPoolCreateInfo pool_create_info{};
@@ -448,7 +448,7 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     vk::AllocateCommandBuffers(m_device->device(), &command_buffer_allocate_info, &command_buffers[1]);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 3, command_buffers);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -456,14 +456,14 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
 
     VkDescriptorPoolCreateInfo ds_pool_ci = {};
     ds_pool_ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    ds_pool_ci.pNext = NULL;
+    ds_pool_ci.pNext = nullptr;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -471,7 +471,7 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
 
@@ -484,9 +484,9 @@ TEST_F(VkBestPracticesLayerTest, TestDestroyFreeNullHandles) {
     err = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_sets[1]);
     ASSERT_VK_SUCCESS(err);
     vk::FreeDescriptorSets(m_device->device(), ds_pool, 3, descriptor_sets);
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 
-    vk::FreeMemory(m_device->device(), VK_NULL_HANDLE, NULL);
+    vk::FreeMemory(m_device->device(), VK_NULL_HANDLE, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -1128,7 +1128,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     device_ci.queueCreateInfoCount = create_queue_infos.size();
     device_ci.pQueueCreateInfos = create_queue_infos.data();
     device_ci.enabledLayerCount = 0;
-    device_ci.ppEnabledLayerNames = NULL;
+    device_ci.ppEnabledLayerNames = nullptr;
     device_ci.enabledExtensionCount = 0;
     device_ci.ppEnabledExtensionNames = nullptr;
     device_ci.pEnabledFeatures = &all_features;
@@ -1393,9 +1393,9 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
 
-    m_errorMonitor->SetBailout(NULL);
+    m_errorMonitor->SetBailout(nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -64,10 +64,10 @@ TEST_F(VkLayerTest, BufferExtents) {
 
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBuffer2Function) {
-        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, NULL, copy_info.srcOffset, copy_info.dstOffset,
+        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, nullptr, copy_info.srcOffset, copy_info.dstOffset,
                                              copy_info.size};
         const VkCopyBufferInfo2KHR copy_buffer_info2 = {
-            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, NULL, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
+            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, nullptr, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferInfo2-srcOffset-00113");
         vkCmdCopyBuffer2Function(m_commandBuffer->handle(), &copy_buffer_info2);
         m_errorMonitor->VerifyFound();
@@ -80,10 +80,10 @@ TEST_F(VkLayerTest, BufferExtents) {
 
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBuffer2Function) {
-        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, NULL, copy_info.srcOffset, copy_info.dstOffset,
+        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, nullptr, copy_info.srcOffset, copy_info.dstOffset,
                                              copy_info.size};
         const VkCopyBufferInfo2KHR copy_buffer_info2 = {
-            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, NULL, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
+            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, nullptr, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferInfo2-dstOffset-00114");
         vkCmdCopyBuffer2Function(m_commandBuffer->handle(), &copy_buffer_info2);
         m_errorMonitor->VerifyFound();
@@ -96,10 +96,10 @@ TEST_F(VkLayerTest, BufferExtents) {
 
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBuffer2Function) {
-        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, NULL, copy_info.srcOffset, copy_info.dstOffset,
+        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, nullptr, copy_info.srcOffset, copy_info.dstOffset,
                                              copy_info.size};
         const VkCopyBufferInfo2KHR copy_buffer_info2 = {
-            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, NULL, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
+            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, nullptr, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferInfo2-size-00115");
         vkCmdCopyBuffer2Function(m_commandBuffer->handle(), &copy_buffer_info2);
         m_errorMonitor->VerifyFound();
@@ -112,10 +112,10 @@ TEST_F(VkLayerTest, BufferExtents) {
 
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBuffer2Function) {
-        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, NULL, copy_info.srcOffset, copy_info.dstOffset,
+        const VkBufferCopy2KHR copy_info2 = {VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR, nullptr, copy_info.srcOffset, copy_info.dstOffset,
                                              copy_info.size};
         const VkCopyBufferInfo2KHR copy_buffer_info2 = {
-            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, NULL, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
+            VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR, nullptr, buffer_one.handle(), buffer_two.handle(), 1, &copy_info2};
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferInfo2-size-00116");
         vkCmdCopyBuffer2Function(m_commandBuffer->handle(), &copy_buffer_info2);
         m_errorMonitor->VerifyFound();
@@ -148,7 +148,7 @@ TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled) {
     sampler_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
     sampler_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 }
 
@@ -167,7 +167,7 @@ TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled12) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 }
 
@@ -188,10 +188,10 @@ TEST_F(VkLayerTest, AnisotropyFeatureDisabled) {
     VkSampler sampler = VK_NULL_HANDLE;
 
     VkResult err;
-    err = vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
     if (VK_SUCCESS == err) {
-        vk::DestroySampler(m_device->device(), sampler, NULL);
+        vk::DestroySampler(m_device->device(), sampler, nullptr);
     }
     sampler = VK_NULL_HANDLE;
 }
@@ -414,7 +414,7 @@ TEST_F(VkLayerTest, SparseBindingImageBufferCreate) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buf_info.size = 2048;
     buf_info.queueFamilyIndexCount = 0;
-    buf_info.pQueueFamilyIndices = NULL;
+    buf_info.pQueueFamilyIndices = nullptr;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     if (m_device->phy().features().sparseResidencyBuffer) {
@@ -446,7 +446,7 @@ TEST_F(VkLayerTest, SparseBindingImageBufferCreate) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     if (m_device->phy().features().sparseResidencyImage2D) {
@@ -497,7 +497,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedTypes) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
 
@@ -549,7 +549,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedSamples) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
 
@@ -596,7 +596,7 @@ TEST_F(VkLayerTest, SparseResidencyFlagMissing) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -635,10 +635,10 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
     buf_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buf_info.size = 256;
     buf_info.queueFamilyIndexCount = 0;
-    buf_info.pQueueFamilyIndices = NULL;
+    buf_info.pQueueFamilyIndices = nullptr;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     buf_info.flags = 0;
-    err = vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer);
+    err = vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &mem_reqs);
@@ -652,10 +652,10 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     uint8_t *pData;
@@ -765,19 +765,19 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
     vk::InvalidateMappedMemoryRanges(m_device->device(), 1, &mmr);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
-    vk::FreeMemory(m_device->device(), mem, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
 
     // device memory not atom size aligned
     alloc_info.allocationSize = (atom_size * 4) + 1;
-    ASSERT_VK_SUCCESS(vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer));
+    ASSERT_VK_SUCCESS(vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer));
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
-    ASSERT_VK_SUCCESS(vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem));
+    ASSERT_VK_SUCCESS(vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem));
     ASSERT_VK_SUCCESS(vk::MapMemory(m_device->device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData));
     // Some platforms have an atomsize of 1 which makes the test meaningless
     if (atom_size > 1) {
@@ -794,15 +794,15 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
                                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::FreeMemory(m_device->device(), mem, NULL);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::FreeMemory(m_device->device(), mem, nullptr);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
     // TODO : If we can get HOST_VISIBLE w/o HOST_COHERENT we can test cases of
     //  kVUID_Core_MemTrack_InvalidMap in validateAndCopyNoncoherentMemoryToDriver()
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
-    vk::FreeMemory(m_device->device(), mem, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
 }
 
 TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
@@ -825,10 +825,10 @@ TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
     }
 
     VkDeviceMemory mem;
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
-    void *mappedAddress = NULL;
+    void *mappedAddress = nullptr;
     err = vk::MapMemory(m_device->device(), mem, 0, VK_WHOLE_SIZE, 0, &mappedAddress);
     m_errorMonitor->VerifyFound();
 
@@ -845,7 +845,7 @@ TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
     vk::InvalidateMappedMemoryRanges(m_device->device(), 1, &memory_range);
     m_errorMonitor->VerifyFound();
 
-    vk::FreeMemory(m_device->device(), mem, NULL);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
 }
 
 TEST_F(VkLayerTest, RebindMemory_MultiObjectDebugUtils) {
@@ -886,7 +886,7 @@ TEST_F(VkLayerTest, RebindMemory_MultiObjectDebugUtils) {
     // Introduce failure, do NOT set memProps to
     // VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
     mem_alloc.memoryTypeIndex = 1;
-    err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetImageMemoryRequirements(m_device->device(), image, &mem_reqs);
@@ -896,9 +896,9 @@ TEST_F(VkLayerTest, RebindMemory_MultiObjectDebugUtils) {
     ASSERT_TRUE(pass);
 
     // allocate 2 memory objects
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem1);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem1);
     ASSERT_VK_SUCCESS(err);
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem2);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem2);
     ASSERT_VK_SUCCESS(err);
 
     // Bind first memory object to Image object
@@ -915,9 +915,9 @@ TEST_F(VkLayerTest, RebindMemory_MultiObjectDebugUtils) {
     err = vk::BindImageMemory(m_device->device(), image, mem2, 0);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImage(m_device->device(), image, NULL);
-    vk::FreeMemory(m_device->device(), mem1, NULL);
-    vk::FreeMemory(m_device->device(), mem2, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
+    vk::FreeMemory(m_device->device(), mem1, nullptr);
+    vk::FreeMemory(m_device->device(), mem2, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryMemoryCommitmentWithoutLazyProperty) {
@@ -982,7 +982,7 @@ TEST_F(VkLayerTest, InvalidSparseImageUsageBits) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -1033,7 +1033,7 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
 
     // Create a view with depth / stencil aspect for image with different usage
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-04441");
-    vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
+    vk::CreateImageView(m_device->device(), &dsvci, nullptr, &dsv);
     m_errorMonitor->VerifyFound();
 
     // Initialize buffer with TRANSFER_DST usage
@@ -1063,7 +1063,7 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
     // equvalent test using using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBufferToImage2Function) {
         const VkBufferImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2_KHR,
-                                               NULL,
+                                               nullptr,
                                                region.bufferRowLength,
                                                region.bufferImageHeight,
                                                region.bufferImageHeight,
@@ -1071,7 +1071,7 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
                                                region.imageOffset,
                                                region.imageExtent};
         VkCopyBufferToImageInfo2KHR buffer_to_image_info2 = {VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2_KHR,
-                                                             NULL,
+                                                             nullptr,
                                                              buffer.handle(),
                                                              image.handle(),
                                                              VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -1139,10 +1139,10 @@ TEST_F(VkLayerTest, CopyBufferToCompressedImage) {
     depth_image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     depth_image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     depth_image_create_info.queueFamilyIndexCount = 0;
-    depth_image_create_info.pQueueFamilyIndices = NULL;
+    depth_image_create_info.pQueueFamilyIndices = nullptr;
 
     VkImage depth_image = VK_NULL_HANDLE;
-    err = vk::CreateImage(m_device->handle(), &depth_image_create_info, NULL, &depth_image);
+    err = vk::CreateImage(m_device->handle(), &depth_image_create_info, nullptr, &depth_image);
     ASSERT_VK_SUCCESS(err);
 
     VkDeviceMemory mem1;
@@ -1156,7 +1156,7 @@ TEST_F(VkLayerTest, CopyBufferToCompressedImage) {
     mem_alloc.allocationSize = mem_reqs.size;
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem1);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem1);
     ASSERT_VK_SUCCESS(err);
     err = vk::BindImageMemory(m_device->device(), depth_image, mem1, 0);
 
@@ -1164,8 +1164,8 @@ TEST_F(VkLayerTest, CopyBufferToCompressedImage) {
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer.handle(), depth_image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImage(m_device->device(), depth_image, NULL);
-    vk::FreeMemory(m_device->device(), mem1, NULL);
+    vk::DestroyImage(m_device->device(), depth_image, nullptr);
+    vk::FreeMemory(m_device->device(), mem1, nullptr);
     m_commandBuffer->end();
 }
 
@@ -1293,9 +1293,9 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
     {
         VkImage image = VK_NULL_HANDLE;
         VkBuffer buffer = VK_NULL_HANDLE;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+        err = vk::CreateImage(device(), &image_create_info, nullptr, &image);
         ASSERT_VK_SUCCESS(err);
-        err = vk::CreateBuffer(device(), &buffer_create_info, NULL, &buffer);
+        err = vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -1311,13 +1311,13 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         ASSERT_TRUE(pass);
 
         VkDeviceMemory image_mem = VK_NULL_HANDLE, buffer_mem = VK_NULL_HANDLE;
-        err = vk::AllocateMemory(device(), &image_mem_alloc, NULL, &image_mem);
+        err = vk::AllocateMemory(device(), &image_mem_alloc, nullptr, &image_mem);
         ASSERT_VK_SUCCESS(err);
-        err = vk::AllocateMemory(device(), &buffer_mem_alloc, NULL, &buffer_mem);
+        err = vk::AllocateMemory(device(), &buffer_mem_alloc, nullptr, &buffer_mem);
         ASSERT_VK_SUCCESS(err);
 
-        vk::FreeMemory(device(), image_mem, NULL);
-        vk::FreeMemory(device(), buffer_mem, NULL);
+        vk::FreeMemory(device(), image_mem, nullptr);
+        vk::FreeMemory(device(), buffer_mem, nullptr);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-memory-parameter");
         err = vk::BindImageMemory(device(), image, image_mem, 0);
@@ -1329,17 +1329,17 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         (void)err;  // This may very well return an error.
         m_errorMonitor->VerifyFound();
 
-        vk::DestroyImage(m_device->device(), image, NULL);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyImage(m_device->device(), image, nullptr);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
     }
 
     // Try to bind memory to an object that already has a memory binding
     {
         VkImage image = VK_NULL_HANDLE;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+        err = vk::CreateImage(device(), &image_create_info, nullptr, &image);
         ASSERT_VK_SUCCESS(err);
         VkBuffer buffer = VK_NULL_HANDLE;
-        err = vk::CreateBuffer(device(), &buffer_create_info, NULL, &buffer);
+        err = vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -1353,9 +1353,9 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         pass = m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
         ASSERT_TRUE(pass);
         VkDeviceMemory image_mem, buffer_mem;
-        err = vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem);
+        err = vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem);
         ASSERT_VK_SUCCESS(err);
-        err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+        err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
         ASSERT_VK_SUCCESS(err);
 
         err = vk::BindImageMemory(device(), image, image_mem, 0);
@@ -1372,19 +1372,19 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         (void)err;  // This may very well return an error.
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), image_mem, NULL);
-        vk::FreeMemory(device(), buffer_mem, NULL);
-        vk::DestroyImage(device(), image, NULL);
-        vk::DestroyBuffer(device(), buffer, NULL);
+        vk::FreeMemory(device(), image_mem, nullptr);
+        vk::FreeMemory(device(), buffer_mem, nullptr);
+        vk::DestroyImage(device(), image, nullptr);
+        vk::DestroyBuffer(device(), buffer, nullptr);
     }
 
     // Try to bind memory to an object with an invalid memoryOffset
     {
         VkImage image = VK_NULL_HANDLE;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+        err = vk::CreateImage(device(), &image_create_info, nullptr, &image);
         ASSERT_VK_SUCCESS(err);
         VkBuffer buffer = VK_NULL_HANDLE;
-        err = vk::CreateBuffer(device(), &buffer_create_info, NULL, &buffer);
+        err = vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -1399,9 +1399,9 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         pass = m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
         ASSERT_TRUE(pass);
         VkDeviceMemory image_mem, buffer_mem;
-        err = vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem);
+        err = vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem);
         ASSERT_VK_SUCCESS(err);
-        err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+        err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
         ASSERT_VK_SUCCESS(err);
 
         // Test unaligned memory offset
@@ -1460,19 +1460,19 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
             }
         }
 
-        vk::FreeMemory(device(), image_mem, NULL);
-        vk::FreeMemory(device(), buffer_mem, NULL);
-        vk::DestroyImage(device(), image, NULL);
-        vk::DestroyBuffer(device(), buffer, NULL);
+        vk::FreeMemory(device(), image_mem, nullptr);
+        vk::FreeMemory(device(), buffer_mem, nullptr);
+        vk::DestroyImage(device(), image, nullptr);
+        vk::DestroyBuffer(device(), buffer, nullptr);
     }
 
     // Try to bind memory to an object with an invalid memory type
     {
         VkImage image = VK_NULL_HANDLE;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+        err = vk::CreateImage(device(), &image_create_info, nullptr, &image);
         ASSERT_VK_SUCCESS(err);
         VkBuffer buffer = VK_NULL_HANDLE;
-        err = vk::CreateBuffer(device(), &buffer_create_info, NULL, &buffer);
+        err = vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -1491,13 +1491,13 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         if (image_unsupported_mem_type_bits != 0) {
             pass = m_device->phy().set_memory_type(image_unsupported_mem_type_bits, &image_alloc_info, 0);
             ASSERT_TRUE(pass);
-            err = vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem);
+            err = vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem);
             ASSERT_VK_SUCCESS(err);
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-memory-01047");
             err = vk::BindImageMemory(device(), image, image_mem, 0);
             (void)err;  // This may very well return an error.
             m_errorMonitor->VerifyFound();
-            vk::FreeMemory(device(), image_mem, NULL);
+            vk::FreeMemory(device(), image_mem, nullptr);
         }
 
         uint32_t buffer_unsupported_mem_type_bits =
@@ -1505,17 +1505,17 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
         if (buffer_unsupported_mem_type_bits != 0) {
             pass = m_device->phy().set_memory_type(buffer_unsupported_mem_type_bits, &buffer_alloc_info, 0);
             ASSERT_TRUE(pass);
-            err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+            err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
             ASSERT_VK_SUCCESS(err);
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memory-01035");
             err = vk::BindBufferMemory(device(), buffer, buffer_mem, 0);
             (void)err;  // This may very well return an error.
             m_errorMonitor->VerifyFound();
-            vk::FreeMemory(device(), buffer_mem, NULL);
+            vk::FreeMemory(device(), buffer_mem, nullptr);
         }
 
-        vk::DestroyImage(device(), image, NULL);
-        vk::DestroyBuffer(device(), buffer, NULL);
+        vk::DestroyImage(device(), image, nullptr);
+        vk::DestroyBuffer(device(), buffer, nullptr);
     }
 
     // Try to bind memory to an image created with sparse memory flags
@@ -1536,7 +1536,7 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
                 return;
             } else {
                 VkImage sparse_image = VK_NULL_HANDLE;
-                err = vk::CreateImage(m_device->device(), &sparse_image_create_info, NULL, &sparse_image);
+                err = vk::CreateImage(m_device->device(), &sparse_image_create_info, nullptr, &sparse_image);
                 ASSERT_VK_SUCCESS(err);
                 VkMemoryRequirements sparse_mem_reqs = {};
                 vk::GetImageMemoryRequirements(m_device->device(), sparse_image, &sparse_mem_reqs);
@@ -1547,16 +1547,16 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
                     pass = m_device->phy().set_memory_type(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                     ASSERT_TRUE(pass);
                     VkDeviceMemory sparse_mem = VK_NULL_HANDLE;
-                    err = vk::AllocateMemory(m_device->device(), &sparse_mem_alloc, NULL, &sparse_mem);
+                    err = vk::AllocateMemory(m_device->device(), &sparse_mem_alloc, nullptr, &sparse_mem);
                     ASSERT_VK_SUCCESS(err);
                     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-image-01045");
                     err = vk::BindImageMemory(m_device->device(), sparse_image, sparse_mem, 0);
                     // This may very well return an error.
                     (void)err;
                     m_errorMonitor->VerifyFound();
-                    vk::FreeMemory(m_device->device(), sparse_mem, NULL);
+                    vk::FreeMemory(m_device->device(), sparse_mem, nullptr);
                 }
-                vk::DestroyImage(m_device->device(), sparse_image, NULL);
+                vk::DestroyImage(m_device->device(), sparse_image, nullptr);
             }
         }
     }
@@ -1569,7 +1569,7 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
             // most likely means sparse formats aren't supported here; skip this test.
         } else {
             VkBuffer sparse_buffer = VK_NULL_HANDLE;
-            err = vk::CreateBuffer(m_device->device(), &sparse_buffer_create_info, NULL, &sparse_buffer);
+            err = vk::CreateBuffer(m_device->device(), &sparse_buffer_create_info, nullptr, &sparse_buffer);
             ASSERT_VK_SUCCESS(err);
             VkMemoryRequirements sparse_mem_reqs = {};
             vk::GetBufferMemoryRequirements(m_device->device(), sparse_buffer, &sparse_mem_reqs);
@@ -1580,16 +1580,16 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
                 pass = m_device->phy().set_memory_type(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                 ASSERT_TRUE(pass);
                 VkDeviceMemory sparse_mem = VK_NULL_HANDLE;
-                err = vk::AllocateMemory(m_device->device(), &sparse_mem_alloc, NULL, &sparse_mem);
+                err = vk::AllocateMemory(m_device->device(), &sparse_mem_alloc, nullptr, &sparse_mem);
                 ASSERT_VK_SUCCESS(err);
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-buffer-01030");
                 err = vk::BindBufferMemory(m_device->device(), sparse_buffer, sparse_mem, 0);
                 // This may very well return an error.
                 (void)err;
                 m_errorMonitor->VerifyFound();
-                vk::FreeMemory(m_device->device(), sparse_mem, NULL);
+                vk::FreeMemory(m_device->device(), sparse_mem, nullptr);
             }
-            vk::DestroyBuffer(m_device->device(), sparse_buffer, NULL);
+            vk::DestroyBuffer(m_device->device(), sparse_buffer, nullptr);
         }
     }
 }
@@ -1645,7 +1645,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
 
         VkImage image;
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image));
 
         VkImagePlaneMemoryRequirementsInfo image_plane_req = LvlInitStruct<VkImagePlaneMemoryRequirementsInfo>();
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -1661,7 +1661,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         ASSERT_TRUE(m_device->phy().set_memory_type(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
 
         VkDeviceMemory image_memory;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &image_memory));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &image_memory));
 
         // Bind disjoint with BindImageMemory instead of BindImageMemory2
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-image-01608");
@@ -1688,7 +1688,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         vkBindImageMemory2Function(device(), 1, &bind_image_info);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), image_memory, NULL);
+        vk::FreeMemory(device(), image_memory, nullptr);
         vk::DestroyImage(device(), image, nullptr);
     }
 
@@ -1711,7 +1711,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         image_create_info.flags = 0;  // no disjoint bit set
 
         VkImage image;
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image));
 
         VkImageMemoryRequirementsInfo2 mem_req_info2 = LvlInitStruct<VkImageMemoryRequirementsInfo2>();
         mem_req_info2.image = image;
@@ -1724,7 +1724,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         ASSERT_TRUE(m_device->phy().set_memory_type(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
 
         VkDeviceMemory image_memory;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &image_memory));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &image_memory));
 
         VkBindImagePlaneMemoryInfo plane_memory_info = LvlInitStruct<VkBindImagePlaneMemoryInfo>();
         plane_memory_info.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -1737,7 +1737,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         vkBindImageMemory2Function(device(), 1, &bind_image_info);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), image_memory, NULL);
+        vk::FreeMemory(device(), image_memory, nullptr);
         vk::DestroyImage(device(), image, nullptr);
     }
 }
@@ -1817,7 +1817,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
     // Try to bind memory to an object with an invalid memoryOffset
 
     VkImage image = VK_NULL_HANDLE;
-    ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image));
+    ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image));
     VkMemoryRequirements image_mem_reqs = {};
     vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
     VkMemoryAllocateInfo image_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
@@ -1825,7 +1825,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
     image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
     ASSERT_TRUE(m_device->phy().set_memory_type(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
     VkDeviceMemory image_mem;
-    ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem));
+    ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem));
 
     // Keep values outside scope so multiple tests cases can reuse
     VkImage mp_image = VK_NULL_HANDLE;
@@ -1833,7 +1833,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
     VkMemoryRequirements2 mp_image_mem_reqs2[2];
     VkMemoryAllocateInfo mp_image_alloc_info[2];
     if (mp_disjoint_support == true) {
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, NULL, &mp_image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, nullptr, &mp_image));
 
         VkImagePlaneMemoryRequirementsInfo image_plane_req = LvlInitStruct<VkImagePlaneMemoryRequirementsInfo>();
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -1861,8 +1861,8 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
         ASSERT_TRUE(
             m_device->phy().set_memory_type(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0));
 
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_image_mem[1]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], nullptr, &mp_image_mem[0]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], nullptr, &mp_image_mem[1]));
     }
 
     // All planes must be bound at once the same here
@@ -1983,10 +1983,10 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
     }
 
     // Free Memory to reset
-    vk::FreeMemory(device(), image_mem, NULL);
+    vk::FreeMemory(device(), image_mem, nullptr);
     if (mp_disjoint_support == true) {
         // only reset plane 0
-        vk::FreeMemory(device(), mp_image_mem[0], NULL);
+        vk::FreeMemory(device(), mp_image_mem[0], nullptr);
     }
 
     // Try to bind memory to an object with an invalid memory type
@@ -2011,12 +2011,12 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
                 ((1 << memory_properties.memoryTypeCount) - 1) & ~mem_req2.memoryRequirements.memoryTypeBits;
             if (image2_unsupported_mem_type_bits != 0) {
                 ASSERT_TRUE(m_device->phy().set_memory_type(image2_unsupported_mem_type_bits, &image_alloc_info, 0));
-                ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem));
+                ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem));
                 bind_image_info.memory = image_mem;
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01615");
                 vkBindImageMemory2Function(device(), 1, &bind_image_info);
                 m_errorMonitor->VerifyFound();
-                vk::FreeMemory(device(), image_mem, NULL);
+                vk::FreeMemory(device(), image_mem, nullptr);
             }
         } else {
             // Same as 01047 but with bindImageMemory2 call
@@ -2024,14 +2024,14 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
                 ((1 << memory_properties.memoryTypeCount) - 1) & ~image_mem_reqs.memoryTypeBits;
             if (image_unsupported_mem_type_bits != 0) {
                 ASSERT_TRUE(m_device->phy().set_memory_type(image_unsupported_mem_type_bits, &image_alloc_info, 0));
-                ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem));
+                ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem));
                 bind_image_info.memory = image_mem;
                 const char *vuid =
                     (mp_extensions) ? "VUID-VkBindImageMemoryInfo-pNext-01615" : "VUID-VkBindImageMemoryInfo-memory-01612";
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
                 vkBindImageMemory2Function(device(), 1, &bind_image_info);
                 m_errorMonitor->VerifyFound();
-                vk::FreeMemory(device(), image_mem, NULL);
+                vk::FreeMemory(device(), image_mem, nullptr);
             }
         }
     }
@@ -2051,7 +2051,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
         if (mp_image_unsupported_mem_type_bits != 0) {
             mp_image_alloc_info[0].allocationSize = mp_image_mem_reqs2[0].memoryRequirements.size;
             ASSERT_TRUE(m_device->phy().set_memory_type(mp_image_unsupported_mem_type_bits, &mp_image_alloc_info[0], 0));
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], nullptr, &mp_image_mem[0]));
 
             VkBindImageMemoryInfo bind_image_info[2];
             bind_image_info[0] = LvlInitStruct<VkBindImageMemoryInfo>(&plane_memory_info[0]);
@@ -2066,14 +2066,14 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01619");
             vkBindImageMemory2Function(device(), 2, bind_image_info);
             m_errorMonitor->VerifyFound();
-            vk::FreeMemory(device(), mp_image_mem[0], NULL);
+            vk::FreeMemory(device(), mp_image_mem[0], nullptr);
         }
     }
 
-    vk::DestroyImage(device(), image, NULL);
+    vk::DestroyImage(device(), image, nullptr);
     if (mp_disjoint_support == true) {
-        vk::FreeMemory(device(), mp_image_mem[1], NULL);
-        vk::DestroyImage(device(), mp_image, NULL);
+        vk::FreeMemory(device(), mp_image_mem[1], nullptr);
+        vk::DestroyImage(device(), mp_image, nullptr);
     }
 }
 
@@ -2099,8 +2099,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         VkBuffer unchecked_buffer = VK_NULL_HANDLE;
         VkDeviceMemory buffer_mem = VK_NULL_HANDLE;
         VkDeviceMemory unchecked_buffer_mem = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::CreateBuffer(device(), &buffer_create_info, NULL, &buffer));
-        ASSERT_VK_SUCCESS(vk::CreateBuffer(device(), &buffer_create_info, NULL, &unchecked_buffer));
+        ASSERT_VK_SUCCESS(vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer));
+        ASSERT_VK_SUCCESS(vk::CreateBuffer(device(), &buffer_create_info, nullptr, &unchecked_buffer));
 
         VkMemoryRequirements buffer_mem_reqs = {};
         vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
@@ -2108,8 +2108,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         // Leave some extra space for alignment wiggle room
         buffer_alloc_info.allocationSize = buffer_mem_reqs.size + buffer_mem_reqs.alignment;
         ASSERT_TRUE(m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &unchecked_buffer_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &unchecked_buffer_mem));
 
         if (buffer_mem_reqs.alignment > 1) {
             VkDeviceSize buffer_offset = 1;
@@ -2126,10 +2126,10 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
             m_errorMonitor->VerifyFound();
         }
 
-        vk::DestroyBuffer(device(), buffer, NULL);
-        vk::DestroyBuffer(device(), unchecked_buffer, NULL);
-        vk::FreeMemory(device(), buffer_mem, NULL);
-        vk::FreeMemory(device(), unchecked_buffer_mem, NULL);
+        vk::DestroyBuffer(device(), buffer, nullptr);
+        vk::DestroyBuffer(device(), unchecked_buffer, nullptr);
+        vk::FreeMemory(device(), buffer_mem, nullptr);
+        vk::FreeMemory(device(), unchecked_buffer_mem, nullptr);
     }
 
     // Next test is a single-plane image
@@ -2152,8 +2152,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         VkImage unchecked_image = VK_NULL_HANDLE;
         VkDeviceMemory image_mem = VK_NULL_HANDLE;
         VkDeviceMemory unchecked_image_mem = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image));
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &unchecked_image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &unchecked_image));
 
         VkMemoryRequirements image_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -2161,8 +2161,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         // Leave some extra space for alignment wiggle room
         image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
         ASSERT_TRUE(m_device->phy().set_memory_type(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_mem));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &unchecked_image_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &unchecked_image_mem));
 
         // single-plane image
         if (image_mem_reqs.alignment > 1) {
@@ -2180,10 +2180,10 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
             m_errorMonitor->VerifyFound();
         }
 
-        vk::DestroyImage(device(), image, NULL);
-        vk::DestroyImage(device(), unchecked_image, NULL);
-        vk::FreeMemory(device(), image_mem, NULL);
-        vk::FreeMemory(device(), unchecked_image_mem, NULL);
+        vk::DestroyImage(device(), image, nullptr);
+        vk::DestroyImage(device(), unchecked_image, nullptr);
+        vk::FreeMemory(device(), image_mem, nullptr);
+        vk::FreeMemory(device(), unchecked_image_mem, nullptr);
     }
 
     // Same style test but with a multi-planar disjoint image
@@ -2237,8 +2237,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         VkMemoryRequirements2 mp_image_mem_reqs2[2];
         VkMemoryAllocateInfo mp_image_alloc_info[2];
 
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, NULL, &mp_image));
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, NULL, &mp_unchecked_image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, nullptr, &mp_image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, nullptr, &mp_unchecked_image));
 
         VkImagePlaneMemoryRequirementsInfo image_plane_req = LvlInitStruct<VkImagePlaneMemoryRequirementsInfo>();
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -2264,10 +2264,10 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
         ASSERT_TRUE(
             m_device->phy().set_memory_type(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0));
 
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_image_mem[1]));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_unchecked_image_mem[0]));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_unchecked_image_mem[1]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], nullptr, &mp_image_mem[0]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], nullptr, &mp_image_mem[1]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[0], nullptr, &mp_unchecked_image_mem[0]));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &mp_image_alloc_info[1], nullptr, &mp_unchecked_image_mem[1]));
 
         // Sets an invalid offset to plane 1
         if (mp_image_mem_reqs2[1].memoryRequirements.alignment > 1) {
@@ -2303,12 +2303,12 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
             m_errorMonitor->VerifyFound();
         }
 
-        vk::DestroyImage(device(), mp_image, NULL);
-        vk::DestroyImage(device(), mp_unchecked_image, NULL);
-        vk::FreeMemory(device(), mp_image_mem[0], NULL);
-        vk::FreeMemory(device(), mp_image_mem[1], NULL);
-        vk::FreeMemory(device(), mp_unchecked_image_mem[0], NULL);
-        vk::FreeMemory(device(), mp_unchecked_image_mem[1], NULL);
+        vk::DestroyImage(device(), mp_image, nullptr);
+        vk::DestroyImage(device(), mp_unchecked_image, nullptr);
+        vk::FreeMemory(device(), mp_image_mem[0], nullptr);
+        vk::FreeMemory(device(), mp_image_mem[1], nullptr);
+        vk::FreeMemory(device(), mp_unchecked_image_mem[0], nullptr);
+        vk::FreeMemory(device(), mp_unchecked_image_mem[1], nullptr);
     }
 }
 
@@ -2355,19 +2355,19 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         VkImage image_b = VK_NULL_HANDLE;
         VkDeviceMemory image_a_mem = VK_NULL_HANDLE;
         VkDeviceMemory image_b_mem = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image_a));
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &image_b));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image_a));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &image_b));
 
         VkMemoryRequirements image_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image_a, &image_mem_reqs);
         VkMemoryAllocateInfo image_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         image_alloc_info.allocationSize = image_mem_reqs.size;
         ASSERT_TRUE(m_device->phy().set_memory_type(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_a_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_a_mem));
         vk::GetImageMemoryRequirements(device(), image_b, &image_mem_reqs);
         image_alloc_info.allocationSize = image_mem_reqs.size;
         ASSERT_TRUE(m_device->phy().set_memory_type(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &image_b_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &image_b_mem));
 
         // Try binding same image twice in array
         VkBindImageMemoryInfo bind_image_info[3];
@@ -2391,10 +2391,10 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         vkBindImageMemory2Function(device(), 2, bind_image_info);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), image_a_mem, NULL);
-        vk::FreeMemory(device(), image_b_mem, NULL);
-        vk::DestroyImage(device(), image_a, NULL);
-        vk::DestroyImage(device(), image_b, NULL);
+        vk::FreeMemory(device(), image_a_mem, nullptr);
+        vk::FreeMemory(device(), image_b_mem, nullptr);
+        vk::DestroyImage(device(), image_a, nullptr);
+        vk::DestroyImage(device(), image_b, nullptr);
     }
 
     if (mp_extensions) {
@@ -2420,13 +2420,13 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         // Creat 1 normal, not disjoint image
         VkImage normal_image = VK_NULL_HANDLE;
         VkDeviceMemory normal_image_mem = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, NULL, &normal_image));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &normal_image));
         VkMemoryRequirements image_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), normal_image, &image_mem_reqs);
         VkMemoryAllocateInfo image_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         image_alloc_info.allocationSize = image_mem_reqs.size;
         ASSERT_TRUE(m_device->phy().set_memory_type(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, NULL, &normal_image_mem));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &image_alloc_info, nullptr, &normal_image_mem));
 
         // Create 2 disjoint images with memory backing each plane
         VkImageCreateInfo mp_image_create_info = image_create_info;
@@ -2437,8 +2437,8 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         VkImage mp_image_b = VK_NULL_HANDLE;
         VkDeviceMemory mp_image_a_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
         VkDeviceMemory mp_image_b_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, NULL, &mp_image_a));
-        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, NULL, &mp_image_b));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, nullptr, &mp_image_a));
+        ASSERT_VK_SUCCESS(vk::CreateImage(device(), &mp_image_create_info, nullptr, &mp_image_b));
 
         AllocateDisjointMemory(m_device, vkGetImageMemoryRequirements2Function, mp_image_a, &mp_image_a_mem[0],
                                VK_IMAGE_ASPECT_PLANE_0_BIT);
@@ -2501,14 +2501,14 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         vkBindImageMemory2Function(device(), 5, bind_image_info);
         m_errorMonitor->VerifyNotFound();
 
-        vk::FreeMemory(device(), normal_image_mem, NULL);
-        vk::FreeMemory(device(), mp_image_a_mem[0], NULL);
-        vk::FreeMemory(device(), mp_image_a_mem[1], NULL);
-        vk::FreeMemory(device(), mp_image_b_mem[0], NULL);
-        vk::FreeMemory(device(), mp_image_b_mem[1], NULL);
-        vk::DestroyImage(device(), normal_image, NULL);
-        vk::DestroyImage(device(), mp_image_a, NULL);
-        vk::DestroyImage(device(), mp_image_b, NULL);
+        vk::FreeMemory(device(), normal_image_mem, nullptr);
+        vk::FreeMemory(device(), mp_image_a_mem[0], nullptr);
+        vk::FreeMemory(device(), mp_image_a_mem[1], nullptr);
+        vk::FreeMemory(device(), mp_image_b_mem[0], nullptr);
+        vk::FreeMemory(device(), mp_image_b_mem[1], nullptr);
+        vk::DestroyImage(device(), normal_image, nullptr);
+        vk::DestroyImage(device(), mp_image_a, nullptr);
+        vk::DestroyImage(device(), mp_image_b, nullptr);
     }
 }
 
@@ -2547,7 +2547,7 @@ TEST_F(VkLayerTest, BindMemoryToDestroyedObject) {
     mem_alloc.allocationSize = 0;
     mem_alloc.memoryTypeIndex = 0;
 
-    err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetImageMemoryRequirements(m_device->device(), image, &mem_reqs);
@@ -2557,11 +2557,11 @@ TEST_F(VkLayerTest, BindMemoryToDestroyedObject) {
     ASSERT_TRUE(pass);
 
     // Allocate memory
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     // Introduce validation failure, destroy Image object before binding
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
     ASSERT_VK_SUCCESS(err);
 
     // Now Try to bind memory to this destroyed object
@@ -2571,7 +2571,7 @@ TEST_F(VkLayerTest, BindMemoryToDestroyedObject) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::FreeMemory(m_device->device(), mem, NULL);
+    vk::FreeMemory(m_device->device(), mem, nullptr);
 }
 
 TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
@@ -2611,7 +2611,7 @@ TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
 
     int i;
     for (i = 0; i <= max_mems; i++) {
-        err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mems[i]);
+        err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mems[i]);
         if (err != VK_SUCCESS) {
             break;
         }
@@ -2619,7 +2619,7 @@ TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
     m_errorMonitor->VerifyFound();
 
     for (int j = 0; j < i; j++) {
-        vk::FreeMemory(m_device->device(), mems[j], NULL);
+        vk::FreeMemory(m_device->device(), mems[j], nullptr);
     }
 }
 
@@ -2657,7 +2657,7 @@ TEST_F(VkLayerTest, ExceedSamplerAllocationCount) {
 
     int i;
     for (i = 0; i <= max_samplers; i++) {
-        err = vk::CreateSampler(m_device->device(), &sampler_create_info, NULL, &samplers[i]);
+        err = vk::CreateSampler(m_device->device(), &sampler_create_info, nullptr, &samplers[i]);
         if (err != VK_SUCCESS) {
             break;
         }
@@ -2665,7 +2665,7 @@ TEST_F(VkLayerTest, ExceedSamplerAllocationCount) {
     m_errorMonitor->VerifyFound();
 
     for (int j = 0; j < i; j++) {
-        vk::DestroySampler(m_device->device(), samplers[j], NULL);
+        vk::DestroySampler(m_device->device(), samplers[j], nullptr);
     }
 }
 
@@ -2883,11 +2883,11 @@ TEST_F(VkLayerTest, BlitImageFormatTypes) {
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdBlitImage2Function) {
         const VkImageBlit2KHR blitRegion2 = {
-            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, NULL,
+            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, nullptr,
             blitRegion.srcSubresource,          {blitRegion.srcOffsets[0], blitRegion.srcOffsets[1]},
             blitRegion.dstSubresource,          {blitRegion.dstOffsets[0], blitRegion.dstOffsets[1]}};
         const VkBlitImageInfo2KHR blit_image_info2 = {VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       unsigned_image.image(),
                                                       unsigned_image.Layout(),
                                                       float_image.image(),
@@ -2913,11 +2913,11 @@ TEST_F(VkLayerTest, BlitImageFormatTypes) {
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdBlitImage2Function) {
         const VkImageBlit2KHR blitRegion2 = {
-            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, NULL,
+            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, nullptr,
             blitRegion.srcSubresource,          {blitRegion.srcOffsets[0], blitRegion.srcOffsets[1]},
             blitRegion.dstSubresource,          {blitRegion.dstOffsets[0], blitRegion.dstOffsets[1]}};
         const VkBlitImageInfo2KHR blit_image_info2 = {VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       float_image.image(),
                                                       float_image.Layout(),
                                                       unsigned_image.image(),
@@ -2943,11 +2943,11 @@ TEST_F(VkLayerTest, BlitImageFormatTypes) {
     // equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdBlitImage2Function) {
         const VkImageBlit2KHR blitRegion2 = {
-            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, NULL,
+            VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR, nullptr,
             blitRegion.srcSubresource,          {blitRegion.srcOffsets[0], blitRegion.srcOffsets[1]},
             blitRegion.dstSubresource,          {blitRegion.dstOffsets[0], blitRegion.dstOffsets[1]}};
         const VkBlitImageInfo2KHR blit_image_info2 = {VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       signed_image.image(),
                                                       signed_image.Layout(),
                                                       float_image.image(),
@@ -3280,7 +3280,7 @@ TEST_F(VkLayerTest, BlitImageOffsets) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj image_1D(m_device);
@@ -3478,7 +3478,7 @@ TEST_F(VkLayerTest, MiscBlitImageTests) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // 2D color image
@@ -3639,7 +3639,7 @@ TEST_F(VkLayerTest, BlitToDepthImageTests) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // 2D depth image
@@ -4006,7 +4006,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 256;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &mem_reqs);
@@ -4017,10 +4017,10 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindBufferMemory(m_device->device(), buffer, mem, 0);
@@ -4032,7 +4032,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkBuffer");
     // Destroy buffer dependency prior to submit to cause ERROR
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -4041,7 +4041,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
 
     m_errorMonitor->VerifyFound();
     vk::QueueWaitIdle(m_device->m_queue);
-    vk::FreeMemory(m_device->handle(), mem, NULL);
+    vk::FreeMemory(m_device->handle(), mem, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
@@ -4055,7 +4055,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 256;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &mem_reqs);
@@ -4066,7 +4066,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
     ASSERT_TRUE(pass);
 
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindBufferMemory(m_device->device(), buffer, buffer_mem, 0);
@@ -4078,8 +4078,8 @@ TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
     buf_barrier.offset = 0;
     buf_barrier.size = VK_WHOLE_SIZE;
 
-    vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                           0, 0, NULL, 1, &buf_barrier, 0, NULL);
+    vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
+                           nullptr, 1, &buf_barrier, 0, nullptr);
     m_commandBuffer->end();
 
     auto submit_info = lvl_init_struct<VkSubmitInfo>();
@@ -4088,12 +4088,12 @@ TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeMemory-memory-00677");
-    vk::FreeMemory(m_device->handle(), buffer_mem, NULL);
+    vk::FreeMemory(m_device->handle(), buffer_mem, nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::QueueWaitIdle(m_device->m_queue);
 
-    vk::DestroyBuffer(m_device->handle(), buffer, NULL);
+    vk::DestroyBuffer(m_device->handle(), buffer, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidCmdBarrierImageDestroyed) {
@@ -4129,7 +4129,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierImageDestroyed) {
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
-                           NULL, 0, NULL, 1, &img_barrier);
+                           nullptr, 0, nullptr, 1, &img_barrier);
     m_commandBuffer->end();
 
     auto submit_info = lvl_init_struct<VkSubmitInfo>();
@@ -4138,7 +4138,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierImageDestroyed) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeMemory-memory-00677");
-    vk::FreeMemory(m_device->handle(), image_mem.handle(), NULL);
+    vk::FreeMemory(m_device->handle(), image_mem.handle(), nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::QueueWaitIdle(m_device->m_queue);
@@ -4165,7 +4165,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 256;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &mem_reqs);
@@ -4176,10 +4176,10 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindBufferMemory(m_device->device(), buffer, mem, 0);
@@ -4200,7 +4200,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
 
     m_commandBuffer->PipelineBarrier2KHR(&dep_info);
 
-    vk::FreeMemory(m_device->handle(), mem, NULL);
+    vk::FreeMemory(m_device->handle(), mem, nullptr);
 
     vk::EndCommandBuffer(m_commandBuffer->handle());
     m_errorMonitor->VerifyFound();
@@ -4213,7 +4213,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
 
     vk::QueueWaitIdle(m_device->m_queue);
 
-    vk::DestroyBuffer(m_device->handle(), buffer, NULL);
+    vk::DestroyBuffer(m_device->handle(), buffer, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -4248,7 +4248,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierImageDestroyed) {
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
     ASSERT_TRUE(pass);
 
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &image_mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &image_mem);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindImageMemory(m_device->device(), image, image_mem, 0);
@@ -4268,7 +4268,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierImageDestroyed) {
 
     m_commandBuffer->PipelineBarrier2KHR(&dep_info);
 
-    vk::FreeMemory(m_device->handle(), image_mem, NULL);
+    vk::FreeMemory(m_device->handle(), image_mem, nullptr);
 
     vk::EndCommandBuffer(m_commandBuffer->handle());
     m_errorMonitor->VerifyFound();
@@ -4281,7 +4281,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierImageDestroyed) {
 
     vk::QueueWaitIdle(m_device->m_queue);
 
-    vk::DestroyImage(m_device->handle(), image, NULL);
+    vk::DestroyImage(m_device->handle(), image, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -4313,7 +4313,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
         bvci.format = VK_FORMAT_R32_SFLOAT;
         bvci.range = VK_WHOLE_SIZE;
 
-        VkResult err = vk::CreateBufferView(m_device->device(), &bvci, NULL, &view);
+        VkResult err = vk::CreateBufferView(m_device->device(), &bvci, nullptr, &view);
         ASSERT_VK_SUCCESS(err);
 
         descriptor_set.WriteDescriptorBufferView(0, view);
@@ -4357,7 +4357,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBufferView(m_device->device(), view, NULL);
+    vk::DestroyBufferView(m_device->device(), view, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Descriptor in binding #0 index 0 is using bufferView");
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
@@ -4366,7 +4366,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
     buffer.init(*m_device, buffer_create_info);
 
     bvci.buffer = buffer.handle();
-    VkResult err = vk::CreateBufferView(m_device->device(), &bvci, NULL, &view);
+    VkResult err = vk::CreateBufferView(m_device->device(), &bvci, nullptr, &view);
     ASSERT_VK_SUCCESS(err);
     descriptor_set.descriptor_writes.clear();
     descriptor_set.WriteDescriptorBufferView(0, view);
@@ -4379,7 +4379,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
     m_commandBuffer->end();
 
     // Delete BufferView in order to invalidate cmd buffer
-    vk::DestroyBufferView(m_device->device(), view, NULL);
+    vk::DestroyBufferView(m_device->device(), view, nullptr);
     // Now attempt submit of cmd buffer
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -4584,7 +4584,7 @@ TEST_F(VkLayerTest, ImageMemoryNotBound) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.flags = 0;
-    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
     // Have to bind memory to image before recording cmd in cmd buffer using it
     VkMemoryRequirements mem_reqs;
@@ -4596,7 +4596,7 @@ TEST_F(VkLayerTest, ImageMemoryNotBound) {
     mem_alloc.allocationSize = mem_reqs.size;
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &image_mem);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &image_mem);
     ASSERT_VK_SUCCESS(err);
 
     // Introduce error, do not call vk::BindImageMemory(m_device->device(), image, image_mem, 0);
@@ -4619,7 +4619,7 @@ TEST_F(VkLayerTest, ImageMemoryNotBound) {
     m_commandBuffer->end();
 
     m_errorMonitor->VerifyFound();
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
     vk::FreeMemory(m_device->device(), image_mem, nullptr);
 }
 
@@ -4640,7 +4640,7 @@ TEST_F(VkLayerTest, BufferMemoryNotBound) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buf_info.size = 1024;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     vk::GetBufferMemoryRequirements(m_device->device(), buffer, &mem_reqs);
@@ -4651,10 +4651,10 @@ TEST_F(VkLayerTest, BufferMemoryNotBound) {
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         printf("%s Failed to set memory type.\n", kSkipPrefix);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
         return;
     }
-    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     // Introduce failure by not calling vkBindBufferMemory(m_device->device(), buffer, mem, 0);
@@ -4675,8 +4675,8 @@ TEST_F(VkLayerTest, BufferMemoryNotBound) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
-    vk::FreeMemory(m_device->handle(), mem, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
+    vk::FreeMemory(m_device->handle(), mem, nullptr);
 }
 
 TEST_F(VkLayerTest, MultiplaneImageLayoutBadAspectFlags) {
@@ -4715,11 +4715,11 @@ TEST_F(VkLayerTest, MultiplaneImageLayoutBadAspectFlags) {
 
     VkImage image_2plane, image_3plane;
     ci.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR;
-    VkResult err = vk::CreateImage(device(), &ci, NULL, &image_2plane);
+    VkResult err = vk::CreateImage(device(), &ci, nullptr, &image_2plane);
     ASSERT_VK_SUCCESS(err);
 
     ci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
-    err = vk::CreateImage(device(), &ci, NULL, &image_3plane);
+    err = vk::CreateImage(device(), &ci, nullptr, &image_3plane);
     ASSERT_VK_SUCCESS(err);
 
     // Query layout of 3rd plane, for a 2-plane image
@@ -4740,8 +4740,8 @@ TEST_F(VkLayerTest, MultiplaneImageLayoutBadAspectFlags) {
     m_errorMonitor->VerifyFound();
 
     // Clean up
-    vk::DestroyImage(device(), image_2plane, NULL);
-    vk::DestroyImage(device(), image_3plane, NULL);
+    vk::DestroyImage(device(), image_2plane, nullptr);
+    vk::DestroyImage(device(), image_3plane, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidBufferViewObject) {
@@ -4773,7 +4773,7 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
         bvci.format = VK_FORMAT_R32_SFLOAT;
         bvci.range = VK_WHOLE_SIZE;
 
-        err = vk::CreateBufferView(m_device->device(), &bvci, NULL, &view);
+        err = vk::CreateBufferView(m_device->device(), &bvci, nullptr, &view);
         ASSERT_VK_SUCCESS(err);
     }
     // First Destroy buffer underlying view which should hit error in CV
@@ -4785,13 +4785,13 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
     descriptor_write.pTexelBufferView = &view;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // Now destroy view itself and verify same error, which is hit in PV this time
-    vk::DestroyBufferView(m_device->device(), view, NULL);
+    vk::DestroyBufferView(m_device->device(), view, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02994");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -4811,7 +4811,7 @@ TEST_F(VkLayerTest, CreateBufferViewNoMemoryBoundToBuffer) {
     buff_ci.size = 256;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     VkBuffer buffer;
-    err = vk::CreateBuffer(m_device->device(), &buff_ci, NULL, &buffer);
+    err = vk::CreateBuffer(m_device->device(), &buff_ci, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkBufferViewCreateInfo buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
@@ -4819,13 +4819,13 @@ TEST_F(VkLayerTest, CreateBufferViewNoMemoryBoundToBuffer) {
     buff_view_ci.format = VK_FORMAT_R8_UNORM;
     buff_view_ci.range = VK_WHOLE_SIZE;
     VkBufferView buff_view;
-    err = vk::CreateBufferView(m_device->device(), &buff_view_ci, NULL, &buff_view);
+    err = vk::CreateBufferView(m_device->device(), &buff_view_ci, nullptr, &buff_view);
 
     m_errorMonitor->VerifyFound();
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
     // If last error is success, it still created the view, so delete it.
     if (err == VK_SUCCESS) {
-        vk::DestroyBufferView(m_device->device(), buff_view, NULL);
+        vk::DestroyBufferView(m_device->device(), buff_view, nullptr);
     }
 }
 
@@ -5859,7 +5859,7 @@ TEST_F(VkLayerTest, InvalidBarriers) {
             VkImage mp_image;
             VkDeviceMemory plane_0_memory;
             VkDeviceMemory plane_1_memory;
-            ASSERT_VK_SUCCESS(vk::CreateImage(m_device->device(), &image_create_info, NULL, &mp_image));
+            ASSERT_VK_SUCCESS(vk::CreateImage(m_device->device(), &image_create_info, nullptr, &mp_image));
 
             VkImagePlaneMemoryRequirementsInfo image_plane_req = LvlInitStruct<VkImagePlaneMemoryRequirementsInfo>();
             image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -5873,13 +5873,13 @@ TEST_F(VkLayerTest, InvalidBarriers) {
             VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
             alloc_info.allocationSize = mem_req2.memoryRequirements.size;
             ASSERT_TRUE(m_device->phy().set_memory_type(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &plane_0_memory));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &plane_0_memory));
 
             image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
             vkGetImageMemoryRequirements2Function(device(), &mem_req_info2, &mem_req2);
             alloc_info.allocationSize = mem_req2.memoryRequirements.size;
             ASSERT_TRUE(m_device->phy().set_memory_type(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, NULL, &plane_1_memory));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &alloc_info, nullptr, &plane_1_memory));
 
             VkBindImagePlaneMemoryInfo plane_0_memory_info = LvlInitStruct<VkBindImagePlaneMemoryInfo>();
             plane_0_memory_info.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -5912,8 +5912,8 @@ TEST_F(VkLayerTest, InvalidBarriers) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
             conc_test("VUID-VkImageMemoryBarrier-image-01673");
 
-            vk::FreeMemory(device(), plane_0_memory, NULL);
-            vk::FreeMemory(device(), plane_1_memory, NULL);
+            vk::FreeMemory(device(), plane_0_memory, nullptr);
+            vk::FreeMemory(device(), plane_1_memory, nullptr);
             vk::DestroyImage(m_device->device(), mp_image, nullptr);
         }
     }
@@ -7265,14 +7265,14 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     // Equivalent tests using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR copy_region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                              NULL,
+                                              nullptr,
                                               copy_region.srcSubresource,
                                               copy_region.srcOffset,
                                               copy_region.dstSubresource,
                                               copy_region.dstOffset,
                                               copy_region.extent};
         VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                NULL,
+                                                nullptr,
                                                 src_image.handle(),
                                                 VK_IMAGE_LAYOUT_GENERAL,
                                                 dst_image.handle(),
@@ -7336,11 +7336,11 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     transfer_dst_image_barrier[0].subresourceRange.levelCount = image_create_info.mipLevels;
     transfer_dst_image_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
-                           NULL, 0, NULL, 1, transfer_dst_image_barrier);
+                           nullptr, 0, nullptr, 1, transfer_dst_image_barrier);
     transfer_dst_image_barrier[0].image = depth_image.handle();
     transfer_dst_image_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
-                           NULL, 0, NULL, 1, transfer_dst_image_barrier);
+                           nullptr, 0, nullptr, 1, transfer_dst_image_barrier);
 
     // Cause errors due to clearing with invalid image layouts
     VkClearColorValue color_clear_value = {};
@@ -7388,7 +7388,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     image_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     m_errorMonitor->ExpectSuccess();
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
-                           NULL, 0, NULL, 1, image_barrier);
+                           nullptr, 0, nullptr, 1, image_barrier);
     m_errorMonitor->VerifyNotFound();
 
     // Now cause error due to bad image layout transition in PipelineBarrier
@@ -7402,7 +7402,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier-oldLayout-01197");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier-oldLayout-01210");
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
-                           NULL, 0, NULL, 1, image_barrier);
+                           nullptr, 0, nullptr, 1, image_barrier);
     m_errorMonitor->VerifyFound();
 
     // Finally some layout errors at RenderPass create time
@@ -7424,7 +7424,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     // error w/ non-general layout
     attach.layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription-None-04437");
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
 
     subpass.inputAttachmentCount = 0;
@@ -7433,7 +7433,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     // error w/ non-color opt or GENERAL layout for color attachment
     attach.layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription-None-04437");
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
 
     subpass.colorAttachmentCount = 0;
@@ -7442,7 +7442,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     // error w/ non-ds opt or GENERAL layout for color attachment
     attach.layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription-None-04437");
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
 
     // For this error we need a valid renderpass so create default one
@@ -7458,7 +7458,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAttachmentDescription-format-03283");
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
 }
 
@@ -7614,14 +7614,14 @@ TEST_F(VkLayerTest, CopyInvalidImageMemory) {
 
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR copy_region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                              NULL,
+                                              nullptr,
                                               copy_region.srcSubresource,
                                               copy_region.srcOffset,
                                               copy_region.dstSubresource,
                                               copy_region.dstOffset,
                                               copy_region.extent};
         VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                NULL,
+                                                nullptr,
                                                 image_no_mem.handle(),
                                                 VK_IMAGE_LAYOUT_GENERAL,
                                                 image.handle(),
@@ -7814,7 +7814,7 @@ TEST_F(VkLayerTest, CreateImageViewBreaksParameterCompatibilityRequirements) {
     VkImage imageSparse;
 
     // Creating a sparse image means we should not bind memory to it.
-    res = vk::CreateImage(m_device->device(), &imgInfo, NULL, &imageSparse);
+    res = vk::CreateImage(m_device->device(), &imgInfo, nullptr, &imageSparse);
     ASSERT_FALSE(res);
 
     // Initialize VkImageViewCreateInfo to create a view that will attempt to utilize VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR.
@@ -8268,7 +8268,7 @@ TEST_F(VkLayerTest, CreateImageViewNoMemoryBoundToImage) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
 
-    err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
 
     VkImageViewCreateInfo image_view_create_info = LvlInitStruct<VkImageViewCreateInfo>();
@@ -8282,7 +8282,7 @@ TEST_F(VkLayerTest, CreateImageViewNoMemoryBoundToImage) {
 
     CreateImageViewTest(*this, &image_view_create_info,
                         " used with no memory bound. Memory should be bound by calling vkBindImageMemory().");
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidImageViewAspect) {
@@ -9519,7 +9519,7 @@ TEST_F(VkLayerTest, CreateImageMinLimitsViolation) {
         bad_image_ci.imageType = VK_IMAGE_TYPE_3D;  // has to be 3D otherwise it might trigger the non-1 error instead
         bad_image_ci.extent = extent;
 
-        vk::CreateImage(m_device->device(), &bad_image_ci, NULL, &null_image);
+        vk::CreateImage(m_device->device(), &bad_image_ci, nullptr, &null_image);
 
         m_errorMonitor->VerifyFound();
     }
@@ -10059,7 +10059,7 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkImageCreateInfo ci = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
-                                  NULL,
+                                  nullptr,
                                   VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT,  // need for multi-planar
                                   VK_IMAGE_TYPE_2D,
                                   VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR,
@@ -10104,16 +10104,16 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     // Create two samplers with two different conversions, such that one will mismatch
     // It will make the second sampler fail to see if the log prints the second sampler or the first sampler.
     VkSampler samplers[2];
-    VkResult err = vk::CreateSampler(m_device->device(), &sci, NULL, &samplers[0]);
+    VkResult err = vk::CreateSampler(m_device->device(), &sci, nullptr, &samplers[0]);
     ASSERT_VK_SUCCESS(err);
     ycbcr_info.conversion = conversions[1];  // Need two samplers with different conversions
-    err = vk::CreateSampler(m_device->device(), &sci, NULL, &samplers[1]);
+    err = vk::CreateSampler(m_device->device(), &sci, nullptr, &samplers[1]);
     ASSERT_VK_SUCCESS(err);
 
     VkSampler BadSampler;
     sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-addressModeU-01646");
-    err = vk::CreateSampler(m_device->device(), &sci, NULL, &BadSampler);
+    err = vk::CreateSampler(m_device->device(), &sci, nullptr, &BadSampler);
     m_errorMonitor->VerifyFound();
 
     sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
@@ -10121,14 +10121,14 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     sci.minLod = 0.0;
     sci.maxLod = 0.0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-addressModeU-01646");
-    err = vk::CreateSampler(m_device->device(), &sci, NULL, &BadSampler);
+    err = vk::CreateSampler(m_device->device(), &sci, nullptr, &BadSampler);
     m_errorMonitor->VerifyFound();
 
     if (features2.features.samplerAnisotropy == VK_TRUE) {
         sci.unnormalizedCoordinates = VK_FALSE;
         sci.anisotropyEnable = VK_TRUE;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-addressModeU-01646");
-        err = vk::CreateSampler(m_device->device(), &sci, NULL, &BadSampler);
+        err = vk::CreateSampler(m_device->device(), &sci, nullptr, &BadSampler);
         m_errorMonitor->VerifyFound();
     }
 
@@ -10176,7 +10176,7 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     descriptor_write.pImageInfo = image_infos;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-01948");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // pImmutableSamplers = nullptr causes an error , VUID-VkWriteDescriptorSet-descriptorType-02738.
@@ -10189,12 +10189,12 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     descriptor_write.descriptorCount = 1;
     descriptor_write.pImageInfo = &image_infos[0];
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02738");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::DestroySamplerYcbcrConversion(m_device->device(), conversions[0], nullptr);
     vk::DestroySamplerYcbcrConversion(m_device->device(), conversions[1], nullptr);
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
     vk::DestroySampler(m_device->device(), samplers[0], nullptr);
     vk::DestroySampler(m_device->device(), samplers[1], nullptr);
 }
@@ -10253,7 +10253,7 @@ TEST_F(VkLayerTest, DepthStencilImageViewWithColorAspectBitError) {
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
 
     VkImageView view;
-    vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &view);
+    vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &view);
     m_errorMonitor->VerifyFound();
 }
 
@@ -10544,7 +10544,7 @@ TEST_F(VkLayerTest, CornerSampledImageNV) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.flags = VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV;
 
@@ -10791,14 +10791,14 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
 
     // test non external conversion with a VK_FORMAT_UNDEFINED
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-04060");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // test for non unorm
     sycci.format = VK_FORMAT_R8G8B8A8_SNORM;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-04060");
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-format-01650");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Force the multi-planar format support desired format features
@@ -10817,7 +10817,7 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     // 01651 set off twice for both xChromaOffset and yChromaOffset
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Cosited feature supported, but midpoint samples set
@@ -10827,7 +10827,7 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     sycci.xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
     sycci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Moving support to Linear to test that it checks either linear or optimal
@@ -10837,7 +10837,7 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     sycci.xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
     sycci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Using forceExplicitReconstruction without feature bit
@@ -10845,14 +10845,14 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     sycci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     sycci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-forceExplicitReconstruction-01656");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Linear chroma filtering without feature bit
     sycci.forceExplicitReconstruction = VK_FALSE;
     sycci.chromaFilter = VK_FILTER_LINEAR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-01657");
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // Add linear feature bit so can create valid SamplerYcbcrConversion
@@ -10860,7 +10860,7 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     formatProps.optimalTilingFeatures = VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT;
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
     m_errorMonitor->ExpectSuccess();
-    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, NULL, &ycbcr_conv);
+    vkCreateSamplerYcbcrConversionFunction(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyNotFound();
 
     // Try to create a Sampler with non-matching filters without feature bit set
@@ -10935,23 +10935,23 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     sycci.components = identity;
     sycci.components.g = VK_COMPONENT_SWIZZLE_A;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581");
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // test components.a
     sycci.components = identity;
     sycci.components.a = VK_COMPONENT_SWIZZLE_R;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02582");
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // make sure zero and one are allowed for components.a
     m_errorMonitor->ExpectSuccess();
     sycci.components.a = VK_COMPONENT_SWIZZLE_ONE;
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, nullptr);
     sycci.components.a = VK_COMPONENT_SWIZZLE_ZERO;
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, nullptr);
     m_errorMonitor->VerifyNotFound();
 
@@ -10960,7 +10960,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     sycci.components.r = VK_COMPONENT_SWIZZLE_G;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02583");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02585");
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // test components.b
@@ -10968,7 +10968,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     sycci.components.b = VK_COMPONENT_SWIZZLE_G;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02584");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02585");
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // test components.r and components.b together
@@ -10976,7 +10976,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     sycci.components.r = VK_COMPONENT_SWIZZLE_B;
     sycci.components.b = VK_COMPONENT_SWIZZLE_B;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02585");
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     // make sure components.r and components.b can be swapped
@@ -10984,7 +10984,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     sycci.components = identity;
     sycci.components.r = VK_COMPONENT_SWIZZLE_B;
     sycci.components.b = VK_COMPONENT_SWIZZLE_R;
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
     vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, nullptr);
     m_errorMonitor->VerifyNotFound();
 
@@ -10996,7 +10996,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
         sycci.components.g = VK_COMPONENT_SWIZZLE_ZERO;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581");
-        vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+        vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
         m_errorMonitor->VerifyFound();
 
         // Non RGB Identity can't have a explicit one swizzle
@@ -11004,7 +11004,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
         sycci.components.g = VK_COMPONENT_SWIZZLE_ONE;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581");
-        vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+        vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
         m_errorMonitor->VerifyFound();
 
         // VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM has 3 component so RGBA conversion has implicit A as one
@@ -11012,7 +11012,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
         sycci.components.g = VK_COMPONENT_SWIZZLE_A;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-components-02581");
-        vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+        vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
         m_errorMonitor->VerifyFound();
     }
     sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;  // reset
@@ -11024,7 +11024,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
         sycci.components = identity;
         sycci.components.g = VK_COMPONENT_SWIZZLE_R;
         m_errorMonitor->ExpectSuccess();
-        vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+        vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
         vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, nullptr);
         m_errorMonitor->VerifyNotFound();
     }
@@ -11032,7 +11032,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     // Create a valid conversion with guaranteed support
     sycci.format = mp_format;
     sycci.components = identity;
-    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, nullptr, &ycbcr_conv);
 
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -11097,7 +11097,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
 
     buffer_create_info.pNext = nullptr;
     VkBuffer buffer;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkBufferDeviceAddressInfoEXT info = LvlInitStruct<VkBufferDeviceAddressInfoEXT>();
@@ -11113,14 +11113,14 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
     m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     VkDeviceMemory buffer_mem;
-    err = vk::AllocateMemory(m_device->device(), &buffer_alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(m_device->device(), &buffer_alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->ExpectSuccess();
     vk::BindBufferMemory(m_device->device(), buffer, buffer_mem, 0);
 
-    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::FreeMemory(m_device->device(), buffer_mem, nullptr);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -11153,7 +11153,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
     buffer_create_info.size = sizeof(uint32_t);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     VkBuffer buffer;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkBufferDeviceAddressInfoEXT info = LvlInitStruct<VkBufferDeviceAddressInfoEXT>();
@@ -11165,7 +11165,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
     vkGetBufferDeviceAddressEXT(m_device->device(), &info);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
 }
 
 TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
@@ -11209,7 +11209,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
 
     buffer_create_info.pNext = nullptr;
     VkBuffer buffer;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkBufferDeviceAddressInfoKHR info = LvlInitStruct<VkBufferDeviceAddressInfoKHR>();
@@ -11238,7 +11238,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
     m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     VkDeviceMemory buffer_mem;
-    err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-bufferDeviceAddress-03339");
@@ -11265,12 +11265,12 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
         }
     }
 
-    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
+    vk::FreeMemory(m_device->device(), buffer_mem, nullptr);
 
     VkMemoryAllocateFlagsInfo alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     buffer_alloc_info.pNext = &alloc_flags;
-    err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
 
     mem_opaque_addr_info.memory = buffer_mem;
     m_errorMonitor->ExpectSuccess();
@@ -11285,8 +11285,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     vkGetBufferDeviceAddressKHR(m_device->device(), &info);
     m_errorMonitor->VerifyNotFound();
 
-    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::FreeMemory(m_device->device(), buffer_mem, nullptr);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
 }
 
 TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
@@ -11324,7 +11324,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     buffer_create_info.size = sizeof(uint32_t);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     VkBuffer buffer;
-    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkBufferDeviceAddressInfoKHR info = LvlInitStruct<VkBufferDeviceAddressInfoKHR>();
@@ -11360,7 +11360,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
     m_device->phy().set_memory_type(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     VkDeviceMemory buffer_mem;
-    err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
 
     VkDeviceMemoryOpaqueCaptureAddressInfoKHR mem_opaque_addr_info = LvlInitStruct<VkDeviceMemoryOpaqueCaptureAddressInfoKHR>();
@@ -11370,7 +11370,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     vkGetDeviceMemoryOpaqueCaptureAddressKHR(m_device->device(), &mem_opaque_addr_info);
     m_errorMonitor->VerifyFound();
 
-    vk::FreeMemory(m_device->device(), buffer_mem, NULL);
+    vk::FreeMemory(m_device->device(), buffer_mem, nullptr);
 
     VkMemoryAllocateFlagsInfo alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR | VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR;
@@ -11378,10 +11378,10 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-flags-03330");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-flags-03331");
-    err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+    err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
+    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
 }
 
 TEST_F(VkLayerTest, CreateImageYcbcrFormats) {
@@ -11580,14 +11580,14 @@ TEST_F(VkLayerTest, InvalidSamplerFilterMinmax) {
     // Wrong mode with a YCbCr Conversion used
     reduction_info.pNext = &ycbcr_info;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-None-01647");
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 
     // Wrong mode with compareEnable
     reduction_info.pNext = nullptr;
     sampler_info.compareEnable = VK_TRUE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-compareEnable-01423");
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 
     vkDestroySamplerYcbcrConversionFunction(m_device->handle(), conversion, nullptr);
@@ -11609,7 +11609,7 @@ TEST_F(VkLayerTest, InvalidMemoryType) {
     mem_alloc.allocationSize = 4;
 
     VkDeviceMemory mem;
-    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
 
     m_errorMonitor->VerifyFound();
 }
@@ -11630,7 +11630,7 @@ TEST_F(VkLayerTest, AllocationBeyondHeapSize) {
     mem_alloc.allocationSize = memory_info.memoryHeaps[memory_info.memoryTypes[0].heapIndex].size + 1;
 
     VkDeviceMemory mem;
-    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
 
     m_errorMonitor->VerifyFound();
 }
@@ -11681,7 +11681,7 @@ TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
     mem_alloc.allocationSize = 4;
 
     VkDeviceMemory mem;
-    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
 
     m_errorMonitor->VerifyFound();
 }
@@ -11711,7 +11711,7 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_create_info.size = 2048;
     buffer_create_info.queueFamilyIndexCount = 0;
-    buffer_create_info.pQueueFamilyIndices = NULL;
+    buffer_create_info.pQueueFamilyIndices = nullptr;
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
@@ -11760,7 +11760,7 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     dedicated_allocate_info.image = normal_image;
     dedicated_allocate_info.buffer = normal_buffer;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-image-01432");
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
     m_errorMonitor->VerifyFound();
 
     if (sparse_support == true) {
@@ -11773,14 +11773,14 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
         dedicated_allocate_info.buffer = VK_NULL_HANDLE;
         memory_allocate_info.allocationSize = sparse_image_memory_req.size;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-image-01434");
-        vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+        vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
         m_errorMonitor->VerifyFound();
 
         dedicated_allocate_info.image = VK_NULL_HANDLE;
         dedicated_allocate_info.buffer = sparse_buffer;
         memory_allocate_info.allocationSize = sparse_buffer_memory_req.size;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01436");
-        vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+        vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
         m_errorMonitor->VerifyFound();
     }
 
@@ -11797,7 +11797,7 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
         dedicated_allocate_info.buffer = VK_NULL_HANDLE;
         memory_allocate_info.allocationSize = mem_req2.memoryRequirements.size;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-image-01797");
-        vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+        vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
         m_errorMonitor->VerifyFound();
     }
 
@@ -11823,14 +11823,14 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     const char *buffer_vuid = "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435";
 #endif
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, image_vuid);
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
     m_errorMonitor->VerifyFound();
 
     memory_allocate_info.allocationSize = normal_buffer_memory_req.size - 1;
     dedicated_allocate_info.image = VK_NULL_HANDLE;
     dedicated_allocate_info.buffer = normal_buffer;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, buffer_vuid);
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &device_memory);
+    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &device_memory);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyImage(device(), normal_image, nullptr);
@@ -11881,7 +11881,7 @@ TEST_F(VkLayerTest, InvalidMemoryRequirements) {
             image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
 
             VkImage image;
-            VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+            VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
             ASSERT_VK_SUCCESS(err);
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageMemoryRequirements-image-01588");
@@ -11924,7 +11924,7 @@ TEST_F(VkLayerTest, InvalidMemoryRequirements) {
 
             // Recreate image without Disjoint bit
             image_create_info.flags = 0;
-            err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+            err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
             ASSERT_VK_SUCCESS(err);
 
             image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -11940,7 +11940,7 @@ TEST_F(VkLayerTest, InvalidMemoryRequirements) {
             // Recreate image with single plane format and with Disjoint bit
             image_create_info.flags = 0;
             image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-            err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+            err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
             ASSERT_VK_SUCCESS(err);
 
             image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -12301,7 +12301,7 @@ TEST_F(VkLayerTest, CustomBorderColor) {
     sampler_info.borderColor = VK_BORDER_COLOR_INT_CUSTOM_EXT;
     // No SCBCCreateInfo in pNext
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-borderColor-04011");
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 
     VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = LvlInitStruct<VkSamplerCustomBorderColorCreateInfoEXT>();
@@ -12309,25 +12309,26 @@ TEST_F(VkLayerTest, CustomBorderColor) {
     sampler_info.pNext = &custom_color_cinfo;
     // Format mismatch
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04013");
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 
     custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
     // Format undefined with no customBorderColorWithoutFormat
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04014");
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyFound();
 
     custom_color_cinfo.format = VK_FORMAT_R8G8B8A8_UINT;
     m_errorMonitor->ExpectSuccess();
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyNotFound();
 
     VkDescriptorSetLayoutBinding dsl_binding = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler};
-    VkDescriptorSetLayoutCreateInfo ds_layout_ci = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, NULL, 0, 1, &dsl_binding};
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0, 1,
+                                                    &dsl_binding};
     VkDescriptorSetLayout ds_layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-pImmutableSamplers-04009");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
@@ -12346,7 +12347,7 @@ TEST_F(VkLayerTest, CustomBorderColor) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateSampler-maxSamplerAllocationCount-04110");
         }
         for (uint32_t i = 0; i < custom_properties.maxCustomBorderColorSamplers; i++) {
-            vk::CreateSampler(m_device->device(), &sampler_info, NULL, &samplers[i]);
+            vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &samplers[i]);
         }
         m_errorMonitor->VerifyFound();
         for (uint32_t i = 0; i < custom_properties.maxCustomBorderColorSamplers - 1; i++) {
@@ -12383,7 +12384,7 @@ TEST_F(VkLayerTest, CustomBorderColorFormatUndefined) {
     custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
     sampler_info.pNext = &custom_color_cinfo;
     m_errorMonitor->ExpectSuccess();
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     m_errorMonitor->VerifyNotFound();
 
     VkImageObj image(m_device);
@@ -12411,7 +12412,7 @@ TEST_F(VkLayerTest, CustomBorderColorFormatUndefined) {
     descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_writes[0].pImageInfo = &img_info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
     char const *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
@@ -12431,7 +12432,7 @@ TEST_F(VkLayerTest, CustomBorderColorFormatUndefined) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, NULL);
+                              &descriptor_set.set_, 0, nullptr);
     VkViewport viewport = m_viewports[0];
     VkRect2D scissor = m_scissors[0];
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -12488,7 +12489,7 @@ TEST_F(VkLayerTest, InvalidExportExternalImageHandleType) {
     image_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkResult result = vk::CreateImage(device(), &image_info, NULL, &image_export);
+    VkResult result = vk::CreateImage(device(), &image_info, nullptr, &image_export);
     if (result != VK_SUCCESS) {
         printf("%s Unable to create a valid external image.\n", kSkipPrefix);
         return;
@@ -12518,7 +12519,7 @@ TEST_F(VkLayerTest, InvalidExportExternalImageHandleType) {
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-memory-02728");
     vk::BindImageMemory(device(), image_export, memory, 0);
@@ -12579,7 +12580,7 @@ TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
     VkBufferCreateInfo buffer_info = LvlInitStruct<VkBufferCreateInfo>(&external_buffer_info);
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_info.size = 4096;
-    VkResult result = vk::CreateBuffer(device(), &buffer_info, NULL, &buffer_export);
+    VkResult result = vk::CreateBuffer(device(), &buffer_info, nullptr, &buffer_export);
     if (result != VK_SUCCESS) {
         printf("%s Unable to create a valid external buffer.\n", kSkipPrefix);
         return;
@@ -12609,7 +12610,7 @@ TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memory-02726");
     vk::BindBufferMemory(device(), buffer_export, memory, 0);
@@ -13095,7 +13096,7 @@ TEST_F(VkLayerTest, InvalidShadingRateUsage) {
 
     // Create a view with the fragment shading rate attachment usage, but that doesn't support it
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-usage-04550");
-    vk::CreateImageView(m_device->device(), &createinfo, NULL, &imageview);
+    vk::CreateImageView(m_device->device(), &createinfo, nullptr, &imageview);
     m_errorMonitor->VerifyFound();
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsrProperties =
@@ -13124,7 +13125,7 @@ TEST_F(VkLayerTest, InvalidShadingRateUsage) {
             createinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-usage-04551");
-            vk::CreateImageView(m_device->device(), &createinfo, NULL, &imageview);
+            vk::CreateImageView(m_device->device(), &createinfo, nullptr, &imageview);
             m_errorMonitor->VerifyFound();
         }
     }
@@ -13298,7 +13299,7 @@ TEST_F(VkLayerTest, SparseMemoryBindOffset) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buffer_create_info.size = 1024;
     buffer_create_info.queueFamilyIndexCount = 0;
-    buffer_create_info.pQueueFamilyIndices = NULL;
+    buffer_create_info.pQueueFamilyIndices = nullptr;
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     if (m_device->phy().features().sparseResidencyBuffer) {
@@ -13322,7 +13323,7 @@ TEST_F(VkLayerTest, SparseMemoryBindOffset) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     if (m_device->phy().features().sparseResidencyImage2D) {
@@ -13445,7 +13446,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCount) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -13558,7 +13559,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -13577,7 +13578,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
         }
     }
 
-    vk::AllocateMemory(device(), &mem_alloc, NULL, &image_mem);
+    vk::AllocateMemory(device(), &mem_alloc, nullptr, &image_mem);
 
     VkRect2D splitInstanceBindregion = {{0, 0}, {16, 16}};
     VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
@@ -13597,7 +13598,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
 TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBindings) {
     TEST_DESCRIPTION("Create descriptor set layout with incompatible bindings.");
 
-    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, NULL,
+    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, nullptr,
                                                          m_errorMonitor))) {
         printf("Descriptor indexing or one of its dependencies not supported, skipping tests\n");
         return;
@@ -13674,7 +13675,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBinding) {
 
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
 
     VkDescriptorSetLayoutBinding binding = {};
     binding.binding = 0;
@@ -13732,7 +13733,7 @@ TEST_F(VkLayerTest, DedicatedAllocationBufferWithInvalidFlags) {
 
     VkBuffer buffer;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-pNext-01571");
-    vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+    vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
     m_errorMonitor->VerifyFound();
 }
 
@@ -13768,7 +13769,7 @@ TEST_F(VkLayerTest, InvalidMemoryAllocatepNextChain) {
     VkDeviceMemory mem;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
-    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
     m_errorMonitor->VerifyFound();
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -13778,7 +13779,7 @@ TEST_F(VkLayerTest, InvalidMemoryAllocatepNextChain) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
     export_memory_info.pNext = &export_memory_info_win32_nv;
-    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
     m_errorMonitor->VerifyFound();
 #endif
 }
@@ -13813,7 +13814,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidLevelOrLayerCount) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -13978,7 +13979,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidType) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -14029,7 +14030,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidFormat) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -14094,7 +14095,7 @@ TEST_F(VkLayerTest, InvalidImageSubresourceRangeAspectMask) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkImageObj image(m_device);
@@ -14164,7 +14165,7 @@ TEST_F(VkLayerTest, InvalidCreateImageQueueFamilies) {
     CreateImageTest(*this, &image_create_info, vuid);
 
     uint32_t queue_node_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, nullptr);
 
     queue_families[1] = queue_node_count;
     CreateImageTest(*this, &image_create_info, vuid);
@@ -15003,7 +15004,7 @@ TEST_F(VkLayerTest, ImageViewMinLod) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImageView(m_device->device(), image_view, NULL);
+    vk::DestroyImageView(m_device->device(), image_view, nullptr);
 }
 
 TEST_F(VkLayerTest, ImageViewMinLodFeature) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -43,7 +43,8 @@ TEST_F(VkLayerTest, BufferExtents) {
 
     PFN_vkCmdCopyBuffer2KHR vkCmdCopyBuffer2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyBuffer2Function = (PFN_vkCmdCopyBuffer2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBuffer2KHR");
+        vkCmdCopyBuffer2Function =
+            reinterpret_cast<PFN_vkCmdCopyBuffer2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBuffer2KHR"));
     }
 
     const VkDeviceSize buffer_size = 2048;
@@ -1006,8 +1007,8 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
 
     PFN_vkCmdCopyBufferToImage2KHR vkCmdCopyBufferToImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyBufferToImage2Function =
-            (PFN_vkCmdCopyBufferToImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBufferToImage2KHR");
+        vkCmdCopyBufferToImage2Function = reinterpret_cast<PFN_vkCmdCopyBufferToImage2KHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBufferToImage2KHR"));
     }
 
     auto format = FindSupportedDepthStencilFormat(gpu());
@@ -1616,9 +1617,10 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
         vkBindImageMemory2Function = vk::BindImageMemory2;
         vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
     } else {
-        vkBindImageMemory2Function = (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
-        vkGetImageMemoryRequirements2Function =
-            (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+        vkBindImageMemory2Function =
+            reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
+        vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
     }
 
     // Try to bind an image created with Disjoint bit
@@ -1768,7 +1770,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
             vkBindImageMemory2Function = vk::BindImageMemory2;
         } else {
             vkBindImageMemory2Function =
-                (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+                reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
         }
     }
 
@@ -1776,8 +1778,8 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
         if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
             vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
         } else {
-            vkGetImageMemoryRequirements2Function =
-                (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+            vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+                vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
         }
     }
 
@@ -2223,10 +2225,10 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
             vkBindImageMemory2Function = vk::BindImageMemory2;
             vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
         } else {
-            vkGetImageMemoryRequirements2Function =
-                (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+            vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+                vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
             vkBindImageMemory2Function =
-                (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+                reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
         }
 
         VkImage mp_image = VK_NULL_HANDLE;
@@ -2333,7 +2335,8 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         vkBindImageMemory2Function = vk::BindImageMemory2;
     } else {
-        vkBindImageMemory2Function = (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+        vkBindImageMemory2Function =
+            reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
     }
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
@@ -2413,8 +2416,8 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
             vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
         } else {
-            vkGetImageMemoryRequirements2Function =
-                (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+            vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+                vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
         }
 
         // Creat 1 normal, not disjoint image
@@ -2586,10 +2589,10 @@ TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+    auto fpvkSetPhysicalDeviceLimitsEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    auto fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -2635,10 +2638,10 @@ TEST_F(VkLayerTest, ExceedSamplerAllocationCount) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+    auto fpvkSetPhysicalDeviceLimitsEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    auto fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -2797,7 +2800,8 @@ TEST_F(VkLayerTest, BlitImageFormatTypes) {
 
     PFN_vkCmdBlitImage2KHR vkCmdBlitImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdBlitImage2Function = (PFN_vkCmdBlitImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBlitImage2KHR");
+        vkCmdBlitImage2Function =
+            reinterpret_cast<PFN_vkCmdBlitImage2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBlitImage2KHR"));
     }
 
     VkFormat f_unsigned = VK_FORMAT_R8G8B8A8_UINT;
@@ -5599,8 +5603,8 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     const bool external_memory = CanEnableDeviceExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
 
     // Set separate depth stencil feature bit
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&separate_depth_stencil_layouts_features);
     if (vkGetPhysicalDeviceFeatures2KHR) {
@@ -5833,9 +5837,9 @@ TEST_F(VkLayerTest, InvalidBarriers) {
             vkGetImageMemoryRequirements2Function = vk::GetImageMemoryRequirements2;
         } else {
             vkBindImageMemory2Function =
-                (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
-            vkGetImageMemoryRequirements2Function =
-                (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+                reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
+            vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+                vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
         }
 
         VkFormatProperties format_properties;
@@ -7156,7 +7160,8 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
 
     PFN_vkCmdCopyImage2KHR vkCmdCopyImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyImage2Function = (PFN_vkCmdCopyImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR");
+        vkCmdCopyImage2Function =
+            reinterpret_cast<PFN_vkCmdCopyImage2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR"));
     }
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
@@ -7557,7 +7562,8 @@ TEST_F(VkLayerTest, CopyInvalidImageMemory) {
 
     PFN_vkCmdCopyImage2KHR vkCmdCopyImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyImage2Function = (PFN_vkCmdCopyImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR");
+        vkCmdCopyImage2Function =
+            reinterpret_cast<PFN_vkCmdCopyImage2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR"));
     }
     VkImageCreateInfo image_info = LvlInitStruct<VkImageCreateInfo>();
     image_info.extent = {64, 64, 1};
@@ -8480,11 +8486,10 @@ TEST_F(VkLayerTest, CreateImageViewFormatMismatchUnrelated) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Load required functions
-    PFN_vkSetPhysicalDeviceFormatPropertiesEXT fpvkSetPhysicalDeviceFormatPropertiesEXT =
-        (PFN_vkSetPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatPropertiesEXT");
-    PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT =
-        (PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(
-            instance(), "vkGetOriginalPhysicalDeviceFormatPropertiesEXT");
+    auto fpvkSetPhysicalDeviceFormatPropertiesEXT = reinterpret_cast<PFN_vkSetPhysicalDeviceFormatPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatPropertiesEXT"));
+    auto fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFormatPropertiesEXT"));
 
     if (!(fpvkSetPhysicalDeviceFormatPropertiesEXT) || !(fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -10284,8 +10289,8 @@ TEST_F(VkLayerTest, ExtensionNotEnabled) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Find address of extension API
-    auto vkCreateSamplerYcbcrConversionKHR =
-        (PFN_vkCreateSamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR");
+    auto vkCreateSamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR"));
     if (vkCreateSamplerYcbcrConversionKHR == nullptr) {
         printf("%s VK_KHR_sampler_ycbcr_conversion not supported by device; skipped.\n", kSkipPrefix);
         return;
@@ -10612,9 +10617,9 @@ TEST_F(VkLayerTest, ImageStencilCreate) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(&device_features));
 
-    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR vkGetPhysicalDeviceImageFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    auto vkGetPhysicalDeviceImageFormatProperties2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>(vk::GetInstanceProcAddr(instance(),
+                                                                                  "vkGetPhysicalDeviceImageFormatProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceImageFormatProperties2KHR != nullptr);
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
@@ -10759,10 +10764,10 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
         vkCreateSamplerYcbcrConversionFunction = vk::CreateSamplerYcbcrConversion;
         vkDestroySamplerYcbcrConversionFunction = vk::DestroySamplerYcbcrConversion;
     } else {
-        vkCreateSamplerYcbcrConversionFunction =
-            (PFN_vkCreateSamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR");
-        vkDestroySamplerYcbcrConversionFunction =
-            (PFN_vkDestroySamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR");
+        vkCreateSamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR"));
+        vkDestroySamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR"));
     }
 
     if (!vkCreateSamplerYcbcrConversionFunction || !vkDestroySamplerYcbcrConversionFunction) {
@@ -11080,8 +11085,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetBufferDeviceAddressEXT vkGetBufferDeviceAddressEXT =
-        (PFN_vkGetBufferDeviceAddressEXT)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressEXT");
+    auto vkGetBufferDeviceAddressEXT =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressEXT>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -11146,8 +11151,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetBufferDeviceAddressEXT vkGetBufferDeviceAddressEXT =
-        (PFN_vkGetBufferDeviceAddressEXT)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressEXT");
+    auto vkGetBufferDeviceAddressEXT =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressEXT>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -11190,10 +11195,10 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
-    PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR vkGetDeviceMemoryOpaqueCaptureAddressKHR =
-        (PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
+    auto vkGetDeviceMemoryOpaqueCaptureAddressKHR = reinterpret_cast<PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR>(
+        vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddressKHR"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -11220,7 +11225,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     m_errorMonitor->VerifyFound();
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-        auto fpGetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddress");
+        auto fpGetBufferDeviceAddress =
+            reinterpret_cast<PFN_vkGetBufferDeviceAddress>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddress"));
         if (nullptr == fpGetBufferDeviceAddress) {
             m_errorMonitor->ExpectSuccess();
             m_errorMonitor->SetError("No ProcAddr for 1.2 core vkGetBufferDeviceAddress");
@@ -11252,8 +11258,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     m_errorMonitor->VerifyFound();
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-        auto fpGetDeviceMemoryOpaqueCaptureAddress =
-            (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddress");
+        auto fpGetDeviceMemoryOpaqueCaptureAddress = reinterpret_cast<PFN_vkGetDeviceMemoryOpaqueCaptureAddress>(
+            vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddress"));
         if (nullptr == fpGetDeviceMemoryOpaqueCaptureAddress) {
             m_errorMonitor->ExpectSuccess();
             m_errorMonitor->SetError("No ProcAddr for 1.2 core vkGetDeviceMemoryOpaqueCaptureAddress");
@@ -11313,12 +11319,12 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
-    PFN_vkGetBufferOpaqueCaptureAddressKHR vkGetBufferOpaqueCaptureAddressKHR =
-        (PFN_vkGetBufferOpaqueCaptureAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferOpaqueCaptureAddressKHR");
-    PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR vkGetDeviceMemoryOpaqueCaptureAddressKHR =
-        (PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
+    auto vkGetBufferOpaqueCaptureAddressKHR = reinterpret_cast<PFN_vkGetBufferOpaqueCaptureAddressKHR>(
+        vk::GetDeviceProcAddr(device(), "vkGetBufferOpaqueCaptureAddressKHR"));
+    auto vkGetDeviceMemoryOpaqueCaptureAddressKHR = reinterpret_cast<PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR>(
+        vk::GetDeviceProcAddr(device(), "vkGetDeviceMemoryOpaqueCaptureAddressKHR"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -11341,8 +11347,8 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     m_errorMonitor->VerifyFound();
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-        auto fpGetBufferOpaqueCaptureAddress =
-            (PFN_vkGetBufferOpaqueCaptureAddress)vk::GetDeviceProcAddr(device(), "vkGetBufferOpaqueCaptureAddress");
+        auto fpGetBufferOpaqueCaptureAddress = reinterpret_cast<PFN_vkGetBufferOpaqueCaptureAddress>(
+            vk::GetDeviceProcAddr(device(), "vkGetBufferOpaqueCaptureAddress"));
         if (nullptr == fpGetBufferOpaqueCaptureAddress) {
             m_errorMonitor->ExpectSuccess();
             m_errorMonitor->SetError("No ProcAddr for 1.2 core vkGetBufferOpaqueCaptureAddress");
@@ -11539,10 +11545,10 @@ TEST_F(VkLayerTest, InvalidSamplerFilterMinmax) {
         vkCreateSamplerYcbcrConversionFunction = vk::CreateSamplerYcbcrConversion;
         vkDestroySamplerYcbcrConversionFunction = vk::DestroySamplerYcbcrConversion;
     } else {
-        vkCreateSamplerYcbcrConversionFunction =
-            (PFN_vkCreateSamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR");
-        vkDestroySamplerYcbcrConversionFunction =
-            (PFN_vkDestroySamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR");
+        vkCreateSamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR"));
+        vkDestroySamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR"));
     }
 
     if (!vkCreateSamplerYcbcrConversionFunction || !vkDestroySamplerYcbcrConversionFunction) {
@@ -11889,8 +11895,8 @@ TEST_F(VkLayerTest, InvalidMemoryRequirements) {
             vk::GetImageMemoryRequirements(m_device->device(), image, &memory_requirements);
             m_errorMonitor->VerifyFound();
 
-            PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2Function =
-                (PFN_vkGetImageMemoryRequirements2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR");
+            auto vkGetImageMemoryRequirements2Function = reinterpret_cast<PFN_vkGetImageMemoryRequirements2KHR>(
+                vk::GetDeviceProcAddr(m_device->handle(), "vkGetImageMemoryRequirements2KHR"));
             ASSERT_TRUE(vkGetImageMemoryRequirements2Function != nullptr);
 
             VkImageMemoryRequirementsInfo2 mem_req_info2 = LvlInitStruct<VkImageMemoryRequirementsInfo2>();
@@ -11982,16 +11988,16 @@ TEST_F(VkLayerTest, FragmentDensityMapEnabled) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentDensityMap2FeaturesEXT density_map2_features =
         LvlInitStruct<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&density_map2_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentDensityMap2PropertiesEXT density_map2_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>();
@@ -12331,8 +12337,8 @@ TEST_F(VkLayerTest, CustomBorderColor) {
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_properties =
         LvlInitStruct<VkPhysicalDeviceCustomBorderColorPropertiesEXT>();
@@ -12526,8 +12532,8 @@ TEST_F(VkLayerTest, InvalidExportExternalImageHandleType) {
     m_errorMonitor->VerifyFound();
 
     if (bind_memory2 == true) {
-        PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
-            (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+        auto vkBindImageMemory2Function =
+            reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
 
         VkBindImageMemoryInfo bind_image_info = LvlInitStruct<VkBindImageMemoryInfo>();
         bind_image_info.image = image_export;
@@ -12617,8 +12623,8 @@ TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
     m_errorMonitor->VerifyFound();
 
     if (bind_memory2 == true) {
-        PFN_vkBindBufferMemory2KHR vkBindBufferMemory2Function =
-            (PFN_vkBindBufferMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR");
+        auto vkBindBufferMemory2Function =
+            reinterpret_cast<PFN_vkBindBufferMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR"));
 
         VkBindBufferMemoryInfo bind_buffer_info = LvlInitStruct<VkBindBufferMemoryInfo>();
         bind_buffer_info.buffer = buffer_export;
@@ -13428,7 +13434,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCount) {
             vkBindImageMemory2Function = vk::BindImageMemory2;
         } else {
             vkBindImageMemory2Function =
-                (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+                reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
         }
     }
 
@@ -13542,7 +13548,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
         vkBindImageMemory2Function = vk::BindImageMemory2;
     } else {
         vkBindImageMemory2Function =
-            (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+            reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
     }
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>(nullptr);
@@ -13604,8 +13610,8 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBindings) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
@@ -13664,8 +13670,8 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBinding) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -13893,8 +13899,8 @@ TEST_F(VkLayerTest, InvalidBindIMageMemoryDeviceGroupInfo) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
-        (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+    auto vkBindImageMemory2Function =
+        reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.flags = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
@@ -14184,8 +14190,8 @@ TEST_F(VkLayerTest, InvalidConditionalRenderingBufferUsage) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT");
+    auto vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 1024;
@@ -14220,8 +14226,8 @@ TEST_F(VkLayerTest, ImageFormatInfoDrmFormatModifier) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto vkGetPhysicalDeviceImageFormatProperties2KHR = (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    auto vkGetPhysicalDeviceImageFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceImageFormatProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceImageFormatProperties2KHR != nullptr);
 
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT image_drm_format_modifier =
@@ -14371,8 +14377,8 @@ TEST_F(VkLayerTest, InvalidConditionalRenderingOffset) {
     m_device_extension_names.push_back(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT");
+    auto vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 128;
@@ -14410,10 +14416,10 @@ TEST_F(VkLayerTest, InvalidBeginConditionalRendering) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT");
-    PFN_vkCmdEndConditionalRenderingEXT vkCmdEndConditionalRenderingEXT =
-        (PFN_vkCmdEndConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdEndConditionalRenderingEXT");
+    auto vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT"));
+    auto vkCmdEndConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdEndConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdEndConditionalRenderingEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 32;
@@ -14553,8 +14559,8 @@ TEST_F(VkLayerTest, CopyMutableDescriptors) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -14839,8 +14845,8 @@ TEST_F(VkLayerTest, ValidateUpdatingMutableDescriptors) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -14949,8 +14955,8 @@ TEST_F(VkLayerTest, ImageViewMinLod) {
     }
     auto image_view_min_lod_features = LvlInitStruct<VkPhysicalDeviceImageViewMinLodFeaturesEXT>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&image_view_min_lod_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (image_view_min_lod_features.minLod == VK_FALSE) {
         printf("%s image view min lod feature not supported. Skipped.\n", kSkipPrefix);
@@ -15040,7 +15046,7 @@ TEST_F(VkLayerTest, ValidateDeviceImageMemoryRequirements) {
         return;
     }
 
-    PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirementsKHR =
+    auto vkGetDeviceImageMemoryRequirementsKHR =
         reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(vk::GetInstanceProcAddr(instance(), "vkGetDeviceImageMemoryRequirementsKHR"));
     assert(vkGetDeviceImageMemoryRequirementsKHR != nullptr);
 

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -5402,12 +5402,11 @@ TEST_F(VkLayerTest, SetDynViewportParamTests) {
 TEST_F(VkLayerTest, SetDynViewportParamMaintenance1Tests) {
     TEST_DESCRIPTION("Verify errors are detected on misuse of SetViewport with a negative viewport extension enabled.");
 
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
-    } else {
-        printf("%s VK_KHR_maintenance1 extension not supported -- skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported -- skipping test\n", kSkipPrefix, VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -5569,10 +5568,9 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
@@ -5694,10 +5692,9 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdBufferOffsetUnaligned) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
@@ -5852,6 +5849,7 @@ TEST_F(VkLayerTest, SetDynScissorParamMultiviewportTests) {
 TEST_F(VkLayerTest, MultiDrawTests) {
     TEST_DESCRIPTION("Test validation of multi_draw extension");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         printf("%s Tests requires Vulkan 1.2+, skipping test\n", kSkipPrefix);
@@ -5865,10 +5863,8 @@ TEST_F(VkLayerTest, MultiDrawTests) {
         printf("%s Test requires (unsupported) multiDraw, skipping\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_MULTI_DRAW_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
-    } else {
-        printf("%s VK_EXT_multi_draw extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_EXT_MULTI_DRAW_EXTENSION_NAME);
         return;
     }
     auto multi_draw_properties = LvlInitStruct<VkPhysicalDeviceMultiDrawPropertiesEXT>();
@@ -5951,15 +5947,14 @@ TEST_F(VkLayerTest, MultiDrawTests) {
 TEST_F(VkLayerTest, MultiDrawFeatures) {
     TEST_DESCRIPTION("Test validation of multi draw feature enabled");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         printf("%s Tests requires Vulkan 1.2+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_MULTI_DRAW_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
-    } else {
-        printf("%s VK_EXT_multi_draw extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_EXT_MULTI_DRAW_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -6087,12 +6082,11 @@ TEST_F(VkLayerTest, DrawIndirectByteCountEXT) {
                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    } else {
-        printf("%s VK_EXT_transform_feedback extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
         return;
     }
 
@@ -6180,11 +6174,10 @@ TEST_F(VkLayerTest, DrawIndirectByteCountEXT) {
 TEST_F(VkLayerTest, DrawIndirectCountKHR) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndirectCountKHR");
 
+    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
-    } else {
-        printf("             VK_KHR_draw_indirect_count Extension not supported, skipping test\n");
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -6286,11 +6279,10 @@ TEST_F(VkLayerTest, DrawIndirectCountKHR) {
 TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndexedIndirectCountKHR");
 
+    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
-    } else {
-        printf("             VK_KHR_draw_indirect_count Extension not supported, skipping test\n");
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -200,8 +200,8 @@ TEST_F(VkLayerTest, DynamicLineStippleNotBound) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto line_rasterization_features = LvlInitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
@@ -395,7 +395,8 @@ TEST_F(VkLayerTest, Sync2SecondaryCommandbufferAsPrimary) {
         printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    auto fpQueueSubmit2KHR = (PFN_vkQueueSubmit2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR");
+    auto fpQueueSubmit2KHR =
+        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferSubmitInfo-commandBuffer-03890");
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
@@ -465,7 +466,8 @@ TEST_F(VkLayerTest, Sync2CommandBufferTwoSubmits) {
         printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    auto fpQueueSubmit2KHR = (PFN_vkQueueSubmit2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR");
+    auto fpQueueSubmit2KHR =
+        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "was begun w/ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT set, but has been submitted");
@@ -1505,8 +1507,8 @@ TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
 
     PFN_vkCmdCopyBufferToImage2KHR vkCmdCopyBufferToImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyBufferToImage2Function =
-            (PFN_vkCmdCopyBufferToImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBufferToImage2KHR");
+        vkCmdCopyBufferToImage2Function = reinterpret_cast<PFN_vkCmdCopyBufferToImage2KHR>(
+            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyBufferToImage2KHR"));
     }
 
     VkPhysicalDeviceFeatures device_features = {};
@@ -2530,7 +2532,8 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
 
     PFN_vkCmdCopyImage2KHR vkCmdCopyImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdCopyImage2Function = (PFN_vkCmdCopyImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR");
+        vkCmdCopyImage2Function =
+            reinterpret_cast<PFN_vkCmdCopyImage2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyImage2KHR"));
     }
 
     // Tests are designed to run without Maintenance1 which was promoted in 1.1
@@ -4599,7 +4602,8 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
 
     PFN_vkCmdResolveImage2KHR vkCmdResolveImage2Function = nullptr;
     if (copy_commands2) {
-        vkCmdResolveImage2Function = (PFN_vkCmdResolveImage2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdResolveImage2KHR");
+        vkCmdResolveImage2Function =
+            reinterpret_cast<PFN_vkCmdResolveImage2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdResolveImage2KHR"));
     }
 
     // Create two images of different types and try to copy between them
@@ -5605,8 +5609,8 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
         vk_testing::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
     // Find address of extension call and make the call
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
     ASSERT_TRUE(vkCmdPushDescriptorSetKHR != nullptr);
 
     // Section 1: Queue family matching/capabilities.
@@ -5728,8 +5732,8 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdBufferOffsetUnaligned) {
     VkWriteDescriptorSet descriptor_write = vk_testing::Device::write_descriptor_set(
         vk_testing::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
     ASSERT_TRUE(vkCmdPushDescriptorSetKHR != nullptr);
 
     m_commandBuffer->begin();
@@ -5874,9 +5878,10 @@ TEST_F(VkLayerTest, MultiDrawTests) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT");
+    auto vkCmdDrawMultiEXT =
+        reinterpret_cast<PFN_vkCmdDrawMultiEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT"));
     auto vkCmdDrawMultiIndexedEXT =
-        (PFN_vkCmdDrawMultiIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT");
+        reinterpret_cast<PFN_vkCmdDrawMultiIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT"));
     assert(vkCmdDrawMultiEXT != nullptr && vkCmdDrawMultiIndexedEXT != nullptr);
 
     VkMultiDrawInfoEXT multi_draws[3] = {};
@@ -5968,9 +5973,10 @@ TEST_F(VkLayerTest, MultiDrawFeatures) {
         return;
     }
 
-    auto vkCmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT");
+    auto vkCmdDrawMultiEXT =
+        reinterpret_cast<PFN_vkCmdDrawMultiEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT"));
     auto vkCmdDrawMultiIndexedEXT =
-        (PFN_vkCmdDrawMultiIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT");
+        reinterpret_cast<PFN_vkCmdDrawMultiIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT"));
     assert(vkCmdDrawMultiEXT != nullptr && vkCmdDrawMultiIndexedEXT != nullptr);
 
     VkMultiDrawInfoEXT multi_draws[3] = {};
@@ -6097,8 +6103,8 @@ TEST_F(VkLayerTest, DrawIndirectByteCountEXT) {
     auto pd_properties = LvlInitStruct<VkPhysicalDeviceProperties2>(&tf_properties);
     vk::GetPhysicalDeviceProperties2(gpu(), &pd_properties);
 
-    PFN_vkCmdDrawIndirectByteCountEXT fpvkCmdDrawIndirectByteCountEXT =
-        (PFN_vkCmdDrawIndirectByteCountEXT)vk::GetDeviceProcAddr(device(), "vkCmdDrawIndirectByteCountEXT");
+    auto fpvkCmdDrawIndirectByteCountEXT =
+        reinterpret_cast<PFN_vkCmdDrawIndirectByteCountEXT>(vk::GetDeviceProcAddr(device(), "vkCmdDrawIndirectByteCountEXT"));
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -6188,7 +6194,7 @@ TEST_F(VkLayerTest, DrawIndirectCountKHR) {
     VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>();
 
     auto vkCmdDrawIndirectCountKHR =
-        (PFN_vkCmdDrawIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
+        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR"));
 
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
@@ -6290,8 +6296,8 @@ TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdDrawIndexedIndirectCountKHR =
-        (PFN_vkCmdDrawIndexedIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR");
+    auto vkCmdDrawIndexedIndirectCountKHR = reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR"));
 
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
@@ -6462,8 +6468,8 @@ TEST_F(VkLayerTest, ExclusiveScissorNV) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables exclusive scissor but disables multiViewport
@@ -6541,8 +6547,8 @@ TEST_F(VkLayerTest, ExclusiveScissorNV) {
 
     // Based on SetDynScissorParamTests
     {
-        auto vkCmdSetExclusiveScissorNV =
-            (PFN_vkCmdSetExclusiveScissorNV)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetExclusiveScissorNV");
+        auto vkCmdSetExclusiveScissorNV = reinterpret_cast<PFN_vkCmdSetExclusiveScissorNV>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetExclusiveScissorNV"));
 
         const VkRect2D scissor = {{0, 0}, {16, 16}};
         const VkRect2D scissors[] = {scissor, scissor};
@@ -6629,8 +6635,8 @@ TEST_F(VkLayerTest, MeshShaderNV) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables mesh_shader
@@ -6701,8 +6707,8 @@ TEST_F(VkLayerTest, MeshShaderNV) {
                                                                "VUID-VkGraphicsPipelineCreateInfo-pStages-02098"}));
     }
 
-    PFN_vkCmdDrawMeshTasksIndirectNV vkCmdDrawMeshTasksIndirectNV =
-        (PFN_vkCmdDrawMeshTasksIndirectNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectNV");
+    auto vkCmdDrawMeshTasksIndirectNV =
+        reinterpret_cast<PFN_vkCmdDrawMeshTasksIndirectNV>(vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectNV"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -7039,8 +7045,8 @@ TEST_F(VkLayerTest, CreateSamplerYcbcrConversionEnable) {
     ycbcr_features.samplerYcbcrConversion = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ycbcr_features));
 
-    PFN_vkCreateSamplerYcbcrConversionKHR vkCreateSamplerYcbcrConversionFunction =
-        (PFN_vkCreateSamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR");
+    auto vkCreateSamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR"));
     if (vkCreateSamplerYcbcrConversionFunction == nullptr) {
         printf("%s did not find vkCreateSamplerYcbcrConversionKHR function pointer;  Skipping.\n", kSkipPrefix);
         return;
@@ -7084,8 +7090,8 @@ TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
     m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
 
     {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         auto tf_features = LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
@@ -7102,8 +7108,8 @@ TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     {
-        auto vkCmdBindTransformFeedbackBuffersEXT = (PFN_vkCmdBindTransformFeedbackBuffersEXT)vk::GetDeviceProcAddr(
-            m_device->device(), "vkCmdBindTransformFeedbackBuffersEXT");
+        auto vkCmdBindTransformFeedbackBuffersEXT = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindTransformFeedbackBuffersEXT"));
         ASSERT_TRUE(vkCmdBindTransformFeedbackBuffersEXT != nullptr);
 
         auto info = LvlInitStruct<VkBufferCreateInfo>();
@@ -7119,8 +7125,8 @@ TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
     }
 
     {
-        auto vkCmdBeginTransformFeedbackEXT =
-            (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+        auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
         ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-transformFeedback-02366");
@@ -7129,8 +7135,8 @@ TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
     }
 
     {
-        auto vkCmdEndTransformFeedbackEXT =
-            (PFN_vkCmdEndTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT");
+        auto vkCmdEndTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT"));
         ASSERT_TRUE(vkCmdEndTransformFeedbackEXT != nullptr);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndTransformFeedbackEXT-transformFeedback-02374");
@@ -7164,8 +7170,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
     m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
 
     {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         auto tf_features = LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
@@ -7182,8 +7188,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdBindTransformFeedbackBuffersEXT =
-        (PFN_vkCmdBindTransformFeedbackBuffersEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindTransformFeedbackBuffersEXT");
+    auto vkCmdBindTransformFeedbackBuffersEXT = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindTransformFeedbackBuffersEXT"));
     ASSERT_TRUE(vkCmdBindTransformFeedbackBuffersEXT != nullptr);
 
     {
@@ -7278,8 +7284,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
 
         // Bind while transform feedback is active.
         {
-            auto vkCmdBeginTransformFeedbackEXT =
-                (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+            auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+                vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
             ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
             vkCmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
 
@@ -7289,8 +7295,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
             vkCmdBindTransformFeedbackBuffersEXT(m_commandBuffer->handle(), 0, 1, &buffer_obj.handle(), offsets, nullptr);
             m_errorMonitor->VerifyFound();
 
-            auto vkCmdEndTransformFeedbackEXT =
-                (PFN_vkCmdEndTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT");
+            auto vkCmdEndTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+                vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT"));
             ASSERT_TRUE(vkCmdEndTransformFeedbackEXT != nullptr);
             vkCmdEndTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
         }
@@ -7315,7 +7321,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
     {
         VkBuffer buffer{};
         {
-            auto vkCreateBuffer = (PFN_vkCreateBuffer)vk::GetDeviceProcAddr(m_device->device(), "vkCreateBuffer");
+            auto vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateBuffer"));
             ASSERT_TRUE(vkCreateBuffer != nullptr);
 
             auto info = LvlInitStruct<VkBufferCreateInfo>();
@@ -7356,8 +7362,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
     m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
 
     {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         auto tf_features = LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
@@ -7374,8 +7380,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdBeginTransformFeedbackEXT =
-        (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+    auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
     ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
 
     {
@@ -7447,8 +7453,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
         vkCmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
         m_errorMonitor->VerifyFound();
 
-        auto vkCmdEndTransformFeedbackEXT =
-            (PFN_vkCmdEndTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT");
+        auto vkCmdEndTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT"));
         ASSERT_TRUE(vkCmdEndTransformFeedbackEXT != nullptr);
 
         vkCmdEndTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
@@ -7479,8 +7485,8 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
     m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
 
     {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         auto tf_features = LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
@@ -7497,14 +7503,14 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdEndTransformFeedbackEXT =
-        (PFN_vkCmdEndTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT");
+    auto vkCmdEndTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT"));
     ASSERT_TRUE(vkCmdEndTransformFeedbackEXT != nullptr);
 
     {
         // Activate transform feedback.
-        auto vkCmdBeginTransformFeedbackEXT =
-            (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+        auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
         ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
         vkCmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
 
@@ -7595,8 +7601,8 @@ TEST_F(VkLayerTest, InvalidUnprotectedCommands) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -7693,11 +7699,11 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -8130,8 +8136,8 @@ TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto atomic_float_features = lvl_init_struct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>();
@@ -8659,8 +8665,8 @@ TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&multiview_props);
@@ -8720,8 +8726,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValues) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &device_features));
 
     // Find address of extension call and make the call
-    PFN_vkCmdSetFragmentShadingRateKHR vkCmdSetFragmentShadingRateKHR =
-        (PFN_vkCmdSetFragmentShadingRateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR");
+    auto vkCmdSetFragmentShadingRateKHR = reinterpret_cast<PFN_vkCmdSetFragmentShadingRateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR"));
     ASSERT_TRUE(vkCmdSetFragmentShadingRateKHR != nullptr);
 
     VkExtent2D fragmentSize = {1, 1};
@@ -8797,8 +8803,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValuesNoFeatures) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Find address of extension call and make the call
-    PFN_vkCmdSetFragmentShadingRateKHR vkCmdSetFragmentShadingRateKHR =
-        (PFN_vkCmdSetFragmentShadingRateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR");
+    auto vkCmdSetFragmentShadingRateKHR = reinterpret_cast<PFN_vkCmdSetFragmentShadingRateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR"));
     ASSERT_TRUE(vkCmdSetFragmentShadingRateKHR != nullptr);
 
     VkExtent2D fragmentSize = {1, 1};
@@ -8850,8 +8856,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoFeatures) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Find address of extension call and make the call
-    PFN_vkCmdSetFragmentShadingRateKHR vkCmdSetFragmentShadingRateKHR =
-        (PFN_vkCmdSetFragmentShadingRateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR");
+    auto vkCmdSetFragmentShadingRateKHR = reinterpret_cast<PFN_vkCmdSetFragmentShadingRateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR"));
     ASSERT_TRUE(vkCmdSetFragmentShadingRateKHR != nullptr);
 
     VkExtent2D fragmentSize = {1, 1};
@@ -8903,8 +8909,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoPipelineRate) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -8921,8 +8927,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoPipelineRate) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Find address of extension call and make the call
-    PFN_vkCmdSetFragmentShadingRateKHR vkCmdSetFragmentShadingRateKHR =
-        (PFN_vkCmdSetFragmentShadingRateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR");
+    auto vkCmdSetFragmentShadingRateKHR = reinterpret_cast<PFN_vkCmdSetFragmentShadingRateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR"));
     ASSERT_TRUE(vkCmdSetFragmentShadingRateKHR != nullptr);
 
     VkExtent2D fragmentSize = {1, 1};
@@ -8971,8 +8977,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
@@ -8984,8 +8990,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -9000,8 +9006,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Find address of extension call and make the call
-    PFN_vkCmdSetFragmentShadingRateKHR vkCmdSetFragmentShadingRateKHR =
-        (PFN_vkCmdSetFragmentShadingRateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR");
+    auto vkCmdSetFragmentShadingRateKHR = reinterpret_cast<PFN_vkCmdSetFragmentShadingRateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFragmentShadingRateKHR"));
     ASSERT_TRUE(vkCmdSetFragmentShadingRateKHR != nullptr);
 
     VkExtent2D fragmentSize = {1, 1};
@@ -9063,8 +9069,8 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimitDy
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
@@ -9076,8 +9082,8 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimitDy
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT eds_features = LvlInitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features =
@@ -9127,8 +9133,8 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimitDy
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
 
     VkViewport viewports[] = {{0, 0, 16, 16, 0, 1}, {1, 1, 16, 16, 0, 1}};
-    PFN_vkCmdSetViewportWithCountEXT vkCmdSetViewportWithCountEXT =
-        (PFN_vkCmdSetViewportWithCountEXT)vk::GetDeviceProcAddr(device(), "vkCmdSetViewportWithCountEXT");
+    auto vkCmdSetViewportWithCountEXT =
+        reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(vk::GetDeviceProcAddr(device(), "vkCmdSetViewportWithCountEXT"));
     vkCmdSetViewportWithCountEXT(m_commandBuffer->handle(), 2, viewports);
 
     // error produced here.
@@ -9416,8 +9422,8 @@ TEST_F(VkLayerTest, TestEndCommandBufferWithConditionalRendering) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetInstanceProcAddr(instance(), "vkCmdBeginConditionalRenderingEXT");
+    auto vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkCmdBeginConditionalRenderingEXT"));
 
     VkBufferObj buffer;
     VkMemoryPropertyFlags reqs = 0;
@@ -9467,11 +9473,11 @@ TEST_F(VkLayerTest, BindPipelineDuringTransformFeedback) {
     pipe_two.InitState();
     pipe_two.CreateGraphicsPipeline();
 
-    auto vkCmdBeginTransformFeedbackEXT =
-        (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+    auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
     ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
-    auto vkCmdEndTransformFeedbackEXT =
-        (PFN_vkCmdEndTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT");
+    auto vkCmdEndTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndTransformFeedbackEXT"));
     ASSERT_TRUE(vkCmdEndTransformFeedbackEXT != nullptr);
 
     m_commandBuffer->begin();
@@ -9589,10 +9595,10 @@ TEST_F(VkLayerTest, InvalidEndConditionalRendering) {
     VkFramebuffer framebuffer;
     vk::CreateFramebuffer(device(), &fbci, nullptr, &framebuffer);
 
-    PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT");
-    PFN_vkCmdEndConditionalRenderingEXT vkCmdEndConditionalRenderingEXT =
-        (PFN_vkCmdEndConditionalRenderingEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdEndConditionalRenderingEXT");
+    auto vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBeginConditionalRenderingEXT"));
+    auto vkCmdEndConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdEndConditionalRenderingEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdEndConditionalRenderingEXT"));
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 32;
@@ -9664,8 +9670,8 @@ TEST_F(VkLayerTest, InvalidBeginTransformFeedbackInMultiviewRenderPass) {
     auto tf_features = LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
     auto pd_features = LvlInitStruct<VkPhysicalDeviceFeatures2>(&tf_features);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &pd_features);
 
@@ -9738,8 +9744,8 @@ TEST_F(VkLayerTest, InvalidBeginTransformFeedbackInMultiviewRenderPass) {
     render_pass_begin_info.renderArea.extent.width = 32;
     render_pass_begin_info.renderArea.extent.height = 32;
 
-    auto vkCmdBeginTransformFeedbackEXT =
-        (PFN_vkCmdBeginTransformFeedbackEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT");
+    auto vkCmdBeginTransformFeedbackEXT = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginTransformFeedbackEXT"));
     ASSERT_TRUE(vkCmdBeginTransformFeedbackEXT != nullptr);
 
     m_commandBuffer->begin();

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -57,8 +57,8 @@ TEST_F(VkLayerTest, InvalidCommandPoolConsistency) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyCommandPool(m_device->device(), command_pool_one, NULL);
-    vk::DestroyCommandPool(m_device->device(), command_pool_two, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool_one, nullptr);
+    vk::DestroyCommandPool(m_device->device(), command_pool_two, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidSecondaryCommandBufferBarrier) {
@@ -369,12 +369,12 @@ TEST_F(VkLayerTest, SecondaryCommandbufferAsPrimary) {
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &secondary.handle();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
 
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
@@ -432,12 +432,12 @@ TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
     VkResult err = VK_SUCCESS;
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
 
     err = vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     ASSERT_VK_SUCCESS(err);
@@ -536,7 +536,7 @@ TEST_F(VkLayerTest, InvalidPushConstants) {
     for (const auto &iter : range_tests) {
         pc_range = iter.range;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, iter.msg);
-        vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+        vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
         m_errorMonitor->VerifyFound();
     }
 
@@ -545,7 +545,7 @@ TEST_F(VkLayerTest, InvalidPushConstants) {
     pc_range.size = 16;
     pc_range.stageFlags = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-stageFlags-requiredbitmask");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // Check for duplicate stage flags in a list of push constant ranges.
@@ -602,7 +602,7 @@ TEST_F(VkLayerTest, InvalidPushConstants) {
         pipeline_layout_ci.pPushConstantRanges = iter.ranges;
         pipeline_layout_ci.pushConstantRangeCount = ranges_per_test;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, iter.msg.begin(), iter.msg.end());
-        vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+        vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
         m_errorMonitor->VerifyFound();
     }
 
@@ -1535,7 +1535,7 @@ TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj image(m_device);
@@ -1692,7 +1692,7 @@ TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyBufferToImage2Function) {
         const VkBufferImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2_KHR,
-                                               NULL,
+                                               nullptr,
                                                region.bufferOffset,
                                                region.bufferRowLength,
                                                region.bufferImageHeight,
@@ -1700,7 +1700,7 @@ TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
                                                region.imageOffset,
                                                region.imageExtent};
         const VkCopyBufferToImageInfo2KHR copy_buffer_to_image_info2 = {VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2_KHR,
-                                                                        NULL,
+                                                                        nullptr,
                                                                         buffer_16.handle(),
                                                                         image.handle(),
                                                                         VK_IMAGE_LAYOUT_GENERAL,
@@ -2551,7 +2551,7 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // Create 1D image
@@ -2605,14 +2605,14 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     // Equivalent sanity check using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                         NULL,
+                                         nullptr,
                                          copy_region.srcSubresource,
                                          copy_region.srcOffset,
                                          copy_region.dstSubresource,
                                          copy_region.dstOffset,
                                          copy_region.extent};
         const VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       image_1D.image(),
                                                       VK_IMAGE_LAYOUT_GENERAL,
                                                       image_2D.image(),
@@ -2635,14 +2635,14 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                         NULL,
+                                         nullptr,
                                          copy_region.srcSubresource,
                                          copy_region.srcOffset,
                                          copy_region.dstSubresource,
                                          copy_region.dstOffset,
                                          copy_region.extent};
         const VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       image_1D.image(),
                                                       VK_IMAGE_LAYOUT_GENERAL,
                                                       image_2D.image(),
@@ -2666,14 +2666,14 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                         NULL,
+                                         nullptr,
                                          copy_region.srcSubresource,
                                          copy_region.srcOffset,
                                          copy_region.dstSubresource,
                                          copy_region.dstOffset,
                                          copy_region.extent};
         const VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       image_2D.image(),
                                                       VK_IMAGE_LAYOUT_GENERAL,
                                                       image_1D.image(),
@@ -2699,14 +2699,14 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                         NULL,
+                                         nullptr,
                                          copy_region.srcSubresource,
                                          copy_region.srcOffset,
                                          copy_region.dstSubresource,
                                          copy_region.dstOffset,
                                          copy_region.extent};
         const VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       image_1D.image(),
                                                       VK_IMAGE_LAYOUT_GENERAL,
                                                       image_2D.image(),
@@ -2728,14 +2728,14 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdCopyImage2Function) {
         const VkImageCopy2KHR region2 = {VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR,
-                                         NULL,
+                                         nullptr,
                                          copy_region.srcSubresource,
                                          copy_region.srcOffset,
                                          copy_region.dstSubresource,
                                          copy_region.dstOffset,
                                          copy_region.extent};
         const VkCopyImageInfo2KHR copy_image_info2 = {VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR,
-                                                      NULL,
+                                                      nullptr,
                                                       image_2D.image(),
                                                       VK_IMAGE_LAYOUT_GENERAL,
                                                       image_1D.image(),
@@ -2857,7 +2857,7 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatchMaintenance1) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // Create 1D image
@@ -2989,7 +2989,7 @@ TEST_F(VkLayerTest, CopyImageCompressedBlockAlignment) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties img_prop = {};
@@ -3140,7 +3140,7 @@ TEST_F(VkLayerTest, CopyImageSinglePlane422Alignment) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // Verify formats
@@ -3255,7 +3255,7 @@ TEST_F(VkLayerTest, CopyImageMultiplaneAspectBits) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // Verify formats
@@ -3361,7 +3361,7 @@ TEST_F(VkLayerTest, CopyImageSrcSizeExceeded) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj src_image(m_device);
@@ -3448,7 +3448,7 @@ TEST_F(VkLayerTest, CopyImageDstSizeExceeded) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj dst_image(m_device);
@@ -3534,7 +3534,7 @@ TEST_F(VkLayerTest, CopyImageZeroSize) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj src_image(m_device);
@@ -4043,7 +4043,7 @@ TEST_F(VkLayerTest, CopyImageSampleCountMismatch) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = NULL;
+    ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageObj image1(m_device);
@@ -4670,14 +4670,14 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdResolveImage2Function) {
         const VkImageResolve2KHR resolveRegion2 = {VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2_KHR,
-                                                   NULL,
+                                                   nullptr,
                                                    resolveRegion.srcSubresource,
                                                    resolveRegion.srcOffset,
                                                    resolveRegion.dstSubresource,
                                                    resolveRegion.dstOffset,
                                                    resolveRegion.extent};
         const VkResolveImageInfo2KHR resolve_image_info2 = {VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2_KHR,
-                                                            NULL,
+                                                            nullptr,
                                                             srcImage.image(),
                                                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                                             dstImage.image(),
@@ -4700,14 +4700,14 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdResolveImage2Function) {
         const VkImageResolve2KHR resolveRegion2 = {VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2_KHR,
-                                                   NULL,
+                                                   nullptr,
                                                    resolveRegion.srcSubresource,
                                                    resolveRegion.srcOffset,
                                                    resolveRegion.dstSubresource,
                                                    resolveRegion.dstOffset,
                                                    resolveRegion.extent};
         const VkResolveImageInfo2KHR resolve_image_info2 = {VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2_KHR,
-                                                            NULL,
+                                                            nullptr,
                                                             srcImage.image(),
                                                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                                             dstImage.image(),
@@ -4730,14 +4730,14 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdResolveImage2Function) {
         const VkImageResolve2KHR resolveRegion2 = {VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2_KHR,
-                                                   NULL,
+                                                   nullptr,
                                                    resolveRegion.srcSubresource,
                                                    resolveRegion.srcOffset,
                                                    resolveRegion.dstSubresource,
                                                    resolveRegion.dstOffset,
                                                    resolveRegion.extent};
         const VkResolveImageInfo2KHR resolve_image_info2 = {VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2_KHR,
-                                                            NULL,
+                                                            nullptr,
                                                             srcImage.image(),
                                                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                                             dstImage.image(),
@@ -4760,14 +4760,14 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
     // Equivalent test using KHR_copy_commands2
     if (copy_commands2 && vkCmdResolveImage2Function) {
         const VkImageResolve2KHR resolveRegion2 = {VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2_KHR,
-                                                   NULL,
+                                                   nullptr,
                                                    resolveRegion.srcSubresource,
                                                    resolveRegion.srcOffset,
                                                    resolveRegion.dstSubresource,
                                                    resolveRegion.dstOffset,
                                                    resolveRegion.extent};
         const VkResolveImageInfo2KHR resolve_image_info2 = {VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2_KHR,
-                                                            NULL,
+                                                            nullptr,
                                                             srcImage.image(),
                                                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                                             dstImage.image(),
@@ -5229,8 +5229,8 @@ TEST_F(VkLayerTest, ExecuteDiffertQueueFlagsSecondaryCB) {
     m_errorMonitor->VerifyFound();
     vk::EndCommandBuffer(command_buffer[0]);
 
-    vk::DestroyCommandPool(m_device->device(), command_pool_A, NULL);
-    vk::DestroyCommandPool(m_device->device(), command_pool_B, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool_A, nullptr);
+    vk::DestroyCommandPool(m_device->device(), command_pool_B, nullptr);
 }
 
 TEST_F(VkLayerTest, ExecuteUnrecordedSecondaryCB) {
@@ -5895,7 +5895,7 @@ TEST_F(VkLayerTest, MultiDrawTests) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMultiEXT-None-02700");
     vkCmdDrawMultiEXT(m_commandBuffer->handle(), 3, multi_draws, 1, 0, sizeof(VkMultiDrawInfoEXT));
     m_errorMonitor->VerifyFound();
@@ -6033,7 +6033,7 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -6205,7 +6205,7 @@ TEST_F(VkLayerTest, DrawIndirectCountKHR) {
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -6234,7 +6234,7 @@ TEST_F(VkLayerTest, DrawIndirectCountKHR) {
     memory_allocate_info.allocationSize = memory_requirements.size;
     m_device->phy().set_memory_type(memory_requirements.memoryTypeBits, &memory_allocate_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     VkDeviceMemory draw_buffer_memory;
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, NULL, &draw_buffer_memory);
+    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &draw_buffer_memory);
     vk::BindBufferMemory(m_device->device(), draw_buffer, draw_buffer_memory, 0);
 
     VkBuffer count_buffer_unbound;
@@ -6308,7 +6308,7 @@ TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -7049,7 +7049,7 @@ TEST_F(VkLayerTest, CreateSamplerYcbcrConversionEnable) {
     // Create Ycbcr conversion
     VkSamplerYcbcrConversion conversions;
     VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = {VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
-                                                            NULL,
+                                                            nullptr,
                                                             VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR,
                                                             VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY,
                                                             VK_SAMPLER_YCBCR_RANGE_ITU_FULL,
@@ -7813,11 +7813,11 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
 
     alloc_info.memoryTypeIndex = memory_type_protected;
     alloc_info.allocationSize = mem_reqs_protected.size;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory_protected);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory_protected);
 
     alloc_info.allocationSize = mem_reqs_unprotected.size;
     alloc_info.memoryTypeIndex = memory_type_unprotected;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory_unprotected);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory_unprotected);
 
     vk::BindBufferMemory(device(), buffer_protected, memory_protected, 0);
     vk::BindBufferMemory(device(), buffer_unprotected, memory_unprotected, 0);
@@ -8178,7 +8178,7 @@ TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {
 
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
 
     VkBufferObj buffer;
     buffer.init(*m_device, 64, 0, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
@@ -8188,7 +8188,7 @@ TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {
     bvci.format = buffer_view_format;
     bvci.range = VK_WHOLE_SIZE;
     VkBufferView buffer_view;
-    vk::CreateBufferView(m_device->device(), &bvci, NULL, &buffer_view);
+    vk::CreateBufferView(m_device->device(), &bvci, nullptr, &buffer_view);
 
     char const *fsSource = R"glsl(
         #version 450
@@ -8308,7 +8308,7 @@ TEST_F(VkLayerTest, DrawWithoutUpdatePushConstants) {
         VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
 
     VkPipelineLayout pipeline_layout;
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
 
     CreatePipelineHelper g_pipe(*this);
     g_pipe.InitInfo();
@@ -8319,7 +8319,7 @@ TEST_F(VkLayerTest, DrawWithoutUpdatePushConstants) {
 
     pipeline_layout_info.pPushConstantRanges = &push_constant_range_small;
     VkPipelineLayout pipeline_layout_small;
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout_small);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout_small);
 
     CreatePipelineHelper g_pipe_small_range(*this);
     g_pipe_small_range.InitInfo();
@@ -8506,13 +8506,13 @@ TEST_F(VkLayerTest, VerifyFilterCubicSamplerInCmdDraw) {
     sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
     sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
     VkSampler sampler;
-    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
 
     auto reduction_mode_ci = LvlInitStruct<VkSamplerReductionModeCreateInfo>();
     reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
     sampler_ci.pNext = &reduction_mode_ci;
     VkSampler sampler_rediction;
-    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler_rediction);
+    vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler_rediction);
 
     VkShaderObj fs(this, bindStateFragSamplerShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
 
@@ -8593,7 +8593,7 @@ TEST_F(VkLayerTest, VerifyImgFilterCubicSamplerInCmdDraw) {
     sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
     sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
     VkSampler sampler;
-    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
 
     static const char fs_src[] = R"glsl(
         #version 450

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -59,7 +59,7 @@ TEST_F(VkLayerTest, InvalidDescriptorPoolConsistency) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool bad_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &bad_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &bad_pool);
     ASSERT_VK_SUCCESS(err);
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -70,7 +70,7 @@ TEST_F(VkLayerTest, InvalidDescriptorPoolConsistency) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorPool(m_device->device(), bad_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), bad_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, BadSubpassIndices) {
@@ -852,7 +852,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
         VkSubpassDescription test_subpass = subpass;
         test_subpass.colorAttachmentCount = (uint32_t)too_many_colors.size();
         test_subpass.pColorAttachments = too_many_colors.data();
-        test_subpass.pResolveAttachments = NULL;
+        test_subpass.pResolveAttachments = nullptr;
         VkRenderPassCreateInfo test_rpci = rpci;
         test_rpci.pSubpasses = &test_subpass;
 
@@ -1640,7 +1640,7 @@ TEST_F(VkLayerTest, InvalidFragmentDensityMapLayerCount) {
 
     auto vkCreateRenderPass2KHR =
         reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
-    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkImageObj image(m_device);
@@ -1659,29 +1659,29 @@ TEST_F(VkLayerTest, InvalidFragmentDensityMapLayerCount) {
     VkFramebuffer fb;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-02747");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
     rp = {};
 
     // Set viewMask to non-zero
     subpass.viewMask = 0x10;
-    err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
     fb_info.renderPass = rp;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-02746");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, RenderPassCreateSubpassNonGraphicsPipeline) {
@@ -2095,7 +2095,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidMixedAttachmentSamplesAMD) {
     VkRenderPass rp;
     VkResult err;
 
-    err = vk::CreateRenderPass(device(), &rpci, NULL, &rp);
+    err = vk::CreateRenderPass(device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyNotFound();
     if (err == VK_SUCCESS) vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
@@ -2200,7 +2200,7 @@ TEST_F(VkLayerTest, RenderPassBeginIncompatibleFramebufferRenderPass) {
     dsvci.subresourceRange.baseMipLevel = 0;
     dsvci.subresourceRange.levelCount = 1;
     dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
+    vk::CreateImageView(m_device->device(), &dsvci, nullptr, &dsv);
 
     // Create a renderPass with a single attachment that uses loadOp CLEAR
     VkAttachmentDescription description = {0,
@@ -2221,9 +2221,9 @@ TEST_F(VkLayerTest, RenderPassBeginIncompatibleFramebufferRenderPass) {
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, &description, 1, &subpass, 0, nullptr};
     VkRenderPass rp1, rp2;
 
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp1);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp1);
     subpass.pDepthStencilAttachment = nullptr;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp2);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp2);
 
     // Create a framebuffer
 
@@ -2283,7 +2283,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
     iavci.subresourceRange.baseMipLevel = 0;
     iavci.subresourceRange.levelCount = 1;
     iavci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk::CreateImageView(m_device->device(), &iavci, NULL, &iav);
+    vk::CreateImageView(m_device->device(), &iavci, nullptr, &iav);
 
     // Create an input depth attachment view
     VkImageObj iadi(m_device);
@@ -2309,7 +2309,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
     cavci.subresourceRange.baseMipLevel = 0;
     cavci.subresourceRange.levelCount = 1;
     cavci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk::CreateImageView(m_device->device(), &cavci, NULL, &cav);
+    vk::CreateImageView(m_device->device(), &cavci, nullptr, &cav);
 
     // Create a renderPass with those attachments
     VkAttachmentDescription descriptions[] = {
@@ -2433,7 +2433,7 @@ TEST_F(VkLayerTest, RenderPassBeginClearOpMismatch) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
 
     VkRenderPassBeginInfo rp_begin = LvlInitStruct<VkRenderPassBeginInfo>();
     rp_begin.renderPass = renderPass();
@@ -2443,7 +2443,7 @@ TEST_F(VkLayerTest, RenderPassBeginClearOpMismatch) {
     TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &rp_begin, rp2Supported,
                         "VUID-VkRenderPassBeginInfo-clearValueCount-00902", "VUID-VkRenderPassBeginInfo-clearValueCount-00902");
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
@@ -2492,7 +2492,7 @@ TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
     dsvci.subresourceRange.baseMipLevel = 0;
     dsvci.subresourceRange.levelCount = 1;
     dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
+    vk::CreateImageView(m_device->device(), &dsvci, nullptr, &dsv);
 
     // Create a renderPass with a single attachment that uses loadOp CLEAR
     VkAttachmentDescription description = {0,
@@ -2513,7 +2513,7 @@ TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, &description, 1, &subpass, 0, nullptr};
     VkRenderPass rp;
 
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
 
     // Create a framebuffer
 
@@ -2650,7 +2650,7 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
         0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &color_ref, nullptr, &depth_stencil_ref, 0, nullptr};
     m_renderPass_subpasses.push_back(subpass);
     m_renderPass_info = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 2, descriptions, 1, &subpass, 0, nullptr};
-    vk::CreateRenderPass(m_device->device(), &m_renderPass_info, NULL, &m_renderPass);
+    vk::CreateRenderPass(m_device->device(), &m_renderPass_info, nullptr, &m_renderPass);
 
     // Create a framebuffer
     m_framebuffer_attachments.push_back(color_image_view);
@@ -2682,7 +2682,7 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     VkPipelineDepthStencilStateCreateInfo pipe_ds_state_ci = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
     pipe_ds_state_ci.depthTestEnable = VK_TRUE;
@@ -3292,7 +3292,7 @@ TEST_F(VkLayerTest, RenderPassDestroyWhileInUse) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->ExpectSuccess();
@@ -3390,7 +3390,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkImageView ivs[2];
@@ -3406,34 +3406,34 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     fb_info.layers = 1;
 
     VkFramebuffer fb;
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
     // Create a renderPass with a depth-stencil attachment created with
     // IMAGE_USAGE_COLOR_ATTACHMENT
     // Add our color attachment to pDepthStencilAttachment
     subpass.pDepthStencilAttachment = &attach;
-    subpass.pColorAttachments = NULL;
+    subpass.pColorAttachments = nullptr;
     VkRenderPass rp_ds;
-    err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp_ds);
+    err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp_ds);
     ASSERT_VK_SUCCESS(err);
     // Set correct attachment count, but attachment has COLOR usage bit set
     fb_info.attachmentCount = 1;
     fb_info.renderPass = rp_ds;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-02633");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
-    vk::DestroyRenderPass(m_device->device(), rp_ds, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp_ds, nullptr);
 
     {
         VkImageCreateInfo image_ci = LvlInitStruct<VkImageCreateInfo>();
@@ -3464,40 +3464,40 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
 
     // Create new renderpass with alternate attachment format from fb
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
-    subpass.pDepthStencilAttachment = NULL;
+    subpass.pDepthStencilAttachment = nullptr;
     subpass.pColorAttachments = &attach;
-    err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     // Cause error due to mis-matched formats between rp & fb
     //  rp attachment 0 now has RGBA8 but corresponding fb attach is BGRA8
     fb_info.renderPass = rp;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-00880");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
     // Create new renderpass with alternate sample count from fb
     attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_4_BIT;
-    err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     // Cause error due to mis-matched sample count between rp & fb
     fb_info.renderPass = rp;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-00881");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
     {
         // Create an image with 2 mip levels.
@@ -3516,54 +3516,54 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
         // Set level count to 2 (only 1 is allowed for FB attachment)
         ivci.subresourceRange.levelCount = 2;
         ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        err = vk::CreateImageView(m_device->device(), &ivci, NULL, &view);
+        err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
         ASSERT_VK_SUCCESS(err);
 
         // Re-create renderpass to have matching sample count
         attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
         subpass.colorAttachmentCount = 1;
-        err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+        err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
         subpass.colorAttachmentCount = 0;
         ASSERT_VK_SUCCESS(err);
 
         fb_info.renderPass = rp;
         fb_info.pAttachments = &view;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-00883");
-        err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+        err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
-            vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+            vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
         }
-        vk::DestroyImageView(m_device->device(), view, NULL);
+        vk::DestroyImageView(m_device->device(), view, nullptr);
     }
 
     // Update view to original color buffer and grow FB dimensions too big
     fb_info.pAttachments = ivs;
     fb_info.width = 1024;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04533");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.width = 256;
 
     fb_info.height = 1024;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04534");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.height = 256;
 
     fb_info.layers = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04535");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.layers = 1;
 
@@ -3595,7 +3595,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             rpci_fragment_density_map.pAttachments = &attach_desc_fragment_density_map;
             VkRenderPass rp_fragment_density_map;
 
-            err = vk::CreateRenderPass(m_device->device(), &rpci_fragment_density_map, NULL, &rp_fragment_density_map);
+            err = vk::CreateRenderPass(m_device->device(), &rpci_fragment_density_map, nullptr, &rp_fragment_density_map);
             ASSERT_VK_SUCCESS(err);
 
             // Create view attachment
@@ -3636,20 +3636,20 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             ASSERT_TRUE(image2.initialized());
 
             ivci.image = image2.handle();
-            err = vk::CreateImageView(m_device->device(), &ivci, NULL, &view_fragment_density_map);
+            err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view_fragment_density_map);
             ASSERT_VK_SUCCESS(err);
 
             fbci.pAttachments = &view_fragment_density_map;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-02555");
-            err = vk::CreateFramebuffer(device(), &fbci, NULL, &fb);
+            err = vk::CreateFramebuffer(device(), &fbci, nullptr, &fb);
 
             m_errorMonitor->VerifyFound();
             if (err == VK_SUCCESS) {
-                vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+                vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
             }
 
-            vk::DestroyImageView(m_device->device(), view_fragment_density_map, NULL);
+            vk::DestroyImageView(m_device->device(), view_fragment_density_map, nullptr);
 
             // Set small height
             VkImageObj image3(m_device);
@@ -3658,22 +3658,22 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             ASSERT_TRUE(image3.initialized());
 
             ivci.image = image3.handle();
-            err = vk::CreateImageView(m_device->device(), &ivci, NULL, &view_fragment_density_map);
+            err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view_fragment_density_map);
             ASSERT_VK_SUCCESS(err);
 
             fbci.pAttachments = &view_fragment_density_map;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-02556");
-            err = vk::CreateFramebuffer(device(), &fbci, NULL, &fb);
+            err = vk::CreateFramebuffer(device(), &fbci, nullptr, &fb);
 
             m_errorMonitor->VerifyFound();
             if (err == VK_SUCCESS) {
-                vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+                vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
             }
 
-            vk::DestroyImageView(m_device->device(), view_fragment_density_map, NULL);
+            vk::DestroyImageView(m_device->device(), view_fragment_density_map, nullptr);
 
-            vk::DestroyRenderPass(m_device->device(), rp_fragment_density_map, NULL);
+            vk::DestroyRenderPass(m_device->device(), rp_fragment_density_map, nullptr);
         }
     }
 
@@ -3697,7 +3697,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
         ivci.components.g = VK_COMPONENT_SWIZZLE_R;
         ivci.components.b = VK_COMPONENT_SWIZZLE_A;
         ivci.components.a = VK_COMPONENT_SWIZZLE_B;
-        err = vk::CreateImageView(m_device->device(), &ivci, NULL, &view);
+        err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
         ASSERT_VK_SUCCESS(err);
 
         fb_info.pAttachments = &view;
@@ -3706,13 +3706,13 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
         fb_info.layers = 1;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-00884");
-        err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+        err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
 
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
-            vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+            vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
         }
-        vk::DestroyImageView(m_device->device(), view, NULL);
+        vk::DestroyImageView(m_device->device(), view, nullptr);
     }
 
     {
@@ -3728,7 +3728,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
                 VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, &rpmvci, 0, 0, nullptr, 1, &subpass, 0, nullptr};
 
             VkRenderPass rp_mv;
-            err = vk::CreateRenderPass(m_device->device(), &rpci_mv, NULL, &rp_mv);
+            err = vk::CreateRenderPass(m_device->device(), &rpci_mv, nullptr, &rp_mv);
             ASSERT_VK_SUCCESS(err);
 
             VkFramebufferCreateInfo fb_info_mv = fb_info;
@@ -3737,13 +3737,13 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             fb_info_mv.renderPass = rp_mv;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-02531");
-            err = vk::CreateFramebuffer(device(), &fb_info_mv, NULL, &fb);
+            err = vk::CreateFramebuffer(device(), &fb_info_mv, nullptr, &fb);
             m_errorMonitor->VerifyFound();
             if (err == VK_SUCCESS) {
-                vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+                vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
             }
 
-            vk::DestroyRenderPass(m_device->device(), rp_mv, NULL);
+            vk::DestroyRenderPass(m_device->device(), rp_mv, nullptr);
 
             VkAttachmentDescription attach_desc_mv = {};
             attach_desc_mv.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -3753,7 +3753,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             rpci_mv.pAttachments = &attach_desc_mv;
             subpass.colorAttachmentCount = 1;
             subpass.pColorAttachments = &attach;
-            err = vk::CreateRenderPass(m_device->device(), &rpci_mv, NULL, &rp_mv);
+            err = vk::CreateRenderPass(m_device->device(), &rpci_mv, nullptr, &rp_mv);
             ASSERT_VK_SUCCESS(err);
 
             // Create an image with 1 layer
@@ -3770,7 +3770,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             ivci.subresourceRange.baseMipLevel = 0;
             ivci.subresourceRange.levelCount = 1;
             ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            err = vk::CreateImageView(m_device->device(), &ivci, NULL, &view);
+            err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
             ASSERT_VK_SUCCESS(err);
 
             fb_info_mv.renderPass = rp_mv;
@@ -3779,14 +3779,14 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
             fb_info_mv.attachmentCount = 1;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-04536");
-            err = vk::CreateFramebuffer(device(), &fb_info_mv, NULL, &fb);
+            err = vk::CreateFramebuffer(device(), &fb_info_mv, nullptr, &fb);
             m_errorMonitor->VerifyFound();
             if (err == VK_SUCCESS) {
-                vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+                vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
             }
 
-            vk::DestroyRenderPass(m_device->device(), rp_mv, NULL);
-            vk::DestroyImageView(m_device->device(), view, NULL);
+            vk::DestroyRenderPass(m_device->device(), rp_mv, nullptr);
+            vk::DestroyImageView(m_device->device(), view, nullptr);
         }
     }
 
@@ -3799,18 +3799,18 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     fb_info.layers = 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-width-00886");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04533");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     // and width=0
     fb_info.width = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-width-00885");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
     // Request fb that exceeds max height
@@ -3819,18 +3819,18 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     fb_info.layers = 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-height-00888");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04534");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     // and height=0
     fb_info.height = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-height-00887");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
     // Request fb that exceeds max layers
@@ -3839,31 +3839,31 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     fb_info.layers = m_device->props.limits.maxFramebufferLayers + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-layers-00890");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04535");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     // and layers=0
     fb_info.layers = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-layers-00889");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
     // Try to create with pAttachments = NULL
     fb_info.layers = 1;
-    fb_info.pAttachments = NULL;
+    fb_info.pAttachments = nullptr;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID_Undefined");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
@@ -3893,7 +3893,7 @@ TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding_samp = {};
@@ -3901,7 +3901,7 @@ TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
     dsl_binding_samp.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     dsl_binding_samp.descriptorCount = 1;
     dsl_binding_samp.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding_samp.pImmutableSamplers = NULL;
+    dsl_binding_samp.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout_samp(m_device, {dsl_binding_samp});
 
@@ -3923,7 +3923,7 @@ TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout_ub(m_device, {dsl_binding});
 
@@ -3935,7 +3935,7 @@ TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
@@ -3959,7 +3959,7 @@ TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -3967,7 +3967,7 @@ TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
 
@@ -3982,7 +3982,7 @@ TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
     err = vk::FreeDescriptorSets(m_device->device(), ds_pool, 1, &descriptorSet);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDescriptorPool) {
@@ -4012,7 +4012,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSet) {
     layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     layout_binding.descriptorCount = 1;
     layout_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    layout_binding.pImmutableSamplers = NULL;
+    layout_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj descriptor_set_layout(m_device, {layout_binding});
 
@@ -4022,7 +4022,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSet) {
     // Set invalid set
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-pDescriptorSets-parameter");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1, &bad_set,
-                              0, NULL);
+                              0, nullptr);
     m_errorMonitor->VerifyFound();
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -4034,7 +4034,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSet) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-firstSet-00360");
     m_errorMonitor->SetUnexpectedError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 2, 1, &good_set,
-                              0, NULL);
+                              0, nullptr);
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }
@@ -4050,7 +4050,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayout) {
     VkPipelineLayoutCreateInfo plci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &bad_layout;
-    vk::CreatePipelineLayout(device(), &plci, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(device(), &plci, nullptr, &pipeline_layout);
 
     m_errorMonitor->VerifyFound();
 }
@@ -4068,17 +4068,17 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     OneOffDescriptorSet::Bindings bindings = {
-        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, NULL},
-        {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, NULL},
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
         {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, static_cast<VkSampler *>(&sampler)},
-        {3, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, NULL},
-        {4, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 3, VK_SHADER_STAGE_FRAGMENT_BIT, NULL},
-        {5, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, NULL},
-        {6, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, NULL}};
+        {3, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {4, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 3, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {5, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {6, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
     OneOffDescriptorSet descriptor_set(m_device, bindings);
     ASSERT_TRUE(descriptor_set.Initialized());
 
@@ -4090,7 +4090,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
 
     // 1) The uniform buffer is intentionally invalid here
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-00324");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // Create a buffer to update the descriptor with
@@ -4118,35 +4118,35 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
     descriptor_write.dstArrayElement = 0;
     descriptor_write.descriptorCount = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorCount-00317");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.dstBinding = 4;
     descriptor_write.dstArrayElement = 0;
     descriptor_write.descriptorCount = 5;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorCount-00317");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.dstBinding = 4;
     descriptor_write.dstArrayElement = 1;
     descriptor_write.descriptorCount = 4;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorCount-00317");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.dstBinding = 4;
     descriptor_write.dstArrayElement = 0;
     descriptor_write.descriptorCount = 4;
     m_errorMonitor->ExpectSuccess();
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     descriptor_write.dstBinding = 4;
     descriptor_write.dstArrayElement = 1;
     descriptor_write.descriptorCount = 3;
     m_errorMonitor->ExpectSuccess();
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     // 3) The second descriptor has a null_ptr pImmutableSamplers and the third descriptor contains an immutable sampler
@@ -4160,7 +4160,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
     imageInfo[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     descriptor_write.pImageInfo = imageInfo;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorCount-00318");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 4) That sampled image descriptors have required layouts -- create images to update the descriptor with
@@ -4178,17 +4178,17 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-04149");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 5) Attempt to update an immutable sampler
     descriptor_write.dstBinding = 2;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02752");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, WriteDescriptorSetIdentitySwizzle) {
@@ -4221,13 +4221,13 @@ TEST_F(VkLayerTest, WriteDescriptorSetIdentitySwizzle) {
     image_view_ci.components.a = VK_COMPONENT_SWIZZLE_A;
 
     VkImageView image_view;
-    vk::CreateImageView(m_device->device(), &image_view_ci, NULL, &image_view);
+    vk::CreateImageView(m_device->device(), &image_view_ci, nullptr, &image_view);
     descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-00336");
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
-    vk::DestroyImageView(m_device->device(), image_view, NULL);
+    vk::DestroyImageView(m_device->device(), image_view, nullptr);
 }
 
 TEST_F(VkLayerTest, WriteDescriptorSetConsecutiveUpdates) {
@@ -4277,7 +4277,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetConsecutiveUpdates) {
         descriptor_write.pBufferInfo = buffer_info;
 
         // Update descriptor
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         // Create PSO that uses the uniform buffers
         char const *fsSource = R"glsl(
@@ -4375,7 +4375,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
     // Create Ycbcr conversion
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;  // guaranteed sampling support
     VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = {VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
-                                                            NULL,
+                                                            nullptr,
                                                             mp_format,
                                                             VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY,
                                                             VK_SAMPLER_YCBCR_RANGE_ITU_FULL,
@@ -4431,7 +4431,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImageView(m_device->device(), image_view, NULL);
+    vk::DestroyImageView(m_device->device(), image_view, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {
@@ -4483,7 +4483,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
         vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                                  &pipe.descriptor_set_->set_, 0, NULL);
+                                  &pipe.descriptor_set_->set_, 0, nullptr);
 
         vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &m_viewports[0]);
         vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &m_scissors[0]);
@@ -4556,7 +4556,7 @@ TEST_F(VkLayerTest, InvalidDrawDescriptorSetBufferDestroyed) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &m_viewports[0]);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &m_scissors[0]);
 
@@ -4586,7 +4586,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool ds_pool;
-    VkResult err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    VkResult err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -4594,7 +4594,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding});
 
@@ -4626,9 +4626,9 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-    err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
-    err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image2);
+    err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image2);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements memory_reqs;
@@ -4644,7 +4644,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     memory_info.allocationSize = aligned_size * 2;
     pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &image_memory);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &image_memory);
     ASSERT_VK_SUCCESS(err);
     err = vk::BindImageMemory(m_device->device(), image, image_memory, 0);
     ASSERT_VK_SUCCESS(err);
@@ -4664,20 +4664,20 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     VkImageView tmp_view;  // First test deletes this view
     VkImageView view;
     VkImageView view2;
-    err = vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &tmp_view);
+    err = vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &tmp_view);
     ASSERT_VK_SUCCESS(err);
-    err = vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &view);
+    err = vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &view);
     ASSERT_VK_SUCCESS(err);
     image_view_create_info.image = image2;
-    err = vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &view2);
+    err = vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &view2);
     ASSERT_VK_SUCCESS(err);
     // Create Samplers
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
     VkSampler sampler2;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler2);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler2);
     ASSERT_VK_SUCCESS(err);
     // Update descriptor with image and sampler
     VkDescriptorImageInfo img_info = {};
@@ -4693,7 +4693,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_write.pImageInfo = &img_info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     // Create PSO to be used for draw-time errors below
     char const *fsSource = R"glsl(
@@ -4735,7 +4735,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptorSet, 0, NULL);
+                              &descriptorSet, 0, nullptr);
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     VkRect2D scissor = {{0, 0}, {16, 16}};
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -4751,13 +4751,13 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     vk::QueueWaitIdle(m_device->m_queue);
 
     // Now destroy imageview and reset cmdBuffer
-    vk::DestroyImageView(m_device->device(), tmp_view, NULL);
+    vk::DestroyImageView(m_device->device(), tmp_view, nullptr);
     m_commandBuffer->reset(0);
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptorSet, 0, NULL);
+                              &descriptorSet, 0, nullptr);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " that is invalid or has been destroyed.");
@@ -4768,20 +4768,20 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
 
     // Re-update descriptor with new view
     img_info.imageView = view;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     // Now test destroying sampler prior to cmd buffer submission
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptorSet, 0, NULL);
+                              &descriptorSet, 0, nullptr);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Destroy sampler invalidates the cmd buffer, causing error on submit
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
     // Attempt to submit cmd buffer
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkSampler");
     submit_info = LvlInitStruct<VkSubmitInfo>();
@@ -4792,7 +4792,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
 
     // Now re-update descriptor with valid sampler and delete image
     img_info.sampler = sampler2;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     VkCommandBufferBeginInfo info = LvlInitStruct<VkCommandBufferBeginInfo>();
     info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
@@ -4801,14 +4801,14 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptorSet, 0, NULL);
+                              &descriptorSet, 0, nullptr);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Destroy image invalidates the cmd buffer, causing error on submit
-    vk::DestroyImage(m_device->device(), image, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
     // Attempt to submit cmd buffer
     submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -4817,7 +4817,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_errorMonitor->VerifyFound();
     // Now update descriptor to be valid, but then update and free descriptor
     img_info.imageView = view2;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_commandBuffer->begin(&info);
 
     // Transit image2 layout from VK_IMAGE_LAYOUT_UNDEFINED into VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
@@ -4828,7 +4828,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptorSet, 0, NULL);
+                              &descriptorSet, 0, nullptr);
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
     m_commandBuffer->Draw(1, 0, 0, 0);
@@ -4838,7 +4838,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
 
     // Immediately try to update the descriptor set in the active command buffer - failure expected
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkUpdateDescriptorSets-None-03047");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // Immediately try to destroy the descriptor set in the active command buffer - failure expected
@@ -4864,12 +4864,12 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_errorMonitor->VerifyFound();
 
     // Cleanup
-    vk::FreeMemory(m_device->device(), image_memory, NULL);
-    vk::DestroySampler(m_device->device(), sampler2, NULL);
-    vk::DestroyImage(m_device->device(), image2, NULL);
-    vk::DestroyImageView(m_device->device(), view, NULL);
-    vk::DestroyImageView(m_device->device(), view2, NULL);
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::FreeMemory(m_device->device(), image_memory, nullptr);
+    vk::DestroySampler(m_device->device(), sampler2, nullptr);
+    vk::DestroyImage(m_device->device(), image2, nullptr);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
+    vk::DestroyImageView(m_device->device(), view2, nullptr);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
@@ -4901,15 +4901,15 @@ TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     VkImageView view;
-    VkResult err = vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &view);
+    VkResult err = vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &view);
     ASSERT_VK_SUCCESS(err);
     // Create Samplers
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
     VkSampler sampler1;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler1);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler1);
     ASSERT_VK_SUCCESS(err);
     // Update descriptor with image and sampler
     VkDescriptorImageInfo img_info = {};
@@ -4932,10 +4932,10 @@ TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
     descriptor_writes[1].dstBinding = 1;
     descriptor_writes[1].pImageInfo = &img_info1;
 
-    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes.data(), 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes.data(), 0, nullptr);
 
     // Destroy the sampler before it's bound to the cmd buffer
-    vk::DestroySampler(m_device->device(), sampler1, NULL);
+    vk::DestroySampler(m_device->device(), sampler1, nullptr);
 
     // Create PSO to be used for draw-time errors below
     char const *fsSource = R"glsl(
@@ -4961,7 +4961,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, NULL);
+                              &descriptor_set.set_, 0, nullptr);
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     VkRect2D scissor = {{0, 0}, {16, 16}};
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
@@ -4973,8 +4973,8 @@ TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
 }
 
 TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
@@ -5063,7 +5063,7 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
         // Set up the descriptor
         img_info.imageView = view->handle();
         img_info.imageLayout = descriptor_layout;
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         for (TestType test_type : test_list) {
             cmd_buf.begin();
@@ -5086,7 +5086,7 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
             cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
             vk::CmdBindPipeline(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
             vk::CmdBindDescriptorSets(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                                      &descriptorSet, 0, NULL);
+                                      &descriptorSet, 0, nullptr);
             vk::CmdSetViewport(cmd_buf.handle(), 0, 1, &viewport);
             vk::CmdSetScissor(cmd_buf.handle(), 0, 1, &scissor);
 
@@ -5251,7 +5251,7 @@ TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+    VkResult err = vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     ASSERT_VK_SUCCESS(err);
     // Initially bind memory to avoid error at bind view time. We'll break binding before update.
     VkMemoryRequirements memory_reqs;
@@ -5265,7 +5265,7 @@ TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
     memory_info.allocationSize = memory_reqs.size;
     pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
-    err = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &image_memory);
+    err = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &image_memory);
     ASSERT_VK_SUCCESS(err);
     err = vk::BindImageMemory(m_device->device(), image, image_memory, 0);
     ASSERT_VK_SUCCESS(err);
@@ -5280,12 +5280,12 @@ TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     VkImageView view;
-    err = vk::CreateImageView(m_device->device(), &image_view_create_info, NULL, &view);
+    err = vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &view);
     ASSERT_VK_SUCCESS(err);
     // Create Samplers
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
     // Update descriptor with image and sampler
     descriptor_set.WriteDescriptorImageInfo(0, view, sampler);
@@ -5296,9 +5296,9 @@ TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
     // Cleanup
-    vk::DestroyImage(m_device->device(), image, NULL);
-    vk::DestroySampler(m_device->device(), sampler, NULL);
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroyImage(m_device->device(), image, nullptr);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
@@ -5339,7 +5339,7 @@ TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, NULL);
+                              &descriptor_set.set_, 0, nullptr);
     m_errorMonitor->VerifyFound();
     uint32_t pDynOff[2] = {0, 756};
     // Now cause error b/c too many dynOffsets in array for # of dyn descriptors
@@ -5400,14 +5400,14 @@ TEST_F(VkLayerTest, DescriptorBufferUpdateNoMemoryBound) {
     buffCI.pQueueFamilyIndices = &qfi;
 
     VkBuffer dynamic_uniform_buffer;
-    err = vk::CreateBuffer(m_device->device(), &buffCI, NULL, &dynamic_uniform_buffer);
+    err = vk::CreateBuffer(m_device->device(), &buffCI, nullptr, &dynamic_uniform_buffer);
     ASSERT_VK_SUCCESS(err);
 
     // Attempt to update descriptor without binding memory to it
     descriptor_set.WriteDescriptorBufferInfo(0, dynamic_uniform_buffer, 0, 1024, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
-    vk::DestroyBuffer(m_device->device(), dynamic_uniform_buffer, NULL);
+    vk::DestroyBuffer(m_device->device(), dynamic_uniform_buffer, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDynamicDescriptorSet) {
@@ -5586,7 +5586,7 @@ TEST_F(VkLayerTest, DynamicOffsetWithNullBuffer) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorBufferInfo-buffer-02998");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorBufferInfo-buffer-02998");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorBufferInfo-buffer-02998");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
     m_errorMonitor->ExpectSuccess();
 
@@ -5686,7 +5686,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     ds_pool_ci.pPoolSizes = ds_type_count;
 
     VkDescriptorPool ds_pool;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     static const uint32_t MAX_DS_TYPES_IN_LAYOUT = 2;
@@ -5695,7 +5695,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     dsl_binding[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding[0].descriptorCount = 5;
     dsl_binding[0].stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding[0].pImmutableSamplers = NULL;
+    dsl_binding[0].pImmutableSamplers = nullptr;
 
     // Create layout identical to set0 layout but w/ different stageFlags
     VkDescriptorSetLayoutBinding dsl_fs_stage_only = {};
@@ -5704,7 +5704,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     dsl_fs_stage_only.descriptorCount = 5;
     dsl_fs_stage_only.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;  // Different stageFlags to cause error at
                                                                   // bind time
-    dsl_fs_stage_only.pImmutableSamplers = NULL;
+    dsl_fs_stage_only.pImmutableSamplers = nullptr;
 
     vector<VkDescriptorSetLayoutObj> ds_layouts;
     // Create 4 unique layouts for full pipelineLayout, and 1 special fs-only
@@ -5720,7 +5720,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     dsl_binding[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
     dsl_binding[1].descriptorCount = 2;
     dsl_binding[1].stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding[1].pImmutableSamplers = NULL;
+    dsl_binding[1].pImmutableSamplers = nullptr;
     ds_layouts.emplace_back(m_device, std::vector<VkDescriptorSetLayoutBinding>({dsl_binding[0], dsl_binding[1]}));
 
     dsl_binding[0].binding = 0;
@@ -5779,7 +5779,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.pBufferInfo = &buffer_info;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     // Create PSO to be used for draw-time errors below
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
@@ -5802,33 +5802,33 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // 1. invalid VkPipelineLayout (layout) passed into vk::CmdBindDescriptorSets
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-layout-parameter");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
-                              CastToHandle<VkPipelineLayout, uintptr_t>(0xbaadb1be), 0, 1, &descriptorSet[0], 0, NULL);
+                              CastToHandle<VkPipelineLayout, uintptr_t>(0xbaadb1be), 0, 1, &descriptorSet[0], 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 2. layoutIndex exceeds # of layouts in layout
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " attempting to bind set to index 1");
     m_errorMonitor->SetUnexpectedError("VUID-vkCmdBindDescriptorSets-firstSet-00360");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, single_pipe_layout.handle(), 0, 2,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 3. Pipeline setLayout[0] has 2 descriptors, but set being bound has 5
     // descriptors
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " has 2 total descriptors, but ");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_layout_one_desc.handle(), 0, 1,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 4. same # of descriptors but mismatch in type
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " is type 'VK_DESCRIPTOR_TYPE_SAMPLER' but binding ");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_layout_five_samp.handle(), 0, 1,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // 5. same # of descriptors but mismatch in stageFlags
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " has stageFlags VK_SHADER_STAGE_FRAGMENT_BIT but binding 0 for ");
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_layout_fs_only.handle(), 0, 1,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // Now that we're done actively using the pipelineLayout that gfx pipeline
@@ -5840,9 +5840,9 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // 1. Error due to not binding required set (we actually use same code as
     // above to disturb set0)
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 2,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_layout_bad_set0.handle(), 1, 1,
-                              &descriptorSet[1], 0, NULL);
+                              &descriptorSet[1], 0, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " uses set #0 but that set is not bound.");
 
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
@@ -5856,7 +5856,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // 2. Error due to bound set not being compatible with PSO's
     // VkPipelineLayout (diff stageFlags in this case)
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 2,
-                              &descriptorSet[0], 0, NULL);
+                              &descriptorSet[0], 0, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " bound as set #0 is not compatible with ");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-02697");
     m_commandBuffer->Draw(1, 0, 0, 0);
@@ -5866,7 +5866,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, NullRenderPass) {
@@ -5879,7 +5879,7 @@ TEST_F(VkLayerTest, NullRenderPass) {
     m_commandBuffer->begin();
     // Don't care about RenderPass handle b/c error should be flagged before
     // that
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), NULL, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), nullptr, VK_SUBPASS_CONTENTS_INLINE);
 
     m_errorMonitor->VerifyFound();
 
@@ -5939,7 +5939,7 @@ TEST_F(VkLayerTest, DSUsageBitsErrors) {
     dsl_bindings[0].descriptorType = VkDescriptorType(0);
     dsl_bindings[0].descriptorCount = 1;
     dsl_bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_bindings[0].pImmutableSamplers = NULL;
+    dsl_bindings[0].pImmutableSamplers = nullptr;
 
     // Create arrays of layout and descriptor objects
     using UpDescriptorSet = std::unique_ptr<vk_testing::DescriptorSet>;
@@ -6012,7 +6012,7 @@ TEST_F(VkLayerTest, DSUsageBitsErrors) {
         descriptor_write.dstSet = descriptor_sets[i]->handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, error_codes[i]);
 
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_errorMonitor->VerifyFound();
         if (VkDescriptorType(i) == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
@@ -6154,7 +6154,7 @@ TEST_F(VkLayerTest, DSBufferInfoErrors) {
 
     auto do_test = [&](const char *desired_failure) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, desired_failure);
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
         m_errorMonitor->VerifyFound();
 
         if (push_descriptor_support) {
@@ -6246,7 +6246,7 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         bci.size = test_case.max_range + test_case.min_align;  // Make buffer bigger than range limit
         bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(m_device->device(), &bci, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(m_device->device(), &bci, nullptr, &buffer);
         if (VK_SUCCESS != err) {
             printf("%s Failed to allocate buffer in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
             continue;
@@ -6261,15 +6261,15 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
         if (!pass) {
             printf("%s Failed to allocate memory in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
-            vk::DestroyBuffer(m_device->device(), buffer, NULL);
+            vk::DestroyBuffer(m_device->device(), buffer, nullptr);
             continue;
         }
 
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+        err = vk::AllocateMemory(m_device->device(), &mem_alloc, nullptr, &mem);
         if (VK_SUCCESS != err) {
             printf("%s Failed to allocate memory in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
-            vk::DestroyBuffer(m_device->device(), buffer, NULL);
+            vk::DestroyBuffer(m_device->device(), buffer, nullptr);
             continue;
         }
         err = vk::BindBufferMemory(m_device->device(), buffer, mem, 0);
@@ -6291,7 +6291,7 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
             buff_info.range = test_case.max_range + 1;
             buff_info.offset = 0;
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.max_range_vu);
-            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
             m_errorMonitor->VerifyFound();
         }
 
@@ -6300,7 +6300,7 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
             buff_info.range = test_case.max_range;
             buff_info.offset = test_case.min_align - 1;
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.min_align_vu);
-            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
             m_errorMonitor->VerifyFound();
         }
 
@@ -6308,12 +6308,12 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         buff_info.range = VK_WHOLE_SIZE;
         buff_info.offset = 0;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.max_range_vu);
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
         m_errorMonitor->VerifyFound();
 
         // Cleanup
-        vk::FreeMemory(m_device->device(), mem, NULL);
-        vk::DestroyBuffer(m_device->device(), buffer, NULL);
+        vk::FreeMemory(m_device->device(), mem, nullptr);
+        vk::DestroyBuffer(m_device->device(), buffer, nullptr);
     }
 }
 
@@ -6373,7 +6373,7 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
             image_view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
             VkImageView image_view;
-            err = vk::CreateImageView(m_device->device(), &image_view_ci, NULL, &image_view);
+            err = vk::CreateImageView(m_device->device(), &image_view_ci, nullptr, &image_view);
             ASSERT_VK_SUCCESS(err);
             descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
 
@@ -6381,7 +6381,7 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, error_msg);
             descriptor_set.UpdateDescriptorSets();
             m_errorMonitor->VerifyFound();
-            vk::DestroyImageView(m_device->device(), image_view, NULL);
+            vk::DestroyImageView(m_device->device(), image_view, nullptr);
         }
     }
 
@@ -6422,7 +6422,7 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
 
             VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
             VkSampler sampler;
-            err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+            err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
             ASSERT_VK_SUCCESS(err);
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorImageInfo-sampler-01564");
@@ -6430,7 +6430,7 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
             descriptor_set.UpdateDescriptorSets();
             m_errorMonitor->VerifyFound();
 
-            vk::DestroySampler(m_device->device(), sampler, NULL);
+            vk::DestroySampler(m_device->device(), sampler, nullptr);
         }
     }
 }
@@ -6449,7 +6449,7 @@ TEST_F(VkLayerTest, DSTypeMismatch) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
@@ -6457,7 +6457,7 @@ TEST_F(VkLayerTest, DSTypeMismatch) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, DSUpdateOutOfBounds) {
@@ -6490,7 +6490,7 @@ TEST_F(VkLayerTest, DSUpdateOutOfBounds) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.pBufferInfo = &buff_info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_errorMonitor->VerifyFound();
 }
@@ -6508,7 +6508,7 @@ TEST_F(VkLayerTest, InvalidDSUpdateIndex) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     // This is the wrong type, but out of bounds will be flagged first
@@ -6516,7 +6516,7 @@ TEST_F(VkLayerTest, InvalidDSUpdateIndex) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, DSUpdateEmptyBinding) {
@@ -6531,7 +6531,7 @@ TEST_F(VkLayerTest, DSUpdateEmptyBinding) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     // descriptor_write.descriptorCount = 1, Lie here to avoid parameter_validation error
@@ -6542,7 +6542,7 @@ TEST_F(VkLayerTest, DSUpdateEmptyBinding) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDSUpdateStruct) {
@@ -6560,7 +6560,7 @@ TEST_F(VkLayerTest, InvalidDSUpdateStruct) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorImageInfo info = {};
@@ -6575,11 +6575,11 @@ TEST_F(VkLayerTest, InvalidDSUpdateStruct) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     descriptor_write.pImageInfo = &info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, SampleDescriptorUpdateError) {
@@ -6613,7 +6613,7 @@ TEST_F(VkLayerTest, ImageViewDescriptorUpdateError) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     VkImageView view = CastToHandle<VkImageView, uintptr_t>(0xbaadbeef);  // invalid imageView object
@@ -6622,7 +6622,7 @@ TEST_F(VkLayerTest, ImageViewDescriptorUpdateError) {
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
@@ -6636,7 +6636,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler immutable_sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &immutable_sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &immutable_sampler);
     ASSERT_VK_SUCCESS(err);
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -6650,7 +6650,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
                   });
 
     VkSampler sampler;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     // SAMPLER binding from layout above
@@ -6664,7 +6664,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     copy_ds_update.dstSet = descriptor_set.set_;
     copy_ds_update.dstBinding = 0;       // ERROR : copy to UNIFORM binding
     copy_ds_update.descriptorCount = 1;  // copy 1 descriptor
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
 
     m_errorMonitor->VerifyFound();
     // Now perform a copy update that fails due to binding out of bounds
@@ -6675,7 +6675,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     copy_ds_update.dstSet = descriptor_set.set_;
     copy_ds_update.dstBinding = 0;
     copy_ds_update.descriptorCount = 1;  // Copy 1 descriptor
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
 
     m_errorMonitor->VerifyFound();
 
@@ -6690,7 +6690,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     copy_ds_update.dstSet = descriptor_set.set_;
     copy_ds_update.dstBinding = 0;
     copy_ds_update.descriptorCount = 5;  // ERROR copy 5 descriptors (out of bounds for layout)
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
 
     m_errorMonitor->VerifyFound();
 
@@ -6701,11 +6701,11 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     copy_ds_update.dstSet = descriptor_set_2.set_;
     copy_ds_update.dstBinding = 0;
     copy_ds_update.descriptorCount = 1;
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
-    vk::DestroySampler(m_device->device(), immutable_sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
+    vk::DestroySampler(m_device->device(), immutable_sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPass) {
@@ -6742,7 +6742,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPass) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddShader(&fs);
@@ -6774,7 +6774,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPass) {
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassFragmentDensityMap) {
@@ -7031,7 +7031,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassMultiview) {
     ivci.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                        VK_COMPONENT_SWIZZLE_IDENTITY};
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 2};
-    vk::CreateImageView(m_device->device(), &ivci, NULL, &iv);
+    vk::CreateImageView(m_device->device(), &ivci, nullptr, &iv);
 
     // Create framebuffers for rp[0] and rp2[0]
     VkFramebufferCreateInfo fbci = LvlInitStruct<VkFramebufferCreateInfo>();
@@ -7301,7 +7301,7 @@ TEST_F(VkLayerTest, UpdateDestroyDescriptorSetLayout) {
     // Put valid data in the good and bad sources, simultaneously doing a positive test on write and copy operations
     m_errorMonitor->ExpectSuccess();
     write_descriptor.dstSet = good_src.set_;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &write_descriptor, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &write_descriptor, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     OneOffDescriptorSet bad_src(m_device, one_uniform_buffer);
@@ -7317,7 +7317,7 @@ TEST_F(VkLayerTest, UpdateDestroyDescriptorSetLayout) {
     // Trigger the three invalid use errors
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, kWriteDestroyedLayout);
     write_descriptor.dstSet = bad_dst.set_;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &write_descriptor, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &write_descriptor, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, kCopyDstDestroyedLayout);
@@ -7413,9 +7413,9 @@ TEST_F(VkLayerTest, FramebufferIncompatible) {
     vk::CmdEndRenderPass(m_commandBuffer->handle());
     vk::EndCommandBuffer(m_commandBuffer->handle());
 
-    vk::DestroyImageView(m_device->device(), view, NULL);
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
-    vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
+    vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
 }
 
 TEST_F(VkLayerTest, RenderPassMissingAttachment) {
@@ -7438,7 +7438,7 @@ TEST_F(VkLayerTest, RenderPassMissingAttachment) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     auto createView = LvlInitStruct<VkImageViewCreateInfo>();
@@ -7465,8 +7465,8 @@ TEST_F(VkLayerTest, RenderPassMissingAttachment) {
 
     // Create the framebuffer then destory the view it uses.
     VkFramebuffer fb;
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
-    vk::DestroyImageView(device(), iv, NULL);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
+    vk::DestroyImageView(device(), iv, nullptr);
     ASSERT_VK_SUCCESS(err);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-framebuffer-parameter");
@@ -7482,8 +7482,8 @@ TEST_F(VkLayerTest, RenderPassMissingAttachment) {
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 
-    vk::DestroyFramebuffer(m_device->device(), fb, NULL);
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, AttachmentDescriptionUndefinedFormat) {
@@ -7511,12 +7511,12 @@ TEST_F(VkLayerTest, AttachmentDescriptionUndefinedFormat) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     rpci.pAttachments = &attach_desc;
     VkRenderPass rp;
-    VkResult result = vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    VkResult result = vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
 
     m_errorMonitor->VerifyFound();
 
     if (result == VK_SUCCESS) {
-        vk::DestroyRenderPass(m_device->device(), rp, NULL);
+        vk::DestroyRenderPass(m_device->device(), rp, nullptr);
     }
 }
 
@@ -7576,25 +7576,25 @@ TEST_F(VkLayerTest, DuplicateDescriptorBinding) {
     dsl_binding[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding[0].descriptorCount = 1;
     dsl_binding[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding[0].pImmutableSamplers = NULL;
+    dsl_binding[0].pImmutableSamplers = nullptr;
     dsl_binding[1].binding = 0;
     dsl_binding[1].descriptorCount = 1;
     dsl_binding[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding[1].descriptorCount = 1;
     dsl_binding[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding[1].pImmutableSamplers = NULL;
+    dsl_binding[1].pImmutableSamplers = nullptr;
     dsl_binding[2].binding = 1;  // Duplicate binding should cause error
     dsl_binding[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding[2].descriptorCount = 1;
     dsl_binding[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding[2].pImmutableSamplers = NULL;
+    dsl_binding[2].pImmutableSamplers = nullptr;
 
     VkDescriptorSetLayoutCreateInfo ds_layout_ci = LvlInitStruct<VkDescriptorSetLayoutCreateInfo>();
     ds_layout_ci.bindingCount = NUM_BINDINGS;
     ds_layout_ci.pBindings = dsl_binding;
     VkDescriptorSetLayout ds_layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutCreateInfo-binding-00279");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 }
 
@@ -7692,7 +7692,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
     auto pipeline_layout = VkPipelineLayoutObj(m_device, {&ds_layout});
@@ -7719,7 +7719,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
 
-    auto err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    auto err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -7779,7 +7779,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
         m_errorMonitor->VerifyFound();
     }
 
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, PushDescriptorSetLayoutWithoutExtension) {
@@ -7828,7 +7828,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayoutWithoutExtension) {
 TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
     TEST_DESCRIPTION("Exercise various create/allocate-time errors related to VK_EXT_descriptor_indexing.");
 
-    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, NULL,
+    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, nullptr,
                                                          m_errorMonitor))) {
         printf("%s Descriptor indexing or one of its dependencies not supported, skipping tests.\n", kSkipPrefix);
         return;
@@ -7964,7 +7964,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
         descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         descriptor_writes[0].pBufferInfo = buffer_info;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-dstArrayElement-00321");
-        vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
         m_errorMonitor->VerifyFound();
         vk::DestroyDescriptorSetLayout(m_device->handle(), ds_layout, nullptr);
         vk::DestroyDescriptorPool(m_device->handle(), pool, nullptr);
@@ -8064,7 +8064,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
     VkBuffer dynamic_uniform_buffer;
-    err = vk::CreateBuffer(m_device->device(), &buffCI, NULL, &dynamic_uniform_buffer);
+    err = vk::CreateBuffer(m_device->device(), &buffCI, nullptr, &dynamic_uniform_buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkDeviceMemory mem;
@@ -8074,7 +8074,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     VkMemoryAllocateInfo mem_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     mem_alloc_info.allocationSize = mem_reqs.size;
     m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    err = vk::AllocateMemory(m_device->device(), &mem_alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(m_device->device(), &mem_alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::BindBufferMemory(m_device->device(), dynamic_uniform_buffer, mem, 0);
@@ -8101,7 +8101,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout;
 
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
 
     // Create a dummy pipeline, since VL inspects which bindings are actually used at draw time
     char const *fsSource = R"glsl(
@@ -8127,7 +8127,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     pipe.CreateVKPipeline(pipeline_layout, m_renderPass);
 
     // Make both bindings valid before binding to the command buffer
-    vk::UpdateDescriptorSets(m_device->device(), 2, &descriptor_write[0], 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 2, &descriptor_write[0], 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
@@ -8140,7 +8140,8 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     for (uint32_t i = 0; i < 2; ++i) {
         m_commandBuffer->begin();
 
-        vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &ds, 0, NULL);
+        vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &ds, 0,
+                                  nullptr);
 
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
@@ -8149,7 +8150,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
 
         m_errorMonitor->VerifyNotFound();
         // Valid to update binding 1 after being bound
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write[1], 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write[1], 0, nullptr);
         m_errorMonitor->VerifyNotFound();
 
         if (i == 0) {
@@ -8163,7 +8164,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
         } else {
             // Invalid to update binding 0 after being bound. But the error is actually
             // generated during vk::EndCommandBuffer
-            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write[0], 0, NULL);
+            vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write[0], 0, nullptr);
             m_errorMonitor->VerifyNotFound();
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -8176,15 +8177,15 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
 
     vk::DestroyDescriptorSetLayout(m_device->handle(), ds_layout, nullptr);
     vk::DestroyDescriptorPool(m_device->handle(), pool, nullptr);
-    vk::DestroyBuffer(m_device->handle(), dynamic_uniform_buffer, NULL);
-    vk::FreeMemory(m_device->handle(), mem, NULL);
-    vk::DestroyPipelineLayout(m_device->handle(), pipeline_layout, NULL);
+    vk::DestroyBuffer(m_device->handle(), dynamic_uniform_buffer, nullptr);
+    vk::FreeMemory(m_device->handle(), mem, nullptr);
+    vk::DestroyPipelineLayout(m_device->handle(), pipeline_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, DescriptorIndexingSetNonIdenticalWrite) {
     TEST_DESCRIPTION("VkWriteDescriptorSet must have identical VkDescriptorBindingFlagBits");
 
-    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, NULL,
+    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, nullptr,
                                                          m_errorMonitor))) {
         printf("%s Descriptor indexing or one of its dependencies not supported, skipping tests.\n", kSkipPrefix);
         return;
@@ -8266,7 +8267,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetNonIdenticalWrite) {
 
     // binding 1 has a different VkDescriptorBindingFlags
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-dstArrayElement-00321");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyDescriptorSetLayout(m_device->handle(), ds_layout, nullptr);
@@ -8358,7 +8359,7 @@ TEST_F(VkLayerTest, CreateDescriptorUpdateTemplate) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout_ub(m_device, {dsl_binding});
     const VkDescriptorSetLayoutObj ds_layout_ub1(m_device, {dsl_binding});
@@ -8535,7 +8536,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_inline_vuid = (supportsDescriptorIndexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
@@ -8552,9 +8553,9 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     pipeline_layout_ci.pSetLayouts = &ds_layout;
     VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
 
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);
     pipeline_layout = VK_NULL_HANDLE;
     vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
     ds_layout = VK_NULL_HANDLE;
@@ -8567,7 +8568,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     ds_layout_ci.pBindings = &dslb;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-descriptorType-02209");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-descriptorType-02210");
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
     vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
     ds_layout = VK_NULL_HANDLE;
@@ -8585,7 +8586,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
 
     VkDescriptorPool ds_pool = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorPoolSize-type-02218");
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     m_errorMonitor->VerifyFound();
     if (ds_pool) {
         vk::DestroyDescriptorPool(m_device->handle(), ds_pool, nullptr);
@@ -8594,7 +8595,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
 
     // Create a valid pool
     ds_type_count.descriptorCount = 32;
-    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &ds_pool);
+    err = vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &ds_pool);
     m_errorMonitor->VerifyNotFound();
 
     // Create two valid sets with 8 bytes each
@@ -8610,7 +8611,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = &dslb_vec[0];
 
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyNotFound();
 
     VkDescriptorSet descriptor_sets[2];
@@ -8637,24 +8638,24 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     descriptor_write.pNext = &write_inline_uniform;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02220");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.dstArrayElement = 1;
     descriptor_write.descriptorCount = 4;
     write_inline_uniform.dataSize = 4;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02219");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.pNext = nullptr;
     descriptor_write.dstArrayElement = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-02221");
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     descriptor_write.pNext = &write_inline_uniform;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     // Test invalid VkCopyDescriptorSet parameters (array element and size must be multiple of 4)
@@ -8669,23 +8670,23 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
 
     copy_ds_update.srcArrayElement = 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyDescriptorSet-srcBinding-02223");
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
     m_errorMonitor->VerifyFound();
 
     copy_ds_update.srcArrayElement = 0;
     copy_ds_update.dstArrayElement = 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyDescriptorSet-dstBinding-02224");
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
     m_errorMonitor->VerifyFound();
 
     copy_ds_update.dstArrayElement = 0;
     copy_ds_update.descriptorCount = 5;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyDescriptorSet-srcBinding-02225");
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
     m_errorMonitor->VerifyFound();
 
     copy_ds_update.descriptorCount = 4;
-    vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
+    vk::UpdateDescriptorSets(m_device->device(), 0, nullptr, 1, &copy_ds_update);
     m_errorMonitor->VerifyNotFound();
 
     vk::DestroyDescriptorPool(m_device->handle(), ds_pool, nullptr);
@@ -8730,7 +8731,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXTFeature) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-descriptorType-04604");
     VkDescriptorSetLayout ds_layout = {};
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 }
 
@@ -8810,16 +8811,16 @@ TEST_F(VkLayerTest, DescriptorSetLayoutMisc) {
 
     // Should succeed with shader stage of 0 or fragment
     m_errorMonitor->ExpectSuccess();
-    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, nullptr, &ds_layout);
     vk::DestroyDescriptorSetLayout(device(), ds_layout, nullptr);
     dsl_binding.stageFlags = 0;
-    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, nullptr, &ds_layout);
     vk::DestroyDescriptorSetLayout(device(), ds_layout, nullptr);
     m_errorMonitor->VerifyNotFound();
 
     dsl_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-descriptorType-01510");
-    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 }
 
@@ -8934,7 +8935,7 @@ TEST_F(VkLayerTest, NullDescriptorsEnabled) {
                                                {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     sampler_descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     sampler_descriptor_set.UpdateDescriptorSets();
     const VkPipelineLayoutObj pipeline_layout(m_device, {&sampler_descriptor_set.layout_});
@@ -9171,7 +9172,7 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
 
     VkSampler sampler = VK_NULL_HANDLE;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
 
     // input index is wrong, it doesn't exist in supbass input attachments and the set and binding is undefined
     // It causes desired failures.
@@ -9460,7 +9461,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
 
     PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
         (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
-    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkImageObj image(m_device);
@@ -9477,12 +9478,12 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
 
     VkFramebuffer fb;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04548");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
@@ -9560,7 +9561,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
 
     PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
         (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
-    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkImageObj image(m_device);
@@ -9581,19 +9582,19 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
 
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width * 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04539");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
 
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height * 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04540");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
 
@@ -9601,42 +9602,42 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
     fb_info.pAttachments = &imageViewLayered;
     fb_info.layers = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04538");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
     if (fsr_properties.layeredShadingRateAttachments == VK_TRUE) {
-        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         ASSERT_VK_SUCCESS(err);
 
         fb_info.renderPass = rp;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04538");
-        err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+        err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
-            vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+            vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
         }
-        vk::DestroyRenderPass(m_device->device(), rp, NULL);
+        vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
         subpass.viewMask = 0x4;
-        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         ASSERT_VK_SUCCESS(err);
         subpass.viewMask = 0;
 
         fb_info.renderPass = rp;
         fb_info.layers = 1;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04537");
-        err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+        err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
-            vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+            vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
         }
 
-        vk::DestroyRenderPass(m_device->device(), rp, NULL);
+        vk::DestroyRenderPass(m_device->device(), rp, nullptr);
     }
 }
 
@@ -9718,14 +9719,14 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
 
     rpci.flags = VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassCreateInfo2-flags-04521");
-    vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
     rpci.flags = 0;
     attach_desc.format =
         FindFormatWithoutFeatures(gpu(), VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     if (attach_desc.format) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassCreateInfo2-pAttachments-04586");
-        vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         m_errorMonitor->VerifyFound();
     }
     attach_desc.format = VK_FORMAT_R8_UINT;
@@ -9733,7 +9734,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
     attach.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04524");
-    vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -9753,7 +9754,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                              "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04530");
     }
-    vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
 
@@ -9763,7 +9764,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
                                          "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04526");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04529");
-    vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
 
@@ -9773,7 +9774,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
                                          "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04527");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04530");
-    vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
 
@@ -9783,7 +9784,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
         fsr_attachment.shadingRateAttachmentTexelSize.width = fsr_properties.maxFragmentShadingRateAttachmentTexelSize.width;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                              "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04531");
-        vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         m_errorMonitor->VerifyFound();
         fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
     }
@@ -9794,7 +9795,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
         fsr_attachment.shadingRateAttachmentTexelSize.height = fsr_properties.maxFragmentShadingRateAttachmentTexelSize.height;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                              "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-04532");
-        vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         m_errorMonitor->VerifyFound();
         fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
     }
@@ -10276,7 +10277,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolFlags) {
 
     VkDescriptorPool bad_pool;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorPoolCreateInfo-flags-04607");
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &bad_pool);
+    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &bad_pool);
     m_errorMonitor->VerifyFound();
 }
 
@@ -10303,13 +10304,13 @@ TEST_F(VkLayerTest, MissingMutableDescriptorTypeFeature) {
 
     VkDescriptorPool bad_pool;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorPoolCreateInfo-flags-04609");
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &bad_pool);
+    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &bad_pool);
     m_errorMonitor->VerifyFound();
 
     ds_type_count.type = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     ds_pool_ci.flags = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorPoolCreateInfo-mutableDescriptorType-04608");
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &bad_pool);
+    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &bad_pool);
     m_errorMonitor->VerifyFound();
 }
 
@@ -10423,14 +10424,14 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
     VkDescriptorPool pool;
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &pool);
+    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, nullptr, &pool);
 
     VkDescriptorSetLayoutBinding dsl_binding_samp = {};
     dsl_binding_samp.binding = 0;
     dsl_binding_samp.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     dsl_binding_samp.descriptorCount = 1;
     dsl_binding_samp.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding_samp.pImmutableSamplers = NULL;
+    dsl_binding_samp.pImmutableSamplers = nullptr;
 
     const VkDescriptorSetLayoutObj ds_layout_samp(m_device, {dsl_binding_samp},
                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_VALVE);
@@ -11165,38 +11166,38 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     VkDescriptorSetLayout ds_layout;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-descriptorTypeCount-04599");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     mutable_descriptor_type_list.descriptorTypeCount = 0;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-descriptorTypeCount-04597");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     mutable_descriptor_type_list.descriptorTypeCount = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04598");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04600");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04601");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04602");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04603");
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10533,6 +10533,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -10540,10 +10541,8 @@ TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
         return;
     }
 
@@ -10676,6 +10675,7 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
     if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
+    AddRequiredExtensions(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     bool rp2Supported = CheckCreateRenderPass2Support(this, m_device_extension_names);
     if (!rp2Supported) {
@@ -10683,12 +10683,11 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
         return;
     }
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Did not find required device extension %s; skipped.\n", kSkipPrefix,
                VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -114,8 +114,8 @@ TEST_F(VkLayerTest, BadSubpassIndices) {
     m_errorMonitor->VerifyFound();
 
     if (rp2_supported) {
-        PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-            (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+        auto vkCreateRenderPass2KHR =
+            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
         safe_VkRenderPassCreateInfo2 create_info2;
         ConvertVkRenderPassCreateInfoToV2KHR(rpci, &create_info2);
 
@@ -450,8 +450,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     }
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&separate_depth_stencil_layouts_features);
     if (vkGetPhysicalDeviceFeatures2KHR) {
@@ -1134,8 +1134,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     }
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&separate_depth_stencil_layouts_features);
     if (vkGetPhysicalDeviceFeatures2KHR) {
@@ -2156,7 +2156,7 @@ TEST_F(VkLayerTest, RenderPassBeginWithinRenderPass) {
 
     if (rp2Supported) {
         vkCmdBeginRenderPass2KHR =
-            (PFN_vkCmdBeginRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRenderPass2KHR");
+            reinterpret_cast<PFN_vkCmdBeginRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRenderPass2KHR"));
     }
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2463,8 +2463,8 @@ TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props =
@@ -2571,15 +2571,14 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-    PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT vkGetPhysicalDeviceMultisamplePropertiesEXT =
-        (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceMultisamplePropertiesEXT");
+    auto vkGetPhysicalDeviceMultisamplePropertiesEXT = reinterpret_cast<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
     assert(vkGetPhysicalDeviceMultisamplePropertiesEXT != nullptr);
-    PFN_vkCmdSetSampleLocationsEXT vkCmdSetSampleLocationsEXT =
-        (PFN_vkCmdSetSampleLocationsEXT)vk::GetInstanceProcAddr(instance(), "vkCmdSetSampleLocationsEXT");
+    auto vkCmdSetSampleLocationsEXT =
+        reinterpret_cast<PFN_vkCmdSetSampleLocationsEXT>(vk::GetInstanceProcAddr(instance(), "vkCmdSetSampleLocationsEXT"));
     assert(vkCmdSetSampleLocationsEXT != nullptr);
 
     VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props =
@@ -2814,7 +2813,8 @@ TEST_F(VkLayerTest, RenderPassNextSubpassExcessive) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     if (rp2Supported) {
-        vkCmdNextSubpass2KHR = (PFN_vkCmdNextSubpass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdNextSubpass2KHR");
+        vkCmdNextSubpass2KHR =
+            reinterpret_cast<PFN_vkCmdNextSubpass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdNextSubpass2KHR"));
     }
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2854,7 +2854,8 @@ TEST_F(VkLayerTest, RenderPassEndBeforeFinalSubpass) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     if (rp2Supported) {
-        vkCmdEndRenderPass2KHR = (PFN_vkCmdEndRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRenderPass2KHR");
+        vkCmdEndRenderPass2KHR =
+            reinterpret_cast<PFN_vkCmdEndRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRenderPass2KHR"));
     }
 
     VkSubpassDescription sd[2] = {{0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 0, nullptr, nullptr, nullptr, 0, nullptr},
@@ -3165,8 +3166,8 @@ TEST_F(VkLayerTest, InvalidRenderPassEndFragmentDensityMapOffsetQCOM) {
         offsetting.pFragmentDensityOffsets = m_vOffsets;
         offsetting.fragmentDensityOffsetCount = 2;
 
-        PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-            (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+        auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
         VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM fdm_offset_properties =
             LvlInitStruct<VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM>();
@@ -4352,8 +4353,8 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
     }
 
     // Enable Sampler YCbCr Conversion
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2Function =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2Function = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2Function != nullptr);
     auto ycbcr_features = LvlInitStruct<VkPhysicalDeviceSamplerYcbcrConversionFeatures>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ycbcr_features);
@@ -4365,10 +4366,10 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCreateSamplerYcbcrConversionKHR vkCreateSamplerYcbcrConversionFunction =
-        (PFN_vkCreateSamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR");
-    PFN_vkDestroySamplerYcbcrConversionKHR vkDestroySamplerYcbcrConversionFunction =
-        (PFN_vkDestroySamplerYcbcrConversionKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR");
+    auto vkCreateSamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCreateSamplerYcbcrConversionKHR"));
+    auto vkDestroySamplerYcbcrConversionFunction = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkDestroySamplerYcbcrConversionKHR"));
     ASSERT_NE(vkCreateSamplerYcbcrConversionFunction, nullptr);
     ASSERT_NE(vkDestroySamplerYcbcrConversionFunction, nullptr);
 
@@ -6079,12 +6080,12 @@ TEST_F(VkLayerTest, DSBufferInfoErrors) {
     descriptor_write.dstSet = descriptor_set.set_;
 
     // Relying on the "return nullptr for non-enabled extensions
-    auto vkCreateDescriptorUpdateTemplateKHR =
-        (PFN_vkCreateDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR");
-    auto vkDestroyDescriptorUpdateTemplateKHR =
-        (PFN_vkDestroyDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR");
-    auto vkUpdateDescriptorSetWithTemplateKHR =
-        (PFN_vkUpdateDescriptorSetWithTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkUpdateDescriptorSetWithTemplateKHR");
+    auto vkCreateDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkCreateDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR"));
+    auto vkDestroyDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkDestroyDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR"));
+    auto vkUpdateDescriptorSetWithTemplateKHR = reinterpret_cast<PFN_vkUpdateDescriptorSetWithTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkUpdateDescriptorSetWithTemplateKHR"));
 
     if (update_template_support) {
         ASSERT_NE(vkCreateDescriptorUpdateTemplateKHR, nullptr);
@@ -6123,9 +6124,9 @@ TEST_F(VkLayerTest, DSBufferInfoErrors) {
 
     // VK_KHR_push_descriptor support
     auto vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    auto vkCmdPushDescriptorSetWithTemplateKHR = (PFN_vkCmdPushDescriptorSetWithTemplateKHR)vk::GetDeviceProcAddr(
-        m_device->device(), "vkCmdPushDescriptorSetWithTemplateKHR");
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
+    auto vkCmdPushDescriptorSetWithTemplateKHR = reinterpret_cast<PFN_vkCmdPushDescriptorSetWithTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetWithTemplateKHR"));
 
     std::unique_ptr<VkDescriptorSetLayoutObj> push_dsl = nullptr;
     std::unique_ptr<VkPipelineLayoutObj> pipeline_layout = nullptr;
@@ -7005,8 +7006,8 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassMultiview) {
     // Create rp2[0] with Multiview, rp2[1] without Multiview (zero viewMask), rp2[2] with Multiview but another viewMask
     VkRenderPass rp2[3];
     if (rp2Supported) {
-        PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-            (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+        auto vkCreateRenderPass2KHR =
+            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
         vkCreateRenderPass2KHR(m_device->device(), &rpci2, nullptr, &rp2[0]);
         subpass2.viewMask = 0x0u;
         rpci2.pSubpasses = &subpass2;
@@ -7739,7 +7740,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
     descriptor_write.dstBinding = 0;
 
     auto vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR"));
 
     for (uint32_t i = 0; i < 2; i++) {
         m_commandBuffer->begin();
@@ -7834,8 +7835,8 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables all supported indexing features except descriptorBindingUniformBufferUpdateAfterBind
@@ -7992,8 +7993,8 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables all supported indexing features except descriptorBindingUniformBufferUpdateAfterBind
@@ -8191,8 +8192,8 @@ TEST_F(VkLayerTest, DescriptorIndexingSetNonIdenticalWrite) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeatures>();
@@ -8366,11 +8367,11 @@ TEST_F(VkLayerTest, CreateDescriptorUpdateTemplate) {
     const VkDescriptorSetLayoutObj ds_layout_ub_push(m_device, {dsl_binding},
                                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
     const VkPipelineLayoutObj pipeline_layout(m_device, {{&ds_layout_ub, &ds_layout_ub1, &ds_layout_ub_push}});
-    PFN_vkCreateDescriptorUpdateTemplateKHR vkCreateDescriptorUpdateTemplateKHR =
-        (PFN_vkCreateDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR");
+    auto vkCreateDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkCreateDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR"));
     ASSERT_NE(vkCreateDescriptorUpdateTemplateKHR, nullptr);
-    PFN_vkDestroyDescriptorUpdateTemplateKHR vkDestroyDescriptorUpdateTemplateKHR =
-        (PFN_vkDestroyDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR");
+    auto vkDestroyDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkDestroyDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR"));
     ASSERT_NE(vkDestroyDescriptorUpdateTemplateKHR, nullptr);
 
     uint64_t badhandle = 0xcadecade;
@@ -8483,8 +8484,8 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto descriptor_indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
@@ -8494,8 +8495,8 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&inline_uniform_block_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     // Get the inline uniform block limits
@@ -8881,8 +8882,8 @@ TEST_F(VkLayerTest, NullDescriptorsEnabled) {
     auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&robustness2_features);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
 
@@ -9073,8 +9074,8 @@ TEST_F(VkLayerTest, RenderPassCreatePotentialFormatFeatures) {
         m_errorMonitor->VerifyFound();
 
         if (rp2Supported) {
-            PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-                (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR");
+            auto vkCreateRenderPass2KHR =
+                reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2KHR"));
             safe_VkRenderPassCreateInfo2 create_info2;
             ConvertVkRenderPassCreateInfoToV2KHR(rpci, &create_info2);
 
@@ -9084,8 +9085,8 @@ TEST_F(VkLayerTest, RenderPassCreatePotentialFormatFeatures) {
             m_errorMonitor->VerifyFound();
 
             // For api version >= 1.2, try core entrypoint
-            PFN_vkCreateRenderPass2 vkCreateRenderPass2 =
-                (PFN_vkCreateRenderPass2)vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2");
+            auto vkCreateRenderPass2 =
+                reinterpret_cast<PFN_vkCreateRenderPass2>(vk::GetDeviceProcAddr(device(), "vkCreateRenderPass2"));
             if (vkCreateRenderPass2) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription2-pResolveAttachments-02899");
                 m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pResolveAttachments-03068");
@@ -9412,16 +9413,16 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -9459,8 +9460,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
 
     VkRenderPass rp;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
@@ -9512,16 +9513,16 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -9559,8 +9560,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
 
     VkRenderPass rp;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
@@ -9667,16 +9668,16 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -9714,8 +9715,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
 
     VkRenderPass rp;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
 
     rpci.flags = VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassCreateInfo2-flags-04521");
@@ -9871,8 +9872,8 @@ TEST_F(VkLayerTest, FramebufferDepthStencilResolveAttachmentTests) {
     renderPassCreateInfo.pSubpasses = &subpassDescription;
     renderPassCreateInfo.pAttachments = attachmentDescriptions;
     VkRenderPass renderPass;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     vkCreateRenderPass2KHR(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     // Depth resolve attachment, mismatched image usage
@@ -9951,11 +9952,11 @@ TEST_F(VkLayerTest, DepthStencilResolveMode) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     assert(vkCreateRenderPass2KHR != nullptr);
 
     VkFormat depthFormat = FindSupportedDepthOnlyFormat(gpu());
@@ -10255,8 +10256,8 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolFlags) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -10325,8 +10326,8 @@ TEST_F(VkLayerTest, MutableDescriptorPoolsWithPartialOverlap) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -10403,8 +10404,8 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);
@@ -10731,8 +10732,8 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
     rpci.attachmentCount = 2;
     rpci.pAttachments = attachmentDescriptions;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
 
     VkRenderPass render_pass;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -10928,8 +10929,8 @@ TEST_F(VkLayerTest, AccelerationStructureBindings) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto acc_structure_props = LvlInitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
@@ -10986,8 +10987,8 @@ TEST_F(VkLayerTest, AccelerationStructureBindingsNV) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto ray_tracing_props = LvlInitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
@@ -11131,8 +11132,8 @@ TEST_F(VkLayerTest, MutableDescriptors) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
@@ -11290,8 +11291,8 @@ TEST_F(VkLayerTest, MutableDescriptorSetLayout) {
     bool push_descriptors = CanEnableDeviceExtension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature not supported. Skipped.\n", kSkipPrefix);

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -1808,10 +1808,10 @@ TEST_F(VkLayerTest, TestBarrierWithDynamicRendering) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkCmdBeginRendering vkCmdBeginRendering =
+    auto vkCmdBeginRendering =
         reinterpret_cast<PFN_vkCmdBeginRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRendering"));
     assert(vkCmdBeginRendering != nullptr);
-    PFN_vkCmdEndRendering vkCmdEndRendering =
+    auto vkCmdEndRendering =
         reinterpret_cast<PFN_vkCmdEndRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRendering"));
     assert(vkCmdEndRendering != nullptr);
 

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -61,8 +61,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
     if (descriptor_indexing) {
-        PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-            (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
         features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&indexing_features);
@@ -553,8 +553,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
 
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&robustness2_features);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
 
@@ -692,9 +692,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     }
 
     if (multi_draw_features.multiDraw) {
-        auto vkCmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT");
+        auto vkCmdDrawMultiEXT =
+            reinterpret_cast<PFN_vkCmdDrawMultiEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT"));
         auto vkCmdDrawMultiIndexedEXT =
-            (PFN_vkCmdDrawMultiIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT");
+            reinterpret_cast<PFN_vkCmdDrawMultiIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT"));
         assert(vkCmdDrawMultiEXT != nullptr && vkCmdDrawMultiIndexedEXT != nullptr);
 
         VkMultiDrawInfoEXT multi_draws[3] = {};
@@ -954,8 +955,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
                             ? LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&mesh_shader_features)
                             : LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
@@ -1011,7 +1012,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     VkBufferDeviceAddressInfoKHR bda_info = LvlInitStruct<VkBufferDeviceAddressInfoKHR>();
     bda_info.buffer = buffer1;
     auto vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR");
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR"));
     ASSERT_TRUE(vkGetBufferDeviceAddressKHR != nullptr);
     auto pBuffer = vkGetBufferDeviceAddressKHR(m_device->device(), &bda_info);
 
@@ -1206,9 +1207,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationInvalidHan
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
+    auto vkCmdBuildAccelerationStructureNV = reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
     VkBufferObj vbo;
@@ -1291,9 +1291,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationBottomLeve
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
+    auto vkCmdBuildAccelerationStructureNV = reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
     VkBufferObj vbo;
@@ -1386,9 +1385,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationBottomLeve
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
+    auto vkCmdBuildAccelerationStructureNV = reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
     VkBufferObj vbo;
@@ -1502,13 +1500,12 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationRestoresSt
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
+    auto vkCmdBuildAccelerationStructureNV = reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR =
+        reinterpret_cast<PFN_vkCmdPushDescriptorSetKHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdPushDescriptorSetKHR"));
     assert(vkCmdPushDescriptorSetKHR != nullptr);
 
     VkBufferObj vbo;
@@ -1736,10 +1733,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
         features13.dynamicRendering = true;
     }
 
-    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+    auto fpvkSetPhysicalDeviceLimitsEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    auto fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -1755,7 +1752,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     auto vkCmdDrawIndirectCountKHR =
-        (PFN_vkCmdDrawIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
+        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR"));
     if (vkCmdDrawIndirectCountKHR == nullptr) {
         printf("%s did not find vkCmdDrawIndirectCountKHR function pointer;  Skipping.\n", kSkipPrefix);
         return;
@@ -1859,7 +1856,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     auto vkCmdDrawIndirectCountKHR =
-        (PFN_vkCmdDrawIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
+        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR"));
     if (vkCmdDrawIndirectCountKHR == nullptr) {
         printf("%s did not find vkCmdDrawIndirectCountKHR function pointer;  Skipping.\n", kSkipPrefix);
         return;
@@ -1937,8 +1934,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     ASSERT_VK_SUCCESS(err);
     m_errorMonitor->VerifyFound();
 
-    auto vkCmdDrawIndexedIndirectCountKHR =
-        (PFN_vkCmdDrawIndexedIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR");
+    auto vkCmdDrawIndexedIndirectCountKHR = reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR"));
     if (vkCmdDrawIndexedIndirectCountKHR == nullptr) {
         printf("%s did not find vkCmdDrawIndexedIndirectCountKHR function pointer;  Skipping.\n", kSkipPrefix);
         return;
@@ -2023,8 +2020,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>();
@@ -2146,8 +2143,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     }
     m_device_extension_names.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     m_device_extension_names.push_back(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&inline_uniform_block_features);
@@ -2344,10 +2341,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationAbort) {
         printf("%s This test should not run on Nexus Player\n", kSkipPrefix);
         return;
     }
-    PFN_vkSetPhysicalDeviceFeaturesEXT fpvkSetPhysicalDeviceFeaturesEXT =
-        (PFN_vkSetPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFeaturesEXT");
-    PFN_vkGetOriginalPhysicalDeviceFeaturesEXT fpvkGetOriginalPhysicalDeviceFeaturesEXT =
-        (PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFeaturesEXT");
+    auto fpvkSetPhysicalDeviceFeaturesEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceFeaturesEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFeaturesEXT"));
+    auto fpvkGetOriginalPhysicalDeviceFeaturesEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceFeaturesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFeaturesEXT"));
 
     if (!(fpvkSetPhysicalDeviceFeaturesEXT) || !(fpvkGetOriginalPhysicalDeviceFeaturesEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -2581,9 +2578,10 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
     }
 
     if (multi_draw_features.multiDraw) {
-        auto vkCmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT");
+        auto vkCmdDrawMultiEXT =
+            reinterpret_cast<PFN_vkCmdDrawMultiEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiEXT"));
         auto vkCmdDrawMultiIndexedEXT =
-            (PFN_vkCmdDrawMultiIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT");
+            reinterpret_cast<PFN_vkCmdDrawMultiIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawMultiIndexedEXT"));
         assert(vkCmdDrawMultiEXT != nullptr && vkCmdDrawMultiIndexedEXT != nullptr);
         VkMultiDrawInfoEXT multi_draws[3] = {};
         multi_draws[0].vertexCount = multi_draws[1].vertexCount = multi_draws[2].vertexCount = 3;
@@ -2750,8 +2748,8 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables mesh_shader
@@ -2800,8 +2798,8 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     VkResult err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
     ASSERT_VK_SUCCESS(err);
 
-    PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV =
-        (PFN_vkCmdDrawMeshTasksNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksNV");
+    auto vkCmdDrawMeshTasksNV =
+        reinterpret_cast<PFN_vkCmdDrawMeshTasksNV>(vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksNV"));
     ASSERT_TRUE(vkCmdDrawMeshTasksNV != nullptr);
 
     m_commandBuffer->begin();

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -182,11 +182,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         descriptor_writes[1].descriptorCount = 6;
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_writes[1].pImageInfo = image_info;
-    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, nullptr);
     if (descriptor_indexing) {
         descriptor_writes[0].dstSet = descriptor_set_variable.set_;
         descriptor_writes[1].dstSet = descriptor_set_variable.set_;
-        vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, nullptr);
     }
 
     ds_binding_flags[0] = 0;
@@ -227,7 +227,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         buffer_descriptor_writes[1].descriptorCount = 5;  // Intentionally don't write index 5
         buffer_descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         buffer_descriptor_writes[1].pBufferInfo = &buffer_test_buffer_info[1];
-        vk::UpdateDescriptorSets(m_device->device(), 2, buffer_descriptor_writes, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 2, buffer_descriptor_writes, 0, nullptr);
     }
 
     // Shader programs for array OOB test in vertex stage:
@@ -516,7 +516,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         vk::QueueSubmit(c_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
         vk::QueueWaitIdle(m_device->m_queue);
         m_errorMonitor->VerifyFound();
-        vk::DestroyPipeline(m_device->handle(), c_pipeline, NULL);
+        vk::DestroyPipeline(m_device->handle(), c_pipeline, nullptr);
     }
     return;
 }
@@ -591,9 +591,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     bvci.buffer = uniform_texel_buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.range = VK_WHOLE_SIZE;
-    vk::CreateBufferView(m_device->device(), &bvci, NULL, &uniform_buffer_view);
+    vk::CreateBufferView(m_device->device(), &bvci, nullptr, &uniform_buffer_view);
     bvci.buffer = storage_texel_buffer.handle();
-    vk::CreateBufferView(m_device->device(), &bvci, NULL, &storage_buffer_view);
+    vk::CreateBufferView(m_device->device(), &bvci, nullptr, &storage_buffer_view);
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                   {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -796,7 +796,7 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     descriptor_write.descriptorType = descriptor_type;
     descriptor_write.pBufferInfo = &buffer_info;
 
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     char const *vsSource =
         "#version 450\n"
@@ -993,7 +993,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
     bci.size = 64;  // Buffer should be 16*4 = 64 bytes
     VkBuffer buffer1;
-    vk::CreateBuffer(device(), &bci, NULL, &buffer1);
+    vk::CreateBuffer(device(), &bci, nullptr, &buffer1);
     VkMemoryRequirements buffer_mem_reqs = {};
     vk::GetBufferMemoryRequirements(device(), buffer1, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
@@ -1003,7 +1003,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     buffer_alloc_info.pNext = &alloc_flags;
     VkDeviceMemory buffer_mem;
-    VkResult err = vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
+    VkResult err = vk::AllocateMemory(device(), &buffer_alloc_info, nullptr, &buffer_mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(m_device->device(), buffer1, buffer_mem, 0);
 
@@ -1030,7 +1030,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     descriptor_writes[0].descriptorCount = 1;
     descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_writes[0].pBufferInfo = buffer_test_buffer_info;
-    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
 
     char const *shader_source =
         "#version 450\n"
@@ -1128,7 +1128,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         pipelineLayoutCreateInfo[0].pPushConstantRanges = push_constant_ranges;
         pipelineLayoutCreateInfo[0].setLayoutCount = 0;
         pipelineLayoutCreateInfo[0].pSetLayouts = nullptr;
-        vk::CreatePipelineLayout(m_device->handle(), pipelineLayoutCreateInfo, NULL, &mesh_pipeline_layout);
+        vk::CreatePipelineLayout(m_device->handle(), pipelineLayoutCreateInfo, nullptr, &mesh_pipeline_layout);
 
         char const *mesh_shader_source =
             "#version 460\n"
@@ -1185,8 +1185,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         vk::DestroyPipelineLayout(m_device->handle(), mesh_pipeline_layout, nullptr);
     }
 
-    vk::DestroyBuffer(m_device->handle(), buffer1, NULL);
-    vk::FreeMemory(m_device->handle(), buffer_mem, NULL);
+    vk::DestroyBuffer(m_device->handle(), buffer1, nullptr);
+    vk::FreeMemory(m_device->handle(), buffer_mem, nullptr);
 }
 
 TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBRayTracingShaders) {
@@ -1782,7 +1782,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
 
     VkPipelineLayout pipeline_layout;
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = LvlInitStruct<VkPipelineLayoutCreateInfo>();
-    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, NULL, &pipeline_layout);
+    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, nullptr, &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
@@ -1856,7 +1856,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     }
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, NULL, pool_flags));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     auto vkCmdDrawIndirectCountKHR =
         (PFN_vkCmdDrawIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
@@ -1886,7 +1886,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
 
     VkPipelineLayout pipeline_layout;
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = LvlInitStruct<VkPipelineLayoutCreateInfo>();
-    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, NULL, &pipeline_layout);
+    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, nullptr, &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
@@ -2052,7 +2052,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
 
     VkPipelineLayout pipeline_layout;
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = LvlInitStruct<VkPipelineLayoutCreateInfo>();
-    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, NULL, &pipeline_layout);
+    VkResult err = vk::CreatePipelineLayout(m_device->handle(), &pipelineLayoutCreateInfo, nullptr, &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
@@ -2222,7 +2222,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     descriptor_writes[1].dstArrayElement = 16;  // Skip first 16 bytes (dummy)
     descriptor_writes[1].descriptorCount = 4;   // Write 4 bytes to val
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
-    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, nullptr);
 
     char const *csSource =
         "#version 450\n"
@@ -2267,7 +2267,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     vk::QueueSubmit(c_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
     m_errorMonitor->VerifyNotFound();
-    vk::DestroyPipeline(m_device->handle(), c_pipeline, NULL);
+    vk::DestroyPipeline(m_device->handle(), c_pipeline, nullptr);
 
     uint32_t *data = (uint32_t *)buffer0.memory().map();
     ASSERT_TRUE(*data = test_data);
@@ -2287,7 +2287,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     vk::GetPhysicalDeviceProperties(phys_devices[m_gpu_index], &properties);
     if (m_device->props.limits.maxBoundDescriptorSets != properties.limits.maxBoundDescriptorSets - 1)
         m_errorMonitor->SetError("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT not functioning as expected");
-    vk::DestroyInstance(test_inst, NULL);
+    vk::DestroyInstance(test_inst, nullptr);
 
     auto set_count = properties.limits.maxBoundDescriptorSets;
     // Now be sure that recovery from an unavailable descriptor set works and that uninstrumented shaders are used
@@ -2306,13 +2306,13 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     dsl_create_info.pBindings = dsl_binding;
     dsl_create_info.bindingCount = 2;
     for (uint32_t i = 0; i < set_count; i++) {
-        vk::CreateDescriptorSetLayout(m_device->handle(), &dsl_create_info, NULL, &layouts[i]);
+        vk::CreateDescriptorSetLayout(m_device->handle(), &dsl_create_info, nullptr, &layouts[i]);
     }
     VkPipelineLayoutCreateInfo pl_create_info = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     VkPipelineLayout pl_layout;
     pl_create_info.setLayoutCount = set_count;
     pl_create_info.pSetLayouts = layouts;
-    vk::CreatePipelineLayout(m_device->handle(), &pl_create_info, NULL, &pl_layout);
+    vk::CreatePipelineLayout(m_device->handle(), &pl_create_info, nullptr, &pl_layout);
     pipeline_info.layout = pl_layout;
     vk::CreateComputePipelines(device(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &c_pipeline);
     m_commandBuffer->begin();
@@ -2323,10 +2323,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     m_commandBuffer->end();
     vk::QueueSubmit(c_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
-    vk::DestroyPipelineLayout(m_device->handle(), pl_layout, NULL);
-    vk::DestroyPipeline(m_device->handle(), c_pipeline, NULL);
+    vk::DestroyPipelineLayout(m_device->handle(), pl_layout, nullptr);
+    vk::DestroyPipeline(m_device->handle(), c_pipeline, nullptr);
     for (uint32_t i = 0; i < set_count; i++) {
-        vk::DestroyDescriptorSetLayout(m_device->handle(), layouts[i], NULL);
+        vk::DestroyDescriptorSetLayout(m_device->handle(), layouts[i], nullptr);
     }
     m_errorMonitor->VerifyNotFound();
     data = (uint32_t *)buffer0.memory().map();
@@ -2467,7 +2467,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
     descriptor_writes[0].descriptorCount = 1;
     descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_writes[0].pBufferInfo = buffer_info;
-    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
 
     char const *shader_source =
         "#version 450\n"

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -83,7 +83,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageViewMismatchTests) {
     renderPassCreateInfo.attachmentCount = 1;
     renderPassCreateInfo.pAttachments = &attachmentDescription;
     VkRenderPass renderPass;
-    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, NULL, &renderPass);
+    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = LvlInitStruct<VkFramebufferAttachmentImageInfoKHR>();
     framebufferAttachmentImageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
@@ -140,11 +140,11 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageViewMismatchTests) {
     // Has subset of usage flags
     VkImageView imageViewSubset;
     imageViewCreateInfo.pNext = &image_view_usage_create_info;
-    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, NULL, &imageViewSubset);
+    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, nullptr, &imageViewSubset);
     imageViewCreateInfo.pNext = nullptr;
 
     VkImageView imageView;
-    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, NULL, &imageView);
+    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, nullptr, &imageView);
 
     VkRenderPassAttachmentBeginInfoKHR renderPassAttachmentBeginInfo = LvlInitStruct<VkRenderPassAttachmentBeginInfo>();
     renderPassAttachmentBeginInfo.attachmentCount = 1;
@@ -403,7 +403,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferFeatureEnableTest) {
     renderPassCreateInfo.attachmentCount = 1;
     renderPassCreateInfo.pAttachments = &attachmentDescription;
     VkRenderPass renderPass;
-    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, NULL, &renderPass);
+    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = LvlInitStruct<VkFramebufferAttachmentImageInfoKHR>();
     framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -495,7 +495,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferCreationTests) {
     renderPassCreateInfo.attachmentCount = 1;
     renderPassCreateInfo.pAttachments = &attachmentDescription;
     VkRenderPass renderPass;
-    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, NULL, &renderPass);
+    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = LvlInitStruct<VkFramebufferAttachmentImageInfoKHR>();
     framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -1186,7 +1186,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
 
     PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
         (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
-    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
@@ -1206,19 +1206,19 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
     fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
-    fb_info.pAttachments = NULL;
+    fb_info.pAttachments = nullptr;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
     fb_info.layers = 1;
 
     VkFramebuffer fb;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04549");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
@@ -1307,7 +1307,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
 
     PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
         (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
-    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+    VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
@@ -1327,7 +1327,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
     fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
-    fb_info.pAttachments = NULL;
+    fb_info.pAttachments = nullptr;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
     fb_info.layers = 1;
@@ -1336,52 +1336,52 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
 
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width * 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04543");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
 
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height * 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04544");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
 
     fbai_info.layerCount = 2;
     fb_info.layers = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04545");
-    err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+    err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
     m_errorMonitor->VerifyFound();
     if (err == VK_SUCCESS) {
-        vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+        vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     }
     fb_info.layers = 1;
     fbai_info.layerCount = 1;
 
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 
     if (fsr_properties.layeredShadingRateAttachments == VK_TRUE) {
         subpass.viewMask = 0x4;
-        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, NULL, &rp);
+        err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
         ASSERT_VK_SUCCESS(err);
         subpass.viewMask = 0;
 
         fbai_info.layerCount = 2;
         fb_info.renderPass = rp;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, kVUIDUndefined);
-        err = vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);
+        err = vk::CreateFramebuffer(device(), &fb_info, nullptr, &fb);
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
-            vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+            vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
         }
         fbai_info.layerCount = 1;
 
-        vk::DestroyRenderPass(m_device->device(), rp, NULL);
+        vk::DestroyRenderPass(m_device->device(), rp, nullptr);
     }
 }
 
@@ -1436,7 +1436,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageView3D) {
     renderPassCreateInfo.attachmentCount = 1;
     renderPassCreateInfo.pAttachments = &attachmentDescription;
     VkRenderPass renderPass;
-    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, NULL, &renderPass);
+    vk::CreateRenderPass(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     // Create Attachments
     VkImageCreateInfo imageCreateInfo = LvlInitStruct<VkImageCreateInfo>();
@@ -1464,7 +1464,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageView3D) {
     imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
     imageViewCreateInfo.subresourceRange.layerCount = 1;
     VkImageView imageView3D;
-    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, NULL, &imageView3D);
+    vk::CreateImageView(m_device->device(), &imageViewCreateInfo, nullptr, &imageView3D);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = LvlInitStruct<VkFramebufferAttachmentImageInfoKHR>();
     framebufferAttachmentImageInfo.flags = 0;

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1033,8 +1033,8 @@ TEST_F(VkLayerTest, ImagelessFramebufferDepthStencilResolveAttachmentTests) {
     renderPassCreateInfo.pSubpasses = &subpassDescription;
     renderPassCreateInfo.pAttachments = attachmentDescriptions;
     VkRenderPass renderPass;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     vkCreateRenderPass2KHR(m_device->device(), &renderPassCreateInfo, nullptr, &renderPass);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfos[2] = {};
@@ -1135,16 +1135,16 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceImagelessFramebufferFeatures if_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features =
@@ -1184,8 +1184,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
 
     VkRenderPass rp;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
@@ -1256,16 +1256,16 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceImagelessFramebufferFeatures if_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features =
@@ -1305,8 +1305,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
 
     VkRenderPass rp;
 
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
+    auto vkCreateRenderPass2KHR =
+        reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR"));
     VkResult err = vkCreateRenderPass2KHR(m_device->device(), &rpci, nullptr, &rp);
     ASSERT_VK_SUCCESS(err);
 
@@ -1613,12 +1613,12 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
     buffer.init(*m_device, buff_ci);
 
     // Relying on the "return nullptr for non-enabled extensions
-    auto vkCreateDescriptorUpdateTemplateKHR =
-        (PFN_vkCreateDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR");
-    auto vkDestroyDescriptorUpdateTemplateKHR =
-        (PFN_vkDestroyDescriptorUpdateTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR");
-    auto vkUpdateDescriptorSetWithTemplateKHR =
-        (PFN_vkUpdateDescriptorSetWithTemplateKHR)vk::GetDeviceProcAddr(m_device->device(), "vkUpdateDescriptorSetWithTemplateKHR");
+    auto vkCreateDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkCreateDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCreateDescriptorUpdateTemplateKHR"));
+    auto vkDestroyDescriptorUpdateTemplateKHR = reinterpret_cast<PFN_vkDestroyDescriptorUpdateTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkDestroyDescriptorUpdateTemplateKHR"));
+    auto vkUpdateDescriptorSetWithTemplateKHR = reinterpret_cast<PFN_vkUpdateDescriptorSetWithTemplateKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkUpdateDescriptorSetWithTemplateKHR"));
 
     ASSERT_NE(vkCreateDescriptorUpdateTemplateKHR, nullptr);
     ASSERT_NE(vkDestroyDescriptorUpdateTemplateKHR, nullptr);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -212,7 +212,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
     VkPrivateDataSlotEXT data_slot;
     VkPrivateDataSlotCreateInfoEXT data_create_info = LvlInitStruct<VkPrivateDataSlotCreateInfoEXT>();
     data_create_info.flags = 0;
-    VkResult err = pfn_vkCreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, NULL, &data_slot);
+    VkResult err = pfn_vkCreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, nullptr, &data_slot);
     if (err != VK_SUCCESS) {
         printf("%s Failed to create private data slot, VkResult %d.\n", kSkipPrefix, err);
     }
@@ -235,7 +235,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
     sampler_info.maxLod = 0.0f;
     sampler_info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
     sampler_info.unnormalizedCoordinates = VK_FALSE;
-    vk::CreateSampler(m_device->handle(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->handle(), &sampler_info, nullptr, &sampler);
 
     static const uint64_t data_value = 0x70AD;
     err = pfn_vkSetPrivateDataEXT(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler, data_slot, data_value);
@@ -248,8 +248,8 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
     if (data != data_value) {
         m_errorMonitor->SetError("Got unexpected private data, %s.\n");
     }
-    pfn_vkDestroyPrivateDataSlotEXT(m_device->handle(), data_slot, NULL);
-    vk::DestroySampler(m_device->handle(), sampler, NULL);
+    pfn_vkDestroyPrivateDataSlotEXT(m_device->handle(), data_slot, nullptr);
+    vk::DestroySampler(m_device->handle(), sampler, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -281,11 +281,11 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
     VkPrivateDataSlotCreateInfoEXT data_create_info = LvlInitStruct<VkPrivateDataSlotCreateInfoEXT>();
     data_create_info.flags = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreatePrivateDataSlot-privateData-04564");
-    vkCreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, NULL, &data_slot);
+    vkCreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, nullptr, &data_slot);
     m_errorMonitor->VerifyFound();
     if (vulkan_13) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreatePrivateDataSlot-privateData-04564");
-        vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+        vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, nullptr, &data_slot);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -326,7 +326,7 @@ TEST_F(VkLayerTest, CustomStypeStructString) {
     bvci.range = VK_WHOLE_SIZE;
 
     m_errorMonitor->ExpectSuccess(kErrorBit);
-    vk::CreateBufferView(m_device->device(), &bvci, NULL, &buffer_view);
+    vk::CreateBufferView(m_device->device(), &bvci, nullptr, &buffer_view);
     m_errorMonitor->VerifyNotFound();
 
     vk::DestroyBufferView(m_device->device(), buffer_view, nullptr);
@@ -376,7 +376,7 @@ TEST_F(VkLayerTest, CustomStypeStructArray) {
     bvci.range = VK_WHOLE_SIZE;
 
     m_errorMonitor->ExpectSuccess(kErrorBit);
-    vk::CreateBufferView(m_device->device(), &bvci, NULL, &buffer_view);
+    vk::CreateBufferView(m_device->device(), &bvci, nullptr, &buffer_view);
     m_errorMonitor->VerifyNotFound();
 
     vk::DestroyBufferView(m_device->device(), buffer_view, nullptr);
@@ -585,13 +585,13 @@ TEST_F(VkLayerTest, RequiredParameter) {
     // Specify NULL for a pointer to a handle
     // Expected to trigger an error with
     // parameter_validation::validate_required_pointer
-    vk::GetPhysicalDeviceFeatures(gpu(), NULL);
+    vk::GetPhysicalDeviceFeatures(gpu(), nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "required parameter pQueueFamilyPropertyCount specified as NULL");
     // Specify NULL for pointer to array count
     // Expected to trigger an error with parameter_validation::validate_array
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), NULL, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), nullptr, nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewport-viewportCount-arraylength");
@@ -604,13 +604,13 @@ TEST_F(VkLayerTest, RequiredParameter) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateImage-pCreateInfo-parameter");
     // Specify a null pImageCreateInfo struct pointer
     VkImage test_image;
-    vk::CreateImage(device(), NULL, NULL, &test_image);
+    vk::CreateImage(device(), nullptr, nullptr, &test_image);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewport-pViewports-parameter");
     // Specify NULL for a required array
     // Expected to trigger an error with parameter_validation::validate_array
-    m_commandBuffer->SetViewport(0, 1, NULL);
+    m_commandBuffer->SetViewport(0, 1, nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "required parameter memory specified as VK_NULL_HANDLE");
@@ -633,7 +633,7 @@ TEST_F(VkLayerTest, RequiredParameter) {
     // Expected to trigger an error with
     // parameter_validation::validate_struct_type
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), NULL, NULL, &memory);
+    vk::AllocateMemory(device(), nullptr, nullptr, &memory);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "value of faceMask must not be 0");
@@ -670,7 +670,7 @@ TEST_F(VkLayerTest, RequiredParameter) {
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.waitSemaphoreCount = 1;
     // Set a null pointer for pWaitSemaphores
-    submitInfo.pWaitSemaphores = NULL;
+    submitInfo.pWaitSemaphores = nullptr;
     submitInfo.pWaitDstStageMask = &stageFlags;
     vk::QueueSubmit(m_device->m_queue, 1, &submitInfo, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
@@ -707,7 +707,7 @@ TEST_F(VkLayerTest, SpecLinks) {
     }
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, spec_version);
-    vk::GetPhysicalDeviceFeatures(gpu(), NULL);
+    vk::GetPhysicalDeviceFeatures(gpu(), nullptr);
     m_errorMonitor->VerifyFound();
 
     // Now generate a 'default' message and check the link
@@ -795,7 +795,7 @@ TEST_F(VkLayerTest, UsePnextOnlyStructWithoutExtensionEnabled) {
 TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     TEST_DESCRIPTION("See if checks occur on structs ONLY used in pnext chains.");
 
-    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, NULL,
+    if (!(CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names, m_device_extension_names, nullptr,
                                                          m_errorMonitor))) {
         printf("Descriptor indexing or one of its dependencies not supported, skipping tests\n");
         return;
@@ -813,7 +813,7 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     indexing_features.descriptorBindingUniformBufferUpdateAfterBind = 800;
 
     uint32_t queue_node_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, nullptr);
     VkQueueFamilyProperties *queue_props = new VkQueueFamilyProperties[queue_node_count];
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, queue_props);
     float priorities[] = {1.0f};
@@ -826,14 +826,14 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     dev_info.queueCreateInfoCount = 1;
     dev_info.pQueueCreateInfos = &queue_info;
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
     dev_info.pNext = &features2;
     VkDevice dev;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "is neither VK_TRUE nor VK_FALSE");
     m_errorMonitor->SetUnexpectedError("Failed to create");
-    vk::CreateDevice(gpu(), &dev_info, NULL, &dev);
+    vk::CreateDevice(gpu(), &dev_info, nullptr, &dev);
     m_errorMonitor->VerifyFound();
 }
 
@@ -849,7 +849,7 @@ TEST_F(VkLayerTest, ReservedParameter) {
     VkSemaphore sem_handle = VK_NULL_HANDLE;
     VkSemaphoreCreateInfo sem_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     sem_info.flags = 1;
-    vk::CreateSemaphore(device(), &sem_info, NULL, &sem_handle);
+    vk::CreateSemaphore(device(), &sem_info, nullptr, &sem_handle);
     m_errorMonitor->VerifyFound();
 }
 
@@ -963,8 +963,8 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
     vk::FreeCommandBuffers(device(), commandpool_2, 1, &commandBuffer);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyCommandPool(device(), commandpool_1, NULL);
-    vk::DestroyCommandPool(device(), commandpool_2, NULL);
+    vk::DestroyCommandPool(device(), commandpool_1, nullptr);
+    vk::DestroyCommandPool(device(), commandpool_2, nullptr);
 }
 
 TEST_F(VkLayerTest, DebugUtilsNameTest) {
@@ -1130,8 +1130,8 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     vk::FreeCommandBuffers(device(), commandpool_2, 1, &commandBuffer);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyCommandPool(device(), commandpool_1, NULL);
-    vk::DestroyCommandPool(device(), commandpool_2, NULL);
+    vk::DestroyCommandPool(device(), commandpool_1, nullptr);
+    vk::DestroyCommandPool(device(), commandpool_2, nullptr);
     fpvkDestroyDebugUtilsMessengerEXT(instance(), my_messenger, nullptr);
 }
 
@@ -1147,7 +1147,7 @@ TEST_F(VkLayerTest, InvalidStructSType) {
     // parameter_validation::validate_struct_type
     VkMemoryAllocateInfo alloc_info = {};
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "parameter pSubmits[0].sType must be");
@@ -1185,7 +1185,7 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     VkApplicationInfo app_info = {};
     event_alloc_info.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
     event_alloc_info.pNext = &app_info;
-    vk::CreateEvent(device(), &event_alloc_info, NULL, &event);
+    vk::CreateEvent(device(), &event_alloc_info, nullptr, &event);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), " chain includes a structure with unexpected VkStructureType ");
@@ -1195,7 +1195,7 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     // Expected to trigger an error with parameter_validation::validate_struct_pnext
     VkDeviceMemory memory = VK_NULL_HANDLE;
     VkMemoryAllocateInfo memory_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(&app_info);
-    vk::AllocateMemory(device(), &memory_alloc_info, NULL, &memory);
+    vk::AllocateMemory(device(), &memory_alloc_info, nullptr, &memory);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), " chain includes a structure with unexpected VkStructureType ");
@@ -1307,12 +1307,12 @@ TEST_F(VkLayerTest, SubmitSignaledFence) {
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
 
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, testFence.handle());
     vk::QueueWaitIdle(m_device->m_queue);
@@ -1378,18 +1378,18 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     device_create_info.queueCreateInfoCount = 1;
     device_create_info.pQueueCreateInfos = &queue_info;
     device_create_info.enabledLayerCount = 0;
-    device_create_info.ppEnabledLayerNames = NULL;
+    device_create_info.ppEnabledLayerNames = nullptr;
     device_create_info.pEnabledFeatures = &features;
 
     VkDevice second_device;
-    ASSERT_VK_SUCCESS(vk::CreateDevice(gpu(), &device_create_info, NULL, &second_device));
+    ASSERT_VK_SUCCESS(vk::CreateDevice(gpu(), &device_create_info, nullptr, &second_device));
 
     // Try to destroy the renderpass from the first device using the second device
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyRenderPass-renderPass-parent");
-    vk::DestroyRenderPass(second_device, m_renderPass, NULL);
+    vk::DestroyRenderPass(second_device, m_renderPass, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDevice(second_device, NULL);
+    vk::DestroyDevice(second_device, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidAllocationCallbacks) {
@@ -1745,7 +1745,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferEventDestroyed) {
 
     VkEvent event;
     VkEventCreateInfo evci = LvlInitStruct<VkEventCreateInfo>();
-    VkResult result = vk::CreateEvent(m_device->device(), &evci, NULL, &event);
+    VkResult result = vk::CreateEvent(m_device->device(), &evci, nullptr, &event);
     ASSERT_VK_SUCCESS(result);
 
     m_commandBuffer->begin();
@@ -1754,7 +1754,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferEventDestroyed) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkEvent");
     // Destroy event dependency prior to submit to cause ERROR
-    vk::DestroyEvent(m_device->device(), event, NULL);
+    vk::DestroyEvent(m_device->device(), event, nullptr);
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -1781,7 +1781,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferQueryPoolDestroyed) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkQueryPool");
     // Destroy query pool dependency prior to submit to cause ERROR
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -1806,14 +1806,14 @@ TEST_F(VkLayerTest, DeviceFeature2AndVertexAttributeDivisorExtensionUnenabled) {
     VkDevice testDevice;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-pNext");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vadf = LvlInitStruct<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>();
     device_create_info.pNext = &vadf;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VK_EXT_vertex_attribute_divisor must be enabled when it creates a device");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1875,7 +1875,7 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-02829");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-02830");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1965,7 +1965,7 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
     VkDevice testDevice;
 
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2024,7 +2024,7 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceVariablePointersFeatures-variablePointers-01431");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2086,7 +2086,7 @@ TEST_F(VkLayerTest, FeaturesMultiview) {
     if (multiview_features.multiviewTessellationShader == VK_TRUE) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceMultiviewFeatures-multiviewTessellationShader-00581");
     }
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2137,7 +2137,7 @@ TEST_F(VkLayerTest, ValidationCacheTestBadMerge) {
 
     VkValidationCacheCreateInfoEXT validationCacheCreateInfo = LvlInitStruct<VkValidationCacheCreateInfoEXT>();
     validationCacheCreateInfo.initialDataSize = 0;
-    validationCacheCreateInfo.pInitialData = NULL;
+    validationCacheCreateInfo.pInitialData = nullptr;
     validationCacheCreateInfo.flags = 0;
     VkValidationCacheEXT validationCache = VK_NULL_HANDLE;
     VkResult res = fpCreateValidationCache(m_device->device(), &validationCacheCreateInfo, nullptr, &validationCache);
@@ -2200,7 +2200,7 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
     // If there is more than one queue family, create a device with a single queue family, then create a buffer
     // with SHARING_MODE_CONCURRENT that uses a non-device PDEV queue family.
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     VkQueueFamilyProperties *queue_props = new VkQueueFamilyProperties[queue_count];
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props);
 
@@ -2229,7 +2229,7 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
     qfi[1] = 2;
     VkBuffer buffer = VK_NULL_HANDLE;
     m_errorMonitor->ExpectSuccess();
-    vk::CreateBuffer(second_device, &buffCI, NULL, &buffer);
+    vk::CreateBuffer(second_device, &buffCI, nullptr, &buffer);
     m_errorMonitor->VerifyNotFound();
     vk::DestroyDevice(second_device, nullptr);
 }
@@ -2249,7 +2249,7 @@ TEST_F(VkLayerTest, InvalidQueryPoolCreate) {
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.enabledLayerCount = 0;
-    device_create_info.ppEnabledLayerNames = NULL;
+    device_create_info.ppEnabledLayerNames = nullptr;
     device_create_info.pEnabledFeatures = &features;
     VkResult err = vk::CreateDevice(gpu(), &device_create_info, nullptr, &local_device);
     ASSERT_VK_SUCCESS(err);
@@ -2283,7 +2283,7 @@ TEST_F(VkLayerTest, InvalidQuerySizes) {
     }
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     const uint32_t timestampValidBits = queue_props[m_device->graphics_queue_node_index_].timestampValidBits;
@@ -2542,7 +2542,7 @@ TEST_F(VkLayerTest, StageMaskGsTsEnabled) {
 
     VkEvent event;
     VkEventCreateInfo evci = LvlInitStruct<VkEventCreateInfo>();
-    VkResult result = vk::CreateEvent(test_device.handle(), &evci, NULL, &event);
+    VkResult result = vk::CreateEvent(test_device.handle(), &evci, nullptr, &event);
     ASSERT_VK_SUCCESS(result);
 
     VkCommandBufferBeginInfo cbbi = LvlInitStruct<VkCommandBufferBeginInfo>();
@@ -2555,8 +2555,8 @@ TEST_F(VkLayerTest, StageMaskGsTsEnabled) {
     vk::CmdSetEvent(cmd_buffer, event, VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyEvent(test_device.handle(), event, NULL);
-    vk::DestroyCommandPool(test_device.handle(), command_pool, NULL);
+    vk::DestroyEvent(test_device.handle(), event, nullptr);
+    vk::DestroyCommandPool(test_device.handle(), command_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, StageMaskHost) {
@@ -2622,7 +2622,7 @@ TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
     // Create Sampler
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     VkSampler sampler;
-    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    VkResult err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     // Create PSO to be used for draw-time errors below
@@ -2650,7 +2650,7 @@ TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     VkViewport viewport = {0, 0, 16, 16, 0, 1};
     VkRect2D scissor = {{0, 0}, {16, 16}};
@@ -2667,11 +2667,11 @@ TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     // Destroy pool while in-flight, causing error
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyDescriptorPool-descriptorPool-00303");
-    vk::DestroyDescriptorPool(m_device->device(), pipe.descriptor_set_->pool_, NULL);
+    vk::DestroyDescriptorPool(m_device->device(), pipe.descriptor_set_->pool_, nullptr);
     m_errorMonitor->VerifyFound();
     vk::QueueWaitIdle(m_device->m_queue);
     // Cleanup
-    vk::DestroySampler(m_device->device(), sampler, NULL);
+    vk::DestroySampler(m_device->device(), sampler, nullptr);
     m_errorMonitor->SetUnexpectedError(
         "If descriptorPool is not VK_NULL_HANDLE, descriptorPool must be a valid VkDescriptorPool handle");
     m_errorMonitor->SetUnexpectedError("Unable to remove DescriptorPool obj");
@@ -2711,7 +2711,7 @@ TEST_F(VkLayerTest, FramebufferInUseDestroyedSignaled) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     // Destroy framebuffer while in-flight
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyFramebuffer-framebuffer-00892");
-    vk::DestroyFramebuffer(m_device->device(), fb, NULL);
+    vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
     m_errorMonitor->VerifyFound();
     // Wait for queue to complete so we can safely destroy everything
     vk::QueueWaitIdle(m_device->m_queue);
@@ -2767,7 +2767,7 @@ TEST_F(VkLayerTest, FramebufferImageInUseDestroyedSignaled) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     // Destroy image attached to framebuffer while in-flight
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyImage-image-01000");
-    vk::DestroyImage(m_device->device(), image.handle(), NULL);
+    vk::DestroyImage(m_device->device(), image.handle(), nullptr);
     m_errorMonitor->VerifyFound();
     // Wait for queue to complete so we can safely destroy image and other objects
     vk::QueueWaitIdle(m_device->m_queue);
@@ -2835,7 +2835,7 @@ TEST_F(VkLayerTest, InUseDestroyedSignaled) {
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              &pipe.descriptor_set_->set_, 0, NULL);
+                              &pipe.descriptor_set_->set_, 0, nullptr);
 
     m_commandBuffer->end();
 
@@ -3004,7 +3004,7 @@ TEST_F(VkLayerTest, QueryPoolPartialTimestamp) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -3052,7 +3052,7 @@ TEST_F(VkLayerTest, QueryPoolPartialTimestamp) {
     m_errorMonitor->VerifyFound();
 
     // Destroy query pool.
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, PerformanceQueryIntel) {
@@ -3088,7 +3088,7 @@ TEST_F(VkLayerTest, PerformanceQueryIntel) {
     m_errorMonitor->VerifyFound();
 
     // Destroy query pool.
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryPoolInUseDestroyedSignaled) {
@@ -3116,14 +3116,14 @@ TEST_F(VkLayerTest, QueryPoolInUseDestroyedSignaled) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyQueryPool-queryPool-00793");
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::QueueWaitIdle(m_device->m_queue);
     // Now that cmd buffer done we can safely destroy query_pool
     m_errorMonitor->SetUnexpectedError("If queryPool is not VK_NULL_HANDLE, queryPool must be a valid VkQueryPool handle");
     m_errorMonitor->SetUnexpectedError("Unable to remove QueryPool obj");
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, PipelineInUseDestroyedSignaled) {
@@ -3177,7 +3177,7 @@ TEST_F(VkLayerTest, ImageViewInUseDestroyedSignaled) {
     VkSampler sampler;
 
     VkResult err;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     VkImageObj image(m_device);
@@ -3260,7 +3260,7 @@ TEST_F(VkLayerTest, BufferViewInUseDestroyedSignaled) {
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.range = VK_WHOLE_SIZE;
 
-    VkResult err = vk::CreateBufferView(m_device->device(), &bvci, NULL, &view);
+    VkResult err = vk::CreateBufferView(m_device->device(), &bvci, nullptr, &view);
     ASSERT_VK_SUCCESS(err);
 
     char const *fsSource = R"glsl(
@@ -3322,7 +3322,7 @@ TEST_F(VkLayerTest, BufferViewInUseDestroyedSignaled) {
     // Now we can actually destroy bufferView
     m_errorMonitor->SetUnexpectedError("If bufferView is not VK_NULL_HANDLE, bufferView must be a valid VkBufferView handle");
     m_errorMonitor->SetUnexpectedError("Unable to remove BufferView obj");
-    vk::DestroyBufferView(m_device->device(), view, NULL);
+    vk::DestroyBufferView(m_device->device(), view, nullptr);
 }
 
 TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
@@ -3335,7 +3335,7 @@ TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
     VkSampler sampler;
 
     VkResult err;
-    err = vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     VkImageObj image(m_device);
@@ -3395,7 +3395,7 @@ TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
     // Now we can actually destroy sampler
     m_errorMonitor->SetUnexpectedError("If sampler is not VK_NULL_HANDLE, sampler must be a valid VkSampler handle");
     m_errorMonitor->SetUnexpectedError("Unable to remove Sampler obj");
-    vk::DestroySampler(m_device->device(), sampler, NULL);  // Destroyed for real
+    vk::DestroySampler(m_device->device(), sampler, nullptr);  // Destroyed for real
 }
 
 TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
@@ -3457,7 +3457,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     VkEvent event;
     VkResult err;
 
-    err = vk::CreateEvent(device(), &event_info, NULL, &event);
+    err = vk::CreateEvent(device(), &event_info, nullptr, &event);
     ASSERT_VK_SUCCESS(err);
 
     err = vk::ResetEvent(device(), event);
@@ -3476,9 +3476,9 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     // Make non-conflicting calls from this thread at the same time.
     for (int i = 0; i < 80000; i++) {
         uint32_t count;
-        vk::EnumeratePhysicalDevices(instance(), &count, NULL);
+        vk::EnumeratePhysicalDevices(instance(), &count, nullptr);
     }
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
 
     // Then do some incorrect operations using multiple threads.
     // Add many entries to command buffer from another thread.
@@ -3486,14 +3486,14 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     // Add many entries to command buffer from this thread at the same time.
     AddToCommandBuffer(&data);
 
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
     commandBuffer.end();
 
-    m_errorMonitor->SetBailout(NULL);
+    m_errorMonitor->SetBailout(nullptr);
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyEvent(device(), event, NULL);
+    vk::DestroyEvent(device(), event, nullptr);
 }
 
 TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
@@ -3539,9 +3539,9 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
 
-    m_errorMonitor->SetBailout(NULL);
+    m_errorMonitor->SetBailout(nullptr);
 
     m_errorMonitor->VerifyFound();
 }
@@ -3622,9 +3622,9 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    test_platform_thread_join(thread, nullptr);
 
-    m_errorMonitor->SetBailout(NULL);
+    m_errorMonitor->SetBailout(nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }
@@ -3663,7 +3663,7 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.enabledLayerCount = 0;
-    device_create_info.ppEnabledLayerNames = NULL;
+    device_create_info.ppEnabledLayerNames = nullptr;
     device_create_info.enabledExtensionCount = 2;
     device_create_info.ppEnabledExtensionNames = (const char *const *)extension_names;
     device_create_info.pEnabledFeatures = &features;
@@ -3672,7 +3672,7 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     // The following unexpected error is coming from the LunarG loader. Do not make it a desired message because platforms that do
     // not use the LunarG loader (e.g. Android) will not see the message and the test will fail.
     m_errorMonitor->SetUnexpectedError("Failed to create device chain.");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -3700,7 +3700,7 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.enabledLayerCount = 0;
-    device_create_info.ppEnabledLayerNames = NULL;
+    device_create_info.ppEnabledLayerNames = nullptr;
     device_create_info.enabledExtensionCount = 1;
     device_create_info.ppEnabledExtensionNames = (const char *const *)extension_names;
     device_create_info.pEnabledFeatures = &features;
@@ -3709,7 +3709,7 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     // The following unexpected error is coming from the LunarG loader. Do not make it a desired message because platforms that do
     // not use the LunarG loader (e.g. Android) will not see the message and the test will fail.
     m_errorMonitor->SetUnexpectedError("Failed to create device chain.");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -3992,7 +3992,7 @@ TEST_F(VkLayerTest, ResetEventThenSet) {
 
     vk::DestroyEvent(m_device->device(), event, nullptr);
     vk::FreeCommandBuffers(m_device->device(), command_pool, 1, &command_buffer);
-    vk::DestroyCommandPool(m_device->device(), command_pool, NULL);
+    vk::DestroyCommandPool(m_device->device(), command_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, ShadingRateImageNV) {
@@ -4050,7 +4050,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV;
     image_create_info.queueFamilyIndexCount = 0;
-    image_create_info.pQueueFamilyIndices = NULL;
+    image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
 
@@ -4096,7 +4096,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     result = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
     m_errorMonitor->VerifyFound();
     if (VK_SUCCESS == result) {
-        vk::DestroyImageView(m_device->device(), view, NULL);
+        vk::DestroyImageView(m_device->device(), view, nullptr);
         view = VK_NULL_HANDLE;
     }
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -4108,7 +4108,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     result = vk::CreateImageView(m_device->device(), &ivci, nullptr, &view);
     m_errorMonitor->VerifyFound();
     if (VK_SUCCESS == result) {
-        vk::DestroyImageView(m_device->device(), view, NULL);
+        vk::DestroyImageView(m_device->device(), view, nullptr);
         view = VK_NULL_HANDLE;
     }
     ivci.format = VK_FORMAT_R8_UINT;
@@ -4329,7 +4329,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
 
     m_commandBuffer->end();
 
-    vk::DestroyImageView(m_device->device(), view, NULL);
+    vk::DestroyImageView(m_device->device(), view, nullptr);
 }
 
 #include "android_ndk_types.h"
@@ -4362,7 +4362,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
 
     VkImage img = VK_NULL_HANDLE;
     auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
+        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, nullptr);
         img = VK_NULL_HANDLE;
     };
 
@@ -4382,7 +4382,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // Various extra errors for having VK_FORMAT_UNDEFINED without VkExternalFormatANDROID
     m_errorMonitor->SetUnexpectedError("VUID_Undefined");
     m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
 
@@ -4391,14 +4391,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     efa.externalFormat = 0;
     ici.pNext = &efa;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01975");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
 
     // undefined format with an unknown external format
     efa.externalFormat = 0xBADC0DE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExternalFormatANDROID-externalFormat-01894");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
 
@@ -4424,7 +4424,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     ici.format = VK_FORMAT_R8G8B8A8_UNORM;
     efa.externalFormat = ahb_fmt_props.externalFormat;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01974");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
     ici.format = VK_FORMAT_UNDEFINED;
@@ -4432,7 +4432,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // external format while MUTABLE
     ici.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02396");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
     ici.flags = 0;
@@ -4440,7 +4440,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // external format while usage other than SAMPLED
     ici.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02397");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -4448,7 +4448,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // external format while tiline other than OPTIMAL
     ici.tiling = VK_IMAGE_TILING_LINEAR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02398");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -4462,7 +4462,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     ici.extent = {64, 64, 64};
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02393");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
 
@@ -4471,7 +4471,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     ici.extent = {64, 64, 1};
     ici.mipLevels = 6;  // should be 7
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02394");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyFound();
     reset_img();
 }
@@ -4503,7 +4503,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
 
     VkImage img = VK_NULL_HANDLE;
     auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
+        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, nullptr);
         img = VK_NULL_HANDLE;
     };
 
@@ -4523,7 +4523,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
     ici.pNext = &emici;
 
     m_errorMonitor->ExpectSuccess();
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     m_errorMonitor->VerifyNotFound();
 
     // attempt to fetch layout from unbound image
@@ -4577,12 +4577,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
 
     VkImage img = VK_NULL_HANDLE;
     auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
+        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, nullptr);
         img = VK_NULL_HANDLE;
     };
     VkDeviceMemory mem_handle = VK_NULL_HANDLE;
     auto reset_mem = [&mem_handle, dev]() {
-        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
+        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, nullptr);
         mem_handle = VK_NULL_HANDLE;
     };
 
@@ -4630,7 +4630,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkResult res = vk::CreateImage(dev, &ici, NULL, &img);
+    VkResult res = vk::CreateImage(dev, &ici, nullptr, &img);
     ASSERT_VK_SUCCESS(res);
 
     // Chained import struct
@@ -4650,7 +4650,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
 
     // Import requires format AHB_FMT_BLOB and usage AHB_USAGE_GPU_DATA_BUFFER
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02384");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
@@ -4661,7 +4661,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     recreate_ahb();
     mai.allocationSize = ahb_props.allocationSize + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     mai.allocationSize = ahb_props.allocationSize;
     reset_mem();
@@ -4669,7 +4669,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     // memoryTypeIndex mismatch
     mai.memoryTypeIndex++;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     mai.memoryTypeIndex--;
     reset_mem();
@@ -4688,7 +4688,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     recreate_ahb();
     mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
@@ -4699,14 +4699,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     recreate_ahb();
     mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
     // Dedicated allocation with incomplete mip chain
     reset_img();
     ici.mipLevels = 2;
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     mdai.image = img;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE;
     recreate_ahb();
@@ -4720,7 +4720,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
             }
         }
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02389");
-        vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+        vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
         m_errorMonitor->VerifyFound();
         reset_mem();
     } else {
@@ -4737,7 +4737,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     recreate_ahb();
     mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02388");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
@@ -4749,14 +4749,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     mai.allocationSize = ahb_props.allocationSize;
     ici.mipLevels = 1;
     ici.format = VK_FORMAT_B8G8R8A8_UNORM;
-    ici.pNext = NULL;
+    ici.pNext = nullptr;
     VkImage img2;
-    vk::CreateImage(dev, &ici, NULL, &img2);
+    vk::CreateImage(dev, &ici, nullptr, &img2);
     mdai.image = img2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02387");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
-    vk::DestroyImage(dev, img2, NULL);
+    vk::DestroyImage(dev, img2, nullptr);
     mdai.image = img;
     reset_mem();
 
@@ -4774,7 +4774,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02386");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
@@ -4791,7 +4791,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-image-02964");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-01874");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
     reset_mem();
 
@@ -4836,7 +4836,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-04061");
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     VkExternalFormatANDROID efa = LvlInitStruct<VkExternalFormatANDROID>();
@@ -4845,7 +4845,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     sycci.pNext = &efa;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-01904");
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->ExpectSuccess();
@@ -4855,7 +4855,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
     // Spec says if we use VkExternalFormatANDROID value of components is ignored.
     sycci.components = {VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO};
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, nullptr, &ycbcr_conv);
     m_errorMonitor->VerifyNotFound();
     vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, nullptr);
 }
@@ -5009,14 +5009,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
 
     // Set up memory allocation
     VkDeviceMemory img_mem = VK_NULL_HANDLE;
     VkMemoryAllocateInfo mai = LvlInitStruct<VkMemoryAllocateInfo>();
     mai.allocationSize = 64 * 64 * 4;
     mai.memoryTypeIndex = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &img_mem);
+    vk::AllocateMemory(dev, &mai, nullptr, &img_mem);
 
     // It shouldn't use vk::GetImageMemoryRequirements for imported AndroidHardwareBuffer when memory isn't bound yet
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageMemoryRequirements-image-04004");
@@ -5026,10 +5026,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     vk::BindImageMemory(dev, img, img_mem, 0);
 
     // Bind image to memory
-    vk::DestroyImage(dev, img, NULL);
-    vk::FreeMemory(dev, img_mem, NULL);
-    vk::CreateImage(dev, &ici, NULL, &img);
-    vk::AllocateMemory(dev, &mai, NULL, &img_mem);
+    vk::DestroyImage(dev, img, nullptr);
+    vk::FreeMemory(dev, img_mem, nullptr);
+    vk::CreateImage(dev, &ici, nullptr, &img);
+    vk::AllocateMemory(dev, &mai, nullptr, &img_mem);
     vk::BindImageMemory(dev, img, img_mem, 0);
 
     // Create a YCbCr conversion, with different external format, chain to view
@@ -5038,7 +5038,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     sycci.format = VK_FORMAT_UNDEFINED;
     sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, nullptr, &ycbcr_conv);
     VkSamplerYcbcrConversionInfo syci = LvlInitStruct<VkSamplerYcbcrConversionInfo>();
     syci.conversion = ycbcr_conv;
 
@@ -5051,7 +5051,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     auto reset_view = [&image_view, dev]() {
-        if (VK_NULL_HANDLE != image_view) vk::DestroyImageView(dev, image_view, NULL);
+        if (VK_NULL_HANDLE != image_view) vk::DestroyImageView(dev, image_view, nullptr);
         image_view = VK_NULL_HANDLE;
     };
 
@@ -5062,13 +5062,13 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02400");
     // Also causes "unsupported format" - should be removed in future spec update
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-None-02273");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(dev, &ivci, nullptr, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
-    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, NULL);
+    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, nullptr);
     sycci.pNext = &efa;
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(dev, &sycci, nullptr, &ycbcr_conv);
     syci.conversion = ycbcr_conv;
 
     // View component swizzle not IDENTITY
@@ -5077,7 +5077,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02401");
     // Also causes "unsupported format" - should be removed in future spec update
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-None-02273");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(dev, &ivci, nullptr, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
@@ -5089,14 +5089,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02399");
     // Also causes "view format different from image format"
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-01762");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(dev, &ivci, nullptr, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
-    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, NULL);
-    vk::DestroyImageView(dev, image_view, NULL);
-    vk::DestroyImage(dev, img, NULL);
-    vk::FreeMemory(dev, img_mem, NULL);
+    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, nullptr);
+    vk::DestroyImageView(dev, image_view, nullptr);
+    vk::DestroyImage(dev, img, nullptr);
+    vk::FreeMemory(dev, img_mem, nullptr);
 }
 #endif  // DISABLEUNTILAHBWORKS
 
@@ -5132,7 +5132,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
 
     VkDeviceMemory mem_handle = VK_NULL_HANDLE;
     auto reset_mem = [&mem_handle, dev]() {
-        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
+        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, nullptr);
         mem_handle = VK_NULL_HANDLE;
     };
 
@@ -5166,7 +5166,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     bci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
     VkBuffer buf = VK_NULL_HANDLE;
-    vk::CreateBuffer(dev, &bci, NULL, &buf);
+    vk::CreateBuffer(dev, &bci, nullptr, &buf);
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(dev, buf, &mem_reqs);
 
@@ -5186,7 +5186,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
         printf("%s No invalid memory type index could be found; skipped.\n", kSkipPrefix);
         AHardwareBuffer_release(ahb);
         reset_mem();
-        vk::DestroyBuffer(dev, buf, NULL);
+        vk::DestroyBuffer(dev, buf, nullptr);
         return;
     }
 
@@ -5194,12 +5194,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImportAndroidHardwareBufferInfoANDROID-buffer-01881");
     // Also causes "non-dedicated allocation format/usage" error
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02384");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
 
     AHardwareBuffer_release(ahb);
     reset_mem();
-    vk::DestroyBuffer(dev, buf, NULL);
+    vk::DestroyBuffer(dev, buf, nullptr);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
@@ -5238,7 +5238,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     VkMemoryAllocateInfo mai = LvlInitStruct<VkMemoryAllocateInfo>();
     mai.allocationSize = 65536;
     mai.memoryTypeIndex = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
 
     PFN_vkGetMemoryAndroidHardwareBufferANDROID pfn_GetMemAHB =
         (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(dev, "vkGetMemoryAndroidHardwareBufferANDROID");
@@ -5253,7 +5253,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
 
     if (ahb) AHardwareBuffer_release(ahb);
     ahb = nullptr;
-    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
+    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, nullptr);
     mem_handle = VK_NULL_HANDLE;
 
     // Add an export struct with AHB handle type to allocation info
@@ -5273,7 +5273,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(dev, &ici, nullptr, &img);
     ASSERT_TRUE(VK_NULL_HANDLE != img);
 
     // Add image to allocation chain as dedicated info, re-allocate
@@ -5281,7 +5281,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     mdai.image = img;
     emai.pNext = &mdai;
     mai.allocationSize = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
     mgahbi.memory = mem_handle;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883");
@@ -5289,8 +5289,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     m_errorMonitor->VerifyFound();
 
     if (ahb) AHardwareBuffer_release(ahb);
-    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
-    vk::DestroyImage(dev, img, NULL);
+    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, nullptr);
+    vk::DestroyImage(dev, img, nullptr);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
@@ -5361,7 +5361,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
-    VkResult result = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
+    VkResult result = vk::AllocateMemory(m_device->device(), &memory_info, nullptr, &memory);
     if ((memory == VK_NULL_HANDLE) || (result != VK_SUCCESS)) {
         printf("%s This test failed to allocate memory for importing\n", kSkipPrefix);
         return;
@@ -5720,7 +5720,7 @@ TEST_F(VkLayerTest, ValidateStride) {
     } else {
         printf("%s Test requires unsupported multiDrawIndirect feature. Skipped.\n", kSkipPrefix);
     }
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, ValidateGeometryNV) {
@@ -6129,7 +6129,7 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureKHR) {
     PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
         (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
 
-    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL, buffer.handle()};
+    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer.handle()};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
     // invalid buffer;
     {
@@ -6274,8 +6274,8 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
     // Can not bind already freed memory
     {
         VkDeviceMemory as_memory_freed = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, NULL, &as_memory_freed));
-        vk::FreeMemory(device(), as_memory_freed, NULL);
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, nullptr, &as_memory_freed));
+        vk::FreeMemory(device(), as_memory_freed, nullptr);
 
         VkBindAccelerationStructureMemoryInfoNV as_bind_info_freed = as_bind_info;
         as_bind_info_freed.memory = as_memory_freed;
@@ -6291,7 +6291,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         as_memory_alloc_bad_alignment.allocationSize += 1;
 
         VkDeviceMemory as_memory_bad_alignment = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc_bad_alignment, NULL, &as_memory_bad_alignment));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc_bad_alignment, nullptr, &as_memory_bad_alignment));
 
         VkBindAccelerationStructureMemoryInfoNV as_bind_info_bad_alignment = as_bind_info;
         as_bind_info_bad_alignment.memory = as_memory_bad_alignment;
@@ -6301,13 +6301,13 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         (void)vkBindAccelerationStructureMemoryNV(device(), 1, &as_bind_info_bad_alignment);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), as_memory_bad_alignment, NULL);
+        vk::FreeMemory(device(), as_memory_bad_alignment, nullptr);
     }
 
     // Can not bind with offset outside the allocation
     {
         VkDeviceMemory as_memory_bad_offset = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, NULL, &as_memory_bad_offset));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, nullptr, &as_memory_bad_offset));
 
         VkBindAccelerationStructureMemoryInfoNV as_bind_info_bad_offset = as_bind_info;
         as_bind_info_bad_offset.memory = as_memory_bad_offset;
@@ -6318,7 +6318,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         (void)vkBindAccelerationStructureMemoryNV(device(), 1, &as_bind_info_bad_offset);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), as_memory_bad_offset, NULL);
+        vk::FreeMemory(device(), as_memory_bad_offset, nullptr);
     }
 
     // Can not bind with offset that doesn't leave enough size
@@ -6326,7 +6326,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         VkDeviceSize offset = (as_memory_requirements.size - 1) & ~(as_memory_requirements.alignment - 1);
         if (offset > 0 && (as_memory_requirements.size < (as_memory_alloc.allocationSize - as_memory_requirements.alignment))) {
             VkDeviceMemory as_memory_bad_offset = VK_NULL_HANDLE;
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, NULL, &as_memory_bad_offset));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, nullptr, &as_memory_bad_offset));
 
             VkBindAccelerationStructureMemoryInfoNV as_bind_info_bad_offset = as_bind_info;
             as_bind_info_bad_offset.memory = as_memory_bad_offset;
@@ -6336,7 +6336,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
             (void)vkBindAccelerationStructureMemoryNV(device(), 1, &as_bind_info_bad_offset);
             m_errorMonitor->VerifyFound();
 
-            vk::FreeMemory(device(), as_memory_bad_offset, NULL);
+            vk::FreeMemory(device(), as_memory_bad_offset, nullptr);
         }
     }
 
@@ -6352,7 +6352,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
             ASSERT_TRUE(m_device->phy().set_memory_type(unsupported_mem_type_bits, &as_memory_alloc_bad_type, 0));
 
             VkDeviceMemory as_memory_bad_type = VK_NULL_HANDLE;
-            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc_bad_type, NULL, &as_memory_bad_type));
+            ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc_bad_type, nullptr, &as_memory_bad_type));
 
             VkBindAccelerationStructureMemoryInfoNV as_bind_info_bad_type = as_bind_info;
             as_bind_info_bad_type.memory = as_memory_bad_type;
@@ -6361,7 +6361,7 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
             (void)vkBindAccelerationStructureMemoryNV(device(), 1, &as_bind_info_bad_type);
             m_errorMonitor->VerifyFound();
 
-            vk::FreeMemory(device(), as_memory_bad_type, NULL);
+            vk::FreeMemory(device(), as_memory_bad_type, nullptr);
         }
     }
 
@@ -6371,8 +6371,8 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
 
         VkDeviceMemory as_memory_twice_1 = VK_NULL_HANDLE;
         VkDeviceMemory as_memory_twice_2 = VK_NULL_HANDLE;
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, NULL, &as_memory_twice_1));
-        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, NULL, &as_memory_twice_2));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, nullptr, &as_memory_twice_1));
+        ASSERT_VK_SUCCESS(vk::AllocateMemory(device(), &as_memory_alloc, nullptr, &as_memory_twice_2));
         VkBindAccelerationStructureMemoryInfoNV as_bind_info_twice_1 = as_bind_info;
         VkBindAccelerationStructureMemoryInfoNV as_bind_info_twice_2 = as_bind_info;
         as_bind_info_twice_1.accelerationStructure = as_twice.handle();
@@ -6386,8 +6386,8 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         (void)vkBindAccelerationStructureMemoryNV(device(), 1, &as_bind_info_twice_2);
         m_errorMonitor->VerifyFound();
 
-        vk::FreeMemory(device(), as_memory_twice_1, NULL);
-        vk::FreeMemory(device(), as_memory_twice_2, NULL);
+        vk::FreeMemory(device(), as_memory_twice_1, nullptr);
+        vk::FreeMemory(device(), as_memory_twice_2, nullptr);
     }
 }
 
@@ -6421,7 +6421,7 @@ TEST_F(VkLayerTest, ValidateWriteDescriptorSetAccelerationStructureNV) {
     acc.pAccelerationStructures = &top_level_as.handle();
     descriptor_write.pNext = &acc;
     m_errorMonitor->ExpectSuccess();
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -6844,7 +6844,7 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
 
     m_commandBuffer->end();
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
@@ -6957,7 +6957,7 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         buf_info.size = 4096;
         buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements mem_reqs;
@@ -6966,7 +6966,7 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         alloc_info.allocationSize = 4096;
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
         vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -6981,17 +6981,17 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
 
         VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.waitSemaphoreCount = 0;
-        submit_info.pWaitSemaphores = NULL;
-        submit_info.pWaitDstStageMask = NULL;
+        submit_info.pWaitSemaphores = nullptr;
+        submit_info.pWaitDstStageMask = nullptr;
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         submit_info.signalSemaphoreCount = 0;
-        submit_info.pSignalSemaphores = NULL;
+        submit_info.pSignalSemaphores = nullptr;
         vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         vk::QueueWaitIdle(queue);
 
         vk::DestroyBuffer(device(), buffer, nullptr);
-        vk::FreeMemory(device(), mem, NULL);
+        vk::FreeMemory(device(), mem, nullptr);
     }
 
     // First command: success.
@@ -7001,7 +7001,7 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         buf_info.size = 4096;
         buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements mem_reqs;
@@ -7010,7 +7010,7 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         alloc_info.allocationSize = 4096;
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
         vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -7028,20 +7028,20 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
 
         VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.waitSemaphoreCount = 0;
-        submit_info.pWaitSemaphores = NULL;
-        submit_info.pWaitDstStageMask = NULL;
+        submit_info.pWaitSemaphores = nullptr;
+        submit_info.pWaitDstStageMask = nullptr;
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         submit_info.signalSemaphoreCount = 0;
-        submit_info.pSignalSemaphores = NULL;
+        submit_info.pSignalSemaphores = nullptr;
         vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         vk::QueueWaitIdle(queue);
 
         vk::DestroyBuffer(device(), buffer, nullptr);
-        vk::FreeMemory(device(), mem, NULL);
+        vk::FreeMemory(device(), mem, nullptr);
     }
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 
     vkReleaseProfilingLockKHR(device());
 }
@@ -7165,19 +7165,19 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
 
         VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.waitSemaphoreCount = 0;
-        submit_info.pWaitSemaphores = NULL;
-        submit_info.pWaitDstStageMask = NULL;
+        submit_info.pWaitSemaphores = nullptr;
+        submit_info.pWaitDstStageMask = nullptr;
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         submit_info.signalSemaphoreCount = 0;
-        submit_info.pSignalSemaphores = NULL;
+        submit_info.pSignalSemaphores = nullptr;
         vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         vk::QueueWaitIdle(queue);
     }
 
     vkReleaseProfilingLockKHR(device());
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
@@ -7293,12 +7293,12 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
 
         VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.waitSemaphoreCount = 0;
-        submit_info.pWaitSemaphores = NULL;
-        submit_info.pWaitDstStageMask = NULL;
+        submit_info.pWaitSemaphores = nullptr;
+        submit_info.pWaitDstStageMask = nullptr;
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         submit_info.signalSemaphoreCount = 0;
-        submit_info.pSignalSemaphores = NULL;
+        submit_info.pSignalSemaphores = nullptr;
 
         vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         vk::QueueWaitIdle(queue);
@@ -7310,7 +7310,7 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
         buf_info.size = 4096;
         buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements mem_reqs;
@@ -7319,7 +7319,7 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         alloc_info.allocationSize = 4096;
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
         vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -7342,12 +7342,12 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
 
         VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
         submit_info.waitSemaphoreCount = 0;
-        submit_info.pWaitSemaphores = NULL;
-        submit_info.pWaitDstStageMask = NULL;
+        submit_info.pWaitSemaphores = nullptr;
+        submit_info.pWaitDstStageMask = nullptr;
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         submit_info.signalSemaphoreCount = 0;
-        submit_info.pSignalSemaphores = NULL;
+        submit_info.pSignalSemaphores = nullptr;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit-pCommandBuffers-03220");
         vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -7356,12 +7356,12 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
         vk::QueueWaitIdle(queue);
 
         vk::DestroyBuffer(device(), buffer, nullptr);
-        vk::FreeMemory(device(), mem, NULL);
+        vk::FreeMemory(device(), mem, nullptr);
     }
 
     vkReleaseProfilingLockKHR(device());
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
@@ -7498,7 +7498,7 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         buf_info.size = 4096;
         buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements mem_reqs;
@@ -7507,7 +7507,7 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         alloc_info.allocationSize = 4096;
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
         vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -7528,12 +7528,12 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
             perf_submit_info.counterPassIndex = nPasses;
             VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>(&perf_submit_info);
             submit_info.waitSemaphoreCount = 0;
-            submit_info.pWaitSemaphores = NULL;
-            submit_info.pWaitDstStageMask = NULL;
+            submit_info.pWaitSemaphores = nullptr;
+            submit_info.pWaitDstStageMask = nullptr;
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &m_commandBuffer->handle();
             submit_info.signalSemaphoreCount = 0;
-            submit_info.pSignalSemaphores = NULL;
+            submit_info.pSignalSemaphores = nullptr;
 
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221");
             vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -7546,12 +7546,12 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
             perf_submit_info.counterPassIndex = passIdx;
             VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>(&perf_submit_info);
             submit_info.waitSemaphoreCount = 0;
-            submit_info.pWaitSemaphores = NULL;
-            submit_info.pWaitDstStageMask = NULL;
+            submit_info.pWaitSemaphores = nullptr;
+            submit_info.pWaitDstStageMask = nullptr;
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &m_commandBuffer->handle();
             submit_info.signalSemaphoreCount = 0;
-            submit_info.pSignalSemaphores = NULL;
+            submit_info.pSignalSemaphores = nullptr;
 
             vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         }
@@ -7581,12 +7581,12 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
             perf_submit_info.counterPassIndex = nPasses - 1;
             VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>(&perf_submit_info);
             submit_info.waitSemaphoreCount = 0;
-            submit_info.pWaitSemaphores = NULL;
-            submit_info.pWaitDstStageMask = NULL;
+            submit_info.pWaitSemaphores = nullptr;
+            submit_info.pWaitDstStageMask = nullptr;
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &m_commandBuffer->handle();
             submit_info.signalSemaphoreCount = 0;
-            submit_info.pSignalSemaphores = NULL;
+            submit_info.pSignalSemaphores = nullptr;
 
             vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         }
@@ -7625,12 +7625,12 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         m_errorMonitor->VerifyNotFound();
 
         vk::DestroyBuffer(device(), buffer, nullptr);
-        vk::FreeMemory(device(), mem, NULL);
+        vk::FreeMemory(device(), mem, nullptr);
     }
 
     vkReleaseProfilingLockKHR(device());
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
@@ -7755,7 +7755,7 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
         buf_info.size = 4096;
         buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         VkBuffer buffer;
-        VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+        VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements mem_reqs;
@@ -7764,7 +7764,7 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
         alloc_info.allocationSize = 4096;
         VkDeviceMemory mem;
-        err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
         vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -7785,12 +7785,12 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
             perf_submit_info.counterPassIndex = 0;
             VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>(&perf_submit_info);
             submit_info.waitSemaphoreCount = 0;
-            submit_info.pWaitSemaphores = NULL;
-            submit_info.pWaitDstStageMask = NULL;
+            submit_info.pWaitSemaphores = nullptr;
+            submit_info.pWaitDstStageMask = nullptr;
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &m_commandBuffer->handle();
             submit_info.signalSemaphoreCount = 0;
-            submit_info.pSignalSemaphores = NULL;
+            submit_info.pSignalSemaphores = nullptr;
 
             vk::QueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
         }
@@ -7799,12 +7799,12 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
         m_errorMonitor->VerifyFound();
 
         vk::DestroyBuffer(device(), buffer, nullptr);
-        vk::FreeMemory(device(), mem, NULL);
+        vk::FreeMemory(device(), mem, nullptr);
     }
 
     vkReleaseProfilingLockKHR(device());
 
-    vk::DestroyQueryPool(m_device->device(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, QueueSubmitNoTimelineSemaphoreInfo) {
@@ -8080,7 +8080,7 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreOutOfOrder) {
 
     // We need two queues for this
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
 
@@ -9218,7 +9218,7 @@ TEST_F(VkLayerTest, InvalidProtectedSubmit) {
     }
     if (alloc_info.memoryTypeIndex < phys_mem_props.memoryTypeCount) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-01872");
-        vk::AllocateMemory(device(), &alloc_info, NULL, &memory_protected);
+        vk::AllocateMemory(device(), &alloc_info, nullptr, &memory_protected);
         m_errorMonitor->VerifyFound();
     }
 
@@ -9367,11 +9367,11 @@ TEST_F(VkLayerTest, InvalidProtectedMemory) {
 
     alloc_info.memoryTypeIndex = memory_type_protected;
     alloc_info.allocationSize = mem_reqs_protected.size;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory_protected);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory_protected);
 
     alloc_info.allocationSize = mem_reqs_unprotected.size;
     alloc_info.memoryTypeIndex = memory_type_unprotected;
-    vk::AllocateMemory(device(), &alloc_info, NULL, &memory_unprotected);
+    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory_unprotected);
 
     // Bind protected buffer with unprotected memory
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-None-01898");
@@ -9417,7 +9417,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysKHR) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements mem_reqs;
@@ -9426,7 +9426,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysKHR) {
     VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     alloc_info.allocationSize = 4096;
     VkDeviceMemory mem;
-    err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -9443,7 +9443,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysKHR) {
     PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
         (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
 
-    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL, buffer};
+    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
 
     VkStridedDeviceAddressRegionKHR stridebufregion = {};
@@ -9520,7 +9520,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirectKHR) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkResult err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+    VkResult err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements mem_reqs;
@@ -9529,7 +9529,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirectKHR) {
     VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     alloc_info.allocationSize = 4096;
     VkDeviceMemory mem;
-    err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
 
@@ -9548,7 +9548,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirectKHR) {
     PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
         (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
 
-    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL, buffer};
+    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
 
     VkStridedDeviceAddressRegionKHR stridebufregion = {};
@@ -9639,7 +9639,7 @@ TEST_F(VkLayerTest, ValidateVkAccelerationStructureVersionInfoKHR) {
 
     {
         VkAccelerationStructureVersionInfoKHR invalid_version = valid_version;
-        invalid_version.pVersionData = NULL;
+        invalid_version.pVersionData = nullptr;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureVersionInfoKHR-pVersionData-parameter");
         vkGetDeviceAccelerationStructureCompatibilityKHR(m_device->handle(), &invalid_version, &compatablity);
         m_errorMonitor->VerifyFound();
@@ -9690,11 +9690,11 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     as_create_info.deviceAddress = 0;
     VkAccelerationStructurekhrObj bot_level_as(*m_device, as_create_info);
 
-    VkBufferDeviceAddressInfo vertexAddressInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+    VkBufferDeviceAddressInfo vertexAddressInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr,
                                                    geometryNV.geometry.triangles.vertexData};
     VkDeviceAddress vertexAddress = vkGetBufferDeviceAddressKHR(m_device->handle(), &vertexAddressInfo);
 
-    VkBufferDeviceAddressInfo indexAddressInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+    VkBufferDeviceAddressInfo indexAddressInfo = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr,
                                                   geometryNV.geometry.triangles.indexData};
     VkDeviceAddress indexAddress = vkGetBufferDeviceAddressKHR(m_device->handle(), &indexAddressInfo);
     VkAccelerationStructureGeometryKHR valid_geometry_triangles = LvlInitStruct<VkAccelerationStructureGeometryKHR>();
@@ -9722,7 +9722,7 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     create_info.usage = VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     create_info.size = acc_struct_properties.minAccelerationStructureScratchOffsetAlignment;
     bot_level_as.create_scratch_buffer(*m_device, &bot_level_as_scratch, &create_info);
-    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, NULL,
+    VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr,
                                                      bot_level_as_scratch.handle()};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
     build_info_khr.flags = 0;
@@ -9732,11 +9732,11 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     build_info_khr.dstAccelerationStructure = bot_level_as.handle();
     build_info_khr.geometryCount = 1;
     build_info_khr.pGeometries = pGeometry;
-    build_info_khr.ppGeometries = NULL;
+    build_info_khr.ppGeometries = nullptr;
     build_info_khr.scratchData.deviceAddress = device_address;
 
     VkAccelerationStructureBuildGeometryInfoKHR build_info_ppGeometries_khr = build_info_khr;
-    build_info_ppGeometries_khr.pGeometries = NULL;
+    build_info_ppGeometries_khr.pGeometries = nullptr;
     build_info_ppGeometries_khr.ppGeometries = &pGeometry;
 
     VkAccelerationStructureBuildRangeInfoKHR build_range_info;
@@ -9795,14 +9795,14 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     // Invalid pInfos
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-parameter");
-        vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, NULL, &pBuildRangeInfos);
+        vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, nullptr, &pBuildRangeInfos);
         m_errorMonitor->VerifyFound();
     }
 
     // Invalid ppBuildRangeInfos
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-parameter");
-        vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, &build_info_khr, NULL);
+        vkCmdBuildAccelerationStructuresKHR(m_commandBuffer->handle(), 1, &build_info_khr, nullptr);
         m_errorMonitor->VerifyFound();
     }
 
@@ -10015,7 +10015,7 @@ TEST_F(VkLayerTest, ObjInUseCmdBuildAccelerationStructureKHR) {
     build_info.dstAccelerationStructure = bot_level_as->handle();
     build_info.geometryCount = 1;
     build_info.pGeometries = &valid_geometry_triangles;
-    build_info.ppGeometries = NULL;
+    build_info.ppGeometries = nullptr;
     build_info.scratchData.deviceAddress = device_address + kBufferOffset;
 
     VkAccelerationStructureBuildRangeInfoKHR build_range_info{};
@@ -11147,7 +11147,7 @@ TEST_F(VkLayerTest, CmdCopyAccelerationStructureToMemoryKHR) {
     buffer.init_no_mem(*m_device, buffer_ci);
 
     auto as_create_info = LvlInitStruct<VkAccelerationStructureCreateInfoKHR>();
-    as_create_info.pNext = NULL;
+    as_create_info.pNext = nullptr;
     as_create_info.buffer = buffer.handle();
     as_create_info.createFlags = 0;
     as_create_info.offset = 0;
@@ -12226,7 +12226,7 @@ TEST_F(VkLayerTest, WriteTimeStampInvalidQuery) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -12371,7 +12371,7 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
     {
         VkDevice testDevice;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-None-04896");
-        vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+        vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
         m_errorMonitor->VerifyFound();
     }
     {
@@ -12380,7 +12380,7 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
         VkDevice testDevice;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-None-04897");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-None-04898");
-        vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+        vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
         m_errorMonitor->VerifyFound();
     }
     {
@@ -12388,7 +12388,7 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
 
         VkDevice testDevice;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-sparseImageFloat32AtomicMinMax-04975");
-        vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+        vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -12886,7 +12886,7 @@ TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
 
     VkDevice testDevice;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-04748");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(gpu(), &device_create_info, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -13201,7 +13201,7 @@ TEST_F(VkLayerTest, QueryPoolResultStatusOnly) {
     vk::GetQueryPoolResults(m_device->device(), query_pool, 0, 1, out_data_size, &data, sizeof(uint32_t), 0);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -171,6 +171,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
@@ -178,9 +179,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PRIVATE_DATA_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
         return;
     }
@@ -257,6 +256,7 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
     TEST_DESCRIPTION("Test privateData feature not being enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
@@ -264,9 +264,7 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PRIVATE_DATA_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
         return;
     }
@@ -428,11 +426,10 @@ TEST_F(VkLayerTest, MessageIdFilterString) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
     auto filter_setting = MessageIdFilter("VUID-VkRenderPassCreateInfo-pNext-01963");
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, filter_setting.pnext));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
         return;
     }
@@ -463,11 +460,10 @@ TEST_F(VkLayerTest, MessageIdFilterHexInt) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
     auto filter_setting = MessageIdFilter("0xa19880e3");
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, filter_setting.pnext));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
         return;
     }
@@ -498,11 +494,10 @@ TEST_F(VkLayerTest, MessageIdFilterInt) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
     auto filter_setting = MessageIdFilter("2711126243");
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, filter_setting.pnext));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
         return;
     }
@@ -864,11 +859,10 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), kValidationLayerName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
-    } else {
-        printf("%s Debug Marker Extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s Extension not supported, skipping test\n", kSkipPrefix, VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -1257,11 +1251,10 @@ TEST_F(VkLayerTest, UnrecognizedValueBadFlag) {
 
 TEST_F(VkLayerTest, UnrecognizedValueBadBool) {
     // Make sure using VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE doesn't trigger a false positive.
+    AddRequiredExtensions(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
-    } else {
-        printf("%s VK_KHR_sampler_mirror_clamp_to_edge extension not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -2117,10 +2110,9 @@ TEST_F(VkLayerTest, BeginQueryOnTimestampPool) {
 }
 
 TEST_F(VkLayerTest, ValidationCacheTestBadMerge) {
+    AddRequiredExtensions(VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), kValidationLayerName, VK_EXT_VALIDATION_CACHE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
         return;
     }
@@ -3061,11 +3053,10 @@ TEST_F(VkLayerTest, QueryPoolPartialTimestamp) {
 TEST_F(VkLayerTest, PerformanceQueryIntel) {
     TEST_DESCRIPTION("Call CmdCopyQueryPoolResults for an Intel performance query.");
 
+    AddRequiredExtensions(VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
-        printf("%s Intel Performance Query Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -3726,14 +3717,14 @@ TEST_F(VkLayerTest, HostQueryResetNotEnabled) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
 
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto fpvkResetQueryPoolEXT =
@@ -3763,14 +3754,13 @@ TEST_F(VkLayerTest, HostQueryResetBadFirstQuery) {
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
         LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -3819,14 +3809,13 @@ TEST_F(VkLayerTest, HostQueryResetBadRange) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
         LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -3861,14 +3850,13 @@ TEST_F(VkLayerTest, HostQueryResetInvalidQueryPool) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
         LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -3904,14 +3892,13 @@ TEST_F(VkLayerTest, HostQueryResetWrongDevice) {
     }
 
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
         LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -6754,11 +6741,10 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
         return;
     }
@@ -6860,11 +6846,10 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
         return;
     }
@@ -7058,11 +7043,10 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
         return;
     }
@@ -7191,11 +7175,10 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
         return;
     }
@@ -7374,18 +7357,13 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-        return;
-    }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Extension %s or %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME,
+               VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
 
@@ -7642,18 +7620,13 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
-        return;
-    }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Extension %s or %s is not supported.\n", kSkipPrefix, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME,
+               VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
         return;
     }
 
@@ -7816,11 +7789,10 @@ TEST_F(VkLayerTest, QueueSubmitNoTimelineSemaphoreInfo) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -7879,11 +7851,10 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8063,11 +8034,10 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreOutOfOrder) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8228,11 +8198,10 @@ TEST_F(VkLayerTest, InvalidWaitSemaphoresType) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8279,11 +8248,10 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreType) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8328,11 +8296,10 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8468,11 +8435,11 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
 TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
     TEST_DESCRIPTION("Signal a Timeline Semaphore with invalid values");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
 
@@ -8579,11 +8546,10 @@ TEST_F(VkLayerTest, InvalidSemaphoreCounterType) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -8754,11 +8720,10 @@ TEST_F(VkLayerTest, ValidateNVDeviceDiagnosticCheckpoints) {
         return;
     }
 
+    AddRequiredExtensions(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix,
                VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
         return;
@@ -10307,10 +10272,10 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -10427,11 +10392,10 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -10785,10 +10749,9 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabledNoMultiview) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -11230,11 +11193,10 @@ TEST_F(VkLayerTest, InvalidVkSemaphoreTypeCreateInfoExtension) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -11273,11 +11235,10 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
         return;
     }
@@ -11388,14 +11349,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11461,14 +11421,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsDisabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11521,14 +11480,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpDisabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11581,14 +11539,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Enabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11663,14 +11620,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsEnabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11745,14 +11701,13 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpEnabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
         return;
     }
@@ -11820,14 +11775,13 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDisabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -11871,14 +11825,13 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateEnabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
@@ -12084,21 +12037,16 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDivisor) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
-        return;
-    }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
-    } else {
-        printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s Extension %s or %s is not supported.\n", kSkipPrefix, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,
+               VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
         return;
     }
 
@@ -12313,10 +12261,9 @@ TEST_F(VkLayerTest, ValidateColorWriteDynamicStateDisabled) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
         return;
     }
@@ -12409,13 +12356,11 @@ TEST_F(VkLayerTest, ExternalMemoryAndExternalMemoryNV) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if ((DeviceExtensionSupported(gpu(), nullptr, VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME)) &&
-        (DeviceExtensionSupported(gpu(), nullptr, VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME))) {
-        m_device_extension_names.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
         return;
     }
@@ -12501,12 +12446,12 @@ TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
 TEST_F(VkLayerTest, ValidateGetPhysicalDeviceVideoFormatProperties) {
     TEST_DESCRIPTION("Validate getting physical device video format properties.");
 
+    AddRequiredExtensions(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME)) {
-        printf("%s Video queue Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkVideoProfileKHR video_profile = LvlInitStruct<VkVideoProfileKHR>();
@@ -12570,15 +12515,15 @@ TEST_F(VkLayerTest, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
     TEST_DESCRIPTION("Using QueueSubmit2KHR when synchronization2 is not enabled");
     SetTargetApiVersion(VK_API_VERSION_1_3);
 
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto fpQueueSubmit2KHR =
         reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
@@ -12663,13 +12608,13 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableFeature) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -12702,13 +12647,13 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableAttachmentCount) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
 
     // Feature required to be supported for extension
     VkPhysicalDeviceColorWriteEnableFeaturesEXT color_write_features = LvlInitStruct<VkPhysicalDeviceColorWriteEnableFeaturesEXT>();
@@ -12763,13 +12708,13 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTRectangleCount) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties =
         LvlInitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
@@ -12804,13 +12749,13 @@ TEST_F(VkLayerTest, InvalidCmdEndQueryIndexedEXTIndex) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_properties =
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
@@ -12863,16 +12808,16 @@ TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         printf("%s Vulkan12Struct requires Vulkan 1.2+, skipping test\n", kSkipPrefix);
         return;
     }
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping tests\n", kSkipPrefix, VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
 
     VkPhysicalDeviceVulkan12Features features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
     features12.bufferDeviceAddress = VK_TRUE;
@@ -12906,13 +12851,13 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties =
         LvlInitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
@@ -12958,13 +12903,13 @@ TEST_F(VkLayerTest, BeginQueryTypeTransformFeedbackStream) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props =
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
@@ -13002,13 +12947,13 @@ TEST_F(VkLayerTest, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto vkCmdSetDiscardRectangleEXT =
         reinterpret_cast<PFN_vkCmdSetDiscardRectangleEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT"));
@@ -13145,15 +13090,14 @@ TEST_F(VkLayerTest, GetQueryPoolResultsFlags) {
     TEST_DESCRIPTION("Test GetQueryPoolResults with invalid pData and stride");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
+    AddRequiredExtensions(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test does not run on Vulkan 1.0, skipping test\n", kSkipPrefix);
         return;
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
         return;
     }
@@ -13179,17 +13123,17 @@ TEST_F(VkLayerTest, QueryPoolResultStatusOnly) {
     TEST_DESCRIPTION("Request result status only query result.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s Test does not run on Vulkan 1.0, skipping test\n", kSkipPrefix);
         return;
     }
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME)) {
-        printf("%s Video queue Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s not supported, skipping tests\n", kSkipPrefix, VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkQueryPool query_pool;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -112,8 +112,8 @@ TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    PFN_vkGetPhysicalDeviceProperties2 vkGetPhysicalDeviceProperties2 =
-        (PFN_vkGetPhysicalDeviceProperties2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2");
+    auto vkGetPhysicalDeviceProperties2 =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2"));
     assert(vkGetPhysicalDeviceProperties2);
 
     VkPhysicalDeviceProperties2 phys_dev_props_2{};
@@ -185,8 +185,8 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto private_data_features = LvlInitStruct<VkPhysicalDevicePrivateDataFeaturesEXT>();
@@ -200,14 +200,14 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    PFN_vkDestroyPrivateDataSlotEXT pfn_vkDestroyPrivateDataSlotEXT =
-        (PFN_vkDestroyPrivateDataSlotEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkDestroyPrivateDataSlotEXT");
-    PFN_vkCreatePrivateDataSlotEXT pfn_vkCreatePrivateDataSlotEXT =
-        (PFN_vkCreatePrivateDataSlotEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCreatePrivateDataSlotEXT");
-    PFN_vkGetPrivateDataEXT pfn_vkGetPrivateDataEXT =
-        (PFN_vkGetPrivateDataEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkGetPrivateDataEXT");
-    PFN_vkSetPrivateDataEXT pfn_vkSetPrivateDataEXT =
-        (PFN_vkSetPrivateDataEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkSetPrivateDataEXT");
+    auto pfn_vkDestroyPrivateDataSlotEXT =
+        reinterpret_cast<PFN_vkDestroyPrivateDataSlotEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkDestroyPrivateDataSlotEXT"));
+    auto pfn_vkCreatePrivateDataSlotEXT =
+        reinterpret_cast<PFN_vkCreatePrivateDataSlotEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCreatePrivateDataSlotEXT"));
+    auto pfn_vkGetPrivateDataEXT =
+        reinterpret_cast<PFN_vkGetPrivateDataEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkGetPrivateDataEXT"));
+    auto pfn_vkSetPrivateDataEXT =
+        reinterpret_cast<PFN_vkSetPrivateDataEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkSetPrivateDataEXT"));
 
     VkPrivateDataSlotEXT data_slot;
     VkPrivateDataSlotCreateInfoEXT data_create_info = LvlInitStruct<VkPrivateDataSlotCreateInfoEXT>();
@@ -274,8 +274,8 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-    PFN_vkCreatePrivateDataSlotEXT vkCreatePrivateDataSlotEXT =
-        (PFN_vkCreatePrivateDataSlotEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCreatePrivateDataSlotEXT");
+    auto vkCreatePrivateDataSlotEXT =
+        reinterpret_cast<PFN_vkCreatePrivateDataSlotEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCreatePrivateDataSlotEXT"));
 
     VkPrivateDataSlotEXT data_slot;
     VkPrivateDataSlotCreateInfoEXT data_create_info = LvlInitStruct<VkPrivateDataSlotCreateInfoEXT>();
@@ -396,8 +396,8 @@ TEST_F(VkLayerTest, DuplicateMessageLimit) {
     auto msg_limit = DuplicateMsgLimit(3);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, msg_limit.pnext));
     ASSERT_NO_FATAL_FAILURE(InitState());
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     // Create an invalid pNext structure to trigger the stateless validation warning
@@ -801,8 +801,8 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device passing in a bad PdevFeatures2 value
@@ -873,8 +873,8 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkDebugMarkerSetObjectNameEXT fpvkDebugMarkerSetObjectNameEXT =
-        (PFN_vkDebugMarkerSetObjectNameEXT)vk::GetInstanceProcAddr(instance(), "vkDebugMarkerSetObjectNameEXT");
+    auto fpvkDebugMarkerSetObjectNameEXT =
+        reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(vk::GetInstanceProcAddr(instance(), "vkDebugMarkerSetObjectNameEXT"));
     if (!(fpvkDebugMarkerSetObjectNameEXT)) {
         printf("%s Can't find fpvkDebugMarkerSetObjectNameEXT; skipped.\n", kSkipPrefix);
         return;
@@ -981,17 +981,17 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkSetDebugUtilsObjectNameEXT fpvkSetDebugUtilsObjectNameEXT =
-        (PFN_vkSetDebugUtilsObjectNameEXT)vk::GetInstanceProcAddr(instance(), "vkSetDebugUtilsObjectNameEXT");
+    auto fpvkSetDebugUtilsObjectNameEXT =
+        reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(vk::GetInstanceProcAddr(instance(), "vkSetDebugUtilsObjectNameEXT"));
     ASSERT_TRUE(fpvkSetDebugUtilsObjectNameEXT);  // Must be extant if extension is enabled
-    PFN_vkCreateDebugUtilsMessengerEXT fpvkCreateDebugUtilsMessengerEXT =
-        (PFN_vkCreateDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(instance(), "vkCreateDebugUtilsMessengerEXT");
+    auto fpvkCreateDebugUtilsMessengerEXT =
+        reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vk::GetInstanceProcAddr(instance(), "vkCreateDebugUtilsMessengerEXT"));
     ASSERT_TRUE(fpvkCreateDebugUtilsMessengerEXT);  // Must be extant if extension is enabled
-    PFN_vkDestroyDebugUtilsMessengerEXT fpvkDestroyDebugUtilsMessengerEXT =
-        (PFN_vkDestroyDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(instance(), "vkDestroyDebugUtilsMessengerEXT");
+    auto fpvkDestroyDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkDestroyDebugUtilsMessengerEXT"));
     ASSERT_TRUE(fpvkDestroyDebugUtilsMessengerEXT);  // Must be extant if extension is enabled
-    PFN_vkCmdInsertDebugUtilsLabelEXT fpvkCmdInsertDebugUtilsLabelEXT =
-        (PFN_vkCmdInsertDebugUtilsLabelEXT)vk::GetInstanceProcAddr(instance(), "vkCmdInsertDebugUtilsLabelEXT");
+    auto fpvkCmdInsertDebugUtilsLabelEXT =
+        reinterpret_cast<PFN_vkCmdInsertDebugUtilsLabelEXT>(vk::GetInstanceProcAddr(instance(), "vkCmdInsertDebugUtilsLabelEXT"));
     ASSERT_TRUE(fpvkCmdInsertDebugUtilsLabelEXT);  // Must be extant if extension is enabled
 
     if (DeviceSimulation()) {
@@ -1171,8 +1171,8 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     }
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), "value of pCreateInfo->pNext must be NULL");
@@ -1519,8 +1519,8 @@ TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
                                                     handle_type};
     VkExternalSemaphorePropertiesKHR esp = {VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR, nullptr};
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        reinterpret_cast<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"));
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1551,8 +1551,8 @@ TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
     HANDLE handle = nullptr;
     VkSemaphoreGetWin32HandleInfoKHR ghi = {VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR, nullptr, export_semaphore,
                                             handle_type};
-    auto vkGetSemaphoreWin32HandleKHR =
-        (PFN_vkGetSemaphoreWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreWin32HandleKHR");
+    auto vkGetSemaphoreWin32HandleKHR = reinterpret_cast<PFN_vkGetSemaphoreWin32HandleKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreWin32HandleKHR"));
     err = vkGetSemaphoreWin32HandleKHR(m_device->device(), &ghi, &handle);
     ASSERT_VK_SUCCESS(err);
 
@@ -1564,22 +1564,24 @@ TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
                                                handle_type,
                                                handle,
                                                nullptr};
-    auto vkImportSemaphoreWin32HandleKHR =
-        (PFN_vkImportSemaphoreWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreWin32HandleKHR");
+    auto vkImportSemaphoreWin32HandleKHR = reinterpret_cast<PFN_vkImportSemaphoreWin32HandleKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreWin32HandleKHR"));
     err = vkImportSemaphoreWin32HandleKHR(m_device->device(), &ihi);
     ASSERT_VK_SUCCESS(err);
 #else
     // Export semaphore payload to an opaque handle
     int fd = 0;
     VkSemaphoreGetFdInfoKHR ghi = {VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR, nullptr, export_semaphore, handle_type};
-    auto vkGetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreFdKHR");
+    auto vkGetSemaphoreFdKHR =
+        reinterpret_cast<PFN_vkGetSemaphoreFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreFdKHR"));
     err = vkGetSemaphoreFdKHR(m_device->device(), &ghi, &fd);
     ASSERT_VK_SUCCESS(err);
 
     // Import opaque handle exported above *temporarily*
     VkImportSemaphoreFdInfoKHR ihi = {VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR, nullptr,     import_semaphore,
                                       VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR,          handle_type, fd};
-    auto vkImportSemaphoreFdKHR = (PFN_vkImportSemaphoreFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR");
+    auto vkImportSemaphoreFdKHR =
+        reinterpret_cast<PFN_vkImportSemaphoreFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR"));
     err = vkImportSemaphoreFdKHR(m_device->device(), &ihi);
     ASSERT_VK_SUCCESS(err);
 #endif
@@ -1649,8 +1651,8 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR"));
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1684,7 +1686,7 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     {
         VkFenceGetWin32HandleInfoKHR ghi = {VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR, nullptr, export_fence, handle_type};
         auto vkGetFenceWin32HandleKHR =
-            (PFN_vkGetFenceWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceWin32HandleKHR");
+            reinterpret_cast<PFN_vkGetFenceWin32HandleKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceWin32HandleKHR"));
         err = vkGetFenceWin32HandleKHR(m_device->device(), &ghi, &handle);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1698,8 +1700,8 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
                                                handle_type,
                                                handle,
                                                nullptr};
-        auto vkImportFenceWin32HandleKHR =
-            (PFN_vkImportFenceWin32HandleKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceWin32HandleKHR");
+        auto vkImportFenceWin32HandleKHR = reinterpret_cast<PFN_vkImportFenceWin32HandleKHR>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceWin32HandleKHR"));
         err = vkImportFenceWin32HandleKHR(m_device->device(), &ifi);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1708,7 +1710,7 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     int fd = 0;
     {
         VkFenceGetFdInfoKHR gfi = {VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR, nullptr, export_fence, handle_type};
-        auto vkGetFenceFdKHR = (PFN_vkGetFenceFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceFdKHR");
+        auto vkGetFenceFdKHR = reinterpret_cast<PFN_vkGetFenceFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkGetFenceFdKHR"));
         err = vkGetFenceFdKHR(m_device->device(), &gfi, &fd);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1717,7 +1719,8 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     {
         VkImportFenceFdInfoKHR ifi = {VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR, nullptr,     import_fence,
                                       VK_FENCE_IMPORT_TEMPORARY_BIT_KHR,          handle_type, fd};
-        auto vkImportFenceFdKHR = (PFN_vkImportFenceFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceFdKHR");
+        auto vkImportFenceFdKHR =
+            reinterpret_cast<PFN_vkImportFenceFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkImportFenceFdKHR"));
         err = vkImportFenceFdKHR(m_device->device(), &ifi);
         ASSERT_VK_SUCCESS(err);
     }
@@ -1990,8 +1993,8 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables variablePointers but not variablePointersStorageBuffer
@@ -2047,8 +2050,8 @@ TEST_F(VkLayerTest, FeaturesMultiview) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto multiview_features = LvlInitStruct<VkPhysicalDeviceMultiviewFeatures>();
@@ -2125,11 +2128,11 @@ TEST_F(VkLayerTest, ValidationCacheTestBadMerge) {
 
     // Load extension functions
     auto fpCreateValidationCache =
-        (PFN_vkCreateValidationCacheEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCreateValidationCacheEXT");
+        reinterpret_cast<PFN_vkCreateValidationCacheEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCreateValidationCacheEXT"));
     auto fpDestroyValidationCache =
-        (PFN_vkDestroyValidationCacheEXT)vk::GetDeviceProcAddr(m_device->device(), "vkDestroyValidationCacheEXT");
+        reinterpret_cast<PFN_vkDestroyValidationCacheEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkDestroyValidationCacheEXT"));
     auto fpMergeValidationCaches =
-        (PFN_vkMergeValidationCachesEXT)vk::GetDeviceProcAddr(m_device->device(), "vkMergeValidationCachesEXT");
+        reinterpret_cast<PFN_vkMergeValidationCachesEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkMergeValidationCachesEXT"));
     if (!fpCreateValidationCache || !fpDestroyValidationCache || !fpMergeValidationCaches) {
         printf("%s Failed to load function pointers for %s\n", kSkipPrefix, VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
         return;
@@ -3068,8 +3071,8 @@ TEST_F(VkLayerTest, PerformanceQueryIntel) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto performance_api_info_intel = LvlInitStruct<VkInitializePerformanceApiInfoINTEL>();
-    PFN_vkInitializePerformanceApiINTEL vkInitializePerformanceApiINTEL =
-        (PFN_vkInitializePerformanceApiINTEL)vk::GetDeviceProcAddr(m_device->device(), "vkInitializePerformanceApiINTEL");
+    auto vkInitializePerformanceApiINTEL = reinterpret_cast<PFN_vkInitializePerformanceApiINTEL>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkInitializePerformanceApiINTEL"));
     vkInitializePerformanceApiINTEL(m_device->device(), &performance_api_info_intel);
 
     VkBufferObj buffer;
@@ -3565,8 +3568,8 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables descriptorBindingStorageBufferUpdateAfterBind
@@ -3733,7 +3736,8 @@ TEST_F(VkLayerTest, HostQueryResetNotEnabled) {
     m_device_extension_names.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3775,7 +3779,8 @@ TEST_F(VkLayerTest, HostQueryResetBadFirstQuery) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3788,7 +3793,8 @@ TEST_F(VkLayerTest, HostQueryResetBadFirstQuery) {
     m_errorMonitor->VerifyFound();
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-        auto fpvkResetQueryPool = (PFN_vkResetQueryPool)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPool");
+        auto fpvkResetQueryPool =
+            reinterpret_cast<PFN_vkResetQueryPool>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPool"));
         if (nullptr == fpvkResetQueryPool) {
             m_errorMonitor->ExpectSuccess();
             m_errorMonitor->SetError("No ProcAddr for 1.2 core vkResetQueryPool");
@@ -3829,7 +3835,8 @@ TEST_F(VkLayerTest, HostQueryResetBadRange) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3870,7 +3877,8 @@ TEST_F(VkLayerTest, HostQueryResetInvalidQueryPool) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     // Create and destroy a query pool.
     VkQueryPool query_pool;
@@ -3912,7 +3920,8 @@ TEST_F(VkLayerTest, HostQueryResetWrongDevice) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT"));
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -4021,8 +4030,8 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     // Create a device that enables shading_rate_image but disables multiViewport
@@ -4218,7 +4227,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
 
     // Test vk::CmdBindShadingRateImageNV errors
     auto vkCmdBindShadingRateImageNV =
-        (PFN_vkCmdBindShadingRateImageNV)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindShadingRateImageNV");
+        reinterpret_cast<PFN_vkCmdBindShadingRateImageNV>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindShadingRateImageNV"));
 
     // if the view is non-NULL, it must be R8_UINT, USAGE_SRI, image layout must match, layout must be valid
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindShadingRateImageNV-imageView-02060");
@@ -4229,8 +4238,8 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     m_errorMonitor->VerifyFound();
 
     // Test vk::CmdSetViewportShadingRatePaletteNV errors
-    auto vkCmdSetViewportShadingRatePaletteNV =
-        (PFN_vkCmdSetViewportShadingRatePaletteNV)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportShadingRatePaletteNV");
+    auto vkCmdSetViewportShadingRatePaletteNV = reinterpret_cast<PFN_vkCmdSetViewportShadingRatePaletteNV>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportShadingRatePaletteNV"));
 
     VkShadingRatePaletteEntryNV paletteEntries[100] = {};
     VkShadingRatePaletteNV palette = {100, paletteEntries};
@@ -4307,8 +4316,8 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
         }
 
         // Test vk::CmdSetCoarseSampleOrderNV errors
-        auto vkCmdSetCoarseSampleOrderNV =
-            (PFN_vkCmdSetCoarseSampleOrderNV)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCoarseSampleOrderNV");
+        auto vkCmdSetCoarseSampleOrderNV = reinterpret_cast<PFN_vkCmdSetCoarseSampleOrderNV>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCoarseSampleOrderNV"));
 
         for (const auto &test_case : test_cases) {
             for (uint32_t i = 0; i < test_case.vuids.size(); ++i) {
@@ -4415,8 +4424,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // Retrieve it's properties to make it's external format 'known' (AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM)
     VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
     pfn_GetAHBProps(dev, ahb, &ahb_props);
 
@@ -4586,8 +4595,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
         mem_handle = VK_NULL_HANDLE;
     };
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // AHB structs
@@ -4959,8 +4968,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     // Retrieve AHB properties to make it's external format 'known'
     VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
     pfn_GetAHBProps(dev, ahb, &ahb_props);
     AHardwareBuffer_release(ahb);
@@ -5136,8 +5145,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
         mem_handle = VK_NULL_HANDLE;
     };
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID"));
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
     // AHB structs
@@ -5240,8 +5249,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExporttBuffer) {
     mai.memoryTypeIndex = 0;
     vk::AllocateMemory(dev, &mai, nullptr, &mem_handle);
 
-    PFN_vkGetMemoryAndroidHardwareBufferANDROID pfn_GetMemAHB =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(dev, "vkGetMemoryAndroidHardwareBufferANDROID");
+    auto pfn_GetMemAHB = reinterpret_cast<PFN_vkGetMemoryAndroidHardwareBufferANDROID>(
+        vk::GetDeviceProcAddr(dev, "vkGetMemoryAndroidHardwareBufferANDROID"));
     ASSERT_TRUE(pfn_GetMemAHB != nullptr);
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID mgahbi = LvlInitStruct<VkMemoryGetAndroidHardwareBufferInfoANDROID>();
@@ -5413,11 +5422,11 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
-    PFN_vkBindBufferMemory2KHR vkBindBufferMemory2Function =
-        (PFN_vkBindBufferMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR");
+    auto pfn_GetAHBProps =
+        reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(vk::GetDeviceProcAddr(m_device->device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID"));
+    auto vkBindBufferMemory2Function =
+        reinterpret_cast<PFN_vkBindBufferMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR"));
 
     m_errorMonitor->ExpectSuccess();
 
@@ -5507,11 +5516,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
-                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
-    PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
-        (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+    auto pfn_GetAHBProps = reinterpret_cast<PFN_vkGetAndroidHardwareBufferPropertiesANDROID>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetAndroidHardwareBufferPropertiesANDROID"));
+    auto vkBindImageMemory2Function =
+        reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
 
     m_errorMonitor->ExpectSuccess();
 
@@ -5797,7 +5805,7 @@ TEST_F(VkLayerTest, ValidateGeometryNV) {
     valid_geometry_aabbs.geometry.aabbs.offset = 0;
     valid_geometry_aabbs.geometry.aabbs.stride = 24;
 
-    PFN_vkCreateAccelerationStructureNV vkCreateAccelerationStructureNV = reinterpret_cast<PFN_vkCreateAccelerationStructureNV>(
+    auto vkCreateAccelerationStructureNV = reinterpret_cast<PFN_vkCreateAccelerationStructureNV>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureNV"));
     assert(vkCreateAccelerationStructureNV != nullptr);
 
@@ -5985,7 +5993,7 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureNV) {
         return;
     }
 
-    PFN_vkCreateAccelerationStructureNV vkCreateAccelerationStructureNV = reinterpret_cast<PFN_vkCreateAccelerationStructureNV>(
+    auto vkCreateAccelerationStructureNV = reinterpret_cast<PFN_vkCreateAccelerationStructureNV>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureNV"));
     assert(vkCreateAccelerationStructureNV != nullptr);
 
@@ -6099,8 +6107,8 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureKHR) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&ray_tracing_features);
@@ -6112,7 +6120,7 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureKHR) {
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_struct_features));
-    PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+    auto vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureKHR"));
     assert(vkCreateAccelerationStructureKHR != nullptr);
 
@@ -6126,8 +6134,8 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureKHR) {
     as_create_info.size = 0;
     as_create_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     as_create_info.deviceAddress = 0;
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
 
     VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer.handle()};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
@@ -6200,18 +6208,18 @@ TEST_F(VkLayerTest, ValidateCreateAccelerationStructureKHRReplayFeature) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     auto acc_struct_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&acc_struct_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     acc_struct_features.accelerationStructureCaptureReplay = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_struct_features));
-    PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+    auto vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureKHR"));
     assert(vkCreateAccelerationStructureKHR != nullptr);
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
     assert(vkGetBufferDeviceAddressKHR != nullptr);
 
     VkBufferObj buffer;
@@ -6242,9 +6250,8 @@ TEST_F(VkLayerTest, ValidateBindAccelerationStructureNV) {
         return;
     }
 
-    PFN_vkBindAccelerationStructureMemoryNV vkBindAccelerationStructureMemoryNV =
-        reinterpret_cast<PFN_vkBindAccelerationStructureMemoryNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkBindAccelerationStructureMemoryNV"));
+    auto vkBindAccelerationStructureMemoryNV = reinterpret_cast<PFN_vkBindAccelerationStructureMemoryNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkBindAccelerationStructureMemoryNV"));
     assert(vkBindAccelerationStructureMemoryNV != nullptr);
 
     VkBufferObj vbo;
@@ -6431,9 +6438,8 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructureNV) {
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
+    auto vkCmdBuildAccelerationStructureNV = reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
     VkBufferObj vbo;
@@ -6629,9 +6635,8 @@ TEST_F(VkLayerTest, ValidateGetAccelerationStructureHandleNV) {
         return;
     }
 
-    PFN_vkGetAccelerationStructureHandleNV vkGetAccelerationStructureHandleNV =
-        reinterpret_cast<PFN_vkGetAccelerationStructureHandleNV>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkGetAccelerationStructureHandleNV"));
+    auto vkGetAccelerationStructureHandleNV = reinterpret_cast<PFN_vkGetAccelerationStructureHandleNV>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkGetAccelerationStructureHandleNV"));
     assert(vkGetAccelerationStructureHandleNV != nullptr);
 
     VkBufferObj vbo;
@@ -6675,7 +6680,7 @@ TEST_F(VkLayerTest, ValidateCmdCopyAccelerationStructureNV) {
         return;
     }
 
-    PFN_vkCmdCopyAccelerationStructureNV vkCmdCopyAccelerationStructureNV = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureNV>(
+    auto vkCmdCopyAccelerationStructureNV = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureNV>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCmdCopyAccelerationStructureNV"));
     assert(vkCmdCopyAccelerationStructureNV != nullptr);
 
@@ -6758,8 +6763,8 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performance_features = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
@@ -6771,10 +6776,9 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performance_features));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -6865,8 +6869,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
@@ -6879,10 +6883,9 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performanceFeatures, pool_flags));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -6937,11 +6940,11 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
+    auto vkAcquireProfilingLockKHR =
+        reinterpret_cast<PFN_vkAcquireProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR"));
     ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR =
+        reinterpret_cast<PFN_vkReleaseProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR"));
     ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
 
     {
@@ -7064,8 +7067,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
@@ -7078,10 +7081,9 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, pool_flags));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -7138,11 +7140,11 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
+    auto vkAcquireProfilingLockKHR =
+        reinterpret_cast<PFN_vkAcquireProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR"));
     ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR =
+        reinterpret_cast<PFN_vkReleaseProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR"));
     ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
 
     {
@@ -7198,8 +7200,8 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
@@ -7212,10 +7214,9 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performanceFeatures, pool_flags));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -7272,11 +7273,11 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
+    auto vkAcquireProfilingLockKHR =
+        reinterpret_cast<PFN_vkAcquireProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR"));
     ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR =
+        reinterpret_cast<PFN_vkReleaseProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR"));
     ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
 
     {
@@ -7388,8 +7389,8 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto hostQueryResetFeatures = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -7407,15 +7408,14 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performanceFeatures, pool_flags));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
-    PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
-        (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
+    auto vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -7477,14 +7477,14 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
+    auto vkAcquireProfilingLockKHR =
+        reinterpret_cast<PFN_vkAcquireProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR"));
     ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR =
+        reinterpret_cast<PFN_vkReleaseProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR"));
     ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
-    PFN_vkResetQueryPoolEXT fpvkResetQueryPoolEXT =
-        (PFN_vkResetQueryPoolEXT)vk::GetInstanceProcAddr(instance(), "vkResetQueryPoolEXT");
+    auto fpvkResetQueryPoolEXT =
+        reinterpret_cast<PFN_vkResetQueryPoolEXT>(vk::GetInstanceProcAddr(instance(), "vkResetQueryPoolEXT"));
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -7657,8 +7657,8 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto hostQueryResetFeatures = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
@@ -7676,15 +7676,14 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performanceFeatures, pool_flags));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
 
-    PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
-        (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
+    auto vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR != nullptr);
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
@@ -7736,11 +7735,11 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
+    auto vkAcquireProfilingLockKHR =
+        reinterpret_cast<PFN_vkAcquireProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR"));
     ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR =
+        reinterpret_cast<PFN_vkReleaseProfilingLockKHR>(vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR"));
     ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
 
     {
@@ -7894,8 +7893,8 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
@@ -8207,7 +8206,8 @@ TEST_F(VkLayerTest, InvalidExternalSemaphore) {
     import_semaphore_fd_info.flags = VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR;
     import_semaphore_fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
     import_semaphore_fd_info.fd = fd;
-    auto vkImportSemaphoreFdKHR = (PFN_vkImportSemaphoreFdKHR)vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR");
+    auto vkImportSemaphoreFdKHR =
+        reinterpret_cast<PFN_vkImportSemaphoreFdKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkImportSemaphoreFdKHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143");
     vkImportSemaphoreFdKHR(device(), &import_semaphore_fd_info);
@@ -8258,7 +8258,8 @@ TEST_F(VkLayerTest, InvalidWaitSemaphoresType) {
     semaphore_wait_info.pSemaphores = &semaphore[0];
     const uint64_t wait_values[] = {10, 40};
     semaphore_wait_info.pValues = &wait_values[0];
-    auto vkWaitSemaphoresKHR = (PFN_vkWaitSemaphoresKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitSemaphoresKHR");
+    auto vkWaitSemaphoresKHR =
+        reinterpret_cast<PFN_vkWaitSemaphoresKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkWaitSemaphoresKHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSemaphoreWaitInfo-pSemaphores-03256");
     vkWaitSemaphoresKHR(m_device->device(), &semaphore_wait_info, 10000);
@@ -8287,8 +8288,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreType) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     auto timelinefeatures = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&timelinefeatures);
@@ -8307,7 +8308,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreType) {
     VkSemaphoreSignalInfo semaphore_signal_info = LvlInitStruct<VkSemaphoreSignalInfo>();
     semaphore_signal_info.semaphore = semaphore;
     semaphore_signal_info.value = 10;
-    auto vkSignalSemaphoreKHR = (PFN_vkSignalSemaphoreKHR)vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR");
+    auto vkSignalSemaphoreKHR =
+        reinterpret_cast<PFN_vkSignalSemaphoreKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSemaphoreSignalInfo-semaphore-03257");
     vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info);
@@ -8340,8 +8342,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
@@ -8360,7 +8362,7 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
     VkSemaphoreSignalInfo semaphore_signal_info = LvlInitStruct<VkSemaphoreSignalInfo>();
     semaphore_signal_info.semaphore = semaphore[0];
     semaphore_signal_info.value = 3;
-    auto vkSignalSemaphoreKHR = (PFN_vkSignalSemaphoreKHR)vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR");
+    auto vkSignalSemaphoreKHR = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSemaphoreSignalInfo-value-03258");
     vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info);
@@ -8478,7 +8480,8 @@ TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
         printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    auto fpQueueSubmit2KHR = (PFN_vkQueueSubmit2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR");
+    auto fpQueueSubmit2KHR =
+        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
@@ -8585,8 +8588,8 @@ TEST_F(VkLayerTest, InvalidSemaphoreCounterType) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     auto timelinefeatures = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&timelinefeatures);
@@ -8603,8 +8606,8 @@ TEST_F(VkLayerTest, InvalidSemaphoreCounterType) {
     VkSemaphore semaphore;
     ASSERT_VK_SUCCESS(vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &semaphore));
 
-    auto vkGetSemaphoreCounterValueKHR =
-        (PFN_vkGetSemaphoreCounterValueKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreCounterValueKHR");
+    auto vkGetSemaphoreCounterValueKHR = reinterpret_cast<PFN_vkGetSemaphoreCounterValueKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetSemaphoreCounterValueKHR"));
     uint64_t value = 0xdeadbeef;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetSemaphoreCounterValue-semaphore-03255");
@@ -8648,9 +8651,8 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
         return;
     }
 
-    PFN_vkGetImageDrmFormatModifierPropertiesEXT vkGetImageDrmFormatModifierPropertiesEXT =
-        (PFN_vkGetImageDrmFormatModifierPropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                              "vkGetImageDrmFormatModifierPropertiesEXT");
+    auto vkGetImageDrmFormatModifierPropertiesEXT = reinterpret_cast<PFN_vkGetImageDrmFormatModifierPropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetImageDrmFormatModifierPropertiesEXT"));
     ASSERT_TRUE(vkGetImageDrmFormatModifierPropertiesEXT != nullptr);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -8765,9 +8767,10 @@ TEST_F(VkLayerTest, ValidateNVDeviceDiagnosticCheckpoints) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto vkGetQueueCheckpointDataNV =
-        (PFN_vkGetQueueCheckpointDataNV)vk::GetDeviceProcAddr(m_device->device(), "vkGetQueueCheckpointDataNV");
+        reinterpret_cast<PFN_vkGetQueueCheckpointDataNV>(vk::GetDeviceProcAddr(m_device->device(), "vkGetQueueCheckpointDataNV"));
 
-    auto vkCmdSetCheckpointNV = (PFN_vkCmdSetCheckpointNV)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCheckpointNV");
+    auto vkCmdSetCheckpointNV =
+        reinterpret_cast<PFN_vkCmdSetCheckpointNV>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCheckpointNV"));
 
     ASSERT_TRUE(vkGetQueueCheckpointDataNV != nullptr);
     ASSERT_TRUE(vkCmdSetCheckpointNV != nullptr);
@@ -8797,8 +8800,8 @@ TEST_F(VkLayerTest, InvalidGetDeviceQueue) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     VkDeviceQueueInfo2 queue_info_2 = LvlInitStruct<VkDeviceQueueInfo2>();
@@ -8852,7 +8855,7 @@ TEST_F(VkLayerTest, InvalidGetDeviceQueue) {
         // vk::GetDeviceQueue(test_device, queue_family_index, 0, &test_queue);
         // m_errorMonitor->VerifyFound();
 
-        PFN_vkGetDeviceQueue2 vkGetDeviceQueue2 = (PFN_vkGetDeviceQueue2)vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2");
+        auto vkGetDeviceQueue2 = reinterpret_cast<PFN_vkGetDeviceQueue2>(vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2"));
         ASSERT_TRUE(vkGetDeviceQueue2 != nullptr);
 
         // Test device created with flag and trying to query with no flag
@@ -8889,7 +8892,7 @@ TEST_F(VkLayerTest, InvalidGetDeviceQueue) {
     // vk::GetDeviceQueue(test_device, queue_family_index + 1, 0, &test_queue);
     // m_errorMonitor->VerifyFound();
 
-    PFN_vkGetDeviceQueue2 vkGetDeviceQueue2 = (PFN_vkGetDeviceQueue2)vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2");
+    auto vkGetDeviceQueue2 = reinterpret_cast<PFN_vkGetDeviceQueue2>(vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2"));
     ASSERT_TRUE(vkGetDeviceQueue2 != nullptr);
 
     queue_info_2.flags = 0;  // same as device creation
@@ -9002,8 +9005,8 @@ TEST_F(VkLayerTest, UniqueQueueDeviceCreationBothProtected) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -9090,8 +9093,8 @@ TEST_F(VkLayerTest, InvalidProtectedQueue) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -9252,8 +9255,8 @@ TEST_F(VkLayerTest, InvalidProtectedMemory) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
@@ -9430,18 +9433,18 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysKHR) {
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkCmdTraceRaysKHR vkCmdTraceRaysKHR = (PFN_vkCmdTraceRaysKHR)vk::GetInstanceProcAddr(instance(), "vkCmdTraceRaysKHR");
+    auto vkCmdTraceRaysKHR = reinterpret_cast<PFN_vkCmdTraceRaysKHR>(vk::GetInstanceProcAddr(instance(), "vkCmdTraceRaysKHR"));
     ASSERT_TRUE(vkCmdTraceRaysKHR != nullptr);
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
 
     VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
@@ -9507,8 +9510,8 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirectKHR) {
     }
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (ray_tracing_features.rayTracingPipelineTraceRaysIndirect == VK_FALSE) {
         printf("%s rayTracingIndirectTraceRays not supported, skipping tests\n", kSkipPrefix);
@@ -9533,20 +9536,20 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirectKHR) {
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
-    PFN_vkCmdTraceRaysIndirectKHR vkCmdTraceRaysIndirectKHR =
-        (PFN_vkCmdTraceRaysIndirectKHR)vk::GetInstanceProcAddr(instance(), "vkCmdTraceRaysIndirectKHR");
+    auto vkCmdTraceRaysIndirectKHR =
+        reinterpret_cast<PFN_vkCmdTraceRaysIndirectKHR>(vk::GetInstanceProcAddr(instance(), "vkCmdTraceRaysIndirectKHR"));
     ASSERT_TRUE(vkCmdTraceRaysIndirectKHR != nullptr);
 
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
 
     VkBufferDeviceAddressInfo device_address_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, buffer};
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
@@ -9613,17 +9616,16 @@ TEST_F(VkLayerTest, ValidateVkAccelerationStructureVersionInfoKHR) {
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (ray_tracing_features.rayTracingPipeline == VK_FALSE) {
         printf("%s rayTracing not supported, skipping tests\n", kSkipPrefix);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
-    PFN_vkGetDeviceAccelerationStructureCompatibilityKHR vkGetDeviceAccelerationStructureCompatibilityKHR =
-        (PFN_vkGetDeviceAccelerationStructureCompatibilityKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetDeviceAccelerationStructureCompatibilityKHR");
+    auto vkGetDeviceAccelerationStructureCompatibilityKHR = reinterpret_cast<PFN_vkGetDeviceAccelerationStructureCompatibilityKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetDeviceAccelerationStructureCompatibilityKHR"));
     ASSERT_TRUE(vkGetDeviceAccelerationStructureCompatibilityKHR != nullptr);
     VkAccelerationStructureVersionInfoKHR valid_version = LvlInitStruct<VkAccelerationStructureVersionInfoKHR>();
     VkAccelerationStructureCompatibilityKHR compatablity;
@@ -9659,12 +9661,12 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
         return;
     }
 
-    PFN_vkCmdBuildAccelerationStructuresKHR vkCmdBuildAccelerationStructuresKHR =
-        (PFN_vkCmdBuildAccelerationStructuresKHR)vk::GetDeviceProcAddr(device(), "vkCmdBuildAccelerationStructuresKHR");
+    auto vkCmdBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(
+        vk::GetDeviceProcAddr(device(), "vkCmdBuildAccelerationStructuresKHR"));
     assert(vkCmdBuildAccelerationStructuresKHR != nullptr);
 
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
 
     auto vkCmdBuildAccelerationStructuresIndirectKHR = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresIndirectKHR>(
         vk::GetDeviceProcAddr(device(), "vkCmdBuildAccelerationStructuresIndirectKHR"));
@@ -9711,8 +9713,8 @@ TEST_F(VkLayerTest, ValidateCmdBuildAccelerationStructuresKHR) {
     VkAccelerationStructureGeometryKHR *pGeometry = &valid_geometry_triangles;
 
     VkAccelerationStructureBuildGeometryInfoKHR build_info_khr = LvlInitStruct<VkAccelerationStructureBuildGeometryInfoKHR>();
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto acc_struct_properties = LvlInitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&acc_struct_properties);
@@ -10089,9 +10091,8 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
+    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
 
     // Check for import/export capability
     // export used to feed memory to test import
@@ -10134,10 +10135,10 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkBindBufferMemory2KHR vkBindBufferMemory2Function =
-        (PFN_vkBindBufferMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR");
-    PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
-        (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
+    auto vkBindBufferMemory2Function =
+        reinterpret_cast<PFN_vkBindBufferMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR"));
+    auto vkBindImageMemory2Function =
+        reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR"));
 
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
@@ -10203,7 +10204,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
 #ifdef _WIN32
     // Export memory to handle
     auto vkGetMemoryWin32HandleKHR =
-        (PFN_vkGetMemoryWin32HandleKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR");
+        reinterpret_cast<PFN_vkGetMemoryWin32HandleKHR>(vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR"));
     ASSERT_TRUE(vkGetMemoryWin32HandleKHR != nullptr);
     VkMemoryGetWin32HandleInfoKHR mghi_buffer = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
                                                  memory_buffer_export.handle(), handle_type};
@@ -10220,7 +10221,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
                                                           handle_type, handle_image};
 #else
     // Export memory to fd
-    auto vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR");
+    auto vkGetMemoryFdKHR = reinterpret_cast<PFN_vkGetMemoryFdKHR>(vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR"));
     ASSERT_TRUE(vkGetMemoryFdKHR != nullptr);
     VkMemoryGetFdInfoKHR mgfi_buffer = {VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, nullptr, memory_buffer_export.handle(),
                                         handle_type};
@@ -10326,25 +10327,28 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     extended_dynamic_state_features.extendedDynamicState = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetCullModeEXT = (PFN_vkCmdSetCullModeEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCullModeEXT");
-    auto vkCmdSetFrontFaceEXT = (PFN_vkCmdSetFrontFaceEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFrontFaceEXT");
-    auto vkCmdSetPrimitiveTopologyEXT =
-        (PFN_vkCmdSetPrimitiveTopologyEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopologyEXT");
-    auto vkCmdSetViewportWithCountEXT =
-        (PFN_vkCmdSetViewportWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT");
+    auto vkCmdSetCullModeEXT =
+        reinterpret_cast<PFN_vkCmdSetCullModeEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetCullModeEXT"));
+    auto vkCmdSetFrontFaceEXT =
+        reinterpret_cast<PFN_vkCmdSetFrontFaceEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetFrontFaceEXT"));
+    auto vkCmdSetPrimitiveTopologyEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveTopologyEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopologyEXT"));
+    auto vkCmdSetViewportWithCountEXT = reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT"));
     auto vkCmdSetScissorWithCountEXT =
-        (PFN_vkCmdSetScissorWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT");
+        reinterpret_cast<PFN_vkCmdSetScissorWithCountEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT"));
     auto vkCmdSetDepthTestEnableEXT =
-        (PFN_vkCmdSetDepthTestEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthTestEnableEXT");
+        reinterpret_cast<PFN_vkCmdSetDepthTestEnableEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthTestEnableEXT"));
     auto vkCmdSetDepthWriteEnableEXT =
-        (PFN_vkCmdSetDepthWriteEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthWriteEnableEXT");
+        reinterpret_cast<PFN_vkCmdSetDepthWriteEnableEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthWriteEnableEXT"));
     auto vkCmdSetDepthCompareOpEXT =
-        (PFN_vkCmdSetDepthCompareOpEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthCompareOpEXT");
-    auto vkCmdSetDepthBoundsTestEnableEXT =
-        (PFN_vkCmdSetDepthBoundsTestEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBoundsTestEnableEXT");
-    auto vkCmdSetStencilTestEnableEXT =
-        (PFN_vkCmdSetStencilTestEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilTestEnableEXT");
-    auto vkCmdSetStencilOpEXT = (PFN_vkCmdSetStencilOpEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilOpEXT");
+        reinterpret_cast<PFN_vkCmdSetDepthCompareOpEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthCompareOpEXT"));
+    auto vkCmdSetDepthBoundsTestEnableEXT = reinterpret_cast<PFN_vkCmdSetDepthBoundsTestEnableEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBoundsTestEnableEXT"));
+    auto vkCmdSetStencilTestEnableEXT = reinterpret_cast<PFN_vkCmdSetStencilTestEnableEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilTestEnableEXT"));
+    auto vkCmdSetStencilOpEXT =
+        reinterpret_cast<PFN_vkCmdSetStencilOpEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetStencilOpEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -10442,20 +10446,20 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetPrimitiveTopologyEXT =
-        (PFN_vkCmdSetPrimitiveTopologyEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopologyEXT");
-    auto vkCmdSetViewportWithCountEXT =
-        (PFN_vkCmdSetViewportWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT");
+    auto vkCmdSetPrimitiveTopologyEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveTopologyEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopologyEXT"));
+    auto vkCmdSetViewportWithCountEXT = reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT"));
     auto vkCmdSetScissorWithCountEXT =
-        (PFN_vkCmdSetScissorWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT");
+        reinterpret_cast<PFN_vkCmdSetScissorWithCountEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT"));
     auto vkCmdBindVertexBuffers2EXT =
-        (PFN_vkCmdBindVertexBuffers2EXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindVertexBuffers2EXT");
+        reinterpret_cast<PFN_vkCmdBindVertexBuffers2EXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindVertexBuffers2EXT"));
     auto vkCmdSetViewportWithCount =
-        (PFN_vkCmdSetViewportWithCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCount");
+        reinterpret_cast<PFN_vkCmdSetViewportWithCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCount"));
     auto vkCmdSetScissorWithCount =
-        (PFN_vkCmdSetScissorWithCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCount");
+        reinterpret_cast<PFN_vkCmdSetScissorWithCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCount"));
     auto vkCmdBindVertexBuffers2 =
-        (PFN_vkCmdBindVertexBuffers2)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindVertexBuffers2");
+        reinterpret_cast<PFN_vkCmdBindVertexBuffers2>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBindVertexBuffers2"));
     if (vulkan_13) {
         assert(vkCmdSetViewportWithCount != nullptr);
         assert(vkCmdSetScissorWithCount != nullptr);
@@ -10800,10 +10804,10 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabledNoMultiview) {
     features2.features.multiViewport = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetViewportWithCountEXT =
-        (PFN_vkCmdSetViewportWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT");
+    auto vkCmdSetViewportWithCountEXT = reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetViewportWithCountEXT"));
     auto vkCmdSetScissorWithCountEXT =
-        (PFN_vkCmdSetScissorWithCountEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT");
+        reinterpret_cast<PFN_vkCmdSetScissorWithCountEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetScissorWithCountEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -10867,8 +10871,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateDeviceFeatureCombinations) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_query_features =
         LvlInitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
@@ -11115,8 +11119,8 @@ TEST_F(VkLayerTest, CmdCopyAccelerationStructureToMemoryKHR) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&ray_tracing_features);
@@ -11129,13 +11133,12 @@ TEST_F(VkLayerTest, CmdCopyAccelerationStructureToMemoryKHR) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_struct_features));
 
-    PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+    auto vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureKHR"));
     assert(vkCreateAccelerationStructureKHR != nullptr);
 
-    PFN_vkDestroyAccelerationStructureKHR vkDestroyAccelerationStructureKHR =
-        reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
-            vk::GetDeviceProcAddr(m_device->handle(), "vkDestroyAccelerationStructureKHR"));
+    auto vkDestroyAccelerationStructureKHR = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkDestroyAccelerationStructureKHR"));
     assert(vkDestroyAccelerationStructureKHR != nullptr);
 
     constexpr VkDeviceSize buffer_size = 4096;
@@ -11155,9 +11158,8 @@ TEST_F(VkLayerTest, CmdCopyAccelerationStructureToMemoryKHR) {
     as_create_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     as_create_info.deviceAddress = 0;
 
-    PFN_vkCmdCopyAccelerationStructureToMemoryKHR vkCmdCopyAccelerationStructureToMemoryKHR =
-        reinterpret_cast<PFN_vkCmdCopyAccelerationStructureToMemoryKHR>(
-            vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureToMemoryKHR"));
+    auto vkCmdCopyAccelerationStructureToMemoryKHR = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureToMemoryKHR>(
+        vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureToMemoryKHR"));
     assert(vkCmdCopyAccelerationStructureToMemoryKHR != nullptr);
 
     VkAccelerationStructureKHR as;
@@ -11285,8 +11287,8 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
@@ -11309,7 +11311,8 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
     VkSemaphoreSignalInfo semaphore_signal_info = LvlInitStruct<VkSemaphoreSignalInfo>();
     semaphore_signal_info.semaphore = semaphore[0];
     semaphore_signal_info.value = 3;
-    auto vkSignalSemaphoreKHR = (PFN_vkSignalSemaphoreKHR)vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR");
+    auto vkSignalSemaphoreKHR =
+        reinterpret_cast<PFN_vkSignalSemaphoreKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR"));
 
     semaphore_signal_info.value = 10;
     ASSERT_VK_SUCCESS(vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
@@ -11409,12 +11412,12 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     extended_dynamic_state2_features.extendedDynamicState2 = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetRasterizerDiscardEnableEXT =
-        (PFN_vkCmdSetRasterizerDiscardEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetRasterizerDiscardEnableEXT");
+    auto vkCmdSetRasterizerDiscardEnableEXT = reinterpret_cast<PFN_vkCmdSetRasterizerDiscardEnableEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetRasterizerDiscardEnableEXT"));
     auto vkCmdSetDepthBiasEnableEXT =
-        (PFN_vkCmdSetDepthBiasEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBiasEnableEXT");
-    auto vkCmdSetPrimitiveRestartEnableEXT =
-        (PFN_vkCmdSetPrimitiveRestartEnableEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveRestartEnableEXT");
+        reinterpret_cast<PFN_vkCmdSetDepthBiasEnableEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDepthBiasEnableEXT"));
+    auto vkCmdSetPrimitiveRestartEnableEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveRestartEnableEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveRestartEnableEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11482,8 +11485,8 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsDisabled) {
     extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetPatchControlPointsEXT =
-        (PFN_vkCmdSetPatchControlPointsEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPatchControlPointsEXT");
+    auto vkCmdSetPatchControlPointsEXT = reinterpret_cast<PFN_vkCmdSetPatchControlPointsEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPatchControlPointsEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11542,7 +11545,8 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpDisabled) {
     extended_dynamic_state2_features.extendedDynamicState2LogicOp = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetLogicOpEXT = (PFN_vkCmdSetLogicOpEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetLogicOpEXT");
+    auto vkCmdSetLogicOpEXT =
+        reinterpret_cast<PFN_vkCmdSetLogicOpEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetLogicOpEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11680,8 +11684,8 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsEnabled) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-    auto vkCmdSetPatchControlPointsEXT =
-        (PFN_vkCmdSetPatchControlPointsEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPatchControlPointsEXT");
+    auto vkCmdSetPatchControlPointsEXT = reinterpret_cast<PFN_vkCmdSetPatchControlPointsEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPatchControlPointsEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11830,7 +11834,8 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDisabled) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto vkCmdSetVertexInputEXT = (PFN_vkCmdSetVertexInputEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT");
+    auto vkCmdSetVertexInputEXT =
+        reinterpret_cast<PFN_vkCmdSetVertexInputEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -11888,7 +11893,8 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateEnabled) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetVertexInputEXT = (PFN_vkCmdSetVertexInputEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT");
+    auto vkCmdSetVertexInputEXT =
+        reinterpret_cast<PFN_vkCmdSetVertexInputEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -12116,7 +12122,8 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDivisor) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetVertexInputEXT = (PFN_vkCmdSetVertexInputEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT");
+    auto vkCmdSetVertexInputEXT =
+        reinterpret_cast<PFN_vkCmdSetVertexInputEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT"));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -12246,7 +12253,7 @@ TEST_F(VkLayerTest, WriteTimeStampInvalidQuery) {
     m_errorMonitor->VerifyFound();
     if (sync2) {
         auto vkCmdWriteTimestamp2KHR =
-            (PFN_vkCmdWriteTimestamp2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR");
+            reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR"));
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdWriteTimestamp2-query-04903");
         vkCmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool.handle(), 1);
@@ -12515,9 +12522,8 @@ TEST_F(VkLayerTest, ValidateGetPhysicalDeviceVideoFormatProperties) {
     VkPhysicalDeviceVideoFormatInfoKHR video_format_info = LvlInitStruct<VkPhysicalDeviceVideoFormatInfoKHR>();
     video_format_info.pVideoProfiles = &video_profiles;
 
-    PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR vkGetPhysicalDeviceVideoFormatPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceVideoFormatPropertiesKHR");
+    auto vkGetPhysicalDeviceVideoFormatPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceVideoFormatPropertiesKHR"));
 
     uint32_t count;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-imageUsage-04844");
@@ -12574,8 +12580,9 @@ TEST_F(VkLayerTest, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
     m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     InitState();
 
-    auto fpQueueSubmit2KHR = (PFN_vkQueueSubmit2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR");
-    auto fpQueueSubmit2 = (PFN_vkQueueSubmit2)vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2");
+    auto fpQueueSubmit2KHR =
+        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
+    auto fpQueueSubmit2 = reinterpret_cast<PFN_vkQueueSubmit2>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2"));
 
     auto submit_info = LvlInitStruct<VkSubmitInfo2KHR>();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit2-synchronization2-03866");
@@ -12669,8 +12676,8 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableFeature) {
 
     VkBool32 color_write_enable[2] = {VK_TRUE, VK_FALSE};
 
-    PFN_vkCmdSetColorWriteEnableEXT vkCmdSetColorWriteEnableEXT =
-        (PFN_vkCmdSetColorWriteEnableEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetColorWriteEnableEXT");
+    auto vkCmdSetColorWriteEnableEXT =
+        reinterpret_cast<PFN_vkCmdSetColorWriteEnableEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetColorWriteEnableEXT"));
 
     CreatePipelineHelper helper(*this);
     helper.InitInfo();
@@ -12713,8 +12720,8 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableAttachmentCount) {
     // need a valid array to index into
     std::vector<VkBool32> color_write_enable(m_device->props.limits.maxColorAttachments + 1, VK_TRUE);
 
-    PFN_vkCmdSetColorWriteEnableEXT vkCmdSetColorWriteEnableEXT =
-        (PFN_vkCmdSetColorWriteEnableEXT)vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetColorWriteEnableEXT");
+    auto vkCmdSetColorWriteEnableEXT =
+        reinterpret_cast<PFN_vkCmdSetColorWriteEnableEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetColorWriteEnableEXT"));
 
     CreatePipelineHelper helper(*this);
     helper.InitInfo();
@@ -12772,7 +12779,7 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTRectangleCount) {
     vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
 
     auto fpCmdSetDiscardRectangleEXT =
-        (PFN_vkCmdSetDiscardRectangleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT");
+        reinterpret_cast<PFN_vkCmdSetDiscardRectangleEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT"));
 
     VkRect2D discard_rectangles = {};
     discard_rectangles.offset.x = 0;
@@ -12812,9 +12819,9 @@ TEST_F(VkLayerTest, InvalidCmdEndQueryIndexedEXTIndex) {
     vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
 
     auto fpCmdBeginQueryIndexedEXT =
-        (PFN_vkCmdBeginQueryIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginQueryIndexedEXT");
+        reinterpret_cast<PFN_vkCmdBeginQueryIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginQueryIndexedEXT"));
     auto fpCmdEndQueryIndexedEXT =
-        (PFN_vkCmdEndQueryIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndQueryIndexedEXT");
+        reinterpret_cast<PFN_vkCmdEndQueryIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndQueryIndexedEXT"));
 
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryType = VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT;
@@ -12915,7 +12922,7 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
     vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
 
     auto fpCmdSetDiscardRectangleEXT =
-        (PFN_vkCmdSetDiscardRectangleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT");
+        reinterpret_cast<PFN_vkCmdSetDiscardRectangleEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT"));
 
     if (discard_rectangle_properties.maxDiscardRectangles == 0) {
         printf("%s Discard rectangles are not supported, skipping test\n", kSkipPrefix);
@@ -13004,7 +13011,7 @@ TEST_F(VkLayerTest, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     InitState();
 
     auto vkCmdSetDiscardRectangleEXT =
-        (PFN_vkCmdSetDiscardRectangleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT");
+        reinterpret_cast<PFN_vkCmdSetDiscardRectangleEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT"));
 
     VkRect2D discard_rectangles = {};
     discard_rectangles.offset.x = 1;
@@ -13072,8 +13079,8 @@ TEST_F(VkLayerTest, ValidateBeginQueryQueryPoolType) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkCmdBeginQueryIndexedEXT vkCmdBeginQueryIndexedEXT =
-        (PFN_vkCmdBeginQueryIndexedEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginQueryIndexedEXT");
+    auto vkCmdBeginQueryIndexedEXT =
+        reinterpret_cast<PFN_vkCmdBeginQueryIndexedEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginQueryIndexedEXT"));
 
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_ci.queryCount = 1;
@@ -13221,7 +13228,7 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     assert(vkCmdCopyAccelerationStructureKHR != nullptr);
 
     auto vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
     assert(vkGetBufferDeviceAddressKHR != nullptr);
 
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
@@ -13521,14 +13528,13 @@ TEST_F(VkLayerTest, TestCmdCopyMemoryToAccelerationStructureKHR) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
+    auto vkGetBufferDeviceAddressKHR =
+        reinterpret_cast<PFN_vkGetBufferDeviceAddressKHR>(vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR"));
     assert(vkGetBufferDeviceAddressKHR != nullptr);
-    PFN_vkCmdCopyMemoryToAccelerationStructureKHR vkCmdCopyMemoryToAccelerationStructureKHR =
-        (PFN_vkCmdCopyMemoryToAccelerationStructureKHR)vk::GetInstanceProcAddr(instance(),
-                                                                               "vkCmdCopyMemoryToAccelerationStructureKHR");
+    auto vkCmdCopyMemoryToAccelerationStructureKHR = reinterpret_cast<PFN_vkCmdCopyMemoryToAccelerationStructureKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkCmdCopyMemoryToAccelerationStructureKHR"));
     assert(vkCmdCopyMemoryToAccelerationStructureKHR != nullptr);
-    PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+    auto vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
         vk::GetDeviceProcAddr(m_device->handle(), "vkCreateAccelerationStructureKHR"));
     assert(vkCreateAccelerationStructureKHR != nullptr);
 
@@ -13764,8 +13770,8 @@ TEST_F(VkLayerTest, BuildAccelerationStructureKHR) {
 
     m_errorMonitor->ExpectSuccess();
 
-    PFN_vkBuildAccelerationStructuresKHR vkBuildAccelerationStructuresKHR =
-        (PFN_vkBuildAccelerationStructuresKHR)vk::GetInstanceProcAddr(instance(), "vkBuildAccelerationStructuresKHR");
+    auto vkBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkBuildAccelerationStructuresKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkBuildAccelerationStructuresKHR"));
     assert(vkBuildAccelerationStructuresKHR);
 
     VkBufferObj buffer;
@@ -13905,8 +13911,8 @@ TEST_F(VkLayerTest, TestWriteAccelerationStructureMemory) {
     auto vkWriteAccelerationStructuresPropertiesKHR = reinterpret_cast<PFN_vkWriteAccelerationStructuresPropertiesKHR>(
         vk::GetInstanceProcAddr(instance(), "vkWriteAccelerationStructuresPropertiesKHR"));
     assert(vkWriteAccelerationStructuresPropertiesKHR);
-    PFN_vkBuildAccelerationStructuresKHR vkBuildAccelerationStructuresKHR =
-        (PFN_vkBuildAccelerationStructuresKHR)vk::GetInstanceProcAddr(instance(), "vkBuildAccelerationStructuresKHR");
+    auto vkBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkBuildAccelerationStructuresKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkBuildAccelerationStructuresKHR"));
     assert(vkBuildAccelerationStructuresKHR);
 
     VkBufferObj buffer;
@@ -14286,7 +14292,7 @@ TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
         vk::GetInstanceProcAddr(instance(), "vkGetDeferredOperationResultKHR"));
     ASSERT_TRUE(vkDeferredOperationJoinKHR != nullptr);
 
-    PFN_vkDestroyDeferredOperationKHR vkDestroyDeferredOperationKHR =
+    auto vkDestroyDeferredOperationKHR =
         reinterpret_cast<PFN_vkDestroyDeferredOperationKHR>(vk::GetInstanceProcAddr(instance(), "vkDestroyDeferredOperationKHR"));
     ASSERT_TRUE(vkDestroyDeferredOperationKHR != nullptr);
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -267,7 +267,7 @@ TEST_F(VkLayerTest, DisabledIndependentBlend) {
     rpci.pAttachments = attach_desc;
 
     VkRenderPass renderpass;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &renderpass);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &renderpass);
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     pipeline.AddShader(&vs);
 
@@ -280,7 +280,7 @@ TEST_F(VkLayerTest, DisabledIndependentBlend) {
     pipeline.AddColorAttachment(1, att_state2);
     pipeline.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderpass);
     m_errorMonitor->VerifyFound();
-    vk::DestroyRenderPass(m_device->device(), renderpass, NULL);
+    vk::DestroyRenderPass(m_device->device(), renderpass, nullptr);
 }
 
 TEST_F(VkLayerTest, BlendingOnFormatWithoutBlendingSupport) {
@@ -333,7 +333,7 @@ TEST_F(VkLayerTest, BlendingOnFormatWithoutBlendingSupport) {
     rpci.pAttachments = &attach_desc;
 
     VkRenderPass rp;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &rp);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &rp);
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     pipeline.AddShader(&vs);
 
@@ -344,7 +344,7 @@ TEST_F(VkLayerTest, BlendingOnFormatWithoutBlendingSupport) {
     pipeline.CreateVKPipeline(descriptorSet.GetPipelineLayout(), rp);
 
     m_errorMonitor->VerifyFound();
-    vk::DestroyRenderPass(m_device->device(), rp, NULL);
+    vk::DestroyRenderPass(m_device->device(), rp, nullptr);
 }
 
 // Is the Pipeline compatible with the expectations of the Renderpass/subpasses?
@@ -677,13 +677,13 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExceedsSetLimit) {
     layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     layout_binding.descriptorCount = 1;
     layout_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    layout_binding.pImmutableSamplers = NULL;
+    layout_binding.pImmutableSamplers = nullptr;
 
     VkDescriptorSetLayoutCreateInfo ds_layout_ci = LvlInitStruct<VkDescriptorSetLayoutCreateInfo>();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &layout_binding;
     VkDescriptorSetLayout ds_layout = {};
-    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     // Create an array of DSLs, one larger than the physical limit
@@ -696,11 +696,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExceedsSetLimit) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-setLayoutCount-00286");
     VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // Clean up
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, CreatePipelineExcessSubsampledPerStageDescriptors) {
@@ -761,7 +761,7 @@ TEST_F(VkLayerTest, CreatePipelineExcessSubsampledPerStageDescriptors) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.flags |= VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT;
     VkSampler sampler = VK_NULL_HANDLE;
-    VkResult err = vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    VkResult err = vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
 
     // just make all the immutable samplers point to the same sampler
@@ -787,17 +787,17 @@ TEST_F(VkLayerTest, CreatePipelineExcessSubsampledPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_sampler_vuid = "VUID-VkPipelineLayoutCreateInfo-pImmutableSamplers-03566";
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, max_sampler_vuid);
 
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
@@ -860,7 +860,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     dslb.descriptorCount = max_samplers;
     dslb.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
     dslb.binding = 1;
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -870,7 +870,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_sampler_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03016"
@@ -900,11 +900,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00240 - too many uniform buffer type descriptors in vertex stage
     dslb_vec.clear();
@@ -920,7 +920,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_uniform_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03017"
@@ -947,11 +947,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03037");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00242 - too many storage buffer type descriptors in compute stage
     dslb_vec.clear();
@@ -970,7 +970,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_storage_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03018"
@@ -998,11 +998,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03024");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00244 - too many sampled image type descriptors in multiple stages
     dslb_vec.clear();
@@ -1022,7 +1022,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_sample_image_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03019"
@@ -1053,11 +1053,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03022");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00246 - too many storage image type descriptors in fragment stage
     dslb_vec.clear();
@@ -1073,7 +1073,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_storage_image_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03020"
@@ -1093,11 +1093,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03026");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d18 - too many input attachments in fragment stage
     dslb_vec.clear();
@@ -1109,7 +1109,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_input_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03021"
@@ -1128,11 +1128,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03027");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
@@ -1195,7 +1195,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     dslb.descriptorCount = sum_samplers / 2;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
     dslb.binding = 1;
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -1205,7 +1205,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_sampler_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03028"
@@ -1243,11 +1243,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d1c - too many uniform buffer type descriptors overall
     dslb_vec.clear();
@@ -1255,12 +1255,12 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dslb.descriptorCount = sum_uniform_buffers + 1;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_uniform_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03029"
@@ -1279,11 +1279,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03023");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d1e - too many dynamic uniform buffer type descriptors overall
     dslb_vec.clear();
@@ -1291,12 +1291,12 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     dslb.descriptorCount = sum_dyn_uniform_buffers + 1;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_uniform_dynamic_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03030"
@@ -1315,11 +1315,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03023");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d20 - too many storage buffer type descriptors overall
     dslb_vec.clear();
@@ -1327,12 +1327,12 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     dslb.descriptorCount = sum_storage_buffers + 1;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_storage_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03031"
@@ -1351,11 +1351,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03024");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d22 - too many dynamic storage buffer type descriptors overall
     dslb_vec.clear();
@@ -1363,12 +1363,12 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
     dslb.descriptorCount = sum_dyn_storage_buffers + 1;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_storage_dynamic_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03032"
@@ -1387,11 +1387,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03024");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d24 - too many sampled image type descriptors overall
     dslb_vec.clear();
@@ -1399,7 +1399,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     dslb.descriptorCount = max_samplers;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
     dslb.binding = 1;
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
@@ -1415,7 +1415,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_sampled_image_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03033"
@@ -1444,11 +1444,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d26 - too many storage image type descriptors overall
     dslb_vec.clear();
@@ -1456,7 +1456,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
     dslb.descriptorCount = sum_storage_images / 2;
     dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
     dslb.binding = 1;
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
@@ -1466,7 +1466,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_storage_image_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03034"
@@ -1486,11 +1486,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03026");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     // VU 0fe00d28 - too many input attachment type descriptors overall
     dslb_vec.clear();
@@ -1498,12 +1498,12 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     dslb.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
     dslb.descriptorCount = sum_input_attachments + 1;
     dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb.pImmutableSamplers = NULL;
+    dslb.pImmutableSamplers = nullptr;
     dslb_vec.push_back(dslb);
 
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
     const char *max_all_input_vuid = (descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-03035"
@@ -1522,11 +1522,11 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03027");
         }
     }
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);  // Unnecessary but harmless if test passed
     pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidCmdBufferPipelineDestroyed) {
@@ -2148,7 +2148,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatReadForFormat) {
         descriptor_write.descriptorCount = 1;
         descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         descriptor_write.pImageInfo = &image_info;
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_commandBuffer->reset();
         m_commandBuffer->begin();
@@ -2315,7 +2315,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
         descriptor_write.descriptorCount = 1;
         descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         descriptor_write.pImageInfo = &image_info;
-        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+        vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
         m_commandBuffer->reset();
         m_commandBuffer->begin();
@@ -2449,7 +2449,7 @@ TEST_F(VkLayerTest, MissingStorageTexelBufferFormatWriteForFormat) {
     buff_view_ci.format = format;
     buff_view_ci.range = VK_WHOLE_SIZE;
     VkBufferView buffer_view;
-    VkResult err = vk::CreateBufferView(m_device->device(), &buff_view_ci, NULL, &buffer_view);
+    VkResult err = vk::CreateBufferView(m_device->device(), &buff_view_ci, nullptr, &buffer_view);
     if (err != VK_SUCCESS) {
         // device profile layer might hide fact this is not a supported buffer view format
         printf("%s Device will not be able to initialize buffer view skipped.\n", kSkipPrefix);
@@ -2462,7 +2462,7 @@ TEST_F(VkLayerTest, MissingStorageTexelBufferFormatWriteForFormat) {
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     descriptor_write.pTexelBufferView = &buffer_view;
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_commandBuffer->reset();
     m_commandBuffer->begin();
@@ -2868,12 +2868,12 @@ TEST_F(VkLayerTest, InvalidPipelineRenderPassShaderResolveQCOM) {
 
     // renderpass has 1xMSAA colorAttachent and 4xMSAA inputAttachment
     VkRenderPass renderpass;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &renderpass);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &renderpass);
 
     // renderpass2 has 1xMSAA colorAttachent and 1xMSAA inputAttachment
     VkRenderPass renderpass2;
     attach_desc[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    vk::CreateRenderPass(m_device->device(), &rpci, NULL, &renderpass2);
+    vk::CreateRenderPass(m_device->device(), &rpci, nullptr, &renderpass2);
 
     // shader uses gl_SamplePosition which causes the SPIR-V to include SampleRateShading capability
     static const char *sampleRateFragShaderText = R"glsl(
@@ -2935,8 +2935,8 @@ TEST_F(VkLayerTest, InvalidPipelineRenderPassShaderResolveQCOM) {
     m_errorMonitor->VerifyFound();
 
     // cleanup
-    vk::DestroyRenderPass(m_device->device(), renderpass, NULL);
-    vk::DestroyRenderPass(m_device->device(), renderpass2, NULL);
+    vk::DestroyRenderPass(m_device->device(), renderpass, nullptr);
+    vk::DestroyRenderPass(m_device->device(), renderpass2, nullptr);
 }
 
 TEST_F(VkLayerTest, CreateGraphicsPipelineWithBadBasePointer) {
@@ -3307,7 +3307,7 @@ primitive ");
 
     VkDescriptorPool ds_pool;
     err = vk::CreateDescriptorPool(m_device->device(),
-VK_DESCRIPTOR_POOL_USAGE_NON_FREE, 1, &ds_pool_ci, NULL, &ds_pool);
+VK_DESCRIPTOR_POOL_USAGE_NON_FREE, 1, &ds_pool_ci, nullptr, &ds_pool);
     ASSERT_VK_SUCCESS(err);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -3315,14 +3315,14 @@ VK_DESCRIPTOR_POOL_USAGE_NON_FREE, 1, &ds_pool_ci, NULL, &ds_pool);
         dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         dsl_binding.descriptorCount = 1;
         dsl_binding.stageFlags = VK_SHADER_STAGE_ALL;
-        dsl_binding.pImmutableSamplers = NULL;
+        dsl_binding.pImmutableSamplers = nullptr;
 
     VkDescriptorSetLayoutCreateInfo ds_layout_ci = LvlInitStruct<VkDescriptorSetLayoutCreateInfo>();
         ds_layout_ci.bindingCount = 1;
         ds_layout_ci.pBindings = &dsl_binding;
 
     VkDescriptorSetLayout ds_layout;
-    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL,
+    err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr,
 &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
@@ -3332,12 +3332,12 @@ VK_DESCRIPTOR_SET_USAGE_NON_FREE, 1, &ds_layout, &descriptorSet);
     ASSERT_VK_SUCCESS(err);
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
-        pipeline_layout_ci.pNext = NULL;
+        pipeline_layout_ci.pNext = nullptr;
         pipeline_layout_ci.setLayoutCount = 1;
         pipeline_layout_ci.pSetLayouts = &ds_layout;
 
     VkPipelineLayout pipeline_layout;
-    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL,
+    err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr,
 &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
@@ -3368,14 +3368,14 @@ VK_DESCRIPTOR_SET_USAGE_NON_FREE, 1, &ds_layout, &descriptorSet);
     VkGraphicsPipelineCreateInfo gp_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>();
         gp_ci.stageCount = 3;
         gp_ci.pStages = shaderStages;
-        gp_ci.pVertexInputState = NULL;
+        gp_ci.pVertexInputState = nullptr;
         gp_ci.pInputAssemblyState = &iaCI;
         gp_ci.pTessellationState = &tsCI;
-        gp_ci.pViewportState = NULL;
-        gp_ci.pRasterizationState = NULL;
-        gp_ci.pMultisampleState = NULL;
-        gp_ci.pDepthStencilState = NULL;
-        gp_ci.pColorBlendState = NULL;
+        gp_ci.pViewportState = nullptr;
+        gp_ci.pRasterizationState = nullptr;
+        gp_ci.pMultisampleState = nullptr;
+        gp_ci.pDepthStencilState = nullptr;
+        gp_ci.pColorBlendState = nullptr;
         gp_ci.flags = VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
         gp_ci.layout = pipeline_layout;
         gp_ci.renderPass = renderPass();
@@ -3388,18 +3388,18 @@ VK_DESCRIPTOR_SET_USAGE_NON_FREE, 1, &ds_layout, &descriptorSet);
     VkPipeline pipeline;
     VkPipelineCache pipelineCache;
 
-    err = vk::CreatePipelineCache(m_device->device(), &pc_ci, NULL,
+    err = vk::CreatePipelineCache(m_device->device(), &pc_ci, nullptr,
 &pipelineCache);
     ASSERT_VK_SUCCESS(err);
     err = vk::CreateGraphicsPipelines(m_device->device(), pipelineCache, 1,
-&gp_ci, NULL, &pipeline);
+&gp_ci, nullptr, &pipeline);
 
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyPipelineCache(m_device->device(), pipelineCache, NULL);
-    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, NULL);
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
-    vk::DestroyDescriptorPool(m_device->device(), ds_pool, NULL);
+    vk::DestroyPipelineCache(m_device->device(), pipelineCache, nullptr);
+    vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
+    vk::DestroyDescriptorPool(m_device->device(), ds_pool, nullptr);
 }
 */
 
@@ -4070,7 +4070,7 @@ TEST_F(VkLayerTest, NumSamplesMismatch) {
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
 
@@ -4117,7 +4117,7 @@ TEST_F(VkLayerTest, NumBlendAttachMismatch) {
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
-    pipe_ms_state_ci.pSampleMask = NULL;
+    pipe_ms_state_ci.pSampleMask = nullptr;
 
     const auto set_MSAA = [&](CreatePipelineHelper &helper) {
         helper.pipe_ms_state_ci_ = pipe_ms_state_ci;
@@ -4354,7 +4354,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     moduleCreateInfo.pCode = (const uint32_t *)&spv;
     moduleCreateInfo.codeSize = 4;
     moduleCreateInfo.flags = 0;
-    vk::CreateShaderModule(m_device->device(), &moduleCreateInfo, NULL, &module);
+    vk::CreateShaderModule(m_device->device(), &moduleCreateInfo, nullptr, &module);
 
     m_errorMonitor->VerifyFound();
 
@@ -4367,7 +4367,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
     module_create_info.flags = 0;
-    vk::CreateShaderModule(m_device->handle(), &module_create_info, NULL, &shader_module);
+    vk::CreateShaderModule(m_device->handle(), &module_create_info, nullptr, &shader_module);
 
     m_errorMonitor->VerifyFound();
 }
@@ -4391,7 +4391,7 @@ TEST_F(VkLayerTest, InvalidSPIRVMagic) {
     moduleCreateInfo.pCode = (const uint32_t *)&spv;
     moduleCreateInfo.codeSize = sizeof(spv);
     moduleCreateInfo.flags = 0;
-    vk::CreateShaderModule(m_device->device(), &moduleCreateInfo, NULL, &module);
+    vk::CreateShaderModule(m_device->device(), &moduleCreateInfo, nullptr, &module);
 
     m_errorMonitor->VerifyFound();
 }
@@ -4666,50 +4666,50 @@ TEST_F(VkLayerTest, InvalidPushConstantRange) {
 
     // stageFlags of 0
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-stageFlags-requiredbitmask");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // offset over limit
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, maxPushConstantsSize, 8};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-offset-00294");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-size-00298");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // offset not multiple of 4
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 1, 8};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-offset-00295");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // size of 0
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 0};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-size-00296");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // size not multiple of 4
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 7};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-size-00297");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // size over limit
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, maxPushConstantsSize + 4};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-size-00298");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // size over limit of non-zero offset
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 4, maxPushConstantsSize};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantRange-size-00298");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 
     // Sanity check its a valid range before making duplicate
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, maxPushConstantsSize};
     m_errorMonitor->ExpectSuccess();
-    ASSERT_VK_SUCCESS(vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, NULL, &pipeline_layout));
+    ASSERT_VK_SUCCESS(vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_info, nullptr, &pipeline_layout));
     vk::DestroyPipelineLayout(m_device->device(), pipeline_layout, nullptr);
     m_errorMonitor->VerifyNotFound();
 
@@ -6605,7 +6605,7 @@ TEST_F(VkLayerTest, MultiplePushDescriptorSets) {
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dsl_binding.descriptorCount = 1;
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dsl_binding.pImmutableSamplers = NULL;
+    dsl_binding.pImmutableSamplers = nullptr;
 
     const unsigned int descriptor_set_layout_count = 2;
     std::vector<VkDescriptorSetLayoutObj> ds_layouts;
@@ -6619,12 +6619,12 @@ TEST_F(VkLayerTest, MultiplePushDescriptorSets) {
     VkPipelineLayout pipeline_layout;
     VkPipelineLayoutCreateInfo pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     pipeline_layout_ci.pushConstantRangeCount = 0;
-    pipeline_layout_ci.pPushConstantRanges = NULL;
+    pipeline_layout_ci.pPushConstantRanges = nullptr;
     pipeline_layout_ci.setLayoutCount = ds_vk_layouts.size();
     pipeline_layout_ci.pSetLayouts = ds_vk_layouts.data();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00293");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 }
 
@@ -6723,7 +6723,7 @@ TEST_F(VkLayerTest, FramebufferMixedSamplesNV) {
         sp.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
         sp.colorAttachmentCount = 1;
         sp.pColorAttachments = &cr;
-        sp.pResolveAttachments = NULL;
+        sp.pResolveAttachments = nullptr;
         sp.pDepthStencilAttachment = &dr;
 
         VkRenderPassCreateInfo rpi = LvlInitStruct<VkRenderPassCreateInfo>();
@@ -6817,7 +6817,7 @@ TEST_F(VkLayerTest, FramebufferMixedSamples) {
         sp.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
         sp.colorAttachmentCount = 1;
         sp.pColorAttachments = &cr;
-        sp.pResolveAttachments = NULL;
+        sp.pResolveAttachments = nullptr;
         sp.pDepthStencilAttachment = &dr;
 
         VkRenderPassCreateInfo rpi = LvlInitStruct<VkRenderPassCreateInfo>();
@@ -8324,7 +8324,7 @@ TEST_F(VkLayerTest, NotCompatibleForSet) {
     descriptor_writes[1].descriptorCount = 1;  // Write 4 bytes to val
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_writes[1].pBufferInfo = &uniform_buffer_info;
-    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 2, descriptor_writes, 0, nullptr);
 
     char const *csSource = R"glsl(
         #version 450
@@ -8477,7 +8477,7 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsNV) {
 
         vkCreateRayTracingPipelinesNV(m_device->handle(), VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         m_errorMonitor->VerifyNotFound();
-        vk::DestroyPipeline(m_device->device(), pipeline, NULL);
+        vk::DestroyPipeline(m_device->device(), pipeline, nullptr);
     }
 
     // General shader index doesn't exist
@@ -9083,8 +9083,8 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
     group_create_info.closestHitShader = VK_SHADER_UNUSED_KHR;
     group_create_info.anyHitShader = VK_SHADER_UNUSED_KHR;
     group_create_info.intersectionShader = VK_SHADER_UNUSED_KHR;
-    VkPipelineLibraryCreateInfoKHR library_count_zero = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, NULL, 0};
-    VkPipelineLibraryCreateInfoKHR library_count_one = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, NULL, 1};
+    VkPipelineLibraryCreateInfoKHR library_count_zero = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, nullptr, 0};
+    VkPipelineLibraryCreateInfoKHR library_count_one = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, nullptr, 1};
     {
         VkRayTracingPipelineCreateInfoKHR pipeline_ci = LvlInitStruct<VkRayTracingPipelineCreateInfoKHR>();
         pipeline_ci.pLibraryInfo = &library_count_zero;
@@ -9113,7 +9113,7 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
         pipeline_ci.layout = empty_pipeline_layout.handle();
-        pipeline_ci.pLibraryInterface = NULL;
+        pipeline_ci.pLibraryInterface = nullptr;
         m_errorMonitor->SetUnexpectedError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                              "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03590");
@@ -9165,7 +9165,7 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
         pipeline_ci.pGroups = &group_create_info;
         pipeline_ci.layout = empty_pipeline_layout.handle();
         pipeline_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
-        pipeline_ci.pLibraryInterface = NULL;
+        pipeline_ci.pLibraryInterface = nullptr;
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-03465");
         vkCreateRayTracingPipelinesKHR(m_device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         m_errorMonitor->VerifyFound();
@@ -9276,7 +9276,7 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsKHR) {
     ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
 
     VkPipeline pipeline = VK_NULL_HANDLE;
-    VkPipelineLibraryCreateInfoKHR library_info = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, NULL, 0};
+    VkPipelineLibraryCreateInfoKHR library_info = {VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, nullptr, 0};
 
     // No raygen stage
     {
@@ -10167,7 +10167,7 @@ TEST_F(VkLayerTest, ValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    err = vk::CreateBuffer(device(), &buf_info, NULL, &buffer);
+    err = vk::CreateBuffer(device(), &buf_info, nullptr, &buffer);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements mem_reqs;
@@ -10176,7 +10176,7 @@ TEST_F(VkLayerTest, ValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR) {
     VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     alloc_info.allocationSize = 4096;
     VkDeviceMemory mem;
-    err = vk::AllocateMemory(device(), &alloc_info, NULL, &mem);
+    err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
     PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR vkGetRayTracingCaptureReplayShaderGroupHandlesKHR =
@@ -10907,7 +10907,7 @@ TEST_F(VkLayerTest, SampledInvalidImageViews) {
     sampler_ci.minFilter = VK_FILTER_LINEAR;  // turned off feature bit for test
     sampler_ci.compareEnable = VK_FALSE;
     VkSampler sampler;
-    err = vk::CreateSampler(device(), &sampler_ci, NULL, &sampler);
+    err = vk::CreateSampler(device(), &sampler_ci, nullptr, &sampler);
     ASSERT_VK_SUCCESS(err);
     VkDescriptorImageInfo combined_sampler_info = {sampler, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
     VkDescriptorImageInfo seperate_sampled_image_info = {VK_NULL_HANDLE, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
@@ -13370,7 +13370,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     rpci.pAttachments = &attach_desc;
 
     VkRenderPass render_pass;
-    vk::CreateRenderPass(device(), &rpci, NULL, &render_pass);
+    vk::CreateRenderPass(device(), &rpci, nullptr, &render_pass);
 
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -15370,7 +15370,7 @@ TEST_F(VkLayerTest, CreatePipelineLayoutWithInvalidSetLayoutFlags) {
 
     VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-04606");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, NULL, &pipeline_layout);
+    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -162,12 +162,10 @@ TEST_F(VkLayerTest, PipelineWrongBindPointRayTracing) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_RAY_TRACING_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_RAY_TRACING_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_NV_RAY_TRACING_EXTENSION_NAME);
         return;
     }
@@ -714,15 +712,14 @@ TEST_F(VkLayerTest, CreatePipelineExcessSubsampledPerStageDescriptors) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Check extension support
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s test requires %s extension. Skipping.\n", kSkipPrefix, VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME);
         return;
     }
-
-    m_device_extension_names.push_back(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME);
 
     auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
         vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
@@ -2807,6 +2804,7 @@ TEST_F(VkLayerTest, InvalidPipelineSamplePNext) {
 
 TEST_F(VkLayerTest, InvalidPipelineRenderPassShaderResolveQCOM) {
     TEST_DESCRIPTION("Test pipeline creation VUIDs added with VK_QCOM_render_pass_shader_resolve extension.");
+    AddRequiredExtensions(VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     // Require sampleRateShading for these tests
@@ -2817,9 +2815,7 @@ TEST_F(VkLayerTest, InvalidPipelineRenderPassShaderResolveQCOM) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME);
         return;
     }
@@ -3888,11 +3884,10 @@ TEST_F(VkLayerTest, PSOLineWidthInvalid) {
 TEST_F(VkLayerTest, PipelineCreationCacheControl) {
     TEST_DESCRIPTION("Test VK_EXT_pipeline_creation_cache_control");
 
+    AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);
-    } else {
-        printf("%s VK_EXT_pipeline_creation_cache_control not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s not supported, skipping tests\n", kSkipPrefix, VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);
         return;
     }
 
@@ -6581,11 +6576,10 @@ TEST_F(VkLayerTest, MultiplePushDescriptorSets) {
         printf("%s Did not find VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME; skipped.\n", kSkipPrefix);
         return;
     }
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    } else {
-        printf("%s Push Descriptors Extension not supported, skipping tests\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         return;
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -6628,10 +6622,9 @@ TEST_F(VkLayerTest, MultiplePushDescriptorSets) {
 TEST_F(VkLayerTest, AMDMixedAttachmentSamplesValidateGraphicsPipeline) {
     TEST_DESCRIPTION("Verify an error message for an incorrect graphics pipeline rasterization sample count.");
 
+    AddRequiredExtensions(VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME);
         return;
     }
@@ -6649,11 +6642,10 @@ TEST_F(VkLayerTest, AMDMixedAttachmentSamplesValidateGraphicsPipeline) {
 TEST_F(VkLayerTest, FramebufferMixedSamplesNV) {
     TEST_DESCRIPTION("Verify VK_NV_framebuffer_mixed_samples.");
 
+    AddRequiredExtensions(VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME);
         return;
     }
@@ -7002,11 +6994,10 @@ TEST_F(VkLayerTest, FramebufferMixedSamplesCoverageReduction) {
 TEST_F(VkLayerTest, FragmentCoverageToColorNV) {
     TEST_DESCRIPTION("Verify VK_NV_fragment_coverage_to_color.");
 
+    AddRequiredExtensions(VK_NV_FRAGMENT_COVERAGE_TO_COLOR_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_FRAGMENT_COVERAGE_TO_COLOR_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_FRAGMENT_COVERAGE_TO_COLOR_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_FRAGMENT_COVERAGE_TO_COLOR_EXTENSION_NAME);
         return;
     }
@@ -7096,11 +7087,10 @@ TEST_F(VkLayerTest, FragmentCoverageToColorNV) {
 TEST_F(VkLayerTest, ViewportSwizzleNV) {
     TEST_DESCRIPTION("Verify VK_NV_viewprot_swizzle.");
 
+    AddRequiredExtensions(VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME);
         return;
     }
@@ -7745,10 +7735,9 @@ TEST_F(VkLayerTest, NonSemanticInfoEnabled) {
 TEST_F(VkLayerTest, GraphicsPipelineStageCreationFeedbackCount) {
     TEST_DESCRIPTION("Test graphics pipeline feedback stage count check.");
 
+    AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
         return;
     }
@@ -7787,10 +7776,9 @@ TEST_F(VkLayerTest, GraphicsPipelineStageCreationFeedbackCount) {
 TEST_F(VkLayerTest, ComputePipelineStageCreationFeedbackCount) {
     TEST_DESCRIPTION("Test compute pipeline feedback stage count check.");
 
+    AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
         return;
     }
@@ -7818,11 +7806,10 @@ TEST_F(VkLayerTest, NVRayTracingPipelineStageCreationFeedbackCount) {
     if (!CreateNVRayTracingPipelineHelper::InitInstanceExtensions(*this, m_instance_extension_names)) {
         return;
     }
+    AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
         return;
     }
@@ -8221,6 +8208,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckLineRasterization) {
 TEST_F(VkLayerTest, FillRectangleNV) {
     TEST_DESCRIPTION("Verify VK_NV_fill_rectangle");
 
+    AddRequiredExtensions(VK_NV_FILL_RECTANGLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     VkPhysicalDeviceFeatures device_features = {};
@@ -8230,9 +8218,7 @@ TEST_F(VkLayerTest, FillRectangleNV) {
     // VK_POLYGON_MODE_POINT will cause an error when the VK_NV_fill_rectangle extension is enabled.
     device_features.fillModeNonSolid = VK_FALSE;
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_FILL_RECTANGLE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_FILL_RECTANGLE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, VK_NV_FILL_RECTANGLE_EXTENSION_NAME);
         return;
     }
@@ -8376,12 +8362,10 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsNV) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_RAY_TRACING_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_RAY_TRACING_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_NV_RAY_TRACING_EXTENSION_NAME);
         return;
     }
@@ -8871,11 +8855,9 @@ TEST_F(VkLayerTest, ValidateRayTracingPipelineNV) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_NV_RAY_TRACING_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_NV_RAY_TRACING_EXTENSION_NAME);
-        m_device_extension_names.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_NV_RAY_TRACING_EXTENSION_NAME);
         return;
     }
@@ -10221,10 +10203,9 @@ TEST_F(VkLayerTest, ValidatePipelineExecutablePropertiesFeature) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
         return;
     }
@@ -11037,6 +11018,7 @@ TEST_F(VkLayerTest, ShaderFloatControl) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         printf("%s test requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
@@ -11044,9 +11026,7 @@ TEST_F(VkLayerTest, ShaderFloatControl) {
     }
 
     // The issue with revision 4 of this extension should not be an issue with the tests
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
         return;
     }
@@ -11740,11 +11720,10 @@ TEST_F(VkLayerTest, ReadShaderClock) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_CLOCK_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
         return;
     }
@@ -11876,11 +11855,10 @@ TEST_F(VkLayerTest, NotSupportProvokingVertexModePerPipeline) {
         printf("%s %s not supported, skipping tests\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported, skipping tests\n", kSkipPrefix, VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
         return;
     }
@@ -12472,12 +12450,12 @@ TEST_F(VkLayerTest, InvlidPipelineDiscardRectangle) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -13202,12 +13180,12 @@ TEST_F(VkLayerTest, ShaderAtomicFloat2) {
 TEST_F(VkLayerTest, BindLibraryPipeline) {
     TEST_DESCRIPTION("Test binding a pipeline that was created with library flag");
 
+    AddRequiredExtensions(VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s test requires %s extension. Skipping.\n", kSkipPrefix, VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     CreateComputePipelineHelper cs_pipeline(*this);
@@ -13233,12 +13211,12 @@ TEST_F(VkLayerTest, TestPipelineColorWriteCreateInfoEXT) {
         return;
     }
 
+    AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s test requires %s extension. Skipping.\n", kSkipPrefix, VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -13277,12 +13255,12 @@ TEST_F(VkLayerTest, ColorBlendAdvanced) {
     }
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
+    AddRequiredExtensions(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s test requires %s extension. Skipping.\n", kSkipPrefix, VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -14475,7 +14453,6 @@ TEST_F(VkLayerTest, TestPipelineRasterizationConservativeStateCreateInfo) {
         printf("%s %s is not supported; skipping\n", kSkipPrefix, VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -724,8 +724,8 @@ TEST_F(VkLayerTest, CreatePipelineExcessSubsampledPerStageDescriptors) {
 
     m_device_extension_names.push_back(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentDensityMap2PropertiesEXT density_map2_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>();
@@ -1609,7 +1609,7 @@ TEST_F(VkLayerTest, InvalidPipeline) {
 
     if (has_khr_indirect) {
         auto fpCmdDrawIndirectCountKHR =
-            (PFN_vkCmdDrawIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
+            reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR"));
         ASSERT_NE(fpCmdDrawIndirectCountKHR, nullptr);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndirectCount-None-02700");
@@ -1619,7 +1619,7 @@ TEST_F(VkLayerTest, InvalidPipeline) {
 
         if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
             auto fpCmdDrawIndirectCount =
-                (PFN_vkCmdDrawIndirectCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCount");
+                reinterpret_cast<PFN_vkCmdDrawIndirectCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCount"));
             if (nullptr == fpCmdDrawIndirectCount) {
                 m_errorMonitor->ExpectSuccess();
                 m_errorMonitor->SetError("No ProcAddr for 1.2 core vkCmdDrawIndirectCount");
@@ -1632,8 +1632,8 @@ TEST_F(VkLayerTest, InvalidPipeline) {
             }
         }
 
-        auto fpCmdDrawIndexedIndirectCountKHR =
-            (PFN_vkCmdDrawIndexedIndirectCountKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR");
+        auto fpCmdDrawIndexedIndirectCountKHR = reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR"));
         ASSERT_NE(fpCmdDrawIndexedIndirectCountKHR, nullptr);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexedIndirectCount-None-02700");
         // stride must be a multiple of 4 and must be greater than or equal to sizeof(VkDrawIndexedIndirectCommand)
@@ -1641,8 +1641,8 @@ TEST_F(VkLayerTest, InvalidPipeline) {
         m_errorMonitor->VerifyFound();
 
         if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-            auto fpCmdDrawIndexedIndirectCount =
-                (PFN_vkCmdDrawIndexedIndirectCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCount");
+            auto fpCmdDrawIndexedIndirectCount = reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCount>(
+                vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCount"));
             if (nullptr == fpCmdDrawIndexedIndirectCount) {
                 m_errorMonitor->ExpectSuccess();
                 m_errorMonitor->SetError("No ProcAddr for 1.2 core vkCmdDrawIndirectCount");
@@ -1761,8 +1761,8 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
     m_errorMonitor->VerifyFound();
 
     if (khx_dg_ext_available) {
-        PFN_vkCmdDispatchBaseKHR fp_vkCmdDispatchBaseKHR =
-            (PFN_vkCmdDispatchBaseKHR)vk::GetInstanceProcAddr(instance(), "vkCmdDispatchBaseKHR");
+        auto fp_vkCmdDispatchBaseKHR =
+            reinterpret_cast<PFN_vkCmdDispatchBaseKHR>(vk::GetInstanceProcAddr(instance(), "vkCmdDispatchBaseKHR"));
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-baseGroupX-00427");
         fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), 1, 1, 1, 0, 0, 0);
@@ -2028,9 +2028,8 @@ TEST_F(VkLayerTest, MissingStorageImageFormatReadForFormat) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-            (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFormatProperties2KHR"));
 
     struct {
         VkFormat format;
@@ -2199,9 +2198,8 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                             "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFormatProperties2KHR"));
 
     struct {
         VkFormat format;
@@ -2636,9 +2634,8 @@ TEST_F(VkLayerTest, MissingSampledImageDepthComparisonForFormat) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                             "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFormatProperties2KHR"));
 
     VkFormat format = VK_FORMAT_UNDEFINED;
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
@@ -4022,8 +4019,8 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_offset_00622) {
         maxVertexInputAttributeOffset = device_props.limits.maxVertexInputAttributeOffset;
         if (maxVertexInputAttributeOffset == 0xFFFFFFFF) {
             // Attempt to artificially lower maximum offset
-            PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-                (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
+            auto fpvkSetPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(
+                vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
             if (!fpvkSetPhysicalDeviceLimitsEXT) {
                 printf("%s All offsets are valid & device_profile_api not found; skipped.\n", kSkipPrefix);
                 return;
@@ -6899,10 +6896,9 @@ TEST_F(VkLayerTest, FramebufferMixedSamplesCoverageReduction) {
 
     uint32_t combination_count = 0;
     std::vector<VkFramebufferMixedSamplesCombinationNV> combinations;
-    PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV
-        vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
-            (PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV)vk::GetInstanceProcAddr(
-                instance(), "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV");
+    auto vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV"));
 
     ASSERT_NO_FATAL_FAILURE(vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu(), &combination_count, nullptr));
     if (combination_count < 1) {
@@ -7200,8 +7196,8 @@ TEST_F(VkLayerTest, CooperativeMatrixNV) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
@@ -7591,8 +7587,8 @@ TEST_F(VkLayerTest, SubgroupExtendedTypesEnabled) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
@@ -7657,8 +7653,8 @@ TEST_F(VkLayerTest, SubgroupExtendedTypesDisabled) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
@@ -8139,8 +8135,8 @@ TEST_F(VkLayerTest, CreatePipelineCheckLineRasterization) {
         }
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto line_rasterization_features = LvlInitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
@@ -8210,8 +8206,8 @@ TEST_F(VkLayerTest, CreatePipelineCheckLineRasterization) {
         std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
                                   "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774"});
 
-    PFN_vkCmdSetLineStippleEXT vkCmdSetLineStippleEXT =
-        (PFN_vkCmdSetLineStippleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetLineStippleEXT");
+    auto vkCmdSetLineStippleEXT =
+        reinterpret_cast<PFN_vkCmdSetLineStippleEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetLineStippleEXT"));
     ASSERT_TRUE(vkCmdSetLineStippleEXT != nullptr);
 
     m_commandBuffer->begin();
@@ -8408,7 +8404,7 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsNV) {
 
     m_errorMonitor->VerifyNotFound();
 
-    PFN_vkCreateRayTracingPipelinesNV vkCreateRayTracingPipelinesNV =
+    auto vkCreateRayTracingPipelinesNV =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesNV"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesNV != nullptr);
 
@@ -8884,8 +8880,8 @@ TEST_F(VkLayerTest, ValidateRayTracingPipelineNV) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto pipleline_features = LvlInitStruct<VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>();
@@ -8909,7 +8905,7 @@ TEST_F(VkLayerTest, ValidateRayTracingPipelineNV) {
     VkShaderObj intr_shader(this, empty_shader, VK_SHADER_STAGE_INTERSECTION_BIT_NV);
     VkShaderObj call_shader(this, empty_shader, VK_SHADER_STAGE_CALLABLE_BIT_NV);
     m_errorMonitor->VerifyNotFound();
-    PFN_vkCreateRayTracingPipelinesNV vkCreateRayTracingPipelinesNV =
+    auto vkCreateRayTracingPipelinesNV =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesNV>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesNV"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesNV != nullptr);
     VkPipeline pipeline = VK_NULL_HANDLE;
@@ -9045,8 +9041,8 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
         return;
     }
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
@@ -9069,7 +9065,7 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
     VkShaderObj intr_shader(this, empty_shader, VK_SHADER_STAGE_INTERSECTION_BIT_KHR);
     VkShaderObj call_shader(this, empty_shader, VK_SHADER_STAGE_CALLABLE_BIT_KHR);
     m_errorMonitor->VerifyNotFound();
-    PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR =
+    auto vkCreateRayTracingPipelinesKHR =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesKHR"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
     VkPipeline pipeline = VK_NULL_HANDLE;
@@ -9239,8 +9235,8 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsKHR) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
@@ -9271,7 +9267,7 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsKHR) {
 
     m_errorMonitor->VerifyNotFound();
 
-    PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR =
+    auto vkCreateRayTracingPipelinesKHR =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesKHR"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
 
@@ -10047,10 +10043,10 @@ TEST_F(VkLayerTest, PipelineMaxPerStageResources) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+    auto fpvkSetPhysicalDeviceLimitsEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    auto fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -10147,8 +10143,8 @@ TEST_F(VkLayerTest, ValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
     vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     if (ray_tracing_features.rayTracingPipelineShaderGroupHandleCaptureReplay == VK_FALSE) {
@@ -10179,16 +10175,16 @@ TEST_F(VkLayerTest, ValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR) {
     err = vk::AllocateMemory(device(), &alloc_info, nullptr, &mem);
     ASSERT_VK_SUCCESS(err);
     vk::BindBufferMemory(device(), buffer, mem, 0);
-    PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR vkGetRayTracingCaptureReplayShaderGroupHandlesKHR =
-        (PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR");
+    auto vkGetRayTracingCaptureReplayShaderGroupHandlesKHR =
+        reinterpret_cast<PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR"));
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-dataSize-arraylength");
     vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(m_device->handle(), rt_pipe.pipeline_, 1, 1, 0, &buffer);
     m_errorMonitor->VerifyFound();
 
     // dataSize must be at least VkPhysicalDeviceRayTracingPropertiesKHR::shaderGroupHandleCaptureReplaySize
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);
@@ -10247,13 +10243,13 @@ TEST_F(VkLayerTest, ValidatePipelineExecutablePropertiesFeature) {
         return;
     }
 
-    PFN_vkGetPipelineExecutableInternalRepresentationsKHR vkGetPipelineExecutableInternalRepresentationsKHR =
-        (PFN_vkGetPipelineExecutableInternalRepresentationsKHR)vk::GetDeviceProcAddr(
-            m_device->device(), "vkGetPipelineExecutableInternalRepresentationsKHR");
-    PFN_vkGetPipelineExecutableStatisticsKHR vkGetPipelineExecutableStatisticsKHR =
-        (PFN_vkGetPipelineExecutableStatisticsKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetPipelineExecutableStatisticsKHR");
-    PFN_vkGetPipelineExecutablePropertiesKHR vkGetPipelineExecutablePropertiesKHR =
-        (PFN_vkGetPipelineExecutablePropertiesKHR)vk::GetDeviceProcAddr(m_device->device(), "vkGetPipelineExecutablePropertiesKHR");
+    auto vkGetPipelineExecutableInternalRepresentationsKHR =
+        reinterpret_cast<PFN_vkGetPipelineExecutableInternalRepresentationsKHR>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkGetPipelineExecutableInternalRepresentationsKHR"));
+    auto vkGetPipelineExecutableStatisticsKHR = reinterpret_cast<PFN_vkGetPipelineExecutableStatisticsKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetPipelineExecutableStatisticsKHR"));
+    auto vkGetPipelineExecutablePropertiesKHR = reinterpret_cast<PFN_vkGetPipelineExecutablePropertiesKHR>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetPipelineExecutablePropertiesKHR"));
     ASSERT_TRUE(vkGetPipelineExecutableInternalRepresentationsKHR != nullptr);
     ASSERT_TRUE(vkGetPipelineExecutableStatisticsKHR != nullptr);
     ASSERT_TRUE(vkGetPipelineExecutablePropertiesKHR != nullptr);
@@ -10297,10 +10293,10 @@ TEST_F(VkLayerTest, LimitsMaxSampleMaskWords) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
-    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+    auto fpvkSetPhysicalDeviceLimitsEXT =
+        reinterpret_cast<PFN_vkSetPhysicalDeviceLimitsEXT>(vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT"));
+    auto fpvkGetOriginalPhysicalDeviceLimitsEXT = reinterpret_cast<PFN_vkGetOriginalPhysicalDeviceLimitsEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT"));
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf("%s Can't find device_profile_api functions; skipped.\n", kSkipPrefix);
@@ -10510,8 +10506,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineCombinerOpsLimit) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
@@ -10523,8 +10519,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineCombinerOpsLimit) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -10599,8 +10595,8 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimit) 
         m_device_extension_names.push_back(VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME);
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
@@ -10612,8 +10608,8 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimit) 
         return;
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
@@ -11058,8 +11054,8 @@ TEST_F(VkLayerTest, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto shader_float_control = LvlInitStruct<VkPhysicalDeviceFloatControlsProperties>();
@@ -13343,9 +13339,8 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT vkGetPhysicalDeviceMultisamplePropertiesEXT =
-        (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceMultisamplePropertiesEXT");
+    auto vkGetPhysicalDeviceMultisamplePropertiesEXT = reinterpret_cast<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
     assert(vkGetPhysicalDeviceMultisamplePropertiesEXT != nullptr);
 
     VkAttachmentReference attach = {};
@@ -14463,8 +14458,8 @@ TEST_F(VkLayerTest, TestWrongPipelineType) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    PFN_vkGetRayTracingShaderGroupStackSizeKHR vkGetRayTracingShaderGroupStackSizeKHR =
-        (PFN_vkGetRayTracingShaderGroupStackSizeKHR)vk::GetInstanceProcAddr(instance(), "vkGetRayTracingShaderGroupStackSizeKHR");
+    auto vkGetRayTracingShaderGroupStackSizeKHR = reinterpret_cast<PFN_vkGetRayTracingShaderGroupStackSizeKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetRayTracingShaderGroupStackSizeKHR"));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-pipeline-04622");
     vkGetRayTracingShaderGroupStackSizeKHR(device(), pipe.pipeline_, 0, VK_SHADER_GROUP_SHADER_GENERAL_KHR);
@@ -14484,8 +14479,8 @@ TEST_F(VkLayerTest, TestPipelineRasterizationConservativeStateCreateInfo) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props =
         LvlInitStruct<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>();
@@ -14600,8 +14595,8 @@ TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props =
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
@@ -15150,8 +15145,8 @@ TEST_F(VkLayerTest, RayTracingLibraryFlags) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
         return;
     }
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
@@ -15173,7 +15168,7 @@ TEST_F(VkLayerTest, RayTracingLibraryFlags) {
 
     VkShaderObj rgen_shader(this, ray_generation_shader, VK_SHADER_STAGE_RAYGEN_BIT_NV);
 
-    PFN_vkCreateRayTracingPipelinesKHR vkCreateRayTracingPipelinesKHR =
+    auto vkCreateRayTracingPipelinesKHR =
         reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesKHR"));
     ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
 

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -70,14 +70,13 @@ TEST_F(VkPortabilitySubsetTest, ValidatePortabilityCreateDevice) {
 TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
     TEST_DESCRIPTION("Portability: CreateEvent when not supported");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -96,14 +95,13 @@ TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
 TEST_F(VkPortabilitySubsetTest, CreateImage) {
     TEST_DESCRIPTION("Portability: CreateImage - VUIDs 04459, 04460");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -224,14 +222,13 @@ TEST_F(VkPortabilitySubsetTest, CreateImageView) {
 TEST_F(VkPortabilitySubsetTest, CreateSampler) {
     TEST_DESCRIPTION("Portability: CreateSampler - VUID 04467");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -249,14 +246,13 @@ TEST_F(VkPortabilitySubsetTest, CreateSampler) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04452");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -285,14 +281,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04456");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -337,14 +332,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04457");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -385,14 +379,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesRasterizationState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04458");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -438,14 +431,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesRasterizationState) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04453");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -487,14 +479,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
 TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUIDs 04454, 04455");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -541,14 +532,13 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState
 TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     TEST_DESCRIPTION("Portability: UpdateDescriptorSets - VUID 04450");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);
@@ -598,14 +588,13 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
 TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
     TEST_DESCRIPTION("Attempt to use shader features that are not supported via portability");
 
+    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitPortabilitySubsetFramework());
 
-    bool portability_supported = DeviceExtensionSupported(gpu(), nullptr, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    if (!portability_supported) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Test requires VK_KHR_portability_subset, skipping\n", kSkipPrefix);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     auto portability_feature = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&portability_feature);

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -299,8 +299,8 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     // Get the current vertex stride to ensure we pass an incorrect value when creating the graphics pipeline

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -56,7 +56,7 @@ TEST_F(VkPortabilitySubsetTest, ValidatePortabilityCreateDevice) {
     dev_info.queueCreateInfoCount = create_queue_infos.size();
     dev_info.pQueueCreateInfos = create_queue_infos.data();
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = 0;
     dev_info.ppEnabledExtensionNames =
         nullptr;  // VK_KHR_portability_subset not included in enabled extensions should trigger 04451
@@ -561,7 +561,7 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     VkSampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.compareEnable = VK_TRUE;  // Incompatible with portability setting
-    vk::CreateSampler(m_device->device(), &sampler_info, NULL, &sampler);
+    vk::CreateSampler(m_device->device(), &sampler_info, nullptr, &sampler);
 
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -589,7 +589,7 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     descriptor_writes[0].pImageInfo = &img_info;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450");
-    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), 1, descriptor_writes, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::DestroySampler(m_device->device(), sampler, nullptr);

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -771,11 +771,11 @@ TEST_F(VkLayerTest, ViewportInheritanceMultiViewport) {
     vk::CmdSetScissor(set_state_fixed_count_cmd, 0, 2, test_data.kScissorArray);
     vk::EndCommandBuffer(set_state_fixed_count_cmd);
 
-    auto vkCmdSetViewportWithCountEXT =
-        PFN_vkCmdSetViewportWithCountEXT(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetViewportWithCountEXT"));
+    auto vkCmdSetViewportWithCountEXT = reinterpret_cast<PFN_vkCmdSetViewportWithCountEXT>(
+        vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetViewportWithCountEXT"));
     assert(vkCmdSetViewportWithCountEXT);
     auto vkCmdSetScissorWithCountEXT =
-        PFN_vkCmdSetScissorWithCountEXT(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetScissorWithCountEXT"));
+        reinterpret_cast<PFN_vkCmdSetScissorWithCountEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetScissorWithCountEXT"));
     assert(vkCmdSetScissorWithCountEXT);
 
     VkCommandBuffer set_state_with_count_cmd = test_data.MakeBeginSubpassCommandBuffer(pool, 0, nullptr);

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -980,12 +980,12 @@ TEST_F(VkLayerTest, PipelineMissingDynamicStateDiscardRectangle) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
         return;
     }
+    AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     bool has_features = false;
     const char* missing_feature_string = nullptr;
     auto self = this;

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -1,5 +1,6 @@
 /* Copyright (c) 2021 The Khronos Group Inc.
  * Copyright (c) 2021 NVIDIA Corporation
+ * Copyright (c) 2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -1135,9 +1135,8 @@ TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+    auto vkGetPhysicalDeviceSurfaceCapabilities2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceSurfaceCapabilities2KHR != nullptr);
 
     VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = LvlInitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
@@ -1295,9 +1294,8 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
         return;
     }
 
-    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+    auto vkGetPhysicalDeviceSurfaceCapabilities2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
     ASSERT_TRUE(vkGetPhysicalDeviceSurfaceCapabilities2KHR != nullptr);
 
     VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = LvlInitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
@@ -1560,19 +1558,18 @@ TEST_F(VkLayerTest, DisplayPlaneSurface) {
     }
 
     // Load all VK_KHR_display functions
-    PFN_vkCreateDisplayModeKHR vkCreateDisplayModeKHR =
-        (PFN_vkCreateDisplayModeKHR)vk::GetInstanceProcAddr(instance(), "vkCreateDisplayModeKHR");
-    PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR =
-        (PFN_vkCreateDisplayPlaneSurfaceKHR)vk::GetInstanceProcAddr(instance(), "vkCreateDisplayPlaneSurfaceKHR");
-    PFN_vkGetDisplayPlaneSupportedDisplaysKHR vkGetDisplayPlaneSupportedDisplaysKHR =
-        (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneSupportedDisplaysKHR");
-    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
-    PFN_vkGetDisplayPlaneCapabilitiesKHR vkGetDisplayPlaneCapabilitiesKHR =
-        (PFN_vkGetDisplayPlaneCapabilitiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneCapabilitiesKHR");
+    auto vkCreateDisplayModeKHR =
+        reinterpret_cast<PFN_vkCreateDisplayModeKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateDisplayModeKHR"));
+    auto vkCreateDisplayPlaneSurfaceKHR =
+        reinterpret_cast<PFN_vkCreateDisplayPlaneSurfaceKHR>(vk::GetInstanceProcAddr(instance(), "vkCreateDisplayPlaneSurfaceKHR"));
+    auto vkGetDisplayPlaneSupportedDisplaysKHR = reinterpret_cast<PFN_vkGetDisplayPlaneSupportedDisplaysKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneSupportedDisplaysKHR"));
+    auto vkGetPhysicalDeviceDisplayPlanePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
+    auto vkGetDisplayModePropertiesKHR =
+        reinterpret_cast<PFN_vkGetDisplayModePropertiesKHR>(vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR"));
+    auto vkGetDisplayPlaneCapabilitiesKHR = reinterpret_cast<PFN_vkGetDisplayPlaneCapabilitiesKHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneCapabilitiesKHR"));
     ASSERT_TRUE(vkCreateDisplayModeKHR != nullptr);
     ASSERT_TRUE(vkCreateDisplayPlaneSurfaceKHR != nullptr);
     ASSERT_TRUE(vkGetDisplayPlaneSupportedDisplaysKHR != nullptr);
@@ -1949,7 +1946,8 @@ TEST_F(VkLayerTest, PresentIdWait) {
     InitSurface(m_width, m_height, surface2);
     InitSwapchain(surface2, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR, swapchain2);
 
-    auto vkWaitForPresentKHR = (PFN_vkWaitForPresentKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR");
+    auto vkWaitForPresentKHR =
+        reinterpret_cast<PFN_vkWaitForPresentKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR"));
     assert(vkWaitForPresentKHR != nullptr);
 
     uint32_t image_count, image_count2;
@@ -2052,7 +2050,8 @@ TEST_F(VkLayerTest, PresentIdWaitFeatures) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_TRUE(InitSwapchain());
 
-    auto vkWaitForPresentKHR = (PFN_vkWaitForPresentKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR");
+    auto vkWaitForPresentKHR =
+        reinterpret_cast<PFN_vkWaitForPresentKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR"));
     assert(vkWaitForPresentKHR != nullptr);
 
     uint32_t image_count;
@@ -2213,17 +2212,15 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
         surface_info.surface = m_surface;
         VkDeviceGroupPresentModeFlagsKHR flags = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
 
-        PFN_vkGetDeviceGroupSurfacePresentModes2EXT vkGetDeviceGroupSurfacePresentModes2EXT =
-            reinterpret_cast<PFN_vkGetDeviceGroupSurfacePresentModes2EXT>(
-                vk::GetInstanceProcAddr(instance(), "vkGetDeviceGroupSurfacePresentModes2EXT"));
+        auto vkGetDeviceGroupSurfacePresentModes2EXT = reinterpret_cast<PFN_vkGetDeviceGroupSurfacePresentModes2EXT>(
+            vk::GetInstanceProcAddr(instance(), "vkGetDeviceGroupSurfacePresentModes2EXT"));
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-06213");
         vkGetDeviceGroupSurfacePresentModes2EXT(device(), &surface_info, &flags);
         m_errorMonitor->VerifyFound();
 
-        PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT vkGetPhysicalDeviceSurfacePresentModes2EXT =
-            (PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfacePresentModes2EXT");
+        auto vkGetPhysicalDeviceSurfacePresentModes2EXT = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfacePresentModes2EXT"));
 
         uint32_t count;
         vkGetPhysicalDeviceSurfacePresentModes2EXT(gpu(), &surface_info, &count, nullptr);
@@ -2243,9 +2240,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (display_surface_counter) {
-        PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT vkGetPhysicalDeviceSurfaceCapabilities2EXT =
-            (PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfaceCapabilities2EXT");
+        auto vkGetPhysicalDeviceSurfaceCapabilities2EXT = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
         VkSurfaceCapabilities2EXT capabilities = LvlInitStruct<VkSurfaceCapabilities2EXT>();
 
@@ -2255,9 +2251,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-            (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+        auto vkGetPhysicalDeviceSurfaceCapabilities2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
 
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
         surface_info.surface = m_surface;
@@ -2276,8 +2271,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR =
-            (PFN_vkGetPhysicalDeviceSurfaceFormats2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceFormats2KHR");
+        auto vkGetPhysicalDeviceSurfaceFormats2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceFormats2KHR"));
 
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
         surface_info.surface = m_surface;

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -848,12 +848,11 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     }
 
     if (!AddSurfaceInstanceExtension()) return;
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (extension_dependency_satisfied && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
+    if (!extension_dependency_satisfied || !AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
         return;
     }
 
@@ -1095,10 +1094,9 @@ TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
         return;
     }
@@ -1254,10 +1252,9 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
-    } else {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
         return;
     }
@@ -1720,13 +1717,13 @@ TEST_F(VkLayerTest, DeviceGroupSubmitInfoSemaphoreCount) {
         return;
     }
     m_instance_extension_names.push_back(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s %s not supported, skipping test\n", kSkipPrefix, VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
 
     uint32_t physical_device_group_count = 0;
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, nullptr);
@@ -1804,6 +1801,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageWithSignaledSemaphore) {
         return;
     }
 
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -1811,9 +1809,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageWithSignaledSemaphore) {
         return;
     }
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
-    } else if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s vkAcquireNextImage2KHR not supported, skipping test\n", kSkipPrefix);
         return;
     }
@@ -1861,16 +1857,16 @@ TEST_F(VkLayerTest, DisplayPresentInfoSrcRect) {
         printf("%s surface extensions not supported, skipping test\n", kSkipPrefix);
         return;
     }
+    AddRequiredExtensions(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AddSwapchainDeviceExtension()) {
         printf("%s swapchain extensions not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME)) {
+    if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported.\n", kSkipPrefix, VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
         return;
     }
-    m_device_extension_names.push_back(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (!InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
         printf("%s Cannot create surface or swapchain, skipping test\n", kSkipPrefix);

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -81,7 +81,7 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     image_create_info.pNext = &image_swapchain_create_info;
 
     VkImage image_from_swapchain;
-    VkResult err = vk::CreateImage(device(), &image_create_info, NULL, &image_from_swapchain);
+    VkResult err = vk::CreateImage(device(), &image_create_info, nullptr, &image_from_swapchain);
     ASSERT_VK_SUCCESS(err);
 
     VkMemoryRequirements mem_reqs = {};
@@ -95,7 +95,7 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
     // some devices don't give us good memory requirements for the swapchain image
     if (pass) {
-        err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+        err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
         ASSERT_VK_SUCCESS(err);
     }
 
@@ -129,9 +129,9 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     vk::BindImageMemory2(m_device->device(), 1, &bind_info);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImage(m_device->device(), image_from_swapchain, NULL);
+    vk::DestroyImage(m_device->device(), image_from_swapchain, nullptr);
     if (mem) {
-        vk::FreeMemory(m_device->device(), mem, NULL);
+        vk::FreeMemory(m_device->device(), mem, nullptr);
     }
     DestroySwapchain();
 }
@@ -188,35 +188,35 @@ TEST_F(VkLayerTest, ValidSwapchainImage) {
     image_create_info = good_create_info;
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyFound();
 
     // mipLevels
     image_create_info = good_create_info;
     image_create_info.mipLevels = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyFound();
 
     // samples
     image_create_info = good_create_info;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyFound();
 
     // tiling
     image_create_info = good_create_info;
     image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyFound();
 
     // initialLayout
     image_create_info = good_create_info;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyFound();
 
     // flags
@@ -224,7 +224,7 @@ TEST_F(VkLayerTest, ValidSwapchainImage) {
         image_create_info = good_create_info;
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-        vk::CreateImage(device(), &image_create_info, NULL, &image);
+        vk::CreateImage(device(), &image_create_info, nullptr, &image);
         m_errorMonitor->VerifyFound();
     }
 
@@ -313,7 +313,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     image_create_info.pNext = &image_swapchain_create_info;
 
     VkImage peer_image;
-    vk::CreateImage(device(), &image_create_info, NULL, &peer_image);
+    vk::CreateImage(device(), &image_create_info, nullptr, &peer_image);
 
     auto bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
     bind_devicegroup_info.deviceIndexCount = 2;
@@ -368,7 +368,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImage(m_device->device(), peer_image, NULL);
+    vk::DestroyImage(m_device->device(), peer_image, nullptr);
     DestroySwapchain();
 }
 
@@ -1388,12 +1388,12 @@ TEST_F(VkLayerTest, InvalidDeviceMask) {
 
     VkDeviceMemory mem;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateFlagsInfo-deviceMask-00675");
-    vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     m_errorMonitor->VerifyFound();
 
     alloc_flags_info.deviceMask = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateFlagsInfo-deviceMask-00676");
-    vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mem);
+    vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mem);
     m_errorMonitor->VerifyFound();
 
     uint32_t pdev_group_count = 0;
@@ -1411,7 +1411,7 @@ TEST_F(VkLayerTest, InvalidDeviceMask) {
                     void *data;
                     VkDeviceMemory mi_mem;
                     alloc_flags_info.deviceMask = 3;
-                    err = vk::AllocateMemory(m_device->device(), &alloc_info, NULL, &mi_mem);
+                    err = vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &mi_mem);
                     if (VK_SUCCESS == err) {
                         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkMapMemory-memory-00683");
                         vk::MapMemory(m_device->device(), mi_mem, 0, 1024, 0, &data);
@@ -2412,7 +2412,7 @@ TEST_F(VkLayerTest, TestCreatingWin32Surface) {
 
     VkWin32SurfaceCreateInfoKHR surface_create_info = LvlInitStruct<VkWin32SurfaceCreateInfoKHR>();
     surface_create_info.hinstance = GetModuleHandle(0);
-    surface_create_info.hwnd = NULL; // Invalid
+    surface_create_info.hwnd = nullptr;  // Invalid
 
     VkSurfaceKHR surface;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308");

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1167,9 +1167,8 @@ bool VkRenderFramework::InitFrameworkAndRetrieveFeatures(VkPhysicalDeviceFeature
             return false;
         }
     }
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(),
-            "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
+        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
 
     if (vkGetPhysicalDeviceFeatures2KHR) {
         vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
@@ -2317,7 +2316,7 @@ void VkCommandBufferObj::PipelineBarrier(VkPipelineStageFlags src_stages, VkPipe
 
 void VkCommandBufferObj::PipelineBarrier2KHR(const VkDependencyInfoKHR *pDependencyInfo) {
     auto fpCmdPipelineBarrier2KHR =
-        (PFN_vkCmdPipelineBarrier2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR");
+        reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR"));
     assert(fpCmdPipelineBarrier2KHR != nullptr);
 
     fpCmdPipelineBarrier2KHR(handle(), pDependencyInfo);
@@ -2391,8 +2390,8 @@ void VkCommandBufferObj::BuildAccelerationStructure(VkAccelerationStructureObj *
 }
 
 void VkCommandBufferObj::BuildAccelerationStructure(VkAccelerationStructureObj *as, VkBuffer scratchBuffer, VkBuffer instanceData) {
-    PFN_vkCmdBuildAccelerationStructureNV vkCmdBuildAccelerationStructureNV =
-        (PFN_vkCmdBuildAccelerationStructureNV)vk::GetDeviceProcAddr(as->dev(), "vkCmdBuildAccelerationStructureNV");
+    auto vkCmdBuildAccelerationStructureNV =
+        reinterpret_cast<PFN_vkCmdBuildAccelerationStructureNV>(vk::GetDeviceProcAddr(as->dev(), "vkCmdBuildAccelerationStructureNV"));
     assert(vkCmdBuildAccelerationStructureNV != nullptr);
 
     vkCmdBuildAccelerationStructureNV(handle(), &as->info(), instanceData, 0, VK_FALSE, as->handle(), VK_NULL_HANDLE, scratchBuffer,
@@ -2421,16 +2420,16 @@ void VkCommandBufferObj::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSu
 void VkCommandBufferObj::EndRenderPass() { vk::CmdEndRenderPass(handle()); }
 
 void VkCommandBufferObj::BeginRendering(const VkRenderingInfoKHR &renderingInfo) {
-    PFN_vkCmdBeginRenderingKHR vkCmdBeginRenderingKHR =
-        (PFN_vkCmdBeginRenderingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRenderingKHR");
+    auto vkCmdBeginRenderingKHR =
+        reinterpret_cast<PFN_vkCmdBeginRenderingKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRenderingKHR"));
     assert(vkCmdBeginRenderingKHR != nullptr);
 
     vkCmdBeginRenderingKHR(handle(), &renderingInfo);
 }
 
 void VkCommandBufferObj::EndRendering() {
-    PFN_vkCmdEndRenderingKHR vkCmdEndRenderingKHR =
-        (PFN_vkCmdEndRenderingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRenderingKHR");
+    auto vkCmdEndRenderingKHR =
+        reinterpret_cast<PFN_vkCmdEndRenderingKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRenderingKHR"));
     assert(vkCmdEndRenderingKHR != nullptr);
 
     vkCmdEndRenderingKHR(handle());

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -53,7 +53,7 @@ ErrorMonitor::~ErrorMonitor() NOEXCEPT { test_platform_thread_delete_mutex(&mute
 
 void ErrorMonitor::MonitorReset() {
     message_flags_ = 0;
-    bailout_ = NULL;
+    bailout_ = nullptr;
     message_found_ = VK_FALSE;
     failure_message_strings_.clear();
     desired_message_strings_.clear();
@@ -289,10 +289,10 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugReporter::DebugCallback(VkDebugUtilsMessageS
 }
 
 VkRenderFramework::VkRenderFramework()
-    : instance_(NULL),
-      m_device(NULL),
+    : instance_(nullptr),
+      m_device(nullptr),
       m_commandPool(VK_NULL_HANDLE),
-      m_commandBuffer(NULL),
+      m_commandBuffer(nullptr),
       m_renderPass(VK_NULL_HANDLE),
       m_framebuffer(VK_NULL_HANDLE),
       m_surface(VK_NULL_HANDLE),
@@ -312,7 +312,7 @@ VkRenderFramework::VkRenderFramework()
       m_clear_via_load_op(true),
       m_depth_clear_color(1.0),
       m_stencil_clear_color(0),
-      m_depthStencil(NULL) {
+      m_depthStencil(nullptr) {
     m_framebuffer_info = LvlInitStruct<VkFramebufferCreateInfo>();
     m_renderPass_info = LvlInitStruct<VkRenderPassCreateInfo>();
     m_renderPassBeginInfo = LvlInitStruct<VkRenderPassBeginInfo>();
@@ -418,7 +418,7 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
 
 // Return true if device is created and extension name is found in the list
 bool VkRenderFramework::DeviceExtensionEnabled(const char *ext_name) {
-    if (NULL == m_device) return false;
+    if (nullptr == m_device) return false;
 
     bool ext_found = false;
     for (auto ext : m_device_extension_names) {
@@ -649,9 +649,9 @@ void VkRenderFramework::ShutdownFramework() {
     m_commandBuffer = nullptr;
     delete m_commandPool;
     m_commandPool = nullptr;
-    if (m_framebuffer) vk::DestroyFramebuffer(device(), m_framebuffer, NULL);
+    if (m_framebuffer) vk::DestroyFramebuffer(device(), m_framebuffer, nullptr);
     m_framebuffer = VK_NULL_HANDLE;
-    if (m_renderPass) vk::DestroyRenderPass(device(), m_renderPass, NULL);
+    if (m_renderPass) vk::DestroyRenderPass(device(), m_renderPass, nullptr);
     m_renderPass = VK_NULL_HANDLE;
 
     m_renderTargets.clear();
@@ -670,13 +670,13 @@ void VkRenderFramework::ShutdownFramework() {
     debug_reporter_.Destroy(instance_);
 
     vk::DestroyInstance(instance_, nullptr);
-    instance_ = NULL;  // In case we want to re-initialize
+    instance_ = nullptr;  // In case we want to re-initialize
 }
 
 ErrorMonitor &VkRenderFramework::Monitor() { return debug_reporter_.error_monitor_; }
 
 void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features) {
-    if (NULL == m_device) {
+    if (nullptr == m_device) {
         VkDeviceObj *temp_device = new VkDeviceObj(0, gpu_, m_device_extension_names);
         *features = temp_device->phy().features();
         delete (temp_device);
@@ -799,7 +799,8 @@ bool VkRenderFramework::InitSurface(float width, float height, VkSurfaceKHR &sur
     wc.hInstance = window_instance;
     wc.lpszClassName = class_name;
     RegisterClass(&wc);
-    HWND window = CreateWindowEx(0, class_name, 0, 0, 0, 0, (int)m_width, (int)m_height, NULL, NULL, window_instance, NULL);
+    HWND window =
+        CreateWindowEx(0, class_name, 0, 0, 0, 0, (int)m_width, (int)m_height, nullptr, nullptr, window_instance, nullptr);
     ShowWindow(window, SW_HIDE);
 
     VkWin32SurfaceCreateInfoKHR surface_create_info = LvlInitStruct<VkWin32SurfaceCreateInfoKHR>();
@@ -818,7 +819,7 @@ bool VkRenderFramework::InitSurface(float width, float height, VkSurfaceKHR &sur
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
     assert(m_surface_dpy == nullptr);
-    m_surface_dpy = XOpenDisplay(NULL);
+    m_surface_dpy = XOpenDisplay(nullptr);
     if (m_surface_dpy) {
         int s = DefaultScreen(m_surface_dpy);
         m_surface_window = XCreateSimpleWindow(m_surface_dpy, RootWindow(m_surface_dpy, s), 0, 0, (int)m_width, (int)m_height, 1,
@@ -834,7 +835,7 @@ bool VkRenderFramework::InitSurface(float width, float height, VkSurfaceKHR &sur
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     if (m_surface == VK_NULL_HANDLE) {
         assert(m_surface_xcb_conn == nullptr);
-        m_surface_xcb_conn = xcb_connect(NULL, NULL);
+        m_surface_xcb_conn = xcb_connect(nullptr, nullptr);
         if (m_surface_xcb_conn) {
             xcb_window_t window = xcb_generate_id(m_surface_xcb_conn);
             VkXcbSurfaceCreateInfoKHR surface_create_info = LvlInitStruct<VkXcbSurfaceCreateInfoKHR>();
@@ -974,7 +975,7 @@ void VkRenderFramework::DestroySwapchain() {
 
 void VkRenderFramework::InitRenderTarget() { InitRenderTarget(1); }
 
-void VkRenderFramework::InitRenderTarget(uint32_t targets) { InitRenderTarget(targets, NULL); }
+void VkRenderFramework::InitRenderTarget(uint32_t targets) { InitRenderTarget(targets, nullptr); }
 
 void VkRenderFramework::InitRenderTarget(VkImageView *dsBinding) { InitRenderTarget(1, dsBinding); }
 
@@ -1039,10 +1040,10 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
-    subpass.pInputAttachments = NULL;
+    subpass.pInputAttachments = nullptr;
     subpass.colorAttachmentCount = targets;
     subpass.pColorAttachments = color_references.data();
-    subpass.pResolveAttachments = NULL;
+    subpass.pResolveAttachments = nullptr;
 
     VkAttachmentReference ds_reference;
     if (dsBinding) {
@@ -1066,11 +1067,11 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         ds_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         subpass.pDepthStencilAttachment = &ds_reference;
     } else {
-        subpass.pDepthStencilAttachment = NULL;
+        subpass.pDepthStencilAttachment = nullptr;
     }
 
     subpass.preserveAttachmentCount = 0;
-    subpass.pPreserveAttachments = NULL;
+    subpass.pPreserveAttachments = nullptr;
 
     VkRenderPassCreateInfo &rp_info = m_renderPass_info;
     rp_info = LvlInitStruct<VkRenderPassCreateInfo>();
@@ -1119,7 +1120,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         rp_info.pDependencies = nullptr;
     }
 
-    vk::CreateRenderPass(device(), &rp_info, NULL, &m_renderPass);
+    vk::CreateRenderPass(device(), &rp_info, nullptr, &m_renderPass);
     // Create Framebuffer and RenderPass with color attachments and any
     // depth/stencil attachment
     VkFramebufferCreateInfo &fb_info = m_framebuffer_info;
@@ -1131,7 +1132,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
     fb_info.height = (uint32_t)m_height;
     fb_info.layers = 1;
 
-    vk::CreateFramebuffer(device(), &fb_info, NULL, &m_framebuffer);
+    vk::CreateFramebuffer(device(), &fb_info, nullptr, &m_framebuffer);
 
     m_renderPassBeginInfo.renderPass = m_renderPass;
     m_renderPassBeginInfo.framebuffer = m_framebuffer;
@@ -1249,7 +1250,7 @@ int VkDescriptorSetObj::AppendDummy() {
     binding.descriptorCount = 1;
     binding.binding = m_layout_bindings.size();
     binding.stageFlags = VK_SHADER_STAGE_ALL;
-    binding.pImmutableSamplers = NULL;
+    binding.pImmutableSamplers = nullptr;
 
     m_layout_bindings.push_back(binding);
     m_type_counts[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER] += binding.descriptorCount;
@@ -1265,7 +1266,7 @@ int VkDescriptorSetObj::AppendBuffer(VkDescriptorType type, VkConstantBufferObj 
     binding.descriptorCount = 1;
     binding.binding = m_layout_bindings.size();
     binding.stageFlags = VK_SHADER_STAGE_ALL;
-    binding.pImmutableSamplers = NULL;
+    binding.pImmutableSamplers = nullptr;
 
     m_layout_bindings.push_back(binding);
     m_type_counts[type] += binding.descriptorCount;
@@ -1282,7 +1283,7 @@ int VkDescriptorSetObj::AppendSamplerTexture(VkSamplerObj *sampler, VkTextureObj
     binding.descriptorCount = 1;
     binding.binding = m_layout_bindings.size();
     binding.stageFlags = VK_SHADER_STAGE_ALL;
-    binding.pImmutableSamplers = NULL;
+    binding.pImmutableSamplers = nullptr;
 
     m_layout_bindings.push_back(binding);
     m_type_counts[VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER] += binding.descriptorCount;
@@ -1336,7 +1337,7 @@ void VkDescriptorSetObj::CreateVKDescriptorSet(VkCommandBufferObj *commandBuffer
     // create VkPipelineLayout
     VkPipelineLayoutCreateInfo pipeline_layout = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     pipeline_layout.setLayoutCount = layouts.size();
-    pipeline_layout.pSetLayouts = NULL;
+    pipeline_layout.pSetLayouts = nullptr;
 
     m_pipeline_layout.init(*m_device, pipeline_layout, layouts);
 
@@ -1447,7 +1448,7 @@ void VkImageObj::ImageMemoryBarrier(VkCommandBufferObj *cmd_buf, VkImageAspectFl
     VkImageMemoryBarrier *pmemory_barrier = &barrier;
 
     // write barrier to the command buffer
-    vk::CmdPipelineBarrier(cmd_buf->handle(), src_stages, dest_stages, VK_DEPENDENCY_BY_REGION_BIT, 0, NULL, 0, NULL, 1,
+    vk::CmdPipelineBarrier(cmd_buf->handle(), src_stages, dest_stages, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
                            pmemory_barrier);
 }
 
@@ -1887,7 +1888,7 @@ VkTextureObj::VkTextureObj(VkDeviceObj *device, uint32_t *colors) : VkImageObj(d
                       VK_IMAGE_TILING_LINEAR, reqs);
     VkSubresourceLayout layout = stagingImage.subresource_layout(subresource(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0));
 
-    if (colors == NULL) colors = tex_colors;
+    if (colors == nullptr) colors = tex_colors;
 
     VkImageViewCreateInfo view = LvlInitStruct<VkImageViewCreateInfo>();
     view.image = VK_NULL_HANDLE;
@@ -2239,7 +2240,7 @@ void VkPipelineObj::InitGraphicsPipelineCreateInfo(VkGraphicsPipelineCreateInfo 
     gp_ci->pInputAssemblyState = &m_ia_state;
 
     gp_ci->sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    gp_ci->pNext = NULL;
+    gp_ci->pNext = nullptr;
     gp_ci->flags = 0;
 
     m_cb_state.attachmentCount = m_colorAttachments.size();
@@ -2481,7 +2482,7 @@ void VkCommandBufferObj::BindDescriptorSet(VkDescriptorSetObj &descriptorSet) {
     // bind pipeline, vertex buffer (descriptor set) and WVP (dynamic buffer view)
     if (set_obj) {
         vk::CmdBindDescriptorSets(handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, descriptorSet.GetPipelineLayout(), 0, 1, &set_obj, 0,
-                                  NULL);
+                                  nullptr);
     }
 }
 

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -249,11 +249,10 @@ TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
 
 TEST_F(VkSyncValTest, Sync2BufferCopyHazards) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
 
@@ -552,11 +551,10 @@ TEST_F(VkSyncValTest, SyncCopyOptimalImageHazards) {
 
 TEST_F(VkSyncValTest, Sync2CopyOptimalImageHazards) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
+    if (!AreRequestedExtensionsEnabled()) {
+        printf("%s %s extension not supported, skipping test\n", kSkipPrefix, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
         return;
     }
 

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1939,7 +1939,7 @@ TEST_F(VkSyncValTest, SyncCmdQuery) {
         return;
     }
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
@@ -3018,7 +3018,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_);
         vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_layout_.handle(), 0,
-                                  1, &g_pipe_0.descriptor_set_->set_, 0, NULL);
+                                  1, &g_pipe_0.descriptor_set_->set_, 0, nullptr);
 
         vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
 
@@ -3026,7 +3026,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
             vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
+                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, nullptr);
 
             // we're racing the writes from subpass 0 with our shader reads
             m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-READ-RACING-WRITE");
@@ -3100,7 +3100,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_);
         vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_layout_.handle(), 0,
-                                  1, &g_pipe_0.descriptor_set_->set_, 0, NULL);
+                                  1, &g_pipe_0.descriptor_set_->set_, 0, nullptr);
 
         vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
 
@@ -3109,7 +3109,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
             vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
+                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, nullptr);
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
         }
         m_errorMonitor->VerifyNotFound();
@@ -3180,7 +3180,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_);
         vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_layout_.handle(), 0,
-                                  1, &g_pipe_0.descriptor_set_->set_, 0, NULL);
+                                  1, &g_pipe_0.descriptor_set_->set_, 0, nullptr);
 
         vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
 
@@ -3188,7 +3188,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
             vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
+                                      g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, nullptr);
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
         }
 
@@ -3613,7 +3613,7 @@ TEST_F(VkLayerTest, Sync2FeatureDisabled) {
     bool timestamp = false;
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits > 0) {
@@ -3851,7 +3851,7 @@ TEST_F(VkSyncValTest, DestroyedUnusedDescriptors) {
     descriptor_writes[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_writes[5].pImageInfo = &image_info[2];
 
-    vk::UpdateDescriptorSets(m_device->device(), descriptor_writes.size(), descriptor_writes.data(), 0, NULL);
+    vk::UpdateDescriptorSets(m_device->device(), descriptor_writes.size(), descriptor_writes.data(), 0, nullptr);
 
     // only descriptor 0 is used, the rest are going to get destroyed
     char const *shader_source = R"glsl(

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -223,7 +223,7 @@ TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
     // CmdWriteBufferMarkerAMD
     if (has_amd_buffer_maker) {
         auto fpCmdWriteBufferMarkerAMD =
-            (PFN_vkCmdWriteBufferMarkerAMD)vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteBufferMarkerAMD");
+            reinterpret_cast<PFN_vkCmdWriteBufferMarkerAMD>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteBufferMarkerAMD"));
         if (!fpCmdWriteBufferMarkerAMD) {
             printf("%s Test requires unsupported vkCmdWriteBufferMarkerAMD feature. Skipped.\n", kSkipPrefix);
         } else {
@@ -261,7 +261,8 @@ TEST_F(VkSyncValTest, Sync2BufferCopyHazards) {
         printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    auto fpCmdPipelineBarrier2KHR = (PFN_vkCmdPipelineBarrier2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR");
+    auto fpCmdPipelineBarrier2KHR =
+        reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR"));
 
     VkBufferObj buffer_a;
     VkBufferObj buffer_b;
@@ -563,7 +564,8 @@ TEST_F(VkSyncValTest, Sync2CopyOptimalImageHazards) {
         printf("%s Synchronization2 not supported, skipping test\n", kSkipPrefix);
         return;
     }
-    auto fpCmdPipelineBarrier2KHR = (PFN_vkCmdPipelineBarrier2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR");
+    auto fpCmdPipelineBarrier2KHR =
+        reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR"));
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1731,7 +1733,7 @@ TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
     if (has_khr_indirect) {
         // DrawIndirectCount
         auto fpCmdDrawIndirectCountKHR =
-            (PFN_vkCmdDrawIndirectCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR");
+            reinterpret_cast<PFN_vkCmdDrawIndirectCount>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndirectCountKHR"));
         if (!fpCmdDrawIndirectCountKHR) {
             printf("%s Test requires unsupported vkCmdDrawIndirectCountKHR feature. Skipped.\n", kSkipPrefix);
         } else {
@@ -1782,8 +1784,8 @@ TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
         }
 
         // DrawIndexedIndirectCount
-        auto fpCmdDrawIndexIndirectCountKHR =
-            (PFN_vkCmdDrawIndirectCount)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR");
+        auto fpCmdDrawIndexIndirectCountKHR = reinterpret_cast<PFN_vkCmdDrawIndirectCount>(
+            vk::GetDeviceProcAddr(m_device->device(), "vkCmdDrawIndexedIndirectCountKHR"));
         if (!fpCmdDrawIndexIndirectCountKHR) {
             printf("%s Test requires unsupported vkCmdDrawIndexedIndirectCountKHR feature. Skipped.\n", kSkipPrefix);
         } else {
@@ -3563,7 +3565,8 @@ TEST_F(VkLayerTest, CmdWaitEvents2KHRUsedButSynchronizaion2Disabled) {
     InitState();
 
     bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-    auto fpCmdWaitEvents2KHR = (PFN_vkCmdWaitEvents2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdWaitEvents2KHR");
+    auto fpCmdWaitEvents2KHR =
+        reinterpret_cast<PFN_vkCmdWaitEvents2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWaitEvents2KHR"));
 
     VkEventObj event;
     event.init(*m_device, VkEventObj::create_info(0));
@@ -3604,11 +3607,13 @@ TEST_F(VkLayerTest, Sync2FeatureDisabled) {
     vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
 
     auto vkCmdPipelineBarrier2KHR =
-        (PFN_vkCmdPipelineBarrier2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR");
-    auto vkCmdResetEvent2KHR = (PFN_vkCmdResetEvent2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdResetEvent2KHR");
-    auto vkCmdSetEvent2KHR = (PFN_vkCmdSetEvent2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetEvent2KHR");
+        reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdPipelineBarrier2KHR"));
+    auto vkCmdResetEvent2KHR =
+        reinterpret_cast<PFN_vkCmdResetEvent2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdResetEvent2KHR"));
+    auto vkCmdSetEvent2KHR =
+        reinterpret_cast<PFN_vkCmdSetEvent2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetEvent2KHR"));
     auto vkCmdWriteTimestamp2KHR =
-        (PFN_vkCmdWriteTimestamp2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR");
+        reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR"));
 
     bool timestamp = false;
 

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -610,8 +610,8 @@ void ImageView::init(const Device &dev, const VkImageViewCreateInfo &info) {
 
 AccelerationStructure::~AccelerationStructure() {
     if (initialized()) {
-        PFN_vkDestroyAccelerationStructureNV vkDestroyAccelerationStructureNV =
-            (PFN_vkDestroyAccelerationStructureNV)vk::GetDeviceProcAddr(device(), "vkDestroyAccelerationStructureNV");
+        auto vkDestroyAccelerationStructureNV = reinterpret_cast<PFN_vkDestroyAccelerationStructureNV>(
+            vk::GetDeviceProcAddr(device(), "vkDestroyAccelerationStructureNV"));
         assert(vkDestroyAccelerationStructureNV != nullptr);
 
         vkDestroyAccelerationStructureNV(device(), handle(), nullptr);
@@ -620,16 +620,15 @@ AccelerationStructure::~AccelerationStructure() {
 
 AccelerationStructureKHR::~AccelerationStructureKHR() {
     if (initialized()) {
-        PFN_vkDestroyAccelerationStructureKHR vkDestroyAccelerationStructureKHR =
-            (PFN_vkDestroyAccelerationStructureKHR)vk::GetDeviceProcAddr(device(), "vkDestroyAccelerationStructureKHR");
+        auto vkDestroyAccelerationStructureKHR = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
+            vk::GetDeviceProcAddr(device(), "vkDestroyAccelerationStructureKHR"));
         assert(vkDestroyAccelerationStructureKHR != nullptr);
         vkDestroyAccelerationStructureKHR(device(), handle(), nullptr);
     }
 }
 VkMemoryRequirements2 AccelerationStructure::memory_requirements() const {
-    PFN_vkGetAccelerationStructureMemoryRequirementsNV vkGetAccelerationStructureMemoryRequirementsNV =
-        (PFN_vkGetAccelerationStructureMemoryRequirementsNV)vk::GetDeviceProcAddr(device(),
-                                                                                  "vkGetAccelerationStructureMemoryRequirementsNV");
+    auto vkGetAccelerationStructureMemoryRequirementsNV = reinterpret_cast<PFN_vkGetAccelerationStructureMemoryRequirementsNV>(
+        vk::GetDeviceProcAddr(device(), "vkGetAccelerationStructureMemoryRequirementsNV"));
     assert(vkGetAccelerationStructureMemoryRequirementsNV != nullptr);
     VkMemoryRequirements2 memoryRequirements = {};
     VkAccelerationStructureMemoryRequirementsInfoNV memoryRequirementsInfo =
@@ -641,9 +640,8 @@ VkMemoryRequirements2 AccelerationStructure::memory_requirements() const {
 }
 
 VkMemoryRequirements2 AccelerationStructure::build_scratch_memory_requirements() const {
-    PFN_vkGetAccelerationStructureMemoryRequirementsNV vkGetAccelerationStructureMemoryRequirementsNV =
-        (PFN_vkGetAccelerationStructureMemoryRequirementsNV)vk::GetDeviceProcAddr(device(),
-                                                                                  "vkGetAccelerationStructureMemoryRequirementsNV");
+    auto vkGetAccelerationStructureMemoryRequirementsNV = reinterpret_cast<PFN_vkGetAccelerationStructureMemoryRequirementsNV>(
+        vk::GetDeviceProcAddr(device(), "vkGetAccelerationStructureMemoryRequirementsNV"));
     assert(vkGetAccelerationStructureMemoryRequirementsNV != nullptr);
 
     VkAccelerationStructureMemoryRequirementsInfoNV memoryRequirementsInfo =
@@ -657,8 +655,8 @@ VkMemoryRequirements2 AccelerationStructure::build_scratch_memory_requirements()
 }
 
 void AccelerationStructure::init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory) {
-    PFN_vkCreateAccelerationStructureNV vkCreateAccelerationStructureNV =
-        (PFN_vkCreateAccelerationStructureNV)vk::GetDeviceProcAddr(dev.handle(), "vkCreateAccelerationStructureNV");
+    auto vkCreateAccelerationStructureNV = reinterpret_cast<PFN_vkCreateAccelerationStructureNV>(
+        vk::GetDeviceProcAddr(dev.handle(), "vkCreateAccelerationStructureNV"));
     assert(vkCreateAccelerationStructureNV != nullptr);
 
     NON_DISPATCHABLE_HANDLE_INIT(vkCreateAccelerationStructureNV, dev, &info);
@@ -669,8 +667,8 @@ void AccelerationStructure::init(const Device &dev, const VkAccelerationStructur
         memory_.init(dev, DeviceMemory::get_resource_alloc_info(dev, memory_requirements().memoryRequirements,
                                                                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
 
-        PFN_vkBindAccelerationStructureMemoryNV vkBindAccelerationStructureMemoryNV =
-            (PFN_vkBindAccelerationStructureMemoryNV)vk::GetDeviceProcAddr(dev.handle(), "vkBindAccelerationStructureMemoryNV");
+        auto vkBindAccelerationStructureMemoryNV = reinterpret_cast<PFN_vkBindAccelerationStructureMemoryNV>(
+            vk::GetDeviceProcAddr(dev.handle(), "vkBindAccelerationStructureMemoryNV"));
         assert(vkBindAccelerationStructureMemoryNV != nullptr);
 
         VkBindAccelerationStructureMemoryInfoNV bind_info = LvlInitStruct<VkBindAccelerationStructureMemoryInfoNV>();
@@ -678,8 +676,8 @@ void AccelerationStructure::init(const Device &dev, const VkAccelerationStructur
         bind_info.memory = memory_.handle();
         EXPECT(vkBindAccelerationStructureMemoryNV(dev.handle(), 1, &bind_info) == VK_SUCCESS);
 
-        PFN_vkGetAccelerationStructureHandleNV vkGetAccelerationStructureHandleNV =
-            (PFN_vkGetAccelerationStructureHandleNV)vk::GetDeviceProcAddr(dev.handle(), "vkGetAccelerationStructureHandleNV");
+        auto vkGetAccelerationStructureHandleNV = reinterpret_cast<PFN_vkGetAccelerationStructureHandleNV>(
+            vk::GetDeviceProcAddr(dev.handle(), "vkGetAccelerationStructureHandleNV"));
         assert(vkGetAccelerationStructureHandleNV != nullptr);
         EXPECT(vkGetAccelerationStructureHandleNV(dev.handle(), handle(), sizeof(uint64_t), &opaque_handle_) == VK_SUCCESS);
     }
@@ -699,8 +697,8 @@ void AccelerationStructure::create_scratch_buffer(const Device &dev, Buffer *buf
 }
 
 void AccelerationStructureKHR::init(const Device &dev, const VkAccelerationStructureCreateInfoKHR &info, bool init_memory) {
-    PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR =
-        (PFN_vkCreateAccelerationStructureKHR)vk::GetDeviceProcAddr(dev.handle(), "vkCreateAccelerationStructureKHR");
+    auto vkCreateAccelerationStructureKHR = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+        vk::GetDeviceProcAddr(dev.handle(), "vkCreateAccelerationStructureKHR"));
     assert(vkCreateAccelerationStructureKHR != nullptr);
     NON_DISPATCHABLE_HANDLE_INIT(vkCreateAccelerationStructureKHR, dev, &info);
     info_ = info;

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -35,7 +35,7 @@ namespace {
 #define NON_DISPATCHABLE_HANDLE_INIT(create_func, dev, ...)                                 \
     do {                                                                                    \
         handle_type handle;                                                                 \
-        auto result = create_func(dev.handle(), __VA_ARGS__, NULL, &handle);                \
+        auto result = create_func(dev.handle(), __VA_ARGS__, nullptr, &handle);             \
         if (EXPECT((result == VK_SUCCESS) || (result == VK_ERROR_VALIDATION_FAILED_EXT))) { \
             if (result == VK_SUCCESS) {                                                     \
                 NonDispHandle::init(dev.handle(), handle);                                  \
@@ -43,9 +43,9 @@ namespace {
         }                                                                                   \
     } while (0)
 
-#define NON_DISPATCHABLE_HANDLE_DTOR(cls, destroy_func)            \
-    cls::~cls() NOEXCEPT {                                         \
-        if (initialized()) destroy_func(device(), handle(), NULL); \
+#define NON_DISPATCHABLE_HANDLE_DTOR(cls, destroy_func)               \
+    cls::~cls() NOEXCEPT {                                            \
+        if (initialized()) destroy_func(device(), handle(), nullptr); \
     }
 
 #define STRINGIFY(x) #x
@@ -82,7 +82,7 @@ std::vector<VkQueueFamilyProperties> PhysicalDevice::queue_properties() const {
     uint32_t count;
 
     // Call once with NULL data to receive count
-    vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, nullptr);
     info.resize(count);
     vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, info.data());
 
@@ -239,7 +239,7 @@ QueueCreateInfoArray::QueueCreateInfoArray(const std::vector<VkQueueFamilyProper
 Device::~Device() NOEXCEPT {
     if (!initialized()) return;
 
-    vk::DestroyDevice(handle(), NULL);
+    vk::DestroyDevice(handle(), nullptr);
 }
 
 void Device::init(std::vector<const char *> &extensions, VkPhysicalDeviceFeatures *features, void *create_device_pnext) {
@@ -267,7 +267,7 @@ void Device::init(std::vector<const char *> &extensions, VkPhysicalDeviceFeature
     dev_info.queueCreateInfoCount = create_queue_infos.size();
     dev_info.pQueueCreateInfos = create_queue_infos.data();
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = extensions.size();
     dev_info.ppEnabledExtensionNames = extensions.data();
 
@@ -291,7 +291,7 @@ void Device::init(std::vector<const char *> &extensions, VkPhysicalDeviceFeature
 void Device::init(const VkDeviceCreateInfo &info) {
     VkDevice dev;
 
-    if (EXPECT(vk::CreateDevice(phy_.handle(), &info, NULL, &dev) == VK_SUCCESS)) Handle::init(dev);
+    if (EXPECT(vk::CreateDevice(phy_.handle(), &info, nullptr, &dev) == VK_SUCCESS)) Handle::init(dev);
 
     init_queues(info);
     init_formats();
@@ -299,7 +299,7 @@ void Device::init(const VkDeviceCreateInfo &info) {
 
 void Device::init_queues(const VkDeviceCreateInfo &info) {
     uint32_t queue_node_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(phy_.handle(), &queue_node_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(phy_.handle(), &queue_node_count, nullptr);
     EXPECT(queue_node_count >= 1);
 
     std::vector<VkQueueFamilyProperties> queue_props(queue_node_count);
@@ -395,12 +395,12 @@ VkResult Queue::submit(const std::vector<const CommandBuffer *> &cmds, const Fen
     const std::vector<VkCommandBuffer> cmd_handles = MakeVkHandles<VkCommandBuffer>(cmds);
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
+    submit_info.pWaitSemaphores = nullptr;
+    submit_info.pWaitDstStageMask = nullptr;
     submit_info.commandBufferCount = (uint32_t)cmd_handles.size();
     submit_info.pCommandBuffers = cmd_handles.data();
     submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
+    submit_info.pSignalSemaphores = nullptr;
 
     VkResult result = vk::QueueSubmit(handle(), 1, &submit_info, fence.handle());
     if (expect_success) EXPECT(result == VK_SUCCESS);
@@ -423,7 +423,7 @@ VkResult Queue::wait() {
 }
 
 DeviceMemory::~DeviceMemory() NOEXCEPT {
-    if (initialized()) vk::FreeMemory(device(), handle(), NULL);
+    if (initialized()) vk::FreeMemory(device(), handle(), nullptr);
 }
 
 void DeviceMemory::init(const Device &dev, const VkMemoryAllocateInfo &info) {
@@ -432,14 +432,14 @@ void DeviceMemory::init(const Device &dev, const VkMemoryAllocateInfo &info) {
 
 const void *DeviceMemory::map(VkFlags flags) const {
     void *data;
-    if (!EXPECT(vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data) == VK_SUCCESS)) data = NULL;
+    if (!EXPECT(vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data) == VK_SUCCESS)) data = nullptr;
 
     return data;
 }
 
 void *DeviceMemory::map(VkFlags flags) {
     void *data;
-    if (!EXPECT(vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data) == VK_SUCCESS)) data = NULL;
+    if (!EXPECT(vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data) == VK_SUCCESS)) data = nullptr;
 
     return data;
 }
@@ -728,7 +728,7 @@ void ShaderModule::init(const Device &dev, const VkShaderModuleCreateInfo &info)
 VkResult ShaderModule::init_try(const Device &dev, const VkShaderModuleCreateInfo &info) {
     VkShaderModule mod;
 
-    VkResult err = vk::CreateShaderModule(dev.handle(), &info, NULL, &mod);
+    VkResult err = vk::CreateShaderModule(dev.handle(), &info, nullptr, &mod);
     if (err == VK_SUCCESS) NonDispHandle::init(dev.handle(), mod);
 
     return err;
@@ -739,10 +739,10 @@ NON_DISPATCHABLE_HANDLE_DTOR(Pipeline, vk::DestroyPipeline)
 void Pipeline::init(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = LvlInitStruct<VkPipelineCacheCreateInfo>();
-    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, NULL, &cache);
+    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, nullptr, &cache);
     if (err == VK_SUCCESS) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateGraphicsPipelines, dev, cache, 1, &info);
-        vk::DestroyPipelineCache(dev.handle(), cache, NULL);
+        vk::DestroyPipelineCache(dev.handle(), cache, nullptr);
     }
 }
 
@@ -750,14 +750,14 @@ VkResult Pipeline::init_try(const Device &dev, const VkGraphicsPipelineCreateInf
     VkPipeline pipe;
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = LvlInitStruct<VkPipelineCacheCreateInfo>();
-    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, NULL, &cache);
+    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, nullptr, &cache);
     EXPECT(err == VK_SUCCESS);
     if (err == VK_SUCCESS) {
-        err = vk::CreateGraphicsPipelines(dev.handle(), cache, 1, &info, NULL, &pipe);
+        err = vk::CreateGraphicsPipelines(dev.handle(), cache, 1, &info, nullptr, &pipe);
         if (err == VK_SUCCESS) {
             NonDispHandle::init(dev.handle(), pipe);
         }
-        vk::DestroyPipelineCache(dev.handle(), cache, NULL);
+        vk::DestroyPipelineCache(dev.handle(), cache, nullptr);
     }
 
     return err;
@@ -766,10 +766,10 @@ VkResult Pipeline::init_try(const Device &dev, const VkGraphicsPipelineCreateInf
 void Pipeline::init(const Device &dev, const VkComputePipelineCreateInfo &info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = LvlInitStruct<VkPipelineCacheCreateInfo>();
-    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, NULL, &cache);
+    VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, nullptr, &cache);
     if (err == VK_SUCCESS) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateComputePipelines, dev, cache, 1, &info);
-        vk::DestroyPipelineCache(dev.handle(), cache, NULL);
+        vk::DestroyPipelineCache(dev.handle(), cache, nullptr);
     }
 }
 
@@ -834,7 +834,7 @@ std::vector<DescriptorSet *> DescriptorPool::alloc_sets(const Device &dev, const
 
 DescriptorSet *DescriptorPool::alloc_sets(const Device &dev, const DescriptorSetLayout &layout) {
     std::vector<DescriptorSet *> set = alloc_sets(dev, layout, 1);
-    return (set.empty()) ? NULL : set[0];
+    return (set.empty()) ? nullptr : set[0];
 }
 
 DescriptorSet::~DescriptorSet() NOEXCEPT {

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2021 The Khronos Group Inc.
  * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replaced `NULL` with `nullptr`
Replaced  C casts with `reinterpret_cast`
Using `AddRequiredExtension()` (did not catch all)