### PR TITLE
tests: Fix AHB tests

### DIFF
--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2140,8 +2140,7 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputStructComponents) {
 
     // There is a crash inside the driver on S10
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test does not currently run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1767,7 +1767,7 @@ TEST_F(VkLayerTest, InvalidExternalFence) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    const auto other_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT; 
+    const auto other_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     const auto bad_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
     const char *bad_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452";
     const char *other_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448";
@@ -4515,13 +4515,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
-
     VkImage img = VK_NULL_HANDLE;
-    auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
-        img = VK_NULL_HANDLE;
-    };
 
     VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>();
     ici.imageType = VK_IMAGE_TYPE_2D;
@@ -4539,27 +4533,24 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     // Various extra errors for having VK_FORMAT_UNDEFINED without VkExternalFormatANDROID
     m_errorMonitor->SetUnexpectedError("VUID_Undefined");
     m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
 
     // also undefined format
     VkExternalFormatANDROID efa = LvlInitStruct<VkExternalFormatANDROID>();
     efa.externalFormat = 0;
     ici.pNext = &efa;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01975");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
 
     // undefined format with an unknown external format
     efa.externalFormat = 0xBADC0DE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExternalFormatANDROID-externalFormat-01894");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
 
-    AHardwareBuffer *ahb;
+    AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
@@ -4573,41 +4564,38 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
-    pfn_GetAHBProps(dev, ahb, &ahb_props);
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
 
     // a defined image format with a non-zero external format
     ici.format = VK_FORMAT_R8G8B8A8_UNORM;
     efa.externalFormat = ahb_fmt_props.externalFormat;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01974");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
     ici.format = VK_FORMAT_UNDEFINED;
 
     // external format while MUTABLE
     ici.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02396");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
     ici.flags = 0;
 
     // external format while usage other than SAMPLED
     ici.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02397");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     // external format while tiline other than OPTIMAL
     ici.tiling = VK_IMAGE_TILING_LINEAR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02398");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
 
     // imageType
@@ -4619,18 +4607,18 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     ici.extent = {64, 64, 64};
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02393");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
 
     // wrong mipLevels
     ici.imageType = VK_IMAGE_TYPE_2D;
     ici.extent = {64, 64, 1};
     ici.mipLevels = 6;  // should be 7
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-02394");
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
     m_errorMonitor->VerifyFound();
-    reset_img();
+
+    AHardwareBuffer_release(ahb);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
@@ -4645,15 +4633,11 @@ TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
 
-    VkImage img = VK_NULL_HANDLE;
-    auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
-        img = VK_NULL_HANDLE;
-    };
+    VkExternalMemoryImageCreateInfo emici = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
+    emici.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&emici);
     ici.imageType = VK_IMAGE_TYPE_2D;
     ici.arrayLayers = 1;
     ici.extent = {64, 64, 1};
@@ -4664,33 +4648,28 @@ TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
     ici.tiling = VK_IMAGE_TILING_LINEAR;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkExternalMemoryImageCreateInfo emici = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
-    emici.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-    ici.pNext = &emici;
-
-    vk::CreateImage(dev, &ici, NULL, &img);
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
 
     // attempt to fetch layout from unbound image
     VkImageSubresource sub_rsrc = {};
     sub_rsrc.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     VkSubresourceLayout sub_layout = {};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout-image-01895");
-    vk::GetImageSubresourceLayout(dev, img, &sub_rsrc, &sub_layout);
+    vk::GetImageSubresourceLayout(device(), image.handle(), &sub_rsrc, &sub_layout);
     m_errorMonitor->VerifyFound();
 
     // attempt to get memory reqs from unbound image
     VkImageMemoryRequirementsInfo2 imri = LvlInitStruct<VkImageMemoryRequirementsInfo2>();
-    imri.image = img;
+    imri.image = image.handle();
     VkMemoryRequirements2 mem_reqs = LvlInitStruct<VkMemoryRequirements2>();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryRequirementsInfo2-image-01897");
-    vk::GetImageMemoryRequirements2(dev, &imri, &mem_reqs);
+    vk::GetImageMemoryRequirements2(device(), &imri, &mem_reqs);
     m_errorMonitor->VerifyFound();
-
-    reset_img();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
-    TEST_DESCRIPTION("Verify AndroidHardwareBuffer memory allocation.");
+TEST_F(VkLayerTest, AndroidHardwareBufferGpuDataBuffer) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer missing USAGE_GPU_DATA_BUFFER.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
@@ -4705,54 +4684,146 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
-
-    VkImage img = VK_NULL_HANDLE;
-    auto reset_img = [&img, dev]() {
-        if (VK_NULL_HANDLE != img) vk::DestroyImage(dev, img, NULL);
-        img = VK_NULL_HANDLE;
-    };
-    VkDeviceMemory mem_handle = VK_NULL_HANDLE;
-    auto reset_mem = [&mem_handle, dev]() {
-        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
-        mem_handle = VK_NULL_HANDLE;
-    };
 
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
-    // AHB structs
     AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
