### PR TITLE
layers: Calculate OpTypeBool as 32-bit ints for limits

### DIFF
--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -1855,6 +1855,11 @@ uint32_t SHADER_MODULE_STATE::GetTypeBitsSize(const spirv_inst_iter &iter) const
     } else if (opcode == spv::OpVariable) {
         const auto type = get_def(iter.word(1));
         return GetTypeBitsSize(type);
+    } else if (opcode == spv::OpTypeBool) {
+        // The Spec states:
+        // "Boolean values considered as 32-bit integer values for the purpose of this calculation"
+        // when getting the size for the limits
+        return 32;
     }
     return 0;
 }

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -384,6 +384,31 @@ TEST_F(VkPositiveLayerTest, ComputeSharedMemoryAtLimit) {
     pipe.CreateComputePipeline();
 }
 
+TEST_F(VkPositiveLayerTest, ComputeSharedMemoryBooleanAtLimit) {
+    TEST_DESCRIPTION("Validate compute shader shared memory is valid at the exact maxComputeSharedMemorySize using Booleans");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    const uint32_t max_shared_memory_size = m_device->phy().properties().limits.maxComputeSharedMemorySize;
+    // "Boolean values considered as 32-bit integer values for the purpose of this calculation."
+    const uint32_t max_shared_bools = max_shared_memory_size / 4;
+
+    std::stringstream csSource;
+    csSource << R"glsl(
+        #version 450
+        shared bool a[)glsl";
+    csSource << (max_shared_bools);
+    csSource << R"glsl(];
+        void main(){}
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.cs_.reset(new VkShaderObj(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT));
+    pipe.InitState();
+    pipe.CreateComputePipeline();
+}
+
 TEST_F(VkPositiveLayerTest, ComputeWorkGroupSizePrecedenceOverLocalSize) {
     // "If an object is decorated with the WorkgroupSize decoration, this takes precedence over any LocalSize or LocalSizeId
     // execution mode."


### PR DESCRIPTION
The 1.3.228 Vulkan Spec added a new clarification that `OpTypeBool` are the same size as 32-bit int for calculating the limits, prior they were being counted as `0` bytes

https://github.com/KhronosGroup/Vulkan-Docs/commit/355367640f2eabd2a0d492010a0afc166696aa72#diff-d753f04f744ff6c91e6b57979b21d920c15f1b59f955cff57d7cc942a0f96e6dR484-R485