### PR TITLE
Revert "tests: Fix ValidateImportMemoryHandleType test on Nvidia laptop"

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8772,7 +8772,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
         (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
 
-    VkMemoryPropertyFlags mem_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    VkMemoryPropertyFlags mem_flags = 0;
     const VkDeviceSize buffer_size = 1024;
 
     // Create export and import buffers


### PR DESCRIPTION
This reverts commit e79cd33a4b10e6f37468d142a3a17171a4e566cc.
This is because internal testing failed on both AMD and Nvidia even though
it works on Github and my machine.  Will investigate more later.