### PR TITLE
Fix assert with multiplane images

### DIFF
--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -320,20 +320,20 @@ void IMAGE_STATE::SetInitialLayoutMap() {
         return;
     }
     if ((createInfo.flags & VK_IMAGE_CREATE_ALIAS_BIT) != 0) {
-        const auto *binding = Binding();
-        assert(binding);
         // Look for another aliasing image and point at its layout state.
         // ObjectBindings() is thread safe since returns by value, and once
         // the weak_ptr is successfully locked, the other image state won't
         // be freed out from under us.
-        for (auto &entry : binding->memory_state->ObjectBindings()) {
-            if (entry.first.type == kVulkanObjectTypeImage) {
-                auto base_node = entry.second.lock();
-                if (base_node) {
-                    auto other_image = static_cast<IMAGE_STATE *>(base_node.get());
-                    if (other_image != this && other_image->IsCompatibleAliasing(this)) {
-                        layout_range_map = other_image->layout_range_map;
-                        break;
+        for (auto const &memory_state : GetBoundMemoryStates()) {
+            for (auto &entry : memory_state->ObjectBindings()) {
+                if (entry.first.type == kVulkanObjectTypeImage) {
+                    auto base_node = entry.second.lock();
+                    if (base_node) {
+                        auto other_image = static_cast<IMAGE_STATE *>(base_node.get());
+                        if (other_image != this && other_image->IsCompatibleAliasing(this)) {
+                            layout_range_map = other_image->layout_range_map;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue in `dEQP-VK.ycbcr.plane_view.memory_alias.g8_b8_r8_3plane_420_unorm_plane_0`. The issue happens whenever we have a multiplane image. Due to backwards compatibility, I kept the `Binding` function, but I overlooked this part of its usage which would always result in an assert with multiplane images