### PR TITLE
layers: Update drawIndirectFirstInstance VUID

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1050,8 +1050,8 @@ bool GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, s
             } else if (debug_record[_kPreValidateSubError] == pre_draw_first_instance_error) {
                 uint32_t index = debug_record[_kPreValidateSubError + 1];
                 strm << "The drawIndirectFirstInstance feature is not enabled, but the firstInstance member of the "
-                        "VkDrawIndirectCommand structure at index "
-                     << index << " is not zero";
+                     << ((buf_info.cmd_type == CMD_DRAWINDIRECT) ? "VkDrawIndirectCommand" : "VkDrawIndexedIndirectCommand")
+                     << " structure at index " << index << " is not zero";
                 vuid_msg = vuid.first_instance_not_zero;
             }
             return_code = false;

--- a/layers/gpu_vuids.h
+++ b/layers/gpu_vuids.h
@@ -53,7 +53,7 @@ struct GpuVuidsCmdDrawIndirect : GpuVuid {
     GpuVuidsCmdDrawIndirect() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndirect-None-02705";
         storage_access_oob = "VUID-vkCmdDrawIndirect-None-02706";
-        first_instance_not_zero = "VUID-vkCmdDrawIndirect-firstInstance-00478";
+        first_instance_not_zero = "VUID-VkDrawIndirectCommand-firstInstance-00501";
     }
 };
 
@@ -61,7 +61,7 @@ struct GpuVuidsCmdDrawIndexedIndirect : GpuVuid {
     GpuVuidsCmdDrawIndexedIndirect() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-02705";
         storage_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-02706";
-        first_instance_not_zero = "VUID-vkCmdDrawIndexedIndirect-firstInstance-00530";
+        first_instance_not_zero = "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554";
     }
 };
 

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -2111,7 +2111,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     err = pipe.CreateVKPipeline(pipeline_layout, renderPass());
     ASSERT_VK_SUCCESS(err);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndirect-firstInstance-00478");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawIndirectCommand-firstInstance-00501");
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
     m_commandBuffer->begin(&begin_info);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -2129,7 +2129,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     m_errorMonitor->VerifyFound();
 
     // Now with an offset and indexed draw
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexedIndirect-firstInstance-00530");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554");
     VkBufferObj indexed_draw_buffer;
     buffer_create_info.size = 4 * sizeof(VkDrawIndexedIndirectCommand);
     indexed_draw_buffer.init(*m_device, buffer_create_info,


### PR DESCRIPTION
I noticed that `VUID-VkDrawIndirectCommand-firstInstance-00501` and `VUID-VkDrawIndexedIndirectCommand-firstInstance-00554` were not "implemented" but realized there are 2 VUIDs doing the same thing, talking to Tobias offline, also agreed the function VUID should be removed in favor of the structure VUID. Raised issue to remove from the spec as well https://github.com/KhronosGroup/Vulkan-Docs/pull/1913