### PR TITLE
Add Spec Constants Shared Memory

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -617,7 +617,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderResolveQCOM(const SHADER_MODULE_STATE& module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderSubgroupSizeControl(safe_VkPipelineShaderStageCreateInfo const* pStage) const;
-    bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage) const;
+    bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, uint32_t total_shared_size) const;
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -86,6 +86,9 @@ void decoration_set::add(uint32_t decoration, uint32_t value) {
         case spv::DecorationPassthroughNV:
             flags |= passthrough_bit;
             break;
+        case spv::DecorationAliased:
+            flags |= aliased_bit;
+            break;
     }
 }
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -275,7 +275,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     SHADER_MODULE_STATE(const uint32_t *code, std::size_t count, spv_target_env env = SPV_ENV_VULKAN_1_0)
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          words(code, code + (count / sizeof(uint32_t))) {
+          words(code, code + (count / sizeof(uint32_t))),
+          static_data_(*this) {
         PreprocessShaderBinary(env);
     }
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -148,6 +148,7 @@ struct decoration_set {
         nonreadable_bit = 1 << 11,
         per_vertex_bit = 1 << 12,
         passthrough_bit = 1 << 13,
+        aliased_bit = 1 << 14,
     };
     static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2721,12 +2721,11 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
                                  string_VkShaderStageFlagBits(stage_state.stage_flag));
             }
 
+            // The new optimized SPIR-V will NOT match the original SHADER_MODULE_STATE object parsing, so a new SHADER_MODULE_STATE
+            // object is needed. This an issue due to each pipeline being able to reuse the same shader module but with different
+            // spec constant values.
             SHADER_MODULE_STATE spec_mod(specialized_spirv);
 
-            // The new optimized SPIR-V will NOT match the SHADER_MODULE_STATE object parsing, so all additional logical will need
-            // to be done without any helper functions. This an issue due to each pipeline being able to reuse the same shader
-            // module but with different spec constant values.
-            //
             // According to https://github.com/KhronosGroup/Vulkan-Docs/issues/1671 anything labeled as "static use" (such as if an
             // input is used or not) don't have to be checked post spec constants freezing since the device compiler is not
             // guaranteed to run things such as dead-code elimination. The following checks are things that don't follow under

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -298,7 +298,6 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryLimitWorkgroupMemoryExplicitLayou
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    m_errorMonitor->ExpectSuccess();
 
     // need at least SPIR-V 1.4 for SPV_KHR_workgroup_memory_explicit_layout
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
@@ -309,13 +308,11 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryLimitWorkgroupMemoryExplicitLayou
     }
 
     auto explicit_layout_features = LvlInitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
-    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&explicit_layout_features);
-    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(explicit_layout_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &explicit_layout_features));
 
     if (!explicit_layout_features.workgroupMemoryExplicitLayout) {
-        printf("%s workgroupMemoryExplicitLayout feature not supported.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "workgroupMemoryExplicitLayout feature not supported.";
     }
 
     const uint32_t max_shared_memory_size = m_device->phy().properties().limits.maxComputeSharedMemorySize;
@@ -370,7 +367,6 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryLimitWorkgroupMemoryExplicitLayou
                                    &specialization_info));
     pipe.InitState();
     pipe.CreateComputePipeline();
-    m_errorMonitor->VerifyNotFound();
 }
 
 TEST_F(VkPositiveLayerTest, ComputeSharedMemoryAtLimit) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3282 (and https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3283)

Just as we did for Spec Constants and `WorkGroupSize` this does the same for `ComputeSharedMemory`. This will apply the spec constant values and then rebuild the `def_index` and use that to get the correct size