### PR TITLE
layers: Remove GetUnifiedCreateInfo

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -570,9 +570,10 @@ class CoreChecks : public ValidationStateTracker {
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE* pPipeline) const;
     bool ValidateComputePipelineShaderState(PIPELINE_STATE* pPipeline) const;
-    uint32_t CalcShaderStageCount(const PIPELINE_STATE* pipeline, VkShaderStageFlagBits stageBit) const;
-    bool GroupHasValidIndex(const PIPELINE_STATE* pipeline, uint32_t group, uint32_t stage) const;
-    bool ValidateRayTracingPipeline(PIPELINE_STATE* pipeline, VkPipelineCreateFlags flags, bool isKHR) const;
+    uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
+    bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;
+    bool ValidateRayTracingPipeline(PIPELINE_STATE* pipeline, const safe_VkRayTracingPipelineCreateInfoCommon& create_info,
+                                    VkPipelineCreateFlags flags, bool isKHR) const;
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule) const override;
     bool ValidatePipelineShaderStage(const PIPELINE_STATE* pipeline, const PipelineStageState& stage_state,

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -345,6 +345,69 @@ void AppendDynamicStateFromSubstate(const Substate &substate, std::vector<VkDyna
     }
 }
 
+template <>
+VkPipeline PIPELINE_STATE::BasePipeline<VkGraphicsPipelineCreateInfo>() const {
+    assert(create_info.graphics.sType == VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);
+    return create_info.graphics.basePipelineHandle;
+}
+template <>
+VkPipeline PIPELINE_STATE::BasePipeline<VkComputePipelineCreateInfo>() const {
+    assert(create_info.compute.sType == VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO);
+    return create_info.compute.basePipelineHandle;
+}
+template <>
+VkPipeline PIPELINE_STATE::BasePipeline<VkRayTracingPipelineCreateInfoKHR>() const {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR);
+    return create_info.raytracing.basePipelineHandle;
+}
+template <>
+VkPipeline PIPELINE_STATE::BasePipeline<VkRayTracingPipelineCreateInfoNV>() const {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV);
+    return create_info.raytracing.basePipelineHandle;
+}
+
+template <>
+int32_t PIPELINE_STATE::BasePipelineIndex<VkGraphicsPipelineCreateInfo>() const {
+    assert(create_info.graphics.sType == VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);
+    return create_info.graphics.basePipelineIndex;
+}
+template <>
+int32_t PIPELINE_STATE::BasePipelineIndex<VkComputePipelineCreateInfo>() const {
+    assert(create_info.compute.sType == VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO);
+    return create_info.compute.basePipelineIndex;
+}
+template <>
+int32_t PIPELINE_STATE::BasePipelineIndex<VkRayTracingPipelineCreateInfoKHR>() const {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR);
+    return create_info.raytracing.basePipelineIndex;
+}
+template <>
+int32_t PIPELINE_STATE::BasePipelineIndex<VkRayTracingPipelineCreateInfoNV>() const {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV);
+    return create_info.raytracing.basePipelineIndex;
+}
+
+template <>
+VkShaderModule PIPELINE_STATE::PIPELINE_STATE::GetShaderModuleByCIIndex<VkGraphicsPipelineCreateInfo>(uint32_t i) {
+    assert(create_info.graphics.sType == VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);
+    return create_info.graphics.pStages[i].module;
+}
+template <>
+VkShaderModule PIPELINE_STATE::GetShaderModuleByCIIndex<VkComputePipelineCreateInfo>(uint32_t) {
+    assert(create_info.compute.sType == VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO);
+    return create_info.compute.stage.module;
+}
+template <>
+VkShaderModule PIPELINE_STATE::GetShaderModuleByCIIndex<VkRayTracingPipelineCreateInfoKHR>(uint32_t i) {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR);
+    return create_info.raytracing.pStages[i].module;
+}
+template <>
+VkShaderModule PIPELINE_STATE::GetShaderModuleByCIIndex<VkRayTracingPipelineCreateInfoNV>(uint32_t i) {
+    assert(create_info.raytracing.sType == VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV);
+    return create_info.raytracing.pStages[i].module;
+}
+
 PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                                std::shared_ptr<const RENDER_PASS_STATE> &&rpstate,
                                std::shared_ptr<const PIPELINE_LAYOUT_STATE> &&layout)

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -876,5 +876,8 @@ span<T> make_span(T *begin, T *end) {
     return make_span<T>(begin, end);
 }
 
+template <typename BaseType>
+using base_type = typename std::remove_const<typename std::remove_pointer<BaseType>::type>::type;
+
 }  // namespace layer_data
 #endif  // LAYER_DATA_H


### PR DESCRIPTION
Removes PIPELINE_STATE::GetUnifiedCreateInfo, instead utilizing template
specialization to return the correct information based on *CreateInfo
type.