### PR TITLE
layers: Fix semaphore check logic in PreCallValidateQueuePresentKHR

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -16765,7 +16765,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                              "vkQueuePresentKHR: pWaitSemaphores[%u] (%s) is not a VK_SEMAPHORE_TYPE_BINARY", i,
                              report_data->FormatHandle(pPresentInfo->pWaitSemaphores[i]).c_str());
         }
-        if (semaphore_state && !semaphore_state->CanBeWaited()) {
+        if (semaphore_state && semaphore_state->Scope() == kSyncScopeInternal && !semaphore_state->CanBeWaited()) {
             LogObjectList objlist(queue);
             objlist.add(pPresentInfo->pWaitSemaphores[i]);
             skip |= LogError(objlist, "VUID-vkQueuePresentKHR-pWaitSemaphores-03268",


### PR DESCRIPTION
When validating the semaphore set in VkPresentInfoKHR, make
PreCallValidateQueuePresentKHR only check semaphores with internal
scope.

Validation Error: [
VUID-vkQueuePresentKHR-pWaitSemaphores-03268 ] vkQueuePresentKHR: Queue
VkQueue 0xde3a98[] is waiting on pWaitSemaphores[0] (VkSemaphore
0xab64de0000000020[]) that has no way to be signaled.

Fixes #4128