-    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
-    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
-    VkImportAndroidHardwareBufferInfoANDROID iahbi = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
-
-    // destroy and re-acquire an AHB, and fetch it's properties
-    auto recreate_ahb = [&ahb, &iahbi, &ahb_desc, &ahb_props, dev, pfn_GetAHBProps]() {
-        if (ahb) AHardwareBuffer_release(ahb);
-        ahb = nullptr;
-        AHardwareBuffer_allocate(&ahb_desc, &ahb);
-        if (ahb) {
-            pfn_GetAHBProps(dev, ahb, &ahb_props);
-            iahbi.buffer = ahb;
-        }
-    };
-
-    // Allocate an AHardwareBuffer
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
     ahb_desc.width = 64;
     ahb_desc.height = 64;
     ahb_desc.layers = 1;
-    recreate_ahb();
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
-    // Create an image w/ external format
-    VkExternalFormatANDROID efa = LvlInitStruct<VkExternalFormatANDROID>();
-    efa.externalFormat = ahb_fmt_props.externalFormat;
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
+    import_ahb_Info.buffer = ahb;
 
-    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&efa);
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    // Import requires format AHB_FMT_BLOB and usage AHB_USAGE_GPU_DATA_BUFFER
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02384");
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferAllocationSize) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct allocationSize is used.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
+    ahb_desc.width = 64;
+    ahb_desc.height = 1;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
+    import_ahb_Info.buffer = ahb;
+
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    // Allocation size mismatch
+    memory_allocate_info.allocationSize = ahb_props.allocationSize + 1;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
+    m_errorMonitor->VerifyFound();
+
+    // memoryTypeIndex mismatch
+    memory_allocate_info.allocationSize = ahb_props.allocationSize;
+    memory_allocate_info.memoryTypeIndex++;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageColor) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct usage for dedicated allocated color image.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
+    ahb_desc.width = 64;
+    ahb_desc.height = 64;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkExternalFormatANDROID external_format = LvlInitStruct<VkExternalFormatANDROID>();
+    external_format.externalFormat = ahb_fmt_props.externalFormat;
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&external_format);
     ici.imageType = VK_IMAGE_TYPE_2D;
     ici.arrayLayers = 1;
     ici.extent = {64, 64, 1};
@@ -4762,175 +4833,505 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMemoryAllocation) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkResult res = vk::CreateImage(dev, &ici, NULL, &img);
-    ASSERT_VK_SUCCESS(res);
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
 
-    // Chained import struct
-    VkMemoryAllocateInfo mai = LvlInitStruct<VkMemoryAllocateInfo>(&iahbi);
-    mai.allocationSize = ahb_props.allocationSize;
-    mai.memoryTypeIndex = 32;
-    // Set index to match one of the bits in ahb_props
-    for (int i = 0; i < 32; i++) {
-        if (ahb_props.memoryTypeBits & (1 << i)) {
-            mai.memoryTypeIndex = i;
-            break;
-        }
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
     }
-    ASSERT_NE(32, mai.memoryTypeIndex);
 
-    // Import w/ non-dedicated memory allocation
+    VkDeviceMemory memory = VK_NULL_HANDLE;
 
-    // Import requires format AHB_FMT_BLOB and usage AHB_USAGE_GPU_DATA_BUFFER
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02384");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    reset_mem();
-
-    // Allocation size mismatch
-    ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
-    ahb_desc.height = 1;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize + 1;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    mai.allocationSize = ahb_props.allocationSize;
-    reset_mem();
-
-    // memoryTypeIndex mismatch
-    mai.memoryTypeIndex++;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    mai.memoryTypeIndex--;
-    reset_mem();
-
-    // Insert dedicated image memory allocation to mai chain
-    VkMemoryDedicatedAllocateInfo mdai = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
-    mdai.image = img;
-    mdai.buffer = VK_NULL_HANDLE;
-    mdai.pNext = mai.pNext;
-    mai.pNext = &mdai;
-
-    // Dedicated allocation with unmatched usage bits for Color
-    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
-    ahb_desc.height = 64;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
     m_errorMonitor->VerifyFound();
-    reset_mem();
 
-    // Dedicated allocation with unmatched usage bits for Depth/Stencil
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageDS) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct usage for dedicated allocated depth/stencil image.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_S8_UINT;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
+    ahb_desc.width = 64;
     ahb_desc.height = 64;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    reset_mem();
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
-    // Dedicated allocation with incomplete mip chain
-    reset_img();
-    ici.mipLevels = 2;
-    vk::CreateImage(dev, &ici, NULL, &img);
-    mdai.image = img;
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE;
-    recreate_ahb();
+    // Incase it hits the below driver bug, catch the false VUID error thrown from driver not creating valid AHB
+    m_errorMonitor->SetUnexpectedError("VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
 
-    if (ahb) {
-        mai.allocationSize = ahb_props.allocationSize;
-        for (int i = 0; i < 32; i++) {
-            if (ahb_props.memoryTypeBits & (1 << i)) {
-                mai.memoryTypeIndex = i;
-                break;
-            }
-        }
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02389");
-        vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-        m_errorMonitor->VerifyFound();
-        reset_mem();
-    } else {
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    if (ahb_fmt_props.format != VK_FORMAT_S8_UINT) {
+        GTEST_SKIP() << "Driver bug: Didn't turn AHB format into VK_FORMAT_S8_UINT";
+    }
+
+    VkExternalFormatANDROID external_format = LvlInitStruct<VkExternalFormatANDROID>();
+    external_format.externalFormat = ahb_fmt_props.externalFormat;
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&external_format);
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_UNDEFINED;
+    ici.mipLevels = 1;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
         AHardwareBuffer_release(ahb);
-        reset_mem();
-        reset_img();
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferMipmapChain) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct mipmap chain.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE;
+    ahb_desc.width = 64;
+    ahb_desc.height = 64;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+    if (!ahb) {
         // ERROR: AHardwareBuffer_allocate() with MIPMAP_COMPLETE fails. It returns -12, NO_MEMORY.
         // The problem seems to happen in Pixel 2, not Pixel 3.
         GTEST_SKIP() << "AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE not supported";
     }
 
