### PR TITLE
layers: Use KHR RayTracing shader alias

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -26,8 +26,8 @@
 #include "cmd_buffer_state.h"
 
 static const VkShaderStageFlags kShaderStageAllRayTracing =
-    VK_SHADER_STAGE_ANY_HIT_BIT_NV | VK_SHADER_STAGE_CALLABLE_BIT_NV | VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV |
-    VK_SHADER_STAGE_INTERSECTION_BIT_NV | VK_SHADER_STAGE_MISS_BIT_NV | VK_SHADER_STAGE_RAYGEN_BIT_NV;
+    VK_SHADER_STAGE_ANY_HIT_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR | VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+    VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_RAYGEN_BIT_KHR;
 
 // Perform initializations that can be done at Create Device time.
 void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
@@ -486,7 +486,7 @@ void debug_printf_state::CommandBuffer::Process(VkQueue queue) {
                 operation_index = draw_index;
             } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
                 operation_index = compute_index;
-            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
                 operation_index = ray_trace_index;
             } else {
                 assert(false);
@@ -502,7 +502,7 @@ void debug_printf_state::CommandBuffer::Process(VkQueue queue) {
                 draw_index++;
             } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
                 compute_index++;
-            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
                 ray_trace_index++;
             } else {
                 assert(false);
@@ -701,7 +701,7 @@ void DebugPrintf::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer command
 
 void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point) {
     if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         return;
     }
     VkResult result;

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -347,7 +347,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
     static const std::map<VkPipelineBindPoint, std::string> bindpoint_errors = {
         std::make_pair(VK_PIPELINE_BIND_POINT_GRAPHICS, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361"),
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361"),
-        std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361")};
+        std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361")};
     skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdBindPipeline()", bindpoint_errors);
 
     return skip;

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -752,7 +752,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                                                      const VkPipelineBindPoint bind_point) {
     using Accessor = CreatePipelineTraits<CreateInfo>;
     if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         return;
     }
 
@@ -807,7 +807,7 @@ void GpuAssistedBase::PostCallRecordPipelineCreations(const uint32_t count, cons
                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                       const VkPipelineBindPoint bind_point, const SafeCreateInfo &modified_create_infos) {
     if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         return;
     }
     for (uint32_t pipeline = 0; pipeline < count; ++pipeline) {
@@ -941,7 +941,7 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
             strm << "Draw ";
         } else if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
             strm << "Compute ";
-        } else if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+        } else if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
             strm << "Ray Trace ";
         } else {
             assert(false);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -32,8 +32,8 @@
 #include "render_pass_state.h"
 
 static const VkShaderStageFlags kShaderStageAllRayTracing =
-    VK_SHADER_STAGE_ANY_HIT_BIT_NV | VK_SHADER_STAGE_CALLABLE_BIT_NV | VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV |
-    VK_SHADER_STAGE_INTERSECTION_BIT_NV | VK_SHADER_STAGE_MISS_BIT_NV | VK_SHADER_STAGE_RAYGEN_BIT_NV;
+    VK_SHADER_STAGE_ANY_HIT_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR | VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+    VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_RAYGEN_BIT_KHR;
 
 // Keep in sync with the GLSL shader below.
 struct GpuAccelerationStructureBuildValidationBuffer {
@@ -1299,7 +1299,7 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue) {
                 operation_index = draw_index;
             } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
                 operation_index = compute_index;
-            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
                 operation_index = ray_trace_index;
             } else {
                 assert(false);
@@ -1315,7 +1315,7 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue) {
                 draw_index++;
             } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
                 compute_index++;
