### PR TITLE
layers: Improve VUID 02697 error message

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1547,8 +1547,8 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
         }
         objlist.add(state.pipeline_layout);
         result |= LogError(objlist, vuid.compatible_pipeline,
-                           "%s(): %s defined with %s is not compatible for maximum set statically used %" PRIu32
-                           " with bound descriptor sets, last bound with %s",
+                           "%s(): The %s (created with %s) statically uses descriptor set (index #%" PRIu32
+                           ") which is not compatible with the currently bound descriptor set's pipeline layout (%s)",
                            CommandTypeString(cmd_type), report_data->FormatHandle(pipe->pipeline()).c_str(),
                            pipe_layouts_log.str().c_str(), pipe->max_active_slot,
                            report_data->FormatHandle(state.pipeline_layout).c_str());


### PR DESCRIPTION
Closes #4347 

I agree with @CarloWood on the issue that the message isn't good, I purposed this fix that changes it from

> vkCmdDispatch(): VkPipeline 0x967dd1000000000e[] defined with VkPipelineLayout 0xead9370000000008[] is not compatible for maximum set statically used 0 with bound descriptor sets, last bound with VkPipelineLayout 0xe88693000000000c[]

to 

> vkCmdDispatch(): The VkPipeline 0x967dd1000000000e[] (created with VkPipelineLayout 0xead9370000000008[]) maximum descriptor set statically used (index #0) is not compatible with the currently bound descriptor sets' pipeline layout (VkPipelineLayout 0xe88693000000000c[])