### PR TITLE
build: Fix compilation errors with deprecated sprintf function

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -765,7 +765,7 @@ bool BestPractices::PreCallValidateBindBufferMemory2(VkDevice device, uint32_t b
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindBufferMemory2() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindBufferMemory2() pBindInfos[%u]", i);
         skip |= ValidateBindBufferMemory(pBindInfos[i].buffer, pBindInfos[i].memory, api_name);
     }
 
@@ -778,7 +778,7 @@ bool BestPractices::PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindBufferMemory2KHR() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindBufferMemory2KHR() pBindInfos[%u]", i);
         skip |= ValidateBindBufferMemory(pBindInfos[i].buffer, pBindInfos[i].memory, api_name);
     }
 
@@ -861,7 +861,7 @@ bool BestPractices::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bi
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindImageMemory2() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindImageMemory2() pBindInfos[%u]", i);
         if (!LvlFindInChain<VkBindImageMemorySwapchainInfoKHR>(pBindInfos[i].pNext)) {
             skip |= ValidateBindImageMemory(pBindInfos[i].image, pBindInfos[i].memory, api_name);
         }
@@ -876,7 +876,7 @@ bool BestPractices::PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindImageMemory2KHR() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindImageMemory2KHR() pBindInfos[%u]", i);
         skip |= ValidateBindImageMemory(pBindInfos[i].image, pBindInfos[i].memory, api_name);
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6366,7 +6366,7 @@ bool CoreChecks::PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bind
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindBufferMemory2() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindBufferMemory2() pBindInfos[%u]", i);
         skip |= ValidateBindBufferMemory(pBindInfos[i].buffer, pBindInfos[i].memory, pBindInfos[i].memoryOffset,
                                          pBindInfos[i].pNext, api_name);
     }
@@ -6379,7 +6379,7 @@ bool CoreChecks::PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_t b
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        sprintf(api_name, "vkBindBufferMemory2KHR() pBindInfos[%u]", i);
+        snprintf(api_name, sizeof(api_name), "vkBindBufferMemory2KHR() pBindInfos[%u]", i);
         skip |= ValidateBindBufferMemory(pBindInfos[i].buffer, pBindInfos[i].memory, pBindInfos[i].memoryOffset,
                                          pBindInfos[i].pNext, api_name);
     }
@@ -15994,7 +15994,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (bind_image_mem_2 == true) {
-            sprintf(error_prefix, "%s pBindInfos[%u]", api_name, i);
+            snprintf(error_prefix, sizeof(error_prefix), "%s pBindInfos[%u]", api_name, i);
         }
 
         const VkBindImageMemoryInfo &bind_info = pBindInfos[i];
@@ -17139,14 +17139,14 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
         std::string error_string = "";
         char str[1024];
         // Here's the first part of the message:
-        sprintf(str, "%s called with a non-supported pCreateInfo->preTransform (i.e. %s).  Supported values are:\n", func_name,
-                string_VkSurfaceTransformFlagBitsKHR(pCreateInfo->preTransform));
+        snprintf(str, sizeof(str), "%s called with a non-supported pCreateInfo->preTransform (i.e. %s).  Supported values are:\n",
+                 func_name, string_VkSurfaceTransformFlagBitsKHR(pCreateInfo->preTransform));
         error_string += str;
         for (int i = 0; i < 32; i++) {
             // Build up the rest of the message:
             if ((1 << i) & capabilities.supportedTransforms) {
                 const char *new_str = string_VkSurfaceTransformFlagBitsKHR(static_cast<VkSurfaceTransformFlagBitsKHR>(1 << i));
-                sprintf(str, "    %s\n", new_str);
+                snprintf(str, sizeof(str), "    %s\n", new_str);
                 error_string += str;
             }
         }
@@ -17163,14 +17163,14 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
         std::string error_string = "";
         char str[1024];
         // Here's the first part of the message:
-        sprintf(str, "%s called with a non-supported pCreateInfo->compositeAlpha (i.e. %s).  Supported values are:\n", func_name,
-                string_VkCompositeAlphaFlagBitsKHR(pCreateInfo->compositeAlpha));
+        snprintf(str, sizeof(str), "%s called with a non-supported pCreateInfo->compositeAlpha (i.e. %s).  Supported values are:\n",
+                 func_name, string_VkCompositeAlphaFlagBitsKHR(pCreateInfo->compositeAlpha));
         error_string += str;
         for (int i = 0; i < 32; i++) {
             // Build up the rest of the message:
             if ((1 << i) & capabilities.supportedCompositeAlpha) {
                 const char *new_str = string_VkCompositeAlphaFlagBitsKHR(static_cast<VkCompositeAlphaFlagBitsKHR>(1 << i));
-                sprintf(str, "    %s\n", new_str);
+                snprintf(str, sizeof(str), "    %s\n", new_str);
                 error_string += str;
             }
         }

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -276,7 +276,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string forma
                 parsed_strings.push_back(substring);
 
                 // Continue with a comma separated list
-                sprintf(tempstring, ", %s", specifier.c_str());
+                snprintf(tempstring, sizeof(tempstring), ", %s", specifier.c_str());
                 substring.string = tempstring;
                 for (int i = 0; i < (count - 1); i++) {
                     parsed_strings.push_back(substring);


### PR DESCRIPTION
This commit modifies sprintf calls to fix the following compilation
errors using XCode 14.0 beta on MacOS:

> 'sprintf' is deprecated: This function is provided for compatibility
> reasons only.  Due to security concerns inherent in the design of
> sprintf(3), it is highly recommended that you use snprintf(3) instead.