### PR TITLE
tests: Fix ValidateImportMemoryHandleType test on Nvidia laptop

### DIFF
--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8793,14 +8793,17 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     VkMemoryPropertyFlags common_flags = export_mem_reqs.memoryTypeBits & import_mem_reqs.memoryTypeBits;
     printf("Memory flags for this device:  0x%08x\n", common_flags);
     if (common_flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+        printf("---DEVICE_LOCAL---\n");
         mem_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     } else if (common_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+        printf("---HOST_VISIBLE---\n");
         mem_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
     } else if (common_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+        printf("---HOST_COHERENT---\n");
         mem_flags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    } else if (common_flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT) {
-        mem_flags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
     }
+    fflush(stdout);
+    sleep(1);
 
     // Allocation info
     auto alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, export_mem_reqs, mem_flags);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8791,6 +8791,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     // Depending on the underlying device, we may need a specific type of memory for this test to work.  So, select the
     // appropriate memory based on shared import/export memory type properties.
     VkMemoryPropertyFlags common_flags = export_mem_reqs.memoryTypeBits & import_mem_reqs.memoryTypeBits;
+    printf("Memory flags for this device:  0x%08x\n", common_flags);
     if (common_flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
         mem_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     } else if (common_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {


### PR DESCRIPTION
Nvidia exposes multiple memory types that have 0 properties.  This
causes a problem if one of those memory types is first for the
ValidateImportMemoryHandleType test because the test will still
select it and then the allocation for the buffer and image
memory import memory will fail with VK_OUT_OF_DEVICE_MEMORY.

This is round 2.  The online CI tests failed because simply chosing
device local wasn't good enough.  Instead, detect what memory types
are required by the underlying hardware for import/export buffer
types, determine the intersection of those, and then select one.

Verified this still works for integrated Intel as well.