### PR TITLE
scripts: Move CompatibleSpirvImageFormat

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -268,7 +268,6 @@ source_set("vulkan_layer_utils") {
   include_dirs = [
     "layers",
     "layers/generated",
-    "$vvl_spirv_headers_dir/include",
   ]
   sources = [
     "$vulkan_headers_dir/include/vulkan/vk_layer.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if (UPDATE_DEPS)
     if (NOT BUILD_TESTS)
         set(_update_deps_arg "--optional=tests")
     endif()
-        
+
     if (UPDATE_DEPS_SKIP_EXISTING_INSTALL)
         set(_update_deps_arg ${_update_deps_arg} "--skip-existing-install")
     endif()
@@ -207,7 +207,7 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "(GNU|Clang)")
       (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0))
         add_compile_options(-Werror)
     endif()
-    
+
 
     set(CMAKE_C_STANDARD 99)
 
@@ -366,7 +366,6 @@ target_include_directories(VkLayer_utils
                                   ${CMAKE_CURRENT_BINARY_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}/layers
                                   ${PROJECT_BINARY_DIR}
-                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR})
 
 if (USE_ROBIN_HOOD_HASHING)

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -29,7 +29,6 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/vk_format_utils.cpp
 LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
-                    $(LOCAL_PATH)/$(THIRD_PARTY)/shaderc/third_party/spirv-tools/external/spirv-headers/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -DUSE_ROBIN_HOOD_HASHING -fvisibility=hidden

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -615,6 +615,7 @@ class CoreChecks : public ValidationStateTracker {
                                           spirv_inst_iter entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidateTexelOffsetLimits(const SHADER_MODULE_STATE& module_state, spirv_inst_iter& insn) const;
     bool ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) const;
+    VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
     bool ValidateShaderStageWritableOrAtomicDescriptor(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                                        bool has_writable_descriptor, bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state,

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -808,3 +808,96 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(spirv_inst_iter& insn) 
     } //spv::OpExtension
     return skip;
 }
+
+// Will return the Vulkan format for a given SPIR-V image format value
+// Note: will return VK_FORMAT_UNDEFINED if non valid input
+// This was in vk_format_utils but the SPIR-V Header dependency was an issue
+//   see https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4647
+VkFormat CoreChecks::CompatibleSpirvImageFormat(uint32_t spirv_image_format) const {
+    switch (spirv_image_format) {
+        case spv::ImageFormatRgb10a2ui:
+            return VK_FORMAT_A2B10G10R10_UINT_PACK32;
+        case spv::ImageFormatRgb10A2:
+            return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+        case spv::ImageFormatR11fG11fB10f:
+            return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+        case spv::ImageFormatRgba16f:
+            return VK_FORMAT_R16G16B16A16_SFLOAT;
+        case spv::ImageFormatRgba16i:
+            return VK_FORMAT_R16G16B16A16_SINT;
+        case spv::ImageFormatRgba16Snorm:
+            return VK_FORMAT_R16G16B16A16_SNORM;
+        case spv::ImageFormatRgba16ui:
+            return VK_FORMAT_R16G16B16A16_UINT;
+        case spv::ImageFormatRgba16:
+            return VK_FORMAT_R16G16B16A16_UNORM;
+        case spv::ImageFormatRg16f:
+            return VK_FORMAT_R16G16_SFLOAT;
+        case spv::ImageFormatRg16i:
+            return VK_FORMAT_R16G16_SINT;
+        case spv::ImageFormatRg16Snorm:
+            return VK_FORMAT_R16G16_SNORM;
+        case spv::ImageFormatRg16ui:
+            return VK_FORMAT_R16G16_UINT;
+        case spv::ImageFormatRg16:
+            return VK_FORMAT_R16G16_UNORM;
+        case spv::ImageFormatR16f:
+            return VK_FORMAT_R16_SFLOAT;
+        case spv::ImageFormatR16i:
+            return VK_FORMAT_R16_SINT;
+        case spv::ImageFormatR16Snorm:
+            return VK_FORMAT_R16_SNORM;
+        case spv::ImageFormatR16ui:
+            return VK_FORMAT_R16_UINT;
+        case spv::ImageFormatR16:
+            return VK_FORMAT_R16_UNORM;
+        case spv::ImageFormatRgba32f:
+            return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case spv::ImageFormatRgba32i:
+            return VK_FORMAT_R32G32B32A32_SINT;
+        case spv::ImageFormatRgba32ui:
+            return VK_FORMAT_R32G32B32A32_UINT;
+        case spv::ImageFormatRg32f:
+            return VK_FORMAT_R32G32_SFLOAT;
+        case spv::ImageFormatRg32i:
+            return VK_FORMAT_R32G32_SINT;
+        case spv::ImageFormatRg32ui:
+            return VK_FORMAT_R32G32_UINT;
+        case spv::ImageFormatR32f:
+            return VK_FORMAT_R32_SFLOAT;
+        case spv::ImageFormatR32i:
+            return VK_FORMAT_R32_SINT;
+        case spv::ImageFormatR32ui:
+            return VK_FORMAT_R32_UINT;
+        case spv::ImageFormatR64i:
+            return VK_FORMAT_R64_SINT;
+        case spv::ImageFormatR64ui:
+            return VK_FORMAT_R64_UINT;
+        case spv::ImageFormatRgba8i:
+            return VK_FORMAT_R8G8B8A8_SINT;
+        case spv::ImageFormatRgba8Snorm:
+            return VK_FORMAT_R8G8B8A8_SNORM;
+        case spv::ImageFormatRgba8ui:
+            return VK_FORMAT_R8G8B8A8_UINT;
+        case spv::ImageFormatRgba8:
+            return VK_FORMAT_R8G8B8A8_UNORM;
+        case spv::ImageFormatRg8i:
+            return VK_FORMAT_R8G8_SINT;
+        case spv::ImageFormatRg8Snorm:
+            return VK_FORMAT_R8G8_SNORM;
+        case spv::ImageFormatRg8ui:
+            return VK_FORMAT_R8G8_UINT;
+        case spv::ImageFormatRg8:
+            return VK_FORMAT_R8G8_UNORM;
+        case spv::ImageFormatR8i:
+            return VK_FORMAT_R8_SINT;
+        case spv::ImageFormatR8Snorm:
+            return VK_FORMAT_R8_SNORM;
+        case spv::ImageFormatR8ui:
+            return VK_FORMAT_R8_UINT;
+        case spv::ImageFormatR8:
+            return VK_FORMAT_R8_UNORM;
+        default:
+            return VK_FORMAT_UNDEFINED;
+     }
+}

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -30,7 +30,6 @@
 #include "vk_layer_utils.h"
 #include <map>
 #include <vector>
