### PR TITLE
Fix testing framework

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3279,6 +3279,8 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         }
 
         if (gpu_assisted) {
+            m_errorMonitor->SetUnexpectedError("VUID-vkCmdTraceRaysNV-callableShaderBindingOffset-02462");
+            m_errorMonitor->SetUnexpectedError("VUID-vkCmdTraceRaysNV-missShaderBindingOffset-02458");
             // Need these values to pass mapped storage buffer checks
             vkCmdTraceRaysNV(ray_tracing_command_buffer.handle(), shader_binding_table_buffer.handle(),
                              ray_tracing_properties.shaderGroupHandleSize * 0ull, shader_binding_table_buffer.handle(),

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -683,12 +683,19 @@ bool CheckSynchronization2SupportAndInitState(VkRenderFramework *framework) {
     PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
         (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(framework->instance(),
                                                                      "vkGetPhysicalDeviceFeatures2");
-    auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
-    auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2>(&sync2_features);
-    vkGetPhysicalDeviceFeatures2(framework->gpu(), &features2);
-    if (!sync2_features.synchronization2) {
-        return false;
+
+    {
+        auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+        auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2>(&sync2_features);
+        vkGetPhysicalDeviceFeatures2(framework->gpu(), &features2);
+        if (!sync2_features.synchronization2) {
+            return false;
+        }
     }
+
+    auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    sync2_features.synchronization2 = VK_TRUE;
+    auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2>(&sync2_features);
     framework->InitState(nullptr, &features2,VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     return true;
 }

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -302,17 +302,17 @@ TEST_F(VkAmdBestPracticesLayerTest, KeepLayoutSmall) {
     binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
     binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-    VkDescriptorSetLayoutCreateInfo DS_layout_info = {};
-    DS_layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    DS_layout_info.bindingCount = 1;
-    DS_layout_info.pBindings = &binding;
+    VkDescriptorSetLayoutCreateInfo ds_layout_info = {};
+    ds_layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    ds_layout_info.bindingCount = 1;
+    ds_layout_info.pBindings = &binding;
 
-    vk_testing::DescriptorSetLayout DS_layout(*m_device, DS_layout_info);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_info);
 
     VkPipelineLayoutCreateInfo pipeline_layout_info = {};
     pipeline_layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     pipeline_layout_info.setLayoutCount = 1;
-    pipeline_layout_info.pSetLayouts = &DS_layout.handle();
+    pipeline_layout_info.pSetLayouts = &ds_layout.handle();
     pipeline_layout_info.pushConstantRangeCount = 1;
     pipeline_layout_info.pPushConstantRanges = &push_range;
 

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -702,35 +702,27 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     InitState();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    constexpr int fence_warn_limit = 5;
+    const auto fence_ci = vk_testing::Fence::create_info();
+    std::vector<vk_testing::Fence> test_fences(fence_warn_limit);
+    for (int i = 0; i < fence_warn_limit - 1; ++i) {
+        test_fences[i].init(*m_device, fence_ci);
+    }
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
                                          "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfFences");
-    uint32_t fence_warn_limit = 5;
-    std::vector<VkFence> testFences(fence_warn_limit);
-    for (uint32_t i = 0; i < fence_warn_limit; i++) {
-        VkFenceCreateInfo fenceInfo = VkFenceObj::create_info();
-        vk::CreateFence(m_device->device(), &fenceInfo, nullptr, &testFences[i]);
-    }
+    test_fences[fence_warn_limit - 1].init(*m_device, fence_ci);
     m_errorMonitor->VerifyFound();
 
+    constexpr int semaphore_warn_limit = 12;
+    const auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
+    std::vector<vk_testing::Semaphore> test_semaphores(semaphore_warn_limit);
+    for (int i = 0; i < semaphore_warn_limit - 1; ++i) {
+        test_semaphores[i].init(*m_device, semaphore_ci);
+    }
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
                                          "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfSemaphores");
-    uint32_t semaphore_warn_limit = 12;
-    std::vector<VkSemaphore> testSemaphores(semaphore_warn_limit);
-    for (uint32_t i = 0; i < semaphore_warn_limit; i++) {
-        VkSemaphoreCreateInfo semaphore_create_info = {};
-        semaphore_create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &testSemaphores[i]);
-    }
-
+    test_semaphores[semaphore_warn_limit - 1].init(*m_device, semaphore_ci);
     m_errorMonitor->VerifyFound();
-
-    for (auto fence : testFences) {
-        vk::DestroyFence(device(), fence, nullptr);
-    }
-
-    for (auto semaphore : testSemaphores) {
-        vk::DestroySemaphore(device(), semaphore, nullptr);
-    }
 }
 
 TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -712,7 +712,8 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     // record a command buffer which records a significant number of depth pre-passes
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, kVUID_BestPractices_EndRenderPass_DepthPrePassUsage);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                         "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage");
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_depth_only.pipeline_);
@@ -917,8 +918,8 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
 
     InitState();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, kVUID_BestPractices_RenderPass_RedundantStore);
