### PR TITLE
Undisable core on CI

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1963,7 +1963,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
             skip |= LogError(device, "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251",
                              "vkCreateImage(): Format %s is not supported for this combination of parameters and "
-                             "VkGetPhysicalDeviceImageFormatProperties returned back %s.",
+                             "vkGetPhysicalDeviceImageFormatProperties returned back %s.",
                              string_VkFormat(pCreateInfo->format), string_VkResult(result));
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1177,7 +1177,7 @@ VkBufferTest::VkBufferTest(VkDeviceObj *aVulkanDevice, VkBufferUsageFlags aBuffe
       VulkanDevice(aVulkanDevice->device()) {
     if (eBindNullBuffer == aTestFlag || eBindFakeBuffer == aTestFlag) {
         VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>();
-        memory_allocate_info.allocationSize = 1;   // fake size -- shouldn't matter for the test
+        memory_allocate_info.allocationSize = size;  // fake size -- shouldn't matter for the test
         memory_allocate_info.memoryTypeIndex = 0;  // fake type -- shouldn't matter for the test
         vk::AllocateMemory(VulkanDevice, &memory_allocate_info, nullptr, &VulkanMemory);
 
@@ -1186,7 +1186,7 @@ VkBufferTest::VkBufferTest(VkDeviceObj *aVulkanDevice, VkBufferUsageFlags aBuffe
         vk::BindBufferMemory(VulkanDevice, VulkanBuffer, VulkanMemory, 0);
     } else {
         VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
-        buffer_create_info.size = 32;
+        buffer_create_info.size = size;
         buffer_create_info.usage = aBufferUsage;
 
         vk::CreateBuffer(VulkanDevice, &buffer_create_info, nullptr, &VulkanBuffer);

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -393,6 +393,8 @@ class VkBufferTest {
     const VkBuffer &GetBuffer();
     void TestDoubleDestroy();
 
+    const VkDeviceSize size = 32;
+
   protected:
     bool AllocateCurrent;
     bool BoundCurrent;

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -60,6 +60,16 @@ TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
 }
 #endif
 
+inline bool CheckFormat(VkPhysicalDevice gpu, VkImageCreateInfo& img_info) {
+    VkImageFormatProperties if_props{};
+    VkResult result = vk::GetPhysicalDeviceImageFormatProperties(gpu, img_info.format, img_info.imageType, img_info.tiling,
+                                                                 img_info.usage, img_info.flags, &if_props);
+    if (result != VK_SUCCESS) {
+        return false;
+    }
+    return true;
+}
+
 TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
     InitBestPracticesFramework(kEnableAMDValidation);
     InitState();
@@ -67,10 +77,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
-
-    // create a colot attachment image with mutable bit set
+    // create a color attachment image with mutable bit set
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                  nullptr,
                                  VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT,
@@ -86,12 +93,15 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
                                  0,
                                  nullptr,
                                  VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImage test_image = VK_NULL_HANDLE;
-    vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+    if (CheckFormat(gpu(), img_info)) {
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                             "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+        VkImage test_image = VK_NULL_HANDLE;
+        vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
+        m_errorMonitor->VerifyFound();
+    }
+
     // create a depth attachment image with mutable bit set
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                 nullptr,
@@ -108,12 +118,15 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
                 0,
                 nullptr,
                 VK_IMAGE_LAYOUT_UNDEFINED};
-    test_image = VK_NULL_HANDLE;
-    vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+    if (CheckFormat(gpu(), img_info)) {
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                             "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+        VkImage test_image = VK_NULL_HANDLE;
+        vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
+        m_errorMonitor->VerifyFound();
+    }
+
     // create a storage image with mutable bit set
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                nullptr,
@@ -130,9 +143,14 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
                0,
                nullptr,
                VK_IMAGE_LAYOUT_UNDEFINED};
-    test_image = VK_NULL_HANDLE;
-    vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
+
+    if (CheckFormat(gpu(), img_info)) {
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                             "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+        VkImage test_image = VK_NULL_HANDLE;
+        vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
+        m_errorMonitor->VerifyFound();
+    }
 }
 
 TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
@@ -151,9 +169,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
         queueFamilies[i] = i;
     }
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
-
-    // create a render target image with mutable bit set
+    // create a concurrent color render target image
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                   nullptr,
                                   0,
@@ -169,12 +185,16 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
                                   (uint32_t)queueFamilies.size(),
                                   queueFamilies.data(),
                                   VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImage test_image = VK_NULL_HANDLE;
-    vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
-    // create a render target image with mutable bit set
+    if (CheckFormat(gpu(), img_info)) {
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                             "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
+        VkImage test_image = VK_NULL_HANDLE;
+        vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
+        m_errorMonitor->VerifyFound();
+    }
+
+    // create a concurrent depth render target image
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                 nullptr,
                 0,
@@ -190,9 +210,14 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
                 (uint32_t)queueFamilies.size(),
                 queueFamilies.data(),
                 VK_IMAGE_LAYOUT_UNDEFINED};
