### PR TITLE
layers: Revert "Use small_vector for storing Descriptors"

### DIFF
--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -741,8 +741,7 @@ class DescriptorBinding {
     const VkDescriptorBindingFlags binding_flags;
     const uint32_t count;
     const bool has_immutable_samplers;
-    //std::vector<bool> updated;
-    small_vector<bool, 1, uint32_t> updated;
+    std::vector<bool> updated;
 };
 
 template <typename T>
@@ -771,7 +770,7 @@ class DescriptorBindingImpl : public DescriptorBinding {
             }
         }
     }
-    small_vector<T, 1, uint32_t> descriptors;
+    std::vector<T> descriptors;
 };
 
 using SamplerBinding = DescriptorBindingImpl<SamplerDescriptor>;

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -173,17 +173,6 @@ class small_vector {
         DebugUpdateWorkingStore();
     }
 
-    small_vector(size_type size, const value_type& value = value_type()) : size_(0), capacity_(N) {
-        reserve(size);
-        auto dest = GetWorkingStore();
-        for (size_type i = 0; i < size; i++) {
-            new (dest) value_type(value);
-            ++dest;
-        }
-        size_ = size;
-    }
-
-
     ~small_vector() { clear(); }
 
     bool operator==(const small_vector &rhs) const {


### PR DESCRIPTION
This reverts commit 94b7c2feac812e060041dff0c243b6950e122a78.

It is also causing CFI errors. Based on:

https://clang.llvm.org/docs/ControlFlowIntegrity.html#bad-cast-checking

this is probably only showing up for Descriptors because:

>    The checks are currently only introduced where the class being casted
>    to is a polymorphic class.

Presumably the other objects stored in small_vector are not polymorphic, but Descriptors are.

This is also for Issue #4333