### PR TITLE
layers: Add static assert for instrument.hpp values

### DIFF
--- a/layers/gpu_pre_draw_constants.h
+++ b/layers/gpu_pre_draw_constants.h
@@ -21,9 +21,14 @@
 #ifndef GPU_PRE_DRAW_CONSTANTS
 #define GPU_PRE_DRAW_CONSTANTS
 
-// values match those found in SPIRV-Tools instrument.hpp file
-#define _kInstErrorPreDrawValidate 8
+// values match those found in SPIRV-Tools instrument.hpp file.
+#define _kInstErrorMax 7
 #define _kInstValidationOutError 7
+// The values in instrument.hpp are for the spirv-opt pass but these values are for the
+// internal gpu_shaders in the VVL. GLSL can't understand .hpp header file so these
+// are defined internally here extending the max values
+#define _kInstErrorPreDrawValidate _kInstErrorMax + 1
+#define _kPreDrawValidateSubError _kInstValidationOutError + 1
 // debug buffer is memset to 0 so need to start at index 1
 #define pre_draw_count_exceeds_bufsize_error 1
 #define pre_draw_count_exceeds_limit_error 2


### PR DESCRIPTION
I commented this in the code well I hope, but this prevents the case when `instrument.hpp` is updated and we will fail the `static_assert` and then only need to update the single `#define` 