-            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+            } else if (buffer_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
                 ray_trace_index++;
             } else {
                 assert(false);
@@ -1820,7 +1820,7 @@ void GpuAssisted::AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBloc
 void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point,
                                               CMD_TYPE cmd_type, const GpuAssistedCmdDrawIndirectState *cdi_state) {
     if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_NV) {
+        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         return;
     }
     VkResult result;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -134,18 +134,18 @@ static uint32_t ExecutionModelToShaderStageFlagBits(uint32_t mode) {
             return VK_SHADER_STAGE_FRAGMENT_BIT;
         case spv::ExecutionModelGLCompute:
             return VK_SHADER_STAGE_COMPUTE_BIT;
-        case spv::ExecutionModelRayGenerationNV:
-            return VK_SHADER_STAGE_RAYGEN_BIT_NV;
-        case spv::ExecutionModelAnyHitNV:
-            return VK_SHADER_STAGE_ANY_HIT_BIT_NV;
-        case spv::ExecutionModelClosestHitNV:
-            return VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV;
-        case spv::ExecutionModelMissNV:
-            return VK_SHADER_STAGE_MISS_BIT_NV;
-        case spv::ExecutionModelIntersectionNV:
-            return VK_SHADER_STAGE_INTERSECTION_BIT_NV;
-        case spv::ExecutionModelCallableNV:
-            return VK_SHADER_STAGE_CALLABLE_BIT_NV;
+        case spv::ExecutionModelRayGenerationKHR:
+            return VK_SHADER_STAGE_RAYGEN_BIT_KHR;
+        case spv::ExecutionModelAnyHitKHR:
+            return VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
+        case spv::ExecutionModelClosestHitKHR:
+            return VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+        case spv::ExecutionModelMissKHR:
+            return VK_SHADER_STAGE_MISS_BIT_KHR;
+        case spv::ExecutionModelIntersectionKHR:
+            return VK_SHADER_STAGE_INTERSECTION_BIT_KHR;
+        case spv::ExecutionModelCallableKHR:
+            return VK_SHADER_STAGE_CALLABLE_BIT_KHR;
         case spv::ExecutionModelTaskNV:
             return VK_SHADER_STAGE_TASK_BIT_NV;
         case spv::ExecutionModelMeshNV:

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1046,12 +1046,12 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE 
             }
             break;
 
-        case VK_SHADER_STAGE_RAYGEN_BIT_NV:
-        case VK_SHADER_STAGE_ANY_HIT_BIT_NV:
-        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV:
-        case VK_SHADER_STAGE_MISS_BIT_NV:
-        case VK_SHADER_STAGE_INTERSECTION_BIT_NV:
-        case VK_SHADER_STAGE_CALLABLE_BIT_NV:
+        case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+        case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+        case VK_SHADER_STAGE_MISS_BIT_KHR:
+        case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+        case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
         case VK_SHADER_STAGE_TASK_BIT_NV:
         case VK_SHADER_STAGE_MESH_BIT_NV:
             break;
@@ -3381,13 +3381,13 @@ bool CoreChecks::ValidateRayTracingPipeline(PIPELINE_STATE *pipeline, const safe
 
         if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_NV ||
             group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV) {
-            if (!GroupHasValidIndex(*pipeline, group.anyHitShader, VK_SHADER_STAGE_ANY_HIT_BIT_NV)) {
+            if (!GroupHasValidIndex(*pipeline, group.anyHitShader, VK_SHADER_STAGE_ANY_HIT_BIT_KHR)) {
                 skip |= LogError(device,
                                  isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-anyHitShader-03479"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-anyHitShader-02418",
                                  ": pGroups[%d]", group_index);
             }
-            if (!GroupHasValidIndex(*pipeline, group.closestHitShader, VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV)) {
+            if (!GroupHasValidIndex(*pipeline, group.closestHitShader, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR)) {
                 skip |= LogError(device,
                                  isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-closestHitShader-03478"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-closestHitShader-02417",

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -718,23 +718,23 @@ EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_typ
         case VK_SHADER_STAGE_COMPUTE_BIT:
             return EShLangCompute;
 
-        case VK_SHADER_STAGE_RAYGEN_BIT_NV:
-            return EShLangRayGenNV;
+        case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+            return EShLangRayGen;
 
-        case VK_SHADER_STAGE_ANY_HIT_BIT_NV:
-            return EShLangAnyHitNV;
+        case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+            return EShLangAnyHit;
 
-        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV:
-            return EShLangClosestHitNV;
+        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+            return EShLangClosestHit;
 
-        case VK_SHADER_STAGE_MISS_BIT_NV:
-            return EShLangMissNV;
+        case VK_SHADER_STAGE_MISS_BIT_KHR:
+            return EShLangMiss;
 
-        case VK_SHADER_STAGE_INTERSECTION_BIT_NV:
-            return EShLangIntersectNV;
+        case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+            return EShLangIntersect;
 
-        case VK_SHADER_STAGE_CALLABLE_BIT_NV:
-            return EShLangCallableNV;
+        case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
+            return EShLangCallable;
 
         case VK_SHADER_STAGE_TASK_BIT_NV:
             return EShLangTaskNV;


### PR DESCRIPTION
Currently doing more validation work for ray tracing (`spirv-val` and now here) and updated some enum to use the `KHR` alias where it is used as a general enum (left if directly dealing with `VK_NV_ray_tracing`) as makes grepping much easier