### PR TITLE
layers: GetLayerEnvVar shouldn't change the layer_config object

### DIFF
--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -389,17 +389,17 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     message_limit.append(".duplicate_message_limit");
     fine_grained_locking.append(".fine_grained_locking");
     std::string list_of_config_enables = getLayerOption(enable_key.c_str());
-    std::string list_of_env_enables = GetLayerEnvVar("VK_LAYER_ENABLES");
+    std::string list_of_env_enables = GetEnvironment("VK_LAYER_ENABLES");
     std::string list_of_config_disables = getLayerOption(disable_key.c_str());
-    std::string list_of_env_disables = GetLayerEnvVar("VK_LAYER_DISABLES");
+    std::string list_of_env_disables = GetEnvironment("VK_LAYER_DISABLES");
     std::string list_of_config_filter_ids = getLayerOption(filter_msg_key.c_str());
-    std::string list_of_env_filter_ids = GetLayerEnvVar("VK_LAYER_MESSAGE_ID_FILTER");
+    std::string list_of_env_filter_ids = GetEnvironment("VK_LAYER_MESSAGE_ID_FILTER");
     std::string list_of_config_stypes = getLayerOption(stypes_key.c_str());
-    std::string list_of_env_stypes = GetLayerEnvVar("VK_LAYER_CUSTOM_STYPE_LIST");
+    std::string list_of_env_stypes = GetEnvironment("VK_LAYER_CUSTOM_STYPE_LIST");
     std::string config_message_limit = getLayerOption(message_limit.c_str());
-    std::string env_message_limit = GetLayerEnvVar("VK_LAYER_DUPLICATE_MESSAGE_LIMIT");
+    std::string env_message_limit = GetEnvironment("VK_LAYER_DUPLICATE_MESSAGE_LIMIT");
     std::string config_fine_grained_locking = getLayerOption(fine_grained_locking.c_str());
-    std::string env_fine_grained_locking = GetLayerEnvVar("VK_LAYER_FINE_GRAINED_LOCKING");
+    std::string env_fine_grained_locking = GetEnvironment("VK_LAYER_FINE_GRAINED_LOCKING");
 
 #if defined(_WIN32)
     std::string env_delimiter = ";";

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -68,7 +68,7 @@ class ConfigFile {
 
 static ConfigFile layer_config;
 
-string GetEnvironment(const char *variable) {
+VK_LAYER_EXPORT std::string GetEnvironment(const char *variable) {
 #if !defined(__ANDROID__) && !defined(_WIN32)
     const char *output = getenv(variable);
     return output == NULL ? "" : output;
@@ -108,8 +108,11 @@ string GetEnvironment(const char *variable) {
 
 VK_LAYER_EXPORT const char *getLayerOption(const char *option) { return layer_config.GetOption(option); }
 VK_LAYER_EXPORT const char *GetLayerEnvVar(const char *option) {
-    layer_config.vk_layer_disables_env_var = GetEnvironment(option);
-    return layer_config.vk_layer_disables_env_var.c_str();
+    // NOTE: new code should use GetEnvironment directly. This is a workaround for the problem
+    // described in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3048
+    static std::string result;
+    result = GetEnvironment(option);
+    return result.c_str();
 }
 
 VK_LAYER_EXPORT const SettingsFileInfo *GetLayerSettingsFileInfo() { return &layer_config.settings_info; }

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 #define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
 #endif
 
-std::string GetEnvironment(const char *variable);
+VK_LAYER_EXPORT std::string GetEnvironment(const char *variable);
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This function was using layer_config.vk_layer_disables_env_var
as temporary storage so that it can return a char * which doesn't
have permanent storage. "Fix" this by using a static std::string
instead.

But really, there's not a safe way to implement this function on
all platforms we support. GetEnvironment() returns a std::string,
which solves this problem. Use that instead.

Fixes #3048