### PR TITLE
build: Use GoogleTest CMake Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,8 +410,6 @@ endif()
 # Add subprojects ----------------------------------------------------------------------------------------------------------------
 
 if(BUILD_TESTS)
-    # Attempt to enable googletest if available.
-    find_package(GTest REQUIRED CONFIG)
     add_subdirectory(tests ${CMAKE_BINARY_DIR}/tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
+include(GoogleTest) # gtest_discover_tests
+
+# GoogleTest is required for testing framework
+find_package(GTest REQUIRED CONFIG)
 
 # Needed to make structure definitions match with glslang libraries
 add_definitions(-DNV_EXTENSIONS -DAMD_EXTENSIONS)
@@ -118,7 +122,14 @@ add_executable(vk_layer_validation_tests
                ../layers/generated/vk_safe_struct.cpp
                ../layers/generated/lvt_function_pointers.cpp
                ${COMMON_CPP})
-add_test(NAME vk_layer_validation_tests COMMAND vk_layer_validation_tests)
+
+# gtest_discover_tests has problem with cross-compiling, but it is faster and more robust
+if (CMAKE_CROSSCOMPILING)
+    gtest_add_tests(TARGET vk_layer_validation_tests)
+else()
+    gtest_discover_tests(vk_layer_validation_tests)
+endif()
+
 add_dependencies(vk_layer_validation_tests VkLayer_khronos_validation VkLayer_khronos_validation-json)
 target_include_directories(vk_layer_validation_tests
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
@@ -131,8 +142,6 @@ target_include_directories(vk_layer_validation_tests
                                   ${VulkanHeaders_INCLUDE_DIR}
                                   ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
-add_dependencies(vk_layer_validation_tests
-                 VkLayer_utils)
 
 option(PORTABILITY_TESTS_USE_DEVSIM "Automatically add the devsim layer for portability tests" OFF)
 if (PORTABILITY_TESTS_USE_DEVSIM)
@@ -150,15 +159,19 @@ if (NOT MSVC)
 endif()
 
 target_include_directories(vk_layer_validation_tests PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
-# Specify target_link_libraries
-target_link_libraries(vk_layer_validation_tests
-                      PRIVATE VkLayer_utils
-                              ${GLSLANG_LIBRARIES}
-			      ${SPIRV_TOOLS_TARGET} SPIRV-Tools-opt
-			      GTest::gtest GTest::gtest_main)
+
+target_link_libraries(vk_layer_validation_tests PRIVATE
+    VkLayer_utils
+    ${GLSLANG_LIBRARIES}
+    ${SPIRV_TOOLS_TARGET}
+    SPIRV-Tools-opt
+    GTest::gtest
+    GTest::gtest_main
+)
 
 if(NOT WIN32)
-    target_link_libraries(vk_layer_validation_tests PRIVATE dl)
+    target_link_libraries(vk_layer_validation_tests PRIVATE ${CMAKE_DL_LIBS})
+
     if(BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_XLIB_SUPPORT)
         target_link_libraries(vk_layer_validation_tests
                               PRIVATE ${XCB_LIBRARIES}


### PR DESCRIPTION
CMake will now discover the tests inside vk_layer_validation_tests: https://cmake.org/cmake/help/latest/module/GoogleTest.html

This makes running ctest much more useful for users. Since it will report all of the tests appropriately. Instead of running 1 giant test.

Plus minor CMake cleanup