### PR TITLE
corechecks: Add execution-time checking timeline semaphores

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -240,8 +240,18 @@ class CommandBuffer: public CMD_BUFFER_STATE {
     void RecordWaitEvents(CMD_TYPE cmd_type, uint32_t eventCount, const VkEvent* pEvents,
                           VkPipelineStageFlags2KHR src_stage_mask) override;
 };
+
+class Semaphore : public SEMAPHORE_STATE {
+  public:
+    Semaphore(ValidationStateTracker& dev, VkSemaphore sem, const VkSemaphoreCreateInfo* pCreateInfo)
+        : SEMAPHORE_STATE(dev, sem, pCreateInfo) {}
+
+  protected:
+    bool Validate(const core_error::Location& loc, const SemOp& op) const override;
+};
 }
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, core_state::CommandBuffer, CMD_BUFFER_STATE);
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkSemaphore, core_state::Semaphore, SEMAPHORE_STATE);
 
 struct TimelineMaxDiffCheck {
     TimelineMaxDiffCheck(uint64_t value_, uint64_t max_diff_) : value(value_), max_diff(max_diff_) {}
@@ -1404,6 +1414,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator) const override;
     bool PreCallValidateCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkFence* pFence) const override;
+    std::shared_ptr<SEMAPHORE_STATE> CreateSemaphore(VkSemaphore semaphore, const VkSemaphoreCreateInfo* pCreateInfo) override;
     bool PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore) const override;
     bool PreCallValidateWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout) const override;

--- a/layers/core_checks/synchronization_validation.cpp
+++ b/layers/core_checks/synchronization_validation.cpp
@@ -1116,7 +1116,7 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
     return ValidateCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, CMD_WAITEVENTS2);
 }
 
-void CORE_CMD_BUFFER_STATE::RecordWaitEvents(CMD_TYPE cmd_type, uint32_t eventCount, const VkEvent *pEvents,
+void core_state::CommandBuffer::RecordWaitEvents(CMD_TYPE cmd_type, uint32_t eventCount, const VkEvent *pEvents,
                                              VkPipelineStageFlags2KHR srcStageMask) {
     // CMD_BUFFER_STATE will add to the events vector.
     auto first_event_index = events.size();

--- a/layers/error_message/core_error_location.cpp
+++ b/layers/error_message/core_error_location.cpp
@@ -104,6 +104,7 @@ const std::string& String(Field field) {
         FIELD_ENTRY(value),
         FIELD_ENTRY(pCommandBuffers),
         FIELD_ENTRY(pSubmits),
+        FIELD_ENTRY(pBindInfo),
         FIELD_ENTRY(pCommandBufferInfos),
         FIELD_ENTRY(semaphore),
         FIELD_ENTRY(commandBuffer),

--- a/layers/error_message/core_error_location.h
+++ b/layers/error_message/core_error_location.h
@@ -112,6 +112,7 @@ enum class Field {
     value,
     pCommandBuffers,
     pSubmits,
+    pBindInfo,
     pCommandBufferInfos,
     semaphore,
     commandBuffer,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -822,6 +822,7 @@ class ValidationStateTracker : public ValidationObject {
                                                        VkSamplerYcbcrConversion* pYcbcrConversion, VkResult result) override;
     void PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                         const VkAllocationCallbacks* pAllocator) override;
+    virtual std::shared_ptr<SEMAPHORE_STATE> CreateSemaphore(VkSemaphore semaphore, const VkSemaphoreCreateInfo* pCreateInfo);
     void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore, VkResult result) override;
     void PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator) override;


### PR DESCRIPTION
There are requirements on the signal value for timeline semaphores that can only be fully checked at execution time. Now that QUEUE_STATE::ThreadFunc provides a location where we know execution dependencies for each submission have completed, we can check it there.
    
This affects the following VUIDs:
    
    VUID-VkBindSparseInfo-pSignalSemaphores-03249
    VUID-VkSubmitInfo-pSignalSemaphores-03242
    VUID-VkSubmitInfo2-semaphore-03882
    
It is important to note that execution time checking cannot block execution of invalid signal operations. To do that we'd have to we'd have to defer queue submissions until all of their dependencies were known to have completed. This would be very tricky and probably slow.
   
There are quite a few other VUIDs related to image layouts, swapchains, and other things that can only be accurately checked this way. They'll be added in future PRs.

