### PR TITLE
Fix state tracking of VkCopyDescriptorSet for KHR-acceleration-structure case

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -897,6 +897,7 @@ void cvdescriptorset::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet 
         return;
     }
     auto acc_desc = static_cast<const AccelerationStructureDescriptor *>(src);
+    is_khr_ = acc_desc->is_khr_;
     if (is_khr_) {
         acc_ = acc_desc->acc_;
         ReplaceStatePtr(set_state, acc_state_, dev_data->GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_), is_bindless);


### PR DESCRIPTION
Minor bugfix for descriptor sets. 

I'm using `VkAccelerationStructureKHR` in my game-engine together with `VkCopyDescriptorSet`. Basically validation layer loses track of `is_khr_`, after copy, and then things start to fall apart causing false validation messages.
```
vkCmdDrawIndexed time: Descriptor in binding #5 index 0 is using acceleration structure VkAccelerationStructureNV 0x0[] that is invalid or has been destroyed.
```