### PR TITLE
build: Use vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,10 @@
 # CMake project initialization ---------------------------------------------------------------------------------------------------
 # This section contains pre-project() initialization, and ends with the project() command.
 
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.15)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(vcpkg)
 
 # Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
@@ -42,94 +45,21 @@ option(BUILD_TESTS "Build the tests" OFF)
 # Enable beta Vulkan extensions
 add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# backcompat
+list(APPEND CMAKE_PREFIX_PATH ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET})
+set(GLSLANG_INSTALL_DIR ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} CACHE PATH "")
+set(VULKAN_HEADERS_INSTALL_DIR ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} CACHE PATH "")
+set(ROBIN_HOOD_HASHING_INSTALL_DIR ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} CACHE PATH "")
+set(SPIRV_HEADERS_INSTALL_DIR  ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} CACHE PATH "")
+set(SPIRV_TOOLS_INSTALL_DIR ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} CACHE PATH "")
 
-if (UPDATE_DEPS)
-    find_package(PythonInterp 3 REQUIRED)
+# https://github.com/KhronosGroup/Vulkan-Headers/pull/207
+find_path(VulkanHeaders_INCLUDE_DIR "vulkan/vulkan.h")
 
-    if (CMAKE_GENERATOR_PLATFORM)
-        set(_target_arch ${CMAKE_GENERATOR_PLATFORM})
-    else()
-        if (MSVC_IDE)
-            message(WARNING "CMAKE_GENERATOR_PLATFORM not set. Using x64 as target architecture.")
-        endif()
-        set(_target_arch x64)
-    endif()
-
-    if (NOT CMAKE_BUILD_TYPE)
-        message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
-        set(_build_type Debug)
-    else()
-        set(_build_type ${CMAKE_BUILD_TYPE})
-    endif()
-
-    message("********************************************************************************")
-    message("* NOTE: Adding target vvl_update_deps to run as needed for updating            *")
-    message("*       dependencies.                                                          *")
-    message("********************************************************************************")
-
-    set(_update_deps_arg "")
-    if (NOT BUILD_TESTS)
-        set(_update_deps_arg "--optional=tests")
-    endif()
-        
-    if (UPDATE_DEPS_SKIP_EXISTING_INSTALL)
-        set(_update_deps_arg ${_update_deps_arg} "--skip-existing-install")
-    endif()
-
-    # Add a target so that update_deps.py will run when necessary
-    # NOTE: This is triggered off of the timestamps of known_good.json and helper.cmake
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake
-                       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
-                       DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json)
-
-    add_custom_target(vvl_update_deps DEPENDS ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
-
-    # Check if update_deps.py needs to be run on first cmake run
-    if (${CMAKE_CURRENT_LIST_DIR}/scripts/known_good.json IS_NEWER_THAN ${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
-        execute_process(
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/update_deps.py --dir ${CMAKE_CURRENT_LIST_DIR}/external --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${_update_deps_arg}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-            RESULT_VARIABLE _update_deps_result
-        )
-        if (NOT (${_update_deps_result} EQUAL 0))
-            message(FATAL_ERROR "Could not run update_deps.py which is necessary to download dependencies.")
-        endif()
-    endif()
-    include(${CMAKE_CURRENT_LIST_DIR}/external/helper.cmake)
-else()
-    message("********************************************************************************")
-    message("* NOTE: Not adding target to run update_deps.py automatically.                 *")
-    message("********************************************************************************")
-    find_package(PythonInterp 3 QUIET)
-endif()
-#backwards compatability settings for other parts of the build system that don't use find_package() variables yet
-if (ROBIN_HOOD_HASHING_INSTALL_DIR)
-    list(APPEND CMAKE_PREFIX_PATH ${ROBIN_HOOD_HASHING_INSTALL_DIR})
-endif()
-if (SPIRV_HEADERS_INSTALL_DIR)
-    list(APPEND CMAKE_PREFIX_PATH ${SPIRV_HEADERS_INSTALL_DIR})
-endif()
-if (SPIRV_TOOLS_INSTALL_DIR)
-    list(APPEND CMAKE_PREFIX_PATH ${SPIRV_TOOLS_INSTALL_DIR})
-endif()
-if (GOOGLETEST_INSTALL_DIR)
-    list(APPEND CMAKE_PREFIX_PATH ${GOOGLETEST_INSTALL_DIR})
-endif()
-
-
-if (TARGET Vulkan::Headers)
-    message(STATUS "Using Vulkan headers from Vulkan::Headers target")
-    get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
-    get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
-else()
-    find_package(VulkanHeaders REQUIRED)
-
-    # xxxnsubtil: this should eventually be replaced by exported targets
-    add_library(Vulkan-Headers INTERFACE)
-    target_include_directories(Vulkan-Headers INTERFACE ${VulkanHeaders_INCLUDE_DIRS})
-    add_library(Vulkan::Headers ALIAS Vulkan-Headers)
-endif()
+find_package(VulkanHeaders REQUIRED)
+add_library(Vulkan-Headers INTERFACE)
+target_include_directories(Vulkan-Headers INTERFACE ${VulkanHeaders_INCLUDE_DIRS})
+add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 
 option(USE_CCACHE "Use ccache" OFF)
 if(USE_CCACHE)
@@ -282,7 +212,6 @@ if(BUILD_LAYERS OR BUILD_TESTS)
 endif()
 
 if(BUILD_TESTS)
-    set(GLSLANG_INSTALL_DIR "GLSLANG-NOTFOUND" CACHE PATH "Absolute path to a glslang install directory")
     if(NOT GLSLANG_INSTALL_DIR AND NOT DEFINED ENV{GLSLANG_INSTALL_DIR} AND NOT TARGET glslang)
         message(FATAL_ERROR "Must define location of glslang binaries -- see BUILD.md")
     endif()
@@ -349,9 +278,6 @@ if (VVL_ENABLE_ASAN)
     # NOTE: Use target_link_options when cmake 3.13 is available on CI
     target_link_libraries(VkLayer_utils PRIVATE "-fsanitize=address")
 endif()
-if (UPDATE_DEPS)
-    add_dependencies(VkLayer_utils vvl_update_deps)
-endif()
 if(WIN32)
     target_compile_definitions(VkLayer_utils PUBLIC _CRT_SECURE_NO_WARNINGS NOMINMAX)
     if(MINGW)
@@ -396,8 +322,14 @@ else()
     message(FATAL_ERROR "Unable to fetch version from vulkan_core.h")
 endif()
 
+find_package(PythonInterp 3 REQUIRED QUIET)
+
 # Optional codegen target --------------------------------------------------------------------------------------------------------
 if(PYTHONINTERP_FOUND)
+    if (NOT EXISTS "${VulkanRegistry_DIR}/vk.xml")
+        message(FATAL_ERROR "Unable to find vk.xml")
+    endif()
+
     add_custom_target(VulkanVL_generated_source
                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_source.py
                               ${VulkanRegistry_DIR} ${SPIRV_HEADERS_INSTALL_DIR}/include/spirv/unified1/ --incremental

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(vcpkg)
 
-# Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
-
 project(Vulkan-ValidationLayers)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -61,9 +61,11 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
       HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
       NO_CMAKE_FIND_ROOT_PATH
       NO_DEFAULT_PATH)
+
   find_path(VulkanRegistry_DIR
       NAMES vk.xml
-      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry
+      HINTS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}
+      PATH_SUFFIXES "registry"
       NO_CMAKE_FIND_ROOT_PATH
       NO_DEFAULT_PATH)
 else()

--- a/cmake/ports/glslang/portfile.cmake
+++ b/cmake/ports/glslang/portfile.cmake
@@ -1,0 +1,46 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO KhronosGroup/glslang
+  REF 28b53119bdfbc43eae532641337a7adbb315b273
+  SHA512 52039c54c75286499294bc03fcfa4ae1377e24924ba6fe31160baa3bbfdb3389437b0b68a7519e6d4df47b8bcecf553f07b8686c9f36efd280e5bd7a74100c8a
+  HEAD_REF master
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
+vcpkg_add_to_path("${PYTHON_PATH}")
+
+if(VCPKG_TARGET_IS_IOS)
+  # this case will report error since all executable will require BUNDLE DESTINATION
+  set(BUILD_BINARIES OFF)
+else()
+  set(BUILD_BINARIES ON)  
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DSKIP_GLSLANG_INSTALL=OFF
+    -DBUILD_EXTERNAL=OFF
+    -DENABLE_GLSLANG_BINARIES=${BUILD_BINARIES}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+
+vcpkg_copy_pdbs()
+
+if(NOT BUILD_BINARIES)
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+else()
+  vcpkg_copy_tools(TOOL_NAMES glslangValidator spirv-remap AUTO_CLEAN)
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+# Install custom usage
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/cmake/ports/glslang/usage
+++ b/cmake/ports/glslang/usage
@@ -1,0 +1,4 @@
+The package glslang provides CMake targets:
+
+    find_package(glslang CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE glslang::OSDependent glslang::glslang glslang::MachineIndependent glslang::GenericCodeGen glslang::OGLCompiler glslang::glslangValidator glslang::spirv-remap glslang::glslang-default-resource-limits glslang::SPVRemapper glslang::SPIRV glslang::HLSL)

--- a/cmake/ports/glslang/vcpkg.json
+++ b/cmake/ports/glslang/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "glslang",
+  "version": "11.11.0",
+  "description": "Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator",
+  "homepage": "https://github.com/KhronosGroup/glslang",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/cmake/ports/spirv-headers/portfile.cmake
+++ b/cmake/ports/spirv-headers/portfile.cmake
@@ -1,0 +1,14 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/SPIRV-Headers
+    REF 87d5b782bec60822aa878941e6b13c0a9a954c9b
+    SHA512 d6ce02e53c259e508d1d72d81cc6aa6b3019e7ecd6a8878d81d8681d9734756f66c762ebd4b8b1d0f9fbb7a8f1f18d72aeb27c56822d810aca5a3e53c51c1ef6
+    HEAD_REF master
+)
+
+# This must be spirv as other spirv packages expect it there.
+file(COPY "${SOURCE_PATH}/include/spirv/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/spirv")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/cmake/ports/spirv-headers/vcpkg.json
+++ b/cmake/ports/spirv-headers/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "spirv-headers",
+  "version": "1.3.216.0",
+  "description": "Machine-readable files for the SPIR-V Registry",
+  "homepage": "https://github.com/KhronosGroup/SPIRV-Headers"
+}

