### PR TITLE
layers: Disable friendly names in SPIR-V validation

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -3841,4 +3841,7 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
         // --allow-localsizeid
         options.SetAllowLocalSizeId(true);
     }
+
+    // Faster validation without friendly names.
+    options.SetFriendlyNames(false);
 }


### PR DESCRIPTION
The friendly-name-mapper in spirv-val is slow. Disabling it in VVL improves performance of an ANGLE test that creates numerous shaders by ~10%.  The cost of SPIR-V validation itself is reduced by ~40%.