### PR TITLE
Validate VkBindImagePlaneMemoryInfo is in pNext when binding planes

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -15312,6 +15312,13 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
             const auto plane_info = LvlFindInChain<VkBindImagePlaneMemoryInfo>(bind_info.pNext);
             auto mem_info = Get<DEVICE_MEMORY_STATE>(bind_info.memory);
 
+            if (image_state->disjoint && plane_info == nullptr) {
+                skip |= LogError(bind_info.image, kVUID_Core_VkBindImageMemoryInfo_pNext_missing_VkBindImagePlaneMemoryInfo,
+                                 "%s: In order to bind planes of a disjoint image, add a VkBindImagePlaneMemoryInfo structure to "
+                                 "the pNext chain of VkBindImageMemoryInfo.",
+                                 error_prefix);
+            }
+
             // Need extra check for disjoint flag incase called without bindImage2 and don't want false positive errors
             // no 'else' case as if that happens another VUID is already being triggered for it being invalid
             if ((plane_info == nullptr) && (image_state->disjoint == false)) {

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -295,6 +295,8 @@ static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithout
 
 static const char DECORATE_UNUSED *kVUID_Core_invalidDepthStencilFormat = "UNASSIGNED-CoreValidation-depthStencil-format";
 
+static const char DECORATE_UNUSED *kVUID_Core_VkBindImageMemoryInfo_pNext_missing_VkBindImagePlaneMemoryInfo = "UNASSIGNED-VkBindImageMemoryInfo-pNext-missing-VkBindImagePlaneMemoryInfo";
+
 // clang-format on
 
 #undef DECORATE_UNUSED

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1604,14 +1604,19 @@ TEST_F(VkPositiveLayerTest, MultiplaneImageTests) {
 
         // Set up 3-plane binding
         VkBindImageMemoryInfo bind_info[3];
+        VkBindImagePlaneMemoryInfo plane_info[3];
         for (int plane = 0; plane < 3; plane++) {
-            bind_info[plane] = LvlInitStruct<VkBindImageMemoryInfo>();
+            plane_info[plane] = LvlInitStruct<VkBindImagePlaneMemoryInfo>();
+            bind_info[plane] = LvlInitStruct<VkBindImageMemoryInfo>(&plane_info[plane]);
             bind_info[plane].image = image;
             bind_info[plane].memoryOffset = 0;
         }
         bind_info[0].memory = p0_mem;
         bind_info[1].memory = p1_mem;
         bind_info[2].memory = p2_mem;
+        plane_info[0].planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
+        plane_info[1].planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
+        plane_info[2].planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
 
         m_errorMonitor->ExpectSuccess();
         vkBindImageMemory2Function(device(), 3, bind_info);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -2498,6 +2498,14 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
         vkBindImageMemory2Function(device(), 6, bind_image_info);
         m_errorMonitor->VerifyFound();
 
+        // Try binding image_a with no plane specified
+        bind_image_info[0].pNext = nullptr;
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                             "UNASSIGNED-VkBindImageMemoryInfo-pNext-missing-VkBindImagePlaneMemoryInfo");
+        vkBindImageMemory2Function(device(), 1, bind_image_info);
+        m_errorMonitor->VerifyFound();
+        bind_image_info[0].pNext = (void *)&plane_memory_info[0];
+
         // Valid case of binding 2 disjoint image and normal image by removing duplicate
         m_errorMonitor->ExpectSuccess();
         vkBindImageMemory2Function(device(), 5, bind_image_info);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -1665,6 +1665,8 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
 
         // Bind disjoint with BindImageMemory instead of BindImageMemory2
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-image-01608");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                             "UNASSIGNED-VkBindImageMemoryInfo-pNext-missing-VkBindImagePlaneMemoryInfo");
         vk::BindImageMemory(device(), image, image_memory, 0);
         m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
I couldn't find any VUID (I think there's none and one should be added) that states a `VkBindImagePlaneMemoryInfo` is needed in the `pNext` of `VkBindImageMemoryInfo` when binding planes of disjoint images.

Without adding it to `pNext`, there's no way to specify to which plane we are binding the memory, and the spec states the following `In order to bind planes of a disjoint image, add a VkBindImagePlaneMemoryInfo structure to the pNext chain of VkBindImageMemoryInfo (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBindImageMemoryInfo.html).`.