### PR TITLE
build: Remove duplicate compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,8 @@ if(MAKE_C_COMPILER_ID MATCHES "Clang")
                         -Wno-sign-conversion
                         -Wno-shorten-64-to-32
                         -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion)
+                        -Wno-enum-enum-conversion
+                        -Wstring-conversion)
 
 endif()
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -230,19 +231,6 @@ elseif(MSVC)
     add_compile_options("/w34057")
     # Warn about signed/unsigned mismatch.
     add_compile_options("/w34245")
-endif()
-
-if(MAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wconversion
-
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion
-                        -Wstring-conversion)
-
 endif()
 
 option(INSTALL_TESTS "Install tests" OFF)


### PR DESCRIPTION
There are 2 spots with `if(MAKE_C_COMPILER_ID MATCHES "Clang")` so removed one (kept the first one as it seems the spot I would expect it to be)