### PR TITLE
cmake: Remove implict ccache/compile_commands.json

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -302,7 +302,44 @@ on/off options currently supported by this repository:
 | BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the components with XCB support. |
 | BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the components with Xlib support. |
 | BUILD_WSI_WAYLAND_SUPPORT | Linux | `ON` | Build the components with Wayland support. |
-| USE_CCACHE | Linux | `OFF` | Enable caching with the CCache program. |
+
+### CCACHE
+
+There are 2 methods to enable CCACHE
+
+1.) Set environment variables
+
+```
+# Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html)
+export CMAKE_CXX_COMPILER_LAUNCHER="/usr/bin/ccache"
+export CMAKE_C_COMPILER_LAUNCHER="/usr/bin/ccache"
+```
+
+2.) Pass in cache variables
+
+```
+cmake ... -D CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
+```
+
+### EXPORT_COMPILE_COMMANDS
+
+There are 2 methods to enable exporting compile commands
+
+1.) Set environment variables
+
+```
+# Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_EXPORT_COMPILE_COMMANDS.html)
+export CMAKE_EXPORT_COMPILE_COMMANDS="ON"
+```
+
+2.) Pass in cache variables
+
+```
+cmake ... -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+```
+
+NOTE: Modern tools will generally enable exporting compile commands for you (EX: VSCode).
+Also CMAKE_EXPORT_COMPILE_COMMANDS is implemented only by Makefile and Ninja generators. For other generators, this option is ignored.
 
 ## Building On Windows
 
@@ -586,8 +623,6 @@ to specify the number of cores to use for the build. For example:
 You can also use
 
     cmake --build .
-
-If your build system supports ccache, you can enable that via CMake option `-DUSE_CCACHE=On`
 
 ### Linux Notes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(Vulkan-ValidationLayers LANGUAGES CXX C)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 set(VVL_CPP_STANDARD 11 CACHE STRING "Set the C++ standard to build against. The value will be passed to cmake's CXX_STANDARD property.")
 
 option(VVL_ENABLE_ASAN "Use address sanitization (specifically -fsanitize=address)" OFF)
@@ -109,14 +107,6 @@ find_package(VulkanHeaders REQUIRED)
 add_library(Vulkan-Headers INTERFACE)
 target_include_directories(Vulkan-Headers INTERFACE ${VulkanHeaders_INCLUDE_DIRS})
 add_library(Vulkan::Headers ALIAS Vulkan-Headers)
-
-option(USE_CCACHE "Use ccache" OFF)
-if(USE_CCACHE)
-    find_program(CCACHE_FOUND ccache)
-    if(CCACHE_FOUND)
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    endif()
-endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -7,9 +7,6 @@
             "build_dir": "glslang/build",
             "install_dir": "glslang/build/install",
             "commit": "28b53119bdfbc43eae532641337a7adbb315b273",
-            "cmake_options": [
-                "-DUSE_CCACHE=ON"
-            ],
             "optional": [
                 "tests"
             ]


### PR DESCRIPTION
Remove CMake code for
- USE_CCACHE
- CMAKE_EXPORT_COMPILE_COMMANDS

Show in the docs how to enable these features via cli or environment variables.