### PR TITLE
layers: Store OpVariables separately

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -601,7 +601,6 @@ class CoreChecks : public ValidationStateTracker {
                                           spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidateTexelOffsetLimits(SHADER_MODULE_STATE const* module_state, spirv_inst_iter& insn) const;
     bool ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const;
-    bool ValidateWorkgroupInitialization(SHADER_MODULE_STATE const* src, spirv_inst_iter& insn) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(VkShaderStageFlagBits stage, bool has_writable_descriptor,
                                                        bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(SHADER_MODULE_STATE const* module_state,
@@ -617,6 +616,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderResolveQCOM(SHADER_MODULE_STATE const* module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderSubgroupSizeControl(safe_VkPipelineShaderStageCreateInfo const* pStage) const;
+    bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage) const;
     bool ValidateAtomicsTypes(SHADER_MODULE_STATE const* module_state) const;
     bool ValidateExecutionModes(SHADER_MODULE_STATE const* module_state, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
@@ -641,6 +641,7 @@ class CoreChecks : public ValidationStateTracker {
                                         shader_stage_attributes const* producer_stage, SHADER_MODULE_STATE const* consumer,
                                         spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
     bool ValidateDecorations(SHADER_MODULE_STATE const* module_state) const;
+    bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateTransformFeedback(SHADER_MODULE_STATE const* module_state) const;
     bool ValidateShaderClock(SHADER_MODULE_STATE const* module_state, spirv_inst_iter& insn) const;
 

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -367,6 +367,10 @@ SHADER_MODULE_STATE::SpirvStaticData::SpirvStaticData(const SHADER_MODULE_STATE 
                 capability_list.push_back(static_cast<spv::Capability>(insn.word(1)));
                 break;
 
+            case spv::OpVariable:
+                variable_inst.push_back(insn);
+                break;
+
             // Execution Mode
             case spv::OpExecutionMode:
             case spv::OpExecutionModeId: {
@@ -1894,21 +1898,6 @@ uint32_t SHADER_MODULE_STATE::GetBaseType(const spirv_inst_iter &iter) const {
 uint32_t SHADER_MODULE_STATE::GetTypeId(uint32_t id) const {
     const auto type = get_def(id);
     return OpcodeHasType(type.opcode()) ? type.word(1) : 0;
-}
-
-uint32_t SHADER_MODULE_STATE::CalcComputeSharedMemory(VkShaderStageFlagBits stage,
-                                                      const spirv_inst_iter &insn) const {
-    if (stage == VK_SHADER_STAGE_COMPUTE_BIT && insn.opcode() == spv::OpVariable) {
-        uint32_t storage_class = insn.word(3);
-        if (storage_class == spv::StorageClassWorkgroup) {  // StorageClass Workgroup is shared memory
-            uint32_t result_type_id = insn.word(1);
-            auto result_type = get_def(result_type_id);
-            auto type = get_def(result_type.word(3));
-            return GetTypeBytesSize(type);
-        }
-    }
-
-    return 0;
 }
 
 // Assumes itr points to an OpConstant instruction

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -243,6 +243,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         // Find all decoration instructions to prevent relooping module later - many checks need this info
         std::vector<spirv_inst_iter> decoration_inst;
         std::vector<spirv_inst_iter> member_decoration_inst;
+        // Find all variable instructions to prevent relookping module later
+        std::vector<spirv_inst_iter> variable_inst;
         // Execution are not tied to an entry point and are their own mapping tied to entry point function
         // [OpEntryPoint function <id> operand] : [Execution Mode Instruction list]
         layer_data::unordered_map<uint32_t, std::vector<spirv_inst_iter>> execution_mode_inst;
@@ -404,8 +406,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     uint32_t GetTypeBytesSize(const spirv_inst_iter &iter) const;
     uint32_t GetBaseType(const spirv_inst_iter &iter) const;
     uint32_t GetTypeId(uint32_t id) const;
-    uint32_t CalcComputeSharedMemory(VkShaderStageFlagBits stage,
-                                     const spirv_inst_iter &insn) const;
 
     bool WritesToGlLayer() const {
         return std::any_of(static_data_.builtin_decoration_list.begin(), static_data_.builtin_decoration_list.end(),


### PR DESCRIPTION
I have an upcoming change that is a lot easier if we save the `OpVariable` in a list as static SPIR-V information. I noticed some other code also would benefit from that, so broke that out into this PR to make the 2 changes easier to distinguish