### PR TITLE
layers: Add check for clearValueCount > attachmentCount

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -129,6 +129,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_SemaphoreCount = "UNASSIG
 static const char DECORATE_UNUSED *kVUID_BestPractices_EmptyDescriptorPool =
     "UNASSIGNED-BestPractices-EmptyDescriptorPool";
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
+static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1718,8 +1718,20 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, Re
                 device, kVUID_BestPractices_ClearValueWithoutLoadOpClear,
                 "This render pass does not have VkRenderPassCreateInfo.pAttachments->loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR "
                 "but VkRenderPassBeginInfo.clearValueCount > 0. VkRenderPassBeginInfo.pClearValues will be ignored and no "
-                "attachments will be cleared");
+                "attachments will be cleared.");
         }
+
+        // Check if there are more clearValues than attachments
+        if(pRenderPassBegin->clearValueCount > rp_state->createInfo.attachmentCount) {
+            // Flag as warning because the overflowing clearValues will be ignored and could even be undefined on certain platforms.
+            // This could signal a bug and there seems to be no reason for this to happen on purpose.
+            skip |= LogWarning(
+                device, kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount,
+                "This render pass has VkRenderPassBeginInfo.clearValueCount > VkRenderPassCreateInfo.attachmentCount "
+                "(%" PRIu32 " > %" PRIu32 ") and as such the clearValues that do not have a corresponding attachment will be ignored.",
+                pRenderPassBegin->clearValueCount, rp_state->createInfo.attachmentCount);
+        }
+
     }
 
     return skip;


### PR DESCRIPTION
Add warning message for when VkRenderPassBeginInfo.clearValueCount > VkRenderPassCreateInfo.attachmentCount.
Add test for this message.
The spec states that this is allowed but that the overflowing clearValues will be ignored, thus the values could even be invalid or undefined. Since these values are ignored, it would always make more sense to pass a maximum value of attachmentCount to clearValueCount.
Since there seems to be no reason to pass a higher clearValueCount, this check could help find some bugs.