### PR TITLE
Use VMA linear allocation algorithm for GPU-AV output buffers

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -735,7 +735,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     buffer_info.size = output_buffer_size;
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     VmaAllocationCreateInfo alloc_info = {};
-    alloc_info.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
+    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &output_block.buffer, &output_block.allocation, nullptr);
     if (result != VK_SUCCESS) {
         ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.");

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -151,8 +151,16 @@ class GpuAssistedBase : public ValidationStateTracker {
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator) override;
 
     template <typename T>
-    void ReportSetupProblem(T object, const char *const specific_message) const {
-        LogError(object, setup_vuid, "Setup Error. Detail: (%s)", specific_message);
+    void ReportSetupProblem(T object, const char *const specific_message, bool vma_fail = false) const {
+        std::string logit = specific_message; 
+        if (vma_fail) {
+            char *stats_string;
+            vmaBuildStatsString(vmaAllocator, &stats_string, false);
+            logit += " VMA statistics = ";
+            logit += stats_string;
+            vmaFreeStatsString(vmaAllocator, stats_string);
+        }
+        LogError(object, setup_vuid, "Setup Error. Detail: (%s)", logit.c_str());
     }
 
   protected:

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -162,6 +162,11 @@ class GpuAssistedBase : public ValidationStateTracker {
         }
         LogError(object, setup_vuid, "Setup Error. Detail: (%s)", logit.c_str());
     }
+    bool GpuGetOption(const char *option, bool default_value) {
+        std::string option_string = getLayerOption(option);
+        transform(option_string.begin(), option_string.end(), option_string.begin(), ::tolower);
+        return !option_string.empty() ? !option_string.compare("true") : default_value;
+    }
 
   protected:
     bool CommandBufferNeedsProcessing(VkCommandBuffer command_buffer) const;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1810,7 +1810,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     alloc_info.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
     result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &output_block.buffer, &output_block.allocation, nullptr);
     if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.");
+        ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.", true);
         aborted = true;
         return;
     }
@@ -1969,7 +1969,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
             result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &di_input_block.buffer, &di_input_block.allocation,
                                      nullptr);
             if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.");
+                ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.", true);
                 aborted = true;
                 return;
             }
@@ -2142,7 +2142,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
             result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &bda_input_block.buffer, &bda_input_block.allocation,
                                      nullptr);
             if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.");
+                ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.", true);
                 aborted = true;
                 return;
             }

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1807,7 +1807,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     buffer_info.size = output_buffer_size;
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     VmaAllocationCreateInfo alloc_info = {};
-    alloc_info.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
+    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &output_block.buffer, &output_block.allocation, nullptr);
     if (result != VK_SUCCESS) {
         ReportSetupProblem(device, "Unable to allocate device memory.  Device could become unstable.", true);
@@ -1964,7 +1964,6 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
             } else {
                 words_needed = 1 + number_of_sets + binding_count + descriptor_count;
             }
-            alloc_info.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
             buffer_info.size = words_needed * 4;
             result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &di_input_block.buffer, &di_input_block.allocation,
                                      nullptr);
@@ -2137,7 +2136,6 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
 
             uint32_t num_buffers = static_cast<uint32_t>(address_ranges.size());
             uint32_t words_needed = (num_buffers + 3) + (num_buffers + 2);
-            alloc_info.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
             buffer_info.size = words_needed * 8;  // 64 bit words
             result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &bda_input_block.buffer, &bda_input_block.allocation,
                                      nullptr);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -243,17 +243,11 @@ void GpuAssisted::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     if (enabled_features.core.robustBufferAccess || enabled_features.robustness2_features.robustBufferAccess2) {
         buffer_oob_enabled = false;
     } else {
-        std::string bufferoob_string = getLayerOption("khronos_validation.gpuav_buffer_oob");
-        transform(bufferoob_string.begin(), bufferoob_string.end(), bufferoob_string.begin(), ::tolower);
-        buffer_oob_enabled = !bufferoob_string.empty() ? !bufferoob_string.compare("true") : true;
+        buffer_oob_enabled = GpuGetOption("khronos_validation.gpuav_buffer_oob", true);
     }
-    std::string descriptor_indexing_string = getLayerOption("khronos_validation.gpuav_descriptor_indexing");
-    transform(descriptor_indexing_string.begin(), descriptor_indexing_string.end(), descriptor_indexing_string.begin(), ::tolower);
-    bool validate_descriptor_indexing = !descriptor_indexing_string.empty() ? !descriptor_indexing_string.compare("true") : true;
 
-    std::string draw_indirect_string = getLayerOption("khronos_validation.validate_draw_indirect");
-    transform(draw_indirect_string.begin(), draw_indirect_string.end(), draw_indirect_string.begin(), ::tolower);
-    validate_draw_indirect = !draw_indirect_string.empty() ? !draw_indirect_string.compare("true") : true;
+    bool validate_descriptor_indexing = GpuGetOption("khronos_validation.gpuav_descriptor_indexing", true);
+    validate_draw_indirect = GpuGetOption("khronos_validation.validate_draw_indirect", true);
 
     if (phys_dev_props.apiVersion < VK_API_VERSION_1_1) {
         ReportSetupProblem(device, "GPU-Assisted validation requires Vulkan 1.1 or later.  GPU-Assisted Validation disabled.");

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -275,7 +275,7 @@ void GpuAssisted::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     if (validate_descriptor_indexing) {
         descriptor_indexing = CheckForDescriptorIndexing(enabled_features);
     }
-    bool use_linear_output_pool = GpuGetOption("khronos_validation.gpuav_vma_linear_output", true);
+    bool use_linear_output_pool = GpuGetOption("khronos_validation.vma_linear_output", true);
     if (use_linear_output_pool) {
         auto output_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
         output_buffer_create_info.size = output_buffer_size;

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -284,6 +284,7 @@ class GpuAssisted : public GpuAssistedBase {
     VkBool32 shaderInt64;
     bool buffer_oob_enabled;
     bool validate_draw_indirect;
+    VmaPool output_buffer_pool = VK_NULL_HANDLE;
     GpuAssistedAccelerationStructureBuildValidationState acceleration_structure_validation_state;
     GpuAssistedPreDrawValidationState pre_draw_validation_state;
 

--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -533,6 +533,23 @@
                                             }
                                         ]
                                     }
+                                },
+                                {
+                                    "key": "vma_linear_output",
+                                    "label": "Use VMA linear memory allocations for GPU-AV output buffers",
+                                    "description": "Use linear allocation algorithm",
+                                    "type": "BOOL",
+                                    "default": true,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
+                                    "dependence": {
+                                        "mode": "ANY",
+                                        "settings": [
+                                            {
+                                                "key": "enables",
+                                                "value": [ "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT" ]
+                                            }
+                                        ]
+                                    }
                                 }
                             ]
                         },

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -92,6 +92,12 @@ khronos_validation.enables =
 # Enable draw indirect checking
 #khronos_validation.validate_draw_indirect = true
 
+# Use linear vma allocator for GPU-AV output buffers
+# =====================
+# <LayerIdentifier>.gpuav_vma_linear_output
+# Use VMA linear memory allocations for GPU-AV output buffers
+#khronos_validation.vma_linear_output = true
+
 # Fine Grained Locking
 # =====================
 # <LayerIdentifier>.fine_grained_locking


### PR DESCRIPTION
VMA allocations are GPU-AV's biggest performance hotspot, and this change improves performance significantly at the cost of using nominally more device memory.  No new out-of-memories were found running the set of performance traces with this option enabled.
Also cleaned up option checking and added VMA stats to out of memory errors.