### PR TITLE
layers: Don't spawn process for android prop lookup

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -249,10 +249,11 @@ static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, debug_
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // On Android, if the default callback system property is set, force the default callback to be printed
-    std::string forceLayerLog = GetEnvironment(kForceDefaultCallbackKey);
-    int forceDefaultCallback = atoi(forceLayerLog.c_str());
-    if (forceDefaultCallback == 1) {
-        debug_data->forceDefaultLogCallback = true;
+    char force_layer_log[8];
+    if (GetAndroidProperty(kForceDefaultCallbackKey, force_layer_log) > 0) {
+        if (atoi(force_layer_log) == 1) {
+            debug_data->forceDefaultLogCallback = true;
+        }
     }
 #endif
 

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -32,6 +32,10 @@
 
 std::string GetEnvironment(const char *variable);
 
+#if defined(__ANDROID__)
+VK_LAYER_EXPORT int GetAndroidProperty(const char *prop, char *out);
+#endif  // defined(__ANDROID__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -92,7 +96,6 @@ const vvl::unordered_map<std::string, VkFlags> log_msg_type_option_definitions =
                                                                                   {std::string("debug"), kDebugBit}};
 
 const char *getLayerOption(const char *option);
-const char *GetLayerEnvVar(const char *option);
 const SettingsFileInfo *GetLayerSettingsFileInfo();
 
 FILE *getLayerLogOutput(const char *option, const char *layer_name);


### PR DESCRIPTION
(might) close #4605 

Removes the Android `GetEnvironment` logic added from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2294 as in Android "Environment" and "Property" values are different things