-    m_errorMonitor->SetAllowedFailureMsg(kVUID_BestPractices_EndRenderPass_RedundantAttachmentOnTile);
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -910,6 +910,11 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant store is used.");
 
     InitBestPracticesFramework(kEnableArmValidation);
+
+    if (IsPlatform(kGalaxyS10)) {
+        GTEST_SKIP() << "Test temporarily disabled on S10 device";
+    }
+
     InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, kVUID_BestPractices_RenderPass_RedundantStore);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1251,6 +1251,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineWithoutRenderPass) {
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
+    // This test checks that no BP messages are incorrectly triggered, but triggers core errors
     m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06603");
     m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06574");
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1061,6 +1061,9 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     vk::GetPhysicalDeviceQueueFamilyProperties2(phys_device_obj.handle(), &queue_count, nullptr);
 
     queue_family_props2.resize(queue_count);
+    for (uint32_t i = 0; i < queue_count; i++) {
+        queue_family_props2[i].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2;
+    }
     vk::GetPhysicalDeviceQueueFamilyProperties2(phys_device_obj.handle(), &queue_count, queue_family_props2.data());
 
     // And for GetPhysicalDeviceQueueFamilyProperties2KHR
@@ -1102,7 +1105,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
         }
     }
 
-    VkPhysicalDeviceFeatures all_features;
+    VkPhysicalDeviceFeatures all_features{};
     VkDeviceCreateInfo device_ci = {};
     device_ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
     device_ci.pNext = nullptr;
@@ -1170,6 +1173,7 @@ TEST_F(VkBestPracticesLayerTest, DepthBiasNoAttachment) {
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 
+    m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 }
 
@@ -1250,6 +1254,9 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineWithoutRenderPass) {
 
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
+
+    m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06603");
+    m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06574");
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1022,8 +1022,8 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     // GetPhysicalDeviceSurfacePresentModesKHR() not called before trying to create a swapchain
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
 
-    // Set unexpected error because warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
+    // Warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR, but only with ARM BP
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -983,15 +983,6 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
         return;
     }
 
-    // GetPhysicalDeviceSurfaceCapabilitiesKHR() not called before trying to create a swapchain
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
-
-    // GetPhysicalDeviceSurfaceFormatsKHR() not called before trying to create a swapchain
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
-
-    // GetPhysicalDeviceSurfacePresentModesKHR() not called before trying to create a swapchain
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
-
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     m_surface_composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
 #else
@@ -1015,13 +1006,6 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     swapchain_create_info.clipped = VK_FALSE;
     swapchain_create_info.oldSwapchain = 0;
 
-    // Set unexpected error because warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
-
-    VkResult err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
-    ASSERT_TRUE(err == VK_ERROR_VALIDATION_FAILED_EXT);
-    m_errorMonitor->VerifyFound();
-
     // Test for successful swapchain creation when GetPhysicalDeviceSurfaceCapabilitiesKHR() and
     // GetPhysicalDeviceSurfaceFormatsKHR() are queried as expected and GetPhysicalDeviceSurfacePresentModesKHR() is not called but
     // the present mode is VK_PRESENT_MODE_FIFO_KHR
@@ -1037,6 +1021,17 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
     swapchain_create_info.imageColorSpace = m_surface_formats[0].colorSpace;
     swapchain_create_info.imageExtent = {m_surface_capabilities.minImageExtent.width, m_surface_capabilities.minImageExtent.height};
