### PR TITLE
Fix multisampled_render_to_single_sampled interpretation of "enabled"

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8694,24 +8694,24 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
 
     if (IsExtEnabled(device_extensions.vk_ext_multisampled_render_to_single_sampled)) {
         const auto msrtss_info = LvlFindInChain<VkMultisampledRenderToSingleSampledInfoEXT>(pRenderingInfo->pNext);
-        for (uint32_t j = 0; j < pRenderingInfo->colorAttachmentCount; ++j) {
-            if (pRenderingInfo->pColorAttachments[j].imageView != VK_NULL_HANDLE) {
-                const auto image_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pColorAttachments[j].imageView);
-                skip |= ValidateMultisampledRenderToSingleSampleView(commandBuffer, image_view_state, msrtss_info, "color",
+        if (msrtss_info) {
+            for (uint32_t j = 0; j < pRenderingInfo->colorAttachmentCount; ++j) {
+                if (pRenderingInfo->pColorAttachments[j].imageView != VK_NULL_HANDLE) {
+                    const auto image_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pColorAttachments[j].imageView);
+                    skip |= ValidateMultisampledRenderToSingleSampleView(commandBuffer, image_view_state, msrtss_info, "color",
+                                                                         func_name);
+                }
+            }
+            if (pRenderingInfo->pDepthAttachment && pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) {
+                const auto depth_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pDepthAttachment->imageView);
+                skip |=
+                    ValidateMultisampledRenderToSingleSampleView(commandBuffer, depth_view_state, msrtss_info, "depth", func_name);
+            }
+            if (pRenderingInfo->pStencilAttachment && pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) {
+                const auto stencil_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pStencilAttachment->imageView);
+                skip |= ValidateMultisampledRenderToSingleSampleView(commandBuffer, stencil_view_state, msrtss_info, "stencil",
                                                                      func_name);
             }
-        }
-        if (pRenderingInfo->pDepthAttachment && pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) {
-            const auto depth_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pDepthAttachment->imageView);
-            skip |=
-                ValidateMultisampledRenderToSingleSampleView(commandBuffer, depth_view_state, msrtss_info, "depth", func_name);
-        }
-        if (pRenderingInfo->pStencilAttachment && pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) {
-            const auto stencil_view_state = Get<IMAGE_VIEW_STATE>(pRenderingInfo->pStencilAttachment->imageView);
-            skip |= ValidateMultisampledRenderToSingleSampleView(commandBuffer, stencil_view_state, msrtss_info, "stencil",
-                                                                 func_name);
-        }
-        if (msrtss_info) {
             if (msrtss_info->rasterizationSamples == VK_SAMPLE_COUNT_1_BIT) {
                 skip |= LogError(commandBuffer, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878",
                                  "%s(): A VkMultisampledRenderToSingleSampledInfoEXT struct is in the pNext chain of "
@@ -8726,11 +8726,10 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
 bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer,
                                                               const std::shared_ptr<const IMAGE_VIEW_STATE> &image_view_state,
                                                               const VkMultisampledRenderToSingleSampledInfoEXT *msrtss_info,
-                                                              const char *attachment_type,
-                                                              const char *func_name) const {
+                                                              const char *attachment_type, const char *func_name) const {
     bool skip = false;
     const auto image_view = image_view_state->Handle();
-    if (msrtss_info) {
+    if (msrtss_info->multisampledRenderToSingleSampledEnable) {
         if ((image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) &&
             (image_view_state->samples != msrtss_info->rasterizationSamples)) {
             skip |=
@@ -8741,56 +8740,51 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
                          func_name, string_VkSampleCountFlagBits(msrtss_info->rasterizationSamples), attachment_type,
                          report_data->FormatHandle(image_view).c_str(), string_VkSampleCountFlagBits(image_view_state->samples));
         }
-    } else if (image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
-        skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-imageView-06858",
-                         "%s(): There is no VkMultisampledRenderToSingleSampledInfoEXT struct in the pNext chain, so "
-                         "VK_SAMPLE_COUNT_1_BIT is required, but %s attachment's "
-                         "imageView (%s) was created with %s",
-                         func_name, attachment_type, report_data->FormatHandle(image_view).c_str(),
-                         string_VkSampleCountFlagBits(image_view_state->samples));
-    }
-    IMAGE_STATE *image_state = image_view_state->image_state.get();
-    if ((image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) &&
-        !(image_state->createInfo.flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
-        skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-imageView-06859",
-                         "%s(): %s attachment %s was created with VK_SAMPLE_COUNT_1_BIT but "
-                         "VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT was not set in "
-                         "pImageCreateInfo.flags when the image used to create the imageView (%s) was created",
-                         func_name, attachment_type, report_data->FormatHandle(image_view).c_str(),
-                         report_data->FormatHandle(image_state->image()).c_str());
-    }
-    VkImageFormatProperties image_properties = {};
-    const VkResult image_properties_result = DispatchGetPhysicalDeviceImageFormatProperties(
-        physical_device, image_view_state->create_info.format, image_state->createInfo.imageType,
-        image_state->createInfo.tiling, image_state->createInfo.usage, image_state->createInfo.flags,
-        &image_properties);
-    if (image_properties_result != VK_SUCCESS) {
-        if (LogError(device, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",
-                     "vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, "
-                     "when called for %s validation with following params: "
-                     "format: %s, imageType: %s, "
-                     "tiling: %s, usage: %s, "
-                     "flags: %s.",
-                     func_name, string_VkFormat(image_view_state->create_info.format),
-                     string_VkImageType(image_state->createInfo.imageType), string_VkImageTiling(image_state->createInfo.tiling),
-                     string_VkImageUsageFlags(image_state->createInfo.usage).c_str(),
-                     string_VkImageCreateFlags(image_state->createInfo.flags).c_str())) {
-            return true;
+        IMAGE_STATE *image_state = image_view_state->image_state.get();
+        if ((image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) &&
+            !(image_state->createInfo.flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
+            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-imageView-06859",
+                             "%s(): %s attachment %s was created with VK_SAMPLE_COUNT_1_BIT but "
+                             "VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT was not set in "
+                             "pImageCreateInfo.flags when the image used to create the imageView (%s) was created",
+                             func_name, attachment_type, report_data->FormatHandle(image_view).c_str(),
+                             report_data->FormatHandle(image_state->image()).c_str());
         }
-    } else if (msrtss_info && !(image_properties.sampleCounts & msrtss_info->rasterizationSamples)) {
-        skip |= LogError(
-            device, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",
-            "%s(): %s attachment %s was created with format %s from image %s, and rasterizationSamples "
-            "specified in VkMultisampledRenderToSingleSampledInfoEXT is %s, but format %s does not support sample "
-            "count %s from an image with imageType: %s, "
-            "tiling: %s, usage: %s, "
-            "flags: %s.",
-            func_name, attachment_type, report_data->FormatHandle(image_view).c_str(),
-            string_VkFormat(image_view_state->create_info.format), report_data->FormatHandle(image_state->Handle()).c_str(),
-            string_VkSampleCountFlagBits(msrtss_info->rasterizationSamples), string_VkFormat(image_view_state->create_info.format),
-            string_VkSampleCountFlagBits(msrtss_info->rasterizationSamples), string_VkImageType(image_state->createInfo.imageType),
-            string_VkImageTiling(image_state->createInfo.tiling), string_VkImageUsageFlags(image_state->createInfo.usage).c_str(),
-            string_VkImageCreateFlags(image_state->createInfo.flags).c_str());
+        VkImageFormatProperties image_properties = {};
+        const VkResult image_properties_result = DispatchGetPhysicalDeviceImageFormatProperties(
+            physical_device, image_view_state->create_info.format, image_state->createInfo.imageType,
+            image_state->createInfo.tiling, image_state->createInfo.usage, image_state->createInfo.flags, &image_properties);
+        if (image_properties_result != VK_SUCCESS) {
+            if (LogError(device, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",
+                         "vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, "
+                         "when called for %s validation with following params: "
+                         "format: %s, imageType: %s, "
+                         "tiling: %s, usage: %s, "
+                         "flags: %s.",
+                         func_name, string_VkFormat(image_view_state->create_info.format),
+                         string_VkImageType(image_state->createInfo.imageType),
+                         string_VkImageTiling(image_state->createInfo.tiling),
+                         string_VkImageUsageFlags(image_state->createInfo.usage).c_str(),
+                         string_VkImageCreateFlags(image_state->createInfo.flags).c_str())) {
+                return true;
+            }
+        } else if (!(image_properties.sampleCounts & msrtss_info->rasterizationSamples)) {
+            skip |= LogError(
+                device, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",
+                "%s(): %s attachment %s was created with format %s from image %s, and rasterizationSamples "
+                "specified in VkMultisampledRenderToSingleSampledInfoEXT is %s, but format %s does not support sample "
+                "count %s from an image with imageType: %s, "
+                "tiling: %s, usage: %s, "
+                "flags: %s.",
+                func_name, attachment_type, report_data->FormatHandle(image_view).c_str(),
+                string_VkFormat(image_view_state->create_info.format), report_data->FormatHandle(image_state->Handle()).c_str(),
+                string_VkSampleCountFlagBits(msrtss_info->rasterizationSamples),
+                string_VkFormat(image_view_state->create_info.format),
+                string_VkSampleCountFlagBits(msrtss_info->rasterizationSamples),
+                string_VkImageType(image_state->createInfo.imageType), string_VkImageTiling(image_state->createInfo.tiling),
+                string_VkImageUsageFlags(image_state->createInfo.usage).c_str(),
+                string_VkImageCreateFlags(image_state->createInfo.flags).c_str());
+        }
     }
     return skip;
 }

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -12952,8 +12952,6 @@ TEST_F(VkLayerTest, MultisampledRenderToSingleSampled) {
 
     color_attachment.imageView = two_count_image_view.handle();
     color_attachment.resolveImageView = VK_NULL_HANDLE;
-    // Image samples can't be COUNT_1 or we get 06861, and has to be COUNT_1, or we get 06858, use COUNT_2 and expect 06858
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06858");
     // If resolveMode is not VK_RESOLVE_MODE_NONE, resolveImageView must not be VK_NULL_HANDLE
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingAttachmentInfo-imageView-06862");
     m_commandBuffer->BeginRendering(begin_rendering_info);


### PR DESCRIPTION
Previous interpretation of "If multisampled-render-to-single-sampled is enabled" was that the extension was enabled. This changes the interpretation to mean that it is enabled for the subpass.