### PR TITLE
layers: Refactor StorageImageFormat tests

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -619,7 +619,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state,
                                               safe_VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
                                               spirv_inst_iter entrypoint) const;
-    bool ValidateShaderStorageImageFormats(const SHADER_MODULE_STATE& module_state, const spirv_inst_iter& insn) const;
+    bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const spirv_inst_iter& insn) const;
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderStageGroupNonUniform(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                             spirv_inst_iter& insn) const;

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -288,8 +288,8 @@ static const char DECORATE_UNUSED *kVUID_Core_CmdDrawMeshTasksIndirectCountNV_Ve
 static const char DECORATE_UNUSED *kVUID_Core_CmdDrawIndirectByteCountEXT_VertexInput = "UNASSIGNED-vkCmdDrawIndirectByteCountEXT-vertexInput-not-specified";
 
 // Format features VUs
-static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageReadWithoutFormat = "UNASSIGNED-features-shaderStorageImageReadWithoutFormat";
-static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithoutFormat = "UNASSIGNED-features-shaderStorageImageWriteWithoutFormat";
+// static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageReadWithoutFormat = "UNASSIGNED-features-shaderStorageImageReadWithoutFormat";
+// static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithoutFormat = "UNASSIGNED-features-shaderStorageImageWriteWithoutFormat";
 // static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageReadWithoutFormat_NonReadable = "UNASSIGNED-features-shaderStorageImageReadWithoutFormat-NonReadable";
 // static const char DECORATE_UNUSED *kVUID_Features_shaderStorageImageWriteWithoutFormat_NonWritable = "UNASSIGNED-features-shaderStorageImageWriteWithoutFormat-NonWritable";
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1064,86 +1064,52 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE 
     return skip;
 }
 
