### PR TITLE
tests: Fix SpirvGroupDecorations test

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -491,6 +491,10 @@ void SHADER_MODULE_STATE::PreprocessShaderBinary(const spv_target_env env) {
             // **THIS ONLY HAPPENS ON INITIALIZATION**. words should remain const for the lifetime
             // of the SHADER_MODULE_STATE instance.
             *const_cast<std::vector<uint32_t> *>(&words) = std::move(optimized_binary);
+            // Will need to update static data now the words have changed or else the def_index will not align
+            // It is really rare this will get here as Group Decorations have been deprecated and before this was added no one ever
+            // raised an issue for a bug that would crash the layers that was around for many releases
+            *const_cast<SpirvStaticData *>(&static_data_) = SpirvStaticData(*this);
         }
     }
 }

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -234,6 +234,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     struct SpirvStaticData {
         SpirvStaticData() = default;
         SpirvStaticData(const SHADER_MODULE_STATE &module_state);
+        SpirvStaticData &operator=(const SpirvStaticData &) = default;
+        SpirvStaticData(SpirvStaticData &&) = default;
 
         // A mapping of <id> to the first word of its def. this is useful because walking type
         // trees, constant expressions, etc requires jumping all over the instruction stream.
@@ -254,7 +256,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         std::unordered_map<uint32_t, atomic_instruction> atomic_inst;
         std::vector<spv::Capability> capability_list;
 
-        bool has_group_decoration = false;
+        bool has_group_decoration{false};
         bool has_specialization_constants{false};
         bool has_invocation_repack_instruction{false};
 

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -809,15 +809,15 @@ TEST_F(VkPositiveLayerTest, SpirvGroupDecorations) {
         dslb[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_ALL;
     }
     if (m_device->props.limits.maxPerStageDescriptorStorageBuffers < dslb_size) {
-        printf("%sNeeded storage buffer bindings exceeds this devices limit.  Skipping tests.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Needed storage buffer bindings (" << dslb_size << ") exceeds this devices limit of "
+                     << m_device->props.limits.maxPerStageDescriptorStorageBuffers;
     }
 
     CreateComputePipelineHelper pipe(*this);
     pipe.InitInfo();
     pipe.dsl_bindings_.resize(dslb_size);
     memcpy(pipe.dsl_bindings_.data(), dslb, dslb_size * sizeof(VkDescriptorSetLayoutBinding));
-    pipe.cs_.reset(new VkShaderObj(this, bindStateMinimalShaderText, VK_SHADER_STAGE_COMPUTE_BIT));
+    pipe.cs_.reset(new VkShaderObj(this, spv_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM));
     pipe.InitState();
     pipe.CreateComputePipeline();
 }


### PR DESCRIPTION
The shader from `spv_source` in the test was never actually being used in the test, Luckily it seems to work correctly locally.

Not sure how this never triggered any `-Wunused-variable` warning (including locally)