### PR TITLE
Transfer event updates from secondary to primary command buffers

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -907,6 +907,9 @@ void CMD_BUFFER_STATE::ExecuteCommands(uint32_t commandBuffersCount, const VkCom
         for (auto &function : sub_cb_state->queryUpdates) {
             queryUpdates.push_back(function);
         }
+        for (auto &function : sub_cb_state->eventUpdates) {
+            eventUpdates.push_back(function);
+        }
         for (auto &function : sub_cb_state->queue_submit_functions) {
             queue_submit_functions.push_back(function);
         }


### PR DESCRIPTION
I think with this test we are able to replicate issue #1556. If the mentioned issue has nothing to do with this, this PR fixes an issue we have with event updates not being transfered from secondary to primary command buffers when executed.