### PR TITLE
tests: Fix device memory requirements test

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -15185,8 +15185,13 @@ TEST_F(VkLayerTest, ImageViewMinLodFeature) {
 TEST_F(VkLayerTest, ValidateDeviceImageMemoryRequirements) {
     TEST_DESCRIPTION("Validate usage of VkDeviceImageMemoryRequirementsKHR.");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        printf("%s Tests requires Vulkan 1.1+, skipping test\n", kSkipPrefix);
+        return;
+    }
     if (!AreRequestedExtensionsEnabled()) {
         printf("%s Extension %s is not supported, skipping test.\n", kSkipPrefix, VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
         return;


### PR DESCRIPTION
VK_KHR_maintenance4 requires VK_API_VERSION_1_1, this crashed with the latest amd driver. 