### PR TITLE
tests: Fix test group and whitespace

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -701,7 +701,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(RenderPassCreateVersion r
             if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
                 auto image_view = attachments[attachment_ref.attachment];
                 auto view_state = Get<IMAGE_VIEW_STATE>(image_view);
-                
+
                 if (view_state) {
                     skip |= ValidateRenderPassLayoutAgainstFramebufferImageUsage(
                         rp_version, attachment_ref.layout, *view_state, framebuffer, render_pass, attachment_ref.attachment,
@@ -5733,7 +5733,7 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
                          layout_loc.Message().c_str());
         }
     }
-    
+
     if (mem_barrier.newLayout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT) {
         if (!enabled_features.attachment_feedback_loop_layout_features.attachmentFeedbackLoopLayout) {
             auto layout_loc = loc.dot(Field::newLayout);

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1223,7 +1223,7 @@ TEST_F(VkPositiveLayerTest, QueriesInMultiviewRenderPass) {
     vk_testing::QueryPool query_pool;
     query_pool.init(*m_device, qpci);
 
-    VkRenderPassBeginInfo rpbi = LvlInitStruct<VkRenderPassBeginInfo>(); 
+    VkRenderPassBeginInfo rpbi = LvlInitStruct<VkRenderPassBeginInfo>();
     rpbi.renderPass = rp.handle();
     rpbi.framebuffer = fb.handle();
     rpbi.renderArea = {{0, 0}, {32, 32}};

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -3246,7 +3246,7 @@ TEST_F(VkPositiveLayerTest, StorageImageWriteSpecConstantMoreComponent) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, StorageTexelBufferWriteMoreComponent) {
+TEST_F(VkPositiveLayerTest, StorageTexelBufferWriteMoreComponent) {
     TEST_DESCRIPTION("Test writing to image with less components.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -16462,7 +16462,7 @@ TEST_F(VkLayerTest, AttachmentFeedbackLoopLayoutFeature) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier-attachmentFeedbackLoopLayout-07313");
     image.SetLayout(VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT);
     m_errorMonitor->VerifyFound();
-    
+
     m_commandBuffer->begin();
     auto img_barrier = lvl_init_struct<VkImageMemoryBarrier2KHR>();
     img_barrier.image = image.handle();

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -2189,7 +2189,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
     } else {
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     }
-    
+
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         maintenance2Supported = true;


### PR DESCRIPTION
I had the positive test as `VkLayerTest`

also found some white space my editor noticed that figured could go well with this nit cleanup PR