### PR TITLE
Make VkRenderFramework::physDevProps() return const ref

### DIFF
--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -318,7 +318,7 @@ VkPhysicalDevice VkRenderFramework::gpu() {
     return gpu_;
 }
 
-VkPhysicalDeviceProperties VkRenderFramework::physDevProps() {
+const VkPhysicalDeviceProperties &VkRenderFramework::physDevProps() {
     EXPECT_NE((VkPhysicalDevice)0, gpu_);  // Invalid to request physical device properties before gpu
     return physDevProps_;
 }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -245,7 +245,7 @@ class VkRenderFramework : public VkTestFramework {
     const VkRenderPassCreateInfo &RenderPassInfo() const { return m_renderPass_info; };
     VkFramebuffer framebuffer() { return m_framebuffer; }
     ErrorMonitor &Monitor();
-    VkPhysicalDeviceProperties physDevProps();
+    const VkPhysicalDeviceProperties &physDevProps();
 
     bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
     bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);


### PR DESCRIPTION
Given how it is used, VkRenderFramework::physDevProps() should return a const reference to avoid unnecessary copy of a not so small structure. Besides, the copy not being deep, copying the `char*` may lead to memory issues in the future (and we are not so far from one at the moment).

This method is used twice:

https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/6086f7993dde6e6d8a9e0f8eef29584289bd216f/tests/vkrenderframework.cpp#L757-L759

https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/6086f7993dde6e6d8a9e0f8eef29584289bd216f/tests/layer_validation_tests.cpp#L1027-L1030
