### PR TITLE
tests: Add submit2 GPU-Val test

### DIFF
--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -1698,7 +1698,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBuildAccelerationStructureValidationRestoresSt
 TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     TEST_DESCRIPTION("GPU validation: Validate maxDrawIndirectCount limit");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);  // instead of enabling feature
     InitGpuAssistedFramework(false);
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
@@ -1806,6 +1806,94 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
         ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
         m_errorMonitor->VerifyFound();
     }
+}
+
+TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
+    TEST_DESCRIPTION("GPU validation: Validate maxDrawIndirectCount limit using vkQueueSubmit2");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    InitGpuAssistedFramework(false);
+    if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
+        GTEST_SKIP() << "At least Vulkan version 1.3 is required";
+    }
+
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        GTEST_SKIP() << "GPU-Assisted validation test requires a driver that can draw.";
+    }
+
+    PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT = nullptr;
+    PFN_vkGetOriginalPhysicalDeviceLimitsEXT fpvkGetOriginalPhysicalDeviceLimitsEXT = nullptr;
+    if (!LoadDeviceProfileLayer(fpvkSetPhysicalDeviceLimitsEXT, fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
+        GTEST_SKIP() << "Failed to load device profile layer.";
+    }
+
+    VkPhysicalDeviceProperties props;
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    props.limits.maxDrawIndirectCount = 1;
+    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+
+    auto features_13 = LvlInitStruct<VkPhysicalDeviceVulkan13Features>();
+    auto features_12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>(&features_13);
+    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&features_12);
+    GetPhysicalDeviceFeatures2(features2);
+    if (!features_12.drawIndirectCount || !features_13.synchronization2) {
+        GTEST_SKIP() << "drawIndirectCount and synchronization2 both not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
+    buffer_create_info.size = 2 * sizeof(VkDrawIndexedIndirectCommand);
+    buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+    VkBufferObj draw_buffer;
+    draw_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkDrawIndexedIndirectCommand *draw_ptr = static_cast<VkDrawIndexedIndirectCommand *>(draw_buffer.memory().map());
+    memset(draw_ptr, 0, 2 * sizeof(VkDrawIndexedIndirectCommand));
+    draw_buffer.memory().unmap();
+
+    VkBufferCreateInfo count_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
+    count_buffer_create_info.size = sizeof(uint32_t);
+    count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+    VkBufferObj count_buffer;
+    count_buffer.init(*m_device, count_buffer_create_info,
+                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
+    count_buffer.memory().unmap();
+
+    VkBufferObj index_buffer;
+    index_buffer.init(*m_device, sizeof(uint32_t), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
+
+    VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = LvlInitStruct<VkPipelineLayoutCreateInfo>();
+    vk_testing::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
+    ASSERT_TRUE(pipeline_layout.initialized());
+
+    VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
+    VkPipelineObj pipe(m_device);
+    pipe.AddShader(&vs);
+    pipe.AddDefaultColorAttachment();
+    ASSERT_VK_SUCCESS(pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass()));
+
+    VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
+    m_commandBuffer->begin(&begin_info);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    VkViewport viewport = {0, 0, 16, 16, 0, 1};
+    vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
+    VkRect2D scissor = {{0, 0}, {16, 16}};
+    vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
+    vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717");
+    vk::CmdDrawIndexedIndirectCount(m_commandBuffer->handle(), draw_buffer.handle(), 0, count_buffer.handle(), 0, 2,
+                                    sizeof(VkDrawIndexedIndirectCommand));
+
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+    VkFenceObj null_fence;
+    // use vkQueueSumit2
+    m_commandBuffer->QueueCommandBuffer(null_fence, true, true);
+    ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -489,7 +489,7 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
 #ifdef VK_USE_PLATFORM_METAL_EXT
     instance_extensions_.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 #endif
-    
+
     RemoveIf(instance_layers_, LayerNotSupportedWithReporting);
     RemoveIf(instance_extensions_, ExtensionNotSupportedWithReporting);
 
@@ -2519,21 +2519,25 @@ void VkCommandBufferObj::Draw(uint32_t vertexCount, uint32_t instanceCount, uint
     vk::CmdDraw(handle(), vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
-void VkCommandBufferObj::QueueCommandBuffer(bool checkSuccess) {
-    VkFenceObj nullFence;
-    QueueCommandBuffer(nullFence, checkSuccess);
+void VkCommandBufferObj::QueueCommandBuffer(bool check_success) {
+    VkFenceObj null_fence;
+    QueueCommandBuffer(null_fence, check_success);
 }
 
-void VkCommandBufferObj::QueueCommandBuffer(const VkFenceObj &fence, bool checkSuccess) {
+void VkCommandBufferObj::QueueCommandBuffer(const VkFenceObj &fence, bool check_success, bool submit_2) {
     VkResult err = VK_SUCCESS;
 
-    err = m_queue->submit(*this, fence, checkSuccess);
-    if (checkSuccess) {
+    if (submit_2) {
+        err = m_queue->submit2(*this, fence, check_success);
+    } else {
+        err = m_queue->submit(*this, fence, check_success);
+    }
+    if (check_success) {
         ASSERT_VK_SUCCESS(err);
     }
 
     err = m_queue->wait();
-    if (checkSuccess) {
+    if (check_success) {
         ASSERT_VK_SUCCESS(err);
     }
 
@@ -2541,7 +2545,6 @@ void VkCommandBufferObj::QueueCommandBuffer(const VkFenceObj &fence, bool checkS
     // Wait for work to finish before cleaning up.
     vk::DeviceWaitIdle(m_device->device());
 }
-
 void VkCommandBufferObj::BindDescriptorSet(VkDescriptorSetObj &descriptorSet) {
     VkDescriptorSet set_obj = descriptorSet.GetDescriptorSetHandle();
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -457,8 +457,8 @@ class VkCommandBufferObj : public vk_testing::CommandBuffer {
     void Draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
     void DrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset,
                      uint32_t firstInstance);
-    void QueueCommandBuffer(bool checkSuccess = true);
-    void QueueCommandBuffer(const VkFenceObj &fence, bool checkSuccess = true);
+    void QueueCommandBuffer(bool check_success = true);
+    void QueueCommandBuffer(const VkFenceObj &fence, bool check_success = true, bool submit_2 = false);
     void SetViewport(uint32_t firstViewport, uint32_t viewportCount, const VkViewport *pViewports);
     void SetStencilReference(VkStencilFaceFlags faceMask, uint32_t reference);
     void UpdateBuffer(VkBuffer buffer, VkDeviceSize dstOffset, VkDeviceSize dataSize, const void *pData);

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -291,6 +291,9 @@ class Queue : public internal::Handle<VkQueue> {
     VkResult submit(const std::vector<const CommandBuffer *> &cmds, const Fence &fence, bool expect_success = true);
     VkResult submit(const CommandBuffer &cmd, const Fence &fence, bool expect_success = true);
     VkResult submit(const CommandBuffer &cmd, bool expect_success = true);
+    // vkQueueSubmit2()
+    VkResult submit2(const std::vector<const CommandBuffer *> &cmds, const Fence &fence, bool expect_success = true);
+    VkResult submit2(const CommandBuffer &cmd, const Fence &fence, bool expect_success = true);
 
     // vkQueueWaitIdle()
     VkResult wait();


### PR DESCRIPTION
So I originally thought there was a bug with `vkQueueSubmit2` for GPU-Validation, but after writing a test I realize there isn't.

This test still adds a missing test for `VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717` and cleans up the `GpuDrawIndirectCountDeviceLimit` a bit. Also, I can see using the `submit2` for future tests