### PR TITLE
syncval: Fix access mask expansion

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -2862,7 +2862,7 @@ SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFl
     result.mask_param = mask_param;
     result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags, disabled_feature_mask);
     result.exec_scope = sync_utils::WithEarlierPipelineStages(result.expanded_mask);
-    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.exec_scope);
+    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
     return result;
 }
 
@@ -2871,7 +2871,7 @@ SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFl
     result.mask_param = mask_param;
     result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags);
     result.exec_scope = sync_utils::WithLaterPipelineStages(result.expanded_mask);
-    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.exec_scope);
+    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
     return result;
 }
 


### PR DESCRIPTION
Access masks should only expand for the pipeline stages explicitly set in the stage mask. So we shouldn't include the earlier or later stages when doing the access mask expansion.

Add a test makes sure sync validation properly handles the pipeline stage and access mask expansion rules.