### PR TITLE
layers: Avoid crashes when dynamic_rendering is enabled

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1035,7 +1035,7 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
 static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(const safe_VkGraphicsPipelineCreateInfo& create_info,
                                                                  std::shared_ptr<const RENDER_PASS_STATE>& rp) {
     std::vector<bp_state::AttachmentInfo> result;
-    if (!rp || rp->use_dynamic_rendering || rp->use_dynamic_rendering_inherited) {
+    if (!rp || rp->UsesDynamicRendering()) {
         return result;
     }
 
@@ -2484,7 +2484,7 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
     // If we have a rect which covers the entire frame buffer, we have a LOAD_OP_CLEAR-like command.
     bool full_clear = ClearAttachmentsIsFullClear(*cmd_state, rectCount, pRects);
 
-    if (!rp_state->use_dynamic_rendering && !rp_state->use_dynamic_rendering_inherited) {
+    if (!rp_state->UsesDynamicRendering()) {
         auto& subpass = rp_state->createInfo.pSubpasses[cmd_state->activeSubpass];
         for (uint32_t i = 0; i < attachmentCount; i++) {
             auto& attachment = pClearAttachments[i];

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -122,6 +122,8 @@ class RENDER_PASS_STATE : public BASE_NODE {
 
     bool UsesColorAttachment(uint32_t subpass) const;
     bool UsesDepthStencilAttachment(uint32_t subpass) const;
+    // prefer this to checking the individual flags unless you REALLY need to check one or the other
+    bool UsesDynamicRendering() const { return use_dynamic_rendering || use_dynamic_rendering_inherited; }
 };
 
 class FRAMEBUFFER_STATE : public BASE_NODE {

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -264,7 +264,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE &m
     std::map<uint32_t, Attachment> location_map;
 
     const auto &rp_state = pipeline->RenderPassState();
-    if (rp_state && !rp_state->use_dynamic_rendering) {
+    if (rp_state && !rp_state->UsesDynamicRendering()) {
         const auto rpci = rp_state->createInfo.ptr();
         const auto subpass = rpci->pSubpasses[subpass_index];
         for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
@@ -1154,7 +1154,7 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
 
     const auto &rp_state = pipeline->RenderPassState();
     if ((stage == VK_SHADER_STAGE_FRAGMENT_BIT) && rp_state) {
-        if (rp_state->use_dynamic_rendering) {
+        if (rp_state->UsesDynamicRendering()) {
             total_resources += rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount;
         } else {
             // "For the fragment shader stage the framebuffer color attachments also count against this limit"
@@ -2930,7 +2930,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
         auto input_attachment_uses = module_state.CollectInterfaceByInputAttachmentIndex(accessible_ids);
 
         const auto &rp_state = pipeline->RenderPassState();
-        if (rp_state && !rp_state->use_dynamic_rendering) {
+        if (rp_state && !rp_state->UsesDynamicRendering()) {
             auto rpci = rp_state->createInfo.ptr();
             auto subpass = pipeline->Subpass();
             for (auto use : input_attachment_uses) {
@@ -3179,7 +3179,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
 
     if (fragment_stage && fragment_stage->module_state->has_valid_spirv) {
         const auto &rp_state = pipeline->RenderPassState();
-        if (rp_state && rp_state->use_dynamic_rendering) {
+        if (rp_state && rp_state->UsesDynamicRendering()) {
             skip |= ValidateFsOutputsAgainstDynamicRenderingRenderPass(*fragment_stage->module_state.get(),
                                                                        fragment_stage->entrypoint, pipeline);
         } else {


### PR DESCRIPTION
Add RENDER_PASS_STATE::UsesDynamicRendering() because several code
paths were going in the 'normal' RenderPass code when
use_dynamic_rendering_inherited == true but use_dynamic_rendering ==
false.