### PR TITLE
build: Fix DispatchExportMetalObjectsEXT generation

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -9442,7 +9442,7 @@ void DispatchExportMetalObjectsEXT(
             WrapPnextChainHandles(layer_data, local_pMetalObjectsInfo->pNext);
         }
     }
-    layer_data->device_dispatch_table.ExportMetalObjectsEXT(device, (const VkExportMetalObjectsInfoEXT*)local_pMetalObjectsInfo);
+    layer_data->device_dispatch_table.ExportMetalObjectsEXT(device, (VkExportMetalObjectsInfoEXT*)local_pMetalObjectsInfo);
 
 }
 #endif // VK_USE_PLATFORM_METAL_EXT

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -2158,7 +2158,10 @@ VkResult DispatchGetDeferredOperationResultKHR(
             for param in params:
                 if param.islocal == True or self.StructWithExtensions(param.type):
                     if param.ispointer == True:
-                        wrapped_paramstext = wrapped_paramstext.replace(param.name, '(%s %s*)local_%s' % ('const', param.type, param.name))
+                        if param.isconst == True:
+                          wrapped_paramstext = wrapped_paramstext.replace(param.name, '(%s %s*)local_%s' % ('const', param.type, param.name))
+                        else:
+                          wrapped_paramstext = wrapped_paramstext.replace(param.name, '(%s*)local_%s' % (param.type, param.name))
                     else:
                         wrapped_paramstext = wrapped_paramstext.replace(param.name, '(%s %s)local_%s' % ('const', param.type, param.name))
 


### PR DESCRIPTION
Don't add const qualifier to pMetalObjectsInfo,
since it can't be passed to ExportMetalObjectsEXT this way.

Fixes #4221