### PR TITLE
build: Revert addition of aligned_alloc()

### DIFF
--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -2688,7 +2688,9 @@ remove them if not needed.
    #define VMA_NULL   nullptr
 #endif
 
-#if defined(__ANDROID_API__) && (__ANDROID_API__ < 16)
+#if defined(_WIN32)
+static void* vma_aligned_alloc(size_t alignment, size_t size) { return _aligned_malloc(size, alignment); }
+#elif defined(__ANDROID_API__) && (__ANDROID_API__ < 16)
 #include <cstdlib>
 static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
@@ -2700,38 +2702,10 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
 
     return memalign(alignment, size);
 }
-#elif defined(__APPLE__) || defined(__ANDROID__) || (defined(__linux__) && defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
-#define ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
-#elif defined(__GNU_LIBRARY__)
-#  if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 16)
-// aligned_alloc() is defined in glibc only for version >= 2.16
-      #define ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
-#  endif
-#endif
-#ifdef ALIGNED_ALLOC_WITH_POSIX_MEMALIGN
+#else
 #include <cstdlib>
-
-#if defined(__APPLE__)
-#include <AvailabilityMacros.h>
-#endif
-
 static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
-    // Unfortunately, aligned_alloc causes VMA to crash due to it returning null pointers. (At least under 11.4)
-    // Therefore, for now disable this specific exception until a proper solution is found.
-    //#if defined(__APPLE__) && (defined(MAC_OS_X_VERSION_10_16) || defined(__IPHONE_14_0))
-    //#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16 || __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
-    //    // For C++14, usr/include/malloc/_malloc.h declares aligned_alloc()) only
-    //    // with the MacOSX11.0 SDK in Xcode 12 (which is what adds
-    //    // MAC_OS_X_VERSION_10_16), even though the function is marked
-    //    // availabe for 10.15. That is why the preprocessor checks for 10.16 but
-    //    // the __builtin_available checks for 10.15.
-    //    // People who use C++17 could call aligned_alloc with the 10.15 SDK already.
-    //    if (__builtin_available(macOS 10.15, iOS 13, *))
-    //        return aligned_alloc(alignment, size);
-    //#endif
-    //#endif
-
     // alignment must be >= sizeof(void*)
     if(alignment < sizeof(void*))
     {
@@ -2742,16 +2716,6 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
     if(posix_memalign(&pointer, alignment, size) == 0)
         return pointer;
     return VMA_NULL;
-}
-#elif defined(_WIN32)
-static void* vma_aligned_alloc(size_t alignment, size_t size)
-{
-    return _aligned_malloc(size, alignment);
-}
-#else
-static void* vma_aligned_alloc(size_t alignment, size_t size)
-{
-    return aligned_alloc(alignment, size);
 }
 #endif
 
@@ -2766,11 +2730,6 @@ static void vma_aligned_free(void* VMA_NULLABLE ptr)
     free(ptr);
 }
 #endif
-
-// If your compiler is not compatible with C++11 and definition of
-// aligned_alloc() function is missing, uncommeting following line may help:
-
-//#include <malloc.h>
 
 // Normal assert to check for programmer's errors, especially in Debug configuration.
 #ifndef VMA_ASSERT


### PR DESCRIPTION
Vulkan-ValidationLayers builds as C++11. aligned_alloc() was only added
in C++17. C headers are not guarenteed to expose the function until
C++17 mode, as noted on OpenBSD, but other implementations such as
glibc do the same.