+
+    // GetPhysicalDeviceSurfacePresentModesKHR() not called before trying to create a swapchain
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
+
+    // Set unexpected error because warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
+
+    VkResult err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+    // ASSERT_TRUE(err == VK_ERROR_VALIDATION_FAILED_EXT);
+    m_errorMonitor->VerifyFound();
+
     swapchain_create_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
     err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1025,13 +1025,13 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     // Set unexpected error because warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR
     m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
-    VkResult err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     // ASSERT_TRUE(err == VK_ERROR_VALIDATION_FAILED_EXT);
     m_errorMonitor->VerifyFound();
 
     swapchain_create_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
-    err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 }
 
 TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1026,7 +1026,6 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
-    // ASSERT_TRUE(err == VK_ERROR_VALIDATION_FAILED_EXT);
     m_errorMonitor->VerifyFound();
 
     swapchain_create_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -959,14 +959,11 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     swapchain_create_info.clipped = VK_FALSE;
     swapchain_create_info.oldSwapchain = 0;
 
-    VkResult err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count");
     swapchain_create_info.minImageCount = 3;
-    err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
-    ASSERT_VK_SUCCESS(err)
+    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 }
 
 TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
@@ -1499,7 +1496,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
 
 TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     TEST_DESCRIPTION("Attempt to allocate more sets and descriptors than descriptor pool has available.");
-    VkResult err;
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
@@ -1541,7 +1538,7 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = set_layouts;
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-EmptyDescriptorPool");
-    err = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, descriptor_sets);
+    vk::AllocateDescriptorSets(m_device->device(), &alloc_info, descriptor_sets);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -5889,7 +5889,16 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    VkPhysicalDeviceFeatures features;
+    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    if (features.multiDrawIndirect == VK_FALSE) {
+        GTEST_SKIP() << "multiDrawIndirect not supported";
+    }
+
+    VkPhysicalDeviceFeatures requiredFeatures{};
+    requiredFeatures.multiDrawIndirect = VK_TRUE;
+    ASSERT_NO_FATAL_FAILURE(InitState(&requiredFeatures));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -2799,6 +2799,14 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     pipe.AddShader(&ts);
     pipe.AddShader(&ms);
     pipe.AddDefaultColorAttachment();
+    VkViewport viewport{};
+    viewport.width = m_width;
+    viewport.height = m_height;
+    pipe.SetViewport({viewport});
+    VkRect2D rect{};
+    rect.extent.width = (uint32_t)m_width;
+    rect.extent.height = (uint32_t)m_height;
+    pipe.SetScissor({rect});
     VkResult err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
     ASSERT_VK_SUCCESS(err);
 
@@ -2807,8 +2815,10 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     ASSERT_TRUE(vkCmdDrawMeshTasksNV != nullptr);
 
     m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
     vkCmdDrawMeshTasksNV(m_commandBuffer->handle(), 1, 0);
