### PR TITLE
Add remaining VK_EXT_blend_operation_advanced VUID

### DIFF
--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -122,6 +122,7 @@ class StatelessValidation : public ValidationObject {
         layer_data::unordered_set<uint32_t> subpasses_using_color_attachment;
         layer_data::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
         std::vector<VkSubpassDescriptionFlags> subpasses_flags;
+        uint32_t color_attachment_count;
     };
 
     // Though this validation object is predominantly statless, the Framebuffer checks are greatly simplified by creating and
@@ -1399,6 +1400,8 @@ class StatelessValidation : public ValidationObject {
         renderpass_state.subpasses_flags.resize(pCreateInfo->subpassCount);
         for (uint32_t subpass = 0; subpass < pCreateInfo->subpassCount; ++subpass) {
             bool uses_color = false;
+            renderpass_state.color_attachment_count = pCreateInfo->pSubpasses[subpass].colorAttachmentCount;
+
             for (uint32_t i = 0; i < pCreateInfo->pSubpasses[subpass].colorAttachmentCount && !uses_color; ++i)
                 if (pCreateInfo->pSubpasses[subpass].pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) uses_color = true;
 

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -286,6 +286,11 @@ static inline uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
     }
 }
 
+// all "advanced blend operation" found in spec
+static inline bool IsAdvanceBlendOperation(const VkBlendOp blend_op) {
+    return (static_cast<int>(blend_op) >= VK_BLEND_OP_ZERO_EXT) && (static_cast<int>(blend_op) <= VK_BLEND_OP_BLUE_EXT);
+}
+
 // Perform a zero-tolerant modulo operation
 static inline VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor) {
     VkDeviceSize result = 0;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1176,6 +1176,22 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpv
     return true;
 }
 
+bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &fpvkSetPhysicalDeviceProperties2EXT) {
+    // Load required functions
+    fpvkSetPhysicalDeviceProperties2EXT =
+        (PFN_VkSetPhysicalDeviceProperties2EXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceProperties2EXT");
+
+    if (!fpvkSetPhysicalDeviceProperties2EXT) {
+        printf(
+            "%s Can't find device_profile_api functions; make sure VK_LAYER_PATH is set correctly to where the validation layers "
+            "are built, the device profile layer should be in the same directory.\n",
+            kSkipPrefix);
+        return false;
+    }
+
+    return true;
+}
+
 bool VkBufferTest::GetTestConditionValid(VkDeviceObj *aVulkanDevice, eTestEnFlags aTestFlag, VkBufferUsageFlags aBufferUsage) {
     if (eInvalidDeviceOffset != aTestFlag && eInvalidMemoryOffset != aTestFlag) {
         return true;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -301,6 +301,7 @@ class VkLayerTest : public VkRenderFramework {
                                 PFN_vkGetOriginalPhysicalDeviceLimitsEXT &fpvkGetOriginalPhysicalDeviceLimitsEXT);
     bool LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpvkSetPhysicalDeviceFeaturesEXT,
                                 PFN_vkGetOriginalPhysicalDeviceFeaturesEXT &fpvkGetOriginalPhysicalDeviceFeaturesEXT);
+    bool LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &fpvkSetPhysicalDeviceProperties2EXT);
 
     VkLayerTest();
 };

--- a/tests/layers/vk_lunarg_device_profile_api_layer.h
+++ b/tests/layers/vk_lunarg_device_profile_api_layer.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2016-2020 Valve Corporation
- * Copyright (c) 2016-2020 LunarG, Inc.
- * Copyright (c) 2016-2020 The Khronos Group Inc.
+ * Copyright (c) 2016-2022 Valve Corporation
+ * Copyright (c) 2016-2022 LunarG, Inc.
+ * Copyright (c) 2016-2022 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)(VkPhysicalDe
                                                                     const VkPhysicalDeviceFeatures *features);
 typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice,
                                                             const VkPhysicalDeviceFeatures newFeatures);
