### PR TITLE
layers: Fix print order upon invalid timeline semaphore signal

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4155,8 +4155,8 @@ struct SemaphoreSubmitState {
                     skip |= core->LogError(objlist, vuid,
                                            "%s signal value (0x%" PRIx64
                                            ") in %s must be greater than current timeline semaphore %s value (0x%" PRIx64 ")",
-                                           loc.Message().c_str(), completed.payload, core->report_data->FormatHandle(queue).c_str(),
-                                           core->report_data->FormatHandle(semaphore).c_str(), value);
+                                           loc.Message().c_str(), value, core->report_data->FormatHandle(queue).c_str(),
+                                           core->report_data->FormatHandle(semaphore).c_str(), completed.payload);
                 } else {
                     skip |= core->ValidateMaxTimelineSemaphoreValueDifference(loc, *semaphore_state, value);
                 }


### PR DESCRIPTION
The order of the current timeline semaphore value and the signal value was backwards, leading to confusing errors like:

```
Validation Error: [ VUID-VkSubmitInfo2-semaphore-03881 ] vkQueueSubmit2():
pSubmits[0].pSignalSemaphoreInfos[0] signal value (0x1) must be greater than current timeline semaphore
VkSemaphore 0x100000000010[] value (0x0)
```

On another note, the VUID which this code is implementing (VUID-VkSubmitInfo2-semaphore-03881), says nothing about the signal value having to be greater than the current value, which I think also led to the confusion in issue #2340.