### PR TITLE
Replace `VK_HEADER_VERSION` with `VK_HEADER_VERSION_COMPLETE`

### DIFF
--- a/build-gn/generate_vulkan_layers_json.py
+++ b/build-gn/generate_vulkan_layers_json.py
@@ -124,7 +124,7 @@ def main():
             for line in infile:
                 line = line.replace('@RELATIVE_LAYER_BINARY@',
                                     relative_path_prefix + layer_lib_name)
-                line = line.replace('@VK_VERSION@', '1.1.' + vk_version)
+                line = line.replace('@VK_VERSION@', '1.3.' + vk_version)
                 json_out_file.write(line)
 
 if __name__ == '__main__':

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -306,7 +306,7 @@ static inline VkDeviceSize SafeDivision(VkDeviceSize dividend, VkDeviceSize divi
 extern "C" {
 #endif
 
-#define VK_LAYER_API_VERSION VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION)
+#define VK_LAYER_API_VERSION VK_HEADER_VERSION_COMPLETE
 
 typedef enum VkStringErrorFlagBits {
     VK_STRING_ERROR_NONE = 0x00000000,

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -244,8 +244,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(VkPhysicalDevice physicalDe
 
 static const VkLayerProperties device_profile_api_LayerProps = {
     "VK_LAYER_LUNARG_device_profile_api",
-    VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION),  // specVersion
-    1,                                         // implementationVersion
+    VK_HEADER_VERSION_COMPLETE,             // specVersion
+    1,                                      // implementationVersion
     "LunarG device profile api Layer",
 };
 


### PR DESCRIPTION
Fixes #4240

The layer without JSON API reports an incorrect version of `1.0.$VK_HEADER_VERSION`, because the constant here was never updated.  Base it on the full version instead to turn this into the correct `1.3.$VK_HEADER_VERSION` (as of writing) to match what is currently used for the `api_version` field in JSON.

---

Creating this as draft because I'd rather _also_ update the scripts to read `VK_HEADER_VERSION_COMPLETE` instead of hardcoding `1.3.{}` all over the place, if maintainers agree?
