### PR TITLE
tests: Fix tests failing on pixel 6

### DIFF
--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -349,6 +349,7 @@ class VkGpuAssistedLayerTest : public VkLayerTest {
                               VkDescriptorType descriptor_type, const char *fragment_shader, const char *expected_error);
 
   protected:
+    bool CanEnableGpuAV();
 };
 
 class VkDebugPrintfTest : public VkLayerTest {

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4288,6 +4288,9 @@ TEST_F(VkPositiveLayerTest, OpCopyObjectSampler) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
 
     auto features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
     auto features2 = GetPhysicalDeviceFeatures2(features12);

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -86,6 +86,9 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     auto alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
     alloc_info.memoryTypeIndex = 0;
     alloc_info.allocationSize = mem_reqs.size;
+    if (alloc_info.allocationSize == 0) {
+        GTEST_SKIP() << "Driver seems to not be returning an valid allocation size and need to end test";
+    }
 
     vk_testing::DeviceMemory mem;
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);


### PR DESCRIPTION
should fix the following from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4425

`VkPositiveLayerTest.OpCopyObjectSampler`
`VkLayerTest.BindImageMemorySwapchain`
`VkGpuAssistedLayerTest.GpuValidationInlineUniformBlockAndMiscGpu`
`VkGpuAssistedLayerTest.DrawTimeShaderUniformBufferTooSmall`
`VkGpuAssistedLayerTest.DrawTimeShaderStorageBufferTooSmall`
`VkGpuAssistedLayerTest.DrawTimeShaderUniformBufferTooSmallArray`
`VkGpuAssistedLayerTest.DrawTimeShaderUniformBufferTooSmallNestedStruct`
`VkGpuAssistedLayerTest.GpuDrawIndirectFirstInstance`

(cc @lunarpapillo )