### PR TITLE
layers: Move some utils into Instruction

### DIFF
--- a/layers/shader_instruction.h
+++ b/layers/shader_instruction.h
@@ -56,6 +56,9 @@ class Instruction {
     // operand id index, return 0 if no type
     uint32_t TypeId() const { return type_id_; }
 
+    // Used when need to print information for an error message
+    std::string Describe() const;
+
     // Only used to get strings in SPIR-V instructions
     // SPIR-V spec (and spirv-val) ensure:
     // "A string is interpreted as a nul-terminated stream of characters"
@@ -64,6 +67,7 @@ class Instruction {
         return (char const*)&words_[operand];
     }
 
+    uint32_t GetConstantValue() const;
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -327,7 +327,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // Used to get human readable strings for error messages
     void DescribeTypeInner(std::ostringstream &ss, uint32_t type) const;
     std::string DescribeType(uint32_t type) const;
-    std::string DescribeInstruction(const Instruction *insn) const;
 
     layer_data::unordered_set<uint32_t> MarkAccessibleIds(layer_data::optional<Instruction> entrypoint) const;
     layer_data::optional<VkPrimitiveTopology> GetTopology(const Instruction &entrypoint) const;
@@ -341,7 +340,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     bool FindLocalSize(const Instruction &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
 
     const Instruction *GetConstantDef(uint32_t id) const;
-    uint32_t GetConstantValue(const Instruction *insn) const;
     uint32_t GetConstantValueById(uint32_t id) const;
     int32_t GetShaderResourceDimensionality(const interface_var &resource) const;
     uint32_t GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const;


### PR DESCRIPTION
Moves both `Describe()` and `GetConstantValue` into the new `Instruction` class

These are pretty low hanging fruit that give a nice little readability boost