### PR TITLE
docs: fix default value of report_flags

### DIFF
--- a/layers/json/VkLayer_khronos_validation.json.in
+++ b/layers/json/VkLayer_khronos_validation.json.in
@@ -282,9 +282,7 @@
                         }
                     ],
                     "default": [
-                        "error",
-                        "warn",
-                        "perf"
+                        "error"
                     ]
                 },
                 {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -23,7 +23,7 @@ khronos_validation.log_filename = stdout
 # <LayerIdentifier>.report_flags
 # Comma-delineated list of options specifying the types of messages to be
 # reported
-khronos_validation.report_flags = error,warn,perf
+khronos_validation.report_flags = error
 
 # Limit Duplicated Messages
 # =====================


### PR DESCRIPTION
layers/vk_layer_config.cpp defaults "report_flags" to just "error":

    value_map_["khronos_validation.report_flags"] = "error";

while "error,warn,perf" is listed as the default in both vk_layer_settings.txt:

    khronos_validation.report_flags = error,warn,perf

and layers/json/VkLayer_khronos_validation.json.in:

    "default": [
        "error",
        "warn",
        "perf"
    ]

This change makes the latter two files match the current code by changing the
default to be just "error".

This affects shipped SDK files as well as vkconfig behavior and SDK documentation.