### PR TITLE
syncval: Cleanup callbacks on syncval destroy

### DIFF
--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -471,6 +471,11 @@ class ValidationStateTracker : public ValidationObject {
         command_buffer_free_callback.reset(new CommandBufferFreeCallback(std::forward<Fn>(fn)));
     }
 
+    void ResetCommandBufferCallbacks() {
+        command_buffer_reset_callback.reset();
+        command_buffer_free_callback.reset();
+    }
+
     using SetImageViewInitialLayoutCallback = std::function<void(CMD_BUFFER_STATE*, const IMAGE_VIEW_STATE&, VkImageLayout)>;
     template <typename Fn>
     void SetSetImageViewInitialLayoutCallback(Fn&& fn) {

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -1173,6 +1173,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
   public:
     using StateTracker = ValidationStateTracker;
     SyncValidator() { container_type = LayerObjectTypeSyncValidation; }
+    virtual ~SyncValidator() { ResetCommandBufferCallbacks(); };
 
     layer_data::unordered_map<VkCommandBuffer, std::shared_ptr<CommandBufferAccessContext>> cb_access_state;
 


### PR DESCRIPTION
Ensure that callbacks into the syncval object aren't called after the
validation object subclass is destroyed.