### PR TITLE
Fix ray tracing tests and check extensions after InitFramework

### DIFF
--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -898,7 +898,7 @@ bool InitFrameworkForRayTracingTest(VkRenderFramework *framework, bool is_khr, b
                                     VkPhysicalDeviceFeatures2KHR *features2 = nullptr, bool mockicd_valid = false);
 
 void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, VkBufferObj *vbo, VkBufferObj *ibo,
-                                                    VkGeometryNV *geometry, VkDeviceSize offset = 0);
+                                                    VkGeometryNV *geometry, VkDeviceSize offset = 0, bool buffer_device_address = false);
 
 void print_android(const char *c);
 #endif  // VKLAYERTEST_H

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -10600,11 +10600,15 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
 TEST_F(VkLayerTest, ValidateDescriptorBindingUpdateAfterBindWithAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure descriptor writing.");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
     if (!InitFrameworkForRayTracingTest(this, false, false)) {
         GTEST_SKIP() << "unable to init ray tracing test";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -10085,13 +10085,16 @@ TEST_F(VkLayerTest, PipelineMaxPerStageResources) {
 
 TEST_F(VkLayerTest, ValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR) {
     TEST_DESCRIPTION("Validate vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetTargetApiVersion(VK_API_VERSION_1_2);
 
     auto rt_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     rt_pipeline_features.rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&rt_pipeline_features);
     if (!InitFrameworkForRayTracingTest(this, true, false, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -500,10 +500,13 @@ VkResult QueryPool::results(uint32_t first, uint32_t count, size_t size, void *d
 
 NON_DISPATCHABLE_HANDLE_DTOR(Buffer, vk::DestroyBuffer)
 
-void Buffer::init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props) {
+void Buffer::init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
     init_no_mem(dev, info);
 
-    internal_mem_.init(dev, DeviceMemory::get_resource_alloc_info(dev, memory_requirements(), mem_props));
+    auto alloc_info = DeviceMemory::get_resource_alloc_info(dev, memory_requirements(), mem_props);
+    alloc_info.pNext = alloc_info_pnext;
+    internal_mem_.init(dev, alloc_info);
+
     bind_memory(internal_mem_, 0);
 }
 

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -399,11 +399,15 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     ~Buffer() NOEXCEPT;
 
     // vkCreateBuffer()
-    void init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props);
+    void init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
     void init(const Device &dev, const VkBufferCreateInfo &info) { init(dev, info, 0); }
     void init(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags mem_props,
               VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, const std::vector<uint32_t> &queue_families = {}) {
         init(dev, create_info(size, usage, &queue_families), mem_props);
+    }
+    void init(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags mem_props, VkBufferUsageFlags usage,
+              void *alloc_info_pnext) {
+        init(dev, create_info(size, usage), mem_props, alloc_info_pnext);
     }
     void init(const Device &dev, VkDeviceSize size) { init(dev, size, 0); }
     void init_as_src(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -635,7 +635,8 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
 
     const VkDevice &dev() const { return device(); }
 
-    void create_scratch_buffer(const Device &dev, Buffer *buffer, VkBufferCreateInfo *pCreateInfo = NULL);
+    void create_scratch_buffer(const Device &dev, Buffer *buffer, VkBufferCreateInfo *pCreateInfo = NULL,
+                               bool buffer_device_address = false);
 
   private:
     VkAccelerationStructureInfoNV info_;
@@ -658,7 +659,8 @@ class AccelerationStructureKHR : public internal::NonDispHandle<VkAccelerationSt
 
     const VkDevice &dev() const { return device(); }
 
-    void create_scratch_buffer(const Device &dev, Buffer *buffer, VkBufferCreateInfo *pCreateInfo = NULL);
+    void create_scratch_buffer(const Device &dev, Buffer *buffer, VkBufferCreateInfo *pCreateInfo = NULL,
+                               bool buffer_device_address = false);
 
   private:
     VkAccelerationStructureCreateInfoKHR info_;


### PR DESCRIPTION
Addresses #4296
Moving extension check to after call to InitFramework to make fewer tests skip
Fix validation errors in now running tests, mostly around use of buffer device address