### PR TITLE
tests: Make ErrorMonitor::SetBailout use an atomic flag

### DIFF
--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -850,7 +850,7 @@ struct ThreadTestData {
     VkDescriptorSet descriptorSet;
     VkBuffer buffer;
     uint32_t binding;
-    bool *bailout;
+    std::atomic<bool> *bailout;
 };
 
 void AddToCommandBuffer(ThreadTestData *);

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -1646,7 +1646,7 @@ TEST_F(VkPositiveLayerTest, ThreadNullFenceCollision) {
 
     ThreadTestData data;
     data.device = m_device->device();
-    bool bailout = false;
+    std::atomic<bool> bailout{false};
     data.bailout = &bailout;
     m_errorMonitor->SetBailout(data.bailout);
 
@@ -1981,12 +1981,12 @@ TEST_F(VkPositiveLayerTest, ResetQueryPoolFromDifferentCBWithFenceAfter) {
 }
 
 struct FenceSemRaceData {
-    VkDevice device;
-    VkSemaphore sem;
-    bool *bailout;
-    uint64_t wait_value;
-    uint64_t timeout;
-    uint32_t iterations;
+    VkDevice device{VK_NULL_HANDLE};
+    VkSemaphore sem{VK_NULL_HANDLE};
+    std::atomic<bool> *bailout{nullptr};
+    uint64_t wait_value{0};
+    uint64_t timeout{1000000000};
+    uint32_t iterations{100000};
 };
 
 void WaitTimelineSem(FenceSemRaceData *data) {
@@ -2037,13 +2037,11 @@ TEST_F(VkPositiveLayerTest, FenceSemThreadRace) {
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &sem_handle;
 
-    bool bailout = false;
-    struct FenceSemRaceData data;
+    std::atomic<bool> bailout{false};
+    FenceSemRaceData data;
     data.device = m_device->device();
     data.sem = sem.handle();
     data.wait_value = signal_value;
-    data.iterations = 100000;
-    data.timeout = 1000000000;
     data.bailout = &bailout;
     std::thread thread(WaitTimelineSem, &data);
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1322,7 +1322,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
     data.buffer = buffer.handle();
-    bool bailout = false;
+    std::atomic<bool> bailout{false};
     data.bailout = &bailout;
     m_errorMonitor->SetBailout(data.bailout);
 

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3505,7 +3505,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
     ThreadTestData data;
     data.commandBuffer = commandBuffer.handle();
     data.event = event;
-    bool bailout = false;
+    std::atomic<bool> bailout{false};
     data.bailout = &bailout;
     m_errorMonitor->SetBailout(data.bailout);
 
@@ -3560,7 +3560,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorCollision) {
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
     data.buffer = buffer.handle();
-    bool bailout = false;
+    std::atomic<bool> bailout{false};
     data.bailout = &bailout;
     m_errorMonitor->SetBailout(data.bailout);
 
@@ -3635,7 +3635,7 @@ TEST_F(VkLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     data.descriptorSet = normal_descriptor_set.set_;
     data.binding = 0;
     data.buffer = buffer.handle();
-    bool bailout = false;
+    std::atomic<bool> bailout{false};
     data.bailout = &bailout;
     m_errorMonitor->SetBailout(data.bailout);
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -153,7 +153,7 @@ void ErrorMonitor::SetError(const char *const errorString) {
     failure_message_strings_.insert(errorString);
 }
 
-void ErrorMonitor::SetBailout(bool *bailout) {
+void ErrorMonitor::SetBailout(std::atomic<bool> *bailout) {
     auto guard = Lock();
     bailout_ = bailout;
 }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -123,7 +123,7 @@ class ErrorMonitor {
     VkBool32 CheckForDesiredMsg(const char *const msgString);
     VkDebugReportFlagsEXT GetMessageFlags();
     void SetError(const char *const errorString);
-    void SetBailout(bool *bailout);
+    void SetBailout(std::atomic<bool> *bailout);
 
     // Helpers
 
@@ -159,7 +159,7 @@ class ErrorMonitor {
     std::vector<std::string> allowed_message_strings_;
     std::vector<std::string> other_messages_;
     mutable std::mutex mutex_;
-    bool *bailout_;
+    std::atomic<bool> *bailout_;
     bool message_found_;
 };
 


### PR DESCRIPTION
Since this is supposed be used to control multithreaded tests it should use std::atomic<bool>.