-    // Dedicated allocation with mis-matched dimension
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>();
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_R8G8B8A8_UNORM;
+    ici.mipLevels = 2;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02389");
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferImageDimensions) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer dimension and VkImage match.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
-    ahb_desc.height = 32;
     ahb_desc.width = 128;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02388");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    reset_mem();
+    ahb_desc.height = 32;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
-    // Dedicated allocation with mis-matched VkFormat
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
-    ahb_desc.height = 64;
-    ahb_desc.width = 64;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize;
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkExternalFormatANDROID external_format = LvlInitStruct<VkExternalFormatANDROID>();
+    external_format.externalFormat = ahb_fmt_props.externalFormat;
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&external_format);
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_UNDEFINED;
     ici.mipLevels = 1;
-    ici.format = VK_FORMAT_B8G8R8A8_UNORM;
-    ici.pNext = NULL;
-    VkImage img2;
-    vk::CreateImage(dev, &ici, NULL, &img2);
-    mdai.image = img2;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02387");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyImage(dev, img2, NULL);
-    mdai.image = img;
-    reset_mem();
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
 
-    // Missing required ahb usage
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
-    recreate_ahb();
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02388");
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
     m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferUnknownFormat) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer uses VK_FORMAT_UNDEFINED for external.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    ahb_desc.width = 64;
+    ahb_desc.height = 64;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>();
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_B8G8R8A8_UNORM;
+    ici.mipLevels = 1;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02387");
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferGpuUsage) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer has a GPU usage flag.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT;
+    ahb_desc.width = 64;
+    ahb_desc.height = 64;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+    if (!ahb) {
+        GTEST_SKIP() << "Was unable to allocate an AHB";
+    }
+
+    // Everything from ahb_props is garbage and not usable
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+    m_errorMonitor->VerifyFound();
+
+    // Since we are creating a invalid AHB for the safe of getting the below AHB, there is a chance the driver will not be forgiving
+    // and still give an usable AHB
+    {
+        AHardwareBuffer_Desc ahb_desc_check = {};
+        AHardwareBuffer_describe(ahb, &ahb_desc_check);
+        if (ahb_desc_check.usage == 0) {
+            GTEST_SKIP() << "Was unable to create a valid AHB to be used";
+        }
+    }
+
+    VkExternalFormatANDROID external_format = LvlInitStruct<VkExternalFormatANDROID>();
+    external_format.externalFormat = 0;
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&external_format);
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_R8G8B8A8_UNORM;
+    ici.mipLevels = 1;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
+        LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>(&dedicated_allocation_info);
+    import_ahb_Info.buffer = ahb;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
 
     // Dedicated allocation with missing usage bits
     // Setting up this test also triggers a slew of others
-    mai.allocationSize = ahb_props.allocationSize + 1;
-    mai.memoryTypeIndex = 0;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02390");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-allocationSize-02383");
+    memory_allocate_info.allocationSize = 4096;
+    memory_allocate_info.memoryTypeIndex = 0;
+    m_errorMonitor->SetUnexpectedError("VUID-VkMemoryAllocateInfo-pNext-02390");
+    m_errorMonitor->SetUnexpectedError("VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
+    m_errorMonitor->SetUnexpectedError("VUID-VkMemoryAllocateInfo-allocationSize-02383");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02386");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
     m_errorMonitor->VerifyFound();
-    reset_mem();
-
-    // Non-import allocation - replace import struct in chain with export struct
-    VkExportMemoryAllocateInfo emai = LvlInitStruct<VkExportMemoryAllocateInfo>();
-    emai.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-    mai.pNext = &emai;
-    emai.pNext = &mdai;  // still dedicated
-    mdai.pNext = nullptr;
-
-    // Export with allocation size non-zero
-    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
-    recreate_ahb();
-    mai.allocationSize = ahb_props.allocationSize;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-01874");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    m_errorMonitor->VerifyFound();
-    reset_mem();
 
     AHardwareBuffer_release(ahb);
-    reset_mem();
-    reset_img();
+}
+
+TEST_F(VkLayerTest, AndroidHardwareBufferExportMemoryAllocate) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer VkExportMemoryAllocateInfo instead of import.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
+    ASSERT_TRUE(pfn_GetAHBProps != nullptr);
+
+    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer_Desc ahb_desc = {};
+    ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    ahb_desc.width = 64;
+    ahb_desc.height = 64;
+    ahb_desc.layers = 1;
+    ahb_desc.stride = 1;
+    AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
+    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+
+    VkExternalFormatANDROID external_format = LvlInitStruct<VkExternalFormatANDROID>();
+    external_format.externalFormat = ahb_fmt_props.externalFormat;
+
+    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>(&external_format);
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_UNDEFINED;
+    ici.mipLevels = 1;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, ici);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    dedicated_allocation_info.image = image.handle();
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    // Non-import allocation - replace import struct in chain with export struct
+    VkExportMemoryAllocateInfo export_memory = LvlInitStruct<VkExportMemoryAllocateInfo>(&dedicated_allocation_info);
+    export_memory.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&export_memory);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        AHardwareBuffer_release(ahb);
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-01874");
+    vk::AllocateMemory(device(), &memory_allocate_info, NULL, &memory);
+    m_errorMonitor->VerifyFound();
+
+    AHardwareBuffer_release(ahb);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
@@ -4948,7 +5349,6 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_features = LvlInitStruct<VkPhysicalDeviceSamplerYcbcrConversionFeatures>();
     ycbcr_features.samplerYcbcrConversion = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ycbcr_features));
