### PR TITLE
layers: SPIR-V Instruction class

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -146,6 +146,8 @@ core_validation_sources = [
   "layers/range_vector.h",
   "layers/shader_module.cpp",
   "layers/shader_module.h",
+  "layers/shader_instruction.cpp",
+  "layers/shader_instruction.h",
   "layers/shader_validation.cpp",
   "layers/shader_validation.h",
   "layers/state_tracker.cpp",

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(VkLayer_khronos_validation SHARED
         ${SRC_DIR}/layers/descriptor_validation.cpp
         ${SRC_DIR}/layers/buffer_validation.cpp
         ${SRC_DIR}/layers/shader_module.cpp
+        ${SRC_DIR}/layers/shader_instruction.cpp
         ${SRC_DIR}/layers/shader_validation.cpp
         ${SRC_DIR}/layers/generated/spirv_validation_helper.cpp
         ${SRC_DIR}/layers/generated/spirv_grammar_helper.cpp

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -53,6 +53,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/descriptor_sets.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/descriptor_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_module.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_instruction.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/spirv_validation_helper.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/spirv_grammar_helper.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -200,6 +200,8 @@ set(CORE_VALIDATION_LIBRARY_FILES
     buffer_validation.h
     shader_module.cpp
     shader_module.h
+    shader_instruction.cpp
+    shader_instruction.h
     shader_validation.cpp
     shader_validation.h
     sync_vuid_maps.cpp

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1277,8 +1277,8 @@ bool BestPractices::PreCallValidateCreateComputePipelines(VkDevice device, VkPip
 
         if (IsExtEnabled(device_extensions.vk_khr_maintenance4)) {
             auto module_state = Get<SHADER_MODULE_STATE>(createInfo.stage.module);
-            for (const auto& builtin : module_state->static_data_.builtin_decoration_list) {
-                if (builtin.builtin == spv::BuiltInWorkgroupSize) {
+            for (const Instruction* inst : module_state->GetBuiltinDecorationList()) {
+                if (inst->GetBuiltIn() == spv::BuiltInWorkgroupSize) {
                     skip |= LogWarning(device, kVUID_BestPractices_SpirvDeprecated_WorkgroupSize,
                                        "vkCreateComputePipelines(): pCreateInfos[ %" PRIu32
                                        "] is using the Workgroup built-in which SPIR-V 1.6 deprecated. The VK_KHR_maintenance4 "
@@ -1296,8 +1296,8 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     bool skip = false;
     auto module_state = Get<SHADER_MODULE_STATE>(createInfo.stage.module);
     // Generate warnings about work group sizes based on active resources.
-    auto entrypoint = module_state->FindEntrypoint(createInfo.stage.pName, createInfo.stage.stage);
-    if (entrypoint == module_state->end()) return false;
+    const Instruction* entrypoint = module_state->FindEntrypoint(createInfo.stage.pName, createInfo.stage.stage);
+    if (!entrypoint) return false;
 
     uint32_t x = 1, y = 1, z = 1;
     module_state->FindLocalSize(entrypoint, x, y, z);

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1296,9 +1296,10 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     bool skip = false;
     auto module_state = Get<SHADER_MODULE_STATE>(createInfo.stage.module);
     // Generate warnings about work group sizes based on active resources.
-    const Instruction* entrypoint = module_state->FindEntrypoint(createInfo.stage.pName, createInfo.stage.stage);
-    if (!entrypoint) return false;
+    auto entrypoint_optional = module_state->FindEntrypoint(createInfo.stage.pName, createInfo.stage.stage);
+    if (!entrypoint_optional) return false;
 
+    const Instruction& entrypoint = *entrypoint_optional;
     uint32_t x = 1, y = 1, z = 1;
     module_state->FindLocalSize(entrypoint, x, y, z);
 
@@ -1327,7 +1328,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
                                       kThreadGroupDispatchCountAlignmentArm);
     }
 
-    auto accessible_ids = module_state->MarkAccessibleIds(entrypoint);
+    auto accessible_ids = module_state->MarkAccessibleIds(entrypoint_optional);
     auto descriptor_uses = module_state->CollectInterfaceByDescriptorSlot(accessible_ids);
 
     unsigned dimensions = 0;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -611,23 +611,23 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePipelineShaderStage(const PIPELINE_STATE* pipeline, const PipelineStageState& stage_state,
                                      bool check_point_size) const;
     bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, const SHADER_MODULE_STATE& module_state,
-                                      spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
+                                      const Instruction* entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, const SHADER_MODULE_STATE& module_state,
-                                          spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
-    bool ValidateTexelOffsetLimits(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
-    bool ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const;
+                                          const Instruction* entrypoint, VkShaderStageFlagBits stage) const;
+    bool ValidateTexelOffsetLimits(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
+    bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                                        bool has_writable_descriptor, bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state,
                                               safe_VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
-                                              spirv_inst_iter entrypoint) const;
-    bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const spirv_inst_iter& insn) const;
+                                              const Instruction* entrypoint) const;
+    bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const Instruction* insn) const;
     bool ValidateShaderStageMaxResources(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                          const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderStageGroupNonUniform(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                            spirv_inst_iter& insn) const;
-    bool ValidateMemoryScope(const SHADER_MODULE_STATE& module_state, const spirv_inst_iter& insn) const;
+                                            const Instruction& insn) const;
+    bool ValidateMemoryScope(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateCooperativeMatrix(const SHADER_MODULE_STATE& module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
                                    const PIPELINE_STATE* pipeline) const;
     bool ValidateShaderResolveQCOM(const SHADER_MODULE_STATE& module_state, safe_VkPipelineShaderStageCreateInfo const* pStage,
@@ -636,18 +636,18 @@ class CoreChecks : public ValidationStateTracker {
                                            safe_VkPipelineShaderStageCreateInfo const* pStage) const;
     bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, uint32_t total_shared_size) const;
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
-    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, spirv_inst_iter entrypoint, VkShaderStageFlagBits stage,
+    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
     bool ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const* vi) const;
     bool ValidateViAgainstVsInputs(safe_VkPipelineVertexInputStateCreateInfo const* vi, const SHADER_MODULE_STATE& module_state,
-                                   spirv_inst_iter entrypoint) const;
-    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, spirv_inst_iter entrypoint,
+                                   const Instruction* entrypoint) const;
+    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
-    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, spirv_inst_iter entrypoint,
+    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
                                                             PIPELINE_STATE const* pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
-    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, spirv_inst_iter entrypoint) const;
+    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;
@@ -656,16 +656,17 @@ class CoreChecks : public ValidationStateTracker {
                              const char* vuid) const;
     bool RequireFeature(const SHADER_MODULE_STATE& module_state, VkBool32 feature, char const* feature_name,
                         const char* vuid) const;
-    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, spirv_inst_iter producer_entrypoint,
+    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, const Instruction* producer_entrypoint,
                                         shader_stage_attributes const* producer_stage, const SHADER_MODULE_STATE& consumer,
-                                        spirv_inst_iter consumer_entrypoint, shader_stage_attributes const* consumer_stage) const;
+                                        const Instruction* consumer_entrypoint,
+                                        shader_stage_attributes const* consumer_stage) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const PipelineStageState& stage_state,
                                 const safe_VkPipelineShaderStageCreateInfo* pStage, const VkPipelineCreateFlags flags) const;
-    bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
-    bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
+    bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
+    bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE* cb_node, const IMAGE_STATE* src_img,
@@ -1649,7 +1650,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue, const char* apiName) const;
     bool PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
-    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const spirv_inst_iter& entrypoint,
+    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
                                        const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
                                        uint32_t local_size_z) const;
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -611,9 +611,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePipelineShaderStage(const PIPELINE_STATE* pipeline, const PipelineStageState& stage_state,
                                      bool check_point_size) const;
     bool ValidatePointListShaderState(const PIPELINE_STATE* pipeline, const SHADER_MODULE_STATE& module_state,
-                                      const Instruction* entrypoint, VkShaderStageFlagBits stage) const;
+                                      const Instruction& entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE* pipeline, const SHADER_MODULE_STATE& module_state,
-                                          const Instruction* entrypoint, VkShaderStageFlagBits stage) const;
+                                          const Instruction& entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidateTexelOffsetLimits(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
@@ -621,7 +621,7 @@ class CoreChecks : public ValidationStateTracker {
                                                        bool has_writable_descriptor, bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state,
                                               safe_VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE* pipeline,
-                                              const Instruction* entrypoint) const;
+                                              const Instruction& entrypoint) const;
     bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const Instruction* insn) const;
     bool ValidateShaderStageMaxResources(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                          const PIPELINE_STATE* pipeline) const;
@@ -636,18 +636,18 @@ class CoreChecks : public ValidationStateTracker {
                                            safe_VkPipelineShaderStageCreateInfo const* pStage) const;
     bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, uint32_t total_shared_size) const;
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
-    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint, VkShaderStageFlagBits stage,
+    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
     bool ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const* vi) const;
     bool ValidateViAgainstVsInputs(safe_VkPipelineVertexInputStateCreateInfo const* vi, const SHADER_MODULE_STATE& module_state,
-                                   const Instruction* entrypoint) const;
-    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
+                                   const Instruction& entrypoint) const;
+    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                             PIPELINE_STATE const* pipeline, uint32_t subpass_index) const;
-    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
+    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                                             PIPELINE_STATE const* pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
-    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint) const;
+    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const shader_struct_member& push_constant_used_in_shader,
                                                         uint32_t& out_issue_index) const;
@@ -656,9 +656,9 @@ class CoreChecks : public ValidationStateTracker {
                              const char* vuid) const;
     bool RequireFeature(const SHADER_MODULE_STATE& module_state, VkBool32 feature, char const* feature_name,
                         const char* vuid) const;
-    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, const Instruction* producer_entrypoint,
+    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, const Instruction& producer_entrypoint,
                                         shader_stage_attributes const* producer_stage, const SHADER_MODULE_STATE& consumer,
-                                        const Instruction* consumer_entrypoint,
+                                        const Instruction& consumer_entrypoint,
                                         shader_stage_attributes const* consumer_stage) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
@@ -1650,7 +1650,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue, const char* apiName) const;
     bool PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
