### PR TITLE
Fixes for swapchain flags VUIDs

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2193,9 +2193,11 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
     if (device_group_create_info.physicalDeviceCount == 1) {
         if (pCreateInfo->flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) {
-            skip |= LogError(device, "VUID-VkImageCreateInfo-physicalDeviceCount-01421",
-                             "vkCreateImage: Device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount 1, but "
-                             "flags contain VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT bit.");
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-physicalDeviceCount-01421",
+                "vkCreateImage: Device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1, but "
+                "flags contain VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT bit. Device creation with "
+                "VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1 may have been implicit.");
         }
     }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -17744,11 +17744,14 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
         }
     }
 
-    if ((pCreateInfo->flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) &&
-        device_group_create_info.physicalDeviceCount == 1) {
+    if ((pCreateInfo->flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) && physical_device_count == 1) {
         if (LogError(device, "VUID-VkSwapchainCreateInfoKHR-physicalDeviceCount-01429",
                      "%s called with flags containing VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR"
-                     "but logical device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1",
+                     "but logical device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1."
+                     "The logical device may have been created without explicitly using VkDeviceGroupDeviceCreateInfo, or with"
+                     "VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to zero. "
+                     "It is equivalent to using VkDeviceGroupDeviceCreateInfo with "
+                     "VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1",
                      func_name)) {
             return true;
         }

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -898,8 +898,15 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
     const auto *device_group_ci = LvlFindInChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);
     if (device_group_ci) {
         physical_device_count = device_group_ci->physicalDeviceCount;
+        if (physical_device_count == 0) {
+            physical_device_count =
+                1;  // see https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceGroupDeviceCreateInfo.html
+        }
         device_group_create_info = *device_group_ci;
     } else {
+        device_group_create_info = LvlInitStruct<VkDeviceGroupDeviceCreateInfo>();
+        device_group_create_info.physicalDeviceCount = 1;  // see previous VkDeviceGroupDeviceCreateInfo link
+        device_group_create_info.pPhysicalDevices = &physical_device;
         physical_device_count = 1;
     }
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4440,7 +4440,7 @@ TEST_F(VkPositiveLayerTest, ProtectedSwapchainImageColorAttachment) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     AddSurfaceExtension();
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -13287,6 +13287,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCount) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-pNext-01627");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01633");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01634");
     vkBindImageMemory2Function(device(), 1, &bindInfo);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -657,6 +657,9 @@ bool VkRenderFramework::AddRequestedInstanceExtensions(const char *ext_name) {
     if (is_instance_ext) {
         const auto &info = InstanceExtensions::get_info(ext_name);
         for (const auto &req : info.requirements) {
+            if (0 == strncmp(req.name, "VK_VERSION", 10)) {
+                continue;
+            }
             if (!AddRequestedInstanceExtensions(req.name)) {
                 return false;
             }


### PR DESCRIPTION
Fixes for issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4274

This PR aims at fixing checks for 2 VUIDs:
`VUID-VkSwapchainCreateInfoKHR-physicalDeviceCount-01429`:
> If the logical device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1, flags must not contain VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR

`VUID-VkSwapchainCreateInfoKHR-flags-03187`:
> If flags contains VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR, then VkSurfaceProtectedCapabilitiesKHR::supportsProtected must be VK_TRUE in the VkSurfaceProtectedCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilities2KHR for surface

## For 01429

The root issue is how `device_group_create_info`, a member variable that was only correctly initialised when a `VkDeviceGroupDeviceCreateInfo` member was in the `pNext` chain of `VkDeviceCreateInfo`. When it is not, according to [the spec](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceGroupDeviceCreateInfo.html), this member is implictly defined with `physicalDeviceCount == 1` and `pPhysicalDevices = &physical_device`. But it was not done in `state_tracker.cpp`.

I checked references to `device_group_create_info`, they are in the following functions:
	- `ValidateBindBufferMemory`
	- `ValidateBindImageMemory`
	- `PreCallValidateGetDeviceGroupSurfacePresentModes2EXT`
	- `PreCallValidateGetDeviceGroupSurfacePresentModesKHR`
It seems that nothing seems to be done here after `device_group_create_info` initialisation update.

I updated the validation message in case `VkDeviceGroupDeviceCreateInfo` is implicitly defined, otherwise the original message would be confusing.

Updating `device_group_create_info` showed that `VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01634` was not triggered in the test `VkLayerTest.InvalidImageSplitInstanceBindRegionCount`, when it should have been.
VUID description is:
> deviceIndexCount must either be zero or equal to the number of physical devices in the logical device

The number of physical device is 1 in this test, but `deviceIndexCount` is 2. The number of physical device used to be 0, so the VUID was not triggered.

## For 03187

This VUID was only checked if the instance extension `VK_KHR_surface_protected_capabilities` was activated by the user, but the check should be performed if the extension is supported, not necessarily enabled. If the extension is not supported and the corresponding swapchain flag is present, a validation error will be triggered.


## For both VUIDs

I added a new test for the 2 VUIDs, `VkLayerTest.InitSwapchainPotentiallyIncompatibleFlag` in `vklayertest_wsi.cpp` (is it a good place to put it?)
