### PR TITLE
Remove std::move calls preventing copy elision

### DIFF
--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -141,9 +141,9 @@ public:
 
     std::shared_ptr<ObjectUseData> FindObject(T object) {
         assert(object_table.contains(object));
-        auto iter = std::move(object_table.find(object));
+        auto iter = object_table.find(object);
         if (iter != object_table.end()) {
-            return std::move(iter->second);
+            return iter->second;
         } else {
             object_data->LogError(object, kVUID_Threading_Info,
                     "Couldn't find %s Object 0x%" PRIxLEAST64

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -285,7 +285,7 @@ class range_map {
             return split_it;  // this is a noop we're keeping the upper half which is the same as split_it;
         }
         // Save the contents of it and erase it
-        auto value = std::move(split_it->second);
+        auto value = split_it->second;
         auto next_it = impl_map_.erase(split_it);  // Keep this, just in case the split point results in an empty "keep" set
 
         if (lower_range.empty() && !SplitOp::keep_upper()) {

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -437,7 +437,7 @@ class ValidationStateTracker : public ValidationObject {
         if (found_it == map.end()) {
             return nullptr;
         }
-        return std::move(found_it->second);
+        return found_it->second;
     };
 
     std::shared_ptr<BUFFER_STATE> GetBufferByAddress(VkDeviceAddress address) {

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -517,7 +517,7 @@ class vl_concurrent_unordered_map {
         bool found = itr != maps[h].end();
 
         if (found) {
-            auto ret = std::move(FindResult(true, itr->second));
+            auto ret = FindResult(true, itr->second);
             maps[h].erase(itr);
             return ret;
         } else {

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -278,9 +278,9 @@ public:
 
     std::shared_ptr<ObjectUseData> FindObject(T object) {
         assert(object_table.contains(object));
-        auto iter = std::move(object_table.find(object));
+        auto iter = object_table.find(object);
         if (iter != object_table.end()) {
-            return std::move(iter->second);
+            return iter->second;
         } else {
             object_data->LogError(object, kVUID_Threading_Info,
                     "Couldn't find %s Object 0x%" PRIxLEAST64


### PR DESCRIPTION
Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4460
Remove some calls to `std::move` that prevent copy elision.