-    VkDevice dev = m_device->device();
 
     VkSamplerYcbcrConversion ycbcr_conv = VK_NULL_HANDLE;
     VkSamplerYcbcrConversionCreateInfo sycci = LvlInitStruct<VkSamplerYcbcrConversionCreateInfo>();
@@ -4958,7 +5358,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-04061");
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     VkExternalFormatANDROID efa = LvlInitStruct<VkExternalFormatANDROID>();
@@ -4967,7 +5367,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     sycci.pNext = &efa;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerYcbcrConversionCreateInfo-format-01904");
     m_errorMonitor->SetUnexpectedError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651");
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
     m_errorMonitor->VerifyFound();
 
     efa.externalFormat = AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420;
@@ -4976,8 +5376,8 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
     // Spec says if we use VkExternalFormatANDROID value of components is ignored.
     sycci.components = {VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO};
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
-    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, nullptr);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
+    vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, nullptr);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferPhysDevImageFormatProp2) {
@@ -5029,8 +5429,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5038,7 +5437,6 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
 
     // Allocate an AHB and fetch its properties
     AHardwareBuffer *ahb = nullptr;
@@ -5054,9 +5452,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props);
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
-    pfn_GetAHBProps(dev, ahb, &ahb_props);
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
     AHardwareBuffer_release(ahb);
 
     VkExternalMemoryImageCreateInfo emici = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
@@ -5078,7 +5477,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
         LvlInitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
     VkAndroidHardwareBufferPropertiesANDROID ahb_props_Ycbcr =
         LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_fmt_props_Ycbcr);
-    pfn_GetAHBProps(dev, ahb, &ahb_props_Ycbcr);
+    pfn_GetAHBProps(device(), ahb, &ahb_props_Ycbcr);
     AHardwareBuffer_release(ahb);
 
     VkExternalFormatANDROID efa_Ycbcr = LvlInitStruct<VkExternalFormatANDROID>();
@@ -5103,28 +5502,28 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    vk::CreateImage(dev, &ici, NULL, &img);
+    vk::CreateImage(device(), &ici, NULL, &img);
 
     // Set up memory allocation
     VkDeviceMemory img_mem = VK_NULL_HANDLE;
     VkMemoryAllocateInfo mai = LvlInitStruct<VkMemoryAllocateInfo>();
     mai.allocationSize = 64 * 64 * 4;
     mai.memoryTypeIndex = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &img_mem);
+    vk::AllocateMemory(device(), &mai, NULL, &img_mem);
 
     // It shouldn't use vk::GetImageMemoryRequirements for imported AndroidHardwareBuffer when memory isn't bound yet
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageMemoryRequirements-image-04004");
     VkMemoryRequirements img_mem_reqs = {};
-    vk::GetImageMemoryRequirements(m_device->device(), img, &img_mem_reqs);
+    vk::GetImageMemoryRequirements(device(), img, &img_mem_reqs);
     m_errorMonitor->VerifyFound();
-    vk::BindImageMemory(dev, img, img_mem, 0);
+    vk::BindImageMemory(device(), img, img_mem, 0);
 
     // Bind image to memory
-    vk::DestroyImage(dev, img, NULL);
-    vk::FreeMemory(dev, img_mem, NULL);
-    vk::CreateImage(dev, &ici, NULL, &img);
-    vk::AllocateMemory(dev, &mai, NULL, &img_mem);
-    vk::BindImageMemory(dev, img, img_mem, 0);
+    vk::DestroyImage(device(), img, NULL);
+    vk::FreeMemory(device(), img_mem, NULL);
+    vk::CreateImage(device(), &ici, NULL, &img);
+    vk::AllocateMemory(device(), &mai, NULL, &img_mem);
+    vk::BindImageMemory(device(), img, img_mem, 0);
 
     // Create a YCbCr conversion, with different external format, chain to view
     VkSamplerYcbcrConversion ycbcr_conv = VK_NULL_HANDLE;
@@ -5132,7 +5531,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     sycci.format = VK_FORMAT_UNDEFINED;
     sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     sycci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
     VkSamplerYcbcrConversionInfo syci = LvlInitStruct<VkSamplerYcbcrConversionInfo>();
     syci.conversion = ycbcr_conv;
 
