### PR TITLE
layers: Hold the write lock in CMD_BUFFER_STATE::Destroy()

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -451,7 +451,10 @@ void CMD_BUFFER_STATE::Destroy() {
 
     // Remove the cb debug labels
     EraseCmdDebugUtilsLabel(dev_data->report_data, commandBuffer());
-    Reset();
+    {
+        auto guard = WriteLock();
+        Reset();
+    }
     BASE_NODE::Destroy();
 }
 


### PR DESCRIPTION
This fixes race conditions in the commmand buffer destroy path.