### PR TITLE
layers: More cleanup for GPUVA

### DIFF
--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -24,10 +24,6 @@
 #include "layer_chassis_dispatch.h"
 #include "cmd_buffer_state.h"
 
-static const VkShaderStageFlags kShaderStageAllRayTracing =
-    VK_SHADER_STAGE_ANY_HIT_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR | VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
-    VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_RAYGEN_BIT_KHR;
-
 // Perform initializations that can be done at Create Device time.
 void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     if (enabled[gpu_validation]) {

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -42,8 +42,8 @@
 #endif
 
 // Implementation for Descriptor Set Manager class
-UtilDescriptorSetManager::UtilDescriptorSetManager(VkDevice device, uint32_t numBindingsInSet)
-    : device(device), numBindingsInSet(numBindingsInSet) {}
+UtilDescriptorSetManager::UtilDescriptorSetManager(VkDevice device, uint32_t num_bindings_in_set)
+    : device(device), num_bindings_in_set(num_bindings_in_set) {}
 
 UtilDescriptorSetManager::~UtilDescriptorSetManager() {
     for (auto &pool : desc_pool_map_) {
@@ -90,7 +90,7 @@ VkResult UtilDescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescripto
         }
         const VkDescriptorPoolSize size_counts = {
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            pool_count * numBindingsInSet,
+            pool_count * num_bindings_in_set,
         };
         auto desc_pool_info = LvlInitStruct<VkDescriptorPoolCreateInfo>();
         desc_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -26,9 +26,13 @@
 
 class GpuAssistedBase;
 
+static const VkShaderStageFlags kShaderStageAllRayTracing =
+    VK_SHADER_STAGE_ANY_HIT_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR | VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
+    VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_RAYGEN_BIT_KHR;
+
 class UtilDescriptorSetManager {
   public:
-    UtilDescriptorSetManager(VkDevice device, uint32_t numBindingsInSet);
+    UtilDescriptorSetManager(VkDevice device, uint32_t num_bindings_in_set);
     ~UtilDescriptorSetManager();
 
     VkResult GetDescriptorSet(VkDescriptorPool *desc_pool, VkDescriptorSetLayout ds_layout, VkDescriptorSet *desc_sets);
@@ -45,7 +49,7 @@ class UtilDescriptorSetManager {
         uint32_t used;
     };
     VkDevice device;
-    uint32_t numBindingsInSet;
+    uint32_t num_bindings_in_set;
     layer_data::unordered_map<VkDescriptorPool, struct PoolTracker> desc_pool_map_;
     mutable std::mutex lock_;
 };

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -31,12 +31,13 @@ struct GpuAssistedDeviceMemoryBlock {
 };
 
 struct GpuAssistedPreDrawResources {
-    VkDescriptorPool desc_pool;
-    VkDescriptorSet desc_set;
-    VkBuffer buffer;
-    VkDeviceSize offset;
-    uint32_t stride;
-    VkDeviceSize buf_size;
+    VkDescriptorPool desc_pool = VK_NULL_HANDLE;
+    VkDescriptorSet desc_set = VK_NULL_HANDLE;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceSize offset = 0;
+    uint32_t stride = 0;
+    VkDeviceSize buf_size = 0;
+    static const uint32_t push_constant_words = 4;
 };
 
 struct GpuAssistedBufferInfo {
@@ -81,8 +82,8 @@ struct GpuAssistedAccelerationStructureBuildValidationBufferInfo {
 
     // The storage buffer used by the validating compute shader whichcontains info about
     // the valid handles and which is written to communicate found invalid handles.
-    VkBuffer validation_buffer = VK_NULL_HANDLE;
-    VmaAllocation validation_buffer_allocation = VK_NULL_HANDLE;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation buffer_allocation = VK_NULL_HANDLE;
 };
 
 struct GpuAssistedAccelerationStructureBuildValidationState {
@@ -99,16 +100,18 @@ struct GpuAssistedAccelerationStructureBuildValidationState {
 
 struct GpuAssistedPreDrawValidationState {
     bool globals_created = false;
-    VkShaderModule validation_shader_module = VK_NULL_HANDLE;
-    VkDescriptorSetLayout validation_ds_layout = VK_NULL_HANDLE;
-    VkPipelineLayout validation_pipeline_layout = VK_NULL_HANDLE;
+    VkShaderModule shader_module = VK_NULL_HANDLE;
+    VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
     vl_concurrent_unordered_map <VkRenderPass, VkPipeline> renderpass_to_pipeline;
+
+    void Destroy(VkDevice device);
 };
 
 struct GpuAssistedCmdDrawIndirectState {
     VkBuffer buffer;
     VkDeviceSize offset;
-    uint32_t drawCount;
+    uint32_t draw_count;
     uint32_t stride;
     VkBuffer count_buffer;
     VkDeviceSize count_buffer_offset;
@@ -255,9 +258,11 @@ class GpuAssisted : public GpuAssistedBase {
                                                const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                VkDeviceAddress indirectDeviceAddress) override;
-    void AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point, CMD_TYPE cmd, const GpuAssistedCmdDrawIndirectState *cdic_state = nullptr);
+    void AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point, CMD_TYPE cmd,
+                                     const GpuAssistedCmdDrawIndirectState* cdi_state = nullptr);
     void AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBlock output_block, GpuAssistedPreDrawResources& resources,
-                                            const LAST_BOUND_STATE& state, VkPipeline *pPipeline, const GpuAssistedCmdDrawIndirectState *cdic_state);
+                                            const LAST_BOUND_STATE& state, VkPipeline* pPipeline,
+                                            const GpuAssistedCmdDrawIndirectState* cdi_state);
     void PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                    VkPhysicalDeviceProperties* pPhysicalDeviceProperties) override;
     void PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,


### PR DESCRIPTION
- Moved `kShaderStageAllRayTracing` to `gpu_utils.h`
- use underscore naming convention in a few spots it was missing
- created a dedicated `Destroy` for `GpuAssistedPreDrawValidationState` to better give it ownership
- removed redundant `validation_` in `pre_draw_validation_state.validation_shader_module` and others related
- Replaced some magic numbers with `const`s