### PR TITLE
layers: Use GetIndexAlignment everywhere

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -3254,15 +3254,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
 
     // no point checking index buffer if the memory is nonexistant/unmapped, or if there is no graphics pipeline bound to this CB
     if (ib_mem && pipeline_binding_iter.IsUsing()) {
-        uint32_t scan_stride;
-        if (ib_type == VK_INDEX_TYPE_UINT8_EXT) {
-            scan_stride = sizeof(uint8_t);
-        } else if (ib_type == VK_INDEX_TYPE_UINT16) {
-            scan_stride = sizeof(uint16_t);
-        } else {
-            scan_stride = sizeof(uint32_t);
-        }
-
+        const uint32_t scan_stride = GetIndexAlignment(ib_type);
         const uint8_t* scan_begin = static_cast<const uint8_t*>(ib_mem) + ib_mem_offset + firstIndex * scan_stride;
         const uint8_t* scan_end = scan_begin + indexCount * scan_stride;
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10936,7 +10936,7 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer
                                          "VK_BUFFER_USAGE_INDEX_BUFFER_BIT");
     skip |= ValidateCmd(cb_node.get(), CMD_BINDINDEXBUFFER);
     skip |= ValidateMemoryIsBoundToBuffer(buffer_state.get(), "vkCmdBindIndexBuffer()", "VUID-vkCmdBindIndexBuffer-buffer-00434");
-    const auto offset_align = GetIndexAlignment(indexType);
+    const auto offset_align = static_cast<VkDeviceSize>(GetIndexAlignment(indexType));
     if (offset % offset_align) {
         skip |= LogError(commandBuffer, "VUID-vkCmdBindIndexBuffer-offset-00432",
                          "vkCmdBindIndexBuffer() offset (0x%" PRIxLEAST64 ") does not fall on alignment (%s) boundary.", offset,

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -1267,18 +1267,9 @@ bool CoreChecks::ValidateCmdDrawIndexedBufferSize(const CMD_BUFFER_STATE &cb_sta
                                                   const char *caller, const char *first_index_vuid) const {
     bool skip = false;
     if (cb_state.status[CBSTATUS_INDEX_BUFFER_BOUND]) {
-        unsigned int index_size = 0;
         const auto &index_buffer_binding = cb_state.index_buffer_binding;
-        if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT16) {
-            index_size = 2;
-        }
-        else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT32) {
-            index_size = 4;
-        }
-        else if (index_buffer_binding.index_type == VK_INDEX_TYPE_UINT8_EXT) {
-            index_size = 1;
-        }
-        VkDeviceSize end_offset = (index_size * (static_cast<VkDeviceSize>(firstIndex) + indexCount)) + index_buffer_binding.offset;
+        const uint32_t index_size = GetIndexAlignment(index_buffer_binding.index_type);
+        VkDeviceSize end_offset = static_cast<VkDeviceSize>(index_size * (firstIndex + indexCount)) + index_buffer_binding.offset;
         if (end_offset > index_buffer_binding.size) {
             skip |= LogError(index_buffer_binding.buffer_state->buffer(), first_index_vuid,
                              "%s: index size (%u) * (firstIndex (%u) + indexCount (%u)) "

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -6488,22 +6488,18 @@ bool StatelessValidation::ValidateGeometryTrianglesNV(const VkGeometryTrianglesN
         triangles.indexType != VK_INDEX_TYPE_NONE_NV) {
         skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexType-02433", "%s", func_name);
     } else {
-        uint32_t index_element_size = 0;
-        if (triangles.indexType == VK_INDEX_TYPE_UINT32) {
-            index_element_size = 4;
-        } else if (triangles.indexType == VK_INDEX_TYPE_UINT16) {
-            index_element_size = 2;
-        }
+        const uint32_t index_element_size = GetIndexAlignment(triangles.indexType);
         if (index_element_size > 0 && SafeModulo(triangles.indexOffset, index_element_size) != 0) {
             skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexOffset-02432", "%s", func_name);
         }
-    }
-    if (triangles.indexType == VK_INDEX_TYPE_NONE_NV) {
-        if (triangles.indexCount != 0) {
-            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexCount-02436", "%s", func_name);
-        }
-        if (triangles.indexData != VK_NULL_HANDLE) {
-            skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexData-02434", "%s", func_name);
+
+        if (triangles.indexType == VK_INDEX_TYPE_NONE_NV) {
+            if (triangles.indexCount != 0) {
+                skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexCount-02436", "%s", func_name);
+            }
+            if (triangles.indexData != VK_NULL_HANDLE) {
+                skip |= LogError(object_handle, "VUID-VkGeometryTrianglesNV-indexData-02434", "%s", func_name);
+            }
         }
     }
 

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -607,10 +607,9 @@ class FilteredGeneratorGenerator {
 
 using EventImageRangeGenerator = FilteredGeneratorGenerator<SyncEventState::ScopeMap, subresource_adapter::ImageRangeGenerator>;
 
-
 ResourceAccessRange GetBufferRange(VkDeviceSize offset, VkDeviceSize buf_whole_size, uint32_t first_index, uint32_t count,
-                                   VkDeviceSize stride) {
-    VkDeviceSize range_start = offset + first_index * stride;
+                                   uint32_t stride) {
+    VkDeviceSize range_start = offset + (first_index * stride);
     VkDeviceSize range_size = 0;
     if (count == UINT32_MAX) {
         range_size = buf_whole_size - range_start;

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -252,7 +252,7 @@ static inline bool IsIdentitySwizzle(VkComponentMapping components) {
     // clang-format on
 }
 
-static inline VkDeviceSize GetIndexAlignment(VkIndexType indexType) {
+static inline uint32_t GetIndexAlignment(VkIndexType indexType) {
     switch (indexType) {
         case VK_INDEX_TYPE_UINT16:
             return 2;
@@ -260,6 +260,8 @@ static inline VkDeviceSize GetIndexAlignment(VkIndexType indexType) {
             return 4;
         case VK_INDEX_TYPE_UINT8_EXT:
             return 1;
+        case VK_INDEX_TYPE_NONE_KHR:  // alias VK_INDEX_TYPE_NONE_NV
+            return 0;
         default:
             // Not a real index type. Express no alignment requirement here; we expect upper layer
             // to have already picked up on the enum being nonsense.


### PR DESCRIPTION
Found a place not using `GetIndexAlignment` and went through and updated everyone to use it (and added `VK_INDEX_TYPE_NONE_KHR` support)

Changed from `VkDeviceSize` to `uint32_t` as only one location actually needed `VkDeviceSize` directly