### PR TITLE
layers: Fix checking buffer view format support

### DIFF
--- a/layers/buffer_state.h
+++ b/layers/buffer_state.h
@@ -77,24 +77,20 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
 #ifdef VK_USE_PLATFORM_METAL_EXT
     const bool metal_bufferview_export;
 #endif  // VK_USE_PLATFORM_METAL_EXT
-    // Format features that matter when accessing the buffer (OpLoad, OpStore,
-    // OpAtomicLoad, etc...)
+    // Format features that matter when accessing the buffer
+    // both as a buffer (ex OpLoad) or image (ex OpImageWrite)
     const VkFormatFeatureFlags2KHR buf_format_features;
-    // Format features that matter when accessing the buffer as a image
-    // (OpImageRead, OpImageWrite, etc...)
-    const VkFormatFeatureFlags2KHR img_format_features;
 
 
     BUFFER_VIEW_STATE(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                      VkFormatFeatureFlags2KHR buf_ff, VkFormatFeatureFlags2KHR img_ff)
+                      VkFormatFeatureFlags2KHR buf_ff)
         : BASE_NODE(bv, kVulkanObjectTypeBufferView),
           create_info(*ci),
           buffer_state(bf),
 #ifdef VK_USE_PLATFORM_METAL_EXT
           metal_bufferview_export(GetMetalExport(ci)),
 #endif
-          buf_format_features(buf_ff),
-          img_format_features(img_ff) {}
+          buf_format_features(buf_ff) {}
 
 
     void LinkChildNodes() override {

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -1388,7 +1388,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                         report_data->FormatHandle(set).c_str(), context.caller, binding, index,
                         report_data->FormatHandle(buffer_view).c_str());
     }
-    if (buffer_view) {
+    if (buffer_view && buffer_view_state) {
         auto buffer = buffer_view_state->create_info.buffer;
         const auto *buffer_state = buffer_view_state->buffer_state.get();
         const VkFormat buffer_view_format = buffer_view_state->create_info.format;
@@ -1400,7 +1400,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                             report_data->FormatHandle(set).c_str(), context.caller, binding, index,
                             report_data->FormatHandle(buffer).c_str());
         }
-        auto format_bits = DescriptorRequirementsBitsFromFormat(buffer_view_format);
+        const auto format_bits = DescriptorRequirementsBitsFromFormat(buffer_view_format);
 
         if (!(reqs & format_bits)) {
             // bad component type
@@ -1413,7 +1413,6 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         }
 
         const VkFormatFeatureFlags2KHR buf_format_features = buffer_view_state->buf_format_features;
-        const VkFormatFeatureFlags2KHR img_format_features = buffer_view_state->img_format_features;
         const VkDescriptorType descriptor_type = context.descriptor_set->GetBinding(binding)->type;
 
         // Verify VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT
@@ -1437,7 +1436,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         if (has_format_feature2) {
             if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
                 if ((reqs & DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT) &&
-                    !(img_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
+                    !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
                     auto set = context.descriptor_set->GetSet();
                     LogObjectList objlist(set);
                     objlist.add(buffer_view);
@@ -1448,11 +1447,11 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                     "contain VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
                                     report_data->FormatHandle(set).c_str(), context.caller, binding, index,
                                     report_data->FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
-                                    string_VkFormatFeatureFlags2KHR(img_format_features).c_str());
+                                    string_VkFormatFeatureFlags2KHR(buf_format_features).c_str());
                 }
 
                 if ((reqs & DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT) &&
-                    !(img_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
+                    !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
                     auto set = context.descriptor_set->GetSet();
                     LogObjectList objlist(set);
                     objlist.add(buffer_view);
@@ -1463,7 +1462,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                     "contain VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
                                     report_data->FormatHandle(set).c_str(), context.caller, binding, index,
                                     report_data->FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
-                                    string_VkFormatFeatureFlags2KHR(img_format_features).c_str());
+                                    string_VkFormatFeatureFlags2KHR(buf_format_features).c_str());
                 }
             }
         }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -381,21 +381,19 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
 
     auto buffer_state = Get<BUFFER_STATE>(pCreateInfo->buffer);
 
-    VkFormatFeatureFlags2KHR buffer_features, image_features;
+    VkFormatFeatureFlags2KHR buffer_features;
     if (has_format_feature2) {
         auto fmt_props_3 = LvlInitStruct<VkFormatProperties3KHR>();
         auto fmt_props_2 = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, pCreateInfo->format, &fmt_props_2);
         buffer_features = fmt_props_3.bufferFeatures;
-        image_features = fmt_props_3.linearTilingFeatures;
     } else {
         VkFormatProperties format_properties;
         DispatchGetPhysicalDeviceFormatProperties(physical_device, pCreateInfo->format, &format_properties);
         buffer_features = format_properties.bufferFeatures;
-        image_features = format_properties.linearTilingFeatures;
     }
 
-    Add(std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo, buffer_features, image_features));
+    Add(std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo, buffer_features));
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2347,12 +2347,12 @@ TEST_F(VkLayerTest, MissingStorageTexelBufferFormatWriteForFormat) {
     auto fmt_props_3 = LvlInitStruct<VkFormatProperties3>();
     auto fmt_props = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
 
-    // set so format can be used as a storage texel buffer, but no WITH_FORMAT support
+    // set so format can be used as a storage texel buffer, but no WITHOUT_FORMAT support
     fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), format, &fmt_props);
     fmt_props.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
-    fmt_props.formatProperties.linearTilingFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
+    fmt_props.formatProperties.bufferFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fmt_props_3.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
-    fmt_props_3.linearTilingFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
+    fmt_props_3.bufferFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fpvkSetPhysicalDeviceFormatProperties2EXT(gpu(), format, fmt_props);
 
     const char *csSource = R"(


### PR DESCRIPTION
These 2 VUIDs were recently updated and made more clear that `bufferFeatures` needs to be checked.