### PR TITLE
layers: Enable fine-grained locking by default

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -181,9 +181,9 @@ void OutputLayerStatusInfo(ValidationObject *context) {
     context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Debug_Warning,
         "VALIDATION LAYERS WARNING: Using debug builds of the validation layers *will* adversely affect performance.");
 #endif
-    if (context->fine_grained_locking) {
+    if (!context->fine_grained_locking) {
         context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Locking_Warning,
-                                       "Fine-grained locking is experimental, crashes or incorrect results are possible.");
+                                       "Fine-grained locking is disabled, this will adversely affect performance of multithreaded applications.");
     }
 }
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -3513,7 +3513,7 @@ class ValidationObject {
         DeviceExtensions device_extensions = {};
         CHECK_DISABLED disabled = {};
         CHECK_ENABLED enabled = {};
-        bool fine_grained_locking{false};
+        bool fine_grained_locking{true};
 
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physical_device = VK_NULL_HANDLE;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -420,5 +420,5 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (config_limit_setting != 0) {
         *settings_data->duplicate_message_limit = config_limit_setting;
     }
-    *settings_data->fine_grained_locking = SetBool(config_fine_grained_locking, env_fine_grained_locking, false);
+    *settings_data->fine_grained_locking = SetBool(config_fine_grained_locking, env_fine_grained_locking, true);
 }

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -367,7 +367,7 @@ class ValidationObject {
         DeviceExtensions device_extensions = {};
         CHECK_DISABLED disabled = {};
         CHECK_ENABLED enabled = {};
-        bool fine_grained_locking{false};
+        bool fine_grained_locking{true};
 
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -831,9 +831,9 @@ void OutputLayerStatusInfo(ValidationObject *context) {
     context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Debug_Warning,
         "VALIDATION LAYERS WARNING: Using debug builds of the validation layers *will* adversely affect performance.");
 #endif
-    if (context->fine_grained_locking) {
+    if (!context->fine_grained_locking) {
         context->LogPerformanceWarning(context->instance, kVUID_Core_CreateInstance_Locking_Warning,
-                                       "Fine-grained locking is experimental, crashes or incorrect results are possible.");
+                                       "Fine-grained locking is disabled, this will adversely affect performance of multithreaded applications.");
     }
 }
 


### PR DESCRIPTION
NOTE: If you encounter a problem with validation from this optimization it can be disabled by setting the environment variable
`VK_LAYER_FINE_GRAINED_LOCKING=0`.

Or by settting `khronos_validation.fine_grained_locking=false` in vk_layer_settings.txt.