### PR TITLE
 layers: Fix CB locking during query callback functions

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -562,6 +562,13 @@ void CMD_BUFFER_STATE::EndQuery(const QueryObject &query_obj) {
     updatedQueries.insert(query_obj);
 }
 
+bool CMD_BUFFER_STATE::UpdatesQuery(const QueryObject &query_obj) const {
+    // Clear out the perf_pass from the caller because it isn't known when the command buffer is recorded.
+    auto key = query_obj;
+    key.perf_pass = 0;
+    return updatedQueries.find(key) != updatedQueries.end();
+}
+
 static bool SetQueryStateMulti(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, uint32_t perfPass, QueryState value,
                                QueryMap *localQueryToStateMap) {
     for (uint32_t i = 0; i < queryCount; i++) {

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -321,7 +321,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
     VkCommandBuffer primaryCommandBuffer;
     // If primary, the secondary command buffers we will call.
-    // If secondary, the primary command buffers we will be called by.
     layer_data::unordered_set<CMD_BUFFER_STATE *> linkedCommandBuffers;
     // Validation functions run at primary CB queue submit time
     using QueueCallback = std::function<bool(const ValidationStateTracker &device_data, const class QUEUE_STATE &queue_state,
@@ -334,8 +333,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::vector<std::function<bool(const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *primary, const FRAMEBUFFER_STATE *)>>
         cmd_execute_commands_functions;
     std::vector<std::function<bool(CMD_BUFFER_STATE &cb, bool do_validate, EventToStageMap *localEventToStageMap)>> eventUpdates;
-    std::vector<std::function<bool(const ValidationStateTracker *device_data, bool do_validate, VkQueryPool &firstPerfQueryPool,
-                                   uint32_t perfQueryPass, QueryMap *localQueryToStateMap)>>
+    std::vector<std::function<bool(CMD_BUFFER_STATE &cb, bool do_validate, VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
+                                   QueryMap *localQueryToStateMap)>>
         queryUpdates;
     layer_data::unordered_set<const cvdescriptorset::DescriptorSet *> validated_descriptor_sets;
     layer_data::unordered_map<const cvdescriptorset::DescriptorSet *, cvdescriptorset::DescriptorSet::CachedValidation>

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -455,6 +455,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     void EndQuery(const QueryObject &query_obj);
     void EndQueries(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);
     void ResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount);
+    bool UpdatesQuery(const QueryObject &query_obj) const;
 
     void BeginRenderPass(CMD_TYPE cmd_type, const VkRenderPassBeginInfo *pRenderPassBegin, VkSubpassContents contents);
     void NextSubpass(CMD_TYPE cmd_type, VkSubpassContents contents);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -356,15 +356,13 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos, const char* api_name) const;
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                  const char* api_name) const;
-    static bool ValidateCopyQueryPoolResults(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer,
-                                             VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, uint32_t perfPass,
-                                             VkQueryResultFlags flags, QueryMap* localQueryToStateMap);
-    static bool VerifyQueryIsReset(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer, QueryObject query_obj,
-                                   const CMD_TYPE cmd_type, VkQueryPool& firstPerfQueryPool, uint32_t perfPass,
-                                   QueryMap* localQueryToStateMap);
-    static bool ValidatePerformanceQuery(const ValidationStateTracker* state_data, VkCommandBuffer commandBuffer,
-                                         QueryObject query_obj, const CMD_TYPE cmd_type, VkQueryPool& firstPerfQueryPool,
-                                         uint32_t perfPass, QueryMap* localQueryToStateMap);
+    static bool ValidateCopyQueryPoolResults(CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
+                                             uint32_t queryCount, uint32_t perfPass, VkQueryResultFlags flags,
+                                             QueryMap* localQueryToStateMap);
+    static bool VerifyQueryIsReset(CMD_BUFFER_STATE& cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+                                   VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
+    static bool ValidatePerformanceQuery(CMD_BUFFER_STATE& cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+                                         VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
     bool ValidateImportSemaphore(VkSemaphore semaphore, const char* caller_name) const;
     bool ValidateBeginQuery(const CMD_BUFFER_STATE* cb_state, const QueryObject& query_obj, VkFlags flags, uint32_t index,
                             CMD_TYPE cmd, const ValidateBeginQueryVuids* vuids) const;

--- a/layers/queue_state.cpp
+++ b/layers/queue_state.cpp
@@ -135,12 +135,15 @@ void QUEUE_STATE::Retire(uint64_t until_seq) {
 
         auto is_query_updated_after = [this](const QueryObject &query_object) {
             for (const auto &submission : submissions_) {
+                if (query_object.perf_pass != submission.perf_submit_pass) {
+                    continue;
+                }
                 for (uint32_t j = 0; j < submission.cbs.size(); ++j) {
                     const auto &next_cb_node = submission.cbs[j];
                     if (!next_cb_node) {
                         continue;
                     }
-                    if (next_cb_node->updatedQueries.find(query_object) != next_cb_node->updatedQueries.end()) {
+                    if (next_cb_node->UpdatesQuery(query_object)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
There were deadlocks and race conditions when running the callbacks in CMD_BUFFER_STATE::queryUpdates. This was because secondary command buffer callbacks were copied into the primary's callback list. Then the callbacks were all called with the primary buffer's lock locked, but not the secondary. Instead, make a callback that loops through the secondary's callbacks in place rather than copying. Then the callback can safely lock the secondary.

Hopefully this is only an interim fix and we can find a better way to implement this without callback lambda voodoo.

Fixes #4243

This PR also un-deletes and updates the tests, and fixes another problem with how perf passes were tracked (see individual commit messages).

