### PR TITLE
Reveal errors

### DIFF
--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -4208,8 +4208,8 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
         }
 
         if (mutable_descriptor_type) {
-            ValidateMutableDescriptorTypeCreateInfo(*pCreateInfo, *mutable_descriptor_type,
-                                                    "vkDescriptorSetLayoutCreateInfo");
+            skip |=
+                ValidateMutableDescriptorTypeCreateInfo(*pCreateInfo, *mutable_descriptor_type, "vkDescriptorSetLayoutCreateInfo");
         }
     }
     if (pCreateInfo) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1836,7 +1836,6 @@ void CreatePipelineHelper::InitFragmentOutputLibInfo(void *p_next) {
 }
 
 void CreatePipelineHelper::InitState() {
-    VkResult err;
     descriptor_set_.reset(new OneOffDescriptorSet(layer_test_.DeviceObj(), dsl_bindings_));
     ASSERT_TRUE(descriptor_set_->Initialized());
 
@@ -1846,7 +1845,14 @@ void CreatePipelineHelper::InitState() {
     pipeline_layout_ =
         VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_}, push_ranges, pipeline_layout_ci_.flags);
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    InitPipelineCache();
+}
+
+void CreatePipelineHelper::InitPipelineCache() {
+    if (pipeline_cache_ != VK_NULL_HANDLE) {
+        vk::DestroyPipelineCache(layer_test_.device(), pipeline_cache_, nullptr);
+    }
+    VkResult err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 
@@ -1925,7 +1931,6 @@ void CreateComputePipelineHelper::InitInfo() {
 }
 
 void CreateComputePipelineHelper::InitState() {
-    VkResult err;
     descriptor_set_.reset(new OneOffDescriptorSet(layer_test_.DeviceObj(), dsl_bindings_));
     ASSERT_TRUE(descriptor_set_->Initialized());
 
@@ -1934,7 +1939,14 @@ void CreateComputePipelineHelper::InitState() {
         pipeline_layout_ci_.pPushConstantRanges + pipeline_layout_ci_.pushConstantRangeCount);
     pipeline_layout_ = VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_}, push_ranges);
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    InitPipelineCache();
+}
+
+void CreateComputePipelineHelper::InitPipelineCache() {
+    if (pipeline_cache_ != VK_NULL_HANDLE) {
+        vk::DestroyPipelineCache(layer_test_.device(), pipeline_cache_, nullptr);
+    }
+    VkResult err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 
@@ -2208,13 +2220,19 @@ void CreateNVRayTracingPipelineHelper::InitInfo(bool isKHR) {
 }
 
 void CreateNVRayTracingPipelineHelper::InitState() {
-    VkResult err;
     descriptor_set_.reset(new OneOffDescriptorSet(layer_test_.DeviceObj(), dsl_bindings_));
     ASSERT_TRUE(descriptor_set_->Initialized());
 
     pipeline_layout_ = VkPipelineLayoutObj(layer_test_.DeviceObj(), {&descriptor_set_->layout_});
 
-    err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
+    InitPipelineCache();
+}
+
+void CreateNVRayTracingPipelineHelper::InitPipelineCache() {
+    if (pipeline_cache_ != VK_NULL_HANDLE) {
+        vk::DestroyPipelineCache(layer_test_.device(), pipeline_cache_, nullptr);
+    }
+    VkResult err = vk::CreatePipelineCache(layer_test_.device(), &pc_ci_, NULL, &pipeline_cache_);
     ASSERT_VK_SUCCESS(err);
 }
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1139,6 +1139,17 @@ VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysical
     return props2;
 }
 
