### PR TITLE
layers: Remove todo and code workaround

### DIFF
--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -206,12 +206,6 @@ extern "C" {
             'components' : []
         }
 
-        # TODO - The current XML has a bug, remove when new headers with fix are added
-        # Was setting theses as 8 instead of 16
-        # https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4975
-        if formatName == 'VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK' or formatName == 'VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK':
-            self.allFormats[formatName]['blockSize'] = 16
-
         if elem.get('blockExtent'):
             self.allFormats[formatName]['blockExtent'] = elem.get('blockExtent')
 


### PR DESCRIPTION
I added this workaround in the original version of the script, can't see the gitlab, but XML seems updated to `16` now and this can be safely removed