### PR TITLE
layers: Use a thread for QUEUE_STATE submission processing

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -18203,13 +18203,12 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const AcquireVersion 
             skip |= LogError(semaphore, semaphore_type_vuid, "%s: %s is not a VK_SEMAPHORE_TYPE_BINARY", func_name,
                              report_data->FormatHandle(semaphore).c_str());
         } else if (semaphore_state->Scope() == kSyncScopeInternal) {
-            auto last_op = semaphore_state->LastOp();
             // TODO: VUIDs 01779 and 01781 cover the case where there are pending wait or signal operations on the
             // semaphore. But we don't currently have a good enough way to track when acquire & present operations
             // are completed. So it is possible to get in a condition where the semaphore is doing
             // acquire / wait / acquire and the first acquire (and thus the wait) have completed, but our state
             // isn't aware of it yet. This results in MANY false positives.
-            if (!last_op && !semaphore_state->Completed().CanBeSignaled()) {
+            if (!semaphore_state->CanBeSignaled()) {
                 const char *vuid = version == ACQUIRE_VERSION_2 ? "VUID-VkAcquireNextImageInfoKHR-semaphore-01288"
                                                                 : "VUID-vkAcquireNextImageKHR-semaphore-01286";
                 skip |= LogError(semaphore, vuid, "%s: Semaphore must not be currently signaled.", func_name);

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -372,7 +372,7 @@ void GpuAssistedBase::PreCallRecordDestroyDevice(VkDevice device, const VkAlloca
 }
 
 gpu_utils_state::Queue::Queue(GpuAssistedBase &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties)
-    : QUEUE_STATE(q, index, flags, queueFamilyProperties), state_(state) {}
+    : QUEUE_STATE(state, q, index, flags, queueFamilyProperties), state_(state) {}
 
 gpu_utils_state::Queue::~Queue() {
     if (barrier_command_buffer_) {

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -586,7 +586,7 @@ SWAPCHAIN_NODE::SWAPCHAIN_NODE(ValidationStateTracker *dev_data_, const VkSwapch
       image_create_info(GetImageCreateInfo(pCreateInfo)),
       dev_data(dev_data_) {}
 
-void SWAPCHAIN_NODE::PresentImage(uint32_t image_index) {
+void SWAPCHAIN_NODE::PresentImage(uint32_t image_index, uint64_t present_id) {
     if (image_index >= images.size()) return;
     assert(acquired_images > 0);
     acquired_images--;
@@ -596,6 +596,9 @@ void SWAPCHAIN_NODE::PresentImage(uint32_t image_index) {
         if (image_state) {
             image_state->layout_locked = true;
         }
+    }
+    if (present_id > max_present_id) {
+        max_present_id = present_id;
     }
 }
 

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -303,7 +303,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
 
     VkSwapchainKHR swapchain() const { return handle_.Cast<VkSwapchainKHR>(); }
 
-    void PresentImage(uint32_t image_index);
+    void PresentImage(uint32_t image_index, uint64_t present_id);
 
     void AcquireImage(uint32_t image_index);
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1774,6 +1774,15 @@ void ValidationStateTracker::RecordImportSemaphoreState(VkSemaphore semaphore, V
     }
 }
 
+void ValidationStateTracker::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
+                                                              VkResult result) {
+    auto semaphore_state = Get<SEMAPHORE_STATE>(pSignalInfo->semaphore);
+    if (semaphore_state) {
+        semaphore_state->RetireTimeline(pSignalInfo->value);
+    }
+}
+
+
 void ValidationStateTracker::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
                                                               VkResult result) {
     auto semaphore_state = Get<SEMAPHORE_STATE>(pSignalInfo->semaphore);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -601,6 +601,7 @@ class ValidationStateTracker : public ValidationObject {
                                                      VkResult result) override;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
     void PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo, VkResult result) override;
+    void PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo, VkResult result) override;
 
     // Create/Destroy/Bind
     void PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -782,11 +782,12 @@ class optional {
     void reset() { DeInit(); }
 
     template <typename... Args>
-    T &emplace(const Args &...args) {
+    T &emplace(Args &&...args) {
         init_ = true;
-        new (&store_.backing) T(args...);
+        new (&store_.backing) T(std::forward<Args>(args)...);
         return store_.obj;
     }
+
     T *operator&() {
         if (init_) return &store_.obj;
         return nullptr;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -675,7 +675,7 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
         return false;
     }
 
-    renderFramework->InitState(nullptr, &features2);
+    renderFramework->InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     return true;
 }
 
@@ -696,7 +696,7 @@ bool CheckSynchronization2SupportAndInitState(VkRenderFramework *framework) {
     auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     sync2_features.synchronization2 = VK_TRUE;
     auto features2 = lvl_init_struct<VkPhysicalDeviceFeatures2>(&sync2_features);
-    framework->InitState(nullptr, &features2,VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    framework->InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     return true;
 }
 

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -2348,6 +2348,7 @@ TEST_F(VkPositiveLayerTest, ImagelessLayoutTracking) {
     present.pImageIndices = &current_buffer;
     present.swapchainCount = 1;
     vk::QueuePresentKHR(m_device->m_queue, &present);
+    vk::QueueWaitIdle(m_device->m_queue);
 
     vk::DestroyRenderPass(m_device->device(), renderPass, nullptr);
     vk::DestroySemaphore(m_device->device(), image_acquired, nullptr);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8349,6 +8349,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
         semaphore_signal_info.value--;
         ASSERT_VK_SUCCESS(vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
 
+        ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
+
         vk::DestroySemaphore(m_device->device(), sem, nullptr);
 
         // Regression test for value difference validations ran against binary semaphores
@@ -8383,6 +8385,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
             semaphore_signal_info.semaphore = timeline_sem;
             semaphore_signal_info.value = 1;
             vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info);
+
+            ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
 
             vk::DestroySemaphore(m_device->device(), binary_sem, nullptr);
             vk::DestroySemaphore(m_device->device(), timeline_sem, nullptr);


### PR DESCRIPTION
Rewrite QUEUE_STATE to use a worker thread to update state. This was necessary to fix a race condtion if multiple threads wait on the same timeline semaphore.
    
    Thread 1:
    vkWaitSemaphores() : wait on semaphore for value N
    
    Thread 2:
    vkQueueSubmit()    : signal semaphore for value N
    vkWaitSemaphores() : wait on semaphore for value N
    
Thread 1 starts waiting before we have any information about which queues(s) will need to make progress before value N will be complete. In the old implementation, that might cause it to not correctly update the queue(s) state after it woke up. That would then lead to false 'object in use' errors. In theory, it might have been possible to fix this problem, but the logic was already confusing. Also, this opens up the possiblity of moving execute time validation and state updates to the queue thread, which might improve performance.
 
Fixes #4308
