### PR TITLE
tests: Fix ValidateImportMemoryHandleType test on Nvidia laptop

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8772,7 +8772,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
         (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
 
-    VkMemoryPropertyFlags mem_flags = 0;
+    VkMemoryPropertyFlags mem_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     const VkDeviceSize buffer_size = 1024;
 
     // Create export and import buffers


### PR DESCRIPTION
Nvidia exposes multiple memory types that have 0 properties.  This
causes a problem if one of those memory types is first for the
ValidateImportMemoryHandleType test because the test will still
select it and then the allocation for the buffer and image
memory import memory will fail with VK_OUT_OF_DEVICE_MEMORY.
Fix this by forcing device local memory flag to be used when querying
a proper memory allocation for this test.

Verified this still works for integrated Intel as well.