### PR TITLE
layers: Save multisample state if render pass is not null

### DIFF
--- a/layers/generated/vk_safe_struct.cpp
+++ b/layers/generated/vk_safe_struct.cpp
@@ -4025,7 +4025,7 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGra
         pRasterizationState = new safe_VkPipelineRasterizationStateCreateInfo(in_struct->pRasterizationState);
     else
         pRasterizationState = NULL;
-    if (in_struct->pMultisampleState && (has_rasterization || is_graphics_library))
+    if (in_struct->pMultisampleState && (renderPass != VK_NULL_HANDLE || has_rasterization || is_graphics_library))
         pMultisampleState = new safe_VkPipelineMultisampleStateCreateInfo(in_struct->pMultisampleState);
     else
         pMultisampleState = NULL; // original pMultisampleState pointer ignored
@@ -4366,7 +4366,7 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreat
         pRasterizationState = new safe_VkPipelineRasterizationStateCreateInfo(in_struct->pRasterizationState);
     else
         pRasterizationState = NULL;
-    if (in_struct->pMultisampleState && (has_rasterization || is_graphics_library))
+    if (in_struct->pMultisampleState && (renderPass != VK_NULL_HANDLE || has_rasterization || is_graphics_library))
         pMultisampleState = new safe_VkPipelineMultisampleStateCreateInfo(in_struct->pMultisampleState);
     else
         pMultisampleState = NULL; // original pMultisampleState pointer ignored

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -1600,7 +1600,7 @@ void CoreChecksOptickInstrumented::PreCallRecordQueuePresentKHR(VkQueue queue, c
                     '        pRasterizationState = new safe_VkPipelineRasterizationStateCreateInfo(in_struct->pRasterizationState);\n'
                     '    else\n'
                     '        pRasterizationState = NULL;\n'
-                    '    if (in_struct->pMultisampleState && (has_rasterization || is_graphics_library))\n'
+                    '    if (in_struct->pMultisampleState && (renderPass != VK_NULL_HANDLE || has_rasterization || is_graphics_library))\n'
                     '        pMultisampleState = new safe_VkPipelineMultisampleStateCreateInfo(in_struct->pMultisampleState);\n'
                     '    else\n'
                     '        pMultisampleState = NULL; // original pMultisampleState pointer ignored\n'

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -837,6 +837,18 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
         1.0f   // lineWidth
     };
 
+    const VkPipelineMultisampleStateCreateInfo pipeline_multisample_state_create_info{
+        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        nullptr,  // pNext
+        0,        // flags
+        VK_SAMPLE_COUNT_1_BIT,
+        VK_FALSE,  // sample shading
+        0.0f,      // minSampleShading
+        nullptr,   // pSampleMask
+        VK_FALSE,  // alphaToCoverageEnable
+        VK_FALSE   // alphaToOneEnable
+    };
+
     vk_testing::PipelineLayout pipeline_layout;
     {
         VkPipelineLayoutCreateInfo pipeline_layout_create_info{
@@ -869,7 +881,7 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
             reinterpret_cast<const VkPipelineTessellationStateCreateInfo *>(hopefully_undereferencable_pointer),
             reinterpret_cast<const VkPipelineViewportStateCreateInfo *>(hopefully_undereferencable_pointer),
             &pipeline_rasterization_state_create_info,
-            reinterpret_cast<const VkPipelineMultisampleStateCreateInfo *>(hopefully_undereferencable_pointer),
+            &pipeline_multisample_state_create_info,
             reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo *>(hopefully_undereferencable_pointer),
             reinterpret_cast<const VkPipelineColorBlendStateCreateInfo *>(hopefully_undereferencable_pointer),
             nullptr,  // dynamic states
@@ -884,18 +896,6 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
         m_commandBuffer->begin();
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.handle());
     }
-
-    const VkPipelineMultisampleStateCreateInfo pipeline_multisample_state_create_info{
-        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
-        nullptr,  // pNext
-        0,        // flags
-        VK_SAMPLE_COUNT_1_BIT,
-        VK_FALSE,  // sample shading
-        0.0f,      // minSampleShading
-        nullptr,   // pSampleMask
-        VK_FALSE,  // alphaToCoverageEnable
-        VK_FALSE   // alphaToOneEnable
-    };
 
     // try enabled rasterizer but no subpass attachments
     {


### PR DESCRIPTION
Several tests in the dEQP-VK.transform_feedback.* group are passing a valid pMultisampleState pointer when creating pipelines with rasterization disabled, and the layers are still generating VUID-VkGraphicsPipelineCreateInfo-renderpass-06631.

The VUID requires multisample state to be passed if the pipeline contains fragment shader state and a non-NULL render pass, but the layers do not save the provided multisample state info due to rasterization being disabled and later emit the validation error incorrectly.

This commit makes the layers save the multisample state if a render pass is provided.