### PR TITLE
layers: Check StoreOpDontCare then LoadOpLoad

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -130,6 +130,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_EmptyDescriptorPool =
     "UNASSIGNED-BestPractices-EmptyDescriptorPool";
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
+static const char DECORATE_UNUSED *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -171,6 +171,8 @@ class Image : public IMAGE_STATE {
         return last_usage;
     }
 
+    IMAGE_SUBRESOURCE_USAGE_BP GetUsage(uint32_t array_layer, uint32_t mip_level) { return usages_[array_layer][mip_level]; }
+
   private:
     void SetupUsages() {
         usages_.resize(createInfo.arrayLayers);

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -326,6 +326,9 @@ class Fence : public internal::NonDispHandle<VkFence> {
   public:
     ~Fence() NOEXCEPT;
 
+    Fence() = default;
+    Fence(const Device &dev, const VkFenceCreateInfo &info) { init(dev, info); }
+
     // vkCreateFence()
     void init(const Device &dev, const VkFenceCreateInfo &info);
 


### PR DESCRIPTION
Add warning message when loading an image in a renderpass with LOAD_OP_LOAD when the last operation on the image was a discard with STORE_OP_DONT_CARE, which results in undefined behaviour.
Closes #293