### PR TITLE
layers: Fix iterating variable descriptors

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -2310,6 +2310,9 @@ void cvdescriptorset::DescriptorSet::UpdateDrawState(ValidationStateTracker *dev
         }
         auto range = layout_->GetGlobalIndexRangeFromIndex(index);
         for (uint32_t i = range.start; i < range.end; ++i) {
+            if (i >= descriptors_.size()) {
+                break;
+            }
             const auto descriptor_class = descriptors_[i]->GetClass();
             switch (descriptor_class) {
             case DescriptorClass::Image:


### PR DESCRIPTION
#4023 changed vector sizes for variable descriptors, so when iterating over them we have to check if the index is greater than the variable size.

Fixes CTS test dEQP-VK.binding_model.descriptorset_random.sets4.constant.ubolimitlow.sbolimitlow.sampledimglow.outimgtexlow.noiub.nouab.comp.noia.4
