### PR TITLE
tests: Replace test_platform_thread with std::thread

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -184,21 +184,16 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFla
 }
 
 #if GTEST_IS_THREADSAFE
-extern "C" void *AddToCommandBuffer(void *arg) {
-    struct thread_data_struct *data = (struct thread_data_struct *)arg;
-
+void AddToCommandBuffer(ThreadTestData *data) {
     for (int i = 0; i < 80000; i++) {
         vk::CmdSetEvent(data->commandBuffer, data->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
         if (*data->bailout) {
             break;
         }
     }
-    return NULL;
 }
 
-extern "C" void *UpdateDescriptor(void *arg) {
-    struct thread_data_struct *data = (struct thread_data_struct *)arg;
-
+void UpdateDescriptor(ThreadTestData *data) {
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = data->buffer;
     buffer_info.offset = 0;
@@ -217,21 +212,17 @@ extern "C" void *UpdateDescriptor(void *arg) {
             break;
         }
     }
-    return NULL;
 }
 
 #endif  // GTEST_IS_THREADSAFE
 
-extern "C" void *ReleaseNullFence(void *arg) {
-    struct thread_data_struct *data = (struct thread_data_struct *)arg;
-
+void ReleaseNullFence(ThreadTestData *data) {
     for (int i = 0; i < 40000; i++) {
         vk::DestroyFence(data->device, VK_NULL_HANDLE, NULL);
         if (*data->bailout) {
             break;
         }
     }
-    return NULL;
 }
 
 void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo *create_info,

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -824,7 +824,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFla
                                                   const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData);
 
 #if GTEST_IS_THREADSAFE
-struct thread_data_struct {
+struct ThreadTestData {
     VkCommandBuffer commandBuffer;
     VkDevice device;
     VkEvent event;
@@ -834,11 +834,11 @@ struct thread_data_struct {
     bool *bailout;
 };
 
-extern "C" void *AddToCommandBuffer(void *arg);
-extern "C" void *UpdateDescriptor(void *arg);
+void AddToCommandBuffer(ThreadTestData *);
+void UpdateDescriptor(ThreadTestData *);
 #endif  // GTEST_IS_THREADSAFE
 
-extern "C" void *ReleaseNullFence(void *arg);
+void ReleaseNullFence(ThreadTestData *);
 
 void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo *create_info,
                           bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid);

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -1708,7 +1708,6 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
 }
 
 TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
-    test_platform_thread thread;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "THREADING ERROR");
 
@@ -1722,11 +1721,11 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
 
     // Call vk::DestroyFence of VK_NULL_HANDLE repeatedly using multiple threads.
     // There should be no validation error from collision of that non-object.
-    test_platform_thread_create(&thread, ReleaseNullFence, (void *)&data);
+    std::thread thread(ReleaseNullFence, (void *)&data);
     for (int i = 0; i < 40000; i++) {
         vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
     }
-    test_platform_thread_join(thread, NULL);
+    thread.join();
 
     m_errorMonitor->SetBailout(NULL);
 

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -1713,7 +1713,7 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    struct thread_data_struct data;
+    ThreadTestData data;
     data.device = m_device->device();
     bool bailout = false;
     data.bailout = &bailout;
@@ -1721,7 +1721,7 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
 
     // Call vk::DestroyFence of VK_NULL_HANDLE repeatedly using multiple threads.
     // There should be no validation error from collision of that non-object.
-    std::thread thread(ReleaseNullFence, (void *)&data);
+    std::thread thread(ReleaseNullFence, &data);
     for (int i = 0; i < 40000; i++) {
         vk::DestroyFence(m_device->device(), VK_NULL_HANDLE, NULL);
     }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,11 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
-#include <assert.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
 
 #include "vk_layer_logging.h"
 
@@ -136,83 +136,5 @@ static inline const char *vk_result_string(VkResult err) {
 static inline void test_error_callback(const char *expr, const char *file, unsigned int line, const char *function) {
     ADD_FAILURE_AT(file, line) << "Assertion: `" << expr << "'";
 }
-
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
-/* Linux-specific common code: */
-
-#include <pthread.h>
-
-// Threads:
-typedef pthread_t test_platform_thread;
-
-static inline int test_platform_thread_create(test_platform_thread *thread, void *(*func)(void *), void *data) {
-    pthread_attr_t thread_attr;
-    pthread_attr_init(&thread_attr);
-    return pthread_create(thread, &thread_attr, func, data);
-}
-static inline int test_platform_thread_join(test_platform_thread thread, void **retval) { return pthread_join(thread, retval); }
-
-// Thread IDs:
-typedef pthread_t test_platform_thread_id;
-static inline test_platform_thread_id test_platform_get_thread_id() { return pthread_self(); }
-
-// Thread mutex:
-typedef pthread_mutex_t test_platform_thread_mutex;
-static inline void test_platform_thread_create_mutex(test_platform_thread_mutex *pMutex) { pthread_mutex_init(pMutex, NULL); }
-static inline void test_platform_thread_lock_mutex(test_platform_thread_mutex *pMutex) { pthread_mutex_lock(pMutex); }
-static inline void test_platform_thread_unlock_mutex(test_platform_thread_mutex *pMutex) { pthread_mutex_unlock(pMutex); }
-static inline void test_platform_thread_delete_mutex(test_platform_thread_mutex *pMutex) { pthread_mutex_destroy(pMutex); }
-typedef pthread_cond_t test_platform_thread_cond;
-static inline void test_platform_thread_init_cond(test_platform_thread_cond *pCond) { pthread_cond_init(pCond, NULL); }
-static inline void test_platform_thread_cond_wait(test_platform_thread_cond *pCond, test_platform_thread_mutex *pMutex) {
-    pthread_cond_wait(pCond, pMutex);
-}
-static inline void test_platform_thread_cond_broadcast(test_platform_thread_cond *pCond) { pthread_cond_broadcast(pCond); }
-
-#elif defined(_WIN32)  // defined(__linux__)
-// Threads:
-typedef HANDLE test_platform_thread;
-static inline int test_platform_thread_create(test_platform_thread *thread, void *(*func)(void *), void *data) {
-    DWORD threadID;
-    *thread = CreateThread(NULL,  // default security attributes
-                           0,     // use default stack size
-                           (LPTHREAD_START_ROUTINE)func,
-                           data,        // thread function argument
-                           0,           // use default creation flags
-                           &threadID);  // returns thread identifier
-    return (*thread != NULL);
-}
-static inline int test_platform_thread_join(test_platform_thread thread, void **retval) {
-    return WaitForSingleObject(thread, INFINITE);
-}
-
-// Thread IDs:
-typedef DWORD test_platform_thread_id;
-static test_platform_thread_id test_platform_get_thread_id() { return GetCurrentThreadId(); }
-
-// Thread mutex:
-typedef CRITICAL_SECTION test_platform_thread_mutex;
-static void test_platform_thread_create_mutex(test_platform_thread_mutex *pMutex) { InitializeCriticalSection(pMutex); }
-static void test_platform_thread_lock_mutex(test_platform_thread_mutex *pMutex) { EnterCriticalSection(pMutex); }
-static void test_platform_thread_unlock_mutex(test_platform_thread_mutex *pMutex) { LeaveCriticalSection(pMutex); }
-static void test_platform_thread_delete_mutex(test_platform_thread_mutex *pMutex) { DeleteCriticalSection(pMutex); }
-typedef CONDITION_VARIABLE test_platform_thread_cond;
-static void test_platform_thread_init_cond(test_platform_thread_cond *pCond) { InitializeConditionVariable(pCond); }
-static void test_platform_thread_cond_wait(test_platform_thread_cond *pCond, test_platform_thread_mutex *pMutex) {
-    SleepConditionVariableCS(pCond, pMutex, INFINITE);
-}
-static void test_platform_thread_cond_broadcast(test_platform_thread_cond *pCond) { WakeAllConditionVariable(pCond); }
-#else                  // defined(_WIN32)
-
-#error The "test_common.h" file must be modified for this OS.
-
-// NOTE: In order to support another OS, an #elif needs to be added (above the
-// "#else // defined(_WIN32)") for that OS, and OS-specific versions of the
-// contents of this file must be created.
-
-// NOTE: Other OS-specific changes are also needed for this OS.  Search for
-// files with "WIN32" in it, as a quick way to find files that must be changed.
-
-#endif  // defined(_WIN32)
 
 #endif  // TEST_COMMON_H

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1341,7 +1341,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
     VkBufferObj buffer;
     buffer.init(*m_device, 256, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    struct thread_data_struct data;
+    ThreadTestData data;
     data.device = device();
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
@@ -1351,10 +1351,10 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    std::thread thread(UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, &data);
     // Update descriptors from this thread at the same time.
 
-    struct thread_data_struct data2;
+    ThreadTestData data2;
     data2.device = device();
     data2.descriptorSet = normal_descriptor_set.set_;
     data2.binding = 1;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1296,7 +1296,6 @@ TEST_F(VkBestPracticesLayerTest, ImageExtendedUsageWithoutMutableFormat) {
 #if GTEST_IS_THREADSAFE
 TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     TEST_DESCRIPTION("Two threads updating the same UAB descriptor set, expected not to generate a threading error");
-    test_platform_thread thread;
     m_errorMonitor->ExpectSuccess();
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -1352,7 +1351,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    test_platform_thread_create(&thread, UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, (void *)&data);
     // Update descriptors from this thread at the same time.
 
     struct thread_data_struct data2;
@@ -1364,7 +1363,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    thread.join();
 
     m_errorMonitor->SetBailout(NULL);
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3440,7 +3440,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     err = vk::ResetEvent(device(), event);
     ASSERT_VK_SUCCESS(err);
 
-    struct thread_data_struct data;
+    ThreadTestData data;
     data.commandBuffer = commandBuffer.handle();
     data.event = event;
     bool bailout = false;
@@ -3449,7 +3449,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
     // First do some correct operations using multiple threads.
     // Add many entries to command buffer from another thread.
-    std::thread thread1(AddToCommandBuffer, (void *)&data);
+    std::thread thread1(AddToCommandBuffer, &data);
     // Make non-conflicting calls from this thread at the same time.
     for (int i = 0; i < 80000; i++) {
         uint32_t count;
@@ -3459,7 +3459,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
     // Then do some incorrect operations using multiple threads.
     // Add many entries to command buffer from another thread.
-    std::thread thread2(AddToCommandBuffer, (void *)&data);
+    std::thread thread2(AddToCommandBuffer, &data);
     // Add many entries to command buffer from this thread at the same time.
     AddToCommandBuffer(&data);
 
@@ -3493,7 +3493,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
     VkBufferObj buffer;
     buffer.init(*m_device, 256, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    struct thread_data_struct data;
+    ThreadTestData data;
     data.device = device();
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
@@ -3503,10 +3503,10 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    std::thread thread(UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, &data);
     // Update descriptors from this thread at the same time.
 
-    struct thread_data_struct data2;
+    ThreadTestData data2;
     data2.device = device();
     data2.descriptorSet = normal_descriptor_set.set_;
     data2.binding = 1;
@@ -3569,7 +3569,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     VkBufferObj buffer;
     buffer.init(*m_device, 256, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    struct thread_data_struct data;
+    ThreadTestData data;
     data.device = device();
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
@@ -3579,10 +3579,10 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    std::thread thread(UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, &data);
     // Update descriptors from this thread at the same time.
 
-    struct thread_data_struct data2;
+    ThreadTestData data2;
     data2.device = device();
     data2.descriptorSet = normal_descriptor_set.set_;
     data2.binding = 1;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3413,8 +3413,6 @@ TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
 
 #if GTEST_IS_THREADSAFE
 TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
-    test_platform_thread thread;
-
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "THREADING ERROR");
     m_errorMonitor->SetAllowedFailureMsg("THREADING ERROR");  // Ignore any extra threading errors found beyond the first one
 
@@ -3451,21 +3449,21 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
     // First do some correct operations using multiple threads.
     // Add many entries to command buffer from another thread.
-    test_platform_thread_create(&thread, AddToCommandBuffer, (void *)&data);
+    std::thread thread1(AddToCommandBuffer, (void *)&data);
     // Make non-conflicting calls from this thread at the same time.
     for (int i = 0; i < 80000; i++) {
         uint32_t count;
         vk::EnumeratePhysicalDevices(instance(), &count, NULL);
     }
-    test_platform_thread_join(thread, NULL);
+    thread1.join();
 
     // Then do some incorrect operations using multiple threads.
     // Add many entries to command buffer from another thread.
-    test_platform_thread_create(&thread, AddToCommandBuffer, (void *)&data);
+    std::thread thread2(AddToCommandBuffer, (void *)&data);
     // Add many entries to command buffer from this thread at the same time.
     AddToCommandBuffer(&data);
 
-    test_platform_thread_join(thread, NULL);
+    thread2.join();
     commandBuffer.end();
 
     m_errorMonitor->SetBailout(NULL);
@@ -3477,7 +3475,6 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
 TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
     TEST_DESCRIPTION("Two threads updating the same descriptor set, expected to generate a threading error");
-    test_platform_thread thread;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "THREADING ERROR : vkUpdateDescriptorSets");
     m_errorMonitor->SetAllowedFailureMsg("THREADING ERROR");  // Ignore any extra threading errors found beyond the first one
@@ -3506,7 +3503,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    test_platform_thread_create(&thread, UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, (void *)&data);
     // Update descriptors from this thread at the same time.
 
     struct thread_data_struct data2;
@@ -3518,7 +3515,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    thread.join();
 
     m_errorMonitor->SetBailout(NULL);
 
@@ -3527,7 +3524,6 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
 
 TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     TEST_DESCRIPTION("Two threads updating the same UAB descriptor set, expected not to generate a threading error");
-    test_platform_thread thread;
     m_errorMonitor->ExpectSuccess();
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -3583,7 +3579,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     m_errorMonitor->SetBailout(data.bailout);
 
     // Update descriptors from another thread.
-    test_platform_thread_create(&thread, UpdateDescriptor, (void *)&data);
+    std::thread thread(UpdateDescriptor, (void *)&data);
     // Update descriptors from this thread at the same time.
 
     struct thread_data_struct data2;
@@ -3595,7 +3591,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
 
     UpdateDescriptor(&data2);
 
-    test_platform_thread_join(thread, NULL);
+    thread.join();
 
     m_errorMonitor->SetBailout(NULL);
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -42,14 +42,13 @@ typename C::iterator RemoveIf(C &container, F &&fn) {
 }
 
 ErrorMonitor::ErrorMonitor(Behavior behavior) : behavior_(behavior) {
-    test_platform_thread_create_mutex(&mutex_);
     MonitorReset();
     if (behavior_ == Behavior::DefaultSuccess) {
         ExpectSuccess(kErrorBit);
     }
 }
 
-ErrorMonitor::~ErrorMonitor() NOEXCEPT { test_platform_thread_delete_mutex(&mutex_); }
+ErrorMonitor::~ErrorMonitor() NOEXCEPT {}
 
 void ErrorMonitor::MonitorReset() {
     message_flags_ = 0;
@@ -63,9 +62,8 @@ void ErrorMonitor::MonitorReset() {
 }
 
 void ErrorMonitor::Reset() {
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     MonitorReset();
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const string msg) { SetDesiredFailureMsg(msgFlags, msg.c_str()); }
@@ -75,30 +73,27 @@ void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const char *cons
         VerifyNotFound();
     }
 
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     desired_message_strings_.insert(msgString);
     message_flags_ |= msgFlags;
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::SetAllowedFailureMsg(const char *const msg) {
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     allowed_message_strings_.emplace_back(msg);
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::SetUnexpectedError(const char *const msg) {
     if (NeedCheckSuccess()) {
         VerifyNotFound();
     }
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     ignore_message_strings_.emplace_back(msg);
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
     VkBool32 result = VK_FALSE;
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     if (bailout_ != nullptr) {
         *bailout_ = true;
     }
@@ -143,8 +138,6 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
             other_messages_.push_back(errorString);
         }
     }
-
-    test_platform_thread_unlock_mutex(&mutex_);
     return result;
 }
 
@@ -157,16 +150,14 @@ bool ErrorMonitor::AnyDesiredMsgFound() const { return message_found_; }
 bool ErrorMonitor::AllDesiredMsgsFound() const { return desired_message_strings_.empty(); }
 
 void ErrorMonitor::SetError(const char *const errorString) {
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     message_found_ = true;
     failure_message_strings_.insert(errorString);
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::SetBailout(bool *bailout) {
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     bailout_ = bailout;
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::DumpFailureMsgs() const {
@@ -181,33 +172,34 @@ void ErrorMonitor::DumpFailureMsgs() const {
 
 void ErrorMonitor::ExpectSuccess(VkDebugReportFlagsEXT const message_flag_mask) {
     // Match ANY message matching specified type
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     desired_message_strings_.insert("");
     message_flags_ = message_flag_mask;
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 void ErrorMonitor::VerifyFound() {
-    test_platform_thread_lock_mutex(&mutex_);
-    // Not receiving expected message(s) is a failure. /Before/ throwing, dump any other messages
-    if (!AllDesiredMsgsFound()) {
-        DumpFailureMsgs();
-        for (const auto &desired_msg : desired_message_strings_) {
-            ADD_FAILURE() << "Did not receive expected error '" << desired_msg << "'";
-        }
-    } else if (GetOtherFailureMsgs().size() > 0) {
-        // Fail test case for any unexpected errors
+    {
+        // the lock must be released before the ExpectSuccess call at the end
+        auto guard = Lock();
+        // Not receiving expected message(s) is a failure. /Before/ throwing, dump any other messages
+        if (!AllDesiredMsgsFound()) {
+            DumpFailureMsgs();
+            for (const auto &desired_msg : desired_message_strings_) {
+                ADD_FAILURE() << "Did not receive expected error '" << desired_msg << "'";
+            }
+        } else if (GetOtherFailureMsgs().size() > 0) {
+            // Fail test case for any unexpected errors
 #if defined(ANDROID)
-        // This will get unexpected errors into the adb log
-        for (auto msg : other_messages_) {
-            __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "[ UNEXPECTED_ERR ] '%s'", msg.c_str());
-        }
+            // This will get unexpected errors into the adb log
+            for (auto msg : other_messages_) {
+                __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "[ UNEXPECTED_ERR ] '%s'", msg.c_str());
+            }
 #else
-        ADD_FAILURE() << "Received unexpected error(s).";
+            ADD_FAILURE() << "Received unexpected error(s).";
 #endif
+        }
+        MonitorReset();
     }
-    MonitorReset();
-    test_platform_thread_unlock_mutex(&mutex_);
 
     if (behavior_ == Behavior::DefaultSuccess) {
         ExpectSuccess();
@@ -215,7 +207,7 @@ void ErrorMonitor::VerifyFound() {
 }
 
 void ErrorMonitor::VerifyNotFound() {
-    test_platform_thread_lock_mutex(&mutex_);
+    auto guard = Lock();
     // ExpectSuccess() configured us to match anything. Any error is a failure.
     if (AnyDesiredMsgFound()) {
         DumpFailureMsgs();
@@ -234,7 +226,6 @@ void ErrorMonitor::VerifyNotFound() {
 #endif
     }
     MonitorReset();
-    test_platform_thread_unlock_mutex(&mutex_);
 }
 
 bool ErrorMonitor::IgnoreMessage(string const &msg) const {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -154,6 +154,7 @@ class ErrorMonitor {
     bool AllDesiredMsgsFound() const;
     void DumpFailureMsgs() const;
     void MonitorReset();
+    std::unique_lock<std::mutex> Lock() const { return std::unique_lock<std::mutex>(mutex_); }
 
     VkFlags message_flags_;
     std::unordered_multiset<std::string> desired_message_strings_;
@@ -161,7 +162,7 @@ class ErrorMonitor {
     std::vector<std::string> ignore_message_strings_;
     std::vector<std::string> allowed_message_strings_;
     std::vector<std::string> other_messages_;
-    test_platform_thread_mutex mutex_;
+    mutable std::mutex mutex_;
     bool *bailout_;
     bool message_found_;
     Behavior behavior_;


### PR DESCRIPTION
Since std::thread is part of C++11 and we only support that version or higher, I don't think we need our own thread wrappers.