+    m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -101,15 +101,7 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
     if (!IgnoreMessage(errorString)) {
         for (auto desired_msg_it = desired_message_strings_.begin(); desired_msg_it != desired_message_strings_.end();
              ++desired_msg_it) {
-            if ((*desired_msg_it).length() == 0) {
-                // An empty desired_msg string "" indicates a positive test - not expecting an error.
-                // Return true to avoid calling layers/driver with this error.
-                // And don't erase the "" string, so it remains if another error is found.
-                result = VK_TRUE;
-                found_expected = true;
-                message_found_ = true;
-                failure_message_strings_.insert(errorString);
-            } else if (errorString.find(*desired_msg_it) != string::npos) {
+            if (errorString.find(*desired_msg_it) != string::npos) {
                 found_expected = true;
                 failure_message_strings_.insert(errorString);
                 message_found_ = true;
@@ -132,6 +124,7 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
         }
 
         if (!found_expected) {
+            result = VK_TRUE;
             printf("Unexpected: %s\n", msgString);
             other_messages_.push_back(errorString);
         }
@@ -171,7 +164,7 @@ void ErrorMonitor::DumpFailureMsgs() const {
 void ErrorMonitor::ExpectSuccess(VkDebugReportFlagsEXT const message_flag_mask) {
     // Match ANY message matching specified type
     auto guard = Lock();
-    desired_message_strings_.insert("");
+    desired_message_strings_.clear();
     message_flags_ = message_flag_mask;
 }
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -467,19 +467,14 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
         }
     }
     if (validation == "all") {
-        auto enables = new VkValidationFeatureEnableEXT[5]{
-            VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-            VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT, VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT,
-            VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
         features->enabledValidationFeatureCount = 3;
-        features->pEnabledValidationFeatures = enables;
+        features->pEnabledValidationFeatures = validation_enable_all;
         features->disabledValidationFeatureCount = 0;
     } else if (validation == "core") {
         features->disabledValidationFeatureCount = 0;
     } else if (validation == "none") {
-        auto disables = new VkValidationFeatureDisableEXT[1]{VK_VALIDATION_FEATURE_DISABLE_ALL_EXT};
         features->disabledValidationFeatureCount = 1;
-        features->pDisabledValidationFeatures = disables;
+        features->pDisabledValidationFeatures = &validation_disable_all;
         features->enabledValidationFeatureCount = 0;
     }
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1041,7 +1041,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
     att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att.initialLayout = (m_clear_via_load_op) ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_GENERAL;
+    att.initialLayout = (m_clear_via_load_op) ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     att.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkAttachmentReference ref = {};

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -31,6 +31,7 @@
 
 #include "vk_format_utils.h"
 #include "vk_extension_helper.h"
+#include "vk_layer_settings_ext.h"
 
 using std::string;
 using std::strncmp;
@@ -465,17 +466,18 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
             features->pNext = first_pnext;
             first_pnext = features;
         }
-    }
-    if (validation == "all") {
-        features->enabledValidationFeatureCount = 3;
-        features->pEnabledValidationFeatures = validation_enable_all;
-        features->disabledValidationFeatureCount = 0;
-    } else if (validation == "core") {
-        features->disabledValidationFeatureCount = 0;
-    } else if (validation == "none") {
-        features->disabledValidationFeatureCount = 1;
-        features->pDisabledValidationFeatures = &validation_disable_all;
-        features->enabledValidationFeatureCount = 0;
+
+        if (validation == "all") {
+            features->enabledValidationFeatureCount = 5;
+            features->pEnabledValidationFeatures = validation_enable_all;
+            features->disabledValidationFeatureCount = 0;
+        } else if (validation == "core") {
+            features->disabledValidationFeatureCount = 0;
+        } else if (validation == "none") {
+            features->disabledValidationFeatureCount = 1;
+            features->pDisabledValidationFeatures = &validation_disable_all;
+            features->enabledValidationFeatureCount = 0;
+        }
     }
 
     return first_pnext;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -468,7 +468,7 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
         }
 
         if (validation == "all") {
-            features->enabledValidationFeatureCount = 5;
+            features->enabledValidationFeatureCount = 4;
             features->pEnabledValidationFeatures = validation_enable_all;
             features->disabledValidationFeatureCount = 0;
         } else if (validation == "core") {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -126,7 +126,6 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
         if (!found_expected) {
             result = VK_TRUE;
             printf("Unexpected: %s\n", msgString);
-            other_messages_.push_back(errorString);
         }
     }
     return result;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -456,16 +456,15 @@ inline void *SetupValidationSettings(void *pnext) {
     auto validation = GetEnvironment("VK_LAYER_TESTS_VALIDATION_FEATURES");
     std::transform(validation.begin(), validation.end(), validation.begin(), ::tolower);
     VkValidationFeaturesEXT *features = nullptr;
-    if (validation == "all" || validation == "core" || validation == "none") {
-        while (pnext) {
-            if (reinterpret_cast<const VkBaseOutStructure *>(pnext)->sType == VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT) {
-                features = reinterpret_cast<VkValidationFeaturesEXT *>(pnext);
-                CheckDisableCoreValidation(features);
-                break;
-            }
-            pnext = reinterpret_cast<const VkBaseOutStructure *>(pnext)->pNext;
+    while (pnext) {
+        if (reinterpret_cast<const VkBaseOutStructure *>(pnext)->sType == VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT) {
+            features = reinterpret_cast<VkValidationFeaturesEXT *>(pnext);
+            CheckDisableCoreValidation(features);
+            break;
         }
-
+        pnext = reinterpret_cast<const VkBaseOutStructure *>(pnext)->pNext;
+    }
+    if (validation == "all" || validation == "core" || validation == "none") {
         if (!features) {
             features = new VkValidationFeaturesEXT{};
             features->sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1464,6 +1464,7 @@ VkRenderpassObj::VkRenderpassObj(VkDeviceObj *dev, const VkFormat format) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 
     rpci.pAttachments = &attach_desc;
 
@@ -1491,6 +1492,8 @@ VkRenderpassObj::VkRenderpassObj(VkDeviceObj *dev, VkFormat format, bool depthSt
         attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 
         rpci.pAttachments = &attach_desc;
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -399,6 +399,11 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_device_extension_names;
 
     VkValidationFeaturesEXT validation_features;
+    VkValidationFeatureEnableEXT validation_enable_all[5] = {
+        VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
+        VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT, VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT,
+        VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
+    VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
 
   private:
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -399,10 +399,10 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_device_extension_names;
 
     VkValidationFeaturesEXT validation_features;
-    VkValidationFeatureEnableEXT validation_enable_all[5] = {
-        VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-        VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT, VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT,
-        VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
+    VkValidationFeatureEnableEXT validation_enable_all[4] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
+                                                             VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
+                                                             VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
+                                                             VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
     VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
 
   private:

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -306,6 +306,8 @@ class VkRenderFramework : public VkTestFramework {
     // if requested extensions are not supported, helper function to get string to print out
     std::string RequiredExtensionsNotSupported() const;
 
+    void *SetupValidationSettings(void *first_pnext);
+
     template <typename GLSLContainer>
     std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const GLSLContainer &code, const char *entry_point = "main",
                                     const VkSpecializationInfo *spec_info = nullptr, const spv_target_env env = SPV_ENV_VULKAN_1_0,
@@ -395,6 +397,8 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_optional_extensions;
     // Device extensions to enable
     std::vector<const char *> m_device_extension_names;
+
+    VkValidationFeaturesEXT validation_features;
 
   private:
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -337,7 +337,7 @@ class VkRenderFramework : public VkTestFramework {
     VkDeviceObj *m_device;
     VkCommandPoolObj *m_commandPool;
     VkCommandBufferObj *m_commandBuffer;
-    VkRenderPass m_renderPass;
+    VkRenderPass m_renderPass = VK_NULL_HANDLE;
     VkRenderPassCreateInfo m_renderPass_info = {};
     std::vector<VkAttachmentDescription> m_renderPass_attachments;
     std::vector<VkSubpassDescription> m_renderPass_subpasses;

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2943,7 +2943,13 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         g_pipe_12.gp_ci_.renderPass = rp.handle();
         g_pipe_12.gp_ci_.subpass = 1;
         g_pipe_12.InitState();
-        ASSERT_VK_SUCCESS(g_pipe_12.CreateGraphicsPipeline());
+        g_pipe_12.LateBindPipelineInfo();
+
+        std::vector<vk_testing::Pipeline> g_pipes(kNumImages - 1);
+        for (size_t i = 0; i < g_pipes.size(); i++) {
+            g_pipe_12.gp_ci_.subpass = i + 1;
+            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+        }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
         g_pipe_12.descriptor_set_->UpdateDescriptorSets();
@@ -2972,13 +2978,12 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
 
         for (uint32_t i = 1; i < subpasses.size(); i++) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
-            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
+            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipes[i - 1].handle());
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
                                       g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
 
             // we're racing the writes from subpass 0 with our shader reads
             m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-READ-RACING-WRITE");
-            m_errorMonitor->SetUnexpectedError("VUID-vkCmdDraw-subpass-02685");
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
             m_errorMonitor->VerifyFound();
         }
@@ -3027,7 +3032,13 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         g_pipe_12.gp_ci_.renderPass = rp.handle();
         g_pipe_12.gp_ci_.subpass = 1;
         g_pipe_12.InitState();
-        ASSERT_VK_SUCCESS(g_pipe_12.CreateGraphicsPipeline());
+        g_pipe_12.LateBindPipelineInfo();
+
+        std::vector<vk_testing::Pipeline> g_pipes(kNumImages - 1);
+        for (size_t i = 0; i < g_pipes.size(); i++) {
+            g_pipe_12.gp_ci_.subpass = i + 1;
+            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+        }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
         g_pipe_12.descriptor_set_->UpdateDescriptorSets();
@@ -3055,11 +3066,10 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
 
         for (uint32_t i = 1; i < subpasses.size(); i++) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
-            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
+            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipes[i - 1].handle());
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
                                       g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
 
-            m_errorMonitor->SetUnexpectedError("VUID-vkCmdDraw-subpass-02685");
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
         }
         // expect this error because 2 subpasses could try to do the store operation
@@ -3106,7 +3116,13 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         g_pipe_12.gp_ci_.renderPass = rp.handle();
         g_pipe_12.gp_ci_.subpass = 1;
         g_pipe_12.InitState();
-        ASSERT_VK_SUCCESS(g_pipe_12.CreateGraphicsPipeline());
+        g_pipe_12.LateBindPipelineInfo();
+
+        std::vector<vk_testing::Pipeline> g_pipes(kNumImages - 1);
+        for (size_t i = 0; i < g_pipes.size(); i++) {
+            g_pipe_12.gp_ci_.subpass = i + 1;
+            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+        }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
         g_pipe_12.descriptor_set_->UpdateDescriptorSets();
@@ -3133,11 +3149,10 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
 
         for (uint32_t i = 1; i < subpasses.size(); i++) {
             vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
-            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_12.pipeline_);
+            vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipes[i - 1].handle());
             vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
                                       g_pipe_12.pipeline_layout_.handle(), 0, 1, &g_pipe_12.descriptor_set_->set_, 0, NULL);
 
-            m_errorMonitor->SetUnexpectedError("VUID-vkCmdDraw-subpass-02685");
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
         }
 

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1543,8 +1543,8 @@ TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
     // DrawIndirect
     VkBufferObj buffer_drawIndirect, buffer_drawIndirect2;
     buffer_usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    buffer_drawIndirect.init(*m_device, buffer_drawIndirect.create_info(sizeof(VkDrawIndirectCommand), buffer_usage, nullptr),
-                             mem_prop);
+    buffer_drawIndirect.init(
+        *m_device, buffer_drawIndirect.create_info(sizeof(VkDrawIndexedIndirectCommand), buffer_usage, nullptr), mem_prop);
     buffer_drawIndirect2.init(*m_device, buffer_drawIndirect2.create_info(sizeof(VkDrawIndirectCommand), buffer_usage, nullptr),
                               mem_prop);
 
@@ -3835,8 +3835,8 @@ TEST_F(VkSyncValTest, TestInvalidExternalSubpassDependency) {
     VkSubpassDependency subpass_dependency = {};
     subpass_dependency.srcSubpass = 0;
     subpass_dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
-    subpass_dependency.srcStageMask = 0;
-    subpass_dependency.dstStageMask = 0;
+    subpass_dependency.srcStageMask = VK_SHADER_STAGE_ALL_GRAPHICS;
+    subpass_dependency.dstStageMask = VK_SHADER_STAGE_ALL_GRAPHICS;
     subpass_dependency.srcAccessMask = 0;
     subpass_dependency.dstAccessMask = 0;
     subpass_dependency.dependencyFlags = 0;
@@ -3872,8 +3872,6 @@ TEST_F(VkSyncValTest, TestInvalidExternalSubpassDependency) {
     rp_ci.dependencyCount = 1;
     rp_ci.pDependencies = &subpass_dependency;
 
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkSubpassDependency-srcStageMask-03937");
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkSubpassDependency-dstStageMask-03937");
     vk_testing::RenderPass render_pass;
     render_pass.init(*m_device, rp_ci);
 
@@ -4529,11 +4527,6 @@ TEST_F(VkSyncValTest, SyncQSSubmit2) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
-    }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        m_device_extension_names.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    } else {
-        GTEST_SKIP() << "Synchronization2 not supported";
     }
 
     if (!CheckSynchronization2SupportAndInitState(this)) {

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2968,6 +2968,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
         m_renderPassBeginInfo.renderPass = rp.handle();
         m_renderPassBeginInfo.framebuffer = fb.handle();
 
+        // Test is intentionally running without dependencies.
         m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass");
         vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe_0.pipeline_);
@@ -3072,9 +3073,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
 
             vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
         }
-        // expect this error because 2 subpasses could try to do the store operation
-        // m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE-RACING-WRITE");
-        // ... and this one because the store could happen during a shader read from another subpass
+        // the store could happen during a shader read from another subpass
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE-RACING-READ");
         vk::CmdEndRenderPass(m_commandBuffer->handle());
         m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Since core checks are currently disabled in best practices (as well as GPU-AV and SyncVal) many tests are invalid, and may cause undefined behavior in the drivers.