### PR TITLE
Issue 4579 - Unconsumed attributes warning&error behavior

### DIFF
--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -23,6 +23,7 @@
 
 #include "chassis.h"
 #include "state_tracker.h"
+#include "shader_validation.h"
 #include "image_state.h"
 #include "cmd_buffer_state.h"
 #include <string>
@@ -443,7 +444,9 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) override;
     bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) const override;
     bool ValidateMultisampledBlendingArm(uint32_t createInfoCount, const VkGraphicsPipelineCreateInfo* pCreateInfos) const;
-
+    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, spirv_inst_iter producer_entrypoint,
+                                        shader_stage_attributes const* producer_stage, const SHADER_MODULE_STATE& consumer,
+                                        spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -309,6 +309,11 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     SHADER_MODULE_STATE() : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule) {}
 
+    static uint32_t GetShaderStageId(VkShaderStageFlagBits stage) {
+        uint32_t bit_pos = uint32_t(u_ffs(stage));
+        return bit_pos - 1;
+    }
+
     const std::vector<spirv_inst_iter> &GetDecorationInstructions() const { return static_data_.decoration_inst; }
 
     const std::unordered_map<uint32_t, atomic_instruction> &GetAtomicInstructions() const { return static_data_.atomic_inst; }

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -39,13 +39,12 @@
 #include "spirv_grammar_helper.h"
 #include "xxhash.h"
 
