### PR TITLE
build: Add GitHub Actions dependency caching

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Valve Corporation
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021-2022 Valve Corporation
+# Copyright (c) 2021-2022 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,14 @@ jobs:
           sudo apt-get install -y libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev \
                                 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
                                 libxcb-randr0-dev cmake
+      - name: Cache dependent components
+        id: cache-deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-linux
+        with:
+          path: external
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.cc }}-${{ matrix.cxx }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_win_linux.py --config ${{ matrix.config }}
         env:
@@ -90,6 +98,14 @@ jobs:
           sudo apt-get install -y libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev \
                                 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
                                 libxcb-randr0-dev cmake
+      - name: Cache dependent components
+        id: cache-deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-linux-cpp20
+        with:
+          path: external
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_win_linux.py --config release --cmake='-DVVL_CPP_STANDARD=20'
         env:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -33,6 +33,14 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
+      - name: Cache dependent components
+        id: cache-deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-macos
+        with:
+          path: external
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Generate build files and dependencies
         run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=ON -DUPDATE_DEPS=ON
       - name: Build Vulkan-ValidationLayers

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -44,5 +44,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
+      - name: Cache dependent components
+        id: cache-deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-windows
+        with:
+          path: external
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_build_desktop.py --config ${{ matrix.config }} --arch ${{ matrix.arch }}


### PR DESCRIPTION
Cache the builds of components that this project depends on to speed up
GitHub Actions builds.

The dependent components are specified in scripts/known_good.json whose
hash is used as a key for the cache.  When the known good file is
updated, a cache won't be found for that hash/key and the components are
rebuilt and cached again.

For the more common case for when the known good file does not change,
the cache is found and the dependent components don't need to be
rebuilt.

Documentation for this GitHub Actions feature can be found at:
https://docs.github.com/en/actions/using-workflows
in the "Caching dependencies to speed up workflows" section.  There are
also APIs available for managing the caches.