### PR TITLE
tests: Pixel6 failure tests fixed

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1292,7 +1292,9 @@ VkRenderPass VkArmBestPracticesLayerTest::CreateRenderPass(VkFormat format, VkAt
     rpinf.dependencyCount = 0;
     rpinf.pDependencies = nullptr;
 
-    vk::CreateRenderPass(m_device->handle(), &rpinf, nullptr, &renderpass);
+    VkResult result = vk::CreateRenderPass(m_device->handle(), &rpinf, nullptr, &renderpass);
+    assert(result == VK_SUCCESS);
+    (void)result;
 
     return renderpass;
 }
@@ -1309,7 +1311,9 @@ VkFramebuffer VkArmBestPracticesLayerTest::CreateFramebuffer(const uint32_t widt
     framebuffer_create_info.height = height;
     framebuffer_create_info.layers = 1;
 
-    vk::CreateFramebuffer(m_device->handle(), &framebuffer_create_info, nullptr, &framebuffer);
+    VkResult result = vk::CreateFramebuffer(m_device->handle(), &framebuffer_create_info, nullptr, &framebuffer);
+    assert(result == VK_SUCCESS);
+    (void)result;
 
     return framebuffer;
 }
@@ -1327,7 +1331,9 @@ VkSampler VkArmBestPracticesLayerTest::CreateDefaultSampler() {
     sampler_create_info.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
     sampler_create_info.maxLod = VK_LOD_CLAMP_NONE;
 
-    vk::CreateSampler(m_device->handle(), &sampler_create_info, nullptr, &sampler);
+    VkResult result = vk::CreateSampler(m_device->handle(), &sampler_create_info, nullptr, &sampler);
+    assert(result == VK_SUCCESS);
+    (void)result;
 
     return sampler;
 }

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -932,7 +932,8 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE));
     framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[0]->targetView(FMT), renderpasses[0]));
 
-    images.push_back(CreateImage(FMT, WIDTH, HEIGHT));
+    images.push_back(
+        CreateImage(FMT, WIDTH, HEIGHT, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
     renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_DONT_CARE));
     framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[1]->targetView(FMT), renderpasses[1]));
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -9565,7 +9565,6 @@ TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
         }
 
         if (dev_limits.maxFramebufferHeight != UINT32_MAX) {
-            image_ci.usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;  // try different one too
             image_ci.extent = {64, dev_limits.maxFramebufferHeight + 1, 1};
             if (dev_limits.maxFramebufferHeight + 1 > img_limits.maxExtent.height) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-extent-02253");

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -7449,8 +7449,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
-        printf("%s CreateImageView calls crash ShieldTV, skipped for this platform.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "CreateImageView calls crash ShieldTV";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -7464,8 +7463,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     auto features2 = GetPhysicalDeviceFeatures2(protected_memory_features);
 
     if (protected_memory_features.protectedMemory == VK_FALSE) {
-        printf("%s protectedMemory feature not supported, skipped.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "protectedMemory feature not supported";
     };
 
     VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties =
@@ -7557,10 +7555,9 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
         }
     }
     if ((memory_type_protected >= phys_mem_props.memoryTypeCount) || (memory_type_unprotected >= phys_mem_props.memoryTypeCount)) {
-        printf("%s No valid memory type index could be found; skipped.\n", kSkipPrefix);
         vk::DestroyBuffer(device(), buffer_protected, nullptr);
         vk::DestroyBuffer(device(), buffer_unprotected, nullptr);
-        return;
+        GTEST_SKIP() << "No valid memory type index could be found";
     }
 
     alloc_info.memoryTypeIndex = memory_type_protected;
@@ -7680,7 +7677,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     // Use protected resources in unprotected command buffer
     g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_protected, 0, 1024);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[0], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+                                                     VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
     m_commandBuffer->begin();
@@ -7777,7 +7774,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     // Use unprotected resources in protected command buffer
     g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 0, 1024);
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_views_descriptor[1], sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+                                                     VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
     protectedCommandBuffer.begin();