@@ -5155,13 +5554,13 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02400");
     // Also causes "unsupported format" - should be removed in future spec update
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-None-02273");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(device(), &ivci, NULL, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
-    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, NULL);
+    vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, NULL);
     sycci.pNext = &efa;
-    vk::CreateSamplerYcbcrConversion(dev, &sycci, NULL, &ycbcr_conv);
+    vk::CreateSamplerYcbcrConversion(device(), &sycci, NULL, &ycbcr_conv);
     syci.conversion = ycbcr_conv;
 
     // View component swizzle not IDENTITY
@@ -5170,7 +5569,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02401");
     // Also causes "unsupported format" - should be removed in future spec update
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-None-02273");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(device(), &ivci, NULL, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
@@ -5182,14 +5581,14 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-02399");
     // Also causes "view format different from image format"
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-01762");
-    vk::CreateImageView(dev, &ivci, NULL, &image_view);
+    vk::CreateImageView(device(), &ivci, NULL, &image_view);
     m_errorMonitor->VerifyFound();
 
     reset_view();
-    vk::DestroySamplerYcbcrConversion(dev, ycbcr_conv, NULL);
-    vk::DestroyImageView(dev, image_view, NULL);
-    vk::DestroyImage(dev, img, NULL);
-    vk::FreeMemory(dev, img_mem, NULL);
+    vk::DestroySamplerYcbcrConversion(device(), ycbcr_conv, NULL);
+    vk::DestroyImageView(device(), image_view, NULL);
+    vk::DestroyImage(device(), img, NULL);
+    vk::FreeMemory(device(), img_mem, NULL);
 }
 #endif  // DISABLEUNTILAHBWORKS
 
@@ -5201,8 +5600,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5210,90 +5608,61 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
 
     VkDeviceMemory mem_handle = VK_NULL_HANDLE;
-    auto reset_mem = [&mem_handle, dev]() {
-        if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
-        mem_handle = VK_NULL_HANDLE;
-    };
 
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(dev, "vkGetAndroidHardwareBufferPropertiesANDROID");
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
+                                                                               "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
 
-    // AHB structs
+    // Allocate an AHardwareBuffer
     AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
-    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
-    VkImportAndroidHardwareBufferInfoANDROID iahbi = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
-
-    // Allocate an AHardwareBuffer
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA;  // non USAGE_GPU_*
     ahb_desc.width = 512;
     ahb_desc.height = 1;
     ahb_desc.layers = 1;
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
+
     m_errorMonitor->SetUnexpectedError("VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-01884");
-    pfn_GetAHBProps(dev, ahb, &ahb_props);
-    iahbi.buffer = ahb;
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
 
     // Create export and import buffers
     VkExternalMemoryBufferCreateInfo ext_buf_info = LvlInitStruct<VkExternalMemoryBufferCreateInfo>();
-    ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
+    ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkBufferCreateInfo bci = LvlInitStruct<VkBufferCreateInfo>(&ext_buf_info);
-    bci.size = ahb_props.allocationSize;
-    bci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
+    import_ahb_Info.buffer = ahb;
 
-    VkBuffer buf = VK_NULL_HANDLE;
-    vk::CreateBuffer(dev, &bci, NULL, &buf);
-    VkMemoryRequirements mem_reqs;
-    vk::GetBufferMemoryRequirements(dev, buf, &mem_reqs);
-
-    // Allocation info
-    VkMemoryAllocateInfo mai = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, mem_reqs, 0);
-    mai.pNext = &iahbi;  // Chained import struct
-    VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
-    unsigned int i;
-    for (i = 0; i < memory_info.memoryTypeCount; i++) {
-        if ((ahb_props.memoryTypeBits & (1 << i))) {
-            mai.memoryTypeIndex = i;
-            break;
-        }
-    }
-    if (i >= memory_info.memoryTypeCount) {
-        printf("%s No invalid memory type index could be found; skipped.\n", kSkipPrefix);
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
         AHardwareBuffer_release(ahb);
-        reset_mem();
-        vk::DestroyBuffer(dev, buf, NULL);
-        return;
+        GTEST_SKIP() << "No invalid memory type index could be found";
     }
 
     // Import as buffer requires usage AHB_USAGE_GPU_DATA_BUFFER
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImportAndroidHardwareBufferInfoANDROID-buffer-01881");
     // Also causes "non-dedicated allocation format/usage" error
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02384");
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &mem_handle);
     m_errorMonitor->VerifyFound();
 
     AHardwareBuffer_release(ahb);
-    reset_mem();
-    vk::DestroyBuffer(dev, buf, NULL);
+    vk::FreeMemory(device(), mem_handle, nullptr);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferExportBuffer) {
-    TEST_DESCRIPTION("Verify AndroidHardwareBuffer export memory as AHB.");
+TEST_F(VkLayerTest, AndroidHardwareBufferExportBufferHandleType) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer export memory as AHB has a valid handleType.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5301,65 +5670,100 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExportBuffer) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    VkDevice dev = m_device->device();
 
-    VkDeviceMemory mem_handle = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
 
     // Allocate device memory, no linked export struct indicating AHB handle type
