### PR TITLE
Fix check for dynamic rendering attachment format use.

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -278,6 +278,7 @@ void CMD_BUFFER_STATE::Reset() {
     memset(&beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
     memset(&inheritanceInfo, 0, sizeof(VkCommandBufferInheritanceInfo));
     hasDrawCmd = false;
+    hasDrawCmdInCurrentRenderPass = false;
     hasTraceRaysCmd = false;
     hasBuildAccelerationStructureCmd = false;
     hasDispatchCmd = false;
@@ -679,6 +680,7 @@ void CMD_BUFFER_STATE::BeginRenderPass(CMD_TYPE cmd_type, const VkRenderPassBegi
 
     active_subpasses = nullptr;
     active_attachments = nullptr;
+    hasDrawCmdInCurrentRenderPass = false;
 
     if (activeFramebuffer) {
         framebuffers.insert(activeFramebuffer);
@@ -750,6 +752,7 @@ void CMD_BUFFER_STATE::BeginRendering(CMD_TYPE cmd_type, const VkRenderingInfo *
     hasRenderPassInstance = true;
 
     active_attachments = nullptr;
+    hasDrawCmdInCurrentRenderPass = false;
     uint32_t attachment_count = (pRenderingInfo->colorAttachmentCount + 2) * 2;
 
     // Set cb_state->active_attachments & cb_state->attachments_view_states
@@ -968,6 +971,7 @@ void CMD_BUFFER_STATE::UpdateStateCmdDrawDispatchType(CMD_TYPE cmd_type, VkPipel
 void CMD_BUFFER_STATE::UpdateStateCmdDrawType(CMD_TYPE cmd_type, VkPipelineBindPoint bind_point) {
     UpdateStateCmdDrawDispatchType(cmd_type, bind_point);
     hasDrawCmd = true;
+    hasDrawCmdInCurrentRenderPass = true;
 
     // Update the consumed viewport/scissor count.
     uint32_t &used = usedViewportScissorCount;

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -182,6 +182,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     const COMMAND_POOL_STATE *command_pool;
     ValidationStateTracker *dev_data;
     bool hasDrawCmd;
+    bool hasDrawCmdInCurrentRenderPass;
     bool hasTraceRaysCmd;
     bool hasBuildAccelerationStructureCmd;
     bool hasDispatchCmd;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9231,7 +9231,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
         if (cb_state->transform_feedback_active) {
             skip |= LogError(pipeline, "VUID-vkCmdBindPipeline-None-02323", "vkCmdBindPipeline(): transform feedback is active.");
         }
-        if (cb_state->activeRenderPass && cb_state->activeRenderPass->use_dynamic_rendering && cb_state->hasDrawCmd) {
+        if (cb_state->activeRenderPass && cb_state->activeRenderPass->use_dynamic_rendering && cb_state->hasDrawCmdInCurrentRenderPass) {
             const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pipeline_state->PNext());
             const auto last_pipeline = cb_state->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
             const auto *last_rendering_struct =


### PR DESCRIPTION
The spec says to check for the current render pass instance, but
code was checking if there were any draw calls at all in the command
buffer.

Ran into this in vkd3d-proton test suite.