### PR TITLE
layers: Fix a vkQueueSubmit()/vkQueueWaitIdle() race

### DIFF
--- a/layers/queue_state.h
+++ b/layers/queue_state.h
@@ -321,7 +321,7 @@ class QUEUE_STATE : public BASE_NODE {
   private:
     using LockGuard = std::unique_lock<std::mutex>;
     void ThreadFunc();
-    layer_data::optional<CB_SUBMISSION> NextSubmission();
+    CB_SUBMISSION *NextSubmission();
     LockGuard Lock() const { return LockGuard(lock_); }
 
     ValidationStateTracker &dev_data_;


### PR DESCRIPTION
Close a race condition in very common code in the test suite that does:

vkQueueSubmit(..., VK_NULL_HANDLE /*fence*/);
vkQueueWaitIdle(...);

While the thread function is processing a CB_SUBMISSION structure, it needs to stay on the deque so that QUEUE_STATE::Wait() can find it.