### PR TITLE
Use current renderpass to create pre-draw GPU-AV pipeline

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1541,7 +1541,7 @@ VkPipeline GpuAssisted::GetValidationPipeline(VkRenderPass render_pass) {
 }
 
 void GpuAssisted::AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBlock output_block,
-                                                     GpuAssistedPreDrawResources &resources, const LAST_BOUND_STATE &state,
+                                                     GpuAssistedPreDrawResources &resources, const VkRenderPass render_pass,
                                                      VkPipeline *pPipeline, const GpuAssistedCmdIndirectState *indirect_state) {
     VkResult result;
     if (!pre_draw_validation_state.initialized) {
@@ -1589,7 +1589,6 @@ void GpuAssisted::AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBloc
         pre_draw_validation_state.initialized = true;
     }
 
-    VkRenderPass render_pass = state.pipeline_state->RenderPassState()->renderPass();
     *pPipeline = GetValidationPipeline(render_pass);
     if (*pPipeline == VK_NULL_HANDLE) {
         ReportSetupProblem(device, "Could not find or create a pipeline.  Aborting GPU-AV");
@@ -1809,7 +1808,8 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
         assert(bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS);
         assert(indirect_state != NULL);
         VkPipeline validation_pipeline;
-        AllocatePreDrawValidationResources(output_block, pre_draw_resources, state, &validation_pipeline, indirect_state);
+        AllocatePreDrawValidationResources(output_block, pre_draw_resources, cb_node->activeRenderPass.get()->renderPass(),
+                                           &validation_pipeline, indirect_state);
         if (aborted) return;
 
         // Save current graphics pipeline state

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -271,7 +271,7 @@ class GpuAssisted : public GpuAssistedBase {
     void AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point, CMD_TYPE cmd,
                                      const GpuAssistedCmdIndirectState* indirect_state = nullptr);
     void AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBlock output_block, GpuAssistedPreDrawResources& resources,
-                                            const LAST_BOUND_STATE& state, VkPipeline* pPipeline,
+                                            const VkRenderPass render_pass, VkPipeline* pPipeline,
                                             const GpuAssistedCmdIndirectState* indirect_state);
     void AllocatePreDispatchValidationResources(GpuAssistedDeviceMemoryBlock output_block,
                                                 GpuAssistedPreDispatchResources& resources,


### PR DESCRIPTION
Use the current renderpass to create the pre-draw pipeline instead of the renderpass used to create the currently bound pipeline, which may have been destroyed