### PR TITLE
tests: Remove devsim references

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,11 +133,6 @@ target_include_directories(vk_layer_validation_tests
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils)
 
-option(PORTABILITY_TESTS_USE_DEVSIM "Automatically add the devsim layer for portability tests" OFF)
-if (PORTABILITY_TESTS_USE_DEVSIM)
-    target_compile_definitions(vk_layer_validation_tests PRIVATE PORTABILITY_TESTS_USE_DEVSIM=1)
-endif()
-
 if (VVL_ENABLE_ASAN)
     target_compile_options(vk_layer_validation_tests  PRIVATE -fsanitize=address)
     # NOTE: Use target_link_options when cmake 3.13 is available on CI

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -786,7 +786,7 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&timeline_semaphore_props);
     vkGetPhysicalDeviceProperties2KHR(renderFramework->gpu(), &pd_props2);
     if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
-        // If using MockICD and devsim the value might be zero'ed and cause false errors
+        // If using MockICD, the value might be zero'ed and cause false errors
         return false;
     }
 
@@ -1033,16 +1033,8 @@ VkLayerTest::VkLayerTest() {
 
     instance_layers_.push_back(kValidationLayerName);
 
-    if (VkTestFramework::m_devsim_layer) {
-        if (InstanceLayerSupported("VK_LAYER_LUNARG_device_simulation")) {
-            instance_layers_.push_back("VK_LAYER_LUNARG_device_simulation");
-        } else {
-            VkTestFramework::m_devsim_layer = false;
-            printf("             Did not find VK_LAYER_LUNARG_device_simulation layer so it will not be enabled.\n");
-        }
-    } else {
-        if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api"))
-            instance_layers_.push_back("VK_LAYER_LUNARG_device_profile_api");
+    if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {
+        instance_layers_.push_back("VK_LAYER_LUNARG_device_profile_api");
     }
 
     if (InstanceLayerSupported(kSynchronization2LayerName)) {
@@ -2486,7 +2478,7 @@ bool InitFrameworkForRayTracingTest(VkRenderFramework *renderFramework, bool isK
 
     renderFramework->InitFramework(user_data, enabled_features);
 
-    if (renderFramework->IsPlatform(kMockICD) || renderFramework->DeviceSimulation()) {
+    if (renderFramework->IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return false;
     }
@@ -2589,7 +2581,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     bool descriptor_indexing = CheckDescriptorIndexingSupportAndInitFramework(
         this, m_instance_extension_names, m_device_extension_names, gpu_assisted ? &validation_features : nullptr, m_errorMonitor);
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -550,10 +550,8 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature12) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
-    // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
+    if (IsPlatform(kMockICD)) {
+        printf("%sNot supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
 
@@ -613,10 +611,8 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithFeature) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
-    // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
+    if (IsPlatform(kMockICD)) {
+        printf("%sNot supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -5040,7 +5040,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
         }
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -5336,12 +5336,11 @@ TEST_F(VkPositiveLayerTest, ImageDescriptorSubresourceLayout) {
     do_test(&image, &view, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
-TEST_F(VkPositiveLayerTest, DevsimLoaderCrash) {
+TEST_F(VkPositiveLayerTest, ExtensionCreateInstanceLoaderCrash) {
     TEST_DESCRIPTION("Test to see if instance extensions are called during CreateInstance.");
 
     // See https://github.com/KhronosGroup/Vulkan-Loader/issues/537 for more details.
-    // This is specifically meant to ensure a crash encountered in devsim does not occur, but also to
-    // attempt to ensure that no extension calls have been added to CreateInstance hooks.
+    // Attempt to ensure that no extension calls have been added to CreateInstance hooks.
     // NOTE: it is certainly possible that a layer will call an extension during the Createinstance hook
     //       and the loader will _not_ crash (e.g., nvidia, android seem to not crash in this case, but AMD does).
     //       So, this test will only catch an erroneous extension _if_ run on HW/a driver that crashes in this use

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1082,9 +1082,7 @@ TEST_F(VkPositiveLayerTest, ShaderDrawParametersWithFeature) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
-    // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -2031,8 +2029,8 @@ TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
         }
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD or devsim, skipping tests\n", kSkipPrefix);
+    if (IsPlatform(kMockICD)) {
+        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
 
@@ -2551,7 +2549,7 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // need real device to produce output to check
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -47,7 +47,7 @@ TEST_F(VkPositiveLayerTest, ToolingExtension) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping test case.\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -333,7 +333,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -447,7 +447,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -81,7 +81,7 @@ TEST_F(VkBestPracticesLayerTest, ValidateReturnCodes) {
         m_errorMonitor->VerifyFound();
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping test case.\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4964,7 +4964,7 @@ TEST_F(VkLayerTest, InvalidTexelBufferAlignment) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11070,7 +11070,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11135,7 +11135,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11180,7 +11180,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11302,7 +11302,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11652,7 +11652,7 @@ TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s MockICD does not support the necessary memory type, skipping test\n", kSkipPrefix);
         return;
     }
@@ -13105,9 +13105,9 @@ TEST_F(VkLayerTest, InvalidShadingRateUsage) {
     vk::GetPhysicalDeviceProperties2(gpu(), &properties);
 
     if (!fsrProperties.layeredShadingRateAttachments) {
-        if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        if (IsPlatform(kMockICD)) {
             printf(
-                "%s DevSim doesn't correctly advertise format support for fragment shading rate attachments, skipping some "
+                "%s mock ICD doesn't correctly advertise format support for fragment shading rate attachments, skipping some "
                 "tests.\n",
                 kSkipPrefix);
         } else {

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -2835,15 +2835,6 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatchMaintenance1) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkFormatProperties format_props;
-    // TODO: Remove this check if or when devsim handles extensions.
-    // The chosen format has mandatory support the transfer src and dst format features when Maitenance1 is enabled. However, our
-    // use of devsim and the mock ICD violate this guarantee.
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_format, &format_props);
-    if (!(format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
-        printf("%s Maintenance1 extension is not supported.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageCreateInfo ci = LvlInitStruct<VkImageCreateInfo>();
     ci.flags = 0;
@@ -5964,7 +5955,7 @@ TEST_F(VkLayerTest, MultiDrawFeatures) {
     auto pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&multi_draw_props);
     vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
     if (multi_draw_props.maxMultiDrawCount == 0) {
-        // If using MockICD and devsim the value might be zero'ed and cause false errors
+        // If using MockICD, the value might be zero'ed and cause false errors
         return;
     }
 
@@ -6010,7 +6001,7 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
     }
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -6624,7 +6615,7 @@ TEST_F(VkLayerTest, MeshShaderNV) {
         }
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -53,7 +53,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -532,7 +532,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     }
 
     InitGpuAssistedFramework(false);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -752,7 +752,7 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     InitGpuAssistedFramework(false);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -928,7 +928,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
     InitGpuAssistedFramework(false);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -1720,7 +1720,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     TEST_DESCRIPTION("GPU validation: Validate maxDrawIndirectCount limit");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     InitGpuAssistedFramework(false);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -1844,7 +1844,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     TEST_DESCRIPTION("GPU validation: Validate Draw*IndirectCount countBuffer contents");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     InitGpuAssistedFramework(false);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -2018,7 +2018,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
         printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
         return;
     }
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -2132,7 +2132,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     features.pEnabledValidationFeatures = enables;
     bool descriptor_indexing = CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names,
                                                                               m_device_extension_names, &features, m_errorMonitor);
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -2438,7 +2438,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s GPU-Assisted printf test requires a driver that can draw.\n", kSkipPrefix);
         return;
     }
@@ -2745,7 +2745,7 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
         }
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -173,7 +173,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping.\n", kSkipPrefix);
         return;
     }
@@ -259,7 +259,7 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping.\n", kSkipPrefix);
         return;
     }
@@ -880,11 +880,6 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
         return;
     }
 
-    if (DeviceSimulation()) {
-        printf("%sSkipping object naming test.\n", kSkipPrefix);
-        return;
-    }
-
     VkBuffer buffer;
     VkDeviceMemory memory_1, memory_2;
     std::string memory_name = "memory_name";
@@ -993,11 +988,6 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     PFN_vkCmdInsertDebugUtilsLabelEXT fpvkCmdInsertDebugUtilsLabelEXT =
         (PFN_vkCmdInsertDebugUtilsLabelEXT)vk::GetInstanceProcAddr(instance(), "vkCmdInsertDebugUtilsLabelEXT");
     ASSERT_TRUE(fpvkCmdInsertDebugUtilsLabelEXT);  // Must be extant if extension is enabled
-
-    if (DeviceSimulation()) {
-        printf("%sSkipping object naming test.\n", kSkipPrefix);
-        return;
-    }
 
     DebugUtilsLabelCheckData callback_data;
     auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
@@ -3442,8 +3432,8 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    // Test takes magnitude of time longer for devsim and slows down testing
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    // Test takes magnitude of time longer for mock ICD and slows down testing
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -4016,7 +4006,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
         }
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -11068,11 +11058,6 @@ TEST_F(VkLayerTest, InvalidSpirvExtension) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1+, skipping tests\n", kSkipPrefix);
-        return;
-    }
 
     const std::string vertex_source = R"spirv(
                OpCapability Shader

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -7195,7 +7195,7 @@ TEST_F(VkLayerTest, CooperativeMatrixNV) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -7288,11 +7288,6 @@ TEST_F(VkLayerTest, SubgroupSupportedProperties) {
     // 1.1 and up only.
     if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
         printf("%s Vulkan 1.1 not supported, skipping test\n", kSkipPrefix);
-        return;
-    }
-
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1, skipping tests\n", kSkipPrefix);
         return;
     }
 
@@ -7534,11 +7529,6 @@ TEST_F(VkLayerTest, SubgroupRequired) {
         return;
     }
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1, skipping tests\n", kSkipPrefix);
-        return;
-    }
-
     VkPhysicalDeviceSubgroupProperties subgroup_prop = GetSubgroupProperties(instance(), gpu());
 
     auto queue_family_properties = m_device->phy().queue_properties();
@@ -7773,7 +7763,7 @@ TEST_F(VkLayerTest, GraphicsPipelineStageCreationFeedbackCount) {
     CreatePipelineHelper::OneshotTest(*this, set_feedback, kErrorBit,
                                       "VUID-VkGraphicsPipelineCreateInfo-pipelineStageCreationFeedbackCount-06594", true);
 
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Driver data writeback check not supported by MockICD, skipping.\n", kSkipPrefix);
     } else {
         m_errorMonitor->ExpectSuccess();
@@ -10242,7 +10232,7 @@ TEST_F(VkLayerTest, ValidatePipelineExecutablePropertiesFeature) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // MockICD will return 0 for the executable count
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
     }
@@ -14608,7 +14598,6 @@ TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&transform_feedback_props);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &pd_props2);
 