-    test_image = VK_NULL_HANDLE;
-    vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
+
+    if (CheckFormat(gpu(), img_info)) {
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
+                                             "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
+        VkImage test_image = VK_NULL_HANDLE;
+        vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
+        m_errorMonitor->VerifyFound();
+    }
 }
 
 TEST_F(VkAmdBestPracticesLayerTest, UsageStorageRT) {

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -428,27 +428,29 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       0,
                                       nullptr,
                                       VK_IMAGE_LAYOUT_UNDEFINED};
-        VkImageObj image_1D(m_device);
-        image_1D.init(&img_info);
-        ASSERT_TRUE(image_1D.initialized());
 
-        m_commandBuffer->begin();
-        image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+        if (CheckFormat(gpu(), img_info)) {
+            VkImageObj image_1D(m_device);
+            image_1D.init(&img_info);
+            ASSERT_TRUE(image_1D.initialized());
 
-        VkClearColorValue clear_value = {{0.0f, 0.0f, 0.0f, 0.0f}};
-        VkImageSubresourceRange image_range = {};
-        image_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        image_range.levelCount = 1;
-        image_range.layerCount = 1;
+            m_commandBuffer->begin();
+            image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                             "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
+            VkClearColorValue clear_value = {{0.0f, 0.0f, 0.0f, 0.0f}};
+            VkImageSubresourceRange image_range = {};
+            image_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            image_range.levelCount = 1;
+            image_range.layerCount = 1;
 
-        vk::CmdClearColorImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear_value, 1,
-                               &image_range);
-        m_errorMonitor->VerifyFound();
+            m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
 
-        m_commandBuffer->end();
+            vk::CmdClearColorImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear_value,
+                                   1, &image_range);
+            m_errorMonitor->VerifyFound();
+
+            m_commandBuffer->end();
+        }
     }
 
     vk::ResetCommandPool(device(), m_commandPool->handle(), 0);
@@ -469,28 +471,30 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       0,
                                       nullptr,
                                       VK_IMAGE_LAYOUT_UNDEFINED};
-        VkImageObj image_1D(m_device);
-        image_1D.init(&img_info);
-        ASSERT_TRUE(image_1D.initialized());
 
-        m_commandBuffer->begin();
-        image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
-                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+        if (CheckFormat(gpu(), img_info)) {
+            VkImageObj image_1D(m_device);
+            image_1D.init(&img_info);
+            ASSERT_TRUE(image_1D.initialized());
 
-        VkClearDepthStencilValue clear_value = {0.0f, 0};
-        VkImageSubresourceRange image_range = {};
-        image_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-        image_range.levelCount = 1;
-        image_range.layerCount = 1;
+            m_commandBuffer->begin();
+            image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                             "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
+            VkClearDepthStencilValue clear_value = {0.0f, 0};
+            VkImageSubresourceRange image_range = {};
+            image_range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+            image_range.levelCount = 1;
+            image_range.layerCount = 1;
 
-        vk::CmdClearDepthStencilImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                      &clear_value, 1, &image_range);
-        m_errorMonitor->VerifyFound();
+            m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
 
-        m_commandBuffer->end();
+            vk::CmdClearDepthStencilImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                          &clear_value, 1, &image_range);
+            m_errorMonitor->VerifyFound();
+
+            m_commandBuffer->end();
+        }
     }
 }
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -912,8 +912,7 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
     InitState();
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count");
+
     if (!InitSurface()) {
         printf("%s Cannot create surface, skipping test\n", kSkipPrefix);
         return;
@@ -959,8 +958,14 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     swapchain_create_info.clipped = VK_FALSE;
     swapchain_create_info.oldSwapchain = 0;
 
-    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
-    m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count");
+
+    // If surface doesn't support 2 images, skip negative test
+    if (m_surface_capabilities.minImageCount <= 2) {
+        vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+        m_errorMonitor->VerifyFound();
+    }
 
     swapchain_create_info.minImageCount = 3;
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1582,12 +1582,12 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;  // Specify that we do nothing with the contents of the attached image
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     attachment.format = image_info.format;
 
     VkAttachmentReference ar{};
     ar.attachment = 0;
-    ar.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    ar.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkSubpassDescription spd{};
     spd.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1442,6 +1442,9 @@ TEST_F(VkBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
         return;
     }
 
+    VkSurfaceCapabilitiesKHR surface_caps{};
+    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &surface_caps);
+
     VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     VkSurfaceTransformFlagBitsKHR preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 
