### PR TITLE
layers: Store descriptors in per-binding vectors

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -533,17 +533,17 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDescriptors(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, const T& binding) const;
 
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::BufferDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::BufferDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::ImageDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::ImageDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::ImageSamplerDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::ImageSamplerDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::TexelDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::TexelDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::AccelerationStructureDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::AccelerationStructureDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
-                            const cvdescriptorset::SamplerDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const cvdescriptorset::SamplerDescriptor& descriptor) const;
 
     // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -512,39 +512,40 @@ class CoreChecks : public ValidationStateTracker {
                                       const PIPELINE_LAYOUT_STATE& pipeline_layout, const uint32_t layoutIndex,
                                       std::string& errorMsg) const;
 
-    bool ValidateDescriptorSetBindingData(const CMD_BUFFER_STATE* cb_node, const cvdescriptorset::DescriptorSet* descriptor_set,
-                                          const std::vector<uint32_t>& dynamic_offsets,
-                                          const std::pair<const uint32_t, DescriptorRequirement>& binding_info,
-                                          VkFramebuffer framebuffer, const std::vector<IMAGE_VIEW_STATE*>* attachments,
-                                          const std::vector<SUBPASS_INFO>* subpasses, bool record_time_validate, const char* caller,
-                                          const DrawDispatchVuid& vuids,
-                                          layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+    struct DescriptorContext {
+        const char* caller;
+        const DrawDispatchVuid& vuids;
+        const CMD_BUFFER_STATE* cb_node;
+        const cvdescriptorset::DescriptorSet* descriptor_set;
+        const std::vector<IMAGE_VIEW_STATE*>* attachments;
+        const std::vector<SUBPASS_INFO>* subpasses;
+        const VkFramebuffer framebuffer;
+        bool record_time_validate;
+        const std::vector<uint32_t>& dynamic_offsets;
+        layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts;
+    };
+    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
 
-    bool ValidateGeneralBufferDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
-                                         const cvdescriptorset::DescriptorSet* descriptor_set,
-                                         const cvdescriptorset::BufferDescriptor& descriptor,
-                                         const std::pair<const uint32_t, DescriptorRequirement>& binding_info,
-                                         uint32_t index) const;
+    bool ValidateDescriptorSetBindingData(const DescriptorContext& context, const DescriptorBindingInfo& binding_info,
+                                          const cvdescriptorset::DescriptorBinding& binding) const;
 
-    bool ValidateImageDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
-                                 const cvdescriptorset::DescriptorSet* descriptor_set,
-                                 const cvdescriptorset::ImageDescriptor& image_descriptor,
-                                 const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,
-                                 bool record_time_validate, const std::vector<IMAGE_VIEW_STATE*>* attachments,
-                                 const std::vector<SUBPASS_INFO>* subpasses, VkFramebuffer framebuffer,
-                                 VkDescriptorType descriptor_type,
-                                 layer_data::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts) const;
+    template <typename T>
+    bool ValidateDescriptors(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, const T& binding) const;
 
-    bool ValidateTexelDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
-                                 const cvdescriptorset::DescriptorSet* descriptor_set,
-                                 const cvdescriptorset::TexelDescriptor& texel_descriptor,
-                                 const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::BufferDescriptor& descriptor) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::ImageDescriptor& descriptor) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::ImageSamplerDescriptor& descriptor) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::TexelDescriptor& descriptor) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::AccelerationStructureDescriptor& descriptor) const;
+    bool ValidateDescriptor(const DescriptorContext& context, const DescriptorBindingInfo& binding_info, uint32_t index,
+                            const cvdescriptorset::SamplerDescriptor& descriptor) const;
 
