### PR TITLE
tests: Cleanup of VkRenderFramework

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1029,33 +1029,33 @@ VkLayerTest::VkLayerTest() {
     // TODO: not quite sure why most of this is here instead of in super
 
     // Add default instance extensions to the list
-    instance_extensions_.push_back(debug_reporter_.debug_extension_name);
+    m_instance_extension_names.push_back(m_debug_reporter.debug_extension_name);
 
-    instance_layers_.push_back(kValidationLayerName);
+    m_instance_layers.push_back(kValidationLayerName);
 
     if (VkTestFramework::m_devsim_layer) {
         if (InstanceLayerSupported("VK_LAYER_LUNARG_device_simulation")) {
-            instance_layers_.push_back("VK_LAYER_LUNARG_device_simulation");
+            m_instance_layers.push_back("VK_LAYER_LUNARG_device_simulation");
         } else {
             VkTestFramework::m_devsim_layer = false;
             printf("             Did not find VK_LAYER_LUNARG_device_simulation layer so it will not be enabled.\n");
         }
     } else {
         if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api"))
-            instance_layers_.push_back("VK_LAYER_LUNARG_device_profile_api");
+            m_instance_layers.push_back("VK_LAYER_LUNARG_device_profile_api");
     }
 
     if (InstanceLayerSupported(kSynchronization2LayerName)) {
-        instance_layers_.push_back(kSynchronization2LayerName);
+        m_instance_layers.push_back(kSynchronization2LayerName);
     }
 
-    app_info_.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    app_info_.pNext = NULL;
-    app_info_.pApplicationName = "layer_tests";
-    app_info_.applicationVersion = 1;
-    app_info_.pEngineName = "unittest";
-    app_info_.engineVersion = 1;
-    app_info_.apiVersion = VK_API_VERSION_1_0;
+    m_app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    m_app_info.pNext = NULL;
+    m_app_info.pApplicationName = "layer_tests";
+    m_app_info.applicationVersion = 1;
+    m_app_info.pEngineName = "unittest";
+    m_app_info.engineVersion = 1;
+    m_app_info.apiVersion = VK_API_VERSION_1_0;
 
     // Find out what version the instance supports and record the default target instance
     auto enumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vk::GetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion");
@@ -1064,7 +1064,7 @@ VkLayerTest::VkLayerTest() {
     } else {
         m_instance_api_version = VK_API_VERSION_1_0;
     }
-    m_target_api_version = app_info_.apiVersion;
+    m_target_api_version = m_app_info.apiVersion;
 }
 
 void VkLayerTest::AddSurfaceExtension() {
@@ -1111,17 +1111,17 @@ uint32_t VkLayerTest::SetTargetApiVersion(uint32_t target_api_version) {
     if (target_api_version == 0) target_api_version = VK_API_VERSION_1_0;
     if (target_api_version <= m_instance_api_version) {
         m_target_api_version = target_api_version;
-        app_info_.apiVersion = m_target_api_version;
+        m_app_info.apiVersion = m_target_api_version;
     } else {
         m_target_api_version = m_instance_api_version;
-        app_info_.apiVersion = m_target_api_version;
+        m_app_info.apiVersion = m_target_api_version;
     }
     return m_target_api_version;
 }
 
 uint32_t VkLayerTest::DeviceValidationVersion() {
     // The validation layers assume the version we are validating to is the apiVersion unless the device apiVersion is lower
-    return std::min(m_target_api_version, physDevProps().apiVersion);
+    return std::min(m_target_api_version, PhysicalDeviceProps().apiVersion);
 }
 
 template <>

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -49,8 +49,8 @@ TEST_F(VkPositiveLayerTest, TwoInstances) {
     VkInstance i1, i2, i3;
 
     VkInstanceCreateInfo ici = LvlInitStruct<VkInstanceCreateInfo>();
-    ici.enabledLayerCount = instance_layers_.size();
-    ici.ppEnabledLayerNames = instance_layers_.data();
+    ici.enabledLayerCount = m_instance_layers.size();
+    ici.ppEnabledLayerNames = m_instance_layers.data();
 
     ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &i1));
 

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -338,7 +338,7 @@ TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
 TEST_F(VkPositiveLayerTest, ApiVersionZero) {
     TEST_DESCRIPTION("Check that apiVersion = 0 is valid.");
     m_errorMonitor->ExpectSuccess();
-    app_info_.apiVersion = 0U;
+    m_app_info.apiVersion = 0U;
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     m_errorMonitor->VerifyNotFound();
 }

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4361,7 +4361,7 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExternalCameraFormat) {
 TEST_F(VkPositiveLayerTest, PhysicalStorageBuffer) {
     TEST_DESCRIPTION("Reproduces Github issue #2467 and effectively #2465 as well.");
 
-    app_info_.apiVersion = VK_API_VERSION_1_2;
+    m_app_info.apiVersion = VK_API_VERSION_1_2;
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     std::vector<const char *> exts = {
@@ -4915,8 +4915,8 @@ TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
     VkInstance instance;
 
     VkInstanceCreateInfo ici = LvlInitStruct<VkInstanceCreateInfo>();
-    ici.enabledLayerCount = instance_layers_.size();
-    ici.ppEnabledLayerNames = instance_layers_.data();
+    ici.enabledLayerCount = m_instance_layers.size();
+    ici.ppEnabledLayerNames = m_instance_layers.data();
 
     auto dbgUtils0 = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
     auto dbgUtils1 = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>(&dbgUtils0);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1050,11 +1050,11 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     TEST_DESCRIPTION("Check that GetPhysicalDeviceQueueFamilyProperties is working as expected");
 
     // Vulkan 1.1 required to test vkGetPhysicalDeviceQueueFamilyProperties2
-    app_info_.apiVersion = VK_API_VERSION_1_1;
+    m_app_info.apiVersion = VK_API_VERSION_1_1;
     // VK_KHR_get_physical_device_properties2 required to test vkGetPhysicalDeviceQueueFamilyProperties2KHR
-    instance_extensions_.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    m_instance_extension_names.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
-    const vk_testing::PhysicalDevice phys_device_obj(gpu_);
+    const vk_testing::PhysicalDevice phys_device_obj(m_gpu);
 
     std::vector<VkQueueFamilyProperties> queue_family_props;
 
@@ -1093,7 +1093,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     TEST_DESCRIPTION("Check that GetPhysicalDeviceQueueFamilyProperties generates appropriate query warning");
 
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
-    const vk_testing::PhysicalDevice phys_device_obj(gpu_);
+    const vk_testing::PhysicalDevice phys_device_obj(m_gpu);
 
     std::vector<VkQueueFamilyProperties> queue_family_props(1);
     uint32_t queue_count = static_cast<uint32_t>(queue_family_props.size());

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -9364,7 +9364,7 @@ TEST_F(VkLayerTest, DrawBlendEnabledFormatFeatures) {
         return;
     }
 
-    VkFormat render_format = VkTestFramework::GetFormat(instance_, m_device);
+    VkFormat render_format = VkTestFramework::GetFormat(m_instance, m_device);
 
     // Set format features from being found
     VkFormatProperties formatProps;

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -45,7 +45,7 @@ TEST_F(VkLayerTest, InstanceExtensionDependencies) {
     ASSERT_TRUE(InstanceExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME));  // Driver should always provide dependencies
 
     Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-ppEnabledExtensionNames-01388");
-    instance_extensions_.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
     const auto ici = GetInstanceCreateInfo();
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
@@ -69,7 +69,7 @@ TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
         printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
         return;
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 
@@ -103,7 +103,7 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
         printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
         return;
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 
@@ -151,7 +151,7 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
         printf("%s Did not find required instance extension %s.\n", kSkipPrefix, VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
         return;
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3699,7 +3699,7 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    vk_testing::PhysicalDevice physical_device(gpu_);
+    vk_testing::PhysicalDevice physical_device(m_gpu);
     VkPhysicalDeviceFeatures features = physical_device.features();
     vk_testing::QueueCreateInfoArray queue_info(physical_device.queue_properties());
     const char *extension_names[1] = {VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME};

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -15894,14 +15894,14 @@ TEST_F(VkLayerTest, InvalidPipelineRenderingParameters) {
 
     VkFormat depth_format = VK_FORMAT_X8_D24_UNORM_PACK32;
 
-    if (ImageFormatAndFeaturesSupported(gpu_, VK_FORMAT_D32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
+    if (ImageFormatAndFeaturesSupported(m_gpu, VK_FORMAT_D32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
                                         VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         depth_format = VK_FORMAT_D32_SFLOAT;
     }
 
     VkFormat stencil_format = VK_FORMAT_D24_UNORM_S8_UINT;
 
-    if (ImageFormatAndFeaturesSupported(gpu_, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (ImageFormatAndFeaturesSupported(m_gpu, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                         VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         stencil_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     }

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -20,7 +20,7 @@ class VkPortabilitySubsetTest : public VkLayerTest {
   public:
     void InitPortabilitySubsetFramework() {
         // VK_KHR_portability_subset extension dependencies
-        instance_extensions_.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        m_instance_extension_names.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
         InitFramework(m_errorMonitor, nullptr);
     }

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -701,8 +701,8 @@ TEST_F(VkLayerTest, SwapchainNotSupported) {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // in "issue" section of VK_KHR_android_surface it talks how querying support is not needed on Android
     // The validation layers currently don't validate this VUID for Android surfaces
-    if (std::find(instance_extensions_.begin(), instance_extensions_.end(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) !=
-        instance_extensions_.end()) {
+    if (std::find(m_instance_extension_names.begin(), m_instance_extension_names.end(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) !=
+        m_instance_extension_names.end()) {
         printf("%s Test does not run on Android Surface, skipping test\n", kSkipPrefix);
         return;
     }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -241,7 +241,7 @@ const std::unordered_map<PlatformType, std::string, std::hash<int>> vk_gpu_table
 
 class VkRenderFramework : public VkTestFramework {
   public:
-    VkInstance instance() { return instance_; }
+    VkInstance instance() { return m_instance; }
     VkDevice device() { return m_device->device(); }
     VkDeviceObj *DeviceObj() const { return m_device; }
     VkPhysicalDevice gpu();
@@ -249,10 +249,10 @@ class VkRenderFramework : public VkTestFramework {
     const VkRenderPassCreateInfo &RenderPassInfo() const { return m_renderPass_info; };
     VkFramebuffer framebuffer() { return m_framebuffer; }
     ErrorMonitor &Monitor();
-    VkPhysicalDeviceProperties physDevProps();
+    VkPhysicalDeviceProperties PhysicalDeviceProps();
 
     static bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
-    static bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);
+    bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);
 
     VkInstanceCreateInfo GetInstanceCreateInfo() const;
     void InitFramework(void * /*unused compatibility parameter*/ = NULL, void *instance_pnext = NULL);
@@ -324,16 +324,14 @@ class VkRenderFramework : public VkTestFramework {
     VkRenderFramework();
     virtual ~VkRenderFramework() = 0;
 
-    DebugReporter debug_reporter_;
-    ErrorMonitor *m_errorMonitor = &debug_reporter_.error_monitor_;  // compatibility alias name
+    DebugReporter m_debug_reporter;
+    ErrorMonitor *m_errorMonitor = &m_debug_reporter.error_monitor_;  // compatibility alias name
 
-    VkApplicationInfo app_info_;
-    std::vector<const char *> instance_layers_;
-    std::vector<const char *> instance_extensions_;
-    std::vector<const char *> &m_instance_extension_names = instance_extensions_;  // compatibility alias name
-    VkInstance instance_;
-    VkPhysicalDevice gpu_ = VK_NULL_HANDLE;
-    VkPhysicalDeviceProperties physDevProps_;
+    VkApplicationInfo m_app_info;
+    std::vector<const char *> m_instance_layers;
+    VkInstance m_instance;
+    VkPhysicalDevice m_gpu = VK_NULL_HANDLE;
+    VkPhysicalDeviceProperties m_physcial_device_props;
 
     uint32_t m_gpu_index;
     VkDeviceObj *m_device;
@@ -395,8 +393,13 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_required_extensions;
     // Optional extensions to try and enable at device creation time
     std::vector<const char *> m_optional_extensions;
+    // instance extensions to enable
+    std::vector<const char *> m_instance_extension_names;
     // Device extensions to enable
     std::vector<const char *> m_device_extension_names;
+    // List of extensions that are supported by the instance/device
+    std::vector<VkExtensionProperties> m_supported_instance_extensions;
+    std::vector<VkExtensionProperties> m_supported_device_extensions;
 
   private:
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -133,14 +133,7 @@ std::vector<VkLayerProperties> GetGlobalLayers() {
 /*
  * Return list of Global extensions provided by the ICD / Loader
  */
-std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExtensions(nullptr); }
-
-/*
- * Return list of Global extensions provided by the specified layer
- * If pLayerName is NULL, will return extensions implemented by the loader /
- * ICDs
- */
-std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
+std::vector<VkExtensionProperties> GetGlobalExtensions() {
     VkResult err;
     uint32_t extension_count;
     std::vector<VkExtensionProperties> extensions;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -80,7 +80,6 @@ class CommandPool;
 
 std::vector<VkLayerProperties> GetGlobalLayers();
 std::vector<VkExtensionProperties> GetGlobalExtensions();
-std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName);
 
 namespace internal {
 


### PR DESCRIPTION
The main 2 things this change does is

1. prevent `InstanceExtensionSupported` and `DeviceExtensionSupported` from querying the extensions list everytime it is called, should ever need to query list once
2. While at it, replaced the few `member_var_` with `m_member_var` for consistency