### PR TITLE
build: Update SPIRV-Headers and -Tools for SPV_EXT_mesh_shader

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -28,13 +28,13 @@
       "name" : "SPIRV-Tools",
       "url" : "https://github.com/KhronosGroup/SPIRV-Tools.git",
       "sub_dir" : "shaderc/third_party/spirv-tools",
-      "commit" : "5e61ea2098220059e89523f1f47b0bcd8c33b89a"
+      "commit" : "4c456f7da67c5437a6fb7d4d20d78e2a5ae2acf2"
     },
     {
       "name" : "SPIRV-Headers",
       "url" : "https://github.com/KhronosGroup/SPIRV-Headers.git",
       "sub_dir" : "shaderc/third_party/spirv-tools/external/spirv-headers",
-      "commit" : "b2a156e1c0434bc8c99aaebba1c7be98be7ac580"
+      "commit" : "87d5b782bec60822aa878941e6b13c0a9a954c9b"
     },
     {
       "name": "robin-hood-hashing",

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -365,6 +365,8 @@ static const layer_data::unordered_map<uint32_t, InstructionInfo> kInstructionTa
     {spv::OpFragmentFetchAMD, {"OpFragmentFetchAMD", true, true, 0, 0, 0}},
     {spv::OpReadClockKHR, {"OpReadClockKHR", true, true, 0, 3, 0}},
     {spv::OpImageSampleFootprintNV, {"OpImageSampleFootprintNV", true, true, 0, 0, 7}},
+    {spv::OpEmitMeshTasksEXT, {"OpEmitMeshTasksEXT", false, false, 0, 0, 0}},
+    {spv::OpSetMeshOutputsEXT, {"OpSetMeshOutputsEXT", false, false, 0, 0, 0}},
     {spv::OpGroupNonUniformPartitionNV, {"OpGroupNonUniformPartitionNV", true, true, 0, 0, 0}},
     {spv::OpWritePackedPrimitiveIndices4x8NV, {"OpWritePackedPrimitiveIndices4x8NV", false, false, 0, 0, 0}},
     {spv::OpReportIntersectionKHR, {"OpReportIntersectionKHR", true, true, 0, 0, 0}},
@@ -745,6 +747,8 @@ const char* string_SpvStorageClass(uint32_t storage_class) {
             return "ShaderRecordBufferNV";
         case spv::StorageClassPhysicalStorageBuffer:
             return "PhysicalStorageBuffer";
+        case spv::StorageClassTaskPayloadWorkgroupEXT:
+            return "TaskPayloadWorkgroupEXT";
         case spv::StorageClassCodeSectionINTEL:
             return "CodeSectionINTEL";
         case spv::StorageClassDeviceOnlyINTEL:

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "5e61ea2098220059e89523f1f47b0bcd8c33b89a"
+#define SPIRV_TOOLS_COMMIT_ID "4c456f7da67c5437a6fb7d4d20d78e2a5ae2acf2"

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -202,8 +202,7 @@ static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirvCapabilit
     {spv::CapabilityIntegerFunctions2INTEL, {0, &VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::shaderIntegerFunctions2, nullptr, ""}},
     {spv::CapabilityInterpolationFunction, {0, &VkPhysicalDeviceFeatures::sampleRateShading, nullptr, ""}},
     {spv::CapabilityMatrix, {VK_API_VERSION_1_0, nullptr, nullptr, ""}},
-    // Not found in current SPIR-V Headers
-    //    {spv::CapabilityMeshShadingEXT, {0, nullptr, &DeviceExtensions::vk_ext_mesh_shader, ""}},
+    {spv::CapabilityMeshShadingEXT, {0, nullptr, &DeviceExtensions::vk_ext_mesh_shader, ""}},
     {spv::CapabilityMeshShadingNV, {0, nullptr, &DeviceExtensions::vk_nv_mesh_shader, ""}},
     {spv::CapabilityMinLod, {0, &VkPhysicalDeviceFeatures::shaderResourceMinLod, nullptr, ""}},
     {spv::CapabilityMultiView, {0, &VkPhysicalDeviceVulkan11Features::multiview, nullptr, ""}},
@@ -508,6 +507,8 @@ static inline const char* string_SpvCapability(uint32_t input_value) {
             return "InterpolationFunction";
          case spv::CapabilityMatrix:
             return "Matrix";
+         case spv::CapabilityMeshShadingEXT:
+            return "MeshShadingEXT";
          case spv::CapabilityMeshShadingNV:
             return "MeshShadingNV";
          case spv::CapabilityMinLod:

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -26,7 +26,7 @@
       "sub_dir": "SPIRV-Headers",
       "build_dir": "SPIRV-Headers/build",
       "install_dir": "SPIRV-Headers/build/install",
-      "commit": "b2a156e1c0434bc8c99aaebba1c7be98be7ac580"
+      "commit": "87d5b782bec60822aa878941e6b13c0a9a954c9b"
     },
     {
       "name": "SPIRV-Tools",
@@ -37,7 +37,7 @@
       "cmake_options": [
         "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers"
       ],
-      "commit": "5e61ea2098220059e89523f1f47b0bcd8c33b89a"
+      "commit": "4c456f7da67c5437a6fb7d4d20d78e2a5ae2acf2"
     },
     {
       "name": "robin-hood-hashing",

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -99,7 +99,6 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
             'TextureBlockMatchQCOM',
             'TextureBoxFilterQCOM',
             'TextureSampleWeightedQCOM',
-            'MeshShadingEXT'
         ]
 
         # There are some enums that share the same value in the SPIR-V header.


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Headers/pull/288
https://github.com/KhronosGroup/SPIRV-Tools/pull/4915

Reenable spv::CapabilityMeshShadingEXT in spirv_validation_generator.py

Fixes #4515