### PR TITLE
tests: Prevent bSupport variable being unused

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1069,38 +1069,36 @@ VkLayerTest::VkLayerTest() {
 
 void VkLayerTest::AddSurfaceExtension() {
     m_enableWSI = true;
-    bool bSupport = false;
+    bool bHasXlib = false;
     // Instance Extensions
     AddRequiredExtensions(VK_KHR_SURFACE_EXTENSION_NAME);
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     AddRequiredExtensions(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-    bSupport = true;
 #endif
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR) && defined(VALIDATION_APK)
     AddRequiredExtensions(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-    bSupport = true;
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-    (void)bSupport;
 #endif
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
     auto temp_dpy = XOpenDisplay(NULL);
     if (temp_dpy) {
         AddRequiredExtensions(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-        bSupport = true;
+        bHasXlib = true;
         XCloseDisplay(temp_dpy);
     }
 #endif
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-    if (!bSupport) {
+    if (!bHasXlib) {
         auto temp_xcb = xcb_connect(NULL, NULL);
         if (temp_xcb) {
             AddRequiredExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
             xcb_disconnect(temp_xcb);
         }
     }
+#else
+    (void)bHasXlib;
 #endif
 
     // Device extensions


### PR DESCRIPTION
A recent refactor in [#4253] made it so that `bSupport` is exclusively used to skip XCB initialization when Xlib is already initialized.  This local variable is not used on any other platform, and shows as the following warning-as-error since clang 13 (used in NDK r24, current stable release) when compiling for Android:

    [arm64-v8a] Compile++      : VulkanLayerValidationTests <= layer_validation_tests.cpp
    jni/../../tests/layer_validation_tests.cpp:1072:10: error: variable 'bSupport' set but not used [-Werror,-Wunused-but-set-variable]
        bool bSupport = false;
             ^
    1 error generated.

It was "addressed" for older Android compilers in the `#elif defined(VK_USE_PLATFORM_ANDROID_KHR)` case, but the warning above has its roots inside `#if defined(VK_USE_PLATFORM_ANDROID_KHR) && defined(VALIDATION_APK)`.  This block assigns `bSupport = true` but no code thereafter ever reads it since `VK_USE_PLATFORM_XCB_KHR` will always be undefined on Android.  This newer compiler is more strict and understands that initialization/assignments without ever being read count as unused-but-set too.  A similar issue should arise when `VK_USE_PLATFORM_WIN32_KHR` is exclusively defined: here `bSupport` is also assigned to `true` yet never read.


---

CC @ncesario-lunarg