### PR TITLE
layers: Explicit incomplete validation support

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -947,7 +947,7 @@ static void DeviceExtensionWarnlist(ValidationObject *layer_data, const VkDevice
         // Check for recognized device extensions
         if (white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceWarnExtensionNames)) {
             layer_data->LogWarning(layer_data->device, kVUIDUndefined,
-                    "Device Extension %s support is incomplete, incorrect results are possible.",
+                    "Device Extension %s validation support is incomplete, incorrect results are possible.",
                     pCreateInfo->ppEnabledExtensionNames[i]);
         }
     }

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -1595,7 +1595,7 @@ static void DeviceExtensionWarnlist(ValidationObject *layer_data, const VkDevice
         // Check for recognized device extensions
         if (white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceWarnExtensionNames)) {
             layer_data->LogWarning(layer_data->device, kVUIDUndefined,
-                    "Device Extension %s support is incomplete, incorrect results are possible.",
+                    "Device Extension %s validation support is incomplete, incorrect results are possible.",
                     pCreateInfo->ppEnabledExtensionNames[i]);
         }
     }


### PR DESCRIPTION
The message "Device Extension %s support is incomplete,
incorrect results are possible." makes it sound like the
driver does not fully support the extension while the real
reason of this message is the incomplete validation support
(mostly fixed by downloading a newer SDK when available).