### PR TITLE
layers: Remove temp fix for re-running spirv-opt

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2878,9 +2878,6 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
         //
         // this will generate branch/switch statements that we want to leverage spirv-opt to apply to make parsing easier
         optimizer.RegisterPass(spvtools::CreateFoldSpecConstantOpAndCompositePass());
-        // Currently need to re-run the pass as spirv-opt has a bug and not folding everything sometimes
-        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4399#issuecomment-1216203563
-        optimizer.RegisterPass(spvtools::CreateFoldSpecConstantOpAndCompositePass());
 
         // Apply the specialization-constant values and revalidate the shader module is valid.
         const char *pSpecializationInfo_vuid = IsExtEnabled(device_extensions.vk_ext_shader_module_identifier)


### PR DESCRIPTION
We added this re-run in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4420 but now with the changes from `spirv-opt` pulled in (https://github.com/KhronosGroup/SPIRV-Tools/pull/4932) there is no need to re-run `spirv-opt`

Note: Some operations are still not supported in the `spirv-opt` pass ([CompositeInsert](https://github.com/KhronosGroup/SPIRV-Tools/pull/4943), non-32 bit ints, and 16 bit floats) but I am actively working on adding support. By "not supported" I mean it will remain as a `OpSpecConstantOp` and not get turned into the desirable `OpConstant`