### PR TITLE
build-android: Use c++_shared

### DIFF
--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -16,6 +16,6 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 # APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
 APP_PLATFORM := android-26
-APP_STL := c++_static
+APP_STL := c++_shared
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,4 +1,4 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
-APP_STL := c++_static
+APP_STL := c++_shared
 APP_PLATFORM := android-23


### PR DESCRIPTION
https://developer.android.com/ndk/guides/cpp-support recommends using
c++_shared for applications that use more than one shared library.
If multiple libraries using c++_static are loaded you end up with
several copies of the globals in the C++ runtime. This also happens
if the same library is dlopen/dlclosed several times. Some of the
c++ runtime globals are thread_local, so each copy consumes a
TLS key. There are only 128 TLS keys allowed on android, and the
unit tests can hit this because of repeatedly loading and unloading
VVL.

See https://github.com/android/ndk/issues/789 and the many issues
linked to it for more info.