### PR TITLE
Don't dereference null pipeline state pointer in Best Practices

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2018,7 +2018,8 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* 
         const auto& current_vtx_bfr_binding_info = cb_state->current_vertex_buffer_binding_info.vertex_buffer_bindings;
 
         // Verify vertex binding
-        if (pipeline_state->vertex_input_state && pipeline_state->vertex_input_state->binding_descriptions.size() <= 0) {
+        if (pipeline_state && pipeline_state->vertex_input_state &&
+            pipeline_state->vertex_input_state->binding_descriptions.size() <= 0) {
             if ((!current_vtx_bfr_binding_info.empty()) && (!cb_state->vertex_buffer_used)) {
                 skip |= LogPerformanceWarning(cb_state->commandBuffer(), kVUID_BestPractices_DrawState_VtxIndexOutOfBounds,
                                               "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",


### PR DESCRIPTION
Fixes crash in dEQP-VK.fragment_shading_rate.renderpass2.multiview.dynamic.noattachment.noshaderrate.keep.keep.1x1.samples2.vs with BP