### PR TITLE
layers: Fix check for dynamic rendering attachment format use

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -213,6 +213,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     // Track if certain commands have been called at least once in lifetime of the command buffer
     // primary command buffers values are set true if a secondary command buffer has a command
     bool has_draw_cmd;
+    bool has_draw_cmd_in_current_render_pass;
     bool has_dispatch_cmd;
     bool has_trace_rays_cmd;
     bool has_build_as_cmd;
@@ -220,8 +221,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     CB_STATE state;         // Track cmd buffer update state
     uint64_t commandCount;  // Number of commands recorded. Currently only used with VK_KHR_performance_query
     uint64_t submitCount;   // Number of times CB has been submitted
-    bool pipeline_bound = false;                  // True if CmdBindPipeline has been called on this command buffer, false otherwise
-    uint64_t commands_since_begin_rendering = 0;  // Number of commands since the last CmdBeginRenderingCommand
+    bool pipeline_bound = false;  // True if CmdBindPipeline has been called on this command buffer, false otherwise
     typedef uint64_t ImageLayoutUpdateCount;
     ImageLayoutUpdateCount image_layout_change_count;  // The sequence number for changes to image layout (for cached validation)
     CBStatusFlags status;                              // Track status of various bindings on cmd buffer

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9551,8 +9551,8 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                  msrtss_info->rasterizationSamples, pipeline_rasterization_samples);
             }
         }
-        if ((cb_state->commands_since_begin_rendering > 0) && cb_state->activeRenderPass &&
-            cb_state->activeRenderPass->UsesDynamicRendering() && cb_state->has_draw_cmd) {
+        if (cb_state->activeRenderPass && cb_state->activeRenderPass->UsesDynamicRendering() &&
+            cb_state->has_draw_cmd_in_current_render_pass) {
             const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pipeline_state->PNext());
             const auto last_pipeline = cb_state->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
             const auto *last_rendering_struct =

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -205,9 +205,10 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingDrawMultiBind) {
     m_commandBuffer->EndRendering();
 
     m_commandBuffer->BeginRendering(begin_rendering_info);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.handle());
+    // NOTE: Setting dynamic state does not count as "using" the currently bound pipeline.
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.handle());
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
     m_commandBuffer->EndRendering();
     m_commandBuffer->end();


### PR DESCRIPTION
The spec says to check for the current render pass instance,
but code was checking if there were any draw calls at all in the command
buffer.