### PR TITLE
tests: Skip SurfacelessQueryTest for devsim

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2579,8 +2579,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         this, m_instance_extension_names, m_device_extension_names, gpu_assisted ? &validation_features : nullptr, m_errorMonitor);
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     std::array<const char *, 2> required_device_extensions = {

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -552,8 +552,7 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature12) {
     // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
     // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
@@ -614,8 +613,7 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithFeature) {
     // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
     // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -235,9 +235,8 @@ TEST_F(VkPositiveLayerTest, SurfacelessQueryTest) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // Use the VK_GOOGLE_surfaceless_query extension to query the available formats and

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4952,8 +4952,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1079,8 +1079,7 @@ TEST_F(VkPositiveLayerTest, ShaderDrawParametersWithFeature) {
     // Devsim won't read in values like maxDescriptorSetUpdateAfterBindUniformBuffers which cause OneshotTest to fail pipeline
     // layout creation if using 1.2 devsim as it enables VK_EXT_descriptor_indexing
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
@@ -2024,8 +2023,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD or devsim, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
@@ -2554,8 +2552,7 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
 
     // need real device to produce output to check
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // glslang currenlty turned the GLSL to

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -48,8 +48,7 @@ TEST_F(VkPositiveLayerTest, ToolingExtension) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping test case.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     m_errorMonitor->ExpectSuccess();

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -334,8 +334,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // create a non-sparse index buffer
@@ -448,8 +447,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     CreatePipelineHelper pipe(*this);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -77,8 +77,7 @@ TEST_F(VkBestPracticesLayerTest, ValidateReturnCodes) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping test case.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // Force a non-success success code by only asking for a subset of query results

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4967,8 +4967,7 @@ TEST_F(VkLayerTest, InvalidTexelBufferAlignment) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
     texel_buffer_alignment_features.texelBufferAlignment = VK_TRUE;
 
@@ -11011,8 +11010,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
@@ -11076,8 +11074,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     buffer_device_address_features.bufferDeviceAddress = VK_FALSE;
@@ -11121,8 +11118,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
@@ -11243,8 +11239,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support this feature, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     buffer_device_address_features.bufferDeviceAddress = VK_FALSE;
@@ -11583,8 +11578,7 @@ TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s MockICD does not support the necessary memory type, skipping test\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, does not support the necessary memory type";
     }
 
     // Find a memory type that includes the device coherent memory property
@@ -13008,10 +13002,8 @@ TEST_F(VkLayerTest, InvalidShadingRateUsage) {
 
     if (!fsrProperties.layeredShadingRateAttachments) {
         if (IsPlatform(kMockICD) || DeviceSimulation()) {
-            printf(
-                "%s DevSim doesn't correctly advertise format support for fragment shading rate attachments, skipping some "
-                "tests.\n",
-                kSkipPrefix);
+            GTEST_SKIP() << "Test not supported by MockICD, DevSim doesn't correctly advertise format support for fragment shading "
+                            "rate attachments";
         } else {
             VkImageObj image2(m_device);
             image2.Init(VkImageObj::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_R8_UINT,

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -5993,8 +5993,7 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -6598,8 +6597,7 @@ TEST_F(VkLayerTest, MeshShaderNV) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -54,8 +54,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 
     VkPhysicalDeviceFeatures2KHR features2 = {};
@@ -532,8 +531,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
 
     InitGpuAssistedFramework(false);
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
         printf("%s Extension %s not supported by device; skipped.\n", kSkipPrefix, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
@@ -752,8 +750,7 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
 
     InitGpuAssistedFramework(false);
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 
     if (IsPlatform(kGalaxyS10)) {
@@ -928,8 +925,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
 
     InitGpuAssistedFramework(false);
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
@@ -1832,8 +1828,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     InitGpuAssistedFramework(false);
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
         m_device_extension_names.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
@@ -2006,8 +2001,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
         return;
     }
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted validation test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
@@ -2120,8 +2114,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     bool descriptor_indexing = CheckDescriptorIndexingSupportAndInitFramework(this, m_instance_extension_names,
                                                                               m_device_extension_names, &features, m_errorMonitor);
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
@@ -2458,8 +2451,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s GPU-Assisted printf test requires a driver that can draw.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     // Make a uniform buffer to be passed to the shader that contains the test number
     uint32_t qfi = 0;
@@ -2765,8 +2757,7 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%sNot suppored by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -228,8 +228,7 @@ TEST_F(VkLayerTest, DestroyInstanceHandleLeak) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!IsPlatform(kMockICD)) {
         // This test leaks a device (on purpose) and should not be run on a real driver
-        printf("%s This test only runs on the mock ICD\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test only runs on the mock ICD";
     }
     const auto ici = GetInstanceCreateInfo();
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -174,8 +174,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PRIVATE_DATA_EXTENSION_NAME)) {
@@ -260,8 +259,7 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_PRIVATE_DATA_EXTENSION_NAME)) {
@@ -1322,8 +1320,7 @@ TEST_F(VkLayerTest, LeakAnObject) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!IsPlatform(kMockICD)) {
         // This test leaks a fence (on purpose) and should not be run on a real driver
-        printf("%s This test only runs on the mock ICD\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test only runs on the mock ICD";
     }
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
@@ -3445,8 +3442,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
     // Test takes magnitude of time longer for devsim and slows down testing
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // Calls AllocateCommandBuffers
@@ -4025,8 +4021,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
@@ -7461,8 +7456,7 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kMockICD)) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
     bool idfm_extensions = DeviceExtensionSupported(gpu(), nullptr, VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
     idfm_extensions = idfm_extensions && DeviceExtensionSupported(gpu(), nullptr, VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
@@ -9897,8 +9891,7 @@ TEST_F(VkLayerTest, InvalidSpirvExtension) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1+, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, DevSim doesn't support Vulkan 1.1+";
     }
 
     const char *vertex_source = R"spirv(

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -7161,8 +7161,7 @@ TEST_F(VkLayerTest, CooperativeMatrixNV) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
@@ -7257,8 +7256,7 @@ TEST_F(VkLayerTest, SubgroupSupportedProperties) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, DevSim doesn't support Vulkan 1.1+";
     }
 
     // Gather all aspects supported
@@ -7500,8 +7498,7 @@ TEST_F(VkLayerTest, SubgroupRequired) {
     }
 
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s DevSim doesn't support Vulkan 1.1, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, DevSim doesn't support Vulkan 1.1+";
     }
 
     VkPhysicalDeviceSubgroupProperties subgroup_prop = GetSubgroupProperties(instance(), gpu());
@@ -10195,8 +10192,7 @@ TEST_F(VkLayerTest, ValidatePipelineExecutablePropertiesFeature) {
 
     // MockICD will return 0 for the executable count
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     PFN_vkGetPipelineExecutableInternalRepresentationsKHR vkGetPipelineExecutableInternalRepresentationsKHR =

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -639,9 +639,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        // will throw a std::bad_alloc sometimes
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, will throw a std::bad_alloc sometimes";
     }
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;
@@ -807,9 +805,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (IsPlatform(kMockICD) || DeviceSimulation()) {
-        // will throw a std::bad_alloc sometimes
-        printf("%s Test not supported by MockICD, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test not supported by MockICD, will throw a std::bad_alloc sometimes";
     }
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;


### PR DESCRIPTION
`SurfacelessQueryTest` was crashing on `DevSim`

While fixing it, I went and added `GTEST_SKIP` to all the places that check for devsim/mockicd