### PR TITLE
Fix, then remove the fragment shader portion of 06896

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -1406,3 +1406,16 @@ void CMD_BUFFER_STATE::UnbindResources() {
     // Pipeline and descriptor sets
     lastBound[BindPoint_Graphics].Reset();
 }
+
+bool CMD_BUFFER_STATE::RasterizationDisabled() const {
+    auto pipeline = lastBound[BindPoint_Graphics].pipeline_state;
+    if (pipeline) {
+        if (pipeline->IsDynamic(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)) {
+            return rasterization_disabled;
+        } else {
+            return pipeline->RasterizationDisabled();
+        }
+    }
+
+    return false;
+}

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -280,6 +280,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t initial_device_mask;
     VkPrimitiveTopology primitiveTopology;
 
+    bool rasterization_disabled = false;
+
     safe_VkRenderPassBeginInfo activeRenderPassBeginInfo;
     std::shared_ptr<RENDER_PASS_STATE> activeRenderPass;
     std::shared_ptr<std::vector<SUBPASS_INFO>> active_subpasses;
@@ -514,6 +516,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t GetDynamicDepthResolveAttachmentImageIndex() { return 2 * GetDynamicColorAttachmentCount() + 1; }
     uint32_t GetDynamicStencilAttachmentImageIndex() { return 2 * GetDynamicColorAttachmentCount() + 2; }
     uint32_t GetDynamicStencilResolveAttachmentImageIndex() { return 2 * GetDynamicColorAttachmentCount() + 3; }
+
+    bool RasterizationDisabled() const;
 
   protected:
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1460,17 +1460,6 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         skip |= ValidateGraphicsPipelineShaderDynamicState(pPipeline, pCB, caller, vuid);
     }
 
-    if (!pCB->RasterizationDisabled()) {
-        // NOTE: we should be able to assume the pipeline has fragment shader state at this point
-        if (pPipeline->fragment_shader_state && ((pPipeline->active_shaders & FragmentShaderState::ValidShaderStages()) == 0)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-06896",
-                             "%s(): Currently bound pipeline %s contains fragment shader state, but stages (%s) does not contain a "
-                             "fragment shader.",
-                             caller, report_data->FormatHandle(pPipeline->pipeline()).c_str(),
-                             string_VkShaderStageFlags(pPipeline->active_shaders).c_str());
-        }
-    }
-
     return skip;
 }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4749,12 +4749,14 @@ void ValidationStateTracker::PreCallRecordCmdSetRasterizerDiscardEnableEXT(VkCom
                                                                            VkBool32 rasterizerDiscardEnable) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETRASTERIZERDISCARDENABLEEXT, CBSTATUS_RASTERIZER_DISCARD_ENABLE_SET);
+    cb_state->rasterization_disabled = rasterizerDiscardEnable == VK_TRUE;
 }
 
 void ValidationStateTracker::PreCallRecordCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer,
     VkBool32 rasterizerDiscardEnable) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETRASTERIZERDISCARDENABLE, CBSTATUS_RASTERIZER_DISCARD_ENABLE_SET);
+    cb_state->rasterization_disabled = rasterizerDiscardEnable == VK_TRUE;
 }
 
 void ValidationStateTracker::PreCallRecordCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -1171,7 +1171,7 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingShaderStages) {
         GTEST_SKIP() << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary not supported.";
     }
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &gpl_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &gpl_features));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -1185,84 +1185,5 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingShaderStages) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-06896");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
-    }
-
-    const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, bindStateVertShaderText);
-    auto vs_ci = LvlInitStruct<VkShaderModuleCreateInfo>();
-    vs_ci.codeSize = vs_spv.size() * sizeof(decltype(vs_spv)::value_type);
-    vs_ci.pCode = vs_spv.data();
-
-    auto stage_ci = LvlInitStruct<VkPipelineShaderStageCreateInfo>(&vs_ci);
-    stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stage_ci.module = VK_NULL_HANDLE;
-    stage_ci.pName = "main";
-
-    // While 06896 is a VkGraphicsPipeline*CreateInfo* VUID, it interacts with dynamnic state, so we need to check wait until draw
-    // time to check it
-
-    CreatePipelineHelper vi_pipe(*this);
-    vi_pipe.InitVertexInputLibInfo();
-    vi_pipe.InitState();
-    ASSERT_VK_SUCCESS(vi_pipe.CreateGraphicsPipeline(true, false));
-
-    // Pre-raster lib created with rasterization _enabled_
-    CreatePipelineHelper vs_pipe(*this);
-    vs_pipe.InitPreRasterLibInfo(1, &stage_ci);
-    vs_pipe.InitState();
-    vs_pipe.CreateGraphicsPipeline();
-
-    // FS lib created with no fragment shader
-    CreatePipelineHelper fs_pipe(*this);
-    fs_pipe.InitFragmentLibInfo(0, nullptr);
-    fs_pipe.InitState();
-    fs_pipe.CreateGraphicsPipeline();
-
-    CreatePipelineHelper fo_pipe(*this);
-    fo_pipe.InitFragmentOutputLibInfo();
-    fo_pipe.gp_ci_.renderPass = fs_pipe.gp_ci_.renderPass;
-    fo_pipe.gp_ci_.subpass = fs_pipe.gp_ci_.subpass;
-    ASSERT_VK_SUCCESS(fo_pipe.CreateGraphicsPipeline());
-
-    {
-        VkPipeline libraries[4] = {vi_pipe.pipeline_, fs_pipe.pipeline_, vs_pipe.pipeline_, fo_pipe.pipeline_};
-
-        auto link_info = LvlInitStruct<VkPipelineLibraryCreateInfoKHR>();
-        link_info.libraryCount = size(libraries);
-        link_info.pLibraries = libraries;
-
-        auto pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
-        vk_testing::Pipeline pipe(*m_device, pipe_ci);
-
-        m_commandBuffer->begin();
-        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-06896");
-        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
-        m_errorMonitor->VerifyFound();
-        m_commandBuffer->EndRenderPass();
-        m_commandBuffer->end();
-    }
-
-    {
-        // If rasterization is disabled, a fragment shader is not necessary
-        vs_pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-        vs_pipe.InitState();
-        ASSERT_VK_SUCCESS(vs_pipe.CreateGraphicsPipeline());
-
-        VkPipeline libraries[4] = {vi_pipe.pipeline_, vs_pipe.pipeline_, fs_pipe.pipeline_, fo_pipe.pipeline_};
-
-        auto link_info = LvlInitStruct<VkPipelineLibraryCreateInfoKHR>();
-        link_info.libraryCount = size(libraries);
-        link_info.pLibraries = libraries;
-
-        auto pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
-        vk_testing::Pipeline pipe(*m_device, pipe_ci);
-
-        m_commandBuffer->begin();
-        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
-        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
-        m_commandBuffer->EndRenderPass();
-        m_commandBuffer->end();
     }
 }


### PR DESCRIPTION
The first commit fixes 06896 to only trigger the missing fragment shader error when rasterization is enabled. The second commit removes this check (see internal issue 3178 for details). I've left the "fix commit" in history because it is my understanding this change will be coming back in the near future, just gated behind something like a maintenance extension check.