### PR TITLE
layers: Fix deadlock in vkCmdBeginRenderPass()

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -239,7 +239,8 @@ CMD_BUFFER_STATE::CMD_BUFFER_STATE(ValidationStateTracker *dev, VkCommandBuffer 
       createInfo(*pCreateInfo),
       command_pool(pool),
       dev_data(dev),
-      unprotected(pool->unprotected) {
+      unprotected(pool->unprotected),
+      lastBound({*this, *this, *this}) {
     Reset();
 }
 
@@ -963,7 +964,7 @@ void CMD_BUFFER_STATE::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPo
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !CompatForSet(set, last_bound, pipeline_layout->compat_for_set)) {
         last_bound.UnbindAndResetPushDescriptorSet(
-            this, std::make_shared<cvdescriptorset::DescriptorSet>(VK_NULL_HANDLE, nullptr, dsl, 0, dev_data));
+            std::make_shared<cvdescriptorset::DescriptorSet>(VK_NULL_HANDLE, nullptr, dsl, 0, dev_data));
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, set, 1, nullptr, push_descriptor_set, 0, nullptr);

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -545,17 +545,16 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
                    VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR)));
 }
 
-void LAST_BOUND_STATE::UnbindAndResetPushDescriptorSet(CMD_BUFFER_STATE *cb_state,
-                                                       std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds) {
+void LAST_BOUND_STATE::UnbindAndResetPushDescriptorSet(std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds) {
     if (push_descriptor_set) {
         for (auto &ps : per_set) {
             if (ps.bound_descriptor_set == push_descriptor_set) {
-                cb_state->RemoveChild(ps.bound_descriptor_set);
+                cb_state.RemoveChild(ps.bound_descriptor_set);
                 ps.bound_descriptor_set.reset();
             }
         }
     }
-    cb_state->AddChild(ds);
+    cb_state.AddChild(ds);
     push_descriptor_set = std::move(ds);
 }
 
@@ -563,6 +562,7 @@ void LAST_BOUND_STATE::Reset() {
     pipeline_state = nullptr;
     pipeline_layout = VK_NULL_HANDLE;
     if (push_descriptor_set) {
+        cb_state.RemoveChild(push_descriptor_set);
         push_descriptor_set->Destroy();
     }
     push_descriptor_set.reset();

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -619,9 +619,11 @@ VkShaderModule PIPELINE_STATE::GetShaderModuleByCIIndex<VkRayTracingPipelineCrea
 
 // Track last states that are bound per pipeline bind point (Gfx & Compute)
 struct LAST_BOUND_STATE {
-    LAST_BOUND_STATE() { Reset(); }  // must define default constructor for portability reasons
-    PIPELINE_STATE *pipeline_state;
-    VkPipelineLayout pipeline_layout;
+    LAST_BOUND_STATE(CMD_BUFFER_STATE &cb) : cb_state(cb) {}
+
+    CMD_BUFFER_STATE &cb_state;
+    PIPELINE_STATE *pipeline_state{nullptr};
+    VkPipelineLayout pipeline_layout{VK_NULL_HANDLE};
     std::shared_ptr<cvdescriptorset::DescriptorSet> push_descriptor_set;
 
     // Ordered bound set tracking where index is set# that given set is bound to
@@ -642,7 +644,7 @@ struct LAST_BOUND_STATE {
 
     void Reset();
 
-    void UnbindAndResetPushDescriptorSet(CMD_BUFFER_STATE *cb_state, std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds);
+    void UnbindAndResetPushDescriptorSet(std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds);
 
     inline bool IsUsing() const { return pipeline_state ? true : false; }
 };


### PR DESCRIPTION
The push descriptorset state object should have cb->RemoveChild() called on it before it is destroyed, to avoid deadlock in CMD_BUFFER_STATE::NotifyInvalidate().

Fixes #4376