### PR TITLE
build: xxhash fixes

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_LAYER_SUPPORT_FILES)
         vk_layer_logging.h
         vk_layer_utils.h
         vk_layer_utils.cpp
+        vk_xxhash.h
         xxhash.h
         xxhash.c
         generated/vk_format_utils.h
@@ -202,7 +203,9 @@ set(CORE_VALIDATION_LIBRARY_FILES
     generated/synchronization_validation_types.cpp
     gpu_validation.cpp
     generated/corechecks_optick_instrumentation.cpp
-    xxhash.c)
+    xxhash.c
+    xxhash.h
+    vk_xxhash.h)
 
 set(OBJECT_LIFETIMES_LIBRARY_FILES
     generated/object_tracker.cpp

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -247,9 +247,9 @@ void CreateFilterMessageIdList(std::string raw_id_list, std::string delimiter, s
         token = GetNextToken(&raw_id_list, delimiter, &pos);
         uint32_t int_id = TokenToUint(token);
         if (int_id == 0) {
-            size_t id_hash = XXH32(token.c_str(), strlen(token.c_str()), 8);  // String
+            const uint32_t id_hash = XXH32(token.data(), token.size(), 8);  // String
             if (id_hash != 0) {
-                int_id = static_cast<uint32_t>(id_hash);
+                int_id = id_hash;
             }
         }
         if ((int_id != 0) && (std::find(filter_list.begin(), filter_list.end(), int_id)) == filter_list.end()) {

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -37,8 +37,7 @@
 #include "chassis.h"
 #include "core_validation.h"
 #include "spirv_grammar_helper.h"
-
-#include "xxhash.h"
+#include "vk_xxhash.h"
 
 static shader_stage_attributes shader_stage_attribs[] = {
     {"vertex shader", false, false, VK_SHADER_STAGE_VERTEX_BIT},

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -55,7 +55,7 @@
 #include "vk_validation_error_messages.h"
 #include "vk_layer_dispatch_table.h"
 #include "vk_safe_struct.h"
-#include "xxhash.h"
+#include "vk_xxhash.h"
 
 // Suppress unused warning on Linux
 #if defined(__GNUC__)
@@ -671,7 +671,7 @@ static inline bool LogMsgEnabled(const debug_report_data *debug_data, const std:
         return false;
     }
     // If message is in filter list, bail out very early
-    uint32_t message_id = XXH32(vuid_text.c_str(), strlen(vuid_text.c_str()), 8);
+    const uint32_t message_id = XXH32(vuid_text.data(), vuid_text.size(), 8);
     if (std::find(debug_data->filter_message_ids.begin(), debug_data->filter_message_ids.end(), message_id)
         != debug_data->filter_message_ids.end()) {
         return false;

--- a/layers/vk_xxhash.h
+++ b/layers/vk_xxhash.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (C) 2015-2022 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Juan Ramos
+ */
+
+// XXH_NO_LONG_LONG: removes compilation of algorithms relying on 64-bit types (XXH3 and XXH64). Only XXH32 will be compiled.
+// We only need XXH32 due to restrictions requiring a 32 bit hash. This also reduces binary size.
+//
+// v0.8.1 also has compilation issues that are removed by setting this define.
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4639
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4640
+#define XXH_NO_LONG_LONG
+
+#include "xxhash.h"


### PR DESCRIPTION
Fixes clang-cl builds by ifdefing out problematic code sections. Minor improvements to source code by avoiding strlen, and using const. Created vk_xxhash.h to define XXH_NO_LONG_LONG instead of defining it in multiple build systems.

closes #4640