### PR TITLE
Add OpImageWrite component count check

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -269,6 +269,7 @@ source_set("vulkan_layer_utils") {
   include_dirs = [
     "layers",
     "layers/generated",
+    "$vvl_spirv_headers_dir/include",
   ]
   sources = [
     "$vulkan_headers_dir/include/vulkan/vk_layer.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ target_include_directories(VkLayer_utils
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}/layers
                                   ${PROJECT_BINARY_DIR}
+                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR})
 
 if (USE_ROBIN_HOOD_HASHING)

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -29,6 +29,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/vk_format_utils.cpp
 LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(THIRD_PARTY)/shaderc/third_party/spirv-tools/external/spirv-headers/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -DUSE_ROBIN_HOOD_HASHING -fvisibility=hidden

--- a/build-gn/secondary/build_overrides/vulkan_validation_layers.gni
+++ b/build-gn/secondary/build_overrides/vulkan_validation_layers.gni
@@ -1,4 +1,4 @@
-# Copyright (c) 2019,2021 LunarG, Inc.
+# Copyright (c) 2019,2021-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # Paths to validation layer dependencies
 vulkan_headers_dir = "//external/Vulkan-Headers"
 vvl_spirv_tools_dir = "//external/SPIRV-Tools"
+vvl_spirv_headers_dir = "//external/SPIRV-Headers"
 vvl_glslang_dir = "//external/glslang/"
 robin_hood_headers_dir = "//external/robin-hood-hashing/src/include"
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -662,6 +662,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const PipelineStageState& stage_state,
                                 const safe_VkPipelineShaderStageCreateInfo* pStage, const VkPipelineCreateFlags flags) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
+    bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* src_img,

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -30,6 +30,7 @@
 #include "vk_layer_utils.h"
 #include <map>
 #include <vector>
