### PR TITLE
tests: fix how global list of extensions/layers is obtained

### DIFF
--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -144,7 +144,7 @@ std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
     uint32_t extension_count = 32;
     std::vector<VkExtensionProperties> extensions(extension_count);
     for (;;) {
-        err = vk::EnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data());
+        err = vk::EnumerateInstanceExtensionProperties(pLayerName, &extension_count, extensions.data());
         if (err == VK_SUCCESS) {
             extensions.resize(extension_count);
             return extensions;


### PR DESCRIPTION
Saw that while working on another PR.
The way all extensions/layers are queried is not really what you are supposed to do. And `GetGlobalExtensions` was not using its `pLayerName` parameter.