### PR TITLE
Fix VUID 01586 format check

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5922,35 +5922,33 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                        << string_VkFormat(image_format) << ", must be " << string_VkFormat(compat_format) << ".";
                     skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-image-01586", "%s", ss.str().c_str());
                 }
-            } else {
-                if (!(image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT)) {
-                    // Format MUST be compatible (in the same format compatibility class) as the format the image was created with
-                    auto image_class = FormatCompatibilityClass(image_format);
-                    auto view_class = FormatCompatibilityClass(view_format);
-                    // Need to only check if one is NONE to handle edge case both are NONE
-                    if ((image_class != view_class) || (image_class == FORMAT_COMPATIBILITY_CLASS::NONE)) {
-                        const char *error_vuid;
-                        if ((!IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
-                            (!IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
-                            error_vuid = "VUID-VkImageViewCreateInfo-image-01018";
-                        } else if ((IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
-                                   (!IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
-                            error_vuid = "VUID-VkImageViewCreateInfo-image-01759";
-                        } else if ((!IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
-                                   (IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
-                            error_vuid = "VUID-VkImageViewCreateInfo-image-01760";
-                        } else {
-                            // both enabled
-                            error_vuid = "VUID-VkImageViewCreateInfo-image-01761";
-                        }
-                        std::stringstream ss;
-                        ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)
-                           << " is not in the same format compatibility class as "
-                           << report_data->FormatHandle(pCreateInfo->image).c_str() << "  format " << string_VkFormat(image_format)
-                           << ".  Images created with the VK_IMAGE_CREATE_MUTABLE_FORMAT BIT "
-                           << "can support ImageViews with differing formats but they must be in the same compatibility class.";
-                        skip |= LogError(pCreateInfo->image, error_vuid, "%s", ss.str().c_str());
+            } else if (!(image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT)) {
+                // Format MUST be compatible (in the same format compatibility class) as the format the image was created with
+                auto image_class = FormatCompatibilityClass(image_format);
+                auto view_class = FormatCompatibilityClass(view_format);
+                // Need to only check if one is NONE to handle edge case both are NONE
+                if ((image_class != view_class) || (image_class == FORMAT_COMPATIBILITY_CLASS::NONE)) {
+                    const char *error_vuid;
+                    if ((!IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
+                        (!IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
+                        error_vuid = "VUID-VkImageViewCreateInfo-image-01018";
+                    } else if ((IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
+                               (!IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
+                        error_vuid = "VUID-VkImageViewCreateInfo-image-01759";
+                    } else if ((!IsExtEnabled(device_extensions.vk_khr_maintenance2)) &&
+                               (IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion))) {
+                        error_vuid = "VUID-VkImageViewCreateInfo-image-01760";
+                    } else {
+                        // both enabled
+                        error_vuid = "VUID-VkImageViewCreateInfo-image-01761";
                     }
+                    std::stringstream ss;
+                    ss << "vkCreateImageView(): ImageView format " << string_VkFormat(view_format)
+                       << " is not in the same format compatibility class as "
+                       << report_data->FormatHandle(pCreateInfo->image).c_str() << "  format " << string_VkFormat(image_format)
+                       << ".  Images created with the VK_IMAGE_CREATE_MUTABLE_FORMAT BIT "
+                       << "can support ImageViews with differing formats but they must be in the same compatibility class.";
+                    skip |= LogError(pCreateInfo->image, error_vuid, "%s", ss.str().c_str());
                 }
             }
         } else {

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -8540,6 +8540,10 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
+    // This test hits a bug in the driver, CTS was written, but incase using an old driver
+    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
+        GTEST_SKIP() << "This test should not be run on the NVIDIA proprietary driver.";
+    }
 
     auto features11 = LvlInitStruct<VkPhysicalDeviceVulkan11Features>();
     auto features2 = GetPhysicalDeviceFeatures2(features11);
@@ -8592,7 +8596,7 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
         VkImageViewCreateInfo ivci = LvlInitStruct<VkImageViewCreateInfo>(&ycbcr_info);
         ivci.image = image_obj.image();
         ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        ivci.format = VK_FORMAT_R8_SNORM;  // Compat is VK_FORMAT_R8_UNORM
+        ivci.format = VK_FORMAT_R8G8_UNORM;  // Compat is VK_FORMAT_R8_UNORM
         ivci.subresourceRange.layerCount = 1;
         ivci.subresourceRange.baseMipLevel = 0;
         ivci.subresourceRange.levelCount = 1;
@@ -8603,6 +8607,10 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
 
         // Correct format succeeds
         ivci.format = VK_FORMAT_R8_UNORM;
+        CreateImageViewTest(*this, &ivci);
+
+        // R8_SNORM is compatible with R8_UNORM
+        ivci.format = VK_FORMAT_R8_SNORM;
         CreateImageViewTest(*this, &ivci);
 
         // Try a multiplane imageview


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4305

Added a commit to also remove the redundant `else { if () { }` statement below this VU