### PR TITLE
layers: Remove crash potential in ValidateImageAspectMask

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -13132,7 +13132,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                              attachment_ref.layout);
 
                     vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-attachment-02525" : "VUID-VkRenderPassCreateInfo-pNext-01963";
-                    skip |= ValidateImageAspectMask(VK_NULL_HANDLE, attachment_format, aspect_mask, function_name, vuid);
+                    // Assuming no disjoint image since there's no handle
+                    skip |= ValidateImageAspectMask(VK_NULL_HANDLE, attachment_format, aspect_mask, false, function_name, vuid);
 
                     if (attach_first_use[attachment_index]) {
                         skip |=
@@ -16561,8 +16562,9 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, VkDevi
 bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(IMAGE_STATE const &image_state,
                                                                VkImageSubresource const &subresource, uint32_t image_idx,
                                                                uint32_t bind_idx) const {
-    bool skip = ValidateImageAspectMask(image_state.image(), image_state.createInfo.format, subresource.aspectMask,
-                                        "vkQueueSparseBind()", "VUID-VkSparseImageMemoryBind-subresource-01106");
+    bool skip =
+        ValidateImageAspectMask(image_state.image(), image_state.createInfo.format, subresource.aspectMask, image_state.disjoint,
+                                "vkQueueSparseBind()", "VUID-VkSparseImageMemoryBind-subresource-01106");
 
     if (subresource.mipLevel >= image_state.createInfo.mipLevels) {
         skip |=

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -877,8 +877,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkBufferView* pView) const override;
 
-    bool ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, const char* func_name,
-                                 const char* vuid = kVUID_Core_DrawState_InvalidImageAspect) const;
+    bool ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, bool is_image_disjoint,
+                                 const char* func_name, const char* vuid = kVUID_Core_DrawState_InvalidImageAspect) const;
 
     bool ValidateImageAcquired(IMAGE_STATE const& image_state, const char* func_name) const;
 


### PR DESCRIPTION
If `image_state->disjoint` was potentially dangerous if `image_state` is null.