### PR TITLE
Implement check for ownership transfer

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -131,6 +131,7 @@ static const char DECORATE_UNUSED *kVUID_BestPractices_EmptyDescriptorPool =
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
 static const char DECORATE_UNUSED *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
 static const char DECORATE_UNUSED *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";
+static const char DECORATE_UNUSED *kVUID_BestPractices_ConcurrentUsageOfExclusiveImage = "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage";
 
 // Arm-specific best practice
 static const char DECORATE_UNUSED *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2652,8 +2652,7 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
 void BestPractices::ValidateImageInQueue(const ValidationStateTracker& vst, const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs,
                                          const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
                                          uint32_t array_layer, uint32_t mip_level) {
-    auto last_usage = state.UpdateUsage(array_layer, mip_level, usage);
-    auto last_queue_family = state.UpdateQueueFamily(qs.queueFamilyIndex);
+    auto last_usage = state.UpdateUsage(array_layer, mip_level, usage, qs.queueFamilyIndex);
 
     // When image was discarded with StoreOpDontCare but is now being read with LoadOpLoad
     if (last_usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_DISCARDED &&

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2568,9 +2568,9 @@ void BestPractices::QueueValidateImage(QueueCallbacks& funcs, const char* functi
 
 void BestPractices::QueueValidateImage(QueueCallbacks& funcs, const char* function_name, std::shared_ptr<bp_state::Image>& state,
                                        IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level) {
-    funcs.push_back([this, function_name, state, usage, array_layer, mip_level](const ValidationStateTracker&, const QUEUE_STATE&,
-                                                                                const CMD_BUFFER_STATE&) -> bool {
-        ValidateImageInQueue(function_name, *state, usage, array_layer, mip_level);
+    funcs.push_back([this, function_name, state, usage, array_layer, mip_level](
+                        const ValidationStateTracker& vst, const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs) -> bool {
+        ValidateImageInQueue(vst, qs, cbs, function_name, *state, usage, array_layer, mip_level);
         return false;
     });
 }
@@ -2649,9 +2649,11 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
     }
 }
 
-void BestPractices::ValidateImageInQueue(const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
+void BestPractices::ValidateImageInQueue(const ValidationStateTracker& vst, const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs,
+                                         const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
                                          uint32_t array_layer, uint32_t mip_level) {
     auto last_usage = state.UpdateUsage(array_layer, mip_level, usage);
+    auto last_queue_family = state.UpdateQueueFamily(qs.queueFamilyIndex);
 
     // When image was discarded with StoreOpDontCare but is now being read with LoadOpLoad
     if (last_usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_DISCARDED &&

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -2652,31 +2652,33 @@ void BestPractices::ValidateImageInQueueArmImg(const char* function_name, const 
 void BestPractices::ValidateImageInQueue(const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs, const char* function_name,
                                          bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer,
                                          uint32_t mip_level) {
-    auto last_queue_family = state.GetLastQueueFamily(array_layer, mip_level);
     auto queue_family = qs.queueFamilyIndex;
     auto last_usage = state.UpdateUsage(array_layer, mip_level, usage, queue_family);
 
     // Concurrent sharing usage of image with exclusive sharing mode
-    if (state.createInfo.sharingMode == VK_SHARING_MODE_EXCLUSIVE && last_queue_family != queue_family) {
+    if (state.createInfo.sharingMode == VK_SHARING_MODE_EXCLUSIVE && last_usage.queue_family_index != queue_family) {
         // if UNDEFINED then first use/acquisition of subresource
-        if (last_usage != IMAGE_SUBRESOURCE_USAGE_BP::UNDEFINED) {
+        if (last_usage.type != IMAGE_SUBRESOURCE_USAGE_BP::UNDEFINED) {
             // If usage might read from the subresource, as contents are undefined
             // so write only is fine
             if (usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_READ_TO_TILE || usage == IMAGE_SUBRESOURCE_USAGE_BP::BLIT_READ ||
                 usage == IMAGE_SUBRESOURCE_USAGE_BP::COPY_READ || usage == IMAGE_SUBRESOURCE_USAGE_BP::DESCRIPTOR_ACCESS ||
                 usage == IMAGE_SUBRESOURCE_USAGE_BP::RESOLVE_READ) {
                 LogWarning(
-                    state.Handle().Cast<VkImage>(), kVUID_BestPractices_ConcurrentUsageOfExclusiveImage,
-                    "%s : Subresource (arrayLayer: %u, mipLevel: %u) of image is used on queue family index %u after being used on "
-                    "queue family index %u, "
+                    state.image(), kVUID_BestPractices_ConcurrentUsageOfExclusiveImage,
+                    "%s : Subresource (arrayLayer: %" PRIu32 ", mipLevel: %" PRIu32
+                    ") of image is used on queue family index %" PRIu32
+                    " after being used on "
+                    "queue family index %" PRIu32
+                    ", "
                     "but has VK_SHARING_MODE_EXCLUSIVE, and has not been acquired and released with a ownership transfer operation",
-                    function_name, array_layer, mip_level, queue_family, last_queue_family);
+                    function_name, array_layer, mip_level, queue_family, last_usage.queue_family_index);
             }
         }
     }
 
     // When image was discarded with StoreOpDontCare but is now being read with LoadOpLoad
-    if (last_usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_DISCARDED &&
+    if (last_usage.type == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_DISCARDED &&
         usage == IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_READ_TO_TILE) {
         LogWarning(device, kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad,
                    "Trying to load an attachment with LOAD_OP_LOAD that was previously stored with STORE_OP_DONT_CARE. This may "
@@ -2684,7 +2686,7 @@ void BestPractices::ValidateImageInQueue(const QUEUE_STATE& qs, const CMD_BUFFER
     }
 
     if (VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) {
-        ValidateImageInQueueArmImg(function_name, state, last_usage, usage, array_layer, mip_level);
+        ValidateImageInQueueArmImg(function_name, state, last_usage.type, usage, array_layer, mip_level);
     }
 }
 
@@ -5064,7 +5066,7 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
                                                                         const CMD_BUFFER_STATE& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {
                 // Update queue family index without changing usage, signifying a correct queue family transfer
-                image->UpdateUsage(layer, level, image->GetUsage(layer, level), qs.queueFamilyIndex);
+                image->UpdateUsage(layer, level, image->GetUsageType(layer, level), qs.queueFamilyIndex);
             });
             return false;
         });

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -5060,9 +5060,8 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
         barrier.dstQueueFamilyIndex == cb->command_pool->queueFamilyIndex) {
         auto image = Get<bp_state::Image>(barrier.image);
         auto subresource_range = barrier.subresourceRange;
-        cb->queue_submit_functions.push_back([this, image, subresource_range](const ValidationStateTracker& vst,
-                                                                              const QUEUE_STATE& qs,
-                                                                              const CMD_BUFFER_STATE& cbs) -> bool {
+        cb->queue_submit_functions.push_back([image, subresource_range](const ValidationStateTracker& vst, const QUEUE_STATE& qs,
+                                                                        const CMD_BUFFER_STATE& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {
                 // Update queue family index without changing usage, signifying a correct queue family transfer
                 image->UpdateUsage(layer, level, image->GetUsage(layer, level), qs.queueFamilyIndex);

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -696,9 +696,8 @@ class BestPractices : public ValidationStateTracker {
                             IMAGE_SUBRESOURCE_USAGE_BP usage, const VkImageSubresourceLayers& range);
     void QueueValidateImage(QueueCallbacks& func, const char* function_name, std::shared_ptr<bp_state::Image>& state,
                             IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
-    void ValidateImageInQueue(const ValidationStateTracker& vst, const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs,
-                              const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
-                              uint32_t array_layer, uint32_t mip_level);
+    void ValidateImageInQueue(const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs, const char* function_name, bp_state::Image& state,
+                              IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
     void ValidateImageInQueueArmImg(const char* function_name, const bp_state::Image& image, IMAGE_SUBRESOURCE_USAGE_BP last_usage,
                                  IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
 

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -185,6 +185,14 @@ class Image : public IMAGE_STATE {
 
     IMAGE_SUBRESOURCE_USAGE_BP GetUsage(uint32_t array_layer, uint32_t mip_level) { return usages_[array_layer][mip_level]; }
 
+    uint32_t UpdateQueueFamily(uint32_t queue_family) {
+        auto last = last_queue_family;
+        last_queue_family = queue_family;
+        return last;
+    }
+
+    uint32_t GetLastQueueFamily() { return last_queue_family; }
+
   private:
     void SetupUsages() {
         usages_.resize(createInfo.arrayLayers);
@@ -197,6 +205,7 @@ class Image : public IMAGE_STATE {
     // Aspects are generally read and written together,
     // and tracking them independently could be misleading.
     std::vector<std::vector<IMAGE_SUBRESOURCE_USAGE_BP>> usages_;
+    uint32_t last_queue_family = VK_QUEUE_FAMILY_IGNORED;
 };
 
 using ImageNoBinding = MEMORY_TRACKED_RESOURCE_STATE<Image, BindableNoMemoryTracker>;
@@ -692,7 +701,8 @@ class BestPractices : public ValidationStateTracker {
                             IMAGE_SUBRESOURCE_USAGE_BP usage, const VkImageSubresourceLayers& range);
     void QueueValidateImage(QueueCallbacks& func, const char* function_name, std::shared_ptr<bp_state::Image>& state,
                             IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);
-    void ValidateImageInQueue(const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
+    void ValidateImageInQueue(const ValidationStateTracker& vst, const QUEUE_STATE& qs, const CMD_BUFFER_STATE& cbs,
+                              const char* function_name, bp_state::Image& state, IMAGE_SUBRESOURCE_USAGE_BP usage,
                               uint32_t array_layer, uint32_t mip_level);
     void ValidateImageInQueueArmImg(const char* function_name, const bp_state::Image& image, IMAGE_SUBRESOURCE_USAGE_BP last_usage,
                                  IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level);

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -2056,7 +2056,10 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     compute_buffer.end();
 
+    // Warning should trigger as we are potentially accessing undefined resources
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage");
     compute_buffer.QueueCommandBuffer();
+    m_errorMonitor->VerifyFound();
 
     vk::ResetCommandPool(device(), graphics_pool.handle(), 0);
     vk::ResetCommandPool(device(), compute_pool.handle(), 0);
@@ -2105,5 +2108,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     compute_buffer.end();
 
+    // Warning shouldn't trigger
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage");
     compute_buffer.QueueCommandBuffer();
+    m_errorMonitor->Finish();
 }

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1952,8 +1952,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     // Setup RenderPass
     VkAttachmentDescription attachment{};
     attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;    // Write to image
-    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;  // Store written image
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;    // Clearing so warning will not trigger on second pass
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;  // Store written image for next queue family
     attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attachment.format = image_info.format;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1911,17 +1911,6 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
         }
     }
 
-    VkQueueObj *transfer_queue = nullptr;
-    for (uint32_t i = 0; i < m_device->dma_queues().size(); ++i) {
-        auto tqi = m_device->dma_queues()[i];
-        if (tqi->get_family_index() != graphics_queue->get_family_index()) {
-            if (compute_queue == nullptr || tqi->get_family_index() != compute_queue->get_family_index()) {
-                transfer_queue = tqi;
-                break;
-            }
-        }
-    }
-
     if (compute_queue == nullptr) {
         GTEST_SKIP() << "No separate queue family from graphics queue";
     }


### PR DESCRIPTION
Keeps the last used queue family with usage per subresource for images
Whenever a new usage appears on queue on a different queue family, check if it is a read operation because it will be undefined
Check for an image pipeline barrier defining an ownership acquisition operation and change the queue family index
Only for images for now, buffers later

Closes #2412 