### PR TITLE
SyncQS Alpha fix: Make RP access context pointers stable

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -2332,8 +2332,9 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(CMD_TYPE cmd_
     // Create an access context the current renderpass.
     const auto barrier_tag = NextCommandTag(cmd_type, ResourceUsageRecord::SubcommandType::kSubpassTransition);
     const auto load_tag = NextSubcommandTag(cmd_type, ResourceUsageRecord::SubcommandType::kLoadOp);
-    render_pass_contexts_.emplace_back(rp_state, render_area, GetQueueFlags(), attachment_views, &cb_access_context_);
-    current_renderpass_context_ = &render_pass_contexts_.back();
+    render_pass_contexts_.emplace_back(layer_data::make_unique<RenderPassAccessContext>(rp_state, render_area, GetQueueFlags(),
+                                                                                        attachment_views, &cb_access_context_));
+    current_renderpass_context_ = render_pass_contexts_.back().get();
     current_renderpass_context_->RecordBeginRenderPass(barrier_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
     return barrier_tag;

--- a/layers/synchronization_validation.h
+++ b/layers/synchronization_validation.h
@@ -1331,7 +1331,7 @@ class CommandBufferAccessContext : public CommandExecutionContext {
     SyncEventsContext events_context_;
 
     // Don't need the following for an active proxy cb context
-    std::vector<RenderPassAccessContext> render_pass_contexts_;
+    std::vector<std::unique_ptr<RenderPassAccessContext>> render_pass_contexts_;
     RenderPassAccessContext *current_renderpass_context_;
     std::vector<SyncOpEntry> sync_ops_;
 };


### PR DESCRIPTION
Store renderpass access contexts as unique pointers, s.t. refernces held stay valid.

