### PR TITLE
Revert part of 4038

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -6247,14 +6247,18 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(const BUFFER_STATE *src_buffer_stat
 
         // Perf improvement potential here
         // The union of the source regions, and the union of the destination regions, must not overlap in memory
-        auto src_region = sparse_container::range<VkDeviceSize>{region.srcOffset, region.srcOffset + region.size};
-        for (uint32_t j = 0; j < regionCount; j++) {
-            auto dst_region =
-                sparse_container::range<VkDeviceSize>{pRegions[j].dstOffset, pRegions[j].dstOffset + pRegions[j].size};
-            if (src_buffer_state->DoesBoundMemoryOverlap(src_region, dst_buffer_state, dst_region)) {
-                vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
-                skip |= LogError(src_buffer_state->buffer(), vuid,
-                                 "%s: Detected overlap between source and dest regions in memory.", func_name);
+        if (src_buffer_state->buffer() == dst_buffer_state->buffer()) {
+            VkDeviceSize src_min = region.srcOffset;
+            VkDeviceSize src_max = region.srcOffset + region.size;
+            for (uint32_t j = 0; j < regionCount; j++) {
+                VkDeviceSize dst_min = pRegions[j].dstOffset;
+                VkDeviceSize dst_max = pRegions[j].dstOffset + region.size;
+                if (((src_min > dst_min) && (src_min < dst_max)) || ((src_max > dst_min) && (src_max < dst_max)) ||
+                    ((src_min == dst_min && src_max == dst_max))) {
+                    vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
+                    skip |= LogError(src_buffer_state->buffer(), vuid,
+                                     "%s: Detected overlap between source and dest regions in memory.", func_name);
+                }
             }
         }
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -15248,8 +15248,9 @@ TEST_F(VkLayerTest, TestCompletelyOverlappingBufferCopy) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
     vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer.handle(), 1, &copy_info);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
-    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer_shared_memory.handle(), 1, &copy_info);
+    // TODO AITOR: Uncomment lines below once we correctly check memory overlap
+    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    // vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer_shared_memory.handle(), 1, &copy_info);
 
     m_commandBuffer->end();
 
@@ -15292,8 +15293,9 @@ TEST_F(VkLayerTest, TestCopyingInterleavedRegions) {
     copy_infos[2].dstOffset = 21;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
     vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer.handle(), 4, copy_infos);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
-    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer_shared_memory.handle(), 4, copy_infos);
+    // TODO AITOR: Uncomment lines below once we correctly check memory overlap
+    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    // vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer.handle(), buffer_shared_memory.handle(), 4, copy_infos);
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->end();


### PR DESCRIPTION
Due to some issues in CI, there's a need to revert how we check VUID-VkCopyBufferInfo2-pRegions-00117 and VUID-vkCmdCopyBuffer-pRegions-00117.

The change will be reintroduced once the sparse resource validation correctly checks what is causing the issue