### PR TITLE
Add unused local variable error to MSVC

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -114,6 +114,7 @@ if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
     add_compile_options("/bigobj")
+    add_compile_options("/we4189")
     # Allow Windows to use multiprocessor compilation
     add_compile_options(/MP)
     # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -26,10 +26,19 @@
 #include <algorithm>
 #include <regex>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4189)
+#endif
+
 #define VMA_IMPLEMENTATION
 // This define indicates that we will supply Vulkan function pointers at initialization
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #include "vk_mem_alloc.h"
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 // Implementation for Descriptor Set Manager class
 UtilDescriptorSetManager::UtilDescriptorSetManager(VkDevice device, uint32_t numBindingsInSet)


### PR DESCRIPTION
Update cmake for windows to treat unused local variable as error to
avoid platform specific errors in CI.

One required pragma added to suppress the error in an included 3rd party file.