### PR TITLE
layers: Fix missing pool check in vkCmdEndQueryIndexed

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -18801,7 +18801,7 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
                                      index, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackStreams);
                 }
                 for (const auto &query_object : cb_state->startedQueries) {
-                    if (query_object.query == query) {
+                    if (query_object.pool == queryPool && query_object.query == query) {
                         if (query_object.index != index) {
                             skip |= LogError(cb_state->commandBuffer(), "VUID-vkCmdEndQueryIndexedEXT-queryType-06696",
                                              "vkCmdEndQueryIndexedEXT(): queryPool is of type %s, but "


### PR DESCRIPTION
This fixed validation error in dEQP-VK.transform_feedback.primitives_generated_query.get.queue_reset.32bit.geom.xfb.no_rast.point_list.pgq_0_xfb_1.single_draw