-    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const Instruction* entrypoint,
+    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                        const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
                                        uint32_t local_size_z) const;
 

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -241,7 +241,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string forma
 std::string DebugPrintf::FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id) {
     std::string format_string;
     SHADER_MODULE_STATE module_state(pgm);
-    if (module_state.words.size() > 0) {
+    if (module_state.words_.size() > 0) {
         for (const auto &insn : module_state) {
             if (insn.opcode() == spv::OpString) {
                 uint32_t offset = insn.offset();

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -622,18 +622,6 @@ bool OpcodeHasResult(uint32_t opcode) {
     return has_result;
 }
 
-// Helper to get the word position of the result operand.
-// Will either be 1 or 2 if it has a result.
-// Will be 0 if there is no result.
-uint32_t OpcodeResultWord(uint32_t opcode) {
-    uint32_t position = 0;
-    if (OpcodeHasResult(opcode)) {
-        position = 1;
-        position += OpcodeHasType(opcode) ? 1 : 0;
-    }
-    return position;
-}
-
 // Return operand position of Memory Scope <ID> or zero if there is none
 uint32_t OpcodeMemoryScopePosition(uint32_t opcode) {
     uint32_t position = 0;

--- a/layers/generated/spirv_grammar_helper.h
+++ b/layers/generated/spirv_grammar_helper.h
@@ -40,7 +40,6 @@ bool ImageSampleOperation(uint32_t opcode);
 
 bool OpcodeHasType(uint32_t opcode);
 bool OpcodeHasResult(uint32_t opcode);
-uint32_t OpcodeResultWord(uint32_t opcode);
 
 uint32_t OpcodeMemoryScopePosition(uint32_t opcode);
 uint32_t OpcodeExecutionScopePosition(uint32_t opcode);

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -659,18 +659,18 @@ static inline const char* string_SpvCapability(uint32_t input_value) {
 bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn) const {
     bool skip = false;
 
-    if (insn.opcode() == spv::OpCapability) {
+    if (insn.Opcode() == spv::OpCapability) {
         // All capabilities are generated so if it is not in the list it is not supported by Vulkan
-        if (spirvCapabilities.count(insn.word(1)) == 0) {
+        if (spirvCapabilities.count(insn.Word(1)) == 0) {
             skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01090",
-                "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.word(1)));
+                "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.Word(1)));
             return skip; // no known capability to validate
         }
 
         // Each capability has one or more requirements to check
         // Only one item has to be satisfied and an error only occurs
         // when all are not satisfied
-        auto caps = spirvCapabilities.equal_range(insn.word(1));
+        auto caps = spirvCapabilities.equal_range(insn.Word(1));
         bool has_support = false;
         for (auto it = caps.first; (it != caps.second) && (has_support == false); ++it) {
             if (it->second.version) {
@@ -689,7 +689,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
                 }
             } else if (it->second.property) {
                 // support is or'ed as only one has to be supported (if applicable)
-                switch (insn.word(1)) {
+                switch (insn.Word(1)) {
                     case spv::CapabilityDenormFlushToZero:
                         has_support |= ((phys_dev_props_core12.shaderDenormFlushToZeroFloat16 & VK_TRUE) != 0);
                         has_support |= ((phys_dev_props_core12.shaderDenormFlushToZeroFloat32 & VK_TRUE) != 0);
@@ -750,19 +750,19 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
 
         if (has_support == false) {
             skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01091",
-                "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.word(1)));
+                "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.Word(1)));
         }
 
         // Portability checks
         if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
             if ((VK_FALSE == enabled_features.portability_subset_features.shaderSampleRateInterpolationFunctions) &&
-                (spv::CapabilityInterpolationFunction == insn.word(1))) {
+                (spv::CapabilityInterpolationFunction == insn.Word(1))) {
                 skip |= LogError(device, "VUID-RuntimeSpirv-shaderSampleRateInterpolationFunctions-06325",
                                     "Invalid shader capability (portability error): interpolation functions are not supported "
                                     "by this platform");
             }
         }
-    } else if (insn.opcode() == spv::OpExtension) {
+    } else if (insn.Opcode() == spv::OpExtension) {
         static const std::string spv_prefix = "SPV_";
         std::string extension_name = insn.GetAsString(1);
 
@@ -800,7 +800,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
                 }
             } else if (it->second.property) {
                 // support is or'ed as only one has to be supported (if applicable)
-                switch (insn.word(1)) {
+                switch (insn.Word(1)) {
                     default:
                         break;
                 }

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -656,7 +656,7 @@ static inline const char* string_SpvCapability(uint32_t input_value) {
     };
 };
 
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn) const {
     bool skip = false;
 
     if (insn.opcode() == spv::OpCapability) {
@@ -764,7 +764,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) 
         }
     } else if (insn.opcode() == spv::OpExtension) {
         static const std::string spv_prefix = "SPV_";
-        std::string extension_name = (char const *)&insn.word(1);
+        std::string extension_name = insn.GetAsString(1);
 
         if (0 == extension_name.compare(0, spv_prefix.size(), spv_prefix)) {
             if (spirvExtensions.count(extension_name) == 0) {

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -232,7 +232,7 @@ static VkPrimitiveTopology GetTopologyAtRasterizer(const PIPELINE_STATE::StageSt
         if (!stage.entrypoint) {
             continue;
         }
-        auto stage_topo = stage.module_state->GetTopology(stage.entrypoint);
+        auto stage_topo = stage.module_state->GetTopology(*(stage.entrypoint));
         if (stage_topo) {
             result = *stage_topo;
         }

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -41,14 +41,14 @@ static bool HasAtomicDescriptor(const std::vector<PipelineStageState::Descriptor
                        [](const PipelineStageState::DescriptorUse &use) { return use.second.is_atomic_operation; });
 }
 
-static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, const Instruction *entrypoint,
+static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, layer_data::optional<Instruction> entrypoint,
                                       const SHADER_MODULE_STATE *module_state) {
     bool primitiverate_written = false;
-    if (stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
-        stage_flag == VK_SHADER_STAGE_MESH_BIT_NV) {
+    if (entrypoint && (stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
+                       stage_flag == VK_SHADER_STAGE_MESH_BIT_NV)) {
         for (const Instruction *inst : module_state->GetBuiltinDecorationList()) {
             if (inst->GetBuiltIn() == spv::BuiltInPrimitiveShadingRateKHR) {
-                primitiverate_written = module_state->IsBuiltInWritten(inst, entrypoint);
+                primitiverate_written = module_state->IsBuiltInWritten(inst, *entrypoint);
             }
             if (primitiverate_written) {
                 break;
@@ -218,7 +218,7 @@ static layer_data::unordered_set<uint32_t> GetFSOutputLocations(const PIPELINE_S
             continue;
         }
         if (stage.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT) {
-            result = stage.module_state->CollectWritableOutputLocationinFS(stage.entrypoint);
+            result = stage.module_state->CollectWritableOutputLocationinFS(*(stage.entrypoint));
             break;
         }
     }

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -102,7 +102,7 @@ struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
-    const Instruction *entrypoint;
+    layer_data::optional<Instruction> entrypoint;
     layer_data::unordered_set<uint32_t> accessible_ids;
     using DescriptorUse = std::pair<DescriptorSlot, interface_var>;
     std::vector<DescriptorUse> descriptor_uses;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -102,7 +102,7 @@ struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
-    spirv_inst_iter entrypoint;
+    const Instruction *entrypoint;
     layer_data::unordered_set<uint32_t> accessible_ids;
     using DescriptorUse = std::pair<DescriptorSlot, interface_var>;
     std::vector<DescriptorUse> descriptor_uses;

--- a/layers/shader_instruction.cpp
+++ b/layers/shader_instruction.cpp
@@ -21,12 +21,12 @@
 
 Instruction::Instruction(std::vector<uint32_t>::const_iterator it) : result_id_(0), type_id_(0) {
     words_.push_back(*it++);
-    for (uint32_t i = 1; i < length(); i++) {
+    for (uint32_t i = 1; i < Length(); i++) {
         words_.push_back(*it++);
     }
 
-    const bool has_result = OpcodeHasResult(opcode());
-    if (OpcodeHasType(opcode())) {
+    const bool has_result = OpcodeHasResult(Opcode());
+    if (OpcodeHasType(Opcode())) {
         type_id_ = 1;
         if (has_result) {
             result_id_ = 2;
@@ -36,34 +36,34 @@ Instruction::Instruction(std::vector<uint32_t>::const_iterator it) : result_id_(
     }
 }
 
-atomic_instruction_info Instruction::GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const {
-    atomic_instruction_info info;
+AtomicInstructionInfo Instruction::GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const {
+    AtomicInstructionInfo info;
 
     // All atomics have a pointer referenced
-    const uint32_t pointer_index = opcode() == spv::OpAtomicStore ? 1 : 3;
-    const Instruction* access = module_state.FindDef(word(pointer_index));
+    const uint32_t pointer_index = Opcode() == spv::OpAtomicStore ? 1 : 3;
+    const Instruction* access = module_state.FindDef(Word(pointer_index));
 
     // spirv-val will catch if not OpTypePointer
-    const Instruction* pointer = module_state.FindDef(access->word(1));
-    info.storage_class = pointer->word(2);
+    const Instruction* pointer = module_state.FindDef(access->Word(1));
+    info.storage_class = pointer->Word(2);
 
-    const Instruction* data_type = module_state.FindDef(pointer->word(3));
-    info.type = data_type->opcode();
+    const Instruction* data_type = module_state.FindDef(pointer->Word(3));
+    info.type = data_type->Opcode();
 
     // TODO - Should have a proper GetBitWidth like spirv-val does
-    assert(data_type->opcode() == spv::OpTypeFloat || data_type->opcode() == spv::OpTypeInt);
-    info.bit_width = data_type->word(2);
+    assert(data_type->Opcode() == spv::OpTypeFloat || data_type->Opcode() == spv::OpTypeInt);
+    info.bit_width = data_type->Word(2);
 
     return info;
 }
 
 spv::BuiltIn Instruction::GetBuiltIn() const {
-    if (opcode() == spv::OpDecorate) {
-        return static_cast<spv::BuiltIn>(word(3));
-    } else if (opcode() == spv::OpMemberDecorate) {
-        return static_cast<spv::BuiltIn>(word(4));
+    if (Opcode() == spv::OpDecorate) {
+        return static_cast<spv::BuiltIn>(Word(3));
+    } else if (Opcode() == spv::OpMemberDecorate) {
+        return static_cast<spv::BuiltIn>(Word(4));
     } else {
-        assert(false); // non valid opcode
+        assert(false);  // non valid Opcode
         return spv::BuiltInMax;
     }
 }

--- a/layers/shader_instruction.cpp
+++ b/layers/shader_instruction.cpp
@@ -20,9 +20,10 @@
 #include "spirv_grammar_helper.h"
 
 Instruction::Instruction(std::vector<uint32_t>::const_iterator it) : result_id_(0), type_id_(0) {
-    words_.push_back(*it++);
+    words_.emplace_back(*it++);
+    words_.reserve(Length());
     for (uint32_t i = 1; i < Length(); i++) {
-        words_.push_back(*it++);
+        words_.emplace_back(*it++);
     }
 
     const bool has_result = OpcodeHasResult(Opcode());

--- a/layers/shader_instruction.cpp
+++ b/layers/shader_instruction.cpp
@@ -1,0 +1,69 @@
+/* Copyright (c) 2022 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Spencer Fricke <spencerfricke@gmail.com>
+ */
+
+#include "shader_instruction.h"
+#include "shader_module.h"
+#include "spirv_grammar_helper.h"
+
+Instruction::Instruction(std::vector<uint32_t>::const_iterator it) : result_id_(0), type_id_(0) {
+    words_.push_back(*it++);
+    for (uint32_t i = 1; i < length(); i++) {
+        words_.push_back(*it++);
+    }
+
+    const bool has_result = OpcodeHasResult(opcode());
+    if (OpcodeHasType(opcode())) {
+        type_id_ = 1;
+        if (has_result) {
+            result_id_ = 2;
+        }
+    } else if (has_result) {
+        result_id_ = 1;
+    }
+}
+
+atomic_instruction_info Instruction::GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const {
+    atomic_instruction_info info;
+
+    // All atomics have a pointer referenced
+    const uint32_t pointer_index = opcode() == spv::OpAtomicStore ? 1 : 3;
+    const Instruction* access = module_state.FindDef(word(pointer_index));
+
+    // spirv-val will catch if not OpTypePointer
+    const Instruction* pointer = module_state.FindDef(access->word(1));
+    info.storage_class = pointer->word(2);
+
+    const Instruction* data_type = module_state.FindDef(pointer->word(3));
+    info.type = data_type->opcode();
+
+    // TODO - Should have a proper GetBitWidth like spirv-val does
+    assert(data_type->opcode() == spv::OpTypeFloat || data_type->opcode() == spv::OpTypeInt);
+    info.bit_width = data_type->word(2);
+
+    return info;
+}
+
+spv::BuiltIn Instruction::GetBuiltIn() const {
+    if (opcode() == spv::OpDecorate) {
+        return static_cast<spv::BuiltIn>(word(3));
+    } else if (opcode() == spv::OpMemberDecorate) {
+        return static_cast<spv::BuiltIn>(word(4));
+    } else {
+        assert(false); // non valid opcode
+        return spv::BuiltInMax;
+    }
+}

--- a/layers/shader_instruction.h
+++ b/layers/shader_instruction.h
@@ -1,0 +1,70 @@
+/* Copyright (c) 2022 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Spencer Fricke <spencerfricke@gmail.com>
+ *
+ * The Shader Instruction file is in charge of holding instruction information
+ */
+#ifndef VULKAN_SHADER_INSTRUCTION_H
+#define VULKAN_SHADER_INSTRUCTION_H
+
+#include <stddef.h>  // size_t for gcc
+#include <stdint.h>
+#include <vector>
+#include <spirv/unified1/spirv.hpp>
+
+struct SHADER_MODULE_STATE;
+
+struct atomic_instruction_info {
+    uint32_t storage_class;
+    uint32_t bit_width;
+    uint32_t type;  // ex. OpTypeInt
+};
+
+// Holds information about a single SPIR-V instruction
+// Provides easy access to len, opcode, and content words without the caller needing to care too much about the physical SPIRV module layout.
+//
+// For more information of the physical module layout to help understand this struct:
+// https://github.com/KhronosGroup/SPIRV-Guide/blob/master/chapters/parsing_instructions.md
+class Instruction {
+    public:
+    Instruction(std::vector<uint32_t>::const_iterator it);
+    ~Instruction() {}
+
+    // The word used to define the Instruction
+    uint32_t word(size_t index) const { return words_[index]; }
+
+    // The words used to define the Instruction
+    const std::vector<uint32_t>& words() const { return words_; }
+
+    uint32_t length() const { return words_[0] >> 16; }
+
+    uint32_t opcode() const { return words_[0] & 0x0ffffu; }
+
+    // operand id index, return 0 if no result
+    uint32_t ResultId() const { return result_id_; }
+    // operand id index, return 0 if no type
+    uint32_t TypeId() const { return type_id_; }
+
+    char const * GetAsString(uint32_t operand) const { return (char const *)&words_.at(operand); }
+    atomic_instruction_info GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
+    spv::BuiltIn GetBuiltIn() const;
+
+    private:
+        std::vector<uint32_t> words_;
+        uint32_t result_id_;
+        uint32_t type_id_;
+};
+
+#endif  // VULKAN_SHADER_INSTRUCTION_H

--- a/layers/shader_instruction.h
+++ b/layers/shader_instruction.h
@@ -45,7 +45,7 @@ class Instruction {
     ~Instruction() = default;
 
     // The word used to define the Instruction
-    uint32_t Word(size_t index) const { return words_[index]; }
+    uint32_t Word(uint32_t index) const { return words_[index]; }
 
     uint32_t Length() const { return words_[0] >> 16; }
 

--- a/layers/shader_instruction.h
+++ b/layers/shader_instruction.h
@@ -69,10 +69,13 @@ class Instruction {
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 
-    private:
-        std::vector<uint32_t> words_;
-        uint32_t result_id_;
-        uint32_t type_id_;
+    bool operator==(Instruction const& other) const { return words_ == other.words_; }
+    bool operator!=(Instruction const& other) const { return words_ != other.words_; }
+
+  private:
+    std::vector<uint32_t> words_;
+    uint32_t result_id_;
+    uint32_t type_id_;
 };
 
 #endif  // VULKAN_SHADER_INSTRUCTION_H

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -898,7 +898,8 @@ void SHADER_MODULE_STATE::DefineStructMember(const Instruction* insn, std::vecto
     data.size = local_offset + data1.size * total_array_length;
 }
 
-static uint32_t UpdateOffset(uint32_t offset, const std::vector<uint32_t> &array_indices, const shader_struct_member &data) {
+uint32_t SHADER_MODULE_STATE::UpdateOffset(uint32_t offset, const std::vector<uint32_t>& array_indices,
+                                           const shader_struct_member& data) const {
     int array_indices_size = static_cast<int>(array_indices.size());
     if (array_indices_size) {
         uint32_t array_index = 0;
@@ -912,7 +913,8 @@ static uint32_t UpdateOffset(uint32_t offset, const std::vector<uint32_t> &array
     return offset;
 }
 
-static void SetUsedBytes(uint32_t offset, const std::vector<uint32_t> &array_indices, const shader_struct_member &data) {
+void SHADER_MODULE_STATE::SetUsedBytes(uint32_t offset, const std::vector<uint32_t>& array_indices,
+                                       const shader_struct_member& data) const {
     int array_indices_size = static_cast<int>(array_indices.size());
     uint32_t block_memory_size = data.size;
     for (uint32_t i = static_cast<int>(array_indices_size); i < data.array_length_hierarchy.size(); ++i) {

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -474,7 +474,8 @@ void SHADER_MODULE_STATE::PreprocessShaderBinary(const spv_target_env env) {
             // Will need to update static data now the words have changed or else the def_index will not align
             // It is really rare this will get here as Group Decorations have been deprecated and before this was added no one ever
             // raised an issue for a bug that would crash the layers that was around for many releases
-            *const_cast<StaticData*>(&static_data_) = StaticData(*this);
+            StaticData new_static_data(*this);
+            *const_cast<StaticData*>(&static_data_) = std::move(new_static_data);
         }
     }
 }

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -275,10 +275,10 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(const
     return ids;
 }
 
-layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const Instruction* entrypoint) const {
+layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const Instruction& entrypoint) const {
     layer_data::optional<VkPrimitiveTopology> result;
 
-    auto entrypoint_id = entrypoint->Word(2);
+    auto entrypoint_id = entrypoint.Word(2);
     bool is_point_mode = false;
 
     auto it = static_data_.execution_mode_inst.find(entrypoint_id);
@@ -425,11 +425,11 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
                 auto entrypoint_name = insn.GetAsString(3);
                 auto execution_model = insn.Word(1);
                 auto entrypoint_stage = ExecutionModelToShaderStageFlagBits(execution_model);
-                entry_points.emplace(entrypoint_name, EntryPoint{&insn, static_cast<VkShaderStageFlagBits>(entrypoint_stage)});
+                entry_points.emplace(entrypoint_name, EntryPoint{insn, static_cast<VkShaderStageFlagBits>(entrypoint_stage)});
 
                 auto range = entry_points.equal_range(entrypoint_name);
                 for (auto it = range.first; it != range.second; ++it) {
-                    if (it->second.insn == &insn) {
+                    if (it->second.insn == insn) {
                         entry_point = &(it->second);
                         break;
                     }
@@ -594,7 +594,7 @@ const Instruction* SHADER_MODULE_STATE::FindEntrypoint(char const* name, VkShade
     auto range = static_data_.entry_points.equal_range(name);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second.stage == stageBits) {
-            return it->second.insn;
+            return &it->second.insn;
         }
     }
     return nullptr;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -429,7 +429,7 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
 
                 auto range = entry_points.equal_range(entrypoint_name);
                 for (auto it = range.first; it != range.second; ++it) {
-                    if (it->second.insn == insn) {
+                    if (insn == it->second.insn.get()) {
                         entry_point = &(it->second);
                         break;
                     }
@@ -595,7 +595,7 @@ layer_data::optional<Instruction> SHADER_MODULE_STATE::FindEntrypoint(char const
     auto range = static_data_.entry_points.equal_range(name);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second.stage == stageBits) {
-            assert(it->second.insn.Opcode() == spv::OpEntryPoint);
+            assert(it->second.insn.get().Opcode() == spv::OpEntryPoint);
             result.emplace(it->second.insn);
             break;
         }

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -166,21 +166,21 @@ static uint32_t ExecutionModelToShaderStageFlagBits(uint32_t mode) {
 //
 // TODO: The set of interesting opcodes here was determined by eyeballing the SPIRV spec. It might be worth
 // converting parts of this to be generated from the machine-readable spec instead.
-layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(spirv_inst_iter entrypoint) const {
+layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(const Instruction* entrypoint) const {
     layer_data::unordered_set<uint32_t> ids;
-    if (entrypoint == end() || !has_valid_spirv) {
+    if (!entrypoint || !has_valid_spirv) {
         return ids;
     }
     layer_data::unordered_set<uint32_t> worklist;
-    worklist.insert(entrypoint.word(2));
+    worklist.insert(entrypoint->word(2));
 
     while (!worklist.empty()) {
         auto id_iter = worklist.begin();
         auto id = *id_iter;
         worklist.erase(id_iter);
 
-        auto insn = get_def(id);
-        if (insn == end()) {
+        const Instruction* insn = FindDef(id);
+        if (!insn) {
             // ID is something we didn't collect in SpirvStaticData. that's OK -- we'll stumble across all kinds of things here
             // that we may not care about.
             continue;
@@ -191,20 +191,20 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(spirv
             continue;  // If we already saw this id, we don't want to walk it again.
         }
 
-        switch (insn.opcode()) {
+        switch (insn->opcode()) {
             case spv::OpFunction:
                 // Scan whole body of the function, enlisting anything interesting
-                while (++insn, insn.opcode() != spv::OpFunctionEnd) {
-                    switch (insn.opcode()) {
+                while (++insn, insn->opcode() != spv::OpFunctionEnd) {
+                    switch (insn->opcode()) {
                         case spv::OpLoad:
-                            worklist.insert(insn.word(3));  // ptr
+                            worklist.insert(insn->word(3));  // ptr
                             break;
                         case spv::OpStore:
-                            worklist.insert(insn.word(1));  // ptr
+                            worklist.insert(insn->word(1));  // ptr
                             break;
                         case spv::OpAccessChain:
                         case spv::OpInBoundsAccessChain:
-                            worklist.insert(insn.word(3));  // base ptr
+                            worklist.insert(insn->word(3));  // base ptr
                             break;
                         case spv::OpSampledImage:
                         case spv::OpImageSampleImplicitLod:
@@ -239,29 +239,29 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(spirv
                         case spv::OpImageSparseGather:
                         case spv::OpImageSparseDrefGather:
                         case spv::OpImageTexelPointer:
-                            worklist.insert(insn.word(3));  // Image or sampled image
+                            worklist.insert(insn->word(3));  // Image or sampled image
                             break;
                         case spv::OpImageWrite:
-                            worklist.insert(insn.word(1));  // Image -- different operand order to above
+                            worklist.insert(insn->word(1));  // Image -- different operand order to above
                             break;
                         case spv::OpFunctionCall:
-                            for (uint32_t i = 3; i < insn.len(); i++) {
-                                worklist.insert(insn.word(i));  // fn itself, and all args
+                            for (uint32_t i = 3; i < insn->length(); i++) {
+                                worklist.insert(insn->word(i));  // fn itself, and all args
                             }
                             break;
 
                         case spv::OpExtInst:
-                            for (uint32_t i = 5; i < insn.len(); i++) {
-                                worklist.insert(insn.word(i));  // Operands to ext inst
+                            for (uint32_t i = 5; i < insn->length(); i++) {
+                                worklist.insert(insn->word(i));  // Operands to ext inst
                             }
                             break;
 
                         default: {
-                            if (AtomicOperation(insn.opcode())) {
-                                if (insn.opcode() == spv::OpAtomicStore) {
-                                    worklist.insert(insn.word(1));  // ptr
+                            if (AtomicOperation(insn->opcode())) {
+                                if (insn->opcode() == spv::OpAtomicStore) {
+                                    worklist.insert(insn->word(1));  // ptr
                                 } else {
-                                    worklist.insert(insn.word(3));  // ptr
+                                    worklist.insert(insn->word(3));  // ptr
                                 }
                             }
                             break;
@@ -275,16 +275,16 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::MarkAccessibleIds(spirv
     return ids;
 }
 
-layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const spirv_inst_iter &entrypoint) const {
+layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const Instruction* entrypoint) const {
     layer_data::optional<VkPrimitiveTopology> result;
 
-    auto entrypoint_id = entrypoint.word(2);
+    auto entrypoint_id = entrypoint->word(2);
     bool is_point_mode = false;
 
     auto it = static_data_.execution_mode_inst.find(entrypoint_id);
     if (it != static_data_.execution_mode_inst.end()) {
-        for (auto insn : it->second) {
-            switch (insn.word(2)) {
+        for (const Instruction* insn : it->second) {
+            switch (insn->word(2)) {
                 case spv::ExecutionModePointMode:
                     // In tessellation shaders, PointMode is separate and trumps the tessellation topology.
                     is_point_mode = true;
@@ -320,147 +320,131 @@ layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology(const
 layer_data::optional<VkPrimitiveTopology> SHADER_MODULE_STATE::GetTopology() const {
     if (static_data_.entry_points.size() > 0) {
         const auto entrypoint = static_data_.entry_points.cbegin()->second;
-        return GetTopology(get_def(entrypoint.offset));
+        return GetTopology(entrypoint.insn);
     }
     return {};
 }
 
-SHADER_MODULE_STATE::SpirvStaticData::SpirvStaticData(const SHADER_MODULE_STATE &module_state) {
-    for (auto insn : module_state) {
-        const uint32_t result_word = OpcodeResultWord(insn.opcode());
-        if (result_word != 0) {
-            def_index[insn.word(result_word)] = insn.offset();
+void SHADER_MODULE_STATE::ParseWords() {
+    std::vector<uint32_t>::const_iterator it = words_.cbegin();
+    it += 5;  // skip first 5 word of header
+    while (it != words_.cend()) {
+        Instruction insn(it);
+        const uint32_t opcode = insn.opcode();
+
+        // Check for opcodes that would require reparsing of the words
+        if (opcode == spv::OpGroupDecorate || opcode == spv::OpDecorationGroup || opcode == spv::OpGroupMemberDecorate) {
+            assert(has_group_decoration == false);  // if assert, spirv-opt didn't flatten it
+            has_group_decoration = true;
+            break;  // no need to continue parsing
+        }
+
+        instructions_.push_back(insn);
+        it += insn.length();
+    }
+    instructions_.shrink_to_fit();
+}
+
+void SHADER_MODULE_STATE::SetStaticData() {
+    for (const Instruction& insn : GetInstructions()) {
+        // Build definition list
+        if (insn.ResultId() != 0) {
+            definitions_[insn.word(insn.ResultId())] = &insn;
         }
 
         switch (insn.opcode()) {
-                // Specialization constants
+            // Specialization constants
             case spv::OpSpecConstantTrue:
             case spv::OpSpecConstantFalse:
             case spv::OpSpecConstant:
             case spv::OpSpecConstantComposite:
             case spv::OpSpecConstantOp:
-                has_specialization_constants = true;
+                static_data_.has_specialization_constants = true;
                 break;
 
-                // Decorations
+            // Decorations
             case spv::OpDecorate: {
                 auto target_id = insn.word(1);
-                decorations[target_id].add(insn.word(2), insn.len() > 3u ? insn.word(3) : 0u);
-                decoration_inst.push_back(insn);
+                static_data_.decorations[target_id].add(insn.word(2), insn.length() > 3u ? insn.word(3) : 0u);
+                static_data_.decoration_inst.push_back(&insn);
                 if (insn.word(2) == spv::DecorationBuiltIn) {
-                    builtin_decoration_list.emplace_back(insn.offset(), static_cast<spv::BuiltIn>(insn.word(3)));
+                    static_data_.builtin_decoration_inst.push_back(&insn);
                 } else if (insn.word(2) == spv::DecorationSpecId) {
-                    spec_const_map[insn.word(3)] = target_id;
+                    static_data_.spec_const_map[insn.word(3)] = target_id;
                 }
 
             } break;
-            case spv::OpGroupDecorate: {
-                auto const &src = decorations[insn.word(1)];
-                for (auto i = 2u; i < insn.len(); i++) decorations[insn.word(i)].merge(src);
-                has_group_decoration = true;
-            } break;
-            case spv::OpDecorationGroup:
-            case spv::OpGroupMemberDecorate: {
-                has_group_decoration = true;
-            } break;
             case spv::OpMemberDecorate: {
-                member_decoration_inst.push_back(insn);
+                static_data_.member_decoration_inst.push_back(&insn);
                 if (insn.word(3) == spv::DecorationBuiltIn) {
-                    builtin_decoration_list.emplace_back(insn.offset(), static_cast<spv::BuiltIn>(insn.word(4)));
+                    static_data_.builtin_decoration_inst.push_back(&insn);
                 }
             } break;
 
             case spv::OpCapability:
-                capability_list.push_back(static_cast<spv::Capability>(insn.word(1)));
+                static_data_.capability_list.push_back(static_cast<spv::Capability>(insn.word(1)));
                 break;
 
             case spv::OpVariable:
-                variable_inst.push_back(insn);
+                static_data_.variable_inst.push_back(&insn);
                 break;
 
             // Execution Mode
             case spv::OpExecutionMode:
             case spv::OpExecutionModeId: {
-                execution_mode_inst[insn.word(1)].push_back(insn);
+                static_data_.execution_mode_inst[insn.word(1)].push_back(&insn);
             } break;
             // Listed from vkspec.html#ray-tracing-repack
             case spv::OpTraceRayKHR:
             case spv::OpTraceRayMotionNV:
             case spv::OpReportIntersectionKHR:
             case spv::OpExecuteCallableKHR:
-                has_invocation_repack_instruction = true;
+                static_data_.has_invocation_repack_instruction = true;
                 break;
 
             default:
                 if (AtomicOperation(insn.opcode()) == true) {
-                    // All atomics have a pointer referenced
-                    spirv_inst_iter access;
-                    if (insn.opcode() == spv::OpAtomicStore) {
-                        access = module_state.get_def(insn.word(1));
-                    } else {
-                        access = module_state.get_def(insn.word(3));
-                    }
-
-                    atomic_instruction atomic;
-
-                    auto pointer = module_state.get_def(access.word(1));
-                    // spirv-val should catch if not pointer
-                    assert(pointer.opcode() == spv::OpTypePointer);
-                    atomic.storage_class = pointer.word(2);
-
-                    auto data_type = module_state.get_def(pointer.word(3));
-                    atomic.type = data_type.opcode();
-
-                    // TODO - Should have a proper GetBitWidth like spirv-val does
-                    assert(data_type.opcode() == spv::OpTypeFloat || data_type.opcode() == spv::OpTypeInt);
-                    atomic.bit_width = data_type.word(2);
-
-                    atomic_inst[insn.offset()] = atomic;
+                    static_data_.atomic_inst.push_back(&insn);
                 }
                 // We don't care about any other defs for now.
                 break;
         }
     }
 
-    entry_points = SHADER_MODULE_STATE::ProcessEntryPoints(module_state);
-    multiple_entry_points = entry_points.size() > 1;
+    static_data_.entry_points = ProcessEntryPoints();
+    static_data_.multiple_entry_points = static_data_.entry_points.size() > 1;
 }
 
-// static
-std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> SHADER_MODULE_STATE::ProcessEntryPoints(
-    const SHADER_MODULE_STATE &module_state) {
-    std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> entry_points;
+std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> SHADER_MODULE_STATE::ProcessEntryPoints() const {
+    std::unordered_multimap<std::string, EntryPoint> entry_points;
     function_set func_set = {};
     EntryPoint *entry_point = nullptr;
+    bool first_function_found = false;
 
-    for (auto insn : module_state) {
-        // offset is not 0, it means it's updated and the offset is in a Function.
-        if (func_set.offset) {
-            func_set.op_lists.emplace(insn.opcode(), insn.offset());
-        } else if (entry_point) {
-            entry_point->decorate_list.emplace(insn.opcode(), insn.offset());
+    for (const Instruction& insn : GetInstructions()) {
+        // TODO - This logic of the pre-function instructions can be outside here
+        if (first_function_found) {
+            func_set.op_lists.push_back(&insn);
         }
 
         switch (insn.opcode()) {
             // Functions
             case spv::OpFunction:
-                func_set.id = insn.word(2);
-                func_set.offset = insn.offset();
+                first_function_found = true;
                 func_set.op_lists.clear();
                 break;
 
             // Entry points ... add to the entrypoint table
             case spv::OpEntryPoint: {
                 // Entry points do not have an id (the id is the function id) and thus need their own table
-                auto entrypoint_name = reinterpret_cast<char const *>(&insn.word(3));
+                auto entrypoint_name = insn.GetAsString(3);
                 auto execution_model = insn.word(1);
                 auto entrypoint_stage = ExecutionModelToShaderStageFlagBits(execution_model);
-                entry_points.emplace(entrypoint_name,
-                                     EntryPoint{insn.offset(), static_cast<VkShaderStageFlagBits>(entrypoint_stage)});
+                entry_points.emplace(entrypoint_name, EntryPoint{&insn, static_cast<VkShaderStageFlagBits>(entrypoint_stage)});
 
                 auto range = entry_points.equal_range(entrypoint_name);
                 for (auto it = range.first; it != range.second; ++it) {
-                    if (it->second.offset == insn.offset()) {
+                    if (it->second.insn == &insn) {
                         entry_point = &(it->second);
                         break;
                     }
@@ -470,77 +454,75 @@ std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> SHADER_MOD
             }
             case spv::OpFunctionEnd: {
                 assert(entry_point != nullptr);
-                func_set.length = insn.offset() - func_set.offset;
                 entry_point->function_set_list.emplace_back(func_set);
                 break;
             }
         }
     }
 
-    SHADER_MODULE_STATE::SetPushConstantUsedInShader(module_state, entry_points);
+    SetPushConstantUsedInShader(entry_points);
     return entry_points;
 }
 
 void SHADER_MODULE_STATE::PreprocessShaderBinary(const spv_target_env env) {
-    if (static_data_.has_group_decoration) {
+    if (has_group_decoration) {
         spvtools::Optimizer optimizer(env);
         optimizer.RegisterPass(spvtools::CreateFlattenDecorationPass());
         std::vector<uint32_t> optimized_binary;
         // Run optimizer to flatten decorations only, set skip_validation so as to not re-run validator
-        auto result = optimizer.Run(words.data(), words.size(), &optimized_binary, spvtools::ValidatorOptions(), true);
+        auto result = optimizer.Run(words_.data(), words_.size(), &optimized_binary, spvtools::ValidatorOptions(), true);
 
         if (result) {
             // NOTE: We need to update words with the result from the spirv-tools optimizer.
             // **THIS ONLY HAPPENS ON INITIALIZATION**. words should remain const for the lifetime
             // of the SHADER_MODULE_STATE instance.
-            *const_cast<std::vector<uint32_t> *>(&words) = std::move(optimized_binary);
+            *const_cast<std::vector<uint32_t>*>(&words_) = std::move(optimized_binary);
             // Will need to update static data now the words have changed or else the def_index will not align
             // It is really rare this will get here as Group Decorations have been deprecated and before this was added no one ever
             // raised an issue for a bug that would crash the layers that was around for many releases
-            *const_cast<SpirvStaticData *>(&static_data_) = SpirvStaticData(*this);
+            ParseWords();
         }
     }
 }
 
 void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, uint32_t type) const {
-    auto insn = get_def(type);
-    assert(insn != end());
+    const Instruction* insn = FindDef(type);
 
-    switch (insn.opcode()) {
+    switch (insn->opcode()) {
         case spv::OpTypeBool:
             ss << "bool";
             break;
         case spv::OpTypeInt:
-            ss << (insn.word(3) ? 's' : 'u') << "int" << insn.word(2);
+            ss << (insn->word(3) ? 's' : 'u') << "int" << insn->word(2);
             break;
         case spv::OpTypeFloat:
-            ss << "float" << insn.word(2);
+            ss << "float" << insn->word(2);
             break;
         case spv::OpTypeVector:
-            ss << "vec" << insn.word(3) << " of ";
-            DescribeTypeInner(ss, insn.word(2));
+            ss << "vec" << insn->word(3) << " of ";
+            DescribeTypeInner(ss, insn->word(2));
             break;
         case spv::OpTypeMatrix:
-            ss << "mat" << insn.word(3) << " of ";
-            DescribeTypeInner(ss, insn.word(2));
+            ss << "mat" << insn->word(3) << " of ";
+            DescribeTypeInner(ss, insn->word(2));
             break;
         case spv::OpTypeArray:
-            ss << "arr[" << GetConstantValueById(insn.word(3)) << "] of ";
-            DescribeTypeInner(ss, insn.word(2));
+            ss << "arr[" << GetConstantValueById(insn->word(3)) << "] of ";
+            DescribeTypeInner(ss, insn->word(2));
             break;
         case spv::OpTypeRuntimeArray:
             ss << "runtime arr[] of ";
-            DescribeTypeInner(ss, insn.word(2));
+            DescribeTypeInner(ss, insn->word(2));
             break;
         case spv::OpTypePointer:
-            ss << "ptr to " << string_SpvStorageClass(insn.word(2)) << " ";
-            DescribeTypeInner(ss, insn.word(3));
+            ss << "ptr to " << string_SpvStorageClass(insn->word(2)) << " ";
+            DescribeTypeInner(ss, insn->word(3));
             break;
         case spv::OpTypeStruct: {
             ss << "struct of (";
-            for (uint32_t i = 2; i < insn.len(); i++) {
-                DescribeTypeInner(ss, insn.word(i));
-                if (i == insn.len() - 1) {
+            for (uint32_t i = 2; i < insn->length(); i++) {
+                DescribeTypeInner(ss, insn->word(i));
+                if (i == insn->length() - 1) {
                     ss << ")";
                 } else {
                     ss << ", ";
@@ -553,10 +535,10 @@ void SHADER_MODULE_STATE::DescribeTypeInner(std::ostringstream &ss, uint32_t typ
             break;
         case spv::OpTypeSampledImage:
             ss << "sampler+";
-            DescribeTypeInner(ss, insn.word(2));
+            DescribeTypeInner(ss, insn->word(2));
             break;
         case spv::OpTypeImage:
-            ss << "image(dim=" << insn.word(3) << ", sampled=" << insn.word(7) << ")";
+            ss << "image(dim=" << insn->word(3) << ", sampled=" << insn->word(7) << ")";
             break;
         case spv::OpTypeAccelerationStructureNV:
             ss << "accelerationStruture";
@@ -573,22 +555,22 @@ std::string SHADER_MODULE_STATE::DescribeType(uint32_t type) const {
     return ss.str();
 }
 
-std::string SHADER_MODULE_STATE::DescribeInstruction(const spirv_inst_iter &insn) const {
+std::string SHADER_MODULE_STATE::DescribeInstruction(const Instruction* insn) const {
     std::ostringstream ss;
-    const uint32_t opcode = insn.opcode();
+    const uint32_t opcode = insn->opcode();
     uint32_t operand_offset = 1;  // where to start printing operands
     // common disassembled for SPIR-V is
     // %result = Opcode %result_type %operands
     if (OpcodeHasResult(opcode)) {
         operand_offset++;
-        ss << "%" << (OpcodeHasType(opcode) ? insn.word(2) : insn.word(1)) << " = ";
+        ss << "%" << (OpcodeHasType(opcode) ? insn->word(2) : insn->word(1)) << " = ";
     }
 
     ss << string_SpvOpcode(opcode);
 
     if (OpcodeHasType(opcode)) {
         operand_offset++;
-        ss << " %" << insn.word(1);
+        ss << " %" << insn->word(1);
     }
 
     // TODO - For now don't list the '%' for any operands since they are only for reference IDs. Without generating a table of each
@@ -597,8 +579,8 @@ std::string SHADER_MODULE_STATE::DescribeInstruction(const spirv_inst_iter &insn
     //
     // For now this safely should be able to assume it will never come across a LiteralString such as in OpExtInstImport or
     // OpEntryPoint
-    for (uint32_t i = operand_offset; i < insn.len(); i++) {
-        ss << " " << insn.word(i);
+    for (uint32_t i = operand_offset; i < insn->length(); i++) {
+        ss << " " << insn->word(i);
     }
     return ss.str();
 }
@@ -614,51 +596,51 @@ const SHADER_MODULE_STATE::EntryPoint *SHADER_MODULE_STATE::FindEntrypointStruct
     return nullptr;
 }
 
-spirv_inst_iter SHADER_MODULE_STATE::FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const {
+const Instruction* SHADER_MODULE_STATE::FindEntrypoint(char const* name, VkShaderStageFlagBits stageBits) const {
     auto range = static_data_.entry_points.equal_range(name);
     for (auto it = range.first; it != range.second; ++it) {
         if (it->second.stage == stageBits) {
-            return at(it->second.offset);
+            return it->second.insn;
         }
     }
-    return end();
+    return nullptr;
 }
 
 // Because the following is legal, need the entry point
 //    OpEntryPoint GLCompute %main "name_a"
 //    OpEntryPoint GLCompute %main "name_b"
 // Assumes shader module contains no spec constants used to set the local size values
-bool SHADER_MODULE_STATE::FindLocalSize(const spirv_inst_iter &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y,
-                                        uint32_t &local_size_z) const {
+bool SHADER_MODULE_STATE::FindLocalSize(const Instruction* entrypoint, uint32_t& local_size_x, uint32_t& local_size_y,
+                                        uint32_t& local_size_z) const {
     // "If an object is decorated with the WorkgroupSize decoration, this takes precedence over any LocalSize or LocalSizeId
     // execution mode."
-    for (const auto &builtin : static_data_.builtin_decoration_list) {
-        if (builtin.builtin == spv::BuiltInWorkgroupSize) {
-            const uint32_t workgroup_size_id = at(builtin.offset).word(1);
-            auto composite_def = get_def(workgroup_size_id);
-            if (composite_def.opcode() == spv::OpConstantComposite) {
+    for (const Instruction* insn : GetBuiltinDecorationList()) {
+        if (insn->GetBuiltIn() == spv::BuiltInWorkgroupSize) {
+            const uint32_t workgroup_size_id = insn->word(1);
+            const Instruction* composite_def = FindDef(workgroup_size_id);
+            if (composite_def->opcode() == spv::OpConstantComposite) {
                 // VUID-WorkgroupSize-WorkgroupSize-04427 makes sure this is a OpTypeVector of int32
-                local_size_x = GetConstantValueById(composite_def.word(3));
-                local_size_y = GetConstantValueById(composite_def.word(4));
-                local_size_z = GetConstantValueById(composite_def.word(5));
+                local_size_x = GetConstantValueById(composite_def->word(3));
+                local_size_y = GetConstantValueById(composite_def->word(4));
+                local_size_z = GetConstantValueById(composite_def->word(5));
                 return true;
             }
         }
     }
 
-    auto entrypoint_id = entrypoint.word(2);
+    auto entrypoint_id = entrypoint->word(2);
     auto it = static_data_.execution_mode_inst.find(entrypoint_id);
     if (it != static_data_.execution_mode_inst.end()) {
-        for (auto insn : it->second) {
-            if (insn.opcode() == spv::OpExecutionMode && insn.word(2) == spv::ExecutionModeLocalSize) {
-                local_size_x = insn.word(3);
-                local_size_y = insn.word(4);
-                local_size_z = insn.word(5);
+        for (const Instruction* insn : it->second) {
+            if (insn->opcode() == spv::OpExecutionMode && insn->word(2) == spv::ExecutionModeLocalSize) {
+                local_size_x = insn->word(3);
+                local_size_y = insn->word(4);
+                local_size_z = insn->word(5);
                 return true;
-            } else if (insn.opcode() == spv::OpExecutionModeId && insn.word(2) == spv::ExecutionModeLocalSizeId) {
-                local_size_x = GetConstantValueById(insn.word(3));
-                local_size_y = GetConstantValueById(insn.word(4));
-                local_size_z = GetConstantValueById(insn.word(5));
+            } else if (insn->opcode() == spv::OpExecutionModeId && insn->word(2) == spv::ExecutionModeLocalSizeId) {
+                local_size_x = GetConstantValueById(insn->word(3));
+                local_size_y = GetConstantValueById(insn->word(4));
+                local_size_z = GetConstantValueById(insn->word(5));
                 return true;
             }
         }
@@ -668,35 +650,35 @@ bool SHADER_MODULE_STATE::FindLocalSize(const spirv_inst_iter &entrypoint, uint3
 
 // If the instruction at id is a constant or copy of a constant, returns a valid iterator pointing to that instruction.
 // Otherwise, returns src->end().
-spirv_inst_iter SHADER_MODULE_STATE::GetConstantDef(uint32_t id) const {
-    auto value = get_def(id);
+const Instruction* SHADER_MODULE_STATE::GetConstantDef(uint32_t id) const {
+    const Instruction* value = FindDef(id);
 
     // If id is a copy, see where it was copied from
-    if ((end() != value) && ((value.opcode() == spv::OpCopyObject) || (value.opcode() == spv::OpCopyLogical))) {
-        id = value.word(3);
-        value = get_def(id);
+    if (value && ((value->opcode() == spv::OpCopyObject) || (value->opcode() == spv::OpCopyLogical))) {
+        id = value->word(3);
+        value = FindDef(id);
     }
 
-    if ((end() != value) && (value.opcode() == spv::OpConstant)) {
+    if (value && (value->opcode() == spv::OpConstant)) {
         return value;
     }
-    return end();
+    return nullptr;
 }
 
 // While simple, function name provides a more human readable description why word(3) is used
-uint32_t SHADER_MODULE_STATE::GetConstantValue(const spirv_inst_iter &itr) const {
+uint32_t SHADER_MODULE_STATE::GetConstantValue(const Instruction* insn) const {
     // This should be a OpConstant (not a OpSpecConstant), if this asserts then 2 things are happening
     // 1. This function is being used where we don't actually know it is a constant and is a bug in the validation layers
     // 2. The CreateFoldSpecConstantOpAndCompositePass didn't fully fold everything and is a bug in spirv-opt
-    assert(itr.opcode() == spv::OpConstant);
-    return itr.word(3);
+    assert(insn->opcode() == spv::OpConstant);
+    return insn->word(3);
 }
 
 // Either returns the constant value described by the instruction at id, or 1
 uint32_t SHADER_MODULE_STATE::GetConstantValueById(uint32_t id) const {
-    auto value = GetConstantDef(id);
+    const Instruction* value = GetConstantDef(id);
 
-    if (end() == value) {
+    if (!value) {
         // TODO: Either ensure that the specialization transform is already performed on a module we're
         //       considering here, OR -- specialize on the fly now.
         return 1;
@@ -708,17 +690,17 @@ uint32_t SHADER_MODULE_STATE::GetConstantValueById(uint32_t id) const {
 // Returns an int32_t corresponding to the spv::Dim of the given resource, when positive, and corresponding to an unknown type, when
 // negative.
 int32_t SHADER_MODULE_STATE::GetShaderResourceDimensionality(const interface_var &resource) const {
-    auto type = get_def(resource.type_id);
+    const Instruction* type = FindDef(resource.type_id);
     while (true) {
-        switch (type.opcode()) {
+        switch (type->opcode()) {
             case spv::OpTypeSampledImage:
-                type = get_def(type.word(2));
+                type = FindDef(type->word(2));
                 break;
             case spv::OpTypePointer:
-                type = get_def(type.word(3));
+                type = FindDef(type->word(3));
                 break;
             case spv::OpTypeImage:
-                return type.word(3);
+                return type->word(3);
             default:
                 return -1;
         }
@@ -726,30 +708,29 @@ int32_t SHADER_MODULE_STATE::GetShaderResourceDimensionality(const interface_var
 }
 
 uint32_t SHADER_MODULE_STATE::GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const {
-    auto insn = get_def(type);
-    assert(insn != end());
+    const Instruction* insn = FindDef(type);
 
-    switch (insn.opcode()) {
+    switch (insn->opcode()) {
         case spv::OpTypePointer:
             // See through the ptr -- this is only ever at the toplevel for graphics shaders we're never actually passing
             // pointers around.
-            return GetLocationsConsumedByType(insn.word(3), strip_array_level);
+            return GetLocationsConsumedByType(insn->word(3), strip_array_level);
         case spv::OpTypeArray:
             if (strip_array_level) {
-                return GetLocationsConsumedByType(insn.word(2), false);
+                return GetLocationsConsumedByType(insn->word(2), false);
             } else {
-                return GetConstantValueById(insn.word(3)) * GetLocationsConsumedByType(insn.word(2), false);
+                return GetConstantValueById(insn->word(3)) * GetLocationsConsumedByType(insn->word(2), false);
             }
         case spv::OpTypeMatrix:
             // Num locations is the dimension * element size
-            return insn.word(3) * GetLocationsConsumedByType(insn.word(2), false);
+            return insn->word(3) * GetLocationsConsumedByType(insn->word(2), false);
         case spv::OpTypeVector: {
-            auto scalar_type = get_def(insn.word(2));
+            const Instruction* scalar_type = FindDef(insn->word(2));
             auto bit_width =
-                (scalar_type.opcode() == spv::OpTypeInt || scalar_type.opcode() == spv::OpTypeFloat) ? scalar_type.word(2) : 32;
+                (scalar_type->opcode() == spv::OpTypeInt || scalar_type->opcode() == spv::OpTypeFloat) ? scalar_type->word(2) : 32;
 
             // Locations are 128-bit wide; 3- and 4-component vectors of 64 bit types require two.
-            return (bit_width * insn.word(3) + 127) / 128;
+            return (bit_width * insn->word(3) + 127) / 128;
         }
         default:
             // Everything else is just 1.
@@ -760,47 +741,46 @@ uint32_t SHADER_MODULE_STATE::GetLocationsConsumedByType(uint32_t type, bool str
 }
 
 uint32_t SHADER_MODULE_STATE::GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const {
-    auto insn = get_def(type);
-    assert(insn != end());
+    const Instruction* insn = FindDef(type);
 
-    switch (insn.opcode()) {
+    switch (insn->opcode()) {
         case spv::OpTypePointer:
             // See through the ptr -- this is only ever at the toplevel for graphics shaders we're never actually passing
             // pointers around.
-            return GetComponentsConsumedByType(insn.word(3), strip_array_level);
+            return GetComponentsConsumedByType(insn->word(3), strip_array_level);
         case spv::OpTypeStruct: {
             uint32_t sum = 0;
-            for (uint32_t i = 2; i < insn.len(); i++) {  // i=2 to skip word(0) and word(1)=ID of struct
-                sum += GetComponentsConsumedByType(insn.word(i), false);
+            for (uint32_t i = 2; i < insn->length(); i++) {  // i=2 to skip word(0) and word(1)=ID of struct
+                sum += GetComponentsConsumedByType(insn->word(i), false);
             }
             return sum;
         }
         case spv::OpTypeArray:
             if (strip_array_level) {
-                return GetComponentsConsumedByType(insn.word(2), false);
+                return GetComponentsConsumedByType(insn->word(2), false);
             } else {
-                return GetConstantValueById(insn.word(3)) * GetComponentsConsumedByType(insn.word(2), false);
+                return GetConstantValueById(insn->word(3)) * GetComponentsConsumedByType(insn->word(2), false);
             }
         case spv::OpTypeMatrix:
             // Num locations is the dimension * element size
-            return insn.word(3) * GetComponentsConsumedByType(insn.word(2), false);
+            return insn->word(3) * GetComponentsConsumedByType(insn->word(2), false);
         case spv::OpTypeVector: {
-            auto scalar_type = get_def(insn.word(2));
+            const Instruction* scalar_type = FindDef(insn->word(2));
             auto bit_width =
-                (scalar_type.opcode() == spv::OpTypeInt || scalar_type.opcode() == spv::OpTypeFloat) ? scalar_type.word(2) : 32;
+                (scalar_type->opcode() == spv::OpTypeInt || scalar_type->opcode() == spv::OpTypeFloat) ? scalar_type->word(2) : 32;
             // One component is 32-bit
-            return (bit_width * insn.word(3) + 31) / 32;
+            return (bit_width * insn->word(3) + 31) / 32;
         }
         case spv::OpTypeFloat: {
-            auto bit_width = insn.word(2);
+            auto bit_width = insn->word(2);
             return (bit_width + 31) / 32;
         }
         case spv::OpTypeInt: {
-            auto bit_width = insn.word(2);
+            auto bit_width = insn->word(2);
             return (bit_width + 31) / 32;
         }
         case spv::OpConstant:
-            return GetComponentsConsumedByType(insn.word(1), false);
+            return GetComponentsConsumedByType(insn->word(1), false);
         default:
             return 0;
     }
@@ -809,12 +789,11 @@ uint32_t SHADER_MODULE_STATE::GetComponentsConsumedByType(uint32_t type, bool st
 // characterizes a SPIR-V type appearing in an interface to a FF stage, for comparison to a VkFormat's characterization above.
 // also used for input attachments, as we statically know their format.
 uint32_t SHADER_MODULE_STATE::GetFundamentalType(uint32_t type) const {
-    auto insn = get_def(type);
-    assert(insn != end());
+    const Instruction* insn = FindDef(type);
 
-    switch (insn.opcode()) {
+    switch (insn->opcode()) {
         case spv::OpTypeInt:
-            return insn.word(3) ? FORMAT_TYPE_SINT : FORMAT_TYPE_UINT;
+            return insn->word(3) ? FORMAT_TYPE_SINT : FORMAT_TYPE_UINT;
         case spv::OpTypeFloat:
             return FORMAT_TYPE_FLOAT;
         case spv::OpTypeVector:
@@ -822,91 +801,90 @@ uint32_t SHADER_MODULE_STATE::GetFundamentalType(uint32_t type) const {
         case spv::OpTypeArray:
         case spv::OpTypeRuntimeArray:
         case spv::OpTypeImage:
-            return GetFundamentalType(insn.word(2));
+            return GetFundamentalType(insn->word(2));
         case spv::OpTypePointer:
-            return GetFundamentalType(insn.word(3));
+            return GetFundamentalType(insn->word(3));
 
         default:
             return 0;
     }
 }
 
-spirv_inst_iter SHADER_MODULE_STATE::GetStructType(spirv_inst_iter def, bool is_array_of_verts) const {
+const Instruction* SHADER_MODULE_STATE::GetStructType(const Instruction* insn, bool is_array_of_verts) const {
     while (true) {
-        if (def.opcode() == spv::OpTypePointer) {
-            def = get_def(def.word(3));
-        } else if (def.opcode() == spv::OpTypeArray && is_array_of_verts) {
-            def = get_def(def.word(2));
+        if (insn->opcode() == spv::OpTypePointer) {
+            insn = FindDef(insn->word(3));
+        } else if (insn->opcode() == spv::OpTypeArray && is_array_of_verts) {
+            insn = FindDef(insn->word(2));
             is_array_of_verts = false;
-        } else if (def.opcode() == spv::OpTypeStruct) {
-            return def;
+        } else if (insn->opcode() == spv::OpTypeStruct) {
+            return insn;
         } else {
-            return end();
+            return nullptr;
         }
     }
 }
 
-void SHADER_MODULE_STATE::DefineStructMember(const spirv_inst_iter &it, const std::vector<uint32_t> &member_decorate_offsets,
-                                             shader_struct_member &data) const {
-    const auto struct_it = GetStructType(it, false);
-    assert(struct_it != end());
+void SHADER_MODULE_STATE::DefineStructMember(const Instruction* insn, std::vector<const Instruction*>& member_decorate_insn,
+                                             shader_struct_member& data) const {
+    const Instruction* struct_type = GetStructType(insn, false);
     data.size = 0;
 
     shader_struct_member data1;
-    uint32_t i = 2;
+    uint32_t element_index = 2;  // offset where first element in OpTypeStruct is
     uint32_t local_offset = 0;
+    // offsets into struct
     std::vector<uint32_t> offsets;
-    offsets.resize(struct_it.len() - i);
+    offsets.resize(struct_type->length() - element_index);
 
     // The members of struct in SPRIV_R aren't always sort, so we need to know their order.
-    for (const auto offset : member_decorate_offsets) {
-        const auto member_decorate = at(offset);
-        if (member_decorate.word(1) != struct_it.word(1)) {
+    for (const Instruction* member_decorate : member_decorate_insn) {
+        if (member_decorate->word(1) != struct_type->word(1)) {
             continue;
         }
 
-        offsets[member_decorate.word(2)] = member_decorate.word(4);
+        offsets[member_decorate->word(2)] = member_decorate->word(4);
     }
 
-    for (const auto offset : offsets) {
+    for (const uint32_t offset : offsets) {
         local_offset = offset;
         data1 = {};
         data1.root = data.root;
         data1.offset = local_offset;
-        auto def_member = get_def(struct_it.word(i));
+        const Instruction* def_member = FindDef(struct_type->word(element_index));
 
         // Array could be multi-dimensional
-        while (def_member.opcode() == spv::OpTypeArray) {
-            const auto len_id = def_member.word(3);
-            const auto def_len = get_def(len_id);
-            data1.array_length_hierarchy.emplace_back(def_len.word(3));  // array length
-            def_member = get_def(def_member.word(2));
+        while (def_member->opcode() == spv::OpTypeArray) {
+            const auto len_id = def_member->word(3);
+            const Instruction* def_len = FindDef(len_id);
+            data1.array_length_hierarchy.emplace_back(def_len->word(3));  // array length
+            def_member = FindDef(def_member->word(2));
         }
 
-        if (def_member.opcode() == spv::OpTypeStruct) {
-            DefineStructMember(def_member, member_decorate_offsets, data1);
-        } else if (def_member.opcode() == spv::OpTypePointer) {
-            if (def_member.word(2) == spv::StorageClassPhysicalStorageBuffer) {
+        if (def_member->opcode() == spv::OpTypeStruct) {
+            DefineStructMember(def_member, member_decorate_insn, data1);
+        } else if (def_member->opcode() == spv::OpTypePointer) {
+            if (def_member->word(2) == spv::StorageClassPhysicalStorageBuffer) {
                 // If it's a pointer with PhysicalStorageBuffer class, this member is essentially a uint64_t containing an address
                 // that "points to something."
                 data1.size = 8;
             } else {
                 // If it's OpTypePointer. it means the member is a buffer, the type will be TypePointer, and then struct
-                DefineStructMember(def_member, member_decorate_offsets, data1);
+                DefineStructMember(def_member, member_decorate_insn, data1);
             }
         } else {
-            if (def_member.opcode() == spv::OpTypeMatrix) {
-                data1.array_length_hierarchy.emplace_back(def_member.word(3));  // matrix's columns. matrix's row is vector.
-                def_member = get_def(def_member.word(2));
+            if (def_member->opcode() == spv::OpTypeMatrix) {
+                data1.array_length_hierarchy.emplace_back(def_member->word(3));  // matrix's columns. matrix's row is vector.
+                def_member = FindDef(def_member->word(2));
             }
 
-            if (def_member.opcode() == spv::OpTypeVector) {
-                data1.array_length_hierarchy.emplace_back(def_member.word(3));  // vector length
-                def_member = get_def(def_member.word(2));
+            if (def_member->opcode() == spv::OpTypeVector) {
+                data1.array_length_hierarchy.emplace_back(def_member->word(3));  // vector length
+                def_member = FindDef(def_member->word(2));
             }
 
             // Get scalar type size. The value in SPRV-R is bit. It needs to translate to byte.
-            data1.size = (def_member.word(2) / 8);
+            data1.size = (def_member->word(2) / 8);
         }
         const auto array_length_hierarchy_szie = data1.array_length_hierarchy.size();
         if (array_length_hierarchy_szie > 0) {
@@ -917,7 +895,7 @@ void SHADER_MODULE_STATE::DefineStructMember(const spirv_inst_iter &it, const st
             }
         }
         data.struct_members.emplace_back(data1);
-        ++i;
+        ++element_index;
     }
     uint32_t total_array_length = 1;
     for (const auto length : data1.array_length_hierarchy) {
@@ -958,23 +936,23 @@ static void SetUsedBytes(uint32_t offset, const std::vector<uint32_t> &array_ind
 }
 
 void SHADER_MODULE_STATE::RunUsedArray(uint32_t offset, std::vector<uint32_t> array_indices, uint32_t access_chain_word_index,
-                                       spirv_inst_iter &access_chain_it, const shader_struct_member &data) const {
-    if (access_chain_word_index < access_chain_it.len()) {
+                                       const Instruction* access_chain, const shader_struct_member& data) const {
+    if (access_chain_word_index < access_chain->length()) {
         if (data.array_length_hierarchy.size() > array_indices.size()) {
-            auto def_it = get_def(access_chain_it.word(access_chain_word_index));
+            const Instruction* def = FindDef(access_chain->word(access_chain_word_index));
             ++access_chain_word_index;
 
-            if (def_it != end() && def_it.opcode() == spv::OpConstant) {
-                array_indices.emplace_back(def_it.word(3));
-                RunUsedArray(offset, array_indices, access_chain_word_index, access_chain_it, data);
+            if (def && def->opcode() == spv::OpConstant) {
+                array_indices.emplace_back(def->word(3));
+                RunUsedArray(offset, array_indices, access_chain_word_index, access_chain, data);
             } else {
                 // If it is a variable, set the all array is used.
-                if (access_chain_word_index < access_chain_it.len()) {
+                if (access_chain_word_index < access_chain->length()) {
                     uint32_t array_length = data.array_length_hierarchy[array_indices.size()];
                     for (uint32_t i = 0; i < array_length; ++i) {
                         auto array_indices2 = array_indices;
                         array_indices2.emplace_back(i);
-                        RunUsedArray(offset, array_indices2, access_chain_word_index, access_chain_it, data);
+                        RunUsedArray(offset, array_indices2, access_chain_word_index, access_chain, data);
                     }
                 } else {
                     SetUsedBytes(offset, array_indices, data);
@@ -982,87 +960,79 @@ void SHADER_MODULE_STATE::RunUsedArray(uint32_t offset, std::vector<uint32_t> ar
             }
         } else {
             offset = UpdateOffset(offset, array_indices, data);
-            RunUsedStruct(offset, access_chain_word_index, access_chain_it, data);
+            RunUsedStruct(offset, access_chain_word_index, access_chain, data);
         }
     } else {
         SetUsedBytes(offset, array_indices, data);
     }
 }
 
-void SHADER_MODULE_STATE::RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, spirv_inst_iter &access_chain_it,
-                                        const shader_struct_member &data) const {
+void SHADER_MODULE_STATE::RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, const Instruction* access_chain,
+                                        const shader_struct_member& data) const {
     std::vector<uint32_t> array_indices_emptry;
 
-    if (access_chain_word_index < access_chain_it.len()) {
-        auto strcut_member_index = GetConstantValueById(access_chain_it.word(access_chain_word_index));
+    if (access_chain_word_index < access_chain->length()) {
+        auto strcut_member_index = GetConstantValueById(access_chain->word(access_chain_word_index));
         ++access_chain_word_index;
 
         auto data1 = data.struct_members[strcut_member_index];
-        RunUsedArray(offset + data1.offset, array_indices_emptry, access_chain_word_index, access_chain_it, data1);
+        RunUsedArray(offset + data1.offset, array_indices_emptry, access_chain_word_index, access_chain, data1);
     }
 }
 
 void SHADER_MODULE_STATE::SetUsedStructMember(const uint32_t variable_id, const std::vector<function_set> &function_set_list,
                                               const shader_struct_member &data) const {
     for (const auto &func_set : function_set_list) {
-        auto range = func_set.op_lists.equal_range(spv::OpAccessChain);
-        for (auto it = range.first; it != range.second; ++it) {
-            auto access_chain = at(it->second);
-            if (access_chain.word(3) == variable_id) {
-                RunUsedStruct(0, 4, access_chain, data);
+        for (const Instruction* insn : func_set.op_lists) {
+            if (insn->opcode() == spv::OpAccessChain) {
+                if (insn->word(3) == variable_id) {
+                    RunUsedStruct(0, 4, insn, data);
+                }
             }
         }
     }
 }
 
-// static
-void SHADER_MODULE_STATE::SetPushConstantUsedInShader(
-    const SHADER_MODULE_STATE &module_state, std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> &entry_points) {
+void SHADER_MODULE_STATE::SetPushConstantUsedInShader(std::unordered_multimap<std::string, EntryPoint>& entry_points) const {
     for (auto &entrypoint : entry_points) {
-        auto range = entrypoint.second.decorate_list.equal_range(spv::OpVariable);
-        for (auto it = range.first; it != range.second; ++it) {
-            const auto def_insn = module_state.at(it->second);
-
-            if (def_insn.word(3) == spv::StorageClassPushConstant) {
-                spirv_inst_iter type = module_state.get_def(def_insn.word(1));
-                const auto range2 = entrypoint.second.decorate_list.equal_range(spv::OpMemberDecorate);
-                std::vector<uint32_t> offsets;
-
-                for (auto it2 = range2.first; it2 != range2.second; ++it2) {
-                    auto member_decorate = module_state.at(it2->second);
-                    if (member_decorate.len() == 5 && member_decorate.word(3) == spv::DecorationOffset) {
-                        offsets.emplace_back(member_decorate.offset());
+        for (const Instruction* var_insn : GetVariableInstructions()) {
+            if (var_insn->word(3) == spv::StorageClassPushConstant) {
+                const Instruction* type = FindDef(var_insn->word(1));
+                std::vector<const Instruction*> member_decorate_insn;
+                for (const Instruction* member_decorate : GetMemberDecorationInstructions()) {
+                    if (member_decorate->length() == 5 && member_decorate->word(3) == spv::DecorationOffset) {
+                        member_decorate_insn.emplace_back(member_decorate);
                     }
                 }
                 entrypoint.second.push_constant_used_in_shader.root = &entrypoint.second.push_constant_used_in_shader;
-                module_state.DefineStructMember(type, offsets, entrypoint.second.push_constant_used_in_shader);
-                module_state.SetUsedStructMember(def_insn.word(2), entrypoint.second.function_set_list,
-                                                 entrypoint.second.push_constant_used_in_shader);
+                DefineStructMember(type, member_decorate_insn, entrypoint.second.push_constant_used_in_shader);
+                SetUsedStructMember(var_insn->word(2), entrypoint.second.function_set_list,
+                                    entrypoint.second.push_constant_used_in_shader);
             }
         }
     }
 }
 
 uint32_t SHADER_MODULE_STATE::DescriptorTypeToReqs(uint32_t type_id) const {
-    auto type = get_def(type_id);
+    const Instruction* type = FindDef(type_id);
 
     while (true) {
-        switch (type.opcode()) {
+        switch (type->opcode()) {
             case spv::OpTypeArray:
             case spv::OpTypeRuntimeArray:
             case spv::OpTypeSampledImage:
-                type = get_def(type.word(2));
+                type = FindDef(type->word(2));
                 break;
             case spv::OpTypePointer:
-                type = get_def(type.word(3));
+                type = FindDef(type->word(3));
                 break;
             case spv::OpTypeImage: {
-                auto dim = type.word(3);
-                auto arrayed = type.word(5);
-                auto msaa = type.word(6);
+                auto dim = type->word(3);
+                auto arrayed = type->word(5);
+                auto msaa = type->word(6);
 
                 uint32_t bits = 0;
-                switch (GetFundamentalType(type.word(2))) {
+                switch (GetFundamentalType(type->word(2))) {
                     case FORMAT_TYPE_FLOAT:
                         bits = DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT;
                         break;
@@ -1105,16 +1075,18 @@ uint32_t SHADER_MODULE_STATE::DescriptorTypeToReqs(uint32_t type_id) const {
 
 // For some built-in analysis we need to know if the variable decorated with as the built-in was actually written to.
 // This function examines instructions in the static call tree for a write to this variable.
-bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_inst_iter entrypoint) const {
-    auto type = builtin_instr.opcode();
-    uint32_t target_id = builtin_instr.word(1);
+bool SHADER_MODULE_STATE::IsBuiltInWritten(const Instruction* builtin_insn, const Instruction* entrypoint) const {
+    auto type = builtin_insn->opcode();
+    uint32_t target_id = builtin_insn->word(1);
     bool init_complete = false;
     uint32_t target_member_offset = 0;
 
     if (type == spv::OpMemberDecorate) {
         // Built-in is part of a structure -- examine instructions up to first function body to get initial IDs
-        auto insn = entrypoint;
-        while (!init_complete && (insn.opcode() != spv::OpFunction)) {
+        for (const Instruction& insn : GetInstructions()) {
+            if (insn.opcode() == spv::OpFunction) {
+                break;
+            }
             switch (insn.opcode()) {
                 case spv::OpTypePointer:
                     if (insn.word(2) == spv::StorageClassOutput) {
@@ -1123,8 +1095,8 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_
                             target_id = insn.word(1);
                         } else {
                             // If the output is an array, check if the element type is what we're looking for
-                            const auto type_insn = get_def(type_id);
-                            if ((type_insn.opcode() == spv::OpTypeArray) && (type_insn.word(2) == target_id)) {
+                            const Instruction* type_def = FindDef(type_id);
+                            if ((type_def->opcode() == spv::OpTypeArray) && (type_def->word(2) == target_id)) {
                                 target_id = insn.word(1);
                                 target_member_offset = 1;
                             }
@@ -1138,7 +1110,6 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_
                     }
                     break;
             }
-            insn++;
         }
     }
 
@@ -1146,7 +1117,7 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_
 
     bool found_write = false;
     layer_data::unordered_set<uint32_t> worklist;
-    worklist.insert(entrypoint.word(2));
+    worklist.insert(entrypoint->word(2));
 
     // Follow instructions in call graph looking for writes to target
     while (!worklist.empty() && !found_write) {
@@ -1154,41 +1125,41 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_
         auto id = *id_iter;
         worklist.erase(id_iter);
 
-        auto insn = get_def(id);
-        if (insn == end()) {
+        const Instruction* insn = FindDef(id);
+        if (!insn) {
             continue;
         }
 
-        if (insn.opcode() == spv::OpFunction) {
+        if (insn->opcode() == spv::OpFunction) {
             // Scan body of function looking for other function calls or items in our ID chain
-            while (++insn, (insn.opcode() != spv::OpFunctionEnd) && !found_write) {
-                switch (insn.opcode()) {
+            while (++insn, (insn->opcode() != spv::OpFunctionEnd) && !found_write) {
+                switch (insn->opcode()) {
                     case spv::OpAccessChain:
                     case spv::OpInBoundsAccessChain:
-                        if (insn.word(3) == target_id) {
+                        if (insn->word(3) == target_id) {
                             if (type == spv::OpMemberDecorate) {
                                 // Get the target member of the struct
                                 // NOTE: this will only work for structs and arrays of structs. Deeper levels of nesting (e.g.,
                                 // arrays of structs of structs) is not currently supported.
-                                const auto value_itr = GetConstantDef(insn.word(4 + target_member_offset));
-                                if (value_itr != end()) {
+                                const Instruction* value_itr = GetConstantDef(insn->word(4 + target_member_offset));
+                                if (value_itr) {
                                     auto value = GetConstantValue(value_itr);
-                                    if (value == builtin_instr.word(2)) {
-                                        target_id = insn.word(2);
+                                    if (value == builtin_insn->word(2)) {
+                                        target_id = insn->word(2);
                                     }
                                 }
                             } else {
-                                target_id = insn.word(2);
+                                target_id = insn->word(2);
                             }
                         }
                         break;
                     case spv::OpStore:
-                        if (insn.word(1) == target_id) {
+                        if (insn->word(1) == target_id) {
                             found_write = true;
                         }
                         break;
                     case spv::OpFunctionCall:
-                        worklist.insert(insn.word(3));
+                        worklist.insert(insn->word(3));
                         break;
                 }
             }
@@ -1227,7 +1198,7 @@ struct shader_module_used_operators {
         if (updated) return;
         updated = true;
 
-        for (auto insn : *module_state) {
+        for (const Instruction& insn : module_state->GetInstructions()) {
             switch (insn.opcode()) {
                 case spv::OpImageSampleImplicitLod:
                 case spv::OpImageSampleProjImplicitLod:
@@ -1236,12 +1207,12 @@ struct shader_module_used_operators {
                 case spv::OpImageSparseSampleProjImplicitLod:
                 case spv::OpImageSparseSampleProjExplicitLod: {
                     // combined image samples are just OpLoad, but also can be separate image and sampler
-                    auto id = module_state->get_def(insn.word(3));  // <id> Sampled Image
-                    auto load_id = (id.opcode() == spv::OpSampledImage) ? id.word(4) : insn.word(3);
+                    const Instruction* id = module_state->FindDef(insn.word(3));  // <id> Sampled Image
+                    auto load_id = (id->opcode() == spv::OpSampledImage) ? id->word(4) : insn.word(3);
                     sampler_load_ids.emplace_back(load_id);
                     sampler_implicitLod_dref_proj_load_ids.emplace_back(load_id);
                     // ImageOperands in index: 5
-                    if (insn.len() > 5 && CheckImageOperandsBiasOffset(insn.word(5))) {
+                    if (insn.length() > 5 && CheckImageOperandsBiasOffset(insn.word(5))) {
                         sampler_bias_offset_load_ids.emplace_back(load_id);
                     }
                     break;
@@ -1249,8 +1220,8 @@ struct shader_module_used_operators {
                 case spv::OpImageDrefGather:
                 case spv::OpImageSparseDrefGather: {
                     // combined image samples are just OpLoad, but also can be separate image and sampler
-                    auto id = module_state->get_def(insn.word(3));  // <id> Sampled Image
-                    auto load_id = (id.opcode() == spv::OpSampledImage) ? id.word(3) : insn.word(3);
+                    const Instruction* id = module_state->FindDef(insn.word(3));  // <id> Sampled Image
+                    auto load_id = (id->opcode() == spv::OpSampledImage) ? id->word(3) : insn.word(3);
                     image_dref_load_ids.emplace_back(load_id);
                     break;
                 }
@@ -1263,15 +1234,15 @@ struct shader_module_used_operators {
                 case spv::OpImageSparseSampleProjDrefImplicitLod:
                 case spv::OpImageSparseSampleProjDrefExplicitLod: {
                     // combined image samples are just OpLoad, but also can be separate image and sampler
-                    auto id = module_state->get_def(insn.word(3));  // <id> Sampled Image
-                    auto sampler_load_id = (id.opcode() == spv::OpSampledImage) ? id.word(4) : insn.word(3);
-                    auto image_load_id = (id.opcode() == spv::OpSampledImage) ? id.word(3) : insn.word(3);
+                    const Instruction* id = module_state->FindDef(insn.word(3));  // <id> Sampled Image
+                    auto sampler_load_id = (id->opcode() == spv::OpSampledImage) ? id->word(4) : insn.word(3);
+                    auto image_load_id = (id->opcode() == spv::OpSampledImage) ? id->word(3) : insn.word(3);
 
                     image_dref_load_ids.emplace_back(image_load_id);
                     sampler_load_ids.emplace_back(sampler_load_id);
                     sampler_implicitLod_dref_proj_load_ids.emplace_back(sampler_load_id);
                     // ImageOperands in index: 6
-                    if (insn.len() > 6 && CheckImageOperandsBiasOffset(insn.word(6))) {
+                    if (insn.length() > 6 && CheckImageOperandsBiasOffset(insn.word(6))) {
                         sampler_bias_offset_load_ids.emplace_back(sampler_load_id);
                     }
                     break;
@@ -1279,10 +1250,10 @@ struct shader_module_used_operators {
                 case spv::OpImageSampleExplicitLod:
                 case spv::OpImageSparseSampleExplicitLod: {
                     // ImageOperands in index: 5
-                    if (insn.len() > 5 && CheckImageOperandsBiasOffset(insn.word(5))) {
+                    if (insn.length() > 5 && CheckImageOperandsBiasOffset(insn.word(5))) {
                         // combined image samples are just OpLoad, but also can be separate image and sampler
-                        auto id = module_state->get_def(insn.word(3));  // <id> Sampled Image
-                        auto load_id = (id.opcode() == spv::OpSampledImage) ? id.word(4) : insn.word(3);
+                        const Instruction* id = module_state->FindDef(insn.word(3));  // <id> Sampled Image
+                        auto load_id = (id->opcode() == spv::OpSampledImage) ? id->word(4) : insn.word(3);
                         sampler_load_ids.emplace_back(load_id);
                         sampler_bias_offset_load_ids.emplace_back(load_id);
                     }
@@ -1313,7 +1284,7 @@ struct shader_module_used_operators {
                 }
                 case spv::OpAccessChain:
                 case spv::OpInBoundsAccessChain: {
-                    if (insn.len() == 4) {
+                    if (insn.length() == 4) {
                         // If it is for struct, the length is only 4.
                         // 2: AccessChain id, 3: object id
                         accesschain_members.emplace(insn.word(2), std::pair<uint32_t, uint32_t>(insn.word(3), 0));
@@ -1370,34 +1341,34 @@ static bool CheckObjectIDFromOpLoad(uint32_t object_id, const std::vector<uint32
 
 // Takes a OpVariable and looks at the the descriptor type it uses. This will find things such as if the variable is writable, image
 // atomic operation, matching images to samplers, etc
-void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it, bool is_storage_buffer, bool is_check_writable,
-                                                   interface_var &out_interface_var) const {
+void SHADER_MODULE_STATE::IsSpecificDescriptorType(const Instruction* insn, bool is_storage_buffer, bool is_check_writable,
+                                                   interface_var& out_interface_var) const {
     shader_module_used_operators used_operators;
-    uint32_t type_id = id_it.word(1);
-    uint32_t id = id_it.word(2);
+    uint32_t type_id = insn->word(1);
+    uint32_t id = insn->word(2);
 
-    auto type = get_def(type_id);
+    const Instruction* type = FindDef(type_id);
 
     // Strip off any array or ptrs. Where we remove array levels, adjust the  descriptor count for each dimension.
-    while (type.opcode() == spv::OpTypeArray || type.opcode() == spv::OpTypePointer || type.opcode() == spv::OpTypeRuntimeArray ||
-           type.opcode() == spv::OpTypeSampledImage) {
-        if (type.opcode() == spv::OpTypeArray || type.opcode() == spv::OpTypeRuntimeArray ||
-            type.opcode() == spv::OpTypeSampledImage) {
-            type = get_def(type.word(2));  // Element type
+    while (type->opcode() == spv::OpTypeArray || type->opcode() == spv::OpTypePointer ||
+           type->opcode() == spv::OpTypeRuntimeArray || type->opcode() == spv::OpTypeSampledImage) {
+        if (type->opcode() == spv::OpTypeArray || type->opcode() == spv::OpTypeRuntimeArray ||
+            type->opcode() == spv::OpTypeSampledImage) {
+            type = FindDef(type->word(2));  // Element type
         } else {
-            type = get_def(type.word(3));  // Pointer type
+            type = FindDef(type->word(3));  // Pointer type
         }
     }
 
-    switch (type.opcode()) {
+    switch (type->opcode()) {
         case spv::OpTypeImage: {
-            auto dim = type.word(3);
+            auto dim = type->word(3);
             if (dim != spv::DimSubpassData) {
                 used_operators.update(this);
 
                 // Sampled == 2 indicates used without a sampler (a storage image)
                 bool is_image_without_format = false;
-                if (type.word(7) == 2) is_image_without_format = type.word(8) == spv::ImageFormatUnknown;
+                if (type->word(7) == 2) is_image_without_format = type->word(8) == spv::ImageFormatUnknown;
 
                 if (CheckObjectIDFromOpLoad(id, used_operators.image_write_load_ids, used_operators.load_members,
                                             used_operators.accesschain_members)) {
@@ -1446,12 +1417,12 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
                                     continue;
                                 }
 
-                                const auto const_itr = GetConstantDef(accesschain_it->second.second);
-                                if (const_itr == end()) {
+                                const Instruction* const_def = GetConstantDef(accesschain_it->second.second);
+                                if (!const_def) {
                                     // access chain index not a constant, skip.
                                     break;
                                 }
-                                image_index = GetConstantValue(const_itr);
+                                image_index = GetConstantValue(const_def);
                             }
                         }
                     }
@@ -1465,13 +1436,13 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
                         auto accesschain_it = used_operators.accesschain_members.find(load_it->second);
 
                         if (accesschain_it != used_operators.accesschain_members.end()) {
-                            const auto const_itr = GetConstantDef(accesschain_it->second.second);
-                            if (const_itr == end()) {
+                            const Instruction* const_def = GetConstantDef(accesschain_it->second.second);
+                            if (!const_def) {
                                 // access chain index representing sampler index is not a constant, skip.
                                 break;
                             }
-                            sampler_id = const_itr.offset();
-                            sampler_index = GetConstantValue(const_itr);
+                            sampler_id = const_def->word(const_def->ResultId());
+                            sampler_index = GetConstantValue(const_def);
                         }
                         auto sampler_dec = get_decorations(sampler_id);
                         if (image_index >= out_interface_var.samplers_used_by_image.size()) {
@@ -1502,16 +1473,16 @@ void SHADER_MODULE_STATE::IsSpecificDescriptorType(const spirv_inst_iter &id_it,
 
         case spv::OpTypeStruct: {
             layer_data::unordered_set<uint32_t> nonwritable_members;
-            if (get_decorations(type.word(1)).flags & decoration_set::buffer_block_bit) is_storage_buffer = true;
-            for (auto insn : static_data_.member_decoration_inst) {
-                if (insn.word(1) == type.word(1) && insn.word(3) == spv::DecorationNonWritable) {
-                    nonwritable_members.insert(insn.word(2));
+            if (get_decorations(type->word(1)).flags & decoration_set::buffer_block_bit) is_storage_buffer = true;
+            for (const Instruction* insn : static_data_.member_decoration_inst) {
+                if (insn->word(1) == type->word(1) && insn->word(3) == spv::DecorationNonWritable) {
+                    nonwritable_members.insert(insn->word(2));
                 }
             }
 
             // A buffer is writable if it's either flavor of storage buffer, and has any member not decorated
             // as nonwritable.
-            if (is_storage_buffer && nonwritable_members.size() != type.len() - 2) {
+            if (is_storage_buffer && nonwritable_members.size() != type->length() - 2) {
                 used_operators.update(this);
 
                 for (auto oid : used_operators.store_pointer_ids) {
@@ -1543,22 +1514,20 @@ std::vector<std::pair<DescriptorSlot, interface_var>> SHADER_MODULE_STATE::Colle
     std::vector<std::pair<DescriptorSlot, interface_var>> out;
 
     for (auto id : accessible_ids) {
-        auto insn = get_def(id);
-        assert(insn != end());
-
-        if (insn.opcode() == spv::OpVariable &&
-            (insn.word(3) == spv::StorageClassUniform ||
-             insn.word(3) == spv::StorageClassUniformConstant ||
-             insn.word(3) == spv::StorageClassStorageBuffer)) {
-            auto d = get_decorations(insn.word(2));
+        const Instruction* insn = FindDef(id);
+        const uint32_t storage_class = insn->word(3);
+        if (insn->opcode() == spv::OpVariable &&
+            (storage_class == spv::StorageClassUniform || storage_class == spv::StorageClassUniformConstant ||
+             storage_class == spv::StorageClassStorageBuffer)) {
+            auto d = get_decorations(insn->word(2));
             uint32_t set = d.descriptor_set;
             uint32_t binding = d.binding;
 
             interface_var v = {};
-            v.id = insn.word(2);
-            v.type_id = insn.word(1);
+            v.id = insn->word(2);
+            v.type_id = insn->word(1);
 
-            IsSpecificDescriptorType(insn, insn.word(3) == spv::StorageClassStorageBuffer,
+            IsSpecificDescriptorType(insn, storage_class == spv::StorageClassStorageBuffer,
                                      !(d.flags & decoration_set::nonwritable_bit), v);
             out.emplace_back(DescriptorSlot{set, binding}, v);
         }
@@ -1567,14 +1536,13 @@ std::vector<std::pair<DescriptorSlot, interface_var>> SHADER_MODULE_STATE::Colle
     return out;
 }
 
-layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationinFS(
-    const spirv_inst_iter &entrypoint) const {
+layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationinFS(const Instruction* entrypoint) const {
     layer_data::unordered_set<uint32_t> location_list;
     const auto outputs = CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, false);
     layer_data::unordered_set<uint32_t> store_pointer_ids;
     layer_data::unordered_map<uint32_t, uint32_t> accesschain_members;
 
-    for (auto insn : *this) {
+    for (const Instruction& insn : GetInstructions()) {
         switch (insn.opcode()) {
             case spv::OpStore:
             case spv::OpAtomicStore: {
@@ -1624,8 +1592,8 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
                                                        uint32_t id, uint32_t type_id, bool is_patch,
                                                        uint32_t /*first_location*/) const {
     // Walk down the type_id presented, trying to determine whether it's actually an interface block.
-    auto type = GetStructType(get_def(type_id), is_array_of_verts && !is_patch);
-    if (type == end() || !(get_decorations(type.word(1)).flags & decoration_set::block_bit)) {
+    const Instruction* type = GetStructType(FindDef(type_id), is_array_of_verts && !is_patch);
+    if (!type || !(get_decorations(type->word(1)).flags & decoration_set::block_bit)) {
         // This isn't an interface block.
         return false;
     }
@@ -1635,20 +1603,21 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
     layer_data::unordered_map<uint32_t, uint32_t> member_patch;
 
     // Walk all the OpMemberDecorate for type's result id -- first pass, collect components.
-    for (auto insn : static_data_.member_decoration_inst) {
-        if (insn.word(1) == type.word(1)) {
-            uint32_t member_index = insn.word(2);
+    for (const Instruction* insn : static_data_.member_decoration_inst) {
+        if (insn->word(1) == type->word(1)) {
+            uint32_t member_index = insn->word(2);
+            uint32_t decoration = insn->word(3);
 
-            if (insn.word(3) == spv::DecorationComponent) {
-                uint32_t component = insn.word(4);
+            if (decoration == spv::DecorationComponent) {
+                uint32_t component = insn->word(4);
                 member_components[member_index] = component;
             }
 
-            if (insn.word(3) == spv::DecorationRelaxedPrecision) {
+            if (decoration == spv::DecorationRelaxedPrecision) {
                 member_relaxed_precision[member_index] = 1;
             }
 
-            if (insn.word(3) == spv::DecorationPatch) {
+            if (decoration == spv::DecorationPatch) {
                 member_patch[member_index] = 1;
             }
         }
@@ -1657,13 +1626,13 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
     // TODO: correctly handle location assignment from outside
 
     // Second pass -- produce the output, from Location decorations
-    for (auto insn : static_data_.member_decoration_inst) {
-        if (insn.word(1) == type.word(1)) {
-            uint32_t member_index = insn.word(2);
-            uint32_t member_type_id = type.word(2 + member_index);
+    for (const Instruction* insn : static_data_.member_decoration_inst) {
+        if (insn->word(1) == type->word(1)) {
+            uint32_t member_index = insn->word(2);
+            uint32_t member_type_id = type->word(2 + member_index);
 
-            if (insn.word(3) == spv::DecorationLocation) {
-                uint32_t location = insn.word(4);
+            if (insn->word(3) == spv::DecorationLocation) {
+                uint32_t location = insn->word(4);
                 uint32_t num_locations = GetLocationsConsumedByType(member_type_id, false);
                 auto component_it = member_components.find(member_index);
                 uint32_t component = component_it == member_components.end() ? 0 : component_it->second;
@@ -1688,7 +1657,7 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, inte
     return true;
 }
 
-std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocation(spirv_inst_iter entrypoint,
+std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocation(const Instruction* entrypoint,
                                                                                     spv::StorageClass sinterface,
                                                                                     bool is_array_of_verts) const {
     // TODO: handle index=1 dual source outputs from FS -- two vars will have the same location, and we DON'T want to clobber.
@@ -1696,16 +1665,15 @@ std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocat
     std::map<location_t, interface_var> out;
 
     for (uint32_t iid : FindEntrypointInterfaces(entrypoint)) {
-        auto insn = get_def(iid);
-        assert(insn != end());
-        assert(insn.opcode() == spv::OpVariable);
+        const Instruction* insn = FindDef(iid);
+        assert(insn->opcode() == spv::OpVariable);
 
         const auto d = get_decorations(iid);
-        bool passthrough = sinterface == spv::StorageClassOutput && insn.word(3) == spv::StorageClassInput &&
+        bool passthrough = sinterface == spv::StorageClassOutput && insn->word(3) == spv::StorageClassInput &&
                            (d.flags & decoration_set::passthrough_bit) != 0;
-        if (insn.word(3) == static_cast<uint32_t>(sinterface) || passthrough) {
-            uint32_t id = insn.word(2);
-            uint32_t type = insn.word(1);
+        if (insn->word(3) == static_cast<uint32_t>(sinterface) || passthrough) {
+            uint32_t id = insn->word(2);
+            uint32_t type = insn->word(1);
 
             auto location = d.location;
             int builtin = d.builtin;
@@ -1737,38 +1705,38 @@ std::map<location_t, interface_var> SHADER_MODULE_STATE::CollectInterfaceByLocat
     return out;
 }
 
-std::vector<uint32_t> SHADER_MODULE_STATE::CollectBuiltinBlockMembers(spirv_inst_iter entrypoint, uint32_t storageClass) const {
+std::vector<uint32_t> SHADER_MODULE_STATE::CollectBuiltinBlockMembers(const Instruction* entrypoint, uint32_t storageClass) const {
     // Find all interface variables belonging to the entrypoint and matching the storage class
     std::vector<uint32_t> variables;
     for (uint32_t id : FindEntrypointInterfaces(entrypoint)) {
-        auto def = get_def(id);
-        assert(def != end());
-        assert(def.opcode() == spv::OpVariable);
+        const Instruction* def = FindDef(id);
+        assert(def->opcode() == spv::OpVariable);
 
-        if (def.word(3) == storageClass) variables.push_back(def.word(1));
+        if (def->word(3) == storageClass) variables.push_back(def->word(1));
     }
 
     // Find all members belonging to the builtin block selected
     std::vector<uint32_t> builtin_block_members;
     for (auto &var : variables) {
-        auto def = get_def(get_def(var).word(3));
+        const Instruction* def = FindDef(FindDef(var)->word(3));
 
         // It could be an array of IO blocks. The element type should be the struct defining the block contents
-        if (def.opcode() == spv::OpTypeArray) def = get_def(def.word(2));
+        if (def->opcode() == spv::OpTypeArray) {
+            def = FindDef(def->word(2));
+        }
 
         // Now find all members belonging to the struct defining the IO block
-        if (def.opcode() == spv::OpTypeStruct) {
-            for (auto set : static_data_.builtin_decoration_list) {
-                auto insn = at(set.offset);
-                if ((insn.opcode() == spv::OpMemberDecorate) && (def.word(1) == insn.word(1))) {
+        if (def->opcode() == spv::OpTypeStruct) {
+            for (const Instruction* insn : GetBuiltinDecorationList()) {
+                if ((insn->opcode() == spv::OpMemberDecorate) && (def->word(1) == insn->word(1))) {
                     // Start with undefined builtin for each struct member.
                     // But only when confirmed the struct is the built-in inteface block (can only be one per shader)
                     if (builtin_block_members.size() == 0) {
-                        builtin_block_members.resize(def.len() - 2, spv::BuiltInMax);
+                        builtin_block_members.resize(def->length() - 2, spv::BuiltInMax);
                     }
-                    auto struct_index = insn.word(2);
+                    auto struct_index = insn->word(2);
                     assert(struct_index < builtin_block_members.size());
-                    builtin_block_members[struct_index] = insn.word(4);
+                    builtin_block_members[struct_index] = insn->word(4);
                 }
             }
         }
@@ -1781,20 +1749,19 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
     layer_data::unordered_set<uint32_t> const &accessible_ids) const {
     std::vector<std::pair<uint32_t, interface_var>> out;
 
-    for (auto insn : static_data_.decoration_inst) {
-        if (insn.word(2) == spv::DecorationInputAttachmentIndex) {
-            auto attachment_index = insn.word(3);
-            auto id = insn.word(1);
+    for (const Instruction* insn : GetDecorationInstructions()) {
+        if (insn->word(2) == spv::DecorationInputAttachmentIndex) {
+            auto attachment_index = insn->word(3);
+            auto id = insn->word(1);
 
             if (accessible_ids.count(id)) {
-                auto def = get_def(id);
-                assert(def != end());
-                if (def.opcode() == spv::OpVariable && def.word(3) == spv::StorageClassUniformConstant) {
-                    auto num_locations = GetLocationsConsumedByType(def.word(1), false);
+                const Instruction* def = FindDef(id);
+                if (def->opcode() == spv::OpVariable && def->word(3) == spv::StorageClassUniformConstant) {
+                    auto num_locations = GetLocationsConsumedByType(def->word(1), false);
                     for (uint32_t offset = 0; offset < num_locations; offset++) {
                         interface_var v = {};
                         v.id = id;
-                        v.type_id = def.word(1);
+                        v.type_id = def->word(1);
                         v.offset = offset;
                         out.emplace_back(attachment_index + offset, v);
                     }
@@ -1806,66 +1773,66 @@ std::vector<std::pair<uint32_t, interface_var>> SHADER_MODULE_STATE::CollectInte
     return out;
 }
 
-uint32_t SHADER_MODULE_STATE::GetNumComponentsInBaseType(const spirv_inst_iter &iter) const {
-    const uint32_t opcode = iter.opcode();
+uint32_t SHADER_MODULE_STATE::GetNumComponentsInBaseType(const Instruction* insn) const {
+    const uint32_t opcode = insn->opcode();
     if (opcode == spv::OpTypeFloat || opcode == spv::OpTypeInt) {
         return 1;
     } else if (opcode == spv::OpTypeVector) {
-        const uint32_t component_count = iter.word(3);
+        const uint32_t component_count = insn->word(3);
         return component_count;
     } else if (opcode == spv::OpTypeMatrix) {
-        const auto column_type = get_def(iter.word(2));
+        const Instruction* column_type = FindDef(insn->word(2));
         const uint32_t vector_length = GetNumComponentsInBaseType(column_type);
         // Because we are calculating components for a single location we do not care about column count
         return vector_length;
     } else if (opcode == spv::OpTypeArray) {
-        const auto element_type = get_def(iter.word(2));
+        const Instruction* element_type = FindDef(insn->word(2));
         const uint32_t element_length = GetNumComponentsInBaseType(element_type);
         return element_length;
     } else if (opcode == spv::OpTypeStruct) {
         uint32_t total_size = 0;
-        for (uint32_t i = 2; i < iter.len(); ++i) {
-            total_size += GetNumComponentsInBaseType(get_def(iter.word(i)));
+        for (uint32_t i = 2; i < insn->length(); ++i) {
+            total_size += GetNumComponentsInBaseType(FindDef(insn->word(i)));
         }
         return total_size;
     } else if (opcode == spv::OpTypePointer) {
-        const auto type = get_def(iter.word(3));
+        const Instruction* type = FindDef(insn->word(3));
         return GetNumComponentsInBaseType(type);
     }
     return 0;
 }
 
-uint32_t SHADER_MODULE_STATE::GetTypeBitsSize(const spirv_inst_iter &iter) const {
-    const uint32_t opcode = iter.opcode();
+uint32_t SHADER_MODULE_STATE::GetTypeBitsSize(const Instruction* insn) const {
+    const uint32_t opcode = insn->opcode();
     if (opcode == spv::OpTypeFloat || opcode == spv::OpTypeInt) {
-        return iter.word(2);
+        return insn->word(2);
     } else if (opcode == spv::OpTypeVector) {
-        const auto component_type = get_def(iter.word(2));
+        const Instruction* component_type = FindDef(insn->word(2));
         uint32_t scalar_width = GetTypeBitsSize(component_type);
-        uint32_t component_count = iter.word(3);
+        uint32_t component_count = insn->word(3);
         return scalar_width * component_count;
     } else if (opcode == spv::OpTypeMatrix) {
-        const auto column_type = get_def(iter.word(2));
+        const Instruction* column_type = FindDef(insn->word(2));
         uint32_t vector_width = GetTypeBitsSize(column_type);
-        uint32_t column_count = iter.word(3);
+        uint32_t column_count = insn->word(3);
         return vector_width * column_count;
     } else if (opcode == spv::OpTypeArray) {
-        const auto element_type = get_def(iter.word(2));
+        const Instruction* element_type = FindDef(insn->word(2));
         uint32_t element_width = GetTypeBitsSize(element_type);
-        const auto length_type = get_def(iter.word(3));
+        const Instruction* length_type = FindDef(insn->word(3));
         uint32_t length = GetConstantValue(length_type);
         return element_width * length;
     } else if (opcode == spv::OpTypeStruct) {
         uint32_t total_size = 0;
-        for (uint32_t i = 2; i < iter.len(); ++i) {
-            total_size += GetTypeBitsSize(get_def(iter.word(i)));
+        for (uint32_t i = 2; i < insn->length(); ++i) {
+            total_size += GetTypeBitsSize(FindDef(insn->word(i)));
         }
         return total_size;
     } else if (opcode == spv::OpTypePointer) {
-        const auto type = get_def(iter.word(3));
+        const Instruction* type = FindDef(insn->word(3));
         return GetTypeBitsSize(type);
     } else if (opcode == spv::OpVariable) {
-        const auto type = get_def(iter.word(1));
+        const Instruction* type = FindDef(insn->word(1));
         return GetTypeBitsSize(type);
     } else if (opcode == spv::OpTypeBool) {
         // The Spec states:
@@ -1876,28 +1843,28 @@ uint32_t SHADER_MODULE_STATE::GetTypeBitsSize(const spirv_inst_iter &iter) const
     return 0;
 }
 
-uint32_t SHADER_MODULE_STATE::GetTypeBytesSize(const spirv_inst_iter &iter) const { return GetTypeBitsSize(iter) / 8; }
+uint32_t SHADER_MODULE_STATE::GetTypeBytesSize(const Instruction* insn) const { return GetTypeBitsSize(insn) / 8; }
 
 // Returns the base type (float, int or unsigned int) or struct (can have multiple different base types inside)
 // Will return 0 if it can not be determined
-uint32_t SHADER_MODULE_STATE::GetBaseType(const spirv_inst_iter &iter) const {
-    const uint32_t opcode = iter.opcode();
+uint32_t SHADER_MODULE_STATE::GetBaseType(const Instruction* insn) const {
+    const uint32_t opcode = insn->opcode();
     if (opcode == spv::OpTypeFloat || opcode == spv::OpTypeInt || opcode == spv::OpTypeBool || opcode == spv::OpTypeStruct) {
         // point to itself as its the base type (or a struct that needs to be traversed still)
-        return iter.word(1);
+        return insn->word(1);
     } else if (opcode == spv::OpTypeVector) {
-        const auto& component_type = get_def(iter.word(2));
+        const Instruction* component_type = FindDef(insn->word(2));
         return GetBaseType(component_type);
     } else if (opcode == spv::OpTypeMatrix) {
-        const auto& column_type = get_def(iter.word(2));
+        const Instruction* column_type = FindDef(insn->word(2));
         return GetBaseType(column_type);
     } else if (opcode == spv::OpTypeArray || opcode == spv::OpTypeRuntimeArray) {
-        const auto& element_type = get_def(iter.word(2));
+        const Instruction* element_type = FindDef(insn->word(2));
         return GetBaseType(element_type);
     } else if (opcode == spv::OpTypePointer) {
-        const auto &storage_class = iter.word(2);
-        const auto& type = get_def(iter.word(3));
-        if (storage_class == spv::StorageClassPhysicalStorageBuffer && type.opcode() == spv::OpTypeStruct) {
+        const auto& storage_class = insn->word(2);
+        const Instruction* type = FindDef(insn->word(3));
+        if (storage_class == spv::StorageClassPhysicalStorageBuffer && type->opcode() == spv::OpTypeStruct) {
             // A physical storage buffer to a struct has a chance to point to itself and can't resolve a baseType
             // GLSL example:
             // layout(buffer_reference) buffer T1 {
@@ -1915,23 +1882,25 @@ uint32_t SHADER_MODULE_STATE::GetBaseType(const spirv_inst_iter &iter) const {
 
 // Returns type_id if id has type or zero otherwise
 uint32_t SHADER_MODULE_STATE::GetTypeId(uint32_t id) const {
-    const auto type = get_def(id);
-    return OpcodeHasType(type.opcode()) ? type.word(1) : 0;
+    const Instruction* type = FindDef(id);
+    return type ? type->word(type->TypeId()) : 0;
 }
 
-std::vector<uint32_t> FindEntrypointInterfaces(const spirv_inst_iter &entrypoint) {
-    assert(entrypoint.opcode() == spv::OpEntryPoint);
+std::vector<uint32_t> FindEntrypointInterfaces(const Instruction* entrypoint) {
+    assert(entrypoint->opcode() == spv::OpEntryPoint);
 
     std::vector<uint32_t> interfaces;
     // Find the end of the entrypoint's name string. additional zero bytes follow the actual null terminator, to fill out the
     // rest of the word - so we only need to look at the last byte in the word to determine which word contains the terminator.
     uint32_t word = 3;
-    while (entrypoint.word(word) & 0xff000000u) {
+    while (entrypoint->word(word) & 0xff000000u) {
         ++word;
     }
     ++word;
 
-    for (; word < entrypoint.len(); word++) interfaces.push_back(entrypoint.word(word));
+    for (; word < entrypoint->length(); word++) {
+        interfaces.push_back(entrypoint->word(word));
+    }
 
     return interfaces;
 }

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -1515,10 +1515,12 @@ std::vector<std::pair<DescriptorSlot, interface_var>> SHADER_MODULE_STATE::Colle
 
     for (auto id : accessible_ids) {
         const Instruction* insn = FindDef(id);
+        if (insn->Opcode() != spv::OpVariable) {
+            continue;
+        }
         const uint32_t storage_class = insn->Word(3);
-        if (insn->Opcode() == spv::OpVariable &&
-            (storage_class == spv::StorageClassUniform || storage_class == spv::StorageClassUniformConstant ||
-             storage_class == spv::StorageClassStorageBuffer)) {
+        if (storage_class == spv::StorageClassUniform || storage_class == spv::StorageClassUniformConstant ||
+            storage_class == spv::StorageClassStorageBuffer) {
             auto d = get_decorations(insn->Word(2));
             uint32_t set = d.descriptor_set;
             uint32_t binding = d.binding;

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -216,7 +216,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     struct StaticData {
         StaticData() = default;
         StaticData(const SHADER_MODULE_STATE &module_state);
-        StaticData &operator=(const StaticData &) = default;
+        // because there is a std::reference_wrapper value in here there is no copy constructor
+        StaticData &operator=(StaticData &&) = default;
         StaticData(StaticData &&) = default;
 
         // List of all instructions in the order they appear in the binary

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -205,7 +205,7 @@ struct shader_struct_member {
 
 struct SHADER_MODULE_STATE : public BASE_NODE {
     struct EntryPoint {
-        const Instruction *insn;  // OpEntryPoint instruction
+        const Instruction &insn;  // OpEntryPoint instruction
         VkShaderStageFlagBits stage;
         std::vector<function_set> function_set_list;
         shader_struct_member push_constant_used_in_shader;
@@ -329,7 +329,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::string DescribeInstruction(const Instruction *insn) const;
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(const Instruction *entrypoint) const;
-    layer_data::optional<VkPrimitiveTopology> GetTopology(const Instruction *entrypoint) const;
+    layer_data::optional<VkPrimitiveTopology> GetTopology(const Instruction &entrypoint) const;
     // TODO (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450)
     // Since we currently don't support multiple entry points, this is a helper to return the topology
     // for the "first" (and for our purposes _only_) entrypoint.

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -205,7 +205,7 @@ struct shader_struct_member {
 
 struct SHADER_MODULE_STATE : public BASE_NODE {
     struct EntryPoint {
-        const Instruction &insn;  // OpEntryPoint instruction
+        std::reference_wrapper<const Instruction> insn;  // OpEntryPoint instruction
         VkShaderStageFlagBits stage;
         std::vector<function_set> function_set_list;
         shader_struct_member push_constant_used_in_shader;

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -123,7 +123,7 @@ struct interface_var {
           is_dref_operation(false) {}
 };
 
-std::vector<uint32_t> FindEntrypointInterfaces(const Instruction *entrypoint);
+std::vector<uint32_t> FindEntrypointInterfaces(const Instruction &entrypoint);
 
 enum FORMAT_TYPE {
     FORMAT_TYPE_FLOAT = 1,  // UNORM, SNORM, FLOAT, USCALED, SSCALED, SRGB -- anything we consider float in the shader
@@ -328,7 +328,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::string DescribeType(uint32_t type) const;
     std::string DescribeInstruction(const Instruction *insn) const;
 
-    layer_data::unordered_set<uint32_t> MarkAccessibleIds(const Instruction *entrypoint) const;
+    layer_data::unordered_set<uint32_t> MarkAccessibleIds(layer_data::optional<Instruction> entrypoint) const;
     layer_data::optional<VkPrimitiveTopology> GetTopology(const Instruction &entrypoint) const;
     // TODO (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450)
     // Since we currently don't support multiple entry points, this is a helper to return the topology
@@ -336,8 +336,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     layer_data::optional<VkPrimitiveTopology> GetTopology() const;
 
     const EntryPoint *FindEntrypointStruct(char const *name, VkShaderStageFlagBits stageBits) const;
-    const Instruction *FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
-    bool FindLocalSize(const Instruction *entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
+    layer_data::optional<Instruction> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
+    bool FindLocalSize(const Instruction &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
 
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValue(const Instruction *insn) const;
@@ -350,19 +350,19 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     uint32_t DescriptorTypeToReqs(uint32_t type_id) const;
 
-    bool IsBuiltInWritten(const Instruction *builtin_insn, const Instruction *entrypoint) const;
+    bool IsBuiltInWritten(const Instruction *builtin_insn, const Instruction &entrypoint) const;
 
     // State tracking helpers for collecting interface information
     void IsSpecificDescriptorType(const Instruction *insn, bool is_storage_buffer, bool is_check_writable,
                                   interface_var &out_interface_var) const;
     std::vector<std::pair<DescriptorSlot, interface_var>> CollectInterfaceByDescriptorSlot(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
-    layer_data::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const Instruction *entrypoint) const;
+    layer_data::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const Instruction &entrypoint) const;
     bool CollectInterfaceBlockMembers(std::map<location_t, interface_var> *out, bool is_array_of_verts, uint32_t id,
                                       uint32_t type_id, bool is_patch, uint32_t first_location) const;
-    std::map<location_t, interface_var> CollectInterfaceByLocation(const Instruction *entrypoint, spv::StorageClass sinterface,
+    std::map<location_t, interface_var> CollectInterfaceByLocation(const Instruction &entrypoint, spv::StorageClass sinterface,
                                                                    bool is_array_of_verts) const;
-    std::vector<uint32_t> CollectBuiltinBlockMembers(const Instruction *entrypoint, uint32_t storageClass) const;
+    std::vector<uint32_t> CollectBuiltinBlockMembers(const Instruction &entrypoint, uint32_t storageClass) const;
     std::vector<std::pair<uint32_t, interface_var>> CollectInterfaceByInputAttachmentIndex(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -348,19 +348,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     uint32_t GetFundamentalType(uint32_t type) const;
     const Instruction *GetStructType(const Instruction *insn, bool is_array_of_verts) const;
 
-    void DefineStructMember(const Instruction *insn, std::vector<const Instruction *> &member_decorate_insn,
-                            shader_struct_member &data) const;
-    void RunUsedArray(uint32_t offset, std::vector<uint32_t> array_indices, uint32_t access_chain_word_index,
-                      const Instruction *access_chain, const shader_struct_member &data) const;
-    void RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, const Instruction *access_chain,
-                       const shader_struct_member &data) const;
-    void SetUsedStructMember(const uint32_t variable_id, const std::vector<function_set> &function_set_list,
-                             const shader_struct_member &data) const;
-
-    // Push consants
-    static void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &module_state,
-                                            std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> &entry_points);
-
     uint32_t DescriptorTypeToReqs(uint32_t type_id) const;
 
     bool IsBuiltInWritten(const Instruction *builtin_insn, const Instruction *entrypoint) const;
@@ -395,10 +382,27 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
                            [](const spv::Capability &capability) { return capability == spv::CapabilityInputAttachment; });
     }
 
+    // Used to set push constants values at shader module initialization time
+    static void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &module_state,
+                                            std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> &entry_points);
+
   private:
     // Functions used for initialization only
     // Used to populate the shader module object
     void PreprocessShaderBinary(spv_target_env env);
+
+    // The following are all helper functions to set the push constants values by tracking if the values are accessed in the entry
+    // point functions and which offset in the structs are used
+    uint32_t UpdateOffset(uint32_t offset, const std::vector<uint32_t> &array_indices, const shader_struct_member &data) const;
+    void SetUsedBytes(uint32_t offset, const std::vector<uint32_t> &array_indices, const shader_struct_member &data) const;
+    void DefineStructMember(const Instruction *insn, std::vector<const Instruction *> &member_decorate_insn,
+                            shader_struct_member &data) const;
+    void RunUsedArray(uint32_t offset, std::vector<uint32_t> array_indices, uint32_t access_chain_word_index,
+                      const Instruction *access_chain, const shader_struct_member &data) const;
+    void RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, const Instruction *access_chain,
+                       const shader_struct_member &data) const;
+    void SetUsedStructMember(const uint32_t variable_id, const std::vector<function_set> &function_set_list,
+                             const shader_struct_member &data) const;
 };
 
 #endif  // VULKAN_SHADER_MODULE_H

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "shader_instruction.h"
 #include "base_node.h"
 #include "sampler_state.h"
 #include <spirv/unified1/spirv.hpp>
@@ -122,8 +123,7 @@ struct interface_var {
           is_dref_operation(false) {}
 };
 
-// Utils taking a spirv_inst_iter
-std::vector<uint32_t> FindEntrypointInterfaces(const spirv_inst_iter &entrypoint);
+std::vector<uint32_t> FindEntrypointInterfaces(const Instruction *entrypoint);
 
 enum FORMAT_TYPE {
     FORMAT_TYPE_FLOAT = 1,  // UNORM, SNORM, FLOAT, USCALED, SSCALED, SRGB -- anything we consider float in the shader
@@ -167,28 +167,8 @@ struct decoration_set {
     void add(uint32_t decoration, uint32_t value);
 };
 
-struct atomic_instruction {
-    uint32_t storage_class;
-    uint32_t bit_width;
-    uint32_t type;  // ex. OpTypeInt
-
-    atomic_instruction() : storage_class(0), bit_width(0), type(0) {}
-};
-
 struct function_set {
-    uint32_t id;
-    uint32_t offset;
-    uint32_t length;
-    std::unordered_multimap<uint32_t, uint32_t> op_lists;  // key: spv::Op,  value: offset
-
-    function_set() : id(0), offset(0), length(0) {}
-};
-
-struct builtin_set {
-    uint32_t offset;  // offset to instruction (OpDecorate or OpMemberDecorate)
-    spv::BuiltIn builtin;
-
-    builtin_set(uint32_t offset, spv::BuiltIn builtin) : offset(offset), builtin(builtin) {}
+    std::vector<const Instruction *> op_lists;
 };
 
 // Contains all the details for a OpTypeStruct
@@ -225,40 +205,30 @@ struct shader_struct_member {
 
 struct SHADER_MODULE_STATE : public BASE_NODE {
     struct EntryPoint {
-        uint32_t offset;  // into module to get OpEntryPoint instruction
+        const Instruction *insn;  // OpEntryPoint instruction
         VkShaderStageFlagBits stage;
-        std::unordered_multimap<uint32_t, uint32_t> decorate_list;  // key: spv::Op,  value: offset
         std::vector<function_set> function_set_list;
         shader_struct_member push_constant_used_in_shader;
     };
 
     // Static/const data extracted from a SPIRV module.
-    struct SpirvStaticData {
-        SpirvStaticData() = default;
-        SpirvStaticData(const SHADER_MODULE_STATE &module_state);
-        SpirvStaticData &operator=(const SpirvStaticData &) = default;
-        SpirvStaticData(SpirvStaticData &&) = default;
-
-        // A mapping of <id> to the first word of its def. this is useful because walking type
-        // trees, constant expressions, etc requires jumping all over the instruction stream.
-        layer_data::unordered_map<uint32_t, uint32_t> def_index;
+    struct StaticData {
         layer_data::unordered_map<uint32_t, decoration_set> decorations;
         // <Specialization constant ID -> target ID> mapping
         layer_data::unordered_map<uint32_t, uint32_t> spec_const_map;
         // Find all decoration instructions to prevent relooping module later - many checks need this info
-        std::vector<spirv_inst_iter> decoration_inst;
-        std::vector<spirv_inst_iter> member_decoration_inst;
+        std::vector<const Instruction *> decoration_inst;
+        std::vector<const Instruction *> member_decoration_inst;
         // Find all variable instructions to prevent relookping module later
-        std::vector<spirv_inst_iter> variable_inst;
+        std::vector<const Instruction *> variable_inst;
         // Execution are not tied to an entry point and are their own mapping tied to entry point function
         // [OpEntryPoint function <id> operand] : [Execution Mode Instruction list]
-        layer_data::unordered_map<uint32_t, std::vector<spirv_inst_iter>> execution_mode_inst;
+        layer_data::unordered_map<uint32_t, std::vector<const Instruction *>> execution_mode_inst;
         // both OpDecorate and OpMemberDecorate builtin instructions
-        std::vector<builtin_set> builtin_decoration_list;
-        std::unordered_map<uint32_t, atomic_instruction> atomic_inst;
+        std::vector<const Instruction *> builtin_decoration_inst;
+        std::vector<const Instruction *> atomic_inst;
         std::vector<spv::Capability> capability_list;
 
-        bool has_group_decoration{false};
         bool has_specialization_constants{false};
         bool has_invocation_repack_instruction{false};
 
@@ -267,61 +237,70 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         bool multiple_entry_points{false};
     };
 
-    // The spirv image itself
-    // NOTE: this _must_ be initialized first.
-    // NOTE: this may end up being an _optimized_ version of what was passed in at initialization time.
-    const std::vector<uint32_t> words;
-
-    const SpirvStaticData static_data_;
+    // This is the SPIR-V module data content
+    const std::vector<uint32_t> words_;
+    // List of all instructions in the order they appear in the binary
+    std::vector<Instruction> instructions_;
+    // Instructions that can be referenced by Ids
+    // A mapping of <id> to the first word of its def. this is useful because walking type
+    // trees, constant expressions, etc requires jumping all over the instruction stream.
+    layer_data::unordered_map<uint32_t, const Instruction *> definitions_;
 
     const bool has_valid_spirv{false};
     const uint32_t gpu_validation_shader_id{std::numeric_limits<uint32_t>::max()};
 
+    bool has_group_decoration{false};
+
     SHADER_MODULE_STATE(const uint32_t *code, std::size_t count, spv_target_env env = SPV_ENV_VULKAN_1_0)
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          words(code, code + (count / sizeof(uint32_t))),
-          static_data_(*this) {
+          words_(code, code + (count / sizeof(uint32_t))) {
+        ParseWords();
         PreprocessShaderBinary(env);
+        SetStaticData();
     }
 
     template <typename SpirvContainer>
     SHADER_MODULE_STATE(const SpirvContainer &spirv)
         : SHADER_MODULE_STATE(spirv.data(), spirv.size() * sizeof(typename SpirvContainer::value_type)) {}
 
-    SHADER_MODULE_STATE(const VkShaderModuleCreateInfo &create_info, spv_target_env env, uint32_t unique_shader_id)
-        : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          words(create_info.pCode, create_info.pCode + create_info.codeSize / sizeof(uint32_t)),
-          static_data_(*this),
-          has_valid_spirv(true),
-          gpu_validation_shader_id(unique_shader_id) {
-        PreprocessShaderBinary(env);
-    }
-
     SHADER_MODULE_STATE(const VkShaderModuleCreateInfo &create_info, VkShaderModule shaderModule, spv_target_env env,
                         uint32_t unique_shader_id)
         : BASE_NODE(shaderModule, kVulkanObjectTypeShaderModule),
-          words(create_info.pCode, create_info.pCode + create_info.codeSize / sizeof(uint32_t)),
-          static_data_(*this),
+          words_(create_info.pCode, create_info.pCode + create_info.codeSize / sizeof(uint32_t)),
           has_valid_spirv(true),
           gpu_validation_shader_id(unique_shader_id) {
+        ParseWords();
         PreprocessShaderBinary(env);
+        SetStaticData();
     }
 
     SHADER_MODULE_STATE() : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule) {}
 
-    const std::vector<spirv_inst_iter> &GetDecorationInstructions() const { return static_data_.decoration_inst; }
+    void ParseWords();
+    void SetStaticData();
 
-    const std::unordered_map<uint32_t, atomic_instruction> &GetAtomicInstructions() const { return static_data_.atomic_inst; }
+    const Instruction *FindDef(uint32_t id) const {
+        auto it = definitions_.find(id);
+        if (it == definitions_.end()) return nullptr;
+        return it->second;
+    }
 
-    const layer_data::unordered_map<uint32_t, std::vector<spirv_inst_iter>> &GetExecutionModeInstructions() const {
+    const std::vector<Instruction> &GetInstructions() const { return instructions_; }
+    const std::vector<const Instruction *> &GetDecorationInstructions() const { return static_data_.decoration_inst; }
+    const std::vector<const Instruction *> &GetMemberDecorationInstructions() const { return static_data_.member_decoration_inst; }
+    const std::vector<const Instruction *> &GetAtomicInstructions() const { return static_data_.atomic_inst; }
+    const std::vector<const Instruction *> &GetVariableInstructions() const { return static_data_.variable_inst; }
+
+    const layer_data::unordered_map<uint32_t, std::vector<const Instruction *>> &GetExecutionModeInstructions() const {
         return static_data_.execution_mode_inst;
     }
 
-    const std::vector<builtin_set> &GetBuiltinDecorationList() const { return static_data_.builtin_decoration_list; }
+    const std::vector<const Instruction *> &GetBuiltinDecorationList() const { return static_data_.builtin_decoration_inst; }
 
     const layer_data::unordered_map<uint32_t, uint32_t> &GetSpecConstMap() const { return static_data_.spec_const_map; }
 
     bool HasSpecConstants() const { return static_data_.has_specialization_constants; }
+    bool HasInvocationRepackInstruction() const { return static_data_.has_invocation_repack_instruction; }
 
     const std::unordered_multimap<std::string, EntryPoint> &GetEntryPoints() const { return static_data_.entry_points; }
 
@@ -337,86 +316,74 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     }
 
     // Expose begin() / end() to enable range-based for
-    spirv_inst_iter begin() const { return spirv_inst_iter(words.begin(), words.begin() + 5); }  // First insn
-    spirv_inst_iter end() const { return spirv_inst_iter(words.begin(), words.end()); }          // Just past last insn
-    // Given an offset into the module, produce an iterator there.
-    spirv_inst_iter at(uint32_t offset) const { return spirv_inst_iter(words.begin(), words.begin() + offset); }
-
-    // Gets an iterator to the definition of an id
-    spirv_inst_iter get_def(uint32_t id) const {
-        auto it = static_data_.def_index.find(id);
-        if (it == static_data_.def_index.end()) {
-            return end();
-        }
-        return at(it->second);
-    }
+    spirv_inst_iter begin() const { return spirv_inst_iter(words_.begin(), words_.begin() + 5); }  // First insn
+    spirv_inst_iter end() const { return spirv_inst_iter(words_.begin(), words_.end()); }          // Just past last insn
 
     // Used to get human readable strings for error messages
     void DescribeTypeInner(std::ostringstream &ss, uint32_t type) const;
     std::string DescribeType(uint32_t type) const;
-    std::string DescribeInstruction(const spirv_inst_iter &insn) const;
+    std::string DescribeInstruction(const Instruction *insn) const;
 
-    layer_data::unordered_set<uint32_t> MarkAccessibleIds(spirv_inst_iter entrypoint) const;
-    layer_data::optional<VkPrimitiveTopology> GetTopology(const spirv_inst_iter &entrypoint) const;
+    layer_data::unordered_set<uint32_t> MarkAccessibleIds(const Instruction *entrypoint) const;
+    layer_data::optional<VkPrimitiveTopology> GetTopology(const Instruction *entrypoint) const;
     // TODO (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450)
     // Since we currently don't support multiple entry points, this is a helper to return the topology
     // for the "first" (and for our purposes _only_) entrypoint.
     layer_data::optional<VkPrimitiveTopology> GetTopology() const;
 
     const EntryPoint *FindEntrypointStruct(char const *name, VkShaderStageFlagBits stageBits) const;
-    spirv_inst_iter FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
-    bool FindLocalSize(const spirv_inst_iter &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y,
-                       uint32_t &local_size_z) const;
+    const Instruction *FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
+    bool FindLocalSize(const Instruction *entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
 
-    spirv_inst_iter GetConstantDef(uint32_t id) const;
-    uint32_t GetConstantValue(const spirv_inst_iter &itr) const;
+    const Instruction *GetConstantDef(uint32_t id) const;
+    uint32_t GetConstantValue(const Instruction *insn) const;
     uint32_t GetConstantValueById(uint32_t id) const;
     int32_t GetShaderResourceDimensionality(const interface_var &resource) const;
     uint32_t GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const;
     uint32_t GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const;
     uint32_t GetFundamentalType(uint32_t type) const;
-    spirv_inst_iter GetStructType(spirv_inst_iter def, bool is_array_of_verts) const;
+    const Instruction *GetStructType(const Instruction *insn, bool is_array_of_verts) const;
 
-    void DefineStructMember(const spirv_inst_iter &it, const std::vector<uint32_t> &member_decorate_offsets,
+    void DefineStructMember(const Instruction *insn, std::vector<const Instruction *> &member_decorate_insn,
                             shader_struct_member &data) const;
     void RunUsedArray(uint32_t offset, std::vector<uint32_t> array_indices, uint32_t access_chain_word_index,
-                      spirv_inst_iter &access_chain_it, const shader_struct_member &data) const;
-    void RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, spirv_inst_iter &access_chain_it,
+                      const Instruction *access_chain, const shader_struct_member &data) const;
+    void RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, const Instruction *access_chain,
                        const shader_struct_member &data) const;
     void SetUsedStructMember(const uint32_t variable_id, const std::vector<function_set> &function_set_list,
                              const shader_struct_member &data) const;
 
     // Push consants
-    static void SetPushConstantUsedInShader(const SHADER_MODULE_STATE &module_state,
-                                            std::unordered_multimap<std::string, SHADER_MODULE_STATE::EntryPoint> &entry_points);
+    void SetPushConstantUsedInShader(std::unordered_multimap<std::string, EntryPoint> &entry_points) const;
+    std::unordered_multimap<std::string, EntryPoint> ProcessEntryPoints() const;
 
     uint32_t DescriptorTypeToReqs(uint32_t type_id) const;
 
-    bool IsBuiltInWritten(spirv_inst_iter builtin_instr, spirv_inst_iter entrypoint) const;
+    bool IsBuiltInWritten(const Instruction *builtin_insn, const Instruction *entrypoint) const;
 
     // State tracking helpers for collecting interface information
-    void IsSpecificDescriptorType(const spirv_inst_iter &id_it, bool is_storage_buffer, bool is_check_writable,
+    void IsSpecificDescriptorType(const Instruction *insn, bool is_storage_buffer, bool is_check_writable,
                                   interface_var &out_interface_var) const;
     std::vector<std::pair<DescriptorSlot, interface_var>> CollectInterfaceByDescriptorSlot(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
-    layer_data::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const spirv_inst_iter &entrypoint) const;
+    layer_data::unordered_set<uint32_t> CollectWritableOutputLocationinFS(const Instruction *entrypoint) const;
     bool CollectInterfaceBlockMembers(std::map<location_t, interface_var> *out, bool is_array_of_verts, uint32_t id,
                                       uint32_t type_id, bool is_patch, uint32_t first_location) const;
-    std::map<location_t, interface_var> CollectInterfaceByLocation(spirv_inst_iter entrypoint, spv::StorageClass sinterface,
+    std::map<location_t, interface_var> CollectInterfaceByLocation(const Instruction *entrypoint, spv::StorageClass sinterface,
                                                                    bool is_array_of_verts) const;
-    std::vector<uint32_t> CollectBuiltinBlockMembers(spirv_inst_iter entrypoint, uint32_t storageClass) const;
+    std::vector<uint32_t> CollectBuiltinBlockMembers(const Instruction *entrypoint, uint32_t storageClass) const;
     std::vector<std::pair<uint32_t, interface_var>> CollectInterfaceByInputAttachmentIndex(
         layer_data::unordered_set<uint32_t> const &accessible_ids) const;
 
-    uint32_t GetNumComponentsInBaseType(const spirv_inst_iter &iter) const;
-    uint32_t GetTypeBitsSize(const spirv_inst_iter &iter) const;
-    uint32_t GetTypeBytesSize(const spirv_inst_iter &iter) const;
-    uint32_t GetBaseType(const spirv_inst_iter &iter) const;
+    uint32_t GetNumComponentsInBaseType(const Instruction *insn) const;
+    uint32_t GetTypeBitsSize(const Instruction *insn) const;
+    uint32_t GetTypeBytesSize(const Instruction *insn) const;
+    uint32_t GetBaseType(const Instruction *insn) const;
     uint32_t GetTypeId(uint32_t id) const;
 
     bool WritesToGlLayer() const {
-        return std::any_of(static_data_.builtin_decoration_list.begin(), static_data_.builtin_decoration_list.end(),
-                           [](const builtin_set &built_in) { return built_in.builtin == spv::BuiltInLayer; });
+        return std::any_of(static_data_.builtin_decoration_inst.begin(), static_data_.builtin_decoration_inst.end(),
+                           [](const Instruction *insn) { return insn->GetBuiltIn() == spv::BuiltInLayer; });
     }
 
     bool HasInputAttachmentCapability() const {
@@ -429,7 +396,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Used to populate the shader module object
     void PreprocessShaderBinary(spv_target_env env);
 
-    static std::unordered_multimap<std::string, EntryPoint> ProcessEntryPoints(const SHADER_MODULE_STATE &module_state);
+    StaticData static_data_;
 };
 
 #endif  // VULKAN_SHADER_MODULE_H

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4528,14 +4528,6 @@ void ValidationStateTracker::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuff
 }
 
 std::shared_ptr<SHADER_MODULE_STATE> ValidationStateTracker::CreateShaderModuleState(const VkShaderModuleCreateInfo &create_info,
-                                                                                     uint32_t unique_shader_id) const {
-    spv_target_env spirv_environment = PickSpirvEnv(api_version, IsExtEnabled(device_extensions.vk_khr_spirv_1_4));
-    bool is_spirv = (create_info.pCode[0] == spv::MagicNumber);
-    return is_spirv ? std::make_shared<SHADER_MODULE_STATE>(create_info, spirv_environment, unique_shader_id)
-                    : std::make_shared<SHADER_MODULE_STATE>();
-}
-
-std::shared_ptr<SHADER_MODULE_STATE> ValidationStateTracker::CreateShaderModuleState(const VkShaderModuleCreateInfo &create_info,
                                                                                      uint32_t unique_shader_id,
                                                                                      VkShaderModule handle) const {
     spv_target_env spirv_environment = PickSpirvEnv(api_version, IsExtEnabled(device_extensions.vk_khr_spirv_1_4));

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -795,9 +795,8 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator) override;
 
     std::shared_ptr<SHADER_MODULE_STATE> CreateShaderModuleState(const VkShaderModuleCreateInfo& create_info,
-                                                                 uint32_t unique_shader_id) const;
-    std::shared_ptr<SHADER_MODULE_STATE> CreateShaderModuleState(const VkShaderModuleCreateInfo& create_info,
-                                                                 uint32_t unique_shader_id, VkShaderModule handle) const;
+                                                                 uint32_t unique_shader_id,
+                                                                 VkShaderModule handle = VK_NULL_HANDLE) const;
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, VkResult result,
                                           void* csm_state) override;

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -200,17 +200,7 @@ class small_vector {
         return true;
     }
 
-    bool operator!=(const small_vector &rhs) const {
-        if (size_ != rhs.size_) return true;
-        auto value = begin();
-        for (const auto &rh_value : rhs) {
-            if (!(*value == rh_value)) {
-                return true;
-            }
-            ++value;
-        }
-        return false;
-    }
+    bool operator!=(const small_vector &rhs) const { return !(*this == rhs); }
 
     small_vector &operator=(const small_vector &other) {
         if (this != &other) {

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -200,6 +200,18 @@ class small_vector {
         return true;
     }
 
+    bool operator!=(const small_vector &rhs) const {
+        if (size_ != rhs.size_) return true;
+        auto value = begin();
+        for (const auto &rh_value : rhs) {
+            if (!(*value == rh_value)) {
+                return true;
+            }
+            ++value;
+        }
+        return false;
+    }
+
     small_vector &operator=(const small_vector &other) {
         if (this != &other) {
             reserve(other.size_);  // reserve doesn't shrink!
@@ -920,8 +932,8 @@ using base_type =
 // Define T unique to each entrypoint which will persist data
 // Use only in with singleton (leaf) validation objects
 // State machine transition state changes of payload relative to TlsGuard object lifecycle:
-//  State INIT: bool(payload_) 
-//  State RESET: NOT bool(payload_) 
+//  State INIT: bool(payload_)
+//  State RESET: NOT bool(payload_)
 //    * PreCallValidate* phase
 //        * Initialized with skip (in PreCallValidate*)
 //            * RESET -> INIT

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -379,7 +379,6 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
         if self.headerFile:
             output += 'bool OpcodeHasType(uint32_t opcode);\n'
             output += 'bool OpcodeHasResult(uint32_t opcode);\n'
-            output += 'uint32_t OpcodeResultWord(uint32_t opcode);\n'
             output += '\n'
             output += 'uint32_t OpcodeMemoryScopePosition(uint32_t opcode);\n'
             output += 'uint32_t OpcodeExecutionScopePosition(uint32_t opcode);\n'
@@ -403,18 +402,6 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
             output += '        has_result = format_info->second.has_result;\n'
             output += '    }\n'
             output += '    return has_result;\n'
-            output += '}\n\n'
-
-            output += '// Helper to get the word position of the result operand.\n'
-            output += '// Will either be 1 or 2 if it has a result.\n'
-            output += '// Will be 0 if there is no result.\n'
-            output += 'uint32_t OpcodeResultWord(uint32_t opcode) {\n'
-            output += '    uint32_t position = 0;\n'
-            output += '    if (OpcodeHasResult(opcode)) {\n'
-            output += '        position = 1;\n'
-            output += '        position += OpcodeHasType(opcode) ? 1 : 0;\n'
-            output += '    }\n'
-            output += '    return position;\n'
             output += '}\n\n'
 
             output += '// Return operand position of Memory Scope <ID> or zero if there is none\n'

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -431,18 +431,18 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
 bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn) const {
     bool skip = false;
 
-    if (insn.opcode() == spv::OpCapability) {
+    if (insn.Opcode() == spv::OpCapability) {
         // All capabilities are generated so if it is not in the list it is not supported by Vulkan
-        if (spirvCapabilities.count(insn.word(1)) == 0) {
+        if (spirvCapabilities.count(insn.Word(1)) == 0) {
             skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01090",
-                "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.word(1)));
+                "vkCreateShaderModule(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", string_SpvCapability(insn.Word(1)));
             return skip; // no known capability to validate
         }
 
         // Each capability has one or more requirements to check
         // Only one item has to be satisfied and an error only occurs
         // when all are not satisfied
-        auto caps = spirvCapabilities.equal_range(insn.word(1));
+        auto caps = spirvCapabilities.equal_range(insn.Word(1));
         bool has_support = false;
         for (auto it = caps.first; (it != caps.second) && (has_support == false); ++it) {
             if (it->second.version) {
@@ -461,7 +461,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
                 }
             } else if (it->second.property) {
                 // support is or'ed as only one has to be supported (if applicable)
-                switch (insn.word(1)) {'''
+                switch (insn.Word(1)) {'''
 
         for name, infos in sorted(self.propertyInfo.items()):
             # Only capabilities here (all items in array are the same)
@@ -489,19 +489,19 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
 
         if (has_support == false) {
             skip |= LogError(device, "VUID-VkShaderModuleCreateInfo-pCode-01091",
-                "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.word(1)));
+                "vkCreateShaderModule(): The SPIR-V Capability (%s) was declared, but none of the requirements were met to use it.", string_SpvCapability(insn.Word(1)));
         }
 
         // Portability checks
         if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
             if ((VK_FALSE == enabled_features.portability_subset_features.shaderSampleRateInterpolationFunctions) &&
-                (spv::CapabilityInterpolationFunction == insn.word(1))) {
+                (spv::CapabilityInterpolationFunction == insn.Word(1))) {
                 skip |= LogError(device, "VUID-RuntimeSpirv-shaderSampleRateInterpolationFunctions-06325",
                                     "Invalid shader capability (portability error): interpolation functions are not supported "
                                     "by this platform");
             }
         }
-    } else if (insn.opcode() == spv::OpExtension) {
+    } else if (insn.Opcode() == spv::OpExtension) {
         static const std::string spv_prefix = "SPV_";
         std::string extension_name = insn.GetAsString(1);
 
@@ -539,7 +539,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
                 }
             } else if (it->second.property) {
                 // support is or'ed as only one has to be supported (if applicable)
-                switch (insn.word(1)) {'''
+                switch (insn.Word(1)) {'''
 
         for name, infos in sorted(self.propertyInfo.items()):
             # Only extensions here (all items in array are the same)

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -428,7 +428,7 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
     # The main function to validate all the extensions and capabilities
     def validateFunction(self):
         output = '''
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn) const {
     bool skip = false;
 
     if (insn.opcode() == spv::OpCapability) {
@@ -503,7 +503,7 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) 
         }
     } else if (insn.opcode() == spv::OpExtension) {
         static const std::string spv_prefix = "SPV_";
-        std::string extension_name = (char const *)&insn.word(1);
+        std::string extension_name = insn.GetAsString(1);
 
         if (0 == extension_name.compare(0, spv_prefix.size(), spv_prefix)) {
             if (spirvExtensions.count(extension_name) == 0) {


### PR DESCRIPTION
This adds a new `Instruction` class in favor of the old `spirv_inst_iter` method. 

- **What this provides** 
   - Having a capsulated `Instruction`  class makes the code more readable that only a single instruction is being passed around and not a random iterator.
   - This makes the code more like `SPIRV-Tools`/`spirv-val`
   - Opens up for more refactoring to move Instruction logic (ex. `Instruction::GetStorageClass` or `Instruction::GetBitWidth`) to be added
   - Will allow us to finally solve issues such as https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4355#issuecomment-1266428301
 - **What is not done**
   - I didn't remove `spirv_inst_iter` completely because both GPU-AV and debug-printf make use of the iterator more and wanted to test it separately as it might include more invasive changes to the code. Plan to do that in a follow-up PR