### PR TITLE
Queue Submit Time Support for RenderPass based operations (default off)

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1650,9 +1650,11 @@ void CreatePipelineHelper::InitDynamicStateInfo() {
     // during late bind
 }
 
-void CreatePipelineHelper::InitShaderInfo() {
-    vs_.reset(new VkShaderObj(&layer_test_, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT));
-    fs_.reset(new VkShaderObj(&layer_test_, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT));
+void CreatePipelineHelper::InitShaderInfo() { ResetShaderInfo(bindStateVertShaderText, bindStateFragShaderText); }
+
+void CreatePipelineHelper::ResetShaderInfo(const char *vertex_shader_text, const char *fragment_shader_text) {
+    vs_.reset(new VkShaderObj(&layer_test_, vertex_shader_text, VK_SHADER_STAGE_VERTEX_BIT));
+    fs_.reset(new VkShaderObj(&layer_test_, fragment_shader_text, VK_SHADER_STAGE_FRAGMENT_BIT));
     // We shouldn't need a fragment shader but add it to be able to run on more devices
     shader_stages_ = {vs_->GetStageCreateInfo(), fs_->GetStageCreateInfo()};
 }

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -176,6 +176,14 @@ static const char bindStateFragUniformShaderText[] = R"glsl(
     }
 )glsl";
 
+static char const bindStateFragSubpassLoadInputText[] = R"glsl(
+        #version 450
+        layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
+        void main() {
+           vec4 color = subpassLoad(x);
+        }
+    )glsl";
+
 // Static arrays helper
 template <class ElementT, size_t array_size>
 size_t size(ElementT (&)[array_size]) {
@@ -498,6 +506,7 @@ struct CreatePipelineHelper {
     void InitViewportInfo();
     void InitDynamicStateInfo();
     void InitShaderInfo();
+    void ResetShaderInfo(const char *vertex_shader_text, const char *fragment_shader_text);
     void InitRasterizationInfo();
     void InitLineRasterizationInfo();
     void InitBlendStateInfo();

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1752,17 +1752,7 @@ void VkImageObj::Init(const VkImageCreateInfo &create_info, VkMemoryPropertyFlag
     else
         newLayout = m_descriptorImageInfo.imageLayout;
 
-    VkImageAspectFlags image_aspect = 0;
-    const auto format = create_info.format;
-    if (FormatIsDepthAndStencil(format)) {
-        image_aspect = VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    } else if (FormatIsDepthOnly(format)) {
-        image_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
-    } else if (FormatIsStencilOnly(format)) {
-        image_aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
-    } else {  // color
-        image_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-    }
+    VkImageAspectFlags image_aspect = aspect_mask(create_info.format);
     SetLayout(image_aspect, newLayout);
 }
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -2487,6 +2487,8 @@ void VkCommandBufferObj::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSu
     vk::CmdBeginRenderPass(handle(), &info, contents);
 }
 
+void VkCommandBufferObj::NextSubpass(VkSubpassContents contents) { vk::CmdNextSubpass(handle(), contents); }
+
 void VkCommandBufferObj::EndRenderPass() { vk::CmdEndRenderPass(handle()); }
 
 void VkCommandBufferObj::BeginRendering(const VkRenderingInfoKHR &renderingInfo) {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -455,6 +455,7 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
     void BindIndexBuffer(VkBufferObj *indexBuffer, VkDeviceSize offset, VkIndexType indexType);
     void BindVertexBuffer(VkConstantBufferObj *vertexBuffer, VkDeviceSize offset, uint32_t binding);
     void BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
+    void NextSubpass(VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
     void EndRenderPass();
     void BeginRendering(const VkRenderingInfoKHR &renderingInfo);
     void EndRendering();
@@ -607,6 +608,7 @@ class VkImageObj : public vk_testing::Image {
 
     void SetLayout(VkCommandBufferObj *cmd_buf, VkImageAspectFlags aspect, VkImageLayout image_layout);
     void SetLayout(VkImageAspectFlags aspect, VkImageLayout image_layout);
+    void SetLayout(VkImageLayout image_layout) { SetLayout(aspect_mask(), image_layout); };
 
     VkImageLayout Layout() const { return m_descriptorImageInfo.imageLayout; }
     uint32_t width() const { return extent().width; }

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2549,7 +2549,6 @@ TEST_F(VkSyncValTest, SyncLayoutTransition) {
         image_input.handle(),
         full_subresource_range,
     };
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "SYNC-HAZARD-WRITE_AFTER_WRITE");
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0u, 0u, nullptr, 0u,
                            nullptr, 1u, &wawBarrier);
     m_errorMonitor->VerifyNotFound();

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -29,6 +29,7 @@
 
 #include "test_common.h"
 #include "vk_typemap_helper.h"
+#include "vk_format_utils.h"
 
 namespace {
 
@@ -604,6 +605,20 @@ VkSubresourceLayout Image::subresource_layout(const VkImageSubresourceLayers &su
 bool Image::transparent() const {
     return (create_info_.tiling == VK_IMAGE_TILING_LINEAR && create_info_.samples == VK_SAMPLE_COUNT_1_BIT &&
             !(create_info_.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)));
+}
+
+VkImageAspectFlags Image::aspect_mask(VkFormat format) {
+    VkImageAspectFlags image_aspect;
+    if (FormatIsDepthAndStencil(format)) {
+        image_aspect = VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
+    } else if (FormatIsDepthOnly(format)) {
+        image_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+    } else if (FormatIsStencilOnly(format)) {
+        image_aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
+    } else {  // color
+        image_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+    }
+    return image_aspect;
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(ImageView, vk::DestroyImageView)

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -545,7 +545,11 @@ class Image : public internal::NonDispHandle<VkImage> {
     bool transparent() const;
     bool copyable() const { return (format_features_ & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT); }
 
+    VkImageAspectFlags aspect_mask() const { return aspect_mask(create_info_.format); }
+
+    VkImageSubresourceRange subresource_range() const { return subresource_range(create_info_, aspect_mask()); }
     VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect) const { return subresource_range(create_info_, aspect); }
+
     VkExtent3D extent() const { return create_info_.extent; }
     VkExtent3D extent(uint32_t mip_level) const { return extent(create_info_.extent, mip_level); }
     VkFormat format() const { return create_info_.format; }
@@ -598,6 +602,8 @@ class Image : public internal::NonDispHandle<VkImage> {
                                                      uint32_t base_array_layer, uint32_t num_layers);
     static VkImageSubresourceRange subresource_range(const VkImageCreateInfo &info, VkImageAspectFlags aspect_mask);
     static VkImageSubresourceRange subresource_range(const VkImageSubresource &subres);
+
+    static VkImageAspectFlags aspect_mask(VkFormat format);
 
     static VkExtent2D extent(int32_t width, int32_t height);
     static VkExtent2D extent(const VkExtent2D &extent, uint32_t mip_level);


### PR DESCRIPTION
Update the first use/replay models to support renderpass and subpass operation validation at queue submit time.