### PR TITLE
Fix warning for loading deprecated extension

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -265,7 +265,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         const char *extension_name = pCreateInfo->ppEnabledExtensionNames[i];
 
-        uint32_t extension_api_version = device_api_version;
+        uint32_t extension_api_version = std::min(api_version, device_api_version);
 
         if (white_list(extension_name, kInstanceExtensionNames)) {
             skip |= LogWarning(instance, kVUID_BestPractices_CreateDevice_ExtensionMismatch,

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -265,13 +265,16 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         const char *extension_name = pCreateInfo->ppEnabledExtensionNames[i];
 
+        uint32_t extension_api_version = device_api_version;
+
         if (white_list(extension_name, kInstanceExtensionNames)) {
             skip |= LogWarning(instance, kVUID_BestPractices_CreateDevice_ExtensionMismatch,
                                "vkCreateDevice(): Attempting to enable Instance Extension %s at CreateDevice time.",
                                extension_name);
+            extension_api_version = api_version;
         }
 
-        skip |= ValidateDeprecatedExtensions("CreateDevice", extension_name, device_api_version,
+        skip |= ValidateDeprecatedExtensions("CreateDevice", extension_name, extension_api_version,
                                              kVUID_BestPractices_CreateDevice_DeprecatedExtension);
         skip |= ValidateSpecialUseExtensions("CreateDevice", extension_name, kSpecialUseDeviceVUIDs);
     }

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -271,7 +271,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
                                extension_name);
         }
 
-        skip |= ValidateDeprecatedExtensions("CreateDevice", extension_name, api_version,
+        skip |= ValidateDeprecatedExtensions("CreateDevice", extension_name, device_api_version,
                                              kVUID_BestPractices_CreateDevice_DeprecatedExtension);
         skip |= ValidateSpecialUseExtensions("CreateDevice", extension_name, kSpecialUseDeviceVUIDs);
     }

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1858,6 +1858,8 @@ TEST_F(VkBestPracticesLayerTest, LoadDeprecatedExtension) {
     dev_info.ppEnabledExtensionNames = &extension;
 
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+    // api version != device version
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateDevice-API-version-mismatch");
 
     VkDevice device = VK_NULL_HANDLE;
     vk::CreateDevice(gpu(), &dev_info, nullptr, &device);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1835,3 +1835,36 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
 
     vk::QueueWaitIdle(m_device->m_queue);
 }
+
+TEST_F(VkBestPracticesLayerTest, LoadDeprecatedExtension) {
+    TEST_DESCRIPTION("Test for loading a vk1.3 deprecated extension with a 1.3 instance on a 1.2 or less device");
+
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+
+    const char *extension = VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
+
+    VkDeviceQueueCreateInfo qci = LvlInitStruct<VkDeviceQueueCreateInfo>();
+    qci.queueFamilyIndex = 0;
+    float priority = 1;
+    qci.pQueuePriorities = &priority;
+    qci.queueCount = 1;
+
+    VkDeviceCreateInfo dev_info = LvlInitStruct<VkDeviceCreateInfo>();
+    dev_info.queueCreateInfoCount = 1;
+    dev_info.pQueueCreateInfos = &qci;
+    dev_info.enabledExtensionCount = 1;
+    dev_info.ppEnabledExtensionNames = &extension;
+
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+
+    VkDevice device = VK_NULL_HANDLE;
+    vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
+
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_3) {
+        m_errorMonitor->VerifyFound();
+    }
+
+    if (device) vk::DestroyDevice(device, nullptr);
+}


### PR DESCRIPTION
When requesting an API version that deprecates an extension that is enabled on the device, a BP warning is always triggered, even if the device doesn't support the requested API version and hasn't deprecated the extension.
This fix compares the extension deprecation version to the device version instead of the instance API version.

Closes #4293 