### PR TITLE
Fix shader validation cache file path

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3572,7 +3572,6 @@ void CoreChecks::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
 
     // Allocate shader validation cache
     if (!disabled[shader_validation_caching] && !disabled[shader_validation] && !core_validation_cache) {
-        std::string validation_cache_path;
         auto tmp_path = GetEnvironment("XDG_CACHE_HOME");
         if (!tmp_path.size()) {
             auto cachepath = GetEnvironment("HOME") + "/.cache";


### PR DESCRIPTION
The local string is masking the path in the class, and then the cache never gets written.  Remove the local variable.
Fixes https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/1013