### PR TITLE
layers: Fix device profile regression typo

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1161,7 +1161,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpv
                                          PFN_vkGetOriginalPhysicalDeviceFeaturesEXT &fpvkGetOriginalPhysicalDeviceFeaturesEXT) {
     // Load required functions
     fpvkSetPhysicalDeviceFeaturesEXT =
-        (PFN_vkSetPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vSetPhysicalDeviceFeaturesEXT");
+        (PFN_vkSetPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFeaturesEXT");
     fpvkGetOriginalPhysicalDeviceFeaturesEXT =
         (PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFeaturesEXT");
 


### PR DESCRIPTION
I introduced this in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4369 by accident. Only 1 GPU-VA test is using this so it was just skipping instead of running