### PR TITLE
tests: Fix DeviceCoherentMemoryDisabledAMD

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -11463,6 +11463,10 @@ TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
         }
     }
 
+    if (deviceCoherentMemoryTypeIndex == memory_info.memoryTypeCount) {
+        GTEST_SKIP() << "Valid memory type index not found";
+    }
+
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAllocateMemory-deviceCoherentMemory-02790");
 
     VkMemoryAllocateInfo mem_alloc = LvlInitStruct<VkMemoryAllocateInfo>();


### PR DESCRIPTION
Part fix for #4587 

for `VkLayerTest.DeviceCoherentMemoryDisabledAMD` this seems like the device is exposing `VK_AMD_device_coherent_memory` and `deviceCoherentMemory` feature without `VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD` or `VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD` which makes the extension useless, but also broke the assumption the test had