-    bool ValidateAccelerationDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
-                                        const cvdescriptorset::DescriptorSet* descriptor_set,
-                                        const cvdescriptorset::AccelerationStructureDescriptor& descriptor,
-                                        const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index) const;
-
+    // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
                                    const cvdescriptorset::DescriptorSet* descriptor_set,
                                    const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -407,8 +407,11 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
       variable_count_(variable_count),
       change_count_(0) {
     // Foreach binding, create default descriptors of given type
-    bindings_.reserve(layout_->GetBindingCount());
-    for (uint32_t i = 0; i < layout_->GetBindingCount(); ++i) {
+    auto binding_count = layout_->GetBindingCount();
+    bindings_.reserve(binding_count);
+    bindings_store_.reserve(binding_count);
+    auto free_binding = bindings_store_.data();
+    for (uint32_t i = 0; i < binding_count; ++i) {
         auto create_info = layout_->GetDescriptorSetLayoutBindingPtrFromIndex(i);
         assert(create_info);
         uint32_t descriptor_count = create_info->descriptorCount;
@@ -420,7 +423,7 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
         auto descriptor_class = DescriptorTypeToClass(type);
         switch (descriptor_class) {
             case PlainSampler: {
-                auto binding = layer_data::make_unique<SamplerBinding>(*create_info, descriptor_count, flags);
+                auto binding = MakeBinding<SamplerBinding>(free_binding++, *create_info, descriptor_count, flags);
                 auto immut = layout_->GetImmutableSamplerPtrFromIndex(i);
                 if (immut) {
                     for (uint32_t di = 0; di < descriptor_count; ++di) {
@@ -435,7 +438,7 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                 break;
             }
             case ImageSampler: {
-                auto binding = layer_data::make_unique<ImageSamplerBinding>(*create_info, descriptor_count, flags);
+                auto binding = MakeBinding<ImageSamplerBinding>(free_binding++, *create_info, descriptor_count, flags);
                 auto immut = layout_->GetImmutableSamplerPtrFromIndex(i);
                 if (immut) {
                     for (uint32_t di = 0; di < descriptor_count; ++di) {
@@ -451,15 +454,15 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
             }
             // ImageDescriptors
             case Image: {
-                bindings_.push_back(layer_data::make_unique<ImageBinding>(*create_info, descriptor_count, flags));
+                bindings_.push_back(MakeBinding<ImageBinding>(free_binding++, *create_info, descriptor_count, flags));
                 break;
             }
             case TexelBuffer: {
-                bindings_.push_back(layer_data::make_unique<TexelBinding>(*create_info, descriptor_count, flags));
+                bindings_.push_back(MakeBinding<TexelBinding>(free_binding++, *create_info, descriptor_count, flags));
                 break;
             }
             case GeneralBuffer: {
-                auto binding = layer_data::make_unique<BufferBinding>(*create_info, descriptor_count, flags);
+                auto binding = MakeBinding<BufferBinding>(free_binding++, *create_info, descriptor_count, flags);
                 if (IsDynamicDescriptor(type)) {
                     for (uint32_t di = 0; di < descriptor_count; ++di) {
                         dynamic_offset_idx_to_descriptor_list_.push_back({i, di});
@@ -469,15 +472,16 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
                 break;
             }
             case InlineUniform: {
-                bindings_.push_back(layer_data::make_unique<InlineUniformBinding>(*create_info, descriptor_count, flags));
+                bindings_.push_back(MakeBinding<InlineUniformBinding>(free_binding++, *create_info, descriptor_count, flags));
                 break;
             }
             case AccelerationStructure: {
-                bindings_.push_back(layer_data::make_unique<AccelerationStructureBinding>(*create_info, descriptor_count, flags));
+                bindings_.push_back(
+                    MakeBinding<AccelerationStructureBinding>(free_binding++, *create_info, descriptor_count, flags));
                 break;
             }
             case Mutable: {
-                bindings_.push_back(layer_data::make_unique<MutableBinding>(*create_info, descriptor_count, flags));
+                bindings_.push_back(MakeBinding<MutableBinding>(free_binding++, *create_info, descriptor_count, flags));
                 break;
             }
             default:

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -824,7 +824,7 @@ class DescriptorBindingImpl : public DescriptorBinding {
             desc.RemoveParent(ds);
         }
     }
-    std::vector<T> descriptors;
+    small_vector<T, 1, uint32_t> descriptors;
 };
 
 using SamplerBinding = DescriptorBindingImpl<SamplerDescriptor>;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -812,7 +812,12 @@ struct DecodedTemplateUpdate {
  */
 class DescriptorSet : public BASE_NODE {
   public:
-    using BindingVector = std::vector<std::unique_ptr<DescriptorBinding>>;
+    // Given that we are providing placement new allocation for descriptors, the deleter needs to *only* call the destructor
+    struct BindingDeleter {
+        void operator()(DescriptorBinding *binding) { binding->~DescriptorBinding(); }
+    };
+    using BindingPtr = std::unique_ptr<DescriptorBinding, BindingDeleter>;
+    using BindingVector = std::vector<BindingPtr>;
     using BindingIterator = BindingVector::iterator;
     using ConstBindingIterator = BindingVector::const_iterator;
     using StateTracker = ValidationStateTracker;
@@ -1009,14 +1014,37 @@ class DescriptorSet : public BASE_NODE {
     }
 
   private:
+    union AnyBinding {
+        SamplerBinding sampler;
+        ImageSamplerBinding image_sampler;
+        ImageBinding image;
+        TexelBinding texel;
+        BufferBinding buffer;
+        InlineUniformBinding inline_uniform;
+        AccelerationStructureBinding accelerator_structure;
+        MutableBinding mutable_binding;
+        ~AnyBinding() = delete;
+    };
+
+    struct alignas(alignof(AnyBinding)) BindingBackingStore {
+        uint8_t data[sizeof(AnyBinding)];
+    };
+
+    template <typename T>
+    std::unique_ptr<T, BindingDeleter> MakeBinding(BindingBackingStore *location, const VkDescriptorSetLayoutBinding &create_info,
+                                                   uint32_t descriptor_count, VkDescriptorBindingFlags flags) {
+        return std::unique_ptr<T, BindingDeleter>(new (reinterpret_cast<T *>(location)) T(create_info, descriptor_count, flags));
+    }
+
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);
     bool some_update_;  // has any part of the set ever been updated?
     DESCRIPTOR_POOL_STATE *pool_state_;
     const std::shared_ptr<DescriptorSetLayout const> layout_;
-    // NOTE: the the backing store for the descriptors must be declared *before* it so it will be destructed *after* it
+    // NOTE: the the backing store for the bindings must be declared *before* it so it will be destructed *after* it
     // "Destructors for nonstatic member objects are called in the reverse order in which they appear in the class declaration."
-    std::vector<std::unique_ptr<DescriptorBinding>> bindings_;
+    std::vector<BindingBackingStore> bindings_store_;
+    std::vector<BindingPtr> bindings_;
     const StateTracker *state_data_;
     uint32_t variable_count_;
     uint64_t change_count_;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1371,14 +1371,16 @@ void GpuAssisted::SetBindingState(uint32_t *data, uint32_t index, const cvdescri
                     data[index++] = 0;
                     continue;
                 }
-                if (desc.active_descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
-                    desc.active_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
-                    desc.active_descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER ||
-                    desc.active_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
-                    const auto size = desc.GetBufferSize();
-                    data[index++] = static_cast<uint32_t>(size);
-                } else {
+                switch (desc.ActiveType()) {
+                case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                    data[index++] = static_cast<uint32_t>(desc.GetBufferSize());
+                    break;
+                default:
                     data[index++] = 1;
+                    break;
                 }
             }
             break;

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -27,7 +27,7 @@ class GpuAssisted;
 struct GpuAssistedDeviceMemoryBlock {
     VkBuffer buffer;
     VmaAllocation allocation;
-    layer_data::unordered_map<uint32_t, const cvdescriptorset::Descriptor*> update_at_submit;
+    layer_data::unordered_map<uint32_t, const cvdescriptorset::DescriptorBinding*> update_at_submit;
 };
 
 struct GpuAssistedPreDrawResources {
@@ -177,7 +177,7 @@ class GpuAssisted : public GpuAssistedBase {
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, GpuAssistedBufferInfo &buffer_info,
         uint32_t operation_index, uint32_t* const debug_output_buffer);
 
-    void SetDescriptorInitialized(uint32_t* pData, uint32_t index, const cvdescriptorset::Descriptor* descriptor);
+    void SetBindingState(uint32_t* data, uint32_t index, const cvdescriptorset::DescriptorBinding* binding);
     void UpdateInstrumentationBuffer(gpuav_state::CommandBuffer* cb_node);
     const GpuVuid& GetGpuVuid(CMD_TYPE cmd_type) const;
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -173,6 +173,17 @@ class small_vector {
         DebugUpdateWorkingStore();
     }
 
+    small_vector(size_type size, const value_type& value = value_type()) : size_(0), capacity_(N) {
+        reserve(size);
+        auto dest = GetWorkingStore();
+        for (size_type i = 0; i < size; i++) {
+            new (dest) value_type(value);
+            ++dest;
+        }
+        size_ = size;
+    }
+
+
     ~small_vector() { clear(); }
 
     bool operator==(const small_vector &rhs) const {


### PR DESCRIPTION
Storing descriptors in type specific, per binding vectors saves
memory (and improves cache utilization). Most descriptor objects are
are 48 bytes or less, but MutableDescriptor is almost 200 bytes.
Per binding storage also allows tight inner loops, which helps
performance for large bindless descriptor sets.