-#include <spirv/unified1/spirv.hpp>
 
 
 enum class COMPONENT_TYPE {
@@ -1930,96 +1929,5 @@ bool FormatHasBlue(VkFormat format) {
 
 bool FormatHasAlpha(VkFormat format) {
     return FormatHasComponent(format, COMPONENT_TYPE::A);
-}
-
-// Will return the Vulkan format for a given SPIR-V image format value
-// Note: will return VK_FORMAT_UNDEFINED if non valid input
-VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {
-    switch (spirv_image_format) {
-        case spv::ImageFormatRgb10a2ui:
-            return VK_FORMAT_A2B10G10R10_UINT_PACK32;
-        case spv::ImageFormatRgb10A2:
-            return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
-        case spv::ImageFormatR11fG11fB10f:
-            return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
-        case spv::ImageFormatRgba16f:
-            return VK_FORMAT_R16G16B16A16_SFLOAT;
-        case spv::ImageFormatRgba16i:
-            return VK_FORMAT_R16G16B16A16_SINT;
-        case spv::ImageFormatRgba16Snorm:
-            return VK_FORMAT_R16G16B16A16_SNORM;
-        case spv::ImageFormatRgba16ui:
-            return VK_FORMAT_R16G16B16A16_UINT;
-        case spv::ImageFormatRgba16:
-            return VK_FORMAT_R16G16B16A16_UNORM;
-        case spv::ImageFormatRg16f:
-            return VK_FORMAT_R16G16_SFLOAT;
-        case spv::ImageFormatRg16i:
-            return VK_FORMAT_R16G16_SINT;
-        case spv::ImageFormatRg16Snorm:
-            return VK_FORMAT_R16G16_SNORM;
-        case spv::ImageFormatRg16ui:
-            return VK_FORMAT_R16G16_UINT;
-        case spv::ImageFormatRg16:
-            return VK_FORMAT_R16G16_UNORM;
-        case spv::ImageFormatR16f:
-            return VK_FORMAT_R16_SFLOAT;
-        case spv::ImageFormatR16i:
-            return VK_FORMAT_R16_SINT;
-        case spv::ImageFormatR16Snorm:
-            return VK_FORMAT_R16_SNORM;
-        case spv::ImageFormatR16ui:
-            return VK_FORMAT_R16_UINT;
-        case spv::ImageFormatR16:
-            return VK_FORMAT_R16_UNORM;
-        case spv::ImageFormatRgba32f:
-            return VK_FORMAT_R32G32B32A32_SFLOAT;
-        case spv::ImageFormatRgba32i:
-            return VK_FORMAT_R32G32B32A32_SINT;
-        case spv::ImageFormatRgba32ui:
-            return VK_FORMAT_R32G32B32A32_UINT;
-        case spv::ImageFormatRg32f:
-            return VK_FORMAT_R32G32_SFLOAT;
-        case spv::ImageFormatRg32i:
-            return VK_FORMAT_R32G32_SINT;
-        case spv::ImageFormatRg32ui:
-            return VK_FORMAT_R32G32_UINT;
-        case spv::ImageFormatR32f:
-            return VK_FORMAT_R32_SFLOAT;
-        case spv::ImageFormatR32i:
-            return VK_FORMAT_R32_SINT;
-        case spv::ImageFormatR32ui:
-            return VK_FORMAT_R32_UINT;
-        case spv::ImageFormatR64i:
-            return VK_FORMAT_R64_SINT;
-        case spv::ImageFormatR64ui:
-            return VK_FORMAT_R64_UINT;
-        case spv::ImageFormatRgba8i:
-            return VK_FORMAT_R8G8B8A8_SINT;
-        case spv::ImageFormatRgba8Snorm:
-            return VK_FORMAT_R8G8B8A8_SNORM;
-        case spv::ImageFormatRgba8ui:
-            return VK_FORMAT_R8G8B8A8_UINT;
-        case spv::ImageFormatRgba8:
-            return VK_FORMAT_R8G8B8A8_UNORM;
-        case spv::ImageFormatRg8i:
-            return VK_FORMAT_R8G8_SINT;
-        case spv::ImageFormatRg8Snorm:
-            return VK_FORMAT_R8G8_SNORM;
-        case spv::ImageFormatRg8ui:
-            return VK_FORMAT_R8G8_UINT;
-        case spv::ImageFormatRg8:
-            return VK_FORMAT_R8G8_UNORM;
-        case spv::ImageFormatR8i:
-            return VK_FORMAT_R8_SINT;
-        case spv::ImageFormatR8Snorm:
-            return VK_FORMAT_R8_SNORM;
-        case spv::ImageFormatR8ui:
-            return VK_FORMAT_R8_UINT;
-        case spv::ImageFormatR8:
-            return VK_FORMAT_R8_UNORM;
-        default:
-            return VK_FORMAT_UNDEFINED;
-     }
 }
 

--- a/layers/generated/vk_format_utils.h
+++ b/layers/generated/vk_format_utils.h
@@ -206,8 +206,6 @@ VK_LAYER_EXPORT bool FormatHasGreen(VkFormat format);
 VK_LAYER_EXPORT bool FormatHasBlue(VkFormat format);
 VK_LAYER_EXPORT bool FormatHasAlpha(VkFormat format);
 
-// SPIR-V
-VK_LAYER_EXPORT VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
 
 // Utils/misc
 static inline bool FormatIsUndef(VkFormat format) { return (format == VK_FORMAT_UNDEFINED); }

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -518,6 +518,7 @@ def makeGenOpts(args):
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,
+            emitFormats       = emitFormatsPat,
             emitSpirv         = emitSpirvPat)
         ]
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,7 +140,6 @@ target_include_directories(vk_layer_validation_tests
                                   ${CMAKE_BINARY_DIR}
                                   ${PROJECT_BINARY_DIR}
                                   ${VulkanHeaders_INCLUDE_DIR}
-                                  ${SPIRV_HEADERS_INCLUDE_DIR}
                                   ${PROJECT_BINARY_DIR}/layers)
 
 option(PORTABILITY_TESTS_USE_DEVSIM "Automatically add the devsim layer for portability tests" OFF)


### PR DESCRIPTION
This "reverts" (really moves) `CompatibleSpirvImageFormat` to not be in `vk_format_utils` this would be a replacement for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4647 as a "temp fix" until we properly deal with how the format utils folder is being used outside the scope of the VVL 

cc @ncesario-lunarg 