### PR TITLE
layers: Fix CFI errors in DescriptorSet memory management

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -409,7 +409,7 @@ cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIP
     // Foreach binding, create default descriptors of given type
     auto binding_count = layout_->GetBindingCount();
     bindings_.reserve(binding_count);
-    bindings_store_.reserve(binding_count);
+    bindings_store_.resize(binding_count);
     auto free_binding = bindings_store_.data();
     for (uint32_t i = 0; i < binding_count; ++i) {
         auto create_info = layout_->GetDescriptorSetLayoutBindingPtrFromIndex(i);


### PR DESCRIPTION
A recent commit:

7b963d8 layers: Add back placement new for DescriptorSet allocations

Causes Control Flow Integrity errors. It looks like this is happening
because the backing store memory was set up reserve() rather than resize(),
so it doesn't necessarily exist. Using resize() should make this memory
voodoo be equivalent to the earlier Descriptor memory voodoo.

Fixes #4333