### PR TITLE
layers: Update 02697 logging for GPLs

### DIFF
--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -347,6 +347,21 @@ void AppendDynamicStateFromSubstate(const Substate &substate, std::vector<VkDyna
     }
 }
 
+std::vector<std::shared_ptr<const PIPELINE_LAYOUT_STATE>> PIPELINE_STATE::PipelineLayoutStateUnion() const {
+    std::vector<std::shared_ptr<const PIPELINE_LAYOUT_STATE>> ret;
+    ret.reserve(2);
+    // Only need to check pre-raster _or_ fragment shader layout; if either one is not merged_graphics_layout, then
+    // merged_graphics_layout is a union
+    if (pre_raster_state) {
+        if (pre_raster_state->pipeline_layout != fragment_shader_state->pipeline_layout) {
+            return {pre_raster_state->pipeline_layout, fragment_shader_state->pipeline_layout};
+        } else {
+            return {pre_raster_state->pipeline_layout};
+        }
+    }
+    return {merged_graphics_layout};
+}
+
 template <>
 VkPipeline PIPELINE_STATE::BasePipeline<VkGraphicsPipelineCreateInfo>() const {
     assert(create_info.graphics.sType == VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO);

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -302,6 +302,8 @@ class PIPELINE_STATE : public BASE_NODE {
         return merged_graphics_layout;
     }
 
+    std::vector<std::shared_ptr<const PIPELINE_LAYOUT_STATE>> PipelineLayoutStateUnion() const;
+
     const std::shared_ptr<const PIPELINE_LAYOUT_STATE> PreRasterPipelineLayoutState() const {
         if (pre_raster_state) {
             return pre_raster_state->pipeline_layout;


### PR DESCRIPTION
Ensure valid pipeline layout handles get printed when logging errors
involving graphics pipeline libraries containing merged layouts.

When using graphics pipeline libraries, it is possible that the "executable pipeline" used at draw time is actually a union of layouts from pre-raster and fragment shader libraries. If this is the case, then currently no information about the original layouts are printed to the user.