### PR TITLE
corechecks: Use TlsGuard<> for submit time image layout checks

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1039,7 +1039,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBarriersToImages(const Location& loc, const CMD_BUFFER_STATE* cb_state, uint32_t imageMemoryBarrierCount,
                                   const ImageBarrier* pImageMemoryBarriers) const;
 
-    void RecordQueuedQFOTransfers(CMD_BUFFER_STATE* pCB);
+    void RecordQueuedQFOTransfers(QFOTransferCBScoreboards<QFOImageTransferBarrier> &qfo_image_scoreboards,
+                                  QFOTransferCBScoreboards<QFOBufferTransferBarrier> &qfo_buffer_scoreboards);
 
     template <typename ImgBarrier>
     void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const ImgBarrier* barrier);
@@ -1118,7 +1119,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCmdBufImageLayouts(const Location& loc, const CMD_BUFFER_STATE& cb_state,
                                     GlobalImageLayoutMap& overlayLayoutMap) const;
 
-    void UpdateCmdBufImageLayouts(const CMD_BUFFER_STATE* cb_state);
+    void UpdateCmdBufImageLayouts(GlobalImageLayoutMap &overlay_image_layout_map);
 
     bool VerifyBoundMemoryIsValid(const DEVICE_MEMORY_STATE* mem_state, const LogObjectList& objlist,
                                   const VulkanTypedHandle& typed_handle, const char* api_name, const char* error_code) const;

--- a/layers/core_checks/image_layout_validation.cpp
+++ b/layers/core_checks/image_layout_validation.cpp
@@ -371,12 +371,13 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const CMD_BUFFE
     return skip;
 }
 
-void CoreChecks::UpdateCmdBufImageLayouts(const CMD_BUFFER_STATE *cb_state) {
-    for (const auto &layout_map_entry : cb_state->image_layout_map) {
+void CoreChecks::UpdateCmdBufImageLayouts(GlobalImageLayoutMap &overlay_image_layout_map) {
+    for (const auto &layout_map_entry : overlay_image_layout_map) {
         const auto *image_state = layout_map_entry.first;
         const auto &subres_map = layout_map_entry.second;
+        if (!subres_map) continue;
         auto guard = image_state->layout_range_map->WriteLock();
-        sparse_container::splice(*image_state->layout_range_map, subres_map->GetLayoutMap(), GlobalLayoutUpdater());
+        sparse_container::splice(*image_state->layout_range_map, *subres_map, sparse_container::value_precedence::prefer_source);
     }
 }
 


### PR DESCRIPTION
ValidateCmdBufImageLayouts() builds up an 'overlay' map of the
changes that will be made to the global layout state for all
images used by the command buffers in a queue submission. By
saving the overlay map in a TlsGuard<>, the work done in
UpdateCmdBufImageLayouts() can be reduced.