### PR TITLE
tests: Hard-code GTest

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -61,7 +61,7 @@
               "-Dgtest_force_shared_crt=ON",
               "-DBUILD_SHARED_LIBS=OFF"
         ],
-        "commit": "main",
+        "commit": "v1.12.0",
         "optional": ["tests"]
     }
   ],


### PR DESCRIPTION
googletest is removing support for C++11 (and seemingly older compilers,
too). Hard-code GTest to a known working good version.