+typedef void(VKAPI_PTR *PFN_VkSetPhysicalDeviceProperties2EXT)(VkPhysicalDevice physicalDevice,
+                                                               const VkPhysicalDeviceProperties2 newProperties);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -12296,6 +12296,7 @@ TEST_F(VkLayerTest, PipelineInvalidAdvancedBlend) {
     VkPipelineColorBlendAttachmentState attachment_state = {};
     attachment_state.blendEnable = VK_TRUE;
     attachment_state.colorBlendOp = VK_BLEND_OP_XOR_EXT;
+    attachment_state.alphaBlendOp = VK_BLEND_OP_XOR_EXT;
 
     VkPipelineColorBlendStateCreateInfo color_blend_state = LvlInitStruct<VkPipelineColorBlendStateCreateInfo>();
     color_blend_state.attachmentCount = 1;
@@ -12303,6 +12304,8 @@ TEST_F(VkLayerTest, PipelineInvalidAdvancedBlend) {
     pipe.gp_ci_.pColorBlendState = &color_blend_state;
 
     pipe.InitState();
+    // When using devsim, advancedBlendMaxColorAttachments will be zero
+    m_errorMonitor->SetUnexpectedError("VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01410");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendAttachmentState-advancedBlendAllOperations-01409");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -12280,14 +12280,11 @@ TEST_F(VkLayerTest, PipelineInvalidAdvancedBlend) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced =
-        LvlInitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
-    VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&blend_operation_advanced);
-    vk::GetPhysicalDeviceProperties2(gpu(), &pd_props2);
+    auto blend_operation_advanced = LvlInitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    GetPhysicalDeviceProperties2(blend_operation_advanced);
 
-    if (blend_operation_advanced.advancedBlendAllOperations == VK_TRUE) {
-        printf("%s blend_operation_advanced.advancedBlendAllOperations is VK_TRUE.\n", kSkipPrefix);
-        return;
+    if (blend_operation_advanced.advancedBlendAllOperations) {
+        GTEST_SKIP() << "advancedBlendAllOperations is VK_TRUE, test needs it not supported.";
     }
 
     CreatePipelineHelper pipe(*this);
@@ -12309,6 +12306,117 @@ TEST_F(VkLayerTest, PipelineInvalidAdvancedBlend) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendAttachmentState-advancedBlendAllOperations-01409");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, PipelineAdvancedBlendInvalidBlendOps) {
+    TEST_DESCRIPTION("Advanced blending with invalid VkBlendOps");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(2));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+    if (IsPlatform(kMockICD) || DeviceSimulation()) {
+        GTEST_SKIP() << "Test not supported by MockICD because need real advancedBlendMaxColorAttachments value";
+    }
+
+    auto blend_operation_advanced = LvlInitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    GetPhysicalDeviceProperties2(blend_operation_advanced);
+
+    if (!blend_operation_advanced.advancedBlendAllOperations) {
+        GTEST_SKIP() << "advancedBlendAllOperations is not supported.";
+    }
+
+    VkPipelineColorBlendStateCreateInfo color_blend_state = LvlInitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendAttachmentState attachment_states[2];
+    memset(attachment_states, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
+
+    // only 1 attachment state, different blend op values
+    const auto set_info_different = [&](CreatePipelineHelper &helper) {
+        attachment_states[0].blendEnable = VK_TRUE;
+        attachment_states[0].colorBlendOp = VK_BLEND_OP_HSL_COLOR_EXT;
+        attachment_states[0].alphaBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
+
+        color_blend_state.attachmentCount = 1;
+        color_blend_state.pAttachments = attachment_states;
+        helper.gp_ci_.pColorBlendState = &color_blend_state;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info_different, kErrorBit,
+                                      "VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01406");
+
+    // Test is if independent blend is not supported
+    if (!blend_operation_advanced.advancedBlendIndependentBlend && blend_operation_advanced.advancedBlendMaxColorAttachments > 1) {
+        const auto set_info_color = [&](CreatePipelineHelper &helper) {
+            attachment_states[0].blendEnable = VK_TRUE;
+            attachment_states[0].colorBlendOp = VK_BLEND_OP_MIN;
+            attachment_states[0].alphaBlendOp = VK_BLEND_OP_MIN;
+            attachment_states[1].blendEnable = VK_TRUE;
+            attachment_states[1].colorBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
+            attachment_states[1].alphaBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
+
+            color_blend_state.attachmentCount = 2;
+            color_blend_state.pAttachments = attachment_states;
+            helper.gp_ci_.pColorBlendState = &color_blend_state;
+        };
+        CreatePipelineHelper::OneshotTest(
+            *this, set_info_color, kErrorBit,
+            std::vector<string>{"VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01407",
+                                "VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01408"});
+    }
+}
+
+TEST_F(VkLayerTest, PipelineAdvancedBlendMaxBlendAttachment) {
+    TEST_DESCRIPTION("Advanced blending with invalid VkBlendOps");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    if (!OverrideDevsimForDeviceProfileLayer()) {
+        GTEST_SKIP() << "Failed to override devsim for device profile layer.";
+    }
+    AddRequiredExtensions(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+
+    PFN_VkSetPhysicalDeviceProperties2EXT fpvkSetPhysicalDeviceProperties2EXT = nullptr;
+    if (!LoadDeviceProfileLayer(fpvkSetPhysicalDeviceProperties2EXT)) {
+        GTEST_SKIP() << "Failed to load device profile layer.";
+    }
+
+    auto set_blend_operation_advanced = LvlInitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    // Other values in struct don't matter for the test
+    set_blend_operation_advanced.advancedBlendMaxColorAttachments = 1;
+    set_blend_operation_advanced.advancedBlendIndependentBlend = VK_TRUE;
+    VkPhysicalDeviceProperties2 set_props = LvlInitStruct<VkPhysicalDeviceProperties2>(&set_blend_operation_advanced);
+    fpvkSetPhysicalDeviceProperties2EXT(gpu(), set_props);
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(2));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+
+    VkPipelineColorBlendStateCreateInfo color_blend_state = LvlInitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendAttachmentState attachment_states[2];
+    memset(attachment_states, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
+
+    // over max blend color attachment count
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        attachment_states[0].blendEnable = VK_TRUE;
+        attachment_states[0].colorBlendOp = VK_BLEND_OP_MIN;
+        attachment_states[0].alphaBlendOp = VK_BLEND_OP_MIN;
+        attachment_states[1].blendEnable = VK_TRUE;
+        attachment_states[1].colorBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
+        attachment_states[1].alphaBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
+
+        color_blend_state.attachmentCount = 2;
+        color_blend_state.pAttachments = attachment_states;
+        helper.gp_ci_.pColorBlendState = &color_blend_state;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01410");
 }
 
 TEST_F(VkLayerTest, InvlidPipelineDiscardRectangle) {


### PR DESCRIPTION
- VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01406
- VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01407
- VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01408
- VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01410

For the test I found it would be easier to set `VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT` so added a commit to add support for `SetPhysicalDeviceProperties2EXT` to the Device Profile Layer