### PR TITLE
build: Fix search path for Vulkan-Headers

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -59,11 +59,13 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
   find_path(VulkanHeaders_INCLUDE_DIR
       NAMES vulkan/vulkan.h
       HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
-      NO_CMAKE_FIND_ROOT_PATH)
+      NO_CMAKE_FIND_ROOT_PATH
+      NO_DEFAULT_PATH)
   find_path(VulkanRegistry_DIR
       NAMES vk.xml
       HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry
-      NO_CMAKE_FIND_ROOT_PATH)
+      NO_CMAKE_FIND_ROOT_PATH
+      NO_DEFAULT_PATH)
 else()
   # If VULKAN_HEADERS_INSTALL_DIR, or one of its variants was not specified,
   # do a normal search without hints.


### PR DESCRIPTION
On a system that has the vulkan headers installed in a "standard" search
location, make sure that if VULKAN_HEADERS_INSTALL_DIR is defined,
"standard" directories are not added to the search path.

I feel like someone else brought this up in the past, and there was a reason we did _not_ already have this, but can't seem to find it now. The reason I'm adding it now is that a package update on my local linux system added the repo's vulkan header package, and only the installed package headers are used, which is causing build errors.

Adding @mikes-lunarg, as I think he is also using Arch and wondering if he's run into the same thing recently (qt6-base appears to be the package responsible, which I'm not even using anymore...)