### PR TITLE
git: Add .editorconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build-android/third_party
 *.includes
 .vscode/
 .DS_Store
+.editorconfig


### PR DESCRIPTION
Used by the MSVC guidelines plugin.