+#include <spirv/unified1/spirv.hpp>
 
 
 enum class COMPONENT_TYPE {
@@ -1925,5 +1926,96 @@ bool FormatHasBlue(VkFormat format) {
 
 bool FormatHasAlpha(VkFormat format) {
     return FormatHasComponent(format, COMPONENT_TYPE::A);
+}
+
+// Will return the Vulkan format for a given SPIR-V image format value
+// Note: will return VK_FORMAT_UNDEFINED if non valid input
+VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {
+    switch (spirv_image_format) {
+        case spv::ImageFormatRgb10a2ui:
+            return VK_FORMAT_A2B10G10R10_UINT_PACK32;
+        case spv::ImageFormatRgb10A2:
+            return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+        case spv::ImageFormatR11fG11fB10f:
+            return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+        case spv::ImageFormatRgba16f:
+            return VK_FORMAT_R16G16B16A16_SFLOAT;
+        case spv::ImageFormatRgba16i:
+            return VK_FORMAT_R16G16B16A16_SINT;
+        case spv::ImageFormatRgba16Snorm:
+            return VK_FORMAT_R16G16B16A16_SNORM;
+        case spv::ImageFormatRgba16ui:
+            return VK_FORMAT_R16G16B16A16_UINT;
+        case spv::ImageFormatRgba16:
+            return VK_FORMAT_R16G16B16A16_UNORM;
+        case spv::ImageFormatRg16f:
+            return VK_FORMAT_R16G16_SFLOAT;
+        case spv::ImageFormatRg16i:
+            return VK_FORMAT_R16G16_SINT;
+        case spv::ImageFormatRg16Snorm:
+            return VK_FORMAT_R16G16_SNORM;
+        case spv::ImageFormatRg16ui:
+            return VK_FORMAT_R16G16_UINT;
+        case spv::ImageFormatRg16:
+            return VK_FORMAT_R16G16_UNORM;
+        case spv::ImageFormatR16f:
+            return VK_FORMAT_R16_SFLOAT;
+        case spv::ImageFormatR16i:
+            return VK_FORMAT_R16_SINT;
+        case spv::ImageFormatR16Snorm:
+            return VK_FORMAT_R16_SNORM;
+        case spv::ImageFormatR16ui:
+            return VK_FORMAT_R16_UINT;
+        case spv::ImageFormatR16:
+            return VK_FORMAT_R16_UNORM;
+        case spv::ImageFormatRgba32f:
+            return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case spv::ImageFormatRgba32i:
+            return VK_FORMAT_R32G32B32A32_SINT;
+        case spv::ImageFormatRgba32ui:
+            return VK_FORMAT_R32G32B32A32_UINT;
+        case spv::ImageFormatRg32f:
+            return VK_FORMAT_R32G32_SFLOAT;
+        case spv::ImageFormatRg32i:
+            return VK_FORMAT_R32G32_SINT;
+        case spv::ImageFormatRg32ui:
+            return VK_FORMAT_R32G32_UINT;
+        case spv::ImageFormatR32f:
+            return VK_FORMAT_R32_SFLOAT;
+        case spv::ImageFormatR32i:
+            return VK_FORMAT_R32_SINT;
+        case spv::ImageFormatR32ui:
+            return VK_FORMAT_R32_UINT;
+        case spv::ImageFormatR64i:
+            return VK_FORMAT_R64_SINT;
+        case spv::ImageFormatR64ui:
+            return VK_FORMAT_R64_UINT;
+        case spv::ImageFormatRgba8i:
+            return VK_FORMAT_R8G8B8A8_SINT;
+        case spv::ImageFormatRgba8Snorm:
+            return VK_FORMAT_R8G8B8A8_SNORM;
+        case spv::ImageFormatRgba8ui:
+            return VK_FORMAT_R8G8B8A8_UINT;
+        case spv::ImageFormatRgba8:
+            return VK_FORMAT_R8G8B8A8_UNORM;
+        case spv::ImageFormatRg8i:
+            return VK_FORMAT_R8G8_SINT;
+        case spv::ImageFormatRg8Snorm:
+            return VK_FORMAT_R8G8_SNORM;
+        case spv::ImageFormatRg8ui:
+            return VK_FORMAT_R8G8_UINT;
+        case spv::ImageFormatRg8:
+            return VK_FORMAT_R8G8_UNORM;
+        case spv::ImageFormatR8i:
+            return VK_FORMAT_R8_SINT;
+        case spv::ImageFormatR8Snorm:
+            return VK_FORMAT_R8_SNORM;
+        case spv::ImageFormatR8ui:
+            return VK_FORMAT_R8_UINT;
+        case spv::ImageFormatR8:
+            return VK_FORMAT_R8_UNORM;
+        default:
+            return VK_FORMAT_UNDEFINED;
+     }
 }
 

--- a/layers/generated/vk_format_utils.h
+++ b/layers/generated/vk_format_utils.h
@@ -206,6 +206,8 @@ VK_LAYER_EXPORT bool FormatHasGreen(VkFormat format);
 VK_LAYER_EXPORT bool FormatHasBlue(VkFormat format);
 VK_LAYER_EXPORT bool FormatHasAlpha(VkFormat format);
 
+// SPIR-V
+VK_LAYER_EXPORT VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
 
 // Utils/misc
 static inline bool FormatIsUndef(VkFormat format) { return (format == VK_FORMAT_UNDEFINED); }

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -153,6 +153,7 @@ class FormatUtilsOutputGenerator(OutputGenerator):
             write('#include "vk_layer_utils.h"', file=self.outFile)
             write('#include <map>', file=self.outFile)
             write('#include <vector>', file=self.outFile)
+            write('#include <spirv/unified1/spirv.hpp>', file=self.outFile)
         elif self.headerFile:
             write('#pragma once', file=self.outFile)
             write('#include <vulkan/vk_layer.h>', file=self.outFile)
@@ -173,6 +174,7 @@ extern "C" {
         write(self.ycbcrFunctions(), file=self.outFile)
         write(self.multiplaneFunctions(), file=self.outFile)
         write(self.sizeFunctions(), file=self.outFile)
+        write(self.spirvFunctions(), file=self.outFile)
         write(self.utilFunctions(), file=self.outFile)
         if self.headerFile:
             export = '''
@@ -203,7 +205,8 @@ extern "C" {
             'blockSize' : int(elem.get('blockSize')),
             'texelsPerBlock' : int(elem.get('texelsPerBlock')),
             'blockExtent' : '1,1,1', # default
-            'components' : []
+            'components' : [],
+            'spirv' : None # default
         }
 
         if elem.get('blockExtent'):
@@ -221,6 +224,10 @@ extern "C" {
                 # create list if first time
                 self.compressedFormats[compressed] = []
             self.compressedFormats[compressed].append(formatName)
+
+        spirvImageFormat = elem.find('spirvimageformat')
+        if (spirvImageFormat is not None):
+            self.allFormats[formatName]['spirv'] = spirvImageFormat.get('name')
 
         self.maxComponentCount = max(self.maxComponentCount, sum(1 for _ in elem.iter('component')))
         # some formats (VK_FORMAT_D16_UNORM_S8_UINT) are not same numeric
@@ -806,6 +813,28 @@ bool FormatHasAlpha(VkFormat format) {
     return FormatHasComponent(format, COMPONENT_TYPE::A);
 }'''
         return output;
+    #
+    # Generate functions for size based functions
+    def spirvFunctions(self):
+        output = ''
+        if self.headerFile:
+            output += '''// SPIR-V
+VK_LAYER_EXPORT VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);'''
+        elif self.sourceFile:
+            output += '\n// Will return the Vulkan format for a given SPIR-V image format value\n'
+            output += '// Note: will return VK_FORMAT_UNDEFINED if non valid input\n'
+            output += 'VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {\n'
+            output += '    switch (spirv_image_format) {\n'
+            for f, info in sorted(self.allFormats.items()):
+                if info['spirv'] is not None:
+                    output += '        case spv::ImageFormat{}:\n'.format(info['spirv'])
+                    output += '            return {};\n'.format(f)
+            output += '        default:\n'
+            output += '            return VK_FORMAT_UNDEFINED;\n'
+            output += '     }\n'
+            output += '}'
+
+        return output
 
     #
     # Misc functions

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ target_include_directories(vk_layer_validation_tests
                                   ${CMAKE_BINARY_DIR}
                                   ${PROJECT_BINARY_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR}
+                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
 add_dependencies(vk_layer_validation_tests
                  VkLayer_utils)


### PR DESCRIPTION
Adds new `VUID-RuntimeSpirv-OpImageWrite-07112` support

This only validates of the `OpImageType` format is not `Unknown`, if it is then `VUID-vkCmdDispatch-None-04115` and `VUID-vkCmdDispatch-OpImageWrite-04469` are used... I was going to add these 2 as well in here, but some other refactoring was needed and bloated this PR

New `CompatibleSpirvImageFormat` generated to map the table in the Spec which SPIR-V image formats go with which `VkFormat`
