### PR TITLE
layers: Add VUIDs 06606, 06607, 06608

### DIFF
--- a/layers/device_state.h
+++ b/layers/device_state.h
@@ -91,6 +91,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceImageViewMinLodFeaturesEXT image_view_min_lod_features;
     VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_query_features;
     VkPhysicalDeviceImage2DViewOf3DFeaturesEXT image_2d_view_of_3d_features;
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT graphics_pipeline_library_features;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1168,6 +1168,12 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         if (image_2d_view_of_3d_features) {
             enabled_features.image_2d_view_of_3d_features = *image_2d_view_of_3d_features;
         }
+
+        const auto graphics_pipeline_library_features =
+            LvlFindInChain<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(pCreateInfo->pNext);
+        if (graphics_pipeline_library_features) {
+            enabled_features.graphics_pipeline_library_features = *graphics_pipeline_library_features;
+        }
     }
 
     // Store physical device properties and physical device mem limits into CoreChecks structs


### PR DESCRIPTION
Adds VUIDs that check for invalid graphics pipeline state when
VK_EXT_graphics_pipeline_library is enabled.