### PR TITLE
codegen: Update 'create' criteria

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -9335,11 +9335,10 @@ VkResult DispatchGetDrmDisplayEXT(
 {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     if (!wrap_handles) return layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-    {
-        display = layer_data->Unwrap(display);
-    }
     VkResult result = layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-
+    if (VK_SUCCESS == result) {
+        *display = layer_data->WrapNew(*display);
+    }
     return result;
 }
 
@@ -9431,11 +9430,10 @@ VkResult DispatchGetWinrtDisplayNV(
 {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     if (!wrap_handles) return layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
-    {
-        pDisplay = layer_data->Unwrap(pDisplay);
-    }
     VkResult result = layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
-
+    if (VK_SUCCESS == result) {
+        *pDisplay = layer_data->WrapNew(*pDisplay);
+    }
     return result;
 }
 #endif // VK_USE_PLATFORM_WIN32_KHR

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -2011,7 +2011,7 @@ VkResult DispatchGetDeferredOperationResultKHR(
             cmd_member_dict = dict(self.cmdMembers)
             cmd_info = cmd_member_dict[proto.text]
             # Handle ndo create/allocate operations
-            if cmd_info[0].iscreate:
+            if cmd_info[-1].iscreate:
                 create_ndo_code = self.generate_create_ndo_code(indent, proto, params, cmd_info)
             else:
                 create_ndo_code = ''
@@ -2074,7 +2074,7 @@ VkResult DispatchGetDeferredOperationResultKHR(
                 if self.struct_contains_ndo(type) == True:
                     islocal = True
             isdestroy = True if True in [destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free', 'ReleasePerformanceConfigurationINTEL']] else False
-            iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL']] else False
+            iscreate = (not isconst) and ispointer
             extstructs = self.registry.validextensionstructs[type] if name == 'pNext' else None
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,


### PR DESCRIPTION
Determine whether or not a command is expected to return a result in a
pointer based on parameter type rather than a hard-coded list of command
names.

Closes #4136.