-    // seen sometimes when using devsim and will crash
     if (transform_feedback_props.maxTransformFeedbackStreams == 0) {
         printf("%s maxTransformFeedbackStreams is zero, skipping test.\n", kSkipPrefix);
         return;

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -691,7 +691,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         // will throw a std::bad_alloc sometimes
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;
@@ -860,7 +860,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     if (!AddSwapchainDeviceExtension()) return;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+    if (IsPlatform(kMockICD)) {
         // will throw a std::bad_alloc sometimes
         printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
         return;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -295,7 +295,6 @@ class VkRenderFramework : public VkTestFramework {
         return DeviceExtensionSupported(name, spec_version);
     }
     bool DeviceExtensionEnabled(const char *name);
-    bool DeviceSimulation();
 
     // Tracks ext_name to be enabled at device creation time and attempts to enable any required instance extensions.
     // Returns true if all required instance extensions are supported or there are no required instance extensions, false

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,6 @@ VkTestFramework::~VkTestFramework() {}
 bool VkTestFramework::m_canonicalize_spv = false;
 bool VkTestFramework::m_strip_spv = false;
 bool VkTestFramework::m_do_everything_spv = false;
-bool VkTestFramework::m_devsim_layer = false;
 int VkTestFramework::m_width = 0;
 int VkTestFramework::m_height = 0;
 int VkTestFramework::m_phys_device_index = -1;
@@ -149,8 +148,6 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_strip_spv = true;
         else if (optionMatch("--canonicalize-SPV", argv[i]))
             m_canonicalize_spv = true;
-        else if (optionMatch("--devsim", argv[i]))
-            m_devsim_layer = true;
         else if (optionMatch("--device-index", argv[i]) && ((i + 1) < *argc)) {
             m_phys_device_index = std::atoi(argv[++i]);
         } else if (optionMatch("--help", argv[i]) || optionMatch("-h", argv[i])) {

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,6 @@ class VkTestFramework : public ::testing::Test {
     static bool m_canonicalize_spv;
     static bool m_strip_spv;
     static bool m_do_everything_spv;
-    static bool m_devsim_layer;
     static int m_phys_device_index;
 
     char **ReadFileData(const char *fileName);

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2021 The Khronos Group Inc.
-//  Copyright (c) 2015-2021 Valve Corporation
-//  Copyright (c) 2015-2021 LunarG, Inc.
-//  Copyright (c) 2015-2021 Google, Inc.
+//  Copyright (c) 2015-2022 The Khronos Group Inc.
+//  Copyright (c) 2015-2022 Valve Corporation
+//  Copyright (c) 2015-2022 LunarG, Inc.
+//  Copyright (c) 2015-2022 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ VkTestFramework::VkTestFramework() {}
 VkTestFramework::~VkTestFramework() {}
 
 // Define static elements
-bool VkTestFramework::m_devsim_layer = false;
 int VkTestFramework::m_phys_device_index = -1;
 ANativeWindow *VkTestFramework::window = nullptr;
 

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2021 The Khronos Group Inc.
-//  Copyright (c) 2015-2021 Valve Corporation
-//  Copyright (c) 2015-2021 LunarG, Inc.
-//  Copyright (c) 2015-2021 Google, Inc.
+//  Copyright (c) 2015-2022 The Khronos Group Inc.
+//  Copyright (c) 2015-2022 Valve Corporation
+//  Copyright (c) 2015-2022 LunarG, Inc.
+//  Copyright (c) 2015-2022 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ class VkTestFramework : public ::testing::Test {
     bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
                    std::vector<uint32_t> &spv, bool debug = false, const spv_target_env spv_ev = SPV_ENV_VULKAN_1_0);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<uint32_t> &spv);
-    static bool m_devsim_layer;
     static int m_phys_device_index;
     static ANativeWindow *window;
 };


### PR DESCRIPTION
Removes references to devsim as it has been removed.

The only tests relying on devsim are for the portability subset. There
is an internal issue to track adding support for running these tests.