### PR TITLE
Fix VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength validation

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -10185,10 +10185,23 @@ bool StatelessValidation::PreCallValidateCmdBindVertexBuffers2(
     const VkDeviceSize*                         pSizes,
     const VkDeviceSize*                         pStrides) const {
     bool skip = false;
-    skip |= validate_array("vkCmdBindVertexBuffers2", "bindingCount", "pBuffers", bindingCount, &pBuffers, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pBuffers-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2", "bindingCount", "pOffsets", bindingCount, &pOffsets, true, true, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pOffsets-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2", "bindingCount", "pSizes", bindingCount, &pSizes, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pSizes-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2", "bindingCount", "pStrides", bindingCount, &pStrides, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pStrides-parameter");
+
+    // Check VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength
+    const bool vuidCondition = (pSizes != nullptr) || (pStrides != nullptr);
+    const bool vuidExpectation = bindingCount > 0;
+    if (vuidCondition)
+    {
+      if (!vuidExpectation)
+      {
+        const char *not_null_msg = "";
+        if ((pSizes != nullptr ) && (pStrides != nullptr)) not_null_msg = "pSizes and pStrides are not NULL"; 
+        else if (pSizes != nullptr ) not_null_msg = "pSizes is not NULL"; 
+        else not_null_msg = "pStrides is not NULL"; 
+        const char *vuid_breach_msg = "vkCmdBindVertexBuffers2: %s, so bindingCount must be greater that 0.";
+        skip |= LogError(device, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", vuid_breach_msg, not_null_msg); 
+      }
+    }
+
     if (!skip) skip |= manual_PreCallValidateCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
     return skip;
 }
@@ -17244,10 +17257,23 @@ bool StatelessValidation::PreCallValidateCmdBindVertexBuffers2EXT(
     bool skip = false;
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdBindVertexBuffers2EXT", VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdBindVertexBuffers2EXT", VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    skip |= validate_array("vkCmdBindVertexBuffers2EXT", "bindingCount", "pBuffers", bindingCount, &pBuffers, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pBuffers-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2EXT", "bindingCount", "pOffsets", bindingCount, &pOffsets, true, true, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pOffsets-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2EXT", "bindingCount", "pSizes", bindingCount, &pSizes, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pSizes-parameter");
-    skip |= validate_array("vkCmdBindVertexBuffers2EXT", "bindingCount", "pStrides", bindingCount, &pStrides, true, false, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", "VUID-vkCmdBindVertexBuffers2-pStrides-parameter");
+
+    // Check VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength
+    const bool vuidCondition = (pSizes != nullptr) || (pStrides != nullptr);
+    const bool vuidExpectation = bindingCount > 0;
+    if (vuidCondition)
+    {
+      if (!vuidExpectation)
+      {
+        const char *not_null_msg = "";
+        if ((pSizes != nullptr ) && (pStrides != nullptr)) not_null_msg = "pSizes and pStrides are not NULL"; 
+        else if (pSizes != nullptr ) not_null_msg = "pSizes is not NULL"; 
+        else not_null_msg = "pStrides is not NULL"; 
+        const char *vuid_breach_msg = "vkCmdBindVertexBuffers2: %s, so bindingCount must be greater that 0.";
+        skip |= LogError(device, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", vuid_breach_msg, not_null_msg); 
+      }
+    }
+
     if (!skip) skip |= manual_PreCallValidateCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
     return skip;
 }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -9392,6 +9392,11 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
         m_errorMonitor->VerifyFound();
     }
 
+    if (vulkan_13) {
+        vkCmdBindVertexBuffers2(commandBuffer.handle(), 0, 0, nullptr, nullptr, nullptr, nullptr);
+    }
+    vkCmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 0, nullptr, nullptr, nullptr, nullptr);
+
     commandBuffer.end();
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4295

The way validation is done currently is a bit complex and seems to miss the [VUID definition](https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength):
>VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength
> If any of pSizes, or pStrides are not NULL, bindingCount must be greater than 0

This PR proposes a simpler validation, that correctly handles the call mentioned in the issue, and the VUID in general. The call was:
```
vkCmdBindVertexBuffers2EXT(cmd_buffer_handle, 0, 0, nullptr, nullptr, nullptr, nullptr);
```

Some questions:
1) The same validation is done at two spots, should it be factorised into a function?
2) The formation used for the `if`s, the variable names, the use of snake_case, is it ok?