### PR TITLE
tests: Restore Sync ordering test.

### DIFF
--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1266,7 +1266,8 @@ uint32_t VkDeviceObj::QueueFamilyMatching(VkQueueFlags with, VkQueueFlags withou
 
 void VkDeviceObj::SetDeviceQueue() {
     ASSERT_NE(true, graphics_queues().empty());
-    m_queue = graphics_queues()[0]->handle();
+    m_queue_obj = graphics_queues()[0];
+    m_queue = m_queue_obj->handle();
 }
 
 VkQueueObj *VkDeviceObj::GetDefaultQueue() {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -77,6 +77,7 @@ class VkDeviceObj : public vk_testing::Device {
     VkPhysicalDeviceProperties props;
     std::vector<VkQueueFamilyProperties> queue_props;
 
+    VkQueueObj *m_queue_obj = nullptr;
     VkQueue m_queue;
 };
 


### PR DESCRIPTION
Fix the broken begin render pass and restore the test that required
success.