-    VkMemoryAllocateInfo mai = LvlInitStruct<VkMemoryAllocateInfo>();
-    mai.allocationSize = 65536;
-    mai.memoryTypeIndex = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>();
+    memory_allocate_info.allocationSize = 65536;
+    memory_allocate_info.memoryTypeIndex = 0;
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
 
     PFN_vkGetMemoryAndroidHardwareBufferANDROID pfn_GetMemAHB =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(dev, "vkGetMemoryAndroidHardwareBufferANDROID");
+        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID");
     ASSERT_TRUE(pfn_GetMemAHB != nullptr);
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID mgahbi = LvlInitStruct<VkMemoryGetAndroidHardwareBufferInfoANDROID>();
-    mgahbi.memory = mem_handle;
+    mgahbi.memory = memory;
     AHardwareBuffer *ahb = nullptr;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-handleTypes-01882");
-    pfn_GetMemAHB(dev, &mgahbi, &ahb);
+    pfn_GetMemAHB(device(), &mgahbi, &ahb);
     m_errorMonitor->VerifyFound();
 
-    if (ahb) AHardwareBuffer_release(ahb);
-    ahb = nullptr;
-    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
-    mem_handle = VK_NULL_HANDLE;
+    vk::FreeMemory(device(), memory, nullptr);
+}
 
-    // Add an export struct with AHB handle type to allocation info
-    VkExportMemoryAllocateInfo emai = LvlInitStruct<VkExportMemoryAllocateInfo>();
-    emai.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-    mai.pNext = &emai;
+TEST_F(VkLayerTest, AndroidHardwareBufferExportImageNonBound) {
+    TEST_DESCRIPTION("Verify AndroidHardwareBuffer export memory as AHB has image bound already.");
 
-    // Create an image, do not bind memory
-    VkImageCreateInfo ici = LvlInitStruct<VkImageCreateInfo>();
-    ici.imageType = VK_IMAGE_TYPE_2D;
-    ici.arrayLayers = 1;
-    ici.extent = {128, 128, 1};
-    ici.format = VK_FORMAT_R8G8B8A8_UNORM;
-    ici.mipLevels = 1;
-    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    ici.samples = VK_SAMPLE_COUNT_1_BIT;
-    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
-    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    vk_testing::Image img(*m_device, ici);
-    ASSERT_TRUE(img.initialized());
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    // Add image to allocation chain as dedicated info, re-allocate
-    VkMemoryDedicatedAllocateInfo mdai = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
-    mdai.image = img.handle();
-    emai.pNext = &mdai;
-    mai.allocationSize = 0;
-    vk::AllocateMemory(dev, &mai, NULL, &mem_handle);
-    mgahbi.memory = mem_handle;
+    if (IsPlatform(kGalaxyS10)) {
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
+    }
+
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    PFN_vkGetMemoryAndroidHardwareBufferANDROID pfn_GetMemAHB =
+        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID");
+    ASSERT_TRUE(pfn_GetMemAHB != nullptr);
+
+    // Create VkImage to be exported to an AHB
+    VkExternalMemoryImageCreateInfo ext_image_info = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
+    ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkImageObj image(m_device);
+    VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>(&ext_image_info);
+    image_create_info.flags = 0;
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
+    image_create_info.extent = {64, 1, 1};
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
+    image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    image.init_no_mem(*m_device, image_create_info);
+
+    VkMemoryDedicatedAllocateInfo memory_dedicated_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
+    memory_dedicated_info.image = image.handle();
+    memory_dedicated_info.buffer = VK_NULL_HANDLE;
+
+    VkExportMemoryAllocateInfo export_memory_info = LvlInitStruct<VkExportMemoryAllocateInfo>(&memory_dedicated_info);
+    export_memory_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkMemoryAllocateInfo memory_info = LvlInitStruct<VkMemoryAllocateInfo>(&export_memory_info);
+
+    // "When allocating new memory for an image that can be exported to an Android hardware buffer, the memory’s allocationSize must
+    // be zero":
+    memory_info.allocationSize = 0;
+
+    // Use any DEVICE_LOCAL memory found
+    bool has_memtype = m_device->phy().set_memory_type(0xFFFFFFFF, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (!has_memtype) {
+        GTEST_SKIP() << "No invalid memory type index could be found";
+    }
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    vk::AllocateMemory(device(), &memory_info, NULL, &memory);
+
+    VkMemoryGetAndroidHardwareBufferInfoANDROID mgahbi = LvlInitStruct<VkMemoryGetAndroidHardwareBufferInfoANDROID>();
+    mgahbi.memory = memory;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883");
-    pfn_GetMemAHB(dev, &mgahbi, &ahb);
+    AHardwareBuffer *ahb = nullptr;
+    pfn_GetMemAHB(device(), &mgahbi, &ahb);
     m_errorMonitor->VerifyFound();
 
-    if (ahb) AHardwareBuffer_release(ahb);
-    if (VK_NULL_HANDLE != mem_handle) vk::FreeMemory(dev, mem_handle, NULL);
+    vk::FreeMemory(device(), memory, NULL);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
@@ -5380,7 +5784,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Allocate an AHardwareBuffer
-    AHardwareBuffer *ahb;
+    AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
@@ -5392,10 +5796,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
                                                                                "vkGetAndroidHardwareBufferPropertiesANDROID");
     ASSERT_TRUE(pfn_GetAHBProps != nullptr);
-    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
 
     VkExternalMemoryBufferCreateInfo ext_buf_info = LvlInitStruct<VkExternalMemoryBufferCreateInfo>();
     ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
@@ -5409,20 +5813,18 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
 
     // Try to get memory requirements prior to binding memory
     VkMemoryRequirements mem_reqs;
-    vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
 
     VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
     import_ahb_Info.buffer = ahb;
 
-    VkMemoryAllocateInfo memory_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
-    memory_info.allocationSize = ahb_props.allocationSize;
-    bool has_memtype = m_device->phy().set_memory_type(ahb_props.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    if (!has_memtype) {
+    VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
         AHardwareBuffer_release(ahb);
         GTEST_SKIP() << "No invalid memory type index could be found";
     }
 
-    vk_testing::DeviceMemory memory(*m_device, memory_info);
+    vk_testing::DeviceMemory memory(*m_device, memory_allocate_info);
     if (memory.handle() == VK_NULL_HANDLE) {
         AHardwareBuffer_release(ahb);
         GTEST_SKIP() << "This test failed to allocate memory for importing";
@@ -5430,6 +5832,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
 
     if (mem_reqs.alignment > 1) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memoryOffset-01036");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-size-01037");
         vk::BindBufferMemory(device(), buffer.handle(), memory.handle(), 1);
         m_errorMonitor->VerifyFound();
     }
@@ -5451,8 +5854,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5462,12 +5864,12 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
+        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(device(),
                                                                                "vkGetAndroidHardwareBufferPropertiesANDROID");
-    PFN_vkBindBufferMemory2KHR vkBindBufferMemory2Function =
-        (PFN_vkBindBufferMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindBufferMemory2KHR");
+    PFN_vkBindBufferMemory2KHR vkBindBufferMemory2KHR =
+        (PFN_vkBindBufferMemory2KHR)vk::GetDeviceProcAddr(device(), "vkBindBufferMemory2KHR");
 
-    AHardwareBuffer *ahb;
+    AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_BLOB;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
@@ -5478,17 +5880,17 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
     // Create buffer without VkExternalMemoryBufferCreateInfo
-    VkBuffer buffer = VK_NULL_HANDLE;
+    VkBufferObj buffer;
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 512;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    vk::CreateBuffer(m_device->device(), &buffer_create_info, nullptr, &buffer);
+    buffer.init_no_mem(*m_device, buffer_create_info);
 
     VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = LvlInitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
     import_ahb_Info.buffer = ahb;
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
-    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
 
     VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
     memory_allocate_info.allocationSize = ahb_props.allocationSize;
@@ -5502,25 +5904,24 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
     }
 
     VkDeviceMemory memory;
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &memory);
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memory-02986");
     m_errorMonitor->SetUnexpectedError("VUID-vkBindBufferMemory-memory-01035");
