### PR TITLE
layers: Fix mutable descriptor state active type state and checking

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -905,7 +905,6 @@ void cvdescriptorset::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet 
 cvdescriptorset::MutableDescriptor::MutableDescriptor()
     : Descriptor(),
       buffer_size_(0),
-      active_descriptor_class_(NoDescriptorClass),
       active_descriptor_type_(VK_DESCRIPTOR_TYPE_MUTABLE_VALVE),
       immutable_(false),
       image_layout_(VK_IMAGE_LAYOUT_UNDEFINED),
@@ -1067,6 +1066,7 @@ void cvdescriptorset::MutableDescriptor::CopyUpdate(DescriptorSet *set_state, co
             default:
                 break;
         }
+        SetDescriptorType(mutable_src->ActiveType(), mutable_src->GetBufferSize());
     }
 }
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -662,10 +662,10 @@ class MutableDescriptor : public Descriptor {
       bool Invalid() const override;
 
       VkDescriptorType ActiveType() const { return active_descriptor_type_; }
-      DescriptorClass ActiveClass() const { return active_descriptor_class_; }
+      DescriptorClass ActiveClass() const { return DescriptorTypeToClass(active_descriptor_type_); }
+
     private:
       VkDeviceSize buffer_size_{0};
-      DescriptorClass active_descriptor_class_{NoDescriptorClass};
       VkDescriptorType active_descriptor_type_{VK_DESCRIPTOR_TYPE_MUTABLE_VALVE};
 
       // Sampler and ImageSampler Descriptor

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -1916,16 +1916,19 @@ bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet *update, const Des
             }
         }
     } else if (src_type == VK_DESCRIPTOR_TYPE_MUTABLE_VALVE) {
-        const auto *descriptor = static_cast<const cvdescriptorset::MutableDescriptor*>(src_set->GetDescriptorFromBinding(update->srcBinding, update->srcArrayElement));
-        if (descriptor->ActiveType() != dst_type) {
-            *error_code = "VUID-VkCopyDescriptorSet-srcSet-04613";
-            std::stringstream error_str;
-            error_str << "Attempting copy update with srcBinding descriptor type VK_DESCRIPTOR_TYPE_MUTABLE_VALVE, but the "
-                         "active descriptor type ("
-                      << string_VkDescriptorType(descriptor->ActiveType())
-                      << ") does not match the dstBinding descriptor type " << string_VkDescriptorType(dst_type) << ".";
-            *error_msg = error_str.str();
-            return false;
+        auto src_iter = src_set->FindDescriptor(update->srcBinding, update->srcArrayElement);
+        for (uint32_t i = 0; i < update->descriptorCount; i++, ++src_iter) {
+            const auto &mutable_src = static_cast<const cvdescriptorset::MutableDescriptor &>(*src_iter);
+            if (mutable_src.ActiveType() != dst_type) {
+                *error_code = "VUID-VkCopyDescriptorSet-srcSet-04613";
+                std::stringstream error_str;
+                error_str << "Attempting copy update with srcBinding descriptor type VK_DESCRIPTOR_TYPE_MUTABLE_VALVE, but the "
+                             "active descriptor type ("
+                          << string_VkDescriptorType(mutable_src.ActiveType()) << ") does not match the dstBinding descriptor type "
+                          << string_VkDescriptorType(dst_type) << ".";
+                *error_msg = error_str.str();
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
Fix a problem with tracking the active descriptor type, which was introduced by https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4126

Fix the check for VUID 04613, which was a preexisting condition. Improve the test case to show what the problem was.