### PR TITLE
build: Update glslang

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -10,7 +10,7 @@
       "name" : "glslang",
       "url" : "https://github.com/KhronosGroup/glslang.git",
       "sub_dir" : "shaderc/third_party/glslang",
-      "commit" : "adbf0d3106b26daa237b10b9bf72b1af7c31092d"
+      "commit" : "7e6b7c26a2a565c677b93f1c1769977cadced306"
     },
     {
       "name" : "Vulkan-Headers",

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "glslang",
       "build_dir" : "glslang/build",
       "install_dir" : "glslang/build/install",
-      "commit": "adbf0d3106b26daa237b10b9bf72b1af7c31092d",
+      "commit": "7e6b7c26a2a565c677b93f1c1769977cadced306",
       "cmake_options" : [
         "-DUSE_CCACHE=ON"
       ],

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1168,12 +1168,10 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
         }
     )glsl";
 
-    // Broken, fixed by :
-    // https://github.com/KhronosGroup/glslang/issues/2975
-    // std::string cs_image_store = cs_image_base + R"glsl(
-    //        imageAtomicStore(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
-    //     }
-    // )glsl";
+    std::string cs_image_store = cs_image_base + R"glsl(
+           imageAtomicStore(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
+        }
+    )glsl";
 
     std::string cs_image_exchange = cs_image_base + R"glsl(
            imageAtomicExchange(z, ivec2(1, 1), y, gl_ScopeDevice, gl_StorageSemanticsImage, gl_SemanticsRelaxed);
@@ -1198,8 +1196,8 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
     current_shader = cs_image_load.c_str();
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
 
-    // current_shader = cs_image_store.c_str();
-    // CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
+    current_shader = cs_image_store.c_str();
+    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);
 
     current_shader = cs_image_exchange.c_str();
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "", true);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -12456,29 +12456,21 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    } else {
-        printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix,
-               VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-        return;
-    }
-
     // Create device without VK_EXT_shader_image_atomic_int64 extension or features enabled
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required for SPIR-V 1.3, skipping test.";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
     VkPhysicalDeviceFeatures available_features = {};
     ASSERT_NO_FATAL_FAILURE(GetPhysicalDeviceFeatures(&available_features));
     if (!available_features.shaderInt64) {
-        printf("%s VkPhysicalDeviceFeatures::shaderInt64 is not supported, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "VkPhysicalDeviceFeatures::shaderInt64 is not supported, skipping tests.";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-
-    if (m_device->props.apiVersion < VK_API_VERSION_1_1) {
-        printf("%s At least Vulkan version 1.1 is required for SPIR-V 1.3, skipping test.\n", kSkipPrefix);
-        return;
-    }
 
     // clang-format off
     std::string cs_image_base = R"glsl(
@@ -12540,8 +12532,8 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64) {
     if (VK_SUCCESS == current_shader->InitFromGLSLTry()) {
         CreateComputePipelineHelper::OneshotTest(
             *this, set_info, kErrorBit,
-            std::vector<string>{"VUID-VkShaderModuleCreateInfo-pCode-01091", "VUID-VkShaderModuleCreateInfo-pCode-04147",
-                                "VUID-RuntimeSpirv-None-06288"});
+            std::vector<string>{"VUID-VkShaderModuleCreateInfo-pCode-01091", "VUID-VkShaderModuleCreateInfo-pCode-01091",
+                                "VUID-VkShaderModuleCreateInfo-pCode-04147", "VUID-RuntimeSpirv-None-06288"});
     }
 
     current_shader = layer_data::make_unique<VkShaderObj>(this, cs_image_exchange.c_str(), VK_SHADER_STAGE_COMPUTE_BIT,


### PR DESCRIPTION
Update glslang to pull in this fix:
https://github.com/KhronosGroup/glslang/pull/2976.

@mikes-lunarg not sure if it's ok to "just update" glslang, or if there are other projects that also need to get updated. If there's more of a process involved, we can disable the affected tests for now.

cc @paul-lunarg.