### PR TITLE
layers: Don't auto-validate SPIR-V after optimization

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2888,7 +2888,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
                                : "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06719";
         std::vector<uint32_t> specialized_spirv;
         auto const optimized =
-            optimizer.Run(module_state.words.data(), module_state.words.size(), &specialized_spirv, options, false);
+            optimizer.Run(module_state.words.data(), module_state.words.size(), &specialized_spirv, options, true);
         if (optimized) {
             spv_context ctx = spvContextCreate(spirv_environment);
             spv_const_binary_t binary{specialized_spirv.data(), specialized_spirv.size()};


### PR DESCRIPTION
In CoreChecks::ValidatePipelineShaderStage, the SPIR-V optimizer is run followed by validation of the optimized shader.  However, the SPIR-V optimizer itself is also validating the optimized SPIR-V.

This change disables the validation done by the optimizer, and lets it be done by CoreChecks::ValidatePipelineShaderStage.

As a result, pipeline-creation-heavy tests in ANGLE see ~10% speed up.