### PR TITLE
Remove check for RelaxedPrecision interface matching

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2998,11 +2998,6 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
                                  a_first.first, a_first.second, a_it->second.is_patch ? "patch" : "vertex", producer_stage->name,
                                  b_it->second.is_patch ? "patch" : "vertex", consumer_stage->name);
             }
-            if (a_it->second.is_relaxed_precision != b_it->second.is_relaxed_precision) {
-                skip |= LogError(producer.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
-                                 "Decoration mismatch on location %" PRIu32 ".%" PRIu32 ": %s and %s stages differ in precision",
-                                 a_first.first, a_first.second, producer_stage->name, consumer_stage->name);
-            }
             uint32_t a_remaining = a_length - a_component;
             uint32_t b_remaining = b_length - b_component;
             if (a_remaining == b_remaining) {  // Sizes match so we can advance both a_it and b_it

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4996,60 +4996,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
             "device extension to allow relaxed interface matching between input and output vectors."});
 }
 
-TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByPrecision) {
-    TEST_DESCRIPTION("Test that the RelaxedPrecision decoration is validated to match");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    char const *vsSource = R"glsl(
-        #version 450
-        layout(location=0) out mediump float x;
-        void main() { gl_Position = vec4(0); x = 1.0; }
-    )glsl";
-    char const *fsSource = R"glsl(
-        #version 450
-        layout(location=0) in highp float x;
-        layout(location=0) out vec4 color;
-        void main() { color = vec4(x); }
-    )glsl";
-
-    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
-    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "differ in precision");
-}
-
-TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByPrecisionBlock) {
-    TEST_DESCRIPTION("Test that the RelaxedPrecision decoration is validated to match");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    char const *vsSource = R"glsl(
-        #version 450
-        out block { layout(location=0) mediump float x; };
-        void main() { gl_Position = vec4(0); x = 1.0; }
-    )glsl";
-    char const *fsSource = R"glsl(
-        #version 450
-        in block { layout(location=0) highp float x; };
-        layout(location=0) out vec4 color;
-        void main() { color = vec4(x); }
-    )glsl";
-
-    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
-    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "differ in precision");
-}
-
 TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
     TEST_DESCRIPTION("Test that a warning is produced for a vertex attribute which is not consumed by the vertex shader");
 


### PR DESCRIPTION
In release 1.3.220, the spec was clarified to say that the RelaxedPrecision qualifier does not need to match across interfaces. See section 15.1.3. Interface Matching.

This commit removes that check and the two associated tests I found.