### PR TITLE
tests: Report all errors by default

### DIFF
--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7191,7 +7191,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 4;
-        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
         VkBufferObj const buffer_obj(*m_device, info);
 
         VkDeviceSize const offsets[1]{};
@@ -7219,6 +7219,10 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindTransformFeedbackBuffersEXT-pBuffers-02364");
         vkCmdBindTransformFeedbackBuffersEXT(m_commandBuffer->handle(), 0, 1, &buffer, offsets, nullptr);
         m_errorMonitor->VerifyFound();
+
+        auto vkDestroyBuffer = (PFN_vkDestroyBuffer)vk::GetDeviceProcAddr(m_device->device(), "vkDestroyBuffer");
+        ASSERT_TRUE(vkDestroyBuffer != nullptr);
+        vkDestroyBuffer(m_device->handle(), buffer, nullptr);
     }
 }
 
@@ -7304,7 +7308,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
         info.size = 4;
-        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
         VkBufferObj const buffer_obj(*m_device, info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-pCounterBuffers-02372");
@@ -7418,7 +7422,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
                 auto info = LvlInitStruct<VkBufferCreateInfo>();
                 // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
                 info.size = 4;
-                m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+                m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
                 VkBufferObj const buffer_obj(*m_device, info);
 
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndTransformFeedbackEXT-pCounterBuffers-02380");

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -52,7 +52,7 @@ ErrorMonitor::ErrorMonitor(Behavior behavior) : behavior_(behavior) {
 ErrorMonitor::~ErrorMonitor() NOEXCEPT { test_platform_thread_delete_mutex(&mutex_); }
 
 void ErrorMonitor::MonitorReset() {
-    message_flags_ = 0;
+    message_flags_ = kErrorBit;  // catch all errors anyway
     bailout_ = NULL;
     message_found_ = VK_FALSE;
     failure_message_strings_.clear();


### PR DESCRIPTION
The current behaviour is to look only for the type of message
we are looking for through SetDesiredFailureMsg, but this will ignore
errors when looking for a warning.