@@ -7866,6 +7863,7 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
     vk::FreeMemory(device(), memory_unprotected, nullptr);
     vk::DestroyFramebuffer(device(), framebuffer, nullptr);
     vk::DestroyRenderPass(device(), render_pass, nullptr);
+    vk::DestroySampler(device(), sampler, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -8302,40 +8302,28 @@ TEST_F(VkLayerTest, CreateDescriptorUpdateTemplate) {
 TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     TEST_DESCRIPTION("Test VK_EXT_inline_uniform_block.");
 
-    if (InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    } else {
-        printf("%s Did not find required instance extension %s; skipped.\n", kSkipPrefix,
-               VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-        return;
-    }
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
+    AddOptionalExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
+    AddOptionalExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    std::array<const char *, 2> required_device_extensions = {
-        {VK_KHR_MAINTENANCE_1_EXTENSION_NAME, VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME}};
-    for (auto device_extension : required_device_extensions) {
-        if (DeviceExtensionSupported(gpu(), nullptr, device_extension)) {
-            m_device_extension_names.push_back(device_extension);
-        } else {
-            printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, device_extension);
-            return;
-        }
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required.";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    if (IsPlatform(kGalaxyS10)) {
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     // Enable descriptor indexing if supported, but don't require it.
-    bool supportsDescriptorIndexing = true;
-    required_device_extensions = {{VK_KHR_MAINTENANCE_3_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME}};
-    for (auto device_extension : required_device_extensions) {
-        if (DeviceExtensionSupported(gpu(), nullptr, device_extension)) {
-            m_device_extension_names.push_back(device_extension);
-        } else {
-            printf("%s %s Extension not supported, skipping tests\n", kSkipPrefix, device_extension);
-            supportsDescriptorIndexing = false;
-            return;
-        }
-    }
+    bool has_descriptor_indexing =
+        IsExtensionsEnabled(VK_KHR_MAINTENANCE_3_EXTENSION_NAME) && IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
     auto descriptor_indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
-    void *pNext = supportsDescriptorIndexing ? &descriptor_indexing_features : nullptr;
+    void *pNext = has_descriptor_indexing ? &descriptor_indexing_features : nullptr;
     // Create a device that enables inline_uniform_block
     auto inline_uniform_block_features = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(pNext);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);
@@ -8348,7 +8336,6 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     auto inline_uniform_props = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&inline_uniform_props);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkDescriptorSetLayoutBinding dslb = {};
@@ -8364,15 +8351,13 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
     if (inline_uniform_props.maxInlineUniformBlockSize < dslb.descriptorCount) {
-        printf("%sDescriptorCount exceeds InlineUniformBlockSize limit, skipping tests\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "DescriptorCount exceeds InlineUniformBlockSize limit";
     }
 
     uint32_t maxBlocks = std::max(inline_uniform_props.maxPerStageDescriptorInlineUniformBlocks,
                                   inline_uniform_props.maxDescriptorSetInlineUniformBlocks);
     if (maxBlocks > 4096) {
-        printf("Too large of a maximum number of inline uniform blocks, skipping tests\n");
-        return;
+        GTEST_SKIP() << "Too large of a maximum number of inline uniform blocks";
     }
 
     for (uint32_t i = 0; i < 1 + maxBlocks; ++i) {
@@ -8385,10 +8370,10 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     VkResult err = vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     ASSERT_VK_SUCCESS(err);
 
-    const char *max_inline_vuid = (supportsDescriptorIndexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
-                                                               : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02212";
-    const char *max_all_inline_vuid = (supportsDescriptorIndexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"
-                                                                   : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02213";
+    const char *max_inline_vuid = (has_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"
+                                                            : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02212";
+    const char *max_all_inline_vuid = (has_descriptor_indexing) ? "VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"
+                                                                : "VUID-VkPipelineLayoutCreateInfo-descriptorType-02213";
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, max_inline_vuid);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, max_all_inline_vuid);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02215");


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4425

Should fix

- VkArmBestPracticesLayerTest.RedundantRenderPassStore
- VkLayerTest.InvalidMixingProtectedResources
- VkLayerTest.CreateImageMaxLimitsViolation

These were cases where the test logic was wrong