-static shader_stage_attributes shader_stage_attribs[] = {
-    {"vertex shader", false, false, VK_SHADER_STAGE_VERTEX_BIT},
-    {"tessellation control shader", true, true, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT},
-    {"tessellation evaluation shader", true, false, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT},
-    {"geometry shader", true, false, VK_SHADER_STAGE_GEOMETRY_BIT},
-    {"fragment shader", false, false, VK_SHADER_STAGE_FRAGMENT_BIT},
-};
+const std::array<shader_stage_attributes, 5> shader_stage_attribs = {
+    {{"vertex shader", false, false, VK_SHADER_STAGE_VERTEX_BIT},
+     {"tessellation control shader", true, true, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT},
+     {"tessellation evaluation shader", true, false, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT},
+     {"geometry shader", true, false, VK_SHADER_STAGE_GEOMETRY_BIT},
+     {"fragment shader", false, false, VK_SHADER_STAGE_FRAGMENT_BIT}}};
 
 static const spirv_inst_iter GetBaseTypeIter(const SHADER_MODULE_STATE &module_state, uint32_t type) {
     const auto &insn = module_state.get_def(type);
@@ -119,11 +118,6 @@ static uint32_t GetFormatType(VkFormat fmt) {
     if (fmt == VK_FORMAT_UNDEFINED) return 0;
     // everything else -- UNORM/SNORM/FLOAT/USCALED/SSCALED is all float in the shader.
     return FORMAT_TYPE_FLOAT;
-}
-
-static uint32_t GetShaderStageId(VkShaderStageFlagBits stage) {
-    uint32_t bit_pos = uint32_t(u_ffs(stage));
-    return bit_pos - 1;
 }
 
 bool CoreChecks::ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const *vi) const {
@@ -3146,108 +3140,55 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
                                                 shader_stage_attributes const *consumer_stage) const {
     bool skip = false;
 
-    auto outputs =
-        producer.CollectInterfaceByLocation(producer_entrypoint, spv::StorageClassOutput, producer_stage->arrayed_output);
-    auto inputs = consumer.CollectInterfaceByLocation(consumer_entrypoint, spv::StorageClassInput, consumer_stage->arrayed_input);
+    auto check_attrib = [this](const SHADER_MODULE_STATE &producer, shader_stage_attributes const *producer_stage,
+                               const ShaderAttribute &out, const SHADER_MODULE_STATE &consumer,
+                               shader_stage_attributes const *consumer_stage, const ShaderAttribute &in) -> bool {
+        bool skip = false;
 
-    auto output_it = outputs.begin();
-    auto input_it = inputs.begin();
-
-    uint32_t output_component = 0;
-    uint32_t input_component = 0;
-
-    // Maps sorted by key (location); walk them together to find mismatches
-    while ((outputs.size() > 0 && output_it != outputs.end()) || (inputs.size() && input_it != inputs.end())) {
-        bool output_at_end = outputs.size() == 0 || output_it == outputs.end();
-        bool input_at_end = inputs.size() == 0 || input_it == inputs.end();
-        auto output_first = output_at_end ? std::make_pair(0u, 0u) : output_it->first;
-        auto input_first = input_at_end ? std::make_pair(0u, 0u) : input_it->first;
-
-        output_first.second += output_component;
-        input_first.second += input_component;
-
-        const auto output_length =
-            output_at_end ? 0 : producer.GetNumComponentsInBaseType(producer.get_def(output_it->second.type_id));
-        const auto input_length =
-            input_at_end ? 0 : consumer.GetNumComponentsInBaseType(consumer.get_def(input_it->second.type_id));
-        assert(output_at_end || output_component < output_length);
-        assert(input_at_end || input_component < input_length);
-
-        if (input_at_end || ((!output_at_end) && (output_first < input_first))) {
+        if (out.IsPartiallyUnconsumedBy(in)) {
             if (!enabled_features.core13.maintenance4) {
-                const std::string msg = std::string{producer_stage->name} + " writes to output location " +
-                                        std::to_string(output_first.first) + "." + std::to_string(output_first.second) +
-                                        " which is not consumed by " + consumer_stage->name +
-                                        ". "
-                                        "Enable VK_KHR_maintenance4 device extension to allow relaxed interface matching between "
-                                        "input and output vectors.";
-                // It is not an error if a stage does not consume all outputs from the previous stage
-                skip |= LogPerformanceWarning(producer.vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed, "%s", msg.c_str());
+                std::string msg = std::string{producer_stage->name} + " writes to output location " + std::to_string(out.location) +
+                                  '.' + std::to_string(out.component) + " which is not consumed by " + consumer_stage->name +
+                                  ". Enable VK_KHR_maintenance4 device extension to allow relaxed interface matching between "
+                                  "input and output vectors. ";
+                skip |= LogError(producer.vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed, "%s", msg.c_str());
             }
-            if ((input_first.first > output_first.first) || input_at_end || (output_component + 1 == output_length)) {
-                output_it++;
-                output_component = 0;
-            } else {
-                output_component++;
-            }
-        } else if (output_at_end || output_first > input_first) {
-            skip |= LogError(consumer.vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
-                             "%s consumes input location %" PRIu32 ".%" PRIu32 " which is not written by %s", consumer_stage->name,
-                             input_first.first, input_first.second, producer_stage->name);
-            if ((output_first.first > input_first.first) || output_at_end || (input_component + 1 == input_length)) {
-                input_it++;
-                input_component = 0;
-            } else {
-                input_component++;
-            }
-        } else {
+        }
+
+        if (out.HasSameLocationAndComponentAs(in)) {
             // subtleties of arrayed interfaces:
             // - if is_patch, then the member is not arrayed, even though the interface may be.
             // - if is_block_member, then the extra array level of an arrayed interface is not
             //   expressed in the member type -- it's expressed in the block type.
-            if (!TypesMatch(producer, consumer, output_it->second.type_id, input_it->second.type_id)) {
+            assert(out.interface);
+            assert(in.interface);
+            if (!TypesMatch(producer, consumer, out.interface->type_id, in.interface->type_id)) {
                 skip |= LogError(producer.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
-                                 "Type mismatch on location %" PRIu32 ".%" PRIu32 ", between %s and %s: '%s' vs '%s'",
-                                 output_first.first, output_first.second, producer_stage->name, consumer_stage->name,
-                                 producer.DescribeType(output_it->second.type_id).c_str(),
-                                 consumer.DescribeType(input_it->second.type_id).c_str());
-                output_it++;
-                input_it++;
-                continue;
+                                 "Type mismatch on location %" PRIu32 ".%" PRIu32 ", between %s and %s: '%s' vs '%s'", out.location,
+                                 out.component, producer_stage->name, consumer_stage->name,
+                                 producer.DescribeType(out.interface->type_id).c_str(),
+                                 consumer.DescribeType(in.interface->type_id).c_str());
             }
-            if (output_it->second.is_patch != input_it->second.is_patch) {
+            if (out.interface->is_patch != in.interface->is_patch) {
                 skip |= LogError(producer.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
                                  "Decoration mismatch on location %" PRIu32 ".%" PRIu32
                                  ": is per-%s in %s stage but per-%s in %s stage",
-                                 output_first.first, output_first.second, output_it->second.is_patch ? "patch" : "vertex",
-                                 producer_stage->name, input_it->second.is_patch ? "patch" : "vertex", consumer_stage->name);
-            }
-            uint32_t output_remaining = output_length - output_component;
-            uint32_t input_remaining = input_length - input_component;
-            if (output_remaining == input_remaining) {  // Sizes match so we can advance both output_it and input_it
-                output_it++;
-                input_it++;
-                output_component = 0;
-                input_component = 0;
-            } else if (output_remaining > input_remaining) {  // a has more components remaining
-                output_component += input_remaining;
-                input_component = 0;
-                input_it++;
-            } else if (input_remaining > output_remaining) {  // b has more components remaining
-                input_component += output_remaining;
-                output_component = 0;
-                output_it++;
-            }
-            if (output_component == 4) {
-                output_component = 0;
-                output_it++;
-            }
-            if (input_component == 4) {
-                input_component = 0;
-                input_it++;
+                                 out.location, out.component, out.interface->is_patch ? "patch" : "vertex", producer_stage->name,
+                                 in.interface->is_patch ? "patch" : "vertex", consumer_stage->name);
             }
         }
-    }
+
+        if (in.DoesConsumeNonExistent(out)) {
+            skip |= LogError(consumer.vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
+                             "%s consumes input location %" PRIu32 ".%" PRIu32 " which is not written by %s", consumer_stage->name,
+                             in.location, in.component, producer_stage->name);
+        }
+
+        return skip;
+    };
+
+    skip |= IterateInterfaceBetweenStages(check_attrib, producer, producer_entrypoint, producer_stage, consumer,
+                                          consumer_entrypoint, consumer_stage);
 
     if (consumer_stage->stage != VK_SHADER_STAGE_FRAGMENT_BIT) {
         auto builtins_producer = producer.CollectBuiltinBlockMembers(producer_entrypoint, spv::StorageClassOutput);
@@ -3334,23 +3275,16 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE *pipel
         skip |= ValidateViAgainstVsInputs(vi_state, *vertex_stage->module_state.get(), vertex_stage->entrypoint);
     }
 
-    for (size_t i = 1; i < pipeline->stage_state.size(); i++) {
-        const auto &producer = pipeline->stage_state[i - 1];
-        const auto &consumer = pipeline->stage_state[i];
-        assert(producer.module_state);
-        if (&producer == fragment_stage) {
-            break;
-        }
-        if (consumer.module_state) {
-            if (consumer.module_state->has_valid_spirv && producer.module_state->has_valid_spirv) {
-                auto producer_id = GetShaderStageId(producer.stage_flag);
-                auto consumer_id = GetShaderStageId(consumer.stage_flag);
-                skip |= ValidateInterfaceBetweenStages(*producer.module_state.get(), producer.entrypoint,
-                                                       &shader_stage_attribs[producer_id], *consumer.module_state.get(),
-                                                       consumer.entrypoint, &shader_stage_attribs[consumer_id]);
-            }
-        }
-    }
+    const auto this_validate_interface_between_stages =
+        [this](const SHADER_MODULE_STATE &producer, spirv_inst_iter producer_entrypoint,
+               shader_stage_attributes const *producer_stage, const SHADER_MODULE_STATE &consumer,
+               spirv_inst_iter consumer_entrypoint, shader_stage_attributes const *consumer_stage) {
+            return ValidateInterfaceBetweenStages(producer, producer_entrypoint, producer_stage, consumer, consumer_entrypoint,
+                                                  consumer_stage);
+        };
+
+    skip |= ValidateInterfaceBetweenAllPipelineStages(pipeline->stage_state, fragment_stage, shader_stage_attribs,
+                                                      this_validate_interface_between_stages);
 
     if (fragment_stage && fragment_stage->module_state->has_valid_spirv) {
         const auto &rp_state = pipeline->RenderPassState();

--- a/layers/shader_validation.h
+++ b/layers/shader_validation.h
@@ -39,6 +39,55 @@ struct shader_stage_attributes {
     VkShaderStageFlags stage;
 };
 
+extern const std::array<shader_stage_attributes, 5> shader_stage_attribs;
+
+struct ShaderAttribute {
+    ShaderAttribute(const SHADER_MODULE_STATE &shader_module,
+                    const std::map<location_t, interface_var>::const_iterator &shader_attributes_iterator,
+                    const std::map<location_t, interface_var>::const_iterator &shader_attributes_iterator_end)
+        : is_valid(shader_attributes_iterator != shader_attributes_iterator_end),
+          is_components_reading_at_beginning(true),
+          location(0),
+          component(0),
+          written_components_count(0),
+          interface(nullptr) {
+        if (is_valid) {
+            location = shader_attributes_iterator->first.first;
+            component = shader_attributes_iterator->first.second;
+            written_components_count =
+                shader_module.GetNumComponentsInBaseType(shader_module.get_def(shader_attributes_iterator->second.type_id));
+            interface = &shader_attributes_iterator->second;
+        }
+    }
+
+    bool is_valid = false;
+    bool is_components_reading_at_beginning = true;
+    uint32_t location = 0;
+    uint32_t component = 0;
+    union {
+        uint32_t written_components_count = 0;
+        uint32_t read_components_count;
+        uint32_t components_count;
+    };
+    interface_var const *interface = nullptr;
+
+    bool IsPartiallyUnconsumedBy(const ShaderAttribute &in) const {
+        return is_valid && !is_components_reading_at_beginning && (!HasSameLocationAndComponentAs(in) || !in.is_valid);
+    }
+    bool IsFullyUnconsumedBy(const ShaderAttribute &in) const {
+        return is_valid && is_components_reading_at_beginning && (location < in.location || !in.is_valid);
+    }
+    bool DoesConsumeNonExistent(const ShaderAttribute &out) const {
+        return is_valid && (!out.is_valid || (out.location > location) || (out.location == location && out.component > component));
+    }
+    bool HasSameLocationAndComponentAs(const ShaderAttribute &rhs) const {
+        return is_valid && rhs.is_valid && (location == rhs.location) && (component == rhs.component);
+    }
+    bool Matches(const ShaderAttribute &rhs) const {
+        return HasSameLocationAndComponentAs(rhs) && (components_count == rhs.components_count);
+    };
+};
+
 class ValidationCache {
   public:
     static VkValidationCacheEXT Create(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
@@ -158,5 +207,105 @@ spv_target_env PickSpirvEnv(uint32_t api_version, bool spirv_1_4);
 
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &options);
+
+template <typename PipeStageState, typename PipeStageStateVec, typename ShaderStageAttributeVec,
+          typename ValidateInterfaceBetweenStagesFunc>
+bool ValidateInterfaceBetweenAllPipelineStages(const PipeStageStateVec &pipeline_stage_states, const PipeStageState *fragment_stage,
+                                               const ShaderStageAttributeVec &shader_stage_attribs,
+                                               const ValidateInterfaceBetweenStagesFunc &validation_func) {
+    bool skip = false;
+    for (size_t i = 1; i < pipeline_stage_states.size(); i++) {
+        const auto &producer = pipeline_stage_states[i - 1];
+        const auto &consumer = pipeline_stage_states[i];
+        assert(producer.module_state);
+        if (&producer == fragment_stage) {
+            break;
+        }
+        if (consumer.module_state) {
+            if (consumer.module_state->has_valid_spirv && producer.module_state->has_valid_spirv) {
+                auto producer_id = SHADER_MODULE_STATE::GetShaderStageId(producer.stage_flag);
+                auto consumer_id = SHADER_MODULE_STATE::GetShaderStageId(consumer.stage_flag);
+                skip |= validation_func(*producer.module_state.get(), producer.entrypoint, &shader_stage_attribs[producer_id],
+                                        *consumer.module_state.get(), consumer.entrypoint, &shader_stage_attribs[consumer_id]);
+            }
+        }
+    }
+    return skip;
+}
+
+template <typename ShaderAttributePairChecker>
+bool IterateInterfaceBetweenStages(const ShaderAttributePairChecker &checker, const SHADER_MODULE_STATE &producer,
+                                   spirv_inst_iter producer_entrypoint, shader_stage_attributes const *producer_stage,
+                                   const SHADER_MODULE_STATE &consumer, spirv_inst_iter consumer_entrypoint,
+                                   shader_stage_attributes const *consumer_stage) {
+    bool skip = false;
+
+    const std::map<location_t, interface_var> shader_outputs =
+        producer.CollectInterfaceByLocation(producer_entrypoint, spv::StorageClassOutput, producer_stage->arrayed_output);
+    const std::map<location_t, interface_var> shader_inputs =
+        consumer.CollectInterfaceByLocation(consumer_entrypoint, spv::StorageClassInput, consumer_stage->arrayed_input);
+
+    auto out_iterator = shader_outputs.begin();
+    auto in_iterator = shader_inputs.begin();
+
+    ShaderAttribute out(producer, out_iterator, shader_outputs.end());
+    ShaderAttribute in(consumer, in_iterator, shader_inputs.end());
+
+    // Walk (out, in) attributes pairs
+    while (out_iterator != shader_outputs.end() || in_iterator != shader_inputs.end()) {
+        skip |= checker(producer, producer_stage, out, consumer, consumer_stage, in);
+
+        const auto increment_out_iterator = [&]() {
+            assert(out_iterator != shader_outputs.end());
+            ++out_iterator;
+            out = ShaderAttribute(producer, out_iterator, shader_outputs.end());
+        };
+
+        const auto increment_in_iterator = [&]() {
+            assert(in_iterator != shader_inputs.end());
+            ++in_iterator;
+            in = ShaderAttribute(consumer, in_iterator, shader_inputs.end());
+        };
+
+        if (out.is_valid && in.is_valid) {
+            if (out.Matches(in)) {
+                increment_out_iterator();
+                increment_in_iterator();
+
+            } else if (out.location == in.location) {
+                const auto untouched_out_component = out.component;
+
+                if (out.component <= in.component) {
+                    out.component += 1;
+                    out.is_components_reading_at_beginning = false;
+                    assert(out.written_components_count >= 1);
+                    out.written_components_count -= 1;
+                    if (out.written_components_count == 0) {
+                        increment_out_iterator();
+                    }
+                }
+                if (in.component <= untouched_out_component) {
+                    in.component += 1;
+                    in.is_components_reading_at_beginning = false;
+                    assert(in.written_components_count >= 1);
+                    in.written_components_count -= 1;
+                    if (in.read_components_count == 0) {
+                        increment_in_iterator();
+                    }
+                }
+            } else if (out.location < in.location) {
+                increment_out_iterator();
+            } else {  // in_attrib.location < out_attrib.location
+                increment_in_iterator();
+            }
+        } else if (out.is_valid) {
+            increment_out_iterator();
+        } else if (in.is_valid) {
+            increment_in_iterator();
+        }
+    }
+
+    return skip;
+}
 
 #endif  // VULKAN_SHADER_VALIDATION_H

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1176,7 +1176,8 @@ TEST_F(VkBestPracticesLayerTest, DepthBiasNoAttachment) {
 TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     TEST_DESCRIPTION("Test that an error is produced for mismatched array sizes across the vertex->fragment shader interface");
 
-    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource = R"glsl(
@@ -1202,7 +1203,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit | kErrorBit,
+    CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit,
                                       "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
 }
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4316,27 +4316,48 @@ TEST_F(VkLayerTest, InvalidSPIRVMagic) {
 }
 
 TEST_F(VkLayerTest, CreatePipelineVertexOutputNotConsumed) {
-    TEST_DESCRIPTION("Test that a warning is produced for a vertex output that is not consumed by the fragment stage");
-
-    SetTargetApiVersion(VK_API_VERSION_1_0);
+    TEST_DESCRIPTION(
+        "Test that an error is produced for a vertex output that is partially consumed by the fragment stage"
+        " if maintenance4 is not enabled");
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource = R"glsl(
         #version 450
-        layout(location=0) out float x;
+        layout(location=0) out vec3 x;
+        layout(location=1) out vec4 y;
+        layout(location=2) out float z;
+        
         void main(){
            gl_Position = vec4(1);
-           x = 0;
+           x = vec3(0);
+           y = vec4(0);
+           z = 0;
         }
     )glsl";
+
+    char const *fsSource = R"glsl(
+      #version 450
+      layout(location=0) in float x;
+      layout(location=0) out vec3 outColor;
+
+      void main(){
+        outColor = vec3(x, vec2(0.42));
+      }
+  )glsl";
+
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
+        helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "not consumed by fragment shader");
+
+    const std::vector<std::string> expected_errors = {
+        "Enable VK_KHR_maintenance4 device extension to allow relaxed interface matching"};
+
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, expected_errors);
 }
 
 TEST_F(VkLayerTest, CreatePipelineCheckShaderSpecializationApplied) {
@@ -14173,8 +14194,7 @@ TEST_F(VkLayerTest, TestInvalidShaderInputAndOutputComponents) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
-        CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit,
-                                          "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
     }
 
     {


### PR DESCRIPTION
Fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4579

Completely unconsumed attributes are allowed, and should result in a performance warning if the best practices layer is enabled.
Partially consumed attributes are allowed if `maintenance4` is enabled, but should still result in a performance warning. They are illegal when `maintenance4` is disabled, and result in an error.