### PR TITLE
layers: Fix spurious VUID-vkCmdEndQueryIndexedEXT-queryType-06696

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -18801,7 +18801,7 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
                                      index, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackStreams);
                 }
                 for (const auto &query_object : cb_state->startedQueries) {
-                    if (query_object.query == query) {
+                    if (query_object.pool == queryPool && query_object.query == query) {
                         if (query_object.index != index) {
                             skip |= LogError(cb_state->commandBuffer(), "VUID-vkCmdEndQueryIndexedEXT-queryType-06696",
                                              "vkCmdEndQueryIndexedEXT(): queryPool is of type %s, but "


### PR DESCRIPTION
Several CTS test in the dEQP-VK.transform_feedback.* group were incorrectly reporting VUID-vkCmdEndQueryIndexedEXT-queryType-06696. The cause is some of these tests using two query pools and the layers not verifying the query pool being checked matched the expected one.