### PR TITLE
Use ofstream to write shader validation cache

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3999,10 +3999,10 @@ void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationC
         }
 
         if (validation_cache_path.size() > 0) {
-            FILE *write_file = fopen(validation_cache_path.c_str(), "wb");
+            std::ofstream write_file(validation_cache_path.c_str(), std::ios::out | std::ios::binary);
             if (write_file) {
-                fwrite(validation_cache_data, sizeof(char), validation_cache_size, write_file);
-                fclose(write_file);
+                write_file.write(static_cast<char *>(validation_cache_data), validation_cache_size);
+                write_file.close();
             } else {
                 LogInfo(device, "UNASSIGNED-cache-write-error", "Cannot open shader validation cache at %s for writing",
                         validation_cache_path.c_str());


### PR DESCRIPTION
I promised to do this in a previous PR