-    vk::BindBufferMemory(m_device->device(), buffer, memory, 0);
+    vk::BindBufferMemory(device(), buffer.handle(), memory, 0);
     m_errorMonitor->VerifyFound();
 
     VkBindBufferMemoryInfo bind_buffer_info = LvlInitStruct<VkBindBufferMemoryInfo>();
-    bind_buffer_info.buffer = buffer;
+    bind_buffer_info.buffer = buffer.handle();
     bind_buffer_info.memory = memory;
     bind_buffer_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindBufferMemoryInfo-memory-02986");
     m_errorMonitor->SetUnexpectedError("VUID-VkBindBufferMemoryInfo-memory-01035");
-    vkBindBufferMemory2Function(m_device->device(), 1, &bind_buffer_info);
+    vkBindBufferMemory2KHR(device(), 1, &bind_buffer_info);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyBuffer(m_device->device(), buffer, nullptr);
-    vk::FreeMemory(m_device->device(), memory, nullptr);
+    vk::FreeMemory(device(), memory, nullptr);
 }
 
 TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
@@ -5530,8 +5931,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {
@@ -5543,10 +5943,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID pfn_GetAHBProps =
         (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)vk::GetDeviceProcAddr(m_device->device(),
                                                                                "vkGetAndroidHardwareBufferPropertiesANDROID");
-    PFN_vkBindImageMemory2KHR vkBindImageMemory2Function =
+    PFN_vkBindImageMemory2KHR vkBindImageMemory2KHR =
         (PFN_vkBindImageMemory2KHR)vk::GetDeviceProcAddr(m_device->handle(), "vkBindImageMemory2KHR");
 
-    AHardwareBuffer *ahb;
+    AHardwareBuffer *ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
@@ -5557,7 +5957,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
     // Create buffer without VkExternalMemoryImageCreateInfo
-    VkImage image = VK_NULL_HANDLE;
+    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -5570,10 +5970,10 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    vk::CreateImage(m_device->device(), &image_create_info, nullptr, &image);
+    image.init_no_mem(*m_device, image_create_info);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = LvlInitStruct<VkMemoryDedicatedAllocateInfo>();
-    memory_dedicated_info.image = image;
+    memory_dedicated_info.image = image.handle();
     memory_dedicated_info.buffer = VK_NULL_HANDLE;
 
     VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
@@ -5581,7 +5981,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     import_ahb_Info.buffer = ahb;
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = LvlInitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
-    pfn_GetAHBProps(m_device->device(), ahb, &ahb_props);
+    pfn_GetAHBProps(device(), ahb, &ahb_props);
 
     VkMemoryAllocateInfo memory_allocate_info = LvlInitStruct<VkMemoryAllocateInfo>(&import_ahb_Info);
     memory_allocate_info.allocationSize = ahb_props.allocationSize;
@@ -5595,26 +5995,25 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     }
 
     VkDeviceMemory memory;
