### PR TITLE
build: Improve GitHub Actions caching

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -67,12 +67,24 @@ jobs:
                                 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
                                 libxcb-randr0-dev cmake
       - name: Cache dependent components
+        # Speed up builds by caching the build/install artifacts so they can be retrieved without rebuilding.
+        # Note: Normally the build/install artifacts are enough to satisfy the dependencies.
+        #       But in this repo, there are extra tests and steps that require files that are not placed in build/install.
+        #       When adding new similar tests, make sure to add any other required directories/files to the cache list.
         id: cache-deps
         uses: actions/cache@v3
         env:
           cache-name: cache-linux
         with:
-          path: external
+          path: |
+            external/glslang/build/install
+            external/Vulkan-Headers/build/install
+            external/SPIRV-Headers/build/install
+            external/SPIRV-Tools/build/install
+            external/robin-hood-hashing/build/install
+            external/googletest/build/install
+            external/Vulkan-Headers/registry
+            external/SPIRV-Headers/include
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.cc }}-${{ matrix.cxx }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_win_linux.py --config ${{ matrix.config }}
@@ -99,12 +111,24 @@ jobs:
                                 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev \
                                 libxcb-randr0-dev cmake
       - name: Cache dependent components
+        # Speed up builds by caching the build/install artifacts so they can be retrieved without rebuilding.
+        # Note: Normally the build/install artifacts are enough to satisfy the dependencies.
+        #       But in this repo, there are extra tests and steps that require files that are not placed in build/install.
+        #       When adding new similar tests, make sure to add any other required directories/files to the cache list.
         id: cache-deps
         uses: actions/cache@v3
         env:
           cache-name: cache-linux-cpp20
         with:
-          path: external
+          path: |
+            external/glslang/build/install
+            external/Vulkan-Headers/build/install
+            external/SPIRV-Headers/build/install
+            external/SPIRV-Tools/build/install
+            external/robin-hood-hashing/build/install
+            external/googletest/build/install
+            external/Vulkan-Headers/registry
+            external/SPIRV-Headers/include
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_win_linux.py --config release --cmake='-DVVL_CPP_STANDARD=20'

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -34,14 +34,26 @@ jobs:
         with:
           python-version: '3.7'
       - name: Cache dependent components
+        # Speed up builds by caching the build/install artifacts so they can be retrieved without rebuilding.
+        # Note: Normally the build/install artifacts are enough to satisfy the dependencies.
+        #       But in this repo, there are extra tests and steps that require files that are not placed in build/install.
+        #       When adding new similar tests, make sure to add any other required directories/files to the cache list.
         id: cache-deps
         uses: actions/cache@v3
         env:
           cache-name: cache-macos
         with:
-          path: external
+          path: |
+            external/glslang/build/install
+            external/Vulkan-Headers/build/install
+            external/SPIRV-Headers/build/install
+            external/SPIRV-Tools/build/install
+            external/robin-hood-hashing/build/install
+            external/googletest/build/install
+            external/Vulkan-Headers/registry
+            external/SPIRV-Headers/include
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Generate build files and dependencies
-        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=ON -DUPDATE_DEPS=ON
+        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=ON -DUPDATE_DEPS=ON -DUPDATE_DEPS_SKIP_EXISTING_INSTALL=ON
       - name: Build Vulkan-ValidationLayers
         run: cmake --build build --parallel $(sysctl -n hw.logicalcpu)

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -45,12 +45,24 @@ jobs:
         with:
           python-version: '3.7'
       - name: Cache dependent components
+        # Speed up builds by caching the build/install artifacts so they can be retrieved without rebuilding.
+        # Note: Normally the build/install artifacts are enough to satisfy the dependencies.
+        #       But in this repo, there are extra tests and steps that require files that are not placed in build/install.
+        #       When adding new similar tests, make sure to add any other required directories/files to the cache list.
         id: cache-deps
         uses: actions/cache@v3
         env:
           cache-name: cache-windows
         with:
-          path: external
+          path: |
+            external/glslang/build/install
+            external/Vulkan-Headers/build/install
+            external/SPIRV-Headers/build/install
+            external/SPIRV-Tools/build/install
+            external/robin-hood-hashing/build/install
+            external/googletest/build/install
+            external/Vulkan-Headers/registry
+            external/SPIRV-Headers/include
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build and Test Vulkan-ValidationLayers
         run: python3 scripts/github_ci_build_desktop.py --config ${{ matrix.config }} --arch ${{ matrix.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,15 +71,19 @@ if (UPDATE_DEPS)
     message("*       dependencies.                                                          *")
     message("********************************************************************************")
 
-    set(_build_tests_arg "")
+    set(_update_deps_arg "")
     if (NOT BUILD_TESTS)
-        set(_build_tests_arg "--optional=tests")
+        set(_update_deps_arg "--optional=tests")
+    endif()
+        
+    if (UPDATE_DEPS_SKIP_EXISTING_INSTALL)
+        set(_update_deps_arg ${_update_deps_arg} "--skip-existing-install")
     endif()
 
     # Add a target so that update_deps.py will run when necessary
     # NOTE: This is triggered off of the timestamps of known_good.json and helper.cmake
     add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake
-                       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_build_tests_arg}
+                       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
                        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json)
 
     add_custom_target(vvl_update_deps DEPENDS ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
@@ -87,7 +91,7 @@ if (UPDATE_DEPS)
     # Check if update_deps.py needs to be run on first cmake run
     if (${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json IS_NEWER_THAN ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
         execute_process(
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_build_tests_arg}
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             RESULT_VARIABLE _update_deps_result
         )

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -78,7 +78,7 @@ def BuildVVL(args, build_tests=False):
 
     utils.make_dirs(VVL_BUILD_DIR)
     print("Run CMake for Validation Layers")
-    cmake_cmd = f'cmake -DUPDATE_DEPS=ON -DCMAKE_BUILD_TYPE={args.configuration.capitalize()} {args.cmake} ..'
+    cmake_cmd = f'cmake -DUPDATE_DEPS=ON -DUPDATE_DEPS_SKIP_EXISTING_INSTALL=ON -DCMAKE_BUILD_TYPE={args.configuration.capitalize()} {args.cmake} ..'
     if IsWindows(): cmake_cmd = cmake_cmd + f' -A {args.arch}'
     if build_tests: cmake_cmd = cmake_cmd + ' -DBUILD_TESTS=ON'
     RunShellCmd(cmake_cmd, VVL_BUILD_DIR)

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -2,7 +2,7 @@
 
 # Copyright 2017 The Glslang Authors. All rights reserved.
 # Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018-2021 LunarG, Inc.
+# Copyright (c) 2018-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -652,6 +652,12 @@ def main():
         help="Delete install directory before building",
         default=False)
     parser.add_argument(
+        '--skip-existing-install',
+        dest='skip_existing_install',
+        action='store_true',
+        help="Skip build if install directory exists",
+        default=False)
+    parser.add_argument(
         '--arch',
         dest='arch',
         choices=['32', '64', 'x86', 'x64', 'win32', 'win64'],
@@ -692,6 +698,14 @@ def main():
         # If the repo has a platform whitelist, skip the repo
         # unless we are building on a whitelisted platform.
         if not repo.on_build_platform:
+            continue
+
+        # Skip building the repo if its install directory already exists
+        # and requested via an option.  This is useful for cases where the
+        # install directory is restored from a cache that is known to be up
+        # to date.
+        if args.skip_existing_install and os.path.isdir(repo.install_dir):
+            print('Skipping build for repo {n} due to existing install directory'.format(n=repo.name))
             continue
 
         # Skip test-only repos if the --tests option was not passed in


### PR DESCRIPTION
- Extend update_deps.py to skip repos if install dir is present
- Cache only build/install directories from dependent repos in the
  external directory

This change keeps update_deps from fetching a repo on top of a cached
repo and building an already built repo. (Previously, the entire
external directory was cached.)

It also significantly lowers the amount of data cached, allowing more
caches (related to versions of known_good.json) to be saved.