### PR TITLE
WIP Two object debug naming conditional code

### DIFF
--- a/layers/base_node.cpp
+++ b/layers/base_node.cpp
@@ -28,6 +28,17 @@
 #include "base_node.h"
 #include "vk_layer_utils.h"
 
+void BASE_NODE::SetName(debug_report_data* report_data, const char* new_name) {
+    auto name_arg = lvl_init_struct<VkDebugMarkerObjectNameInfoEXT>();
+    name_arg.object = handle_.handle;
+    name_arg.objectType = get_debug_report_enum[handle_.type];
+    name_arg.pObjectName = new_name;
+    report_data->DebugReportSetMarkerObjectName(&name_arg);
+#ifdef BASE_NODE_DEBUG_NAME
+    debug_name_ = std::string(new_name);
+#endif
+}
+
 BASE_NODE::~BASE_NODE() { Destroy(); }
 
 void BASE_NODE::Destroy() {

--- a/layers/base_node.h
+++ b/layers/base_node.h
@@ -50,6 +50,9 @@ struct hash<VulkanTypedHandle> {
 // returns a shared_ptr version of the current object. It requires the object to
 // be created with std::make_shared<> and it MUST NOT be used from the constructor
 class BASE_NODE : public std::enable_shared_from_this<BASE_NODE> {
+#ifdef BASE_NODE_DEBUG_NAME
+    std::string debug_name_;
+#endif
   public:
     // Parent nodes are stored as weak_ptrs to avoid cyclic memory dependencies.
     // Because weak_ptrs cannot safely be used as hash keys, the parents are stored
@@ -60,6 +63,9 @@ class BASE_NODE : public std::enable_shared_from_this<BASE_NODE> {
 
     template <typename Handle>
     BASE_NODE(Handle h, VulkanObjectType t) : handle_(h, t), destroyed_(false) {}
+
+    void SetName(debug_report_data *report_data, const char *new_name);
+    void SetName(debug_report_data *report_data, const std::string &new_name) { SetName(report_data, new_name.c_str()); }
 
     // because shared_from_this() does not work from the constructor, this 2nd phase
     // constructor is where a state object should call AddParent() on its child nodes.

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -4430,6 +4430,9 @@ void SyncValidator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     QueueId queue_id = QueueSyncState::kQueueIdBase;
     ForEachShared<QUEUE_STATE>([this, &queue_id](const std::shared_ptr<QUEUE_STATE> &queue_state) {
         auto queue_flags = physical_device_state->queue_family_properties[queue_state->queueFamilyIndex].queueFlags;
+        char WIP_number[256];
+        sprintf(WIP_number, "QID: %d", queue_id);
+        queue_state->SetName(report_data, WIP_number);
         std::shared_ptr<QueueSyncState> queue_sync_state = std::make_shared<QueueSyncState>(queue_state, queue_flags, queue_id++);
         queue_sync_states_.emplace(std::make_pair(queue_state->Queue(), std::move(queue_sync_state)));
     });


### PR DESCRIPTION
For Reviewers:
 * Useful?
 * What would be needed to commit *off* or to commit *on*?
 

Added two debugging compile time options useful for debugging VVL.

Define DEFAULT_OBJECT_NAMES
	Gives each object a unqiue name <type_name>_<seq_no>.
	Sequence number is atomic and monotonic in creation order.
	Useful when unique handles is disabled and driver returns are
	inconsistent. BASE_NODE::SetName wraps debug extension for
	convenience.
Define BASE_NODE_DEBUG_NAME
	Stores the last name from SetName as the first member of
	BASE_NODE.