### PR TITLE
Warn when overallocating from descriptor pool

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -123,6 +123,8 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SpirvDeprecated_Workgroup
 static const char DECORATE_UNUSED *kVUID_BestPractices_ImageCreateFlags = "UNASSIGNED-BestPractices-ImageCreateFlags";
 static const char DECORATE_UNUSED *kVUID_BestPractices_TransitionUndefinedToReadOnly =
     "UNASSIGNED-BestPractices-TransitionUndefinedToReadOnly";
+static const char DECORATE_UNUSED *kVUID_BestPractices_EmptyDescriptorPool =
+    "UNASSIGNED-BestPractices-EmptyDescriptorPool";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -602,6 +602,17 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
                 "same logical device. On some drivers or architectures it may be most optimal to re-use existing descriptor sets.",
                 VendorSpecificTag(kBPVendorArm));
         }
+
+        if (IsExtEnabled(device_extensions.vk_khr_maintenance1)) {
+            // Track number of descriptorSets allowable in this pool
+            if (pool_state->GetAvailableSets() < pAllocateInfo->descriptorSetCount) {
+                skip |= LogWarning(pool_state->Handle(), kVUID_BestPractices_EmptyDescriptorPool,
+                                 "vkAllocateDescriptorSets(): Unable to allocate %" PRIu32 " descriptorSets from %s"
+                                 ". This pool only has %" PRIu32 " descriptorSets remaining.",
+                                 pAllocateInfo->descriptorSetCount, report_data->FormatHandle(pool_state->Handle()).c_str(),
+                                 pool_state->GetAvailableSets());
+            }
+        }
     }
 
     return skip;


### PR DESCRIPTION
Closes #2488
Closes #3510

This is the same as VUID 00306, but that VUID does not apply when VK_KHR_maintenance1 is enabled. As this is not invalid per the spec it can only fit in best practices. 