--- a/cmake/ports/spirv-tools/portfile.cmake
+++ b/cmake/ports/spirv-tools/portfile.cmake
@@ -1,0 +1,88 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/SPIRV-Tools
+    REF 4dbc66380dd63aabbd33c38198008449d0a5807a
+    SHA512 7807378c0673dd8f597ea5b7c4bef1be4d508e3d03425406d98c5b9e678daea7ccf4184b65e4e178a8a6d0233ef321d4ab20857674a229c54c37974b576c5d9c
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
+
+if(VCPKG_TARGET_IS_IOS)
+    message(STATUS "Using iOS trplet. Executables won't be created...")
+    set(TOOLS_INSTALL OFF)
+    set(SKIP_EXECUTABLES ON) 
+else()
+    set(TOOLS_INSTALL ON)
+    set(SKIP_EXECUTABLES OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSPIRV-Headers_SOURCE_DIR=${CURRENT_INSTALLED_DIR}
+        -DSPIRV_WERROR=OFF
+        -DSPIRV_SKIP_TESTS=ON
+        -DSPIRV_SKIP_EXECUTABLES=${SKIP_EXECUTABLES}
+        -DENABLE_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
+        -DSPIRV_TOOLS_BUILD_STATIC=ON
+        -DENABLE_SPIRV_TOOLS_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+ # the directory name is capitalized as opposed to the port name
+if(WIN32)
+    vcpkg_cmake_config_fixup(CONFIG_PATH SPIRV-Tools/cmake PACKAGE_NAME SPIRV-Tools)
+    vcpkg_cmake_config_fixup(CONFIG_PATH SPIRV-Tools-link/cmake PACKAGE_NAME SPIRV-Tools-link)
+    vcpkg_cmake_config_fixup(CONFIG_PATH SPIRV-Tools-lint/cmake PACKAGE_NAME SPIRV-Tools-lint)
+    vcpkg_cmake_config_fixup(CONFIG_PATH SPIRV-Tools-opt/cmake PACKAGE_NAME SPIRV-Tools-opt)
+    vcpkg_cmake_config_fixup(CONFIG_PATH SPIRV-Tools-reduce/cmake PACKAGE_NAME SPIRV-Tools-reduce)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SPIRV-Tools PACKAGE_NAME SPIRV-Tools DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SPIRV-Tools-link PACKAGE_NAME SPIRV-Tools-link DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SPIRV-Tools-lint PACKAGE_NAME SPIRV-Tools-lint DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SPIRV-Tools-opt PACKAGE_NAME SPIRV-Tools-opt DO_NOT_DELETE_PARENT_CONFIG_PATH)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SPIRV-Tools-reduce PACKAGE_NAME SPIRV-Tools-reduce) # now delete
+endif()
+vcpkg_fixup_pkgconfig()
+
+if(TOOLS_INSTALL)
+    vcpkg_copy_tools(
+        TOOL_NAMES 
+            spirv-as 
+            spirv-cfg 
+            spirv-dis 
+            spirv-link 
+            spirv-lint 
+            spirv-opt 
+            spirv-reduce 
+            spirv-val 
+        AUTO_CLEAN
+    )
+endif()
+
+if(WIN32)
+    file(REMOVE_RECURSE 
+        "${CURRENT_PACKAGES_DIR}/debug/SPIRV-Tools" 
+        "${CURRENT_PACKAGES_DIR}/debug/SPIRV-Tools-link"
+        "${CURRENT_PACKAGES_DIR}/debug/SPIRV-Tools-lint"  
+        "${CURRENT_PACKAGES_DIR}/debug/SPIRV-Tools-opt"
+        "${CURRENT_PACKAGES_DIR}/debug/SPIRV-Tools-reduce" 
+        "${CURRENT_PACKAGES_DIR}/SPIRV-Tools" 
+        "${CURRENT_PACKAGES_DIR}/SPIRV-Tools-link" 
+        "${CURRENT_PACKAGES_DIR}/SPIRV-Tools-lint" 
+        "${CURRENT_PACKAGES_DIR}/SPIRV-Tools-opt" 
+        "${CURRENT_PACKAGES_DIR}/SPIRV-Tools-reduce"
+    )
+endif()
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # lesspipe.sh is the only file there
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/cmake/ports/spirv-tools/vcpkg.json
+++ b/cmake/ports/spirv-tools/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "spirv-tools",
+  "version": "2022.2",
+  "description": "API and commands for processing SPIR-V modules",
+  "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "spirv-headers",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/cmake/ports/vulkan-headers/portfile.cmake
+++ b/cmake/ports/vulkan-headers/portfile.cmake
@@ -1,0 +1,16 @@
+# header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/Vulkan-Headers
+    REF v1.3.230
+    SHA512 1d94c220e6e0a274c57ffac09885d7154ed5b79aebd6018a20117d0f7907a5af875e697908b4cd4acdb9c4f6b0ff96f4c70b8d68dd2c1c2add90f41d85feaa2e
+    HEAD_REF master
+)
+
+# This must be vulkan as other vulkan packages expect it there.
+file(COPY "${SOURCE_PATH}/include/vulkan/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/vulkan")
+file(COPY "${SOURCE_PATH}/include/vk_video/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/vk_video")
+file(COPY "${SOURCE_PATH}/registry/" DESTINATION "${CURRENT_PACKAGES_DIR}/registry")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/cmake/ports/vulkan-headers/vcpkg.json
+++ b/cmake/ports/vulkan-headers/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "vulkan-headers",
+  "version": "1.3.230",
+  "description": "Vulkan header files and API registry",
+  "homepage": "https://github.com/KhronosGroup/Vulkan-Headers"
+}

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -13,4 +13,8 @@ list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/spirv-h
 list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/spirv-tools")
 list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/vulkan-headers")
 
