### PR TITLE
layers: Update dynamic color write enable state comparison

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1362,7 +1362,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         const auto color_blend_state = pCB->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)->ColorBlendState();
         if (color_blend_state) {
             uint32_t blend_attachment_count = color_blend_state->attachmentCount;
-            if (pCB->dynamicColorWriteEnableAttachmentCount != blend_attachment_count) {
+            if (pCB->dynamicColorWriteEnableAttachmentCount < blend_attachment_count) {
                 skip |= LogError(
                     pCB->commandBuffer(), vuid.color_write_enable,
                     "%s(): Currently bound pipeline was created with VkPipelineColorBlendStateCreateInfo::attachmentCount %" PRIu32


### PR DESCRIPTION
as of the latest spec, the comparison for this has changed such that
the only failure case is when the number of bools passed is less
than the number of blend attachments