### PR TITLE
Shows the issue mentioned with sparse bound buffers

### DIFF
--- a/layers/buffer_state.cpp
+++ b/layers/buffer_state.cpp
@@ -75,6 +75,8 @@ bool BUFFER_STATE::DoesBoundMemoryOverlap(const sparse_container::range<VkDevice
 
 std::vector<BUFFER_STATE::MemRange> BUFFER_STATE::ComputeMemoryRanges(const sparse_container::range<VkDeviceSize> &region) const {
     std::vector<MemRange> ranges;
+    if (bound_memory_.empty()) return ranges;
+
     auto it = bound_memory_.begin();
 
     VkDeviceSize range_start = 0u;
@@ -85,7 +87,7 @@ std::vector<BUFFER_STATE::MemRange> BUFFER_STATE::ComputeMemoryRanges(const spar
     while (it != bound_memory_.end()) {
         range_end += it->second.size;
         if (range_start <= point && point <= range_end) {
-            if (range_end < point) point = range_end;
+            point = range_end < region.end ? range_end : region.end;
             ranges.emplace_back(
                 MemRange{it->first, {it->second.offset + (region.begin - range_start), it->second.offset + (point - range_start)}});
             break;

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -15580,3 +15580,96 @@ TEST_F(VkLayerTest, TestBarrierAccessVideoDecode) {
 
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(VkLayerTest, AitorTest) {
+    TEST_DESCRIPTION("Showcase issue with sparse binding and memory overlap checks");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    if (!m_device->phy().features().sparseBinding) {
+        printf("%s Test requires unsupported sparseBinding feature. Skipped.\n", kSkipPrefix);
+        return;
+    }
+
+    m_errorMonitor->ExpectSuccess();
+
+    VkSemaphoreCreateInfo s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphore semaphore = VK_NULL_HANDLE;
+    VkSemaphore semaphore2 = VK_NULL_HANDLE;
+    vk::CreateSemaphore(m_device->handle(), &s_info, nullptr, &semaphore);
+    vk::CreateSemaphore(m_device->handle(), &s_info, nullptr, &semaphore2);
+
+    VkBufferCopy copy_info;
+    copy_info.srcOffset = 0;
+    copy_info.dstOffset = 0;
+    copy_info.size = 256;
+
+    VkBufferCreateInfo b_info = vk_testing::Buffer::create_info(
+        copy_info.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
+    b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    VkBufferObj buffer_sparse;
+    buffer_sparse.init_no_mem(*m_device, b_info);
+    VkBufferObj buffer_sparse2;
+    buffer_sparse2.init_no_mem(*m_device, b_info);
+
+    VkMemoryRequirements buffer_mem_reqs;
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_mem_alloc =
+        vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    vk_testing::DeviceMemory buffer_mem;
+    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vk_testing::DeviceMemory buffer_mem2;
+    buffer_mem2.init(*m_device, buffer_mem_alloc);
+
+    VkSparseMemoryBind buffer_memory_bind = {};
+    buffer_memory_bind.size = buffer_mem_reqs.size;
+    buffer_memory_bind.memory = buffer_mem.handle();
+
+    VkSparseBufferMemoryBindInfo buffer_memory_bind_infos[2] = {};
+    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].bindCount = 1;
+    buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind;
+    buffer_memory_bind_infos[1].buffer = buffer_sparse2.handle();
+    buffer_memory_bind_infos[1].bindCount = 1;
+    buffer_memory_bind_infos[1].pBinds = &buffer_memory_bind;
+
+    VkBindSparseInfo bind_info = LvlInitStruct<VkBindSparseInfo>();
+    bind_info.bufferBindCount = 2;
+    bind_info.pBufferBinds = buffer_memory_bind_infos;
+    bind_info.signalSemaphoreCount = 1;
+    bind_info.pSignalSemaphores = &semaphore;
+
+    uint32_t sparse_index = m_device->QueueFamilyMatching(VK_QUEUE_SPARSE_BINDING_BIT, 0u);
+    VkQueue sparse_queue = m_device->graphics_queues()[sparse_index]->handle();
+
+    vk::QueueBindSparse(m_device->m_queue, 1, &bind_info, VK_NULL_HANDLE);
+    // Set up complete
+
+    m_commandBuffer->begin();
+    // This copy should be completely legal as long as we change the memory for buffer_sparse to not overlap with
+    // buffer_sparse2's memory on queue submission, or viceversa
+    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
+    m_commandBuffer->end();
+
+    buffer_memory_bind.memory = buffer_mem2.handle();
+    bind_info.bufferBindCount = 1;
+    bind_info.waitSemaphoreCount = 1;
+    bind_info.pWaitSemaphores = &semaphore;
+    bind_info.pSignalSemaphores = &semaphore2;
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, VK_NULL_HANDLE);
+
+    VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &semaphore2;
+    submit_info.pWaitDstStageMask = &mask;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+    vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+
+    m_errorMonitor->VerifyNotFound();
+
+    vk::DestroySemaphore(m_device->handle(), semaphore2, nullptr);
+    vk::DestroySemaphore(m_device->handle(), semaphore, nullptr);
+}


### PR DESCRIPTION
Here's a test that showcases the issue with sparse bound buffers and how it leads to false positives due to validation not being pushed to queue submission.

Some extra fixes added to the utility.