### PR TITLE
Remove validated_descriptor_sets

### DIFF
--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -543,7 +543,8 @@ class BestPractices : public ValidationStateTracker {
                                             const VkSubpassBeginInfo* pSubpassBeginInfo) const override;
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) const override;
     bool PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) const override;
-    void ValidateBoundDescriptorSets(bp_state::CommandBuffer& commandBuffer, const char* function_name);
+    void ValidateBoundDescriptorSets(bp_state::CommandBuffer& commandBuffer, VkPipelineBindPoint bind_point,
+                                     const char* function_name);
     bool PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer) const override;
     bool PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer) const override;
 

--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -326,6 +326,8 @@ void CMD_BUFFER_STATE::Reset() {
     startedQueries.clear();
     image_layout_map.clear();
     aliased_image_layout_map.clear();
+    descriptorset_cache.clear();
+    validated_descriptor_sets.clear();
     current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
     vertex_buffer_used = false;
     primaryCommandBuffer = VK_NULL_HANDLE;
@@ -813,6 +815,10 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     if (CB_RECORDED == state || CB_INVALID_COMPLETE == state) {
         Reset();
     }
+
+    descriptorset_cache.clear();
+    validated_descriptor_sets.clear();
+
     // Set updated state here in case implicit reset occurs above
     state = CB_RECORDING;
     beginInfo = *pBeginInfo;

--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -327,7 +327,6 @@ void CMD_BUFFER_STATE::Reset() {
     image_layout_map.clear();
     aliased_image_layout_map.clear();
     descriptorset_cache.clear();
-    validated_descriptor_sets.clear();
     current_vertex_buffer_binding_info.vertex_buffer_bindings.clear();
     vertex_buffer_used = false;
     primaryCommandBuffer = VK_NULL_HANDLE;
@@ -817,7 +816,6 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     }
 
     descriptorset_cache.clear();
-    validated_descriptor_sets.clear();
 
     // Set updated state here in case implicit reset occurs above
     state = CB_RECORDING;
@@ -889,7 +887,6 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
 void CMD_BUFFER_STATE::End(VkResult result) {
     // Cached validation is specific to a specific recording of a specific command buffer.
     descriptorset_cache.clear();
-    validated_descriptor_sets.clear();
     if (VK_SUCCESS == result) {
         state = CB_RECORDED;
     }
@@ -1184,10 +1181,6 @@ void CMD_BUFFER_STATE::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipelin
                 assert(input_dynamic_offsets <= (p_dynamic_offsets + dynamic_offset_count));
             } else {
                 last_bound.per_set[set_idx].dynamicOffsets.clear();
-            }
-            if (!descriptor_set->IsPushDescriptor()) {
-                // Can't cache validation of push_descriptors
-                validated_descriptor_sets.insert(descriptor_set.get());
             }
         }
     }

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -337,7 +337,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::vector<std::function<bool(const ValidationStateTracker *device_data, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                    uint32_t perfQueryPass, QueryMap *localQueryToStateMap)>>
         queryUpdates;
-    layer_data::unordered_set<const cvdescriptorset::DescriptorSet *> validated_descriptor_sets;
     layer_data::unordered_map<const cvdescriptorset::DescriptorSet *, cvdescriptorset::DescriptorSet::CachedValidation>
         descriptorset_cache;
     // Contents valid only after an index buffer is bound (CBSTATUS_INDEX_BUFFER_BOUND set)


### PR DESCRIPTION
Remove validated_descriptor_sets as it was only used in one place and was not cleared correctly, causing a crash.
Replaced usage with lastBound[].per_set