-bool CoreChecks::ValidateShaderStorageImageFormats(const SHADER_MODULE_STATE &module_state, const spirv_inst_iter &insn) const {
+bool CoreChecks::ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE &module_state,
+                                                            const spirv_inst_iter &insn) const {
     bool skip = false;
+    // Go through all variables for images and check decorations
+    assert(insn.opcode() == spv::OpVariable);
+    // spirv-val validates this is an OpTypePointer
+    const spirv_inst_iter pointer_def = module_state.get_def(insn.word(1));
+    if (pointer_def.word(2) != spv::StorageClassUniformConstant) {
+        return skip;  // Vulkan Spec says storage image must be UniformConstant
+    }
+    spirv_inst_iter type_def = module_state.get_def(pointer_def.word(3));
 
-    switch (insn.opcode()) {
-        // Go through all ImageRead/Write instructions
-        case spv::OpImageSparseRead:
-        case spv::OpImageRead: {
-            // spirv-val validates this is an OpTypeImage
-            const uint32_t image = module_state.GetTypeId(insn.word(3));
-            const spirv_inst_iter image_def = module_state.get_def(image);
+    // Unpack an optional level of arraying
+    if (type_def.opcode() == spv::OpTypeArray || type_def.opcode() == spv::OpTypeRuntimeArray) {
+        type_def = module_state.get_def(type_def.word(2));
+    }
 
-            const uint32_t dim = image_def.word(3);
-            const uint32_t image_format = image_def.word(8);
-            // If the Image Dim operand is not SubpassData, the Image Format must not be Unknown, unless the
-            // StorageImageReadWithoutFormat Capability was declared.
-            if (dim != spv::DimSubpassData && image_format == spv::ImageFormatUnknown) {
-                skip |= RequireFeature(enabled_features.core.shaderStorageImageReadWithoutFormat,
-                                       "shaderStorageImageReadWithoutFormat", kVUID_Features_shaderStorageImageReadWithoutFormat);
-            }
-            break;
-        }
-        case spv::OpImageWrite: {
-            // spirv-val validates this is an OpTypeImage
-            const uint32_t image = module_state.GetTypeId(insn.word(1));
-            const spirv_inst_iter image_def = module_state.get_def(image);
-
-            const uint32_t image_format = image_def.word(8);
-            if (image_format == spv::ImageFormatUnknown) {
-                skip |= RequireFeature(enabled_features.core.shaderStorageImageWriteWithoutFormat,
-                                       "shaderStorageImageWriteWithoutFormat", kVUID_Features_shaderStorageImageWriteWithoutFormat);
-            }
-            break;
+    if (type_def != module_state.end() && type_def.opcode() == spv::OpTypeImage) {
+        // Only check if the Image Dim operand is not SubpassData
+        const uint32_t dim = type_def.word(3);
+        // Only check storage images
+        const uint32_t sampled = type_def.word(7);
+        const uint32_t image_format = type_def.word(8);
+        if ((dim == spv::DimSubpassData) || (sampled != 2) || (image_format != spv::ImageFormatUnknown)) {
+            return skip;
         }
 
-        // Go through all variables for images and check decorations
-        case spv::OpVariable: {
-            // spirv-val validates this is an OpTypePointer
-            const spirv_inst_iter pointer_def = module_state.get_def(insn.word(1));
-            if (pointer_def.word(2) != spv::StorageClassUniformConstant) {
-                break;  // Vulkan Spec says storage image must be UniformConstant
-            }
-            spirv_inst_iter type_def = module_state.get_def(pointer_def.word(3));
+        const uint32_t var_id = insn.word(2);
+        decoration_set img_decorations = module_state.get_decorations(var_id);
 
-            // Unpack an optional level of arraying
-            if (type_def.opcode() == spv::OpTypeArray || type_def.opcode() == spv::OpTypeRuntimeArray) {
-                type_def = module_state.get_def(type_def.word(2));
-            }
+        if (!enabled_features.core.shaderStorageImageReadWithoutFormat &&
+            !(img_decorations.flags & decoration_set::nonreadable_bit)) {
+            skip |= LogError(device, "VUID-RuntimeSpirv-OpTypeImage-06270",
+                             "shaderStorageImageReadWithoutFormat is not supported but\n%s\nhas an Image\n%s\nwith Unknown "
+                             "format and is not decorated with NonReadable",
+                             module_state.DescribeInstruction(module_state.get_def(var_id)).c_str(),
+                             module_state.DescribeInstruction(type_def).c_str());
+        }
 
-            if (type_def != module_state.end() && type_def.opcode() == spv::OpTypeImage) {
-                // Only check if the Image Dim operand is not SubpassData
-                const uint32_t dim = type_def.word(3);
-                // Only check storage images
-                const uint32_t sampled = type_def.word(7);
-                const uint32_t image_format = type_def.word(8);
-                if ((dim == spv::DimSubpassData) || (sampled != 2) || (image_format != spv::ImageFormatUnknown)) {
-                    break;
-                }
-
-                const uint32_t var_id = insn.word(2);
-                decoration_set img_decorations = module_state.get_decorations(var_id);
-
-                if (!enabled_features.core.shaderStorageImageReadWithoutFormat &&
-                    !(img_decorations.flags & decoration_set::nonreadable_bit)) {
-                    skip |= LogError(device, "VUID-RuntimeSpirv-OpTypeImage-06270",
-                                     "shaderStorageImageReadWithoutFormat is not supported but\n%s\nhas an Image\n%s\nwith Unknown "
-                                     "format and is not decorated with NonReadable",
-                                     module_state.DescribeInstruction(module_state.get_def(var_id)).c_str(),
-                                     module_state.DescribeInstruction(type_def).c_str());
-                }
-
-                if (!enabled_features.core.shaderStorageImageWriteWithoutFormat &&
-                    !(img_decorations.flags & decoration_set::nonwritable_bit)) {
-                    skip |= LogError(device, "VUID-RuntimeSpirv-OpTypeImage-06269",
-                                     "shaderStorageImageWriteWithoutFormat is not supported but\n%s\nhas an Image\n%s\nwith "
-                                     "Unknown format and is not decorated with NonWritable",
-                                     module_state.DescribeInstruction(module_state.get_def(var_id)).c_str(),
-                                     module_state.DescribeInstruction(type_def).c_str());
-                }
-            }
-            break;
+        if (!enabled_features.core.shaderStorageImageWriteWithoutFormat &&
+            !(img_decorations.flags & decoration_set::nonwritable_bit)) {
+            skip |= LogError(device, "VUID-RuntimeSpirv-OpTypeImage-06269",
+                             "shaderStorageImageWriteWithoutFormat is not supported but\n%s\nhas an Image\n%s\nwith "
+                             "Unknown format and is not decorated with NonWritable",
+                             module_state.DescribeInstruction(module_state.get_def(var_id)).c_str(),
+                             module_state.DescribeInstruction(type_def).c_str());
         }
     }
 
@@ -2551,6 +2517,18 @@ bool CoreChecks::ValidateVariables(const SHADER_MODULE_STATE &module_state) cons
                                 StorageClassName(storage_class), module_state.DescribeInstruction(insn).c_str());
            }
         }
+
+        // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
+        // disabled if VK_KHR_format_feature_flags2 is supported.
+        //
+        //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
+        //
+        // The other checks need to take into account the format features and so
+        // we apply that in the descriptor set matching validation code (see
+        // descriptor_sets.cpp).
+        if (!has_format_feature2) {
+            skip |= ValidateShaderStorageImageFormatsVariables(module_state, insn);
+        }
     }
 
     return skip;
