### PR TITLE
Add AS Read access flag VUs

### DIFF
--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -1030,4 +1030,58 @@ const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
     return result;
 }
 
+static const std::map<AccelerationStructureError, std::vector<Entry>> kAccelerationStructureErrors{
+    {AccelerationStructureError::kWithRayTracingPipelineWithRayQuery,
+     {
+         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06256"},
+         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-06256"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-06256"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2-dstAccessMask-06256"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2-srcAccessMask-06256"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2-dstAccessMask-06256"},
+     }},
+    {AccelerationStructureError::kWithRayTracingPipelineWithoutRayQuery,
+     {
+         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06254"},
+         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-06254"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-06254"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2-dstAccessMask-06254"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2-srcAccessMask-06254"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2-dstAccessMask-06254"},
+     }},
+    {AccelerationStructureError::kWithoutRayTracingPipelineWithRayQuery,
+     {
+         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06257"},
+         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-06257"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-06257"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2-dstAccessMask-06257"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2-srcAccessMask-06257"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2-dstAccessMask-06257"},
+     }},
+    {AccelerationStructureError::kWithoutRayTracingPipelineWithoutRayQuery,
+     {
+         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06255"},
+         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-06255"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-06255"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2-dstAccessMask-06255"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2-srcAccessMask-06255"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2-dstAccessMask-06255"},
+     }},
+};
+
+const std::string &GetAccelerationStructureVUID(const Location &loc, bool rayTracingPipeline, bool rayQuery) {
+    AccelerationStructureError error =
+        (rayTracingPipeline && rayQuery)    ? AccelerationStructureError::kWithRayTracingPipelineWithRayQuery
+        : (rayTracingPipeline && !rayQuery) ? AccelerationStructureError::kWithRayTracingPipelineWithoutRayQuery
+        : (!rayTracingPipeline && rayQuery) ? AccelerationStructureError::kWithoutRayTracingPipelineWithRayQuery
+                                            : AccelerationStructureError::kWithoutRayTracingPipelineWithoutRayQuery;
+    const auto &result = FindVUID(error, loc, kAccelerationStructureErrors);
+    assert(!result.empty());
+    if (result.empty()) {
+         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-AccelerationStructure-error");
+         return unhandled;
+    }
+    return result;
+}
+
 };  // namespace sync_vuid_maps

--- a/layers/sync_vuid_maps.h
+++ b/layers/sync_vuid_maps.h
@@ -108,4 +108,13 @@ enum class SubmitError {
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error);
 
+enum class AccelerationStructureError {
+    kWithRayTracingPipelineWithRayQuery,
+    kWithRayTracingPipelineWithoutRayQuery,
+    kWithoutRayTracingPipelineWithRayQuery,
+    kWithoutRayTracingPipelineWithoutRayQuery
+};
+
+const std::string &GetAccelerationStructureVUID(const Location &loc, bool rayTracingPipeline, bool rayQuery);
+
 };  // namespace sync_vuid_maps

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -286,6 +286,16 @@ static inline uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
     }
 }
 
+// return true if VK_PIPELINE_STAGE_*_SHADER_BIT
+// TODO - generate all VK_PIPELINE_STAGE_*_SHADER_BIT from the XML, should be new stages too often though
+static inline bool IsPipelineShaderStageBit(VkPipelineStageFlags2 stage) {
+    return stage & (VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
+                    VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT | VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT |
+                    VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT |
+                    VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR | VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV |
+                    VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV);
+}
+
 // Perform a zero-tolerant modulo operation
 static inline VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor) {
     VkDeviceSize result = 0;

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -287,7 +287,7 @@ static inline uint32_t GetPlaneIndex(VkImageAspectFlags aspect) {
 }
 
 // return true if VK_PIPELINE_STAGE_*_SHADER_BIT
-// TODO - generate all VK_PIPELINE_STAGE_*_SHADER_BIT from the XML, should be new stages too often though
+// TODO - generate all VK_PIPELINE_STAGE_*_SHADER_BIT from the XML, should not be new stages too often though
 static inline bool IsPipelineShaderStageBit(VkPipelineStageFlags2 stage) {
     return stage & (VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
                     VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT | VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT |


### PR DESCRIPTION
adds 
- `VUID-VkMemoryBarrier2-*-06254` 
- `VUID-VkMemoryBarrier2-*-06255`
- `VUID-VkMemoryBarrier2-*-06256`
- `VUID-VkMemoryBarrier2-*-06257`

These are all making use of the `VK_KHR_acceleration_structure`/`VK_KHR_ray_tracing_pipeline`/`VK_KHR_ray_query`

----

Spec for the [fun 4 way VUID](https://github.com/KhronosGroup/Vulkan-Docs/blob/8dcc7469b01529600b712596a5a48ec8c710e228/chapters/commonvalidity/access_mask_2_common.txt#L215-L250) but here is the cheat sheet

```
With `VK_KHR_ray_tracing_pipeline` and Without `VK_KHR_ray_query`
[[VUID-{refpage}-{accessMaskName}-06254]]

Without `VK_KHR_ray_tracing_pipeline` and Without `VK_KHR_ray_query`
[[VUID-{refpage}-{accessMaskName}-06255]]

With `VK_KHR_ray_tracing_pipeline` and With `VK_KHR_ray_query`
[[VUID-{refpage}-{accessMaskName}-06256]]

Without `VK_KHR_ray_tracing_pipeline` and With `VK_KHR_ray_query`
[[VUID-{refpage}-{accessMaskName}-06257]]
```