### PR TITLE
layers: Fix depthstencil attachment usage detection with dynamic render

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -276,7 +276,8 @@ VkResult DispatchCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
             auto dynamic_rendering = LvlFindInChain<VkPipelineRenderingCreateInfo>(pCreateInfos[idx0].pNext);
             if (dynamic_rendering) {
                 uses_color_attachment        = (dynamic_rendering->colorAttachmentCount > 0);
-                uses_depthstencil_attachment = (dynamic_rendering->depthAttachmentFormat != VK_FORMAT_UNDEFINED);
+                uses_depthstencil_attachment = (dynamic_rendering->depthAttachmentFormat != VK_FORMAT_UNDEFINED ||
+                                                dynamic_rendering->stencilAttachmentFormat != VK_FORMAT_UNDEFINED);
             }
 
             local_pCreateInfos[idx0].initialize(&pCreateInfos[idx0], uses_color_attachment, uses_depthstencil_attachment);

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -193,7 +193,8 @@ VkResult DispatchCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
             auto dynamic_rendering = LvlFindInChain<VkPipelineRenderingCreateInfo>(pCreateInfos[idx0].pNext);
             if (dynamic_rendering) {
                 uses_color_attachment        = (dynamic_rendering->colorAttachmentCount > 0);
-                uses_depthstencil_attachment = (dynamic_rendering->depthAttachmentFormat != VK_FORMAT_UNDEFINED);
+                uses_depthstencil_attachment = (dynamic_rendering->depthAttachmentFormat != VK_FORMAT_UNDEFINED ||
+                                                dynamic_rendering->stencilAttachmentFormat != VK_FORMAT_UNDEFINED);
             }
 
             local_pCreateInfos[idx0].initialize(&pCreateInfos[idx0], uses_color_attachment, uses_depthstencil_attachment);


### PR DESCRIPTION
it's never explicitly spelled out in text, but this combination of VUs
allows for depthAttachmentFormat to be unset while stencilAttachmentFormat is set:

VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06200
* If depthAttachmentFormat is not VK_FORMAT_UNDEFINED and stencilAttachmentFormat is not
  VK_FORMAT_UNDEFINED, depthAttachmentFormat must equal stencilAttachmentFormat

VUID-VkGraphicsPipelineCreateInfo-renderPass-06053
* If renderPass is VK_NULL_HANDLE, the pipeline is being created with fragment shader
  state and fragment output interface state, and either of
  VkPipelineRenderingCreateInfo::depthAttachmentFormat
  or
  VkPipelineRenderingCreateInfo::stencilAttachmentFormat
  are not VK_FORMAT_UNDEFINED, pDepthStencilState must be a valid pointer to a valid
  VkPipelineDepthStencilStateCreateInfo structure