### PR TITLE
layers: Fix crash when validating GetDrmDisplayEXT

### DIFF
--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -9490,11 +9490,10 @@ VkResult DispatchGetDrmDisplayEXT(
 {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     if (!wrap_handles) return layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-    {
-        display = layer_data->Unwrap(display);
-    }
     VkResult result = layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-
+    if (VK_SUCCESS == result) {
+        *display = layer_data->WrapNew(*display);
+    }
     return result;
 }
 

--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -734,6 +734,16 @@ void ThreadSafety::PostCallRecordGetRandROutputDisplayEXT(
 
 #endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
+void ThreadSafety::PostCallRecordGetDrmDisplayEXT(
+    VkPhysicalDevice                            physicalDevice,
+    int32_t                                     drmFd,
+    uint32_t                                    connectorId,
+    VkDisplayKHR*                               display,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) || (display == nullptr)) return;
+    CreateObjectParentInstance(*display);
+}
+
 void ThreadSafety::PreCallRecordRegisterDisplayEventEXT(
     VkDevice                                    device,
     VkDisplayKHR                                display,

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -642,6 +642,13 @@ void PostCallRecordGetRandROutputDisplayEXT(
 
 #endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
+void PostCallRecordGetDrmDisplayEXT(
+    VkPhysicalDevice                            physicalDevice,
+    int32_t                                     drmFd,
+    uint32_t                                    connectorId,
+    VkDisplayKHR*                               display,
+    VkResult                                    result) override;
+
 void PreCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -2186,7 +2186,7 @@ void DispatchGetAccelerationStructureBuildSizesKHR(
                 if self.struct_contains_ndo(type) == True:
                     islocal = True
             isdestroy = True if True in [destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free', 'ReleasePerformanceConfigurationINTEL']] else False
-            iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL']] else False
+            iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'GetDrmDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL']] else False
             extstructs = self.registry.validextensionstructs[type] if name == 'pNext' else None
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -633,7 +633,14 @@ void PostCallRecordGetRandROutputDisplayEXT(
     VkDisplayKHR*                               pDisplay,
     VkResult                                    result) override;
 
-#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT"""
+#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+void PostCallRecordGetDrmDisplayEXT(
+    VkPhysicalDevice                            physicalDevice,
+    int32_t                                     drmFd,
+    uint32_t                                    connectorId,
+    VkDisplayKHR*                               display,
+    VkResult                                    result) override;"""
 
 
     inline_custom_source_preamble = """
@@ -1345,6 +1352,16 @@ void ThreadSafety::PostCallRecordGetRandROutputDisplayEXT(
 
 #endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
+void ThreadSafety::PostCallRecordGetDrmDisplayEXT(
+    VkPhysicalDevice                            physicalDevice,
+    int32_t                                     drmFd,
+    uint32_t                                    connectorId,
+    VkDisplayKHR*                               display,
+    VkResult                                    result) {
+    if ((result != VK_SUCCESS) || (display == nullptr)) return;
+    CreateObjectParentInstance(*display);
+}
+
 void ThreadSafety::PreCallRecordRegisterDisplayEventEXT(
     VkDevice                                    device,
     VkDisplayKHR                                display,
@@ -1796,6 +1813,7 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(
             'vkGetDisplayModeProperties2KHR',
             'vkGetDisplayPlaneCapabilities2KHR',
             'vkGetRandROutputDisplayEXT',
+            'vkGetDrmDisplayEXT',
             'vkDeviceWaitIdle',
             'vkRegisterDisplayEventEXT',
             'vkCreateRayTracingPipelinesKHR',


### PR DESCRIPTION
This creates the `display` object so it needs to be added to this list.