### PR TITLE
Two small fixes, one might have performance implications.

### DIFF
--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -285,7 +285,7 @@ class Device : public internal::Handle<VkDevice> {
 
 class Queue : public internal::Handle<VkQueue> {
   public:
-    explicit Queue(VkQueue queue, int index) : Handle(queue) { family_index_ = index; }
+    explicit Queue(VkQueue queue, uint32_t index) : Handle(queue) { family_index_ = index; }
 
     // vkQueueSubmit()
     VkResult submit(const std::vector<const CommandBuffer *> &cmds, const Fence &fence, bool expect_success = true);
@@ -295,10 +295,10 @@ class Queue : public internal::Handle<VkQueue> {
     // vkQueueWaitIdle()
     VkResult wait();
 
-    int get_family_index() { return family_index_; }
+    uint32_t get_family_index() { return family_index_; }
 
   private:
-    int family_index_;
+    uint32_t family_index_;
 };
 
 class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {


### PR DESCRIPTION
1) small vector::reserve wasn't updating capacity_ , meaning that large_store_ emplace was going to be N^2.  Also added a debug-only feature as reading the backing_store was driving me batty

2) return queue_index information as uint32_t which is consistent with the queue count in the queue family props