### PR TITLE
tests: Fix glslang target env

### DIFF
--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -14100,7 +14100,7 @@ TEST_F(VkLayerTest, ComputeSharedMemorySpecConstantSet) {
     specialization_info.pData = &data;
 
     const auto set_info = [&](CreateComputePipelineHelper &helper) {
-        helper.cs_.reset(new VkShaderObj(this, cs_source.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3,
+        helper.cs_.reset(new VkShaderObj(this, cs_source.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0,
                                          SPV_SOURCE_GLSL, &specialization_info));
     };
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -763,6 +763,9 @@ class VkShaderObj : public vk_testing::ShaderModule {
                 case SPV_ENV_UNIVERSAL_1_5:
                     language_version = glslang::EShTargetSpv_1_5;
                     break;
+                case SPV_ENV_UNIVERSAL_1_6:
+                    language_version = glslang::EShTargetSpv_1_6;
+                    break;
                 case SPV_ENV_VULKAN_1_0:
                     client_version = glslang::EShTargetVulkan_1_0;
                     break;
@@ -774,7 +777,12 @@ class VkShaderObj : public vk_testing::ShaderModule {
                     client_version = glslang::EShTargetVulkan_1_2;
                     language_version = glslang::EShTargetSpv_1_5;
                     break;
+                case SPV_ENV_VULKAN_1_3:
+                    client_version = glslang::EShTargetVulkan_1_3;
+                    language_version = glslang::EShTargetSpv_1_6;
+                    break;
                 default:
+                    assert(false && "Invalid SPIR-V environment");
                     break;
             }
         }


### PR DESCRIPTION
Adds support for Vulkan 1.3 and SPV 1.6 (apparently we did not have any tests relying on any SPV features > 1.5 up to this point).