### PR TITLE
build: Fix CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 if (UPDATE_DEPS)
     find_package(PythonInterp 3 REQUIRED)
 
-    if (CMAKE_GENERATOR_PLATFORM)
-        set(_target_arch ${CMAKE_GENERATOR_PLATFORM})
-    else()
-        if (MSVC_IDE)
-            message(WARNING "CMAKE_GENERATOR_PLATFORM not set. Using x64 as target architecture.")
-        endif()
-        set(_target_arch x64)
-    endif()
-
     if (NOT CMAKE_BUILD_TYPE)
         message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
         set(_build_type Debug)
@@ -63,40 +54,50 @@ if (UPDATE_DEPS)
         set(_build_type ${CMAKE_BUILD_TYPE})
     endif()
 
+    include(vvl_initial_cache)
+
     message("********************************************************************************")
     message("* NOTE: Adding target vvl_update_deps to run as needed for updating            *")
     message("*       dependencies.                                                          *")
     message("********************************************************************************")
 
+    set(update_deps_py "${PROJECT_SOURCE_DIR}/scripts/update_deps.py")
+    set(known_good_json "${PROJECT_SOURCE_DIR}/scripts/known_good.json")
+    set(external_helper_cmake "${PROJECT_SOURCE_DIR}/external/helper.cmake")
+
     set(_update_deps_arg "")
     if (NOT BUILD_TESTS)
         set(_update_deps_arg "--optional=tests")
     endif()
-        
+
     if (UPDATE_DEPS_SKIP_EXISTING_INSTALL)
         set(_update_deps_arg ${_update_deps_arg} "--skip-existing-install")
     endif()
 
     # Add a target so that update_deps.py will run when necessary
-    # NOTE: This is triggered off of the timestamps of known_good.json and helper.cmake
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake
-                       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
-                       DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json)
+    # NOTE: This is triggered off of the timestamps of known_good.json, helper.cmake, and vvl_initial_cache
+    add_custom_command(
+        OUTPUT ${external_helper_cmake}
+        COMMAND ${PYTHON_EXECUTABLE} ${update_deps_py} ${_update_deps_arg}
+            --dir ${PROJECT_SOURCE_DIR}/external --config ${_build_type} --initial_cache ${VVL_INITIAL_CACHE}
+        DEPENDS ${known_good_json} ${VVL_INITIAL_CACHE}
+    )
 
-    add_custom_target(vvl_update_deps DEPENDS ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+    add_custom_target(vvl_update_deps DEPENDS ${external_helper_cmake})
 
     # Check if update_deps.py needs to be run on first cmake run
-    if (${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json IS_NEWER_THAN ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+    if (${known_good_json} IS_NEWER_THAN ${external_helper_cmake})
         execute_process(
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            COMMAND ${PYTHON_EXECUTABLE} ${update_deps_py} ${_update_deps_arg}
+                --dir ${PROJECT_SOURCE_DIR}/external --config ${_build_type} --initial_cache ${VVL_INITIAL_CACHE}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE _update_deps_result
         )
         if (NOT (${_update_deps_result} EQUAL 0))
             message(FATAL_ERROR "Could not run update_deps.py which is necessary to download dependencies.")
         endif()
     endif()
-    include(${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
+    include(${external_helper_cmake})
 else()
     message("********************************************************************************")
     message("* NOTE: Not adding target to run update_deps.py automatically.                 *")

--- a/cmake/vvl_initial_cache.cmake
+++ b/cmake/vvl_initial_cache.cmake
@@ -1,0 +1,61 @@
+# Generate a CMake file with all information that may be 
+# needed by external projects we build with update_deps.py
+
+set(vvl_cmake_info "")
+
+# Ensure the same generator is used
+list(APPEND vvl_cmake_info "CMAKE_GENERATOR")
+
+# Ensure the same toolchain file is used
+list(APPEND vvl_cmake_info "CMAKE_TOOLCHAIN_FILE")
+
+foreach(lang C CXX ASM)
+    # Ensure flags passed via command line are used
+    list(APPEND vvl_cmake_info "CMAKE_${lang}_FLAGS")
+    # Ensure the same compilers are used
+    list(APPEND vvl_cmake_info "CMAKE_${lang}_COMPILER")
+endforeach()
+
+if (APPLE)
+    # Ensure the deployment target is consistent to avoid linker warnings
+    list(APPEND vvl_cmake_info "CMAKE_OSX_DEPLOYMENT_TARGET")
+    # Ensure the same system root is used
+    list(APPEND vvl_cmake_info "CMAKE_OSX_SYSROOT")
+endif()
+
+if (MSVC_IDE)
+    # Ensure the same platform is targeted
+    list(APPEND vvl_cmake_info "CMAKE_GENERATOR_PLATFORM")
+    # Ensure the same toolset is used
+    list(APPEND vvl_cmake_info "CMAKE_GENERATOR_TOOLSET")
+endif()
+
+# NOTE: This files timestamp will be updated anytime CMake is run,
+# making it problematic to pass to update_deps, this is addressed by configure_file,
+# as suggessted by the CMake docs.
+set(_initial_cache "${CMAKE_CURRENT_BINARY_DIR}/.vvl/_env.cmake")
+file(WRITE ${_initial_cache} "message(STATUS \"VVL: Setting cache variables\")\n")
+
+foreach(var IN LISTS vvl_cmake_info)
+    # Ignore variables that were never defined
+    # EX: Often CMAKE_TOOLCHAIN_FILE isn't defined
+    if (NOT DEFINED ${var})
+        continue()
+    endif()
+
+    # EX: If var is CMAKE_GENERATOR, value is Ninja
+    set(value ${${var}})
+
+    # Ignore values that were never defined
+    # EX: Often CMAKE_CXX_FLAGS has no value
+    if ("${value}" STREQUAL "")
+        continue()
+    endif()
+
+    file(APPEND ${_initial_cache} "set(${var} ${value} CACHE INTERNAL \"\" FORCE) \n")
+endforeach()
+
+set(VVL_INITIAL_CACHE "${CMAKE_CURRENT_BINARY_DIR}/.vvl/g_inital_cache.cmake")
+
+# Use the configure_file() command to update the file only when its content changes.
+configure_file(${_initial_cache} ${VVL_INITIAL_CACHE} COPYONLY)


### PR DESCRIPTION
Generate a CMake module with information that external projects being built with update_deps.py will need to have a consistent build.

That means CMAKE_TOOLCHAIN_FILE, CMAKE_OSX_DEPLOYMENT_TARGET, etc. Will propogate correctly.

However, this only works when -D UPDATE_DEPS=ON is enabled since it requires an existing/in-progress CMake build.

closes #3866
closes #4614