@@ -1449,7 +1452,7 @@ TEST_F(VkBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
     swapchain_create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
     swapchain_create_info.pNext = 0;
     swapchain_create_info.surface = m_surface;
-    swapchain_create_info.minImageCount = 2;
+    swapchain_create_info.minImageCount = std::max(2u, surface_caps.minImageCount);
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
     swapchain_create_info.imageColorSpace = m_surface_formats[0].colorSpace;
     swapchain_create_info.imageExtent = {m_surface_capabilities.minImageExtent.width, m_surface_capabilities.minImageExtent.height};

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -471,7 +471,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    InitState();
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkDeviceQueueCreateInfo queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     queue_ci.queueFamilyIndex = 0;
@@ -520,23 +520,24 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     memory_ai.allocationSize = memory_requirements.size;
     memory_ai.memoryTypeIndex = memory_type_index;
 
-    vk_testing::DeviceMemory memory(test_device, memory_ai);
+    vk_testing::DeviceMemory memory_a(test_device, memory_ai);
+    vk_testing::DeviceMemory memory_b(test_device, memory_ai);
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
                                              "UNASSIGNED-BestPractices-BindMemory-NoPriority");
-        vk::BindBufferMemory(test_device.handle(), buffer_a.handle(), memory.handle(), 0);
+        vk::BindBufferMemory(test_device.handle(), buffer_a.handle(), memory_a.handle(), 0);
         m_errorMonitor->VerifyFound();
     }
 
     auto vkSetDeviceMemoryPriorityEXT = reinterpret_cast<PFN_vkSetDeviceMemoryPriorityEXT>(
         vk::GetDeviceProcAddr(test_device.handle(), "vkSetDeviceMemoryPriorityEXT"));
-    vkSetDeviceMemoryPriorityEXT(test_device.handle(), memory.handle(), 0.5f);
+    vkSetDeviceMemoryPriorityEXT(test_device.handle(), memory_b.handle(), 0.5f);
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
                                              "UNASSIGNED-BestPractices-BindMemory-NoPriority");
-        vk::BindBufferMemory(test_device.handle(), buffer_b.handle(), memory.handle(), 0);
+        vk::BindBufferMemory(test_device.handle(), buffer_b.handle(), memory_b.handle(), 0);
         m_errorMonitor->Finish();
     }
 }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -2842,7 +2842,8 @@ TEST_F(VkLayerTest, InUseDestroyedSignaled) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_test.GetBuffer(), 0, 1024, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_test.GetBuffer(), 0, buffer_test.size,
+                                                    VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
     VkEvent event;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -467,8 +467,8 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
         }
 
         if (validation == "all") {
-            features->enabledValidationFeatureCount = 4;
-            features->pEnabledValidationFeatures = validation_enable_all;
+            features->enabledValidationFeatureCount = validation_enable_all.size();
+            features->pEnabledValidationFeatures = validation_enable_all.data();
             features->disabledValidationFeatureCount = 0;
         } else if (validation == "core") {
             features->disabledValidationFeatureCount = 0;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -461,6 +461,7 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
     }
     if (validation == "all" || validation == "core" || validation == "none") {
         if (!features) {
+            static VkValidationFeaturesEXT validation_features;
             features = &validation_features;
             features->sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
             features->pNext = first_pnext;
@@ -468,12 +469,17 @@ void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
         }
 
         if (validation == "all") {
+            static const std::array<const VkValidationFeatureEnableEXT, 4> validation_enable_all = {
+                {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
+                 VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
+                 VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT}};
             features->enabledValidationFeatureCount = validation_enable_all.size();
             features->pEnabledValidationFeatures = validation_enable_all.data();
             features->disabledValidationFeatureCount = 0;
         } else if (validation == "core") {
             features->disabledValidationFeatureCount = 0;
         } else if (validation == "none") {
+            static const VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
             features->disabledValidationFeatureCount = 1;
             features->pDisabledValidationFeatures = &validation_disable_all;
             features->enabledValidationFeatureCount = 0;

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -446,6 +446,7 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
 inline void CheckDisableCoreValidation(VkValidationFeaturesEXT &features) {
     auto disable = GetEnvironment("VK_LAYER_TESTS_DISABLE_CORE_VALIDATION");
     std::transform(disable.begin(), disable.end(), disable.begin(), ::tolower);
+    disable = "false"; // Always undisable for CI
     if (disable == "false" || disable == "0" || disable == "FALSE") {       // default is to change nothing, unless flag is correctly specified
         features.disabledValidationFeatureCount = 0;                        // remove all disables to get all validation messages
     }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -398,13 +398,6 @@ class VkRenderFramework : public VkTestFramework {
     // Device extensions to enable
     std::vector<const char *> m_device_extension_names;
 
-    VkValidationFeaturesEXT validation_features;
-    const std::array<const VkValidationFeatureEnableEXT, 4> validation_enable_all = {
-        {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-         VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
-         VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT}};
-    VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
-
   private:
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the
     // extension is not supported, no extension names are added for instance creation. `ext_name` can refer to a device or instance

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -399,10 +399,10 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_device_extension_names;
 
     VkValidationFeaturesEXT validation_features;
-    VkValidationFeatureEnableEXT validation_enable_all[4] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
+    const std::array<const VkValidationFeatureEnableEXT, 4> validation_enable_all = {
+        {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
+         VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
+         VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT}};
     VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
 
   private:


### PR DESCRIPTION
This PR reenables core validation on all tests by default.
The aim is to get validation errors on CI and fix them progressively so maybe we can officially reenable core by default on master.