### PR TITLE
Add check for VUID-vkCmdDraw-None-02686

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1590,7 +1590,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
 
             // Check if all input attachments are bound
             // VUID-vkCmdDraw-None-02686
-            std::set<VkImageView> subpass_input_views;
+            std::unordered_map<VkImageView, uint32_t> subpass_input_views;
             const auto &subpass = cb_node->activeRenderPass->createInfo.pSubpasses[cb_node->activeSubpass];
             for (const auto &stage : pipe->stage_state) {
                 if (stage.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT) {
@@ -1600,7 +1600,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                         if (index != VK_ATTACHMENT_UNUSED) {
                             VkImageView input_attachment_view =
                                 cb_node->activeFramebuffer->attachments_view_state[index]->Handle().Cast<VkImageView>();
-                            subpass_input_views.insert(input_attachment_view);
+                            subpass_input_views.insert(std::make_pair(input_attachment_view, i));
                         }
                     }
 
@@ -1620,8 +1620,9 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                     // Image view isn't used by subpass as an input attachment with this framebuffer, is this a VUID
                                     // ?
                                     if (subpass_input_views.count(image_view) == 0) {
-                                        result |= LogError(image_view, "UNASSIGNED-input-attachment-descriptor-not-in-subpass",
-                                                           "Input attachment image view is not a subpass input attachment");
+                                        result |=
+                                            LogError(image_view, "UNASSIGNED-input-attachment-descriptor-not-in-subpass",
+                                                     "Input attachment descriptor image view is not a subpass input attachment");
                                     } else {
                                         subpass_input_views.erase(image_view);
                                     }
@@ -1636,9 +1637,10 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
 
             // Report error for every unbound input attachment
             for (auto view : subpass_input_views) {
-                result |= LogError(view, vuid.subpass_input,
-                                   "%s(): Input attachments of subpass %" PRIu32 " are not bound by descriptor sets.",
-                                   CommandTypeString(cmd_type), cb_node->activeSubpass);
+                result |=
+                    LogError(view.first, vuid.subpass_input,
+                             "%s(): Input attachment index %" PRIu32 " of subpass %" PRIu32 " is not bound by descriptor sets.",
+                             CommandTypeString(cmd_type), view.second, cb_node->activeSubpass);
             }
         }
     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1621,7 +1621,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                     // ?
                                     if (subpass_input_views.count(image_view) == 0) {
                                         result |=
-                                            LogError(image_view, "UNASSIGNED-input-attachment-descriptor-not-in-subpass",
+                                            LogError(image_view, kVUID_Core_InputDescriptorInvalid,
                                                      "Input attachment descriptor image view is not a subpass input attachment");
                                     } else {
                                         subpass_input_views.erase(image_view);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -59,7 +59,6 @@ struct DrawDispatchVuid {
     const char* viewport_scissor_count = kVUIDUndefined;
     const char* primitive_topology = kVUIDUndefined;
     const char* corner_sampled_address_mode = kVUIDUndefined;
-    // subpass input doesn't validate anything because those checks were done in ValidateCreateGraphicsPipelines
     const char* subpass_input = kVUIDUndefined;
     const char* imageview_atomic = kVUIDUndefined;
     const char* push_constants_set = kVUIDUndefined;

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -297,6 +297,8 @@ static const char DECORATE_UNUSED *kVUID_Core_invalidDepthStencilFormat = "UNASS
 
 static const char DECORATE_UNUSED *kVUID_Core_VkBindImageMemoryInfo_pNext_missing_VkBindImagePlaneMemoryInfo = "UNASSIGNED-VkBindImageMemoryInfo-pNext-missing-VkBindImagePlaneMemoryInfo";
 
+static const char DECORATE_UNUSED *kVUID_Core_InputDescriptorInvalid = "UNASSIGNED-input-attachment-descriptor-not-in-subpass";
+
 // clang-format on
 
 #undef DECORATE_UNUSED


### PR DESCRIPTION
Add check for not binding all input attachments that are used in a subpass.
Also adds a check for when an input attachment descriptor image view isn't used as input attachment in current subpass/framebuffer. Is this already a VUID ? I can't find it anywhere, and seems like it should be.

Closes #4494 