+bool VkLayerTest::IsDriver(VkDriverId driver_id) {
+    if (VkRenderFramework::IgnoreDisableChecks()) {
+        return false;
+    } else {
+        auto driver_properties = LvlInitStruct<VkPhysicalDeviceDriverProperties>();
+        auto physical_device_properties2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&driver_properties);
+        GetPhysicalDeviceProperties2(physical_device_properties2);
+        return (driver_properties.driverID == driver_id);
+    }
+}
+
 bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
     PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -508,6 +508,7 @@ struct CreatePipelineHelper {
     // TDB -- add control for optional and/or additional initialization
     void InitInfo();
     void InitState();
+    void InitPipelineCache();
     void LateBindPipelineInfo();
     VkResult CreateGraphicsPipeline(bool implicit_destroy = true, bool do_late_bind = true);
 
@@ -581,6 +582,7 @@ struct CreateComputePipelineHelper {
     // TDB -- add control for optional and/or additional initialization
     void InitInfo();
     void InitState();
+    void InitPipelineCache();
     void LateBindPipelineInfo();
     VkResult CreateComputePipeline(bool implicit_destroy = true, bool do_late_bind = true);
 
@@ -657,6 +659,7 @@ struct CreateNVRayTracingPipelineHelper {
     void InitPipelineCacheInfo();
     void InitInfo(bool isKHR = false);
     void InitState();
+    void InitPipelineCache();
     void LateBindPipelineInfo(bool isKHR = false);
     VkResult CreateNVRayTracingPipeline(bool implicit_destroy = true, bool do_late_bind = true);
     VkResult CreateKHRRayTracingPipeline(bool implicit_destroy = true, bool do_late_bind = true);

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -274,6 +274,8 @@ class VkLayerTest : public VkRenderFramework {
         return GetPhysicalDeviceProperties2(props2);
     }
 
+    bool IsDriver(VkDriverId driver_id);
+
   protected:
     uint32_t m_instance_api_version = 0;
     uint32_t m_target_api_version = 0;

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -1060,12 +1060,11 @@ TEST_F(VkPositiveLayerTest, DestroyQueryPoolAfterGetQueryPoolResults) {
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
 
-    VkQueryPool query_pool;
-    vk::CreateQueryPool(device(), &query_pool_create_info, nullptr, &query_pool);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
 
     m_commandBuffer->begin();
-    vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool, 0, 1);
-    vk::CmdWriteTimestamp(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
+    vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool.handle(), 0, 1);
+    vk::CmdWriteTimestamp(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool.handle(), 0);
     m_commandBuffer->end();
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
@@ -1077,10 +1076,8 @@ TEST_F(VkPositiveLayerTest, DestroyQueryPoolAfterGetQueryPoolResults) {
     uint8_t data[out_data_size];
     VkResult res;
     do {
-        res = vk::GetQueryPoolResults(m_device->device(), query_pool, 0, 1, out_data_size, &data, 4, 0);
+        res = vk::GetQueryPoolResults(m_device->device(), query_pool.handle(), 0, 1, out_data_size, &data, 4, 0);
     } while (res != VK_SUCCESS);
-
-    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, ClearRectWith2DArray) {

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -1078,6 +1078,8 @@ TEST_F(VkPositiveLayerTest, DestroyQueryPoolAfterGetQueryPoolResults) {
     do {
         res = vk::GetQueryPoolResults(m_device->device(), query_pool.handle(), 0, 1, out_data_size, &data, 4, 0);
     } while (res != VK_SUCCESS);
+
+    vk::QueueWaitIdle(m_device->m_queue);
 }
 
 TEST_F(VkPositiveLayerTest, ClearRectWith2DArray) {

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -573,4 +573,6 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingSuspendResumeDraw) {
     vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
 
     m_errorMonitor->VerifyNotFound();
+
+    vk::QueueWaitIdle(m_device->m_queue);
 }

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1763,6 +1763,8 @@ TEST_F(VkPositiveLayerTest, TestFormatCompatibility) {
     VkImage image;
     vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
     m_errorMonitor->VerifyNotFound();
+
+    vk::DestroyImage(m_device->device(), image, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, TestCreatingFramebufferFrom3DImage) {

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1820,6 +1820,9 @@ TEST_F(VkPositiveLayerTest, TestCreatingFramebufferFrom3DImage) {
     VkFramebuffer framebuffer;
     vk::CreateFramebuffer(m_device->device(), &fci, nullptr, &framebuffer);
     m_errorMonitor->VerifyNotFound();
+
+    vk::DestroyFramebuffer(m_device->handle(), framebuffer, nullptr);
+    vk::DestroyImageView(m_device->handle(), view, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, TestMappingMemoryWithMultiInstanceHeapFlag) {

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1862,6 +1862,8 @@ TEST_F(VkPositiveLayerTest, TestMappingMemoryWithMultiInstanceHeapFlag) {
     m_errorMonitor->ExpectSuccess();
     vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
     m_errorMonitor->VerifyNotFound();
+
+    vk::FreeMemory(m_device->device(), memory, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1927,7 +1927,7 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
-    vk_testing::Image image_from_swapchain(*m_device, image_create_info);
+    vk_testing::Image image_from_swapchain(*m_device, image_create_info, vk_testing::no_mem);
 
     auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
     bind_swapchain_info.swapchain = m_swapchain;
@@ -2033,8 +2033,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
-    VkImage peer_image;
-    ASSERT_VK_SUCCESS(vk::CreateImage(device(), &image_create_info, nullptr, &peer_image));
+    vk_testing::Image peer_image(*m_device, image_create_info, vk_testing::no_mem);
 
     auto bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
     std::array<uint32_t, 1> deviceIndices = {{0}};
@@ -2048,7 +2047,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     bind_swapchain_info.imageIndex = 0;
 
     auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
-    bind_info.image = peer_image;
+    bind_info.image = peer_image.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
 
@@ -2096,7 +2095,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
     copy_region.extent = {10, 10, 1};
-    vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image,
+    vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
     m_commandBuffer->end();

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1927,15 +1927,14 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
-    VkImage image_from_swapchain;
-    vk::CreateImage(device(), &image_create_info, NULL, &image_from_swapchain);
+    vk_testing::Image image_from_swapchain(*m_device, image_create_info);
 
     auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = 0;
 
     auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
-    bind_info.image = image_from_swapchain;
+    bind_info.image = image_from_swapchain.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
 
@@ -1958,12 +1957,9 @@ TEST_F(VkPositiveLayerTest, CmdCopySwapchainImage) {
     m_commandBuffer->begin();
 
     m_errorMonitor->ExpectSuccess();
-    vk::CmdCopyImage(m_commandBuffer->handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, image_from_swapchain,
+    vk::CmdCopyImage(m_commandBuffer->handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, image_from_swapchain.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyNotFound();
-
-    vk::DestroyImage(m_device->device(), image_from_swapchain, NULL);
-    DestroySwapchain();
 }
 
 TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
@@ -2436,7 +2432,6 @@ TEST_F(VkPositiveLayerTest, ImagelessLayoutTracking) {
     vk::QueuePresentKHR(m_device->m_queue, &present);
     m_errorMonitor->VerifyNotFound();
 
-    DestroySwapchain();
     vk::DestroyRenderPass(m_device->device(), renderPass, nullptr);
     vk::DestroySemaphore(m_device->device(), image_acquired, nullptr);
     vk::DestroyFramebuffer(m_device->device(), framebuffer, nullptr);

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -768,7 +768,6 @@ TEST_F(VkPositiveLayerTest, TestAcquiringSwapchainImages) {
 
     vk::DestroySemaphore(device(), submit_semaphore, nullptr);
     vk::DestroySemaphore(device(), acquire_semaphore, nullptr);
-    DestroySwapchain();
 }
 
 TEST_F(VkPositiveLayerTest, ValidateGetAccelerationStructureBuildSizes) {
@@ -895,6 +894,4 @@ TEST_F(VkPositiveLayerTest, TestSwapchainImageFenceWait) {
 
     vk::QueueWaitIdle(m_device->m_queue);
     m_errorMonitor->VerifyNotFound();
-
-    DestroySwapchain();
 }

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4582,14 +4582,15 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     image_swapchain_create_info.swapchain = m_swapchain;
 
     image_create_info.pNext = &image_swapchain_create_info;
-    std::array<vk_testing::Image, 3> images;
+    std::vector<vk_testing::Image> images(m_surface_capabilities.minImageCount);
 
+    int i = 0;
     m_errorMonitor->ExpectSuccess();
     for (auto &image : images) {
         image.init(*m_device, image_create_info);
         auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
         bind_swapchain_info.swapchain = m_swapchain;
-        bind_swapchain_info.imageIndex = 0;
+        bind_swapchain_info.imageIndex = i++;
 
         auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
         bind_info.image = image.handle();

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -2886,6 +2886,11 @@ TEST_F(VkPositiveLayerTest, SeparateDepthStencilSubresourceLayout) {
     m_commandBuffer->end();
     m_commandBuffer->QueueCommandBuffer(false);
     m_errorMonitor->VerifyNotFound();
+
+    vk::DestroyRenderPass(device(), render_pass_separate, nullptr);
+    vk::DestroyRenderPass(device(), render_pass_combined, nullptr);
+    vk::DestroyFramebuffer(device(), framebuffer_separate, nullptr);
+    vk::DestroyFramebuffer(device(), framebuffer_combined, nullptr);
 }
 
 TEST_F(VkPositiveLayerTest, SwapchainImageFormatProps) {
@@ -7171,6 +7176,10 @@ TEST_F(VkPositiveLayerTest, TestUpdateAfterBind) {
     vk::DestroyBuffer(device(), buffer2, nullptr);
     vk::DestroyBuffer(device(), buffer3, nullptr);
 
+    vk::FreeMemory(device(), memory1, nullptr);
+    vk::FreeMemory(device(), memory2, nullptr);
+    vk::FreeMemory(device(), memory3, nullptr);
+
     m_errorMonitor->VerifyNotFound();
 }
 
@@ -7304,6 +7313,9 @@ TEST_F(VkPositiveLayerTest, TestPartiallyBoundDescriptors) {
     vk::QueueWaitIdle(m_device->m_queue);
 
     vk::DestroyBuffer(device(), buffer3, nullptr);
+
+    vk::FreeMemory(device(), memory1, nullptr);
+    vk::FreeMemory(device(), memory3, nullptr);
 
     m_errorMonitor->VerifyNotFound();
 }

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -2985,7 +2985,6 @@ TEST_F(VkPositiveLayerTest, SwapchainImageFormatProps) {
     // teardown
     vk::DestroyImageView(device(), image_view, nullptr);
     vk::DestroyFramebuffer(device(), framebuffer, nullptr);
-    DestroySwapchain();
 }
 
 TEST_F(VkPositiveLayerTest, SwapchainExclusiveModeQueueFamilyPropertiesReferences) {
@@ -4583,25 +4582,21 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     image_swapchain_create_info.swapchain = m_swapchain;
 
     image_create_info.pNext = &image_swapchain_create_info;
-    std::array<VkImage, 3> images;
+    std::array<vk_testing::Image, 3> images;
 
     m_errorMonitor->ExpectSuccess();
     for (auto &image : images) {
-        vk::CreateImage(m_device->device(), &image_create_info, NULL, &image);
+        image.init(*m_device, image_create_info);
         auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
         bind_swapchain_info.swapchain = m_swapchain;
         bind_swapchain_info.imageIndex = 0;
 
         auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
-        bind_info.image = image;
+        bind_info.image = image.handle();
         bind_info.memory = VK_NULL_HANDLE;
         bind_info.memoryOffset = 0;
 
         vkBindImageMemory2KHR(m_device->device(), 1, &bind_info);
-    }
-    DestroySwapchain();
-    for (auto &image : images) {
-        vk::DestroyImage(m_device->device(), image, nullptr);
     }
     m_errorMonitor->VerifyNotFound();
 }
@@ -4772,7 +4767,6 @@ TEST_F(VkPositiveLayerTest, ProtectedSwapchainImageColorAttachment) {
     vk::CmdEndRenderPass(protectedCommandBuffer.handle());
     protectedCommandBuffer.end();
 
-    DestroySwapchain();
     m_errorMonitor->VerifyNotFound();
 }
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4587,7 +4587,7 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     int i = 0;
     m_errorMonitor->ExpectSuccess();
     for (auto &image : images) {
-        image.init(*m_device, image_create_info);
+        image.init_no_mem(*m_device, image_create_info);
         auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
         bind_swapchain_info.swapchain = m_swapchain;
         bind_swapchain_info.imageIndex = i++;

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1040,5 +1040,7 @@ TEST_F(VkPositiveLayerTest, CreateRenderPassWithViewMask) {
 
     VkRenderPass render_pass;
     vkCreateRenderPass2KHR(device(), &render_pass_ci, nullptr, &render_pass);
+
+    vk::DestroyRenderPass(device(), render_pass, nullptr);
     m_errorMonitor->VerifyNotFound();
 }

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -640,8 +640,7 @@ TEST_F(VkPositiveLayerTest, ImagelessFramebufferNonZeroBaseMip) {
     pd_imageless_fb_features.imagelessFramebuffer = VK_TRUE;
     auto pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&pd_imageless_fb_features);
     if (!InitFrameworkAndRetrieveFeatures(pd_features2)) {
-        printf("%s Failed to initialize physical device and query features\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Failed to initialize physical device and query features";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -649,8 +648,7 @@ TEST_F(VkPositiveLayerTest, ImagelessFramebufferNonZeroBaseMip) {
     }
 
     if (pd_imageless_fb_features.imagelessFramebuffer != VK_TRUE) {
-        printf("%s VkPhysicalDeviceImagelessFramebufferFeaturesKHR::imagelessFramebuffer feature not supported\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "VkPhysicalDeviceImagelessFramebufferFeaturesKHR::imagelessFramebuffer feature not supported";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -665,6 +663,7 @@ TEST_F(VkPositiveLayerTest, ImagelessFramebufferNonZeroBaseMip) {
     VkAttachmentDescription attachment_desc = {};
     attachment_desc.format = formats[0];
     attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     VkAttachmentReference attachment_ref = {};
     attachment_ref.layout = VK_IMAGE_LAYOUT_GENERAL;
@@ -703,6 +702,7 @@ TEST_F(VkPositiveLayerTest, ImagelessFramebufferNonZeroBaseMip) {
     fb_ci.pAttachments = nullptr;
     fb_ci.renderPass = rp.handle();
     vk_testing::Framebuffer fb(*m_device, fb_ci);
+    ASSERT_TRUE(fb.initialized());
 
     auto image_ci = LvlInitStruct<VkImageCreateInfo>();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -257,12 +257,10 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryLimitWorkgroupMemoryExplicitLayou
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &explicit_layout_features));
 
     if (!explicit_layout_features.workgroupMemoryExplicitLayout) {
-        printf("%s workgroupMemoryExplicitLayout feature not supported.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "workgroupMemoryExplicitLayout feature not supported.";
     }
 
     const uint32_t max_shared_memory_size = m_device->phy().properties().limits.maxComputeSharedMemorySize;
-    const uint32_t max_shared_ints = max_shared_memory_size / 4;
     const uint32_t max_shared_vec4 = max_shared_memory_size / 16;
 
     std::stringstream csSource;
@@ -273,21 +271,13 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryLimitWorkgroupMemoryExplicitLayou
         // Both structs by themselves are 16 bytes less than the max
         shared X {
             vec4 x1[)glsl";
-    csSource << (max_shared_vec4 - 16);
+    csSource << (max_shared_vec4 - 1);
     csSource << R"glsl(];
             vec4 x2;
         };
 
-        shared Y {
-            int y1[)glsl";
-    csSource << (max_shared_ints - 4);
-    csSource << R"glsl(];
-            int y2;
-        };
-
         void main() {
             x2.x = 0.0f; // prevent dead-code elimination
-            y2 = 0;
         }
     )glsl";
 
@@ -2132,11 +2122,11 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputStructComponents) {
 TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
     TEST_DESCRIPTION("Test task and mesh shader");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -2149,8 +2139,7 @@ TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mesh_shader_features);
     vkGetPhysicalDeviceFeatures2(gpu(), &features2);
     if (!mesh_shader_features.meshShader || !mesh_shader_features.taskShader) {
-        printf("%s Test requires (unsupported) meshShader and taskShader features, skipping test.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Test requires (unsupported) meshShader and taskShader features, skipping test.";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2164,11 +2153,8 @@ TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
     if ((vulkan11_props.subgroupSupportedStages & VK_SHADER_STAGE_TASK_BIT_NV) == 0) {
-        printf(
-            "%s VkPhysicalDeviceVulkan11Properties::subgroupSupportedStages does not include VK_SHADER_STAGE_TASK_BIT_NV, skipping "
-            "test.\n",
-            kSkipPrefix);
-        return;
+        GTEST_SKIP() << "%s VkPhysicalDeviceVulkan11Properties::subgroupSupportedStages does not include "
+                        "VK_SHADER_STAGE_TASK_BIT_NV, skipping test.";
     }
 
     static const char taskShaderText[] = R"glsl(

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1168,10 +1168,12 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
         }
     )glsl";
 
-    std::string cs_image_store = cs_image_base + R"glsl(
-           imageAtomicStore(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
-        }
-    )glsl";
+    // Broken, fixed by :
+    // https://github.com/KhronosGroup/glslang/issues/2975
+    // std::string cs_image_store = cs_image_base + R"glsl(
+    //        imageAtomicStore(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
+    //     }
+    // )glsl";
 
     std::string cs_image_exchange = cs_image_base + R"glsl(
            imageAtomicExchange(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
@@ -1196,8 +1198,8 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
     current_shader = cs_image_load.c_str();
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
 
-    current_shader = cs_image_store.c_str();
-    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
+    // current_shader = cs_image_store.c_str();
+    // CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
 
     current_shader = cs_image_exchange.c_str();
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2515,11 +2515,8 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
 
     // require to make enable logic simpler
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -2527,7 +2524,7 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
 
     auto float16int8_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&float16int8_features);
-    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(features2);
     if (float16int8_features.shaderInt8 == VK_FALSE) {
         printf("%s shaderInt8 feature not supported; skipped.\n", kSkipPrefix);
         return;

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -568,7 +568,6 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
     err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
     ASSERT_VK_SUCCESS(err)
-    DestroySwapchain();
 }
 
 TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -955,7 +955,6 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
     ASSERT_VK_SUCCESS(err)
-    DestroySwapchain();
 }
 
 TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
@@ -1031,8 +1030,6 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     m_errorMonitor->ExpectSuccess(kWarningBit);
     err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
-
-    DestroySwapchain();
 }
 
 TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -13548,6 +13548,8 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBinding) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkDescriptorSetLayoutCreateInfo-descriptorType-04594");
     vk::CreateDescriptorSetLayout(m_device->handle(), &create_info, nullptr, &setLayout);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroySampler(m_device->handle(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, DedicatedAllocationBufferWithInvalidFlags) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -9962,8 +9962,6 @@ TEST_F(VkLayerTest, IllegalAddressModeWithCornerSampledNV) {
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-
-    vk::DestroySampler(m_device->device(), sampler.handle(), nullptr);
 }
 
 TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -12807,7 +12807,6 @@ TEST_F(VkLayerTest, CreateImageViewIncompatibleFormat) {
     imgViewInfo.format = imageInfo.format;
     CreateImageViewTest(*this, &imgViewInfo, {});
 
-    imageInfo.flags |= VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
     VkImageObj mut_compat_image(m_device);
     mut_compat_image.init(&imageInfo);
     ASSERT_TRUE(mut_compat_image.initialized());

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -10088,8 +10088,7 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
                                        });
 
     if (!descriptor_set.set_) {
-        printf("%s Failed to allocate descriptor set, skipping test.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Failed to allocate descriptor set, skipping test.";
     }
 
     // Use the same image view twice, using the same sampler, with the *second* mismatched with the *second* immutable sampler

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -12587,16 +12587,15 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesCombinedSampler) {
     VkImageView view_fail = image_3d.targetView(format, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
                                                 VK_REMAINING_ARRAY_LAYERS, VK_IMAGE_VIEW_TYPE_3D);
 
-    VkSampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
     sampler_ci.maxLod = 0;
-    ASSERT_VK_SUCCESS(vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler));
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_fail, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, view_pass, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_fail, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, view_pass, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 2);
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, view_pass, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, view_pass, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 2);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
@@ -12702,17 +12701,15 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSampler) {
 
     // Need 2 samplers (and ImageView) because testing both VUID and it will tie both errors to the same sampler/imageView, but only
     // 02703 will be triggered since it's first in the validation code
-    VkSampler sampler_a;
-    VkSampler sampler_b;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
     sampler_ci.maxLod = 0;
-    ASSERT_VK_SUCCESS(vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler_a));
-    ASSERT_VK_SUCCESS(vk::CreateSampler(m_device->device(), &sampler_ci, nullptr, &sampler_b));
+    vk_testing::Sampler sampler_a(*m_device, sampler_ci);
+    vk_testing::Sampler sampler_b(*m_device, sampler_ci);
 
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler_a, VK_DESCRIPTOR_TYPE_SAMPLER,
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler_a.handle(), VK_DESCRIPTOR_TYPE_SAMPLER,
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 1);
-    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler_b, VK_DESCRIPTOR_TYPE_SAMPLER,
+    g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler_b.handle(), VK_DESCRIPTOR_TYPE_SAMPLER,
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0, 1);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, view_pass_a, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(3, view_pass_b, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -8205,6 +8205,12 @@ TEST_F(VkLayerTest, DrawWithoutUpdatePushConstants) {
                          68, dummy_values);
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyNotFound();
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+
+    vk::DestroyPipelineLayout(m_device->handle(), pipeline_layout, nullptr);
+    vk::DestroyPipelineLayout(m_device->handle(), pipeline_layout_small, nullptr);
 }
 
 TEST_F(VkLayerTest, VerifyVertextBinding) {

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7191,7 +7191,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 4;
-        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
         VkBufferObj const buffer_obj(*m_device, info);
 
         VkDeviceSize const offsets[1]{};
@@ -7301,7 +7301,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
         info.size = 4;
-        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+        m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
         VkBufferObj const buffer_obj(*m_device, info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-pCounterBuffers-02372");
@@ -7415,7 +7415,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
                 auto info = LvlInitStruct<VkBufferCreateInfo>();
                 // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
                 info.size = 4;
-                m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-parameter");
+                m_errorMonitor->SetUnexpectedError("VUID-VkBufferCreateInfo-usage-requiredbitmask");
                 VkBufferObj const buffer_obj(*m_device, info);
 
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndTransformFeedbackEXT-pCounterBuffers-02380");

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4423,6 +4423,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
     m_errorMonitor->VerifyFound();
 
     vk::DestroyImageView(m_device->device(), image_view, NULL);
+    vkDestroySamplerYcbcrConversionFunction(m_device->device(), conversion, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -9410,12 +9410,12 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
     if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
         GTEST_SKIP() << "This test is crashing on some AMD + Windows platforms without any validation errors getting hit; requires "
                         "investigation.";
-    }
-    if (!AreRequiredExtensionsEnabled()) {
-        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10289,8 +10289,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
-    VkDescriptorPool pool;
-    vk::CreateDescriptorPool(m_device->device(), &ds_pool_ci, NULL, &pool);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding dsl_binding_samp = {};
     dsl_binding_samp.binding = 0;
@@ -10306,7 +10305,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
 
     VkDescriptorSetAllocateInfo alloc_info = LvlInitStruct<VkDescriptorSetAllocateInfo>();
     alloc_info.descriptorSetCount = 1;
-    alloc_info.descriptorPool = pool;
+    alloc_info.descriptorPool = pool.handle();
     alloc_info.pSetLayouts = &set_layout;
 
     VkDescriptorSet descriptor_set;
@@ -10939,17 +10938,16 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     TEST_DESCRIPTION("Test mutable descriptors");
 
     AddRequiredExtensions(VK_VALVE_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
-    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
         printf("%s mutableDescriptorType feature is not supported, skipping test.\n", kSkipPrefix);
         return;
@@ -10989,30 +10987,42 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
+
     mutable_descriptor_type_list.descriptorTypeCount = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04598");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04600");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
+
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04601");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04602");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
+
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04603");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, DescriptorUpdateTemplate) {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -6237,7 +6237,8 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         bci.usage = test_case.buffer_usage;
         bci.size = test_case.max_range + test_case.min_align;  // Make buffer bigger than range limit
         bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        vk_testing::Buffer buffer(*m_device, bci);
+        vk_testing::Buffer buffer;
+        buffer.init_no_mem(*m_device, bci);
         if (buffer.handle() == VK_NULL_HANDLE) {
             printf("%s Failed to allocate buffer in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
             continue;
@@ -6252,14 +6253,12 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
         if (!pass) {
             printf("%s Failed to allocate memory in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
-            vk::DestroyBuffer(m_device->device(), buffer.handle(), NULL);
             continue;
         }
 
         vk_testing::DeviceMemory mem(*m_device, mem_alloc);
         if (mem.handle() == VK_NULL_HANDLE) {
             printf("%s Failed to allocate memory in DSBufferLimitErrors; skipped.\n", kSkipPrefix);
-            vk::DestroyBuffer(m_device->device(), buffer.handle(), NULL);
             continue;
         }
         VkResult err = vk::BindBufferMemory(m_device->device(), buffer.handle(), mem.handle(), 0);

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -9412,6 +9412,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
@@ -10085,9 +10086,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMasks) {
     TEST_DESCRIPTION("Create a render pass with some view masks 0 and some not 0");
 
     // Check for VK_KHR_get_physical_device_properties2
-    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    }
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     bool rp2Supported = CheckCreateRenderPass2Support(this, m_device_extension_names);
@@ -10105,7 +10104,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMasks) {
 
     auto render_pass_multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&render_pass_multiview_props);
-    vk::GetPhysicalDeviceProperties2(gpu(), &prop2);
+    GetPhysicalDeviceProperties2(prop2);
     if (render_pass_multiview_props.maxMultiviewViewCount < 2) {
         printf("%s maxMultiviewViewCount lower than required, skipping test.\n", kSkipPrefix);
         return;
@@ -10657,7 +10656,7 @@ TEST_F(VkLayerTest, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) {
 
     auto inlineUniformProps = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&inlineUniformProps);
-    vk::GetPhysicalDeviceProperties2(gpu(), &prop2);
+    GetPhysicalDeviceProperties2(prop2);
 
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT extEnable = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>();
     extEnable.inlineUniformBlock = VK_TRUE;
@@ -11954,7 +11953,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewOffsets) {
 
     auto render_pass_multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&render_pass_multiview_props);
-    vk::GetPhysicalDeviceProperties2(gpu(), &prop2);
+    GetPhysicalDeviceProperties2(prop2);
     if (render_pass_multiview_props.maxMultiviewViewCount < 2) {
         printf("%s maxMultiviewViewCount lower than required, skipping test.\n", kSkipPrefix);
         return;

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10395,14 +10395,11 @@ TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
-    }
-
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -10431,26 +10428,26 @@ TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &swapchain);
 
     VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    VkSemaphore semaphore;
-    ASSERT_VK_SUCCESS(vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &semaphore));
+    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    ASSERT_TRUE(semaphore.initialized());
 
     VkAcquireNextImageInfoKHR acquire_info = LvlInitStruct<VkAcquireNextImageInfoKHR>();
     acquire_info.swapchain = m_swapchain;
     acquire_info.timeout = std::numeric_limits<uint64_t>::max();
-    acquire_info.semaphore = semaphore;
+    acquire_info.semaphore = semaphore.handle();
     acquire_info.fence = VK_NULL_HANDLE;
     acquire_info.deviceMask = 0x1;
 
     uint32_t dummy;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireNextImageKHR-swapchain-01285");
-    vk::AcquireNextImageKHR(device(), m_swapchain, std::numeric_limits<uint64_t>::max(), semaphore, VK_NULL_HANDLE, &dummy);
+    vk::AcquireNextImageKHR(device(), m_swapchain, std::numeric_limits<uint64_t>::max(), semaphore.handle(), VK_NULL_HANDLE,
+                            &dummy);
     m_errorMonitor->VerifyFound();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAcquireNextImageInfoKHR-swapchain-01675");
     vk::AcquireNextImage2KHR(device(), &acquire_info, &dummy);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroySwapchainKHR(device(), swapchain, nullptr);
-    DestroySwapchain();
+    vk::DestroySwapchainKHR(m_device->device(), swapchain, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidDeviceGroupRenderArea) {
@@ -10511,7 +10508,7 @@ TEST_F(VkLayerTest, RenderPassBeginNullValues) {
     TEST_DESCRIPTION("Test invalid null entries for clear color");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     auto rpbi = m_renderPassBeginInfo;
@@ -10760,27 +10757,23 @@ TEST_F(VkLayerTest, AccelerationStructureBindings) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-
     auto acc_structure_props = LvlInitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
-    auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&acc_structure_props);
-    vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
+    GetPhysicalDeviceProperties2(acc_structure_props);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     uint32_t maxBlocks = acc_structure_props.maxPerStageDescriptorUpdateAfterBindAccelerationStructures;
     if (maxBlocks > 4096) {
-        printf(
-            "Too large of a maximum number of per stage descriptor update after bind for acceleration structures, skipping "
-            "tests\n");
-        return;
+        GTEST_SKIP() << "Too large of a maximum number of per stage descriptor update after bind for acceleration structures, "
+                        "skipping tests";
+    }
+    if (maxBlocks < 1) {
+        GTEST_SKIP() << "Test requires maxPerStageDescriptorUpdateAfterBindAccelerationStructures >= 1";
     }
 
     std::vector<VkDescriptorSetLayoutBinding> dslb_vec = {};
@@ -10798,17 +10791,15 @@ TEST_F(VkLayerTest, AccelerationStructureBindings) {
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
 
-    vk_testing::DescriptorSetLayout ds_layout;
-    VkDescriptorSetLayout dsl_handle = ds_layout.handle();
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &dsl_handle);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
+    ASSERT_TRUE(ds_layout.initialized());
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     pipeline_layout_ci.setLayoutCount = 1;
-    pipeline_layout_ci.pSetLayouts = &dsl_handle;
+    pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
 
-    VkPipelineLayout pipeline_layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-03572");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
+    vk_testing::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
     m_errorMonitor->VerifyFound();
 }
 
@@ -10816,26 +10807,23 @@ TEST_F(VkLayerTest, AccelerationStructureBindingsNV) {
     TEST_DESCRIPTION("Use more bindings with a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV than allowed");
 
     AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-
     auto ray_tracing_props = LvlInitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
-    auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_props);
-    vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
+    GetPhysicalDeviceProperties2(ray_tracing_props);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     uint32_t maxBlocks = ray_tracing_props.maxDescriptorSetAccelerationStructures;
     if (maxBlocks > 4096) {
-        printf("Too large of a maximum number of descriptor set acceleration structures, skipping tests\n");
-        return;
+        GTEST_SKIP() << "Too large of a maximum number of descriptor set acceleration structures, skipping tests";
+    }
+    if (maxBlocks < 1) {
+        GTEST_SKIP() << "Test requires maxDescriptorSetAccelerationStructures >= 1";
     }
 
     std::vector<VkDescriptorSetLayoutBinding> dslb_vec = {};
@@ -10853,17 +10841,15 @@ TEST_F(VkLayerTest, AccelerationStructureBindingsNV) {
     ds_layout_ci.bindingCount = dslb_vec.size();
     ds_layout_ci.pBindings = dslb_vec.data();
 
-    vk_testing::DescriptorSetLayout ds_layout;
-    VkDescriptorSetLayout dsl_handle = ds_layout.handle();
-    vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, nullptr, &dsl_handle);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
+    ASSERT_TRUE(ds_layout.initialized());
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     pipeline_layout_ci.setLayoutCount = 1;
-    pipeline_layout_ci.pSetLayouts = &dsl_handle;
+    pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
 
-    VkPipelineLayout pipeline_layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02381");
-    vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_ci, nullptr, &pipeline_layout);
+    vk_testing::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10980,50 +10980,36 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
-
     mutable_descriptor_type_list.descriptorTypeCount = 0;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-descriptorTypeCount-04597");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
-
     mutable_descriptor_type_list.descriptorTypeCount = 2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04598");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
-
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04600");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
-
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04601");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
-
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04602");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
-
     descriptor_types[1] = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-pDescriptorTypes-04603");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
-
-    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 }
 
 TEST_F(VkLayerTest, DescriptorUpdateTemplate) {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10949,8 +10949,7 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
     GetPhysicalDeviceFeatures2(features2);
     if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        printf("%s mutableDescriptorType feature is not supported, skipping test.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "mutableDescriptorType feature is not supported, skipping test";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -10980,6 +10979,8 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMutableDescriptorTypeListVALVE-descriptorTypeCount-04599");
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyDescriptorSetLayout(m_device->device(), ds_layout, nullptr);
 
     mutable_descriptor_type_list.descriptorTypeCount = 0;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_MUTABLE_VALVE;

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -12405,16 +12405,16 @@ TEST_F(VkLayerTest, TestAllocatingVariableDescriptorSets) {
     TEST_DESCRIPTION("Test allocating large variable descriptor sets");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&indexing_features);
-    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(features2);
     if (indexing_features.descriptorBindingVariableDescriptorCount == VK_FALSE) {
-        printf("%s descriptorBindingVariableDescriptorCount feature not supported, skipping test.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "descriptorBindingVariableDescriptorCount feature not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -9338,25 +9338,20 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
-    vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    GetPhysicalDeviceProperties2(properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
-    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(features2);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
         GTEST_SKIP() << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate not supported.";
@@ -9423,24 +9418,18 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
-    vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    GetPhysicalDeviceProperties2(properties2);
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
     auto multiview_features = LvlInitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
     if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         fsr_features.pNext = &multiview_features;
     }
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&fsr_features);
-    vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+    GetPhysicalDeviceFeatures2(features2);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
         GTEST_SKIP() << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate not supported.";

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -178,13 +178,11 @@ TEST_F(VkLayerTest, DynamicRenderingCommandDraw) {
                                    VK_COMPONENT_SWIZZLE_IDENTITY},
                                   {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1}};
 
-    VkImageView depth_image_view;
-    err = vk::CreateImageView(m_device->device(), &ivci, nullptr, &depth_image_view);
-    ASSERT_VK_SUCCESS(err);
+    vk_testing::ImageView depth_image_view(*m_device, ivci);
 
     VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-    depth_attachment.imageView = depth_image_view;
+    depth_attachment.imageView = depth_image_view.handle();
 
     VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
     begin_rendering_info.pDepthAttachment = &depth_attachment;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -11274,6 +11274,8 @@ TEST_F(VkLayerTest, WaitEventsDifferentQueues) {
                       nullptr, 0, nullptr, 1, &image_memory_barrier);
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
+
+    vk::DestroyEvent(m_device->handle(), event, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidColorWriteEnableFeature) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4467,8 +4467,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -4627,10 +4626,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
         m_errorMonitor->VerifyFound();
         reset_mem();
     } else {
+        AHardwareBuffer_release(ahb);
+        reset_mem();
+        reset_img();
         // ERROR: AHardwareBuffer_allocate() with MIPMAP_COMPLETE fails. It returns -12, NO_MEMORY.
         // The problem seems to happen in Pixel 2, not Pixel 3.
-        printf("%s AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE not supported, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE not supported";
     }
 
     // Dedicated allocation with mis-matched dimension
@@ -11578,6 +11579,7 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
     TEST_DESCRIPTION("Test CmdSetDiscardRectangleEXT with invalid offsets in pDiscardRectangles");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -11589,14 +11591,13 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
 
     auto phys_dev_props_2 = LvlInitStruct<VkPhysicalDeviceProperties2>();
     phys_dev_props_2.pNext = &discard_rectangle_properties;
-    vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+    GetPhysicalDeviceProperties2(phys_dev_props_2);
 
     auto fpCmdSetDiscardRectangleEXT =
         (PFN_vkCmdSetDiscardRectangleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetDiscardRectangleEXT");
 
     if (discard_rectangle_properties.maxDiscardRectangles == 0) {
-        printf("%s Discard rectangles are not supported, skipping test\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Discard rectangles are not supported";
     }
 
     VkRect2D discard_rectangles = {};

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1301,10 +1301,12 @@ TEST_F(VkLayerTest, SubmitSignaledFence) {
 TEST_F(VkLayerTest, LeakAnObject) {
     TEST_DESCRIPTION("Create a fence and destroy its device without first destroying the fence.");
 
+    GTEST_SKIP() << "This test always fails, fix needed";
+
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!IsPlatform(kMockICD)) {
         // This test leaks a fence (on purpose) and should not be run on a real driver
-        // GTEST_SKIP() << "This test only runs on the mock ICD";
+        GTEST_SKIP() << "This test only runs on the mock ICD";
     }
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -11954,6 +11954,9 @@ TEST_F(VkLayerTest, DestroyActiveQueryPool) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyQueryPool-queryPool-00793");
     vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
     m_errorMonitor->VerifyFound();
+
+    vk::QueueWaitIdle(m_device->m_queue);
+    vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
 TEST_F(VkLayerTest, ValidateExternalMemoryImageLayout) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5170,11 +5170,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     ahb_desc.stride = 1;
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
-    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
-    pfn_GetAHBProps(dev, ahb, &ahb_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
 
     VkExternalMemoryBufferCreateInfo ext_buf_info = LvlInitStruct<VkExternalMemoryBufferCreateInfo>();
     ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1304,7 +1304,7 @@ TEST_F(VkLayerTest, LeakAnObject) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!IsPlatform(kMockICD)) {
         // This test leaks a fence (on purpose) and should not be run on a real driver
-        GTEST_SKIP() << "This test only runs on the mock ICD";
+        // GTEST_SKIP() << "This test only runs on the mock ICD";
     }
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
@@ -1332,9 +1332,6 @@ TEST_F(VkLayerTest, LeakAnObject) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyDevice-device-00378");
     vk::DestroyDevice(leaky_device, nullptr);
     m_errorMonitor->VerifyFound();
-
-    vk::DestroyFence(leaky_device, leaked_fence, nullptr);
-    vk::DestroyDevice(leaky_device, nullptr);
 }
 
 TEST_F(VkLayerTest, UseObjectWithWrongDevice) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1301,8 +1301,6 @@ TEST_F(VkLayerTest, SubmitSignaledFence) {
 TEST_F(VkLayerTest, LeakAnObject) {
     TEST_DESCRIPTION("Create a fence and destroy its device without first destroying the fence.");
 
-    GTEST_SKIP() << "This test always fails, fix needed";
-
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!IsPlatform(kMockICD)) {
         // This test leaks a fence (on purpose) and should not be run on a real driver
@@ -1334,6 +1332,11 @@ TEST_F(VkLayerTest, LeakAnObject) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyDevice-device-00378");
     vk::DestroyDevice(leaky_device, nullptr);
     m_errorMonitor->VerifyFound();
+
+    // There's no way we can destroy the fence at this point. Even though DestroyDevice failed, the loader has already removed
+    // references to the device
+    m_errorMonitor->SetUnexpectedError("VUID-vkDestroyDevice-device-00378");
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-ObjectTracker-ObjectLeak");
 }
 
 TEST_F(VkLayerTest, UseObjectWithWrongDevice) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1332,6 +1332,9 @@ TEST_F(VkLayerTest, LeakAnObject) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyDevice-device-00378");
     vk::DestroyDevice(leaky_device, nullptr);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyFence(leaky_device, leaked_fence, nullptr);
+    vk::DestroyDevice(leaky_device, nullptr);
 }
 
 TEST_F(VkLayerTest, UseObjectWithWrongDevice) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2203,6 +2203,7 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
     m_errorMonitor->ExpectSuccess();
     vk::CreateBuffer(second_device, &buffCI, NULL, &buffer);
     m_errorMonitor->VerifyNotFound();
+    vk::DestroyBuffer(second_device, buffer, nullptr);
     vk::DestroyDevice(second_device, nullptr);
 }
 
@@ -7274,6 +7275,7 @@ TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
 
             m_errorMonitor->VerifyNotFound();
 
+            ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
             vk::DestroySemaphore(m_device->device(), binary_sem, nullptr);
             vk::DestroySemaphore(m_device->device(), timeline_sem, nullptr);
         }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5184,7 +5184,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     buffer_create_info.size = ahb_props.allocationSize;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
-    vk_testing::Buffer buffer(*m_device, buffer_create_info);
+    vk_testing::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_create_info);
 
     // Try to get memory requirements prior to binding memory
     VkMemoryRequirements mem_reqs;
@@ -5194,7 +5195,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     import_ahb_Info.buffer = ahb;
 
     VkMemoryAllocateInfo memory_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
-    memory_info.allocationSize = ahb_props.allocationSize;  // save room for offset
+    memory_info.allocationSize = ahb_props.allocationSize;
     bool has_memtype = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
         AHardwareBuffer_release(ahb);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -11838,17 +11838,24 @@ TEST_F(VkLayerTest, QueryPoolResultStatusOnly) {
 TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     TEST_DESCRIPTION("Test CmdCopyQueryPoolResults with unsupported query type");
 
+    m_errorMonitor->ExpectSuccess();
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(bda_features);
-    if (!bda_features.bufferDeviceAddress) {
-        GTEST_SKIP() << "bufferDeviceAddress not enabled.";
+
+    auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&as_features);
+    vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+
+    if (as_features.accelerationStructure == VK_FALSE) {
+        printf("%s accelerationStructure feature is not supported.\n", kSkipPrefix);
+        return;
     }
+
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     auto vkCmdCopyAccelerationStructureKHR = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(
@@ -11871,15 +11878,10 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
 
     VkBufferDeviceAddressInfo device_address_info = LvlInitStruct<VkBufferDeviceAddressInfo>();
     device_address_info.buffer = buffer_no_mem.handle();
-    VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
-    if (device_address == 0) {
-        GTEST_SKIP() << "Failed to get device address, skipping test.";
-    }
 
     auto as_create_info = LvlInitStruct<VkAccelerationStructureCreateInfoKHR>();
     as_create_info.buffer = buffer_no_mem.handle();
     as_create_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
-    as_create_info.deviceAddress = device_address;
 
     vk_testing::AccelerationStructureKHR invalid_as(*m_device, as_create_info);
 
@@ -11893,6 +11895,8 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
 
     m_commandBuffer->begin();
+
+    m_errorMonitor->VerifyNotFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyAccelerationStructureKHR-buffer-03737");

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -11842,7 +11842,14 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE3_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -11872,16 +11879,12 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     VkBufferObj buffer;
     buffer.init(*m_device, buffer_ci);
 
-    VkBufferDeviceAddressInfo device_address_info = LvlInitStruct<VkBufferDeviceAddressInfo>();
-    device_address_info.buffer = buffer_no_mem.handle();
-
     auto as_create_info = LvlInitStruct<VkAccelerationStructureCreateInfoKHR>();
     as_create_info.buffer = buffer_no_mem.handle();
     as_create_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
 
     vk_testing::AccelerationStructureKHR invalid_as(*m_device, as_create_info);
 
-    device_address_info.buffer = buffer.handle();
     as_create_info.buffer = buffer.handle();
     vk_testing::AccelerationStructureKHR valid_as(*m_device, as_create_info);
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2536,47 +2536,47 @@ TEST_F(VkLayerTest, StageMaskHost) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkEvent event;
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-    vk::CreateEvent(m_device->device(), &event_create_info, nullptr, &event);
+    vk_testing::Event event(*m_device, event_create_info);
+    ASSERT_TRUE(event.initialized());
 
     m_commandBuffer->begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetEvent-stageMask-01149");
-    vk::CmdSetEvent(m_commandBuffer->handle(), event, VK_PIPELINE_STAGE_HOST_BIT);
+    vk::CmdSetEvent(m_commandBuffer->handle(), event.handle(), VK_PIPELINE_STAGE_HOST_BIT);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResetEvent-stageMask-01153");
-    vk::CmdResetEvent(m_commandBuffer->handle(), event, VK_PIPELINE_STAGE_HOST_BIT);
+    vk::CmdResetEvent(m_commandBuffer->handle(), event.handle(), VK_PIPELINE_STAGE_HOST_BIT);
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->end();
 
     VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    VkSemaphore semaphore;
-    ASSERT_VK_SUCCESS(vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &semaphore));
+    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    ASSERT_TRUE(semaphore.initialized());
 
     VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_HOST_BIT;
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
 
     // Signal the semaphore so the next test can wait on it.
     submit_info.signalSemaphoreCount = 1;
-    submit_info.pSignalSemaphores = &semaphore;
+    submit_info.pSignalSemaphores = &semaphore.handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyNotFound();
 
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores = nullptr;
     submit_info.waitSemaphoreCount = 1;
-    submit_info.pWaitSemaphores = &semaphore;
+    submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &stage_flags;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubmitInfo-pWaitDstStageMask-00078");
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyEvent(m_device->device(), event, nullptr);
-    vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
+    // Need to ensure semaphore is not in use before the test ends and it gets destroyed
+    vk::QueueWaitIdle(m_device->m_queue);
 }
 
 TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
@@ -11185,6 +11185,9 @@ TEST_F(VkLayerTest, QueueSubmitWaitingSameSemaphore) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit-pWaitSemaphores-00068");
     vk::QueueSubmit(other, 1, &waitSubmitInfo, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
+
+    // Need to ensure semaphores are not in use before destroying them
+    vk::QueueWaitIdle(m_device->m_queue);
 }
 
 TEST_F(VkLayerTest, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
@@ -11713,17 +11716,17 @@ TEST_F(VkLayerTest, ValidateBeginQueryQueryPoolType) {
     if (khr_acceleration_structure) {
         {
             query_pool_ci.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
-            VkQueryPool query_pool;
-            vk::CreateQueryPool(device(), &query_pool_ci, nullptr, &query_pool);
+            vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
+            ASSERT_TRUE(query_pool.initialized());
 
             m_commandBuffer->begin();
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-04728");
-            vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool, 0, 0);
+            vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
             m_errorMonitor->VerifyFound();
 
             if (ext_transform_feedback) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQueryIndexedEXT-queryType-04728");
-                vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool, 0, 0, 0);
+                vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool.handle(), 0, 0, 0);
                 m_errorMonitor->VerifyFound();
             }
             m_commandBuffer->end();
@@ -11731,17 +11734,17 @@ TEST_F(VkLayerTest, ValidateBeginQueryQueryPoolType) {
 
         {
             query_pool_ci.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
-            VkQueryPool query_pool;
-            vk::CreateQueryPool(device(), &query_pool_ci, nullptr, &query_pool);
+            vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
+            ASSERT_TRUE(query_pool.initialized());
 
             m_commandBuffer->begin();
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-04728");
-            vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool, 0, 0);
+            vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
             m_errorMonitor->VerifyFound();
 
             if (ext_transform_feedback) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQueryIndexedEXT-queryType-04728");
-                vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool, 0, 0, 0);
+                vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool.handle(), 0, 0, 0);
                 m_errorMonitor->VerifyFound();
             }
             m_commandBuffer->end();
@@ -11749,17 +11752,17 @@ TEST_F(VkLayerTest, ValidateBeginQueryQueryPoolType) {
     }
     if (nv_ray_tracing) {
         query_pool_ci.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV;
-        VkQueryPool query_pool;
-        vk::CreateQueryPool(device(), &query_pool_ci, nullptr, &query_pool);
+        vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
+        ASSERT_TRUE(query_pool.initialized());
 
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-04729");
-        vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool, 0, 0);
+        vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
 
         if (ext_transform_feedback) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQueryIndexedEXT-queryType-04729");
-            vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool, 0, 0, 0);
+            vkCmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool.handle(), 0, 0, 0);
             m_errorMonitor->VerifyFound();
         }
         m_commandBuffer->end();
@@ -11833,11 +11836,16 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    ASSERT_NO_FATAL_FAILURE(InitState());
+    auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    auto features2 = GetPhysicalDeviceFeatures2(bda_features);
+    if (!bda_features.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not enabled.";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     auto vkCmdCopyAccelerationStructureKHR = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(
         vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureKHR"));
@@ -11852,6 +11860,7 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     VkBufferObj buffer_no_mem;
     buffer_no_mem.init_no_mem(*m_device, buffer_ci);
+    ASSERT_TRUE(buffer_no_mem.initialized());
 
     VkBufferObj buffer;
     buffer.init(*m_device, buffer_ci);
@@ -11860,8 +11869,7 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
     device_address_info.buffer = buffer_no_mem.handle();
     VkDeviceAddress device_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &device_address_info);
     if (device_address == 0) {
-        printf("%s Failed to get device address, skipping test.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Failed to get device address, skipping test.";
     }
 
     auto as_create_info = LvlInitStruct<VkAccelerationStructureCreateInfoKHR>();
@@ -13131,6 +13139,9 @@ TEST_F(VkLayerTest, TestMultipleQueuesWaitingOnSemaphore) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit-pWaitSemaphores-00068");
     vk::QueueSubmit(other, 1, &wait_submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
+
+    // Need to ensure semaphore is not in use before the test ends and it gets destroyed
+    vk::QueueWaitIdle(m_device->m_queue);
 }
 
 TEST_F(VkLayerTest, IncompatibleRenderPass) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5144,8 +5144,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5186,17 +5185,15 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     memory_info.allocationSize = mem_reqs.size + mem_reqs.alignment;  // save room for offset
     bool has_memtype = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
-        printf("%s No invalid memory type index could be found; skipped.\n", kSkipPrefix);
         AHardwareBuffer_release(ahb);
         vk::DestroyBuffer(m_device->device(), buffer, nullptr);
-        return;
+        GTEST_SKIP() << "No invalid memory type index could be found";
     }
 
     VkDeviceMemory memory = VK_NULL_HANDLE;
     VkResult result = vk::AllocateMemory(m_device->device(), &memory_info, NULL, &memory);
     if ((memory == VK_NULL_HANDLE) || (result != VK_SUCCESS)) {
-        printf("%s This test failed to allocate memory for importing\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test failed to allocate memory for importing";
     }
 
     if (mem_reqs.alignment > 1) {
@@ -5214,6 +5211,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
 
     vk::DestroyBuffer(m_device->device(), buffer, nullptr);
     vk::FreeMemory(m_device->device(), memory, nullptr);
+    AHardwareBuffer_release(ahb);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -5202,14 +5202,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
 
     if (mem_reqs.alignment > 1) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memoryOffset-01036");
-        vk::BindBufferMemory(device(), buffer, memory.handle(), 1);
+        vk::BindBufferMemory(device(), buffer.handle(), memory.handle(), 1);
         m_errorMonitor->VerifyFound();
     }
 
     VkDeviceSize buffer_offset = (mem_reqs.size - 1) & ~(mem_reqs.alignment - 1);
     if (buffer_offset > 0) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-size-01037");
-        vk::BindBufferMemory(device(), buffer, memory.handle(), buffer_offset);
+        vk::BindBufferMemory(device(), buffer.handle(), memory.handle(), buffer_offset);
         m_errorMonitor->VerifyFound();
     }
 
@@ -11624,6 +11624,7 @@ TEST_F(VkLayerTest, BeginQueryTypeTransformFeedbackStream) {
         "Call CmdBeginQuery with query type transform feedback stream when transformFeedbackQueries is not supported.");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -11634,7 +11635,7 @@ TEST_F(VkLayerTest, BeginQueryTypeTransformFeedbackStream) {
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
     VkPhysicalDeviceProperties2 phys_dev_props_2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&transform_feedback_props);
 
-    vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+    GetPhysicalDeviceProperties2(phys_dev_props_2);
     if (transform_feedback_props.transformFeedbackQueries) {
         printf("%s Transform feedback queries are supported, skipping test\n", kSkipPrefix);
         return;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4466,8 +4466,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
     }
 
     if (!AreRequiredExtensionsEnabled()) {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -11862,10 +11862,6 @@ TEST_F(VkLayerTest, CopyUnboundAccelerationStructure) {
         vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureKHR"));
     assert(vkCmdCopyAccelerationStructureKHR != nullptr);
 
-    auto vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddressKHR)vk::GetDeviceProcAddr(device(), "vkGetBufferDeviceAddressKHR");
-    assert(vkGetBufferDeviceAddressKHR != nullptr);
-
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -13278,6 +13278,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     TEST_DESCRIPTION("Validate using VkPhysicalDeviceSampleLocationsPropertiesEXT");
 
     AddRequiredExtensions(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -13286,7 +13287,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
 
     VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations = LvlInitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
     VkPhysicalDeviceProperties2 phys_props = LvlInitStruct<VkPhysicalDeviceProperties2>(&sample_locations);
-    vk::GetPhysicalDeviceProperties2(gpu(), &phys_props);
+    GetPhysicalDeviceProperties2(phys_props);
 
     if (sample_locations.variableSampleLocations) {
         GTEST_SKIP() << "VkPhysicalDeviceSampleLocationsPropertiesEXT::variableSampleLocations is supported, skipping.";

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -3093,7 +3093,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props =
         LvlInitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&pdvad_props);
-    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+    GetPhysicalDeviceProperties2(pd_props2);
 
     VkVertexInputBindingDivisorDescriptionEXT vibdd = {};
     VkPipelineVertexInputDivisorStateCreateInfoEXT pvids_ci = LvlInitStruct<VkPipelineVertexInputDivisorStateCreateInfoEXT>();
@@ -3185,7 +3185,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorDisabled) {
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props =
         LvlInitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&pdvad_props);
-    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+    GetPhysicalDeviceProperties2(pd_props2);
 
     VkVertexInputBindingDivisorDescriptionEXT vibdd = {};
     vibdd.binding = 0;

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -14148,6 +14148,7 @@ TEST_F(VkLayerTest, UsingRasterizationStateStreamExtWithoutEnabled) {
 TEST_F(VkLayerTest, TestPipelineRasterizationStateStreamCreateInfoEXT) {
     TEST_DESCRIPTION("Test using TestRasterizationStateStreamCreateInfoEXT with invalid rasterizationStream.");
 
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
@@ -14168,7 +14169,7 @@ TEST_F(VkLayerTest, TestPipelineRasterizationStateStreamCreateInfoEXT) {
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
 
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&transfer_feedback_props);
-    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+    GetPhysicalDeviceProperties2(pd_props2);
 
     if (!transfer_feedback_props.transformFeedbackRasterizationStreamSelect &&
         transfer_feedback_props.maxTransformFeedbackStreams == 0) {

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -130,8 +130,6 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     vk::BindImageMemory2(m_device->device(), 1, &bind_info);
 
     vk::DestroyImage(m_device->device(), image_from_swapchain, nullptr);
-
-    // image_from_swapchain is controlled by the implementation, so do not destroy it
 }
 
 TEST_F(VkLayerTest, ValidSwapchainImage) {

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -221,8 +221,6 @@ TEST_F(VkLayerTest, ValidSwapchainImage) {
         vk::CreateImage(device(), &image_create_info, NULL, &image);
         m_errorMonitor->VerifyFound();
     }
-
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
@@ -457,7 +455,9 @@ TEST_F(VkLayerTest, ValidSwapchainImageParams) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSwapchainCreateInfoKHR-physicalDeviceCount-01429");
     vk::CreateSwapchainKHR(device(), &create_info_bad_flags, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();
-    DestroySwapchain();
+
+    // No valid swapchain
+    m_swapchain = VK_NULL_HANDLE;
 }
 
 TEST_F(VkLayerTest, SwapchainAcquireImageNoSync) {
@@ -480,8 +480,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync) {
         vk::AcquireNextImageKHR(device(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, VK_NULL_HANDLE, &dummy);
         m_errorMonitor->VerifyFound();
     }
-
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
@@ -525,8 +523,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
         vk::AcquireNextImage2KHR(device(), &acquire_info, &dummy);
         m_errorMonitor->VerifyFound();
     }
-
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore) {
@@ -624,7 +620,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     m_errorMonitor->VerifyFound();
 
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
@@ -663,7 +658,6 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
 
     // Cleanup
     vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, UINT64_MAX);
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, GetSwapchainImageAndTryDestroy) {
@@ -685,8 +679,6 @@ TEST_F(VkLayerTest, GetSwapchainImageAndTryDestroy) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyImage-image-04882");
     vk::DestroyImage(device(), images.at(0), nullptr);
     m_errorMonitor->VerifyFound();
-
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainNotSupported) {
@@ -835,7 +827,6 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
 
     // Cleanup
     vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, UINT64_MAX);
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, InvalidSwapchainImageFormatList) {
@@ -946,7 +937,6 @@ TEST_F(VkLayerTest, InvalidSwapchainImageFormatList) {
     m_errorMonitor->ExpectSuccess();
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainMinImageCountNonShared) {
@@ -1001,7 +991,6 @@ TEST_F(VkLayerTest, SwapchainMinImageCountNonShared) {
     m_errorMonitor->ExpectSuccess();
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
@@ -1101,7 +1090,6 @@ TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
     m_errorMonitor->ExpectSuccess();
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyNotFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainInvalidUsageNonShared) {
@@ -1152,7 +1140,6 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageNonShared) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSwapchainCreateInfoKHR-imageUsage-01276");
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
@@ -1247,7 +1234,6 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSwapchainCreateInfoKHR-imageUsage-01384");
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, InvalidDeviceMask) {
@@ -1424,7 +1410,6 @@ TEST_F(VkLayerTest, InvalidDeviceMask) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAcquireNextImageInfoKHR-deviceMask-01291");
     vk::AcquireNextImage2KHR(m_device->device(), &acquire_next_image_info, &imageIndex);
     m_errorMonitor->VerifyFound();
-    DestroySwapchain();
 
     // Test VkDeviceGroupSubmitInfo
     VkDeviceGroupSubmitInfo device_group_submit_info = LvlInitStruct<VkDeviceGroupSubmitInfo>();
@@ -1612,7 +1597,6 @@ TEST_F(VkLayerTest, WarningSwapchainCreateInfoPreTransform) {
     m_errorMonitor->SetUnexpectedError("VUID-VkSwapchainCreateInfoKHR-preTransform-01279");
     InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR);
     m_errorMonitor->VerifyFound();
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, DeviceGroupSubmitInfoSemaphoreCount) {
@@ -1743,7 +1727,6 @@ TEST_F(VkLayerTest, SwapchainAcquireImageWithSignaledSemaphore) {
     m_errorMonitor->VerifyFound();
 
     vk::DestroySemaphore(device(), semaphore, nullptr);
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, DisplayPresentInfoSrcRect) {
@@ -1897,7 +1880,6 @@ TEST_F(VkLayerTest, PresentIdWait) {
     vkWaitForPresentKHR(device(), swapchain2, 5, UINT64_MAX);
     m_errorMonitor->VerifyFound();
 
-    DestroySwapchain();
     vk::DestroySwapchainKHR(m_device->device(), swapchain2, nullptr);
     vk::DestroySwapchainKHR(m_device->device(), swapchain3, nullptr);
     vk::DestroySurfaceKHR(instance(), surface2, nullptr);
@@ -1957,8 +1939,6 @@ TEST_F(VkLayerTest, PresentIdWaitFeatures) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkWaitForPresentKHR-presentWait-06234");
     vkWaitForPresentKHR(device(), m_swapchain, 1, UINT64_MAX);
     m_errorMonitor->VerifyFound();
-
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, GetSwapchainImagesCountButNotImages) {
@@ -2326,7 +2306,6 @@ TEST_F(VkLayerTest, UseSwapchainImageBeforeWait) {
     m_errorMonitor->VerifyFound();
 
     vk::DestroySemaphore(device(), acquire_semaphore, nullptr);
-    DestroySwapchain();
 }
 
 TEST_F(VkLayerTest, TestCreatingSwapchainWithInvalidExtent) {

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -292,8 +292,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
-    VkImage peer_image;
-    vk::CreateImage(device(), &image_create_info, NULL, &peer_image);
+    vk_testing::Image peer_image(*m_device, image_create_info);
 
     auto bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
     bind_devicegroup_info.deviceIndexCount = 1;
@@ -307,7 +306,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     bind_swapchain_info.imageIndex = 0;
 
     auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
-    bind_info.image = peer_image;
+    bind_info.image = peer_image.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
     vk::BindImageMemory2(m_device->device(), 1, &bind_info);
@@ -332,7 +331,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
     copy_region.extent = {10, 10, 1};
-    vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image,
+    vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
     m_commandBuffer->end();

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -100,30 +100,30 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
 
-    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-image-01630");
-    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01632");
-    // vk::BindImageMemory2(m_device->device(), 1, &bind_info);
-    // m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-image-01630");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01632");
+    vk::BindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
 
     auto bind_swapchain_info = LvlInitStruct<VkBindImageMemorySwapchainInfoKHR>();
     bind_swapchain_info.swapchain = VK_NULL_HANDLE;
     bind_swapchain_info.imageIndex = 0;
     bind_info.pNext = &bind_swapchain_info;
 
-    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-RequiredParameter");
-    // vk::BindImageMemory2(m_device->device(), 1, &bind_info);
-    // m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-RequiredParameter");
+    vk::BindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
 
     bind_info.memory = mem.handle();
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = std::numeric_limits<uint32_t>::max();
 
-    // if (mem.initialized()) {
-    //     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01631");
-    // }
-    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644");
-    // vk::BindImageMemory2(m_device->device(), 1, &bind_info);
-    // m_errorMonitor->VerifyFound();
+    if (mem.initialized()) {
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01631");
+    }
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644");
+    vk::BindImageMemory2(m_device->device(), 1, &bind_info);
+    m_errorMonitor->VerifyFound();
 
     bind_info.memory = VK_NULL_HANDLE;
     bind_swapchain_info.imageIndex = 0;

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -292,7 +292,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
-    vk_testing::Image peer_image(*m_device, image_create_info);
+    vk_testing::Image peer_image(*m_device, image_create_info, vk_testing::no_mem);
 
     auto bind_devicegroup_info = LvlInitStruct<VkBindImageMemoryDeviceGroupInfo>();
     bind_devicegroup_info.deviceIndexCount = 1;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -691,6 +691,11 @@ void VkRenderFramework::ShutdownFramework() {
 
     debug_reporter_.Destroy(instance_);
 
+    if (m_surface != VK_NULL_HANDLE) {
+        vk::DestroySurfaceKHR(instance_, m_surface, nullptr);
+        m_surface = VK_NULL_HANDLE;
+    }
+
     vk::DestroyInstance(instance_, nullptr);
     instance_ = NULL;  // In case we want to re-initialize
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -738,7 +738,10 @@ bool VkRenderFramework::IsDriver(VkDriverId driver_id) {
         // Assumes api version 1.2+
         auto driver_properties = LvlInitStruct<VkPhysicalDeviceDriverProperties>();
         auto physical_device_properties2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&driver_properties);
-        vk::GetPhysicalDeviceProperties2(gpu_, &physical_device_properties2);
+        auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
+            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
+        assert(vkGetPhysicalDeviceProperties2KHR);
+        vkGetPhysicalDeviceProperties2KHR(gpu_, &physical_device_properties2);
         return (driver_properties.driverID == driver_id);
     }
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -685,6 +685,8 @@ void VkRenderFramework::ShutdownFramework() {
         DestroySwapchain();
     }
 
+    DestroySwapchain();
+
     // reset the driver
     delete m_device;
     m_device = nullptr;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -731,21 +731,6 @@ bool VkRenderFramework::IsPlatform(PlatformType platform) {
     }
 }
 
-bool VkRenderFramework::IsDriver(VkDriverId driver_id) {
-    if (VkRenderFramework::IgnoreDisableChecks()) {
-        return false;
-    } else {
-        // Assumes api version 1.2+
-        auto driver_properties = LvlInitStruct<VkPhysicalDeviceDriverProperties>();
-        auto physical_device_properties2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&driver_properties);
-        auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
-        assert(vkGetPhysicalDeviceProperties2KHR);
-        vkGetPhysicalDeviceProperties2KHR(gpu_, &physical_device_properties2);
-        return (driver_properties.driverID == driver_id);
-    }
-}
-
 void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *props) { *props = physDevProps_; }
 
 void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *create_device_pnext,

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -664,6 +664,7 @@ bool VkRenderFramework::CanEnableDeviceExtension(const std::string &dev_ext_name
 }
 
 void VkRenderFramework::ShutdownFramework() {
+    // TODO this needs to be moved to the end of this function
     debug_reporter_.error_monitor_.Reset();
 
     // Nothing to shut down without a VkInstance
@@ -695,6 +696,10 @@ void VkRenderFramework::ShutdownFramework() {
 
     vk::DestroyInstance(instance_, nullptr);
     instance_ = NULL;  // In case we want to re-initialize
+
+    // TODO: this needs to be added to catch resources that are not cleaned up at the end of the test
+    // debug_reporter_.error_monitor_.VerifyNotFound();
+    // debug_reporter_.error_monitor_.Reset();
 }
 
 ErrorMonitor &VkRenderFramework::Monitor() { return debug_reporter_.error_monitor_; }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -51,7 +51,7 @@ ErrorMonitor::ErrorMonitor(Behavior behavior) : behavior_(behavior) {
 ErrorMonitor::~ErrorMonitor() NOEXCEPT {}
 
 void ErrorMonitor::MonitorReset() {
-    message_flags_ = 0;
+    message_flags_ = kErrorBit;
     bailout_ = NULL;
     message_found_ = VK_FALSE;
     failure_message_strings_.clear();
@@ -664,9 +664,6 @@ bool VkRenderFramework::CanEnableDeviceExtension(const std::string &dev_ext_name
 }
 
 void VkRenderFramework::ShutdownFramework() {
-    // TODO this needs to be moved to the end of this function
-    debug_reporter_.error_monitor_.Reset();
-
     // Nothing to shut down without a VkInstance
     if (!instance_) return;
 
@@ -697,9 +694,8 @@ void VkRenderFramework::ShutdownFramework() {
     vk::DestroyInstance(instance_, nullptr);
     instance_ = NULL;  // In case we want to re-initialize
 
-    // TODO: this needs to be added to catch resources that are not cleaned up at the end of the test
-    // debug_reporter_.error_monitor_.VerifyNotFound();
-    // debug_reporter_.error_monitor_.Reset();
+    debug_reporter_.error_monitor_.VerifyNotFound();
+    debug_reporter_.error_monitor_.Reset();
 }
 
 ErrorMonitor &VkRenderFramework::Monitor() { return debug_reporter_.error_monitor_; }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -279,7 +279,6 @@ class VkRenderFramework : public VkTestFramework {
     bool InitFrameworkAndRetrieveFeatures(VkPhysicalDeviceFeatures2KHR &features2);
 
     static bool IgnoreDisableChecks();
-    bool IsDriver(VkDriverId driver_id);
     bool IsPlatform(PlatformType platform);
     void GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features);
     void GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *props);

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -354,7 +354,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<VkImageView> m_framebuffer_attachments;
 
     // WSI items
-    VkSurfaceKHR m_surface;
+    VkSurfaceKHR m_surface = VK_NULL_HANDLE;
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
     Display *m_surface_dpy;
     Window m_surface_window;

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -951,7 +951,7 @@ VkSamplerYcbcrConversionCreateInfo SamplerYcbcrConversion::DefaultConversionInfo
 
 SamplerYcbcrConversion::~SamplerYcbcrConversion() NOEXCEPT {
     if (initialized()) {
-        if (khr_) {
+        if (!khr_) {
             vk::DestroySamplerYcbcrConversion(device(), handle(), nullptr);
         } else {
             auto vkDestroySamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -176,7 +176,8 @@ bool PhysicalDevice::set_memory_type(const uint32_t type_bits, VkMemoryAllocateI
         if ((type_mask & 1) == 1) {
             // Type is available, does it match user properties?
             if ((memory_properties_.memoryTypes[i].propertyFlags & properties) == properties &&
-                (memory_properties_.memoryTypes[i].propertyFlags & forbid) == 0) {
+                (memory_properties_.memoryTypes[i].propertyFlags & forbid) == 0 &&
+                (memory_properties_.memoryHeaps[memory_properties_.memoryTypes[i].heapIndex].size >= info->allocationSize)) {
                 info->memoryTypeIndex = i;
                 return true;
             }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -355,6 +355,8 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
 
 class Event : public internal::NonDispHandle<VkEvent> {
   public:
+    Event() = default;
+    Event(const Device &dev, const VkEventCreateInfo &info) { init(dev, info); }
     ~Event() NOEXCEPT;
 
     // vkCreateEvent()
@@ -390,10 +392,14 @@ class QueryPool : public internal::NonDispHandle<VkQueryPool> {
     static VkQueryPoolCreateInfo create_info(VkQueryType type, uint32_t slot_count);
 };
 
+struct NoMemT {};
+static constexpr NoMemT no_mem{};
+
 class Buffer : public internal::NonDispHandle<VkBuffer> {
   public:
     explicit Buffer() : NonDispHandle() {}
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info) { init(dev, info); }
+    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, NoMemT) { init_no_mem(dev, info); }
     explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
 
     ~Buffer() NOEXCEPT;
@@ -507,6 +513,7 @@ class Image : public internal::NonDispHandle<VkImage> {
   public:
     explicit Image() : NonDispHandle(), format_features_(0) {}
     explicit Image(const Device &dev, const VkImageCreateInfo &info) : format_features_(0) { init(dev, info); }
+    explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT) : format_features_(0) { init_no_mem(dev, info); }
 
     ~Image() NOEXCEPT;
 
@@ -754,6 +761,8 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
 
 class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
   public:
+    DescriptorPool() = default;
+    DescriptorPool(const Device &dev, const VkDescriptorPoolCreateInfo &info) { init(dev, info); }
     ~DescriptorPool() NOEXCEPT;
 
     // Descriptor sets allocated from this pool will need access to the original

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -889,6 +889,25 @@ class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
     void init(const Device &dev, const VkFramebufferCreateInfo &info);
 };
 
+class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConversion> {
+  public:
+    SamplerYcbcrConversion() = default;
+    SamplerYcbcrConversion(const Device &dev, VkFormat format, bool khr) : khr_(khr) {
+        init(dev, DefaultConversionInfo(format), khr);
+    }
+    SamplerYcbcrConversion(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr) : khr_(khr) {
+        init(dev, info, khr);
+    }
+    ~SamplerYcbcrConversion() NOEXCEPT;
+
+    void init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr);
+    VkSamplerYcbcrConversionInfo ConversionInfo();
+
+    static VkSamplerYcbcrConversionCreateInfo DefaultConversionInfo(VkFormat format);
+
+    bool khr_ = false;
+};
+
 inline VkMemoryAllocateInfo DeviceMemory::alloc_info(VkDeviceSize size, uint32_t memory_type_index) {
     VkMemoryAllocateInfo info = LvlInitStruct<VkMemoryAllocateInfo>();
     info.allocationSize = size;


### PR DESCRIPTION
This PR enables validation errors after the end of the test until after cleanup.
It also reenables all validation errors (kErrorBit) which in some cases were ignored
It adds DeviceWaitIdle after the test before cleanup
It adds many fixes, mostly destroy calls and vk_testing