### PR TITLE
Fix queries in render pass with multiview

### DIFF
--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -25,6 +25,9 @@
  * Author: Tobias Hector <tobias.hector@amd.com>
  * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
+
+#include <bitset>
+
 #include "render_pass_state.h"
 #include "convert_to_renderpass2.h"
 #include "image_state.h"
@@ -326,6 +329,26 @@ uint32_t RENDER_PASS_STATE::GetDynamicRenderingViewMask() const {
         return inheritance_rendering_info.viewMask;
     } else if (use_dynamic_rendering) {
         return dynamic_rendering_begin_rendering_info.viewMask;
+    }
+    return 0;
+}
+
+uint32_t RENDER_PASS_STATE::GetViewMaskBits(uint32_t subpass) const {
+    if (use_dynamic_rendering_inherited) {
+        constexpr int num_bits = std::numeric_limits<decltype(inheritance_rendering_info.viewMask)>::digits;
+        std::bitset<num_bits> view_bits(inheritance_rendering_info.viewMask);
+        return static_cast<uint32_t>(view_bits.count());
+    } else if (use_dynamic_rendering) {
+        constexpr int num_bits = std::numeric_limits<decltype(dynamic_rendering_begin_rendering_info.viewMask)>::digits;
+        std::bitset<num_bits> view_bits(dynamic_rendering_begin_rendering_info.viewMask);
+        return static_cast<uint32_t>(view_bits.count());
+    } else {
+        const auto *subpass_desc = &createInfo.pSubpasses[subpass];
+        if (subpass_desc) {
+            constexpr int num_bits = std::numeric_limits<decltype(subpass_desc->viewMask)>::digits;
+            std::bitset<num_bits> view_bits(subpass_desc->viewMask);
+            return static_cast<uint32_t>(view_bits.count());
+        }
     }
     return 0;
 }

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -126,6 +126,7 @@ class RENDER_PASS_STATE : public BASE_NODE {
     bool UsesDynamicRendering() const { return use_dynamic_rendering || use_dynamic_rendering_inherited; }
     uint32_t GetDynamicRenderingColorAttachmentCount() const;
     uint32_t GetDynamicRenderingViewMask() const;
+    uint32_t GetViewMaskBits(uint32_t subpass) const;
 };
 
 class FRAMEBUFFER_STATE : public BASE_NODE {


### PR DESCRIPTION
From the spec:

> If queries are used while executing a render pass instance that has multiview enabled, the query uses N consecutive query indices in the query pool (starting at query) where N is the number of bits set in the view mask in the subpass the query is used in.