@@ -2964,18 +2942,6 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
         skip |= ValidateShaderClock(module_state, insn);
         skip |= ValidateShaderStageGroupNonUniform(module_state, pStage->stage, insn);
         skip |= ValidateMemoryScope(module_state, insn);
-
-        // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
-        // disabled if VK_KHR_format_feature_flags2 is supported.
-        //
-        //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
-        //
-        // The other checks need to take into account the format features and so
-        // we apply that in the descriptor set matching validation code (see
-        // descriptor_sets.cpp).
-        if (!has_format_feature2) {
-            skip |= ValidateShaderStorageImageFormats(module_state, insn);
-        }
     }
 
     skip |= ValidateTransformFeedback(module_state);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -1846,8 +1846,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatRead) {
     VkPhysicalDeviceFeatures feat;
     vk::GetPhysicalDeviceFeatures(gpu(), &feat);
     if (feat.shaderStorageImageReadWithoutFormat) {
-        printf("%s format less storage image read supported.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "shaderStorageImageReadWithoutFormat is supported";
     }
 
     // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
@@ -1856,13 +1855,13 @@ TEST_F(VkLayerTest, MissingStorageImageFormatRead) {
     //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
     //
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        printf("%s %s supported, skipping.\n", kSkipPrefix, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
-        return;
+        GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
     // Make sure compute pipeline has a compute shader stage set
     const char *csSource = R"(
                OpCapability Shader
+               OpCapability StorageImageReadWithoutFormat
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %4 "main"
@@ -1912,7 +1911,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatRead) {
     cs_pipeline.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-features-shaderStorageImageReadWithoutFormat");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-01091");
     cs_pipeline.CreateComputePipeline(true, false);  // need false to prevent late binding
     m_errorMonitor->VerifyFound();
 }
@@ -1925,8 +1924,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWrite) {
     VkPhysicalDeviceFeatures feat;
     vk::GetPhysicalDeviceFeatures(gpu(), &feat);
     if (feat.shaderStorageImageWriteWithoutFormat) {
-        printf("%s format less storage image write supported.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "shaderStorageImageWriteWithoutFormat is supported";
     }
 
     // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
@@ -1935,13 +1933,13 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWrite) {
     //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
     //
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        printf("%s %s supported, skipping.\n", kSkipPrefix, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
-        return;
+        GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
     // Make sure compute pipeline has a compute shader stage set
     const char *csSource = R"(
                   OpCapability Shader
+                  OpCapability StorageImageReadWithoutFormat
              %1 = OpExtInstImport "GLSL.std.450"
                   OpMemoryModel Logical GLSL450
                   OpEntryPoint GLCompute %main "main"
@@ -1988,7 +1986,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWrite) {
     cs_pipeline.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-features-shaderStorageImageWriteWithoutFormat");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-01091");
     cs_pipeline.CreateComputePipeline(true, false);  // need false to prevent late binding
     m_errorMonitor->VerifyFound();
 }
@@ -2050,8 +2048,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatReadForFormat) {
     }
 
     if (n_tests == 0) {
-        printf("%s Could not build a test case.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Could not build a test case.";
     }
 
     // Make sure compute pipeline has a compute shader stage set
@@ -2219,8 +2216,7 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
     }
 
     if (n_tests == 0) {
-        printf("%s Could not build a test case.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Could not build a test case.";
     }
 
     // Make sure compute pipeline has a compute shader stage set
@@ -2502,6 +2498,7 @@ TEST_F(VkLayerTest, MissingNonReadableDecorationStorageImageFormatRead) {
          %21 = OpConstant %19 1
          %22 = OpConstantComposite %20 %21 %21 %21
           %4 = OpFunction %2 None %3
+          %l = OpLabel
           %9 = OpVariable %8 Function
                OpReturn
                OpFunctionEnd
@@ -2574,6 +2571,7 @@ TEST_F(VkLayerTest, MissingNonWritableDecorationStorageImageFormatWrite) {
         %v3uint = OpTypeVector %uint 3
         %uint_1 = OpConstant %uint 1
           %main = OpFunction %void None %3
+             %l = OpLabel
                   OpReturn
                   OpFunctionEnd
                   )";


### PR DESCRIPTION
So I am 99% sure no one (including CI) was running these tests as they did not have valid SPIR-V and I just ran on a device without `shaderStorageImageReadWithoutFormat` feature support and realized this

- The `UNASSIGNED-features-shaderStorageImageReadWithoutFormat` (and `write`) VU is redundant as `spirv-val` is checking it and there is no way to hit this VU in the VVL https://github.com/KhronosGroup/SPIRV-Tools/pull/2486/files
- With the `UNASSIGNED` VU gone, the only thing being checked in `ValidateShaderStorageImageFormats()` was the `OpVariable` so moved that function into the `ValidateVariables` to save from call it every instruction