### PR TITLE
tests: Cache instance layer and extension enumeration

### DIFF
--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -252,8 +252,8 @@ class VkRenderFramework : public VkTestFramework {
     ErrorMonitor &Monitor();
     VkPhysicalDeviceProperties physDevProps();
 
-    static bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
-    static bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);
+    bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
+    bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);
 
     VkInstanceCreateInfo GetInstanceCreateInfo() const;
     void InitFramework(void * /*unused compatibility parameter*/ = NULL, void *instance_pnext = NULL);
@@ -324,6 +324,9 @@ class VkRenderFramework : public VkTestFramework {
   protected:
     VkRenderFramework();
     virtual ~VkRenderFramework() = 0;
+
+    std::vector<VkLayerProperties> available_layers_; // allow caching of available layers
+    std::vector<VkExtensionProperties> available_extensions_; // allow caching of available instance extensions
 
     DebugReporter debug_reporter_;
     ErrorMonitor *m_errorMonitor = &debug_reporter_.error_monitor_;  // compatibility alias name

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -111,22 +111,17 @@ VkPhysicalDeviceFeatures PhysicalDevice::features() const {
  */
 std::vector<VkLayerProperties> GetGlobalLayers() {
     VkResult err;
-    uint32_t layer_count;
-    std::vector<VkLayerProperties> layers;
-
+    uint32_t layer_count = 32;
+    std::vector<VkLayerProperties> layers(layer_count);
     do {
-        err = vk::EnumerateInstanceLayerProperties(&layer_count, nullptr);
-        assert(!err);
-        if (err || 0 == layer_count) return {};
-
-        layers.resize(layer_count);
         err = vk::EnumerateInstanceLayerProperties(&layer_count, layers.data());
+        if (err || 0 == layer_count) return {};
+        if (err == VK_INCOMPLETE) layer_count *= 2; // wasn't enough space, increase it
+        layers.resize(layer_count);
+
     } while (VK_INCOMPLETE == err);
 
     assert(!err);
-    if (err) return {};
-    layers.resize(layer_count);
-
     return layers;
 }
 
@@ -142,22 +137,16 @@ std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExten
  */
 std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
     VkResult err;
-    uint32_t extension_count;
-    std::vector<VkExtensionProperties> extensions;
-
+    uint32_t extension_count = 32;
+    std::vector<VkExtensionProperties> extensions(extension_count);
     do {
-        err = vk::EnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
-        assert(!err);
-        if (err || 0 == extension_count) return {};
-
-        extensions.resize(extension_count);
         err = vk::EnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data());
+        if (err || 0 == extension_count) return {};
+        if (err == VK_INCOMPLETE) extension_count *= 2; // wasn't enough space, increase it
+        extensions.resize(extension_count);
     } while (VK_INCOMPLETE == err);
 
     assert(!err);
-    if (err) return {};
-    extensions.resize(extension_count);
-
     return extensions;
 }
 
@@ -167,18 +156,14 @@ std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
  */
 std::vector<VkExtensionProperties> PhysicalDevice::extensions(const char *pLayerName) const {
     VkResult err;
-    uint32_t extension_count;
-    std::vector<VkExtensionProperties> extensions;
+    uint32_t extension_count = 256;
+    std::vector<VkExtensionProperties> extensions(extension_count);
     do {
-        err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extension_count, nullptr);
-        if (err || 0 == extension_count) return {};
-
-        extensions.resize(extension_count);
         err = vk::EnumerateDeviceExtensionProperties(handle(), pLayerName, &extension_count, extensions.data());
+        if (err || 0 == extension_count) return {};
+        if (err == VK_INCOMPLETE) extension_count *= 2; // wasn't enough space, increase it
+        extensions.resize(extension_count);
     } while (VK_INCOMPLETE == err);
-
-    if (err) return {};
-    extensions.resize(extension_count);
 
     return extensions;
 }
@@ -207,18 +192,14 @@ bool PhysicalDevice::set_memory_type(const uint32_t type_bits, VkMemoryAllocateI
  */
 std::vector<VkLayerProperties> PhysicalDevice::layers() const {
     VkResult err;
-    uint32_t layer_count;
-    std::vector<VkLayerProperties> layers;
+    uint32_t layer_count = 32;
+    std::vector<VkLayerProperties> layers(layer_count);
     do {
-        err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, nullptr);
-        if (err || 0 == layer_count) return {};
-
-        layers.resize(layer_count);
         err = vk::EnumerateDeviceLayerProperties(handle(), &layer_count, layers.data());
+        if (err || 0 == layer_count) return {};
+        if (err == VK_INCOMPLETE) layer_count *= 2; // wasn't enough space, increase it
+        layers.resize(layer_count);
     } while (VK_INCOMPLETE == err);
-
-    if (err) return {};
-    layers.resize(layer_count);
 
     return layers;
 }


### PR DESCRIPTION
Help speed up tests by calling the enumerate extension and layer functions
with an already provided buffer of adequate size, then storing the found
list in a vector for any subsequent queries.

In my rudimentary performance analysis, I found that master would execute in about 2m 9s while this PR in about 2m 5s. Not a huge difference, but its a relatively simple change to claw back a bit of time.