### PR TITLE
Fix layer implementation of vk_layerGetPhysicalDeviceProcAddr

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -13327,6 +13327,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
 #pragma warning( suppress: 6262 ) // VS analysis: this uses more than 16 kiB, which is fine here at global scope
 #endif
 const layer_data::unordered_map<std::string, function_data> name_to_funcptr_map = {
+    {"vk_layerGetPhysicalDeviceProcAddr", {kFuncTypeInst, (void*)GetPhysicalDeviceProcAddr}},
     {"vkCreateInstance", {kFuncTypeInst, (void*)CreateInstance}},
     {"vkDestroyInstance", {kFuncTypeInst, (void*)DestroyInstance}},
     {"vkEnumeratePhysicalDevices", {kFuncTypeInst, (void*)EnumeratePhysicalDevices}},

--- a/layers/generated/vk_dispatch_table_helper.h
+++ b/layers/generated/vk_dispatch_table_helper.h
@@ -1746,6 +1746,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
 static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {
     memset(table, 0, sizeof(*table));
     // Instance function pointers
+    table->GetPhysicalDeviceProcAddr = (PFN_GetPhysicalDeviceProcAddr) gpa(instance, "vk_layerGetPhysicalDeviceProcAddr");
     table->DestroyInstance = (PFN_vkDestroyInstance) gpa(instance, "vkDestroyInstance");
     table->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices) gpa(instance, "vkEnumeratePhysicalDevices");
     table->GetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures) gpa(instance, "vkGetPhysicalDeviceFeatures");

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -294,6 +294,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
             table += 'static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {\n'
             table += '    memset(table, 0, sizeof(*table));\n'
             table += '    // Instance function pointers\n'
+            table += '    table->GetPhysicalDeviceProcAddr = (PFN_GetPhysicalDeviceProcAddr) gpa(instance, "vk_layerGetPhysicalDeviceProcAddr");\n'
 
         stubbed_functions = dict(self.stub_list)
         for item in entries:

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -319,7 +319,6 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
             'vkEnumerateInstanceVersion',
             'vkGetDeviceProcAddr',
             'vkGetInstanceProcAddr',
-            'vkGetPhysicalDeviceProcAddr',
         ]
 
         if self.helper_file_type == 'optick_instrumentation_header':

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -142,7 +142,6 @@ class LayerChassisOutputGenerator(OutputGenerator):
         # Include functions here to be interecpted w/ manually implemented function bodies
         'vkGetDeviceProcAddr',
         'vkGetInstanceProcAddr',
-        'vkGetPhysicalDeviceProcAddr',
         'vkCreateDevice',
         'vkDestroyDevice',
         'vkCreateInstance',
@@ -1808,7 +1807,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         OutputGenerator.__init__(self, errFile, warnFile, diagFile)
         # Internal state - accumulators for different inner block text
         self.sections = dict([(section, []) for section in self.ALL_SECTIONS])
-        self.intercepts = []
+        # We need to manually add an entry for vk_layerGetPhysicalDeviceProcAddr because it isn't in the xml,
+        # but it must be queryable from vkGetInstanceProcAddr()
+        self.intercepts = [ '    {"%s", {%s, (void*)%s}},' % ("vk_layerGetPhysicalDeviceProcAddr", "kFuncTypeInst", "GetPhysicalDeviceProcAddr") ]
         self.intercept_enums = ''
         self.dispatch_vector_fcns = ''
         self.virtual_fcn_defs = ''

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -313,6 +313,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
         return (PFN_vkVoidFunction)GetOriginalPhysicalDeviceFormatProperties2EXT;
     if (!strcmp(name, "vkGetOriginalPhysicalDeviceFeaturesEXT")) return (PFN_vkVoidFunction)GetOriginalPhysicalDeviceFeaturesEXT;
     if (!strcmp(name, "vkSetPhysicalDeviceFeaturesEXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceFeaturesEXT;
+    if (!strcmp(name, "vk_layerGetPhysicalDeviceProcAddr")) return (PFN_vkVoidFunction)GetPhysicalDeviceProcAddr;
     assert(instance);
     layer_data *instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
     auto &table = instance_data->dispatch_table;


### PR DESCRIPTION
This function must be queryable from vkGetInstanceProcAddr() - see https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md

This fixes the crash reported in https://github.com/KhronosGroup/Vulkan-Loader/issues/950