### PR TITLE
layers: Fix format features check for buffer views

### DIFF
--- a/layers/buffer_state.h
+++ b/layers/buffer_state.h
@@ -61,11 +61,20 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
   public:
     const VkBufferViewCreateInfo create_info;
     std::shared_ptr<BUFFER_STATE> buffer_state;
-    const VkFormatFeatureFlags2KHR format_features;
+    // Format features that matter when accessing the buffer (OpLoad, OpStore,
+    // OpAtomicLoad, etc...)
+    const VkFormatFeatureFlags2KHR buf_format_features;
+    // Format features that matter when accessing the buffer as a image
+    // (OpImageRead, OpImageWrite, etc...)
+    const VkFormatFeatureFlags2KHR img_format_features;
 
     BUFFER_VIEW_STATE(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                      VkFormatFeatureFlags2KHR ff)
-        : BASE_NODE(bv, kVulkanObjectTypeBufferView), create_info(*ci), buffer_state(bf), format_features(ff) {}
+                      VkFormatFeatureFlags2KHR buf_ff, VkFormatFeatureFlags2KHR img_ff)
+        : BASE_NODE(bv, kVulkanObjectTypeBufferView),
+          create_info(*ci),
+          buffer_state(bf),
+          buf_format_features(buf_ff),
+          img_format_features(img_ff) {}
 
     void LinkChildNodes() override {
         // Connect child node(s), which cannot safely be done in the constructor.

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1739,12 +1739,13 @@ bool CoreChecks::ValidateTexelDescriptor(const char *caller, const DrawDispatchV
                             string_VkFormat(buffer_view_format));
         }
 
-        const VkFormatFeatureFlags2KHR format_features = buffer_view_state->format_features;
+        const VkFormatFeatureFlags2KHR buf_format_features = buffer_view_state->buf_format_features;
+        const VkFormatFeatureFlags2KHR img_format_features = buffer_view_state->img_format_features;
         const VkDescriptorType descriptor_type = descriptor_set->GetTypeFromBinding(binding);
 
         // Verify VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT
         if ((reqs & DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION) && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) &&
-            !(format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
+            !(buf_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
             auto set = descriptor_set->GetSet();
             LogObjectList objlist(set);
             objlist.add(buffer_view);
@@ -1759,7 +1760,7 @@ bool CoreChecks::ValidateTexelDescriptor(const char *caller, const DrawDispatchV
 
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
             if ((reqs & DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT) &&
-                !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
+                !(img_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
                 auto set = descriptor_set->GetSet();
                 LogObjectList objlist(set);
                 objlist.add(buffer_view);
@@ -1770,11 +1771,11 @@ bool CoreChecks::ValidateTexelDescriptor(const char *caller, const DrawDispatchV
                                 "contain VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
                                 report_data->FormatHandle(set).c_str(), caller, binding, index,
                                 report_data->FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
-                                string_VkFormatFeatureFlags2KHR(format_features).c_str());
+                                string_VkFormatFeatureFlags2KHR(img_format_features).c_str());
             }
 
             if ((reqs & DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT) &&
-                !(format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
+                !(img_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
                 auto set = descriptor_set->GetSet();
                 LogObjectList objlist(set);
                 objlist.add(buffer_view);
@@ -1785,7 +1786,7 @@ bool CoreChecks::ValidateTexelDescriptor(const char *caller, const DrawDispatchV
                                 "contain VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
                                 report_data->FormatHandle(set).c_str(), caller, binding, index,
                                 report_data->FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
-                                string_VkFormatFeatureFlags2KHR(format_features).c_str());
+                                string_VkFormatFeatureFlags2KHR(img_format_features).c_str());
             }
         }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -349,19 +349,21 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
 
     auto buffer_state = Get<BUFFER_STATE>(pCreateInfo->buffer);
 
-    VkFormatFeatureFlags2KHR buffer_features;
+    VkFormatFeatureFlags2KHR buffer_features, image_features;
     if (has_format_feature2) {
         auto fmt_props_3 = LvlInitStruct<VkFormatProperties3KHR>();
         auto fmt_props_2 = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, pCreateInfo->format, &fmt_props_2);
         buffer_features = fmt_props_3.bufferFeatures;
+        image_features = fmt_props_3.linearTilingFeatures;
     } else {
         VkFormatProperties format_properties;
         DispatchGetPhysicalDeviceFormatProperties(physical_device, pCreateInfo->format, &format_properties);
         buffer_features = format_properties.bufferFeatures;
+        image_features = format_properties.linearTilingFeatures;
     }
 
-    Add(std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo, buffer_features));
+    Add(std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo, buffer_features, image_features));
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2385,8 +2385,9 @@ TEST_F(VkLayerTest, MissingStorageTexelBufferFormatWriteForFormat) {
     // set so format can be used as a storage texel buffer, but no WITH_FORMAT support
     fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), format, &fmt_props);
     fmt_props.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
+    fmt_props.formatProperties.linearTilingFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fmt_props_3.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
-    fmt_props_3.bufferFeatures = (fmt_props_3.bufferFeatures & ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT);
+    fmt_props_3.linearTilingFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fpvkSetPhysicalDeviceFormatProperties2EXT(gpu(), format, fmt_props);
 
     const std::string csSource = R"(


### PR DESCRIPTION
If we use a VkBufferView with OpImageRead/OpImageWrite then the format
features that apply are the ones of the image, not the buffer.

This fixes 934991a2ee

Closes #4049.