+# Sets the minimum macOS version for compiled binaries. This also changes what versions of
+# the macOS platform SDK that CMake will search for. See the CMake documentation for CMAKE_OSX_DEPLOYMENT_TARGET for more information.
+set(VCPKG_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
+
 set(CMAKE_TOOLCHAIN_FILE "${FETCHCONTENT_BASE_DIR}/vcpkg-src/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "")

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -1,0 +1,16 @@
+include(FetchContent)
+FetchContent_Declare(vcpkg 
+    GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
+    GIT_TAG 2022.09.27
+)
+FetchContent_MakeAvailable(vcpkg)
+
+# https://github.com/microsoft/vcpkg/blob/master/docs/users/buildsystems/cmake-integration.md
+
+set(VCPKG_OVERLAY_PORTS "")
+list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/glslang")
+list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/spirv-headers")
+list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/spirv-tools")
+list(APPEND VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ports/vulkan-headers")
+
+set(CMAKE_TOOLCHAIN_FILE "${FETCHCONTENT_BASE_DIR}/vcpkg-src/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+    "name": "vulkan-validation-layers",
+    "dependencies": [
+      "glslang",
+      "vulkan-headers",
+      "spirv-headers",
+      "spirv-tools",
+      "robin-hood-hashing",
+      "gtest"
+    ]
+}


### PR DESCRIPTION
Using vcpkg would replace update_deps.py

- Use industry standard
- Works much better with CMake
- Very fast
- Supports multi-configuration generators
- Cleaner builds (vcpkg detects errors very quickly)
- Custom ports in case upstream doesn't work

closes #4614
closes #3866