-    vk::AllocateMemory(m_device->device(), &memory_allocate_info, nullptr, &memory);
+    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindImageMemory-memory-02990");
     m_errorMonitor->SetUnexpectedError("VUID-vkBindImageMemory-memory-01047");
     m_errorMonitor->SetUnexpectedError("VUID-vkBindImageMemory-size-01049");
-    vk::BindImageMemory(m_device->device(), image, memory, 0);
+    vk::BindImageMemory(m_device->device(), image.handle(), memory, 0);
     m_errorMonitor->VerifyFound();
 
     VkBindImageMemoryInfo bind_image_info = LvlInitStruct<VkBindImageMemoryInfo>();
-    bind_image_info.image = image;
+    bind_image_info.image = image.handle();
     bind_image_info.memory = memory;
     bind_image_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-memory-02990");
     m_errorMonitor->SetUnexpectedError("VUID-VkBindImageMemoryInfo-pNext-01617");
     m_errorMonitor->SetUnexpectedError("VUID-VkBindImageMemoryInfo-pNext-01615");
-    vkBindImageMemory2Function(m_device->device(), 1, &bind_image_info);
+    vkBindImageMemory2KHR(m_device->device(), 1, &bind_image_info);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyImage(m_device->device(), image, nullptr);
     vk::FreeMemory(m_device->device(), memory, nullptr);
 }
 

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -223,8 +223,7 @@ TEST_F(VkLayerTest, ValidSwapchainImage) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
     if (IsPlatform(kGalaxyS10)) {
-        printf("%s This test should not run on Galaxy S10\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     if (!AreRequiredExtensionsEnabled()) {

--- a/tests/vktestframeworkandroid.cpp
+++ b/tests/vktestframeworkandroid.cpp
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2021 The Khronos Group Inc.
-//  Copyright (c) 2015-2021 Valve Corporation
-//  Copyright (c) 2015-2021 LunarG, Inc.
-//  Copyright (c) 2015-2021 Google, Inc.
+//  Copyright (c) 2015-2022 The Khronos Group Inc.
+//  Copyright (c) 2015-2022 Valve Corporation
+//  Copyright (c) 2015-2022 LunarG, Inc.
+//  Copyright (c) 2015-2022 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -171,4 +171,24 @@ bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t o
     spvBinaryDestroy(binary);
 
     return true;
+}
+
+// Helper to get the memory type index for AHB object that are being imported
+// returns false if can't set the values correctly
+bool VkTestFramework::SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHardwareBufferPropertiesANDROID ahb_props,
+                                                 VkMemoryAllocateInfo &info) {
+    // Set index to match one of the bits in ahb_props that is also only Device Local
+    // Android implemenetations "should have" a DEVICE_LOCAL only index designed for AHB
+    VkMemoryPropertyFlagBits property = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    VkPhysicalDeviceMemoryProperties mem_props = device->phy().memory_properties();
+    // AHB object hold the real allocationSize needed
+    info.allocationSize = ahb_props.allocationSize;
+    info.memoryTypeIndex = mem_props.memoryTypeCount + 1;
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+        if ((ahb_props.memoryTypeBits & (1 << i)) && ((mem_props.memoryTypes[i].propertyFlags & property) == property)) {
+            info.memoryTypeIndex = i;
+            break;
+        }
+    }
+    return info.memoryTypeIndex < mem_props.memoryTypeCount;
 }

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -1,9 +1,9 @@
 //  VK tests
 //
-//  Copyright (c) 2015-2021 The Khronos Group Inc.
-//  Copyright (c) 2015-2021 Valve Corporation
-//  Copyright (c) 2015-2021 LunarG, Inc.
-//  Copyright (c) 2015-2021 Google, Inc.
+//  Copyright (c) 2015-2022 The Khronos Group Inc.
+//  Copyright (c) 2015-2022 Valve Corporation
+//  Copyright (c) 2015-2022 LunarG, Inc.
+//  Copyright (c) 2015-2022 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ class VkTestFramework : public ::testing::Test {
     static bool m_devsim_layer;
     static int m_phys_device_index;
     static ANativeWindow *window;
+
+    bool SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHardwareBufferPropertiesANDROID ahb_props,
+                                    VkMemoryAllocateInfo &info);
 };
 
 class TestEnvironment : public ::testing::Environment {


### PR DESCRIPTION
Went through each `AndroidHardwareBuffer` test, cleaned it up to be more like the other test code, broke up `AndroidHardwareBufferMemoryAllocation` as it was to large. Tested on Adreno  and Mali Pixel device.

Should fix quite a few tests in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4425 (and hopefully https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4587)