### PR TITLE
corechecks: Clean up some Image descriptor and layout methods

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9375,7 +9375,7 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
     VkImageSubresourceLayers subresource = {range.aspectMask, range.baseMipLevel, range.baseArrayLayer, range.layerCount};
 
     if (image_state) {
-        skip |= VerifyImageLayout(cb_state.get(), image_state, subresource, imageLayout, VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV,
+        skip |= VerifyImageLayout(*cb_state, *image_state, subresource, imageLayout, VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV,
                                   "vkCmdCopyImage()", "VUID-vkCmdBindShadingRateImageNV-imageLayout-02063",
                                   "VUID-vkCmdBindShadingRateImageNV-imageView-02062", &hit_error);
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -701,22 +701,22 @@ class CoreChecks : public ValidationStateTracker {
                                 VkImageLayout explicit_layout, const RangeFactory& range_factory, const char* caller,
                                 const char* layout_mismatch_msg_code, bool* error) const;
 
-    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
+    bool VerifyImageLayout(const CMD_BUFFER_STATE& cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceRange& range,
                            VkImageAspectFlags view_aspect, VkImageLayout explicit_layout, VkImageLayout optimal_layout,
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,
                            bool* error) const;
 
-    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_VIEW_STATE* image_view_state, VkImageLayout explicit_layout,
+    bool VerifyImageLayout(const CMD_BUFFER_STATE& cb_node, const IMAGE_VIEW_STATE& image_view_state, VkImageLayout explicit_layout,
                            const char* caller, const char* layout_mismatch_msg_code, bool* error) const;
 
-    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state, const VkImageSubresourceRange& range,
+    bool VerifyImageLayout(const CMD_BUFFER_STATE& cb_node, const IMAGE_STATE& image_state, const VkImageSubresourceRange& range,
                            VkImageLayout explicit_layout, VkImageLayout optimal_layout, const char* caller,
                            const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code, bool* error) const {
         return VerifyImageLayout(cb_node, image_state, range, 0, explicit_layout, optimal_layout, caller, layout_invalid_msg_code,
                                  layout_mismatch_msg_code, error);
     }
 
-    bool VerifyImageLayout(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* image_state,
+    bool VerifyImageLayout(const CMD_BUFFER_STATE& cb_node, const IMAGE_STATE& image_state,
                            const VkImageSubresourceLayers& subLayers, VkImageLayout explicit_layout, VkImageLayout optimal_layout,
                            const char* caller, const char* layout_invalid_msg_code, const char* layout_mismatch_msg_code,
                            bool* error) const;

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -951,7 +951,7 @@ bool CoreChecks::ValidateImageDescriptor(
             }
             if (!already_validated) {
                 bool hit_error = false;
-                VerifyImageLayout(cb_node, image_view_state, image_layout, caller, "VUID-VkDescriptorImageInfo-imageLayout-00344",
+                VerifyImageLayout(*cb_node, *image_view_state, image_layout, caller, "VUID-VkDescriptorImageInfo-imageLayout-00344",
                                   &hit_error);
                 if (hit_error) {
                     auto set = descriptor_set->GetSet();

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -876,9 +876,7 @@ bool CoreChecks::ValidateImageDescriptor(
     std::vector<const SAMPLER_STATE *> sampler_states;
     VkImageView image_view = image_descriptor.GetImageView();
     const IMAGE_VIEW_STATE *image_view_state = image_descriptor.GetImageViewState();
-    VkImageLayout image_layout = image_descriptor.GetImageLayout();
     const auto binding = binding_info.first;
-    const auto reqs = binding_info.second.reqs;
 
     if (image_descriptor.GetClass() == cvdescriptorset::DescriptorClass::ImageSampler) {
         sampler_states.emplace_back(
@@ -911,8 +909,8 @@ bool CoreChecks::ValidateImageDescriptor(
                         report_data->FormatHandle(image_view).c_str());
     }
     if (image_view) {
+        const auto reqs = binding_info.second.reqs;
         const auto &image_view_ci = image_view_state->create_info;
-        const auto *image_state = image_view_state->image_state.get();
 
         if (reqs & DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS) {
             if (~reqs & (1 << image_view_ci.viewType)) {
@@ -939,6 +937,7 @@ bool CoreChecks::ValidateImageDescriptor(
         // NOTE: Submit time validation of UPDATE_AFTER_BIND image layout is not possible with the
         // image layout tracking as currently implemented, so only record_time_validation is done
         if (!disabled[image_layout_validation] && record_time_validate) {
+            VkImageLayout image_layout = image_descriptor.GetImageLayout();
             // Verify Image Layout
             // No "invalid layout" VUID required for this call, since the optimal_layout parameter is UNDEFINED.
             // The caller provides a checked_layouts map when there are a large number of layouts to check,
@@ -1320,7 +1319,7 @@ bool CoreChecks::ValidateImageDescriptor(
                     }
                 }
             }
-
+            const auto image_state = image_view_state->image_state.get();
             if ((image_state->createInfo.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) &&
                 (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
                  sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||


### PR DESCRIPTION
Use reference arguments in VerifyImageLayout() methods and optimize some local variables in ValidateImageDescriptor()