### PR TITLE
layers: Fix VK_REMAINING_* on Z-Cull tracking

### DIFF
--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -1059,6 +1059,58 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
         m_errorMonitor->VerifyFound();
     }
 
+    discard_barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
+
+    {
+        SCOPED_TRACE("Transfer clear with VK_REMAINING_ARRAY_LAYERS");
+
+        vk::CmdBeginRendering(cmd, &begin_rendering_info);
+
+        vk::CmdSetDepthCompareOp(cmd, VK_COMPARE_OP_LESS);
+        for (int i = 0; i < 60; ++i) m_commandBuffer->Draw(0, 0, 0, 0);
+
+        vk::CmdEndRendering(cmd);
+
+        VkClearDepthStencilValue ds_value{};
+        vk::CmdClearDepthStencilImage(cmd, image.handle(), VK_IMAGE_LAYOUT_GENERAL, &ds_value, 1,
+                                      &discard_barrier.subresourceRange);
+
+        vk::CmdBeginRendering(cmd, &begin_rendering_info);
+
+        vk::CmdSetDepthCompareOp(cmd, VK_COMPARE_OP_GREATER);
+        for (int i = 0; i < 40; ++i) m_commandBuffer->Draw(0, 0, 0, 0);
+
+        set_desired_failure_msg();
+        vk::CmdEndRendering(cmd);
+        m_errorMonitor->Finish();
+    }
+
+    discard_barrier.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+
+    {
+        SCOPED_TRACE("Transfer clear with VK_REMAINING_MIP_LEVELS");
+
+        vk::CmdBeginRendering(cmd, &begin_rendering_info);
+
+        vk::CmdSetDepthCompareOp(cmd, VK_COMPARE_OP_LESS);
+        for (int i = 0; i < 60; ++i) m_commandBuffer->Draw(0, 0, 0, 0);
+
+        vk::CmdEndRendering(cmd);
+
+        VkClearDepthStencilValue ds_value{};
+        vk::CmdClearDepthStencilImage(cmd, image.handle(), VK_IMAGE_LAYOUT_GENERAL, &ds_value, 1,
+                                      &discard_barrier.subresourceRange);
+
+        vk::CmdBeginRendering(cmd, &begin_rendering_info);
+
+        vk::CmdSetDepthCompareOp(cmd, VK_COMPARE_OP_GREATER);
+        for (int i = 0; i < 40; ++i) m_commandBuffer->Draw(0, 0, 0, 0);
+
+        set_desired_failure_msg();
+        vk::CmdEndRendering(cmd);
+        m_errorMonitor->Finish();
+    }
+
     m_commandBuffer->end();
 }
 


### PR DESCRIPTION
Fix the usage of VK_REMAINING_ARRAY_LAYERS and VK_REMAINING_MIP_LEVELS on NVIDIA Best Practices when tracking Z-Cull state.

This adds a generic function for iterating over all subresources while having VK_REMAINING_* in mind.
I tried using `IMAGE_STATE::subresource_encoder`, but I couldn't find a way to iterate all subresources with it.

I haven't been able to test this yet, for some unknown reason the tests are not picking up my locally built validation layers.

Fixes #4456.