### PR TITLE
docs: Documentation cleanup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,16 +1,14 @@
 # Build Instructions
 
-## Index
-
 1. [Requirements](#requirements)
-1. [Building](#building)
-1. [Contributing](#contributing-to-the-repository)
-1. [Repository Content](#repository-content)
-1. [Repository Set-Up](#repository-set-up)
+1. [Building Overview](#building-overview)
+1. [Generated source code](#generated-source-code)
+1. [Dependencies](#dependencies)
 1. [Windows Build](#building-on-windows)
 1. [Linux Build](#building-on-linux)
 1. [Android Build](#building-on-android)
 1. [MacOS build](#building-on-macos)
+1. [Installed Files](#installed-files)
 
 ## Requirements
 
@@ -18,71 +16,49 @@
 1. CMake >= 3.10.2
 1. C++ >= c++17 compiler. See platform-specific sections below for supported compiler versions.
 
-## Building
+## Building Overview
 
-**NOTE**: See [this](#google-test) first if you are also building the tests.
+The following will be enough for most people, for platform-specific instructions, see below.
 
 ```bash
-# One-time generation
-mkdir build # Arbitrary build directory
+git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
+cd Vulkan-ValidationLayers
+
+mkdir build
 cd build
 
-# Run './scripts/update_deps.py --help' for more information
-# NOTE: You can alternatively set -DUPDATE_DEPS=ON during cmake generation
-#       to have a cmake target automatically run this as needed.
+# Linux
 python3 ../scripts/update_deps.py --dir ../external --arch x64 --config debug
+cmake -G Ninja -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
 
-# NOTE: If using -DUPDATE_DEPS=ON, CMAKE_BUILD_TYPE is used to determine the build type
-#       of external dependencies. For generators such as Visual Studio that usually ignore
-#       CMAKE_BUILD_TYPE, it's a good idea to still set CMAKE_BUILD_TYPE in this case to control
-#       the build type of dependencies. If you want a "mix" (e.g., Release dependencies, Debug VVL),
-#       you will want to use `update_deps.py` manually.
-cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+# Windows
+python3 ..\scripts\update_deps.py --dir ..\external --arch x64 --config debug
+cmake -A x64 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
 
-# Building
 cmake --build . --config Debug
 ```
+### CCACHE
 
-Note the `-C ../external/helper.cmake` argument passed to cmake. This is necessary when
-calling the `update_deps.py` script manually. See below for more details.
-
-These are general instructions that should "just work" on Windows and Linux. For platform-specific
-build instructions, see the appropriate `<Platform> Build` section below.
-
-### update_deps.py --cmake_var
-
-When using update_deps.py you may want to pass arguments to the CMake build.
-Here is an example highlighting how to pass a CMAKE_TOOLCHAIN_FILE.
+There are 2 methods to enable CCACHE:
 
 ```bash
-update_deps.py ... --cmake_var CMAKE_TOOLCHAIN_FILE=/home/.../arm64.cmake
+# 1) Set environment variables
+# Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html)
+export CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
+export CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
+
+# 2) Pass in cache variables`
+cmake ... -D CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache -D CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
 ```
 
-## Contributing to the Repository
+## Generated source code
 
-If you intend to contribute, the preferred work flow is for you to develop
-your contribution in a fork of this repository in your GitHub account and then
-submit a pull request. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file
-in this repository for more details.
+This repository contains generated source code in the `layers/generated`
+directory which is not intended to be modified directly.
 
-## Repository Content
+Please see the [Generated Code documentation](./docs/generated_code.md) for more information
 
-This repository contains the source code necessary to build the Vulkan
-validation layers and their tests.
-
-### Installed Files
-
-The `install` target installs the following files under the directory
-indicated by *install_dir*:
-
-- *install_dir*`/lib` : The Vulkan validation layer libraries
-- *install_dir*`/share/vulkan/explicit_layer.d` : The Vulkan validation layer
-  JSON files (Linux and MacOS)
-
-The `uninstall` target can be used to remove the above files from the install
-directory.
-
-## Repository Set-Up
+## Dependencies
 
 ### Display Drivers
 
@@ -90,11 +66,25 @@ This repository does not contain a Vulkan-capable driver. You will need to
 obtain and install a Vulkan driver from your graphics hardware vendor or from
 some other suitable source if you intend to run Vulkan applications.
 
-### Download the Repository
+### Building dependencies with script and Known-Good revisions
 
-To create your local git repository:
+There is a Python utility script, `scripts/update_deps.py`, that you can use to
+gather and build the dependent repositories mentioned above. This script uses
+information stored in the `scripts/known_good.json` file to check out dependent
+repository revisions that are known to be compatible with the revision of this
+repository that you currently have checked out.
 
-    git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
+The script will produce a `helper.cmake` file that can be consumed by the cmake
+
+run './scripts/update_deps.py --help' for more information
+
+#### Updating with CMAKE_TOOLCHAIN_FILE
+
+When cross compiling, you may want to pass arguments to the CMake build
+
+```bash
+update_deps.py ... --cmake_var CMAKE_TOOLCHAIN_FILE=/home/.../arm64.cmake
+```
 
 ### Repository Dependencies
 
@@ -110,90 +100,24 @@ resolved with the "install directory" override and are listed below. The
 "install directory" override can also be used to force the use of a specific
 version of that dependency.
 
-Alternatively, an automated method for obtaining and installing repo dependencies
-is provided, and described below, in
-[Building Dependent Repositories...](#building-dependent-repositories-with-known-good-revisions)
+> Note: All test will be downloaded, built, and installed with `update_deps.py`
 
-#### Vulkan-Headers
+- [Vulkan Headers repository](https://github.com/KhronosGroup/Vulkan-Headers)
+    - You must clone the headers repository and build its `install` target
+- [SPIRV-Headers repository](https://github.com/KhronosGroup/SPIRV-Headers)
+    - You must clone the headers repository and build its `install` target
+- [SPIRV-Tools repository](https://github.com/KhronosGroup/SPIRV-Tools)
+    - You must clone the headers repository and build its `install` target
+- [robin-hood-hashing repository](https://github.com/martinus/robin-hood-hashing)
+    - This is a header-only reimplementation of `std::unordered_map` and `std::unordered_set` which provides substantial performance improvements on all platforms.
+    - You must clone this repository and build its `install` target
 
-This repository has a required dependency on the
-[Vulkan Headers repository](https://github.com/KhronosGroup/Vulkan-Headers).
-You must clone the headers repository and build its `install` target before
-building this repository. The Vulkan-Headers repository is required because it
-contains the Vulkan API definition files (registry) that are required to build
-the validation layers. You must also take note of the headers' install
-directory and pass it on the CMake command line for building this repository,
-as described below.
+For running the tests:
 
-#### SPIRV-Headers
-
-This repository has a required dependency on the
-[SPIRV-Headers repository](https://github.com/KhronosGroup/SPIRV-Headers).
-The SPIRV-Headers repository is required because it supports components that are
-required to build the validation layers. You must clone the SPIRV-Headers repository
-and build its `install` target. Follow the build instructions in the SPIRV-Headers
-[README.md](https://github.com/KhronosGroup/SPIRV-Headers/blob/master/README.md)
-file. You must also take note of the SPIRV-headers install directory
-and pass it on the CMake command line for building this repository, as
-described below.
-
-#### SPIRV-Tools
-
-This repository has a required dependency on the
-[SPIRV-Tools repository](https://github.com/KhronosGroup/SPIRV-Tools).
-The SPIRV-Tools repository is required because it contains components that are
-required to build the validation layers. You must clone the SPIRV-Tools repository
-and build its `install` target. Follow the build instructions in the SPIRV-Tools
-[README.md](https://github.com/KhronosGroup/SPIRV-Tools/blob/master/README.md)
-file. You must also take note of the SPIRV-Tools install directory
-and pass it on the CMake command line for building this repository, as
-described below.
-
-#### Robin Hood hashing
-This repository has an optional dependency on the
-[robin-hood-hashing repository](https://github.com/martinus/robin-hood-hashing).
-This is a header-only reimplementation of `std::unordered_map` and `std::unordered_set`
-which provides substantial performance improvements on all platforms.
-You must clone this repository and build its `install` target before
-building it with the CMake option `RH_STANDALONE_PROJECT` set to `OFF`
-OR set the Vulkan-ValidationLayers CMake option `USE_ROBIN_HOOD_HASHING` to `OFF`.
-
-#### glslang
-
-The validation layer tests depend on the
-[glslang repository](https://github.com/KhronosGroup/glslang).
-You must clone the glslang repository
-and build its `install` target. Follow the build instructions in the glslang
-[README.md](https://github.com/KhronosGroup/glslang/blob/master/README.md)
-file. You must also take note of the glslang install directory
-and pass it on the CMake command line for building this repository, as
-described below.
-
-#### Google Test
-
-The validation layer tests depend on the
-[Google Test](https://github.com/google/googletest). To build the tests, pass the `-DBUILD_TESTS=ON` option when
-generating the project:
-```bash
-cmake ... -DUPDATE_DEPS=ON -DBUILD_TESTS=ON ...
-```
-This will ensure googletest is downloaded and the appropriate version is used.
-
-#### Vulkan-Loader
-
-The validation layer tests depend on the Vulkan loader when they execute and
-so a loader is needed only if the tests are built and run.
-
-A loader can be used from an installed LunarG SDK, an installed Linux package,
-or from a driver installation on Windows.
-
-If a loader is not available from any of these methods and/or it is important
-to use a loader built from a repository, then you must build the
-[Vulkan-Loader repository](https://github.com/KhronosGroup/Vulkan-Loader.git)
-with its install target. Take note of its install directory location and pass
-it on the CMake command line for building this repository, as described below.
-
-If you do not intend to run the tests, you do not need a Vulkan loader.
+- [Vulkan-Loader repository](https://github.com/KhronosGroup/Vulkan-Loader.git)
+- [glslang repository](https://github.com/KhronosGroup/glslang)
+    - You must clone the headers repository and build its `install` target
+- [Google Test](https://github.com/google/googletest)
 
 ### Build and Install Directories
 
@@ -204,44 +128,7 @@ instructions follow this convention, although you can use any name for these
 directories and place them in any location (see option `--dir` in the
 [notes](#notes)).
 
-### Building Dependent Repositories with Known-Good Revisions
-
-There is a Python utility script, `scripts/update_deps.py`, that you can use to
-gather and build the dependent repositories mentioned above. This script uses
-information stored in the `scripts/known_good.json` file to check out dependent
-repository revisions that are known to be compatible with the revision of this
-repository that you currently have checked out. As such, this script is useful
-as a quick-start tool for common use cases and default configurations.
-
-For all platforms, start with:
-
-    git clone git@github.com:KhronosGroup/Vulkan-ValidationLayers.git
-    cd Vulkan-ValidationLayers
-    mkdir build
-    cd build
-
-For 64-bit Linux and MacOS, continue with:
-
-    ../scripts/update_deps.py
-    cmake -C helper.cmake ..
-    cmake --build .
-
-For 64-bit Windows, continue with:
-
-    ..\scripts\update_deps.py --arch x64
-    cmake -A x64 -C helper.cmake ..
-    cmake --build .
-
-For 32-bit Windows, continue with:
-
-    ..\scripts\update_deps.py --arch Win32
-    cmake -A Win32 -C helper.cmake ..
-    cmake --build .
-
-Please see the more detailed build information later in this file if you have
-specific requirements for configuring and building these components.
-
-#### Notes
+### Notes
 
 - You may need to adjust some of the CMake options based on your platform. See
   the platform-specific sections later in this document.
@@ -277,89 +164,33 @@ specific requirements for configuring and building these components.
   `VVL_CPP_STANDARD` option at cmake generation time. Current code is written
   to compile under C++17.
 
-### Generated source code
-
-This repository contains generated source code in the `layers/generated`
-directory which is not intended to be modified directly. Instead, changes should be
-made to the corresponding generator in the `scripts` directory. The source files can
-then be regenerated using `scripts/generate_source.py`:
-
-    python3 scripts/generate_source.py PATH_TO_VULKAN_HEADERS_REGISTRY_DIR PATH_TO_SPIRV_HEADERS_GRAMMAR_DIR
-
-    // Example
-    python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
-
-A helper CMake target `VulkanVL_generated_source` is also provided to simplify
-the invocation of `scripts/generate_source.py` from the build directory:
-
-    cmake --build . --target VulkanVL_generated_source
-
-If Python is found on your system, the Vulkan Registry and SPIRV-Headers *must* be present!
-
-### Build Options
-
-When generating native platform build files through CMake, several options can
-be specified to customize the build. Some of the options are binary on/off
-options, while others take a string as input. The following is a table of all
-on/off options currently supported by this repository:
-
-| Option | Platform | Default | Description |
-| ------ | -------- | ------- | ----------- |
-| BUILD_LAYERS | All | `ON` | Controls whether or not the validation layers are built. |
-| BUILD_LAYER_SUPPORT_FILES | All | `OFF` | Controls whether or not layer support files are installed. |
-| BUILD_TESTS | All | `OFF` | Controls whether or not the validation layer tests are built. |
-| INSTALL_TESTS | All | `OFF` | Controls whether or not the validation layer tests are installed. This option is only available when `BUILD_TESTS` is `ON` |
-| BUILD_WERROR | All | `OFF` | Controls whether or not to treat compiler warnings as errors. |
-| BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the components with XCB support. |
-| BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the components with Xlib support. |
-| BUILD_WSI_WAYLAND_SUPPORT | Linux | `ON` | Build the components with Wayland support. |
-
-### CMakePresets.json (3.21+)
-
-CMakePresets.json can save developer time by specifying common build flags.
-
-```bash
-# Enables tests, enable werror, etc.
-cmake -S . -B build/ --preset dev
-```
-
-### CCACHE
-
-There are 2 methods to enable CCACHE:
-
-1.) Set environment variables
-
-```bash
-# Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html)
-export CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
-export CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-```
-
-2.) Pass in cache variables
-
-```
-cmake ... -D CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache -D CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-```
+## Cmake
 
 ### EXPORT_COMPILE_COMMANDS
 
 There are 2 methods to enable exporting compile commands:
 
-1.) Set environment variables
 
 ```bash
+# 1) Set environment variables
 # Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_EXPORT_COMPILE_COMMANDS.html)
 export CMAKE_EXPORT_COMPILE_COMMANDS=ON
-```
 
-2.) Pass in cache variables
-
-```
+# 2) Pass in cache variables
 cmake ... -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
 ```
 
 NOTE: Modern tools will generally enable exporting compile commands for you (e.g. VSCode).
 Also `CMAKE_EXPORT_COMPILE_COMMANDS` is implemented only by Makefile and Ninja generators. For other generators, this option is ignored.
+
+### CMakePresets.json (3.21+)
+
+[CMakePresets.json](./CMakePresets.json) can save developer time by specifying common build flags.
+
+```bash
+# Enables tests, enable werror, etc.
+cmake -S . -B build/ --preset dev
+```
 
 ## Building On Windows
 
@@ -384,77 +215,23 @@ Also `CMAKE_EXPORT_COMPILE_COMMANDS` is implemented only by Makefile and Ninja g
 
 ### Windows Build - Microsoft Visual Studio
 
-The general approach is to run CMake to generate the Visual Studio project
-files. Then either run CMake with the `--build` option to build from the
-command line or use the Visual Studio IDE to open the generated solution and
-work with the solution interactively.
-
-#### Windows Quick Start
-
-    cd Vulkan-ValidationLayers
-    mkdir build
-    cd build
-    cmake -A x64 -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-                 ..
-    cmake --build .
-
-The above commands instruct CMake to find and use the default Visual Studio
-installation to generate a Visual Studio solution and projects for the x64
-architecture. The second CMake command builds the Debug (default)
-configuration of the solution.
-
-See below for the details.
-
-#### Use `CMake` to Create the Visual Studio Project Files
-
-Change your current directory to the top of the cloned repository directory,
-create a build directory and generate the Visual Studio project files:
-
-    cd Vulkan-ValidationLayers
-    mkdir build
-    cd build
-    cmake -A x64 -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir
-                 -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-                 ..
-
-> Note: The `..` parameter tells `cmake` the location of the top of the
-> repository. If you place your build directory someplace else, you'll need to
-> specify the location of the repository top differently.
+Run CMake to generate the Visual Studio project files.
 
 The `-A` option is used to select either the "Win32" or "x64" architecture.
 
 If a generator for a specific version of Visual Studio is required, you can
-specify it with the `-G` switch.  For example, to specify Visual Studio 2022, use:
+specify it with the `-G` switch.
 
-    64-bit: -G "Visual Studio 17 2022"
-    32-bit: -G "Visual Studio 17 2022" -A Win32
+```batch
+# Generates Visual Studio 2022 for x64
+cmake -G "Visual Studio 17 2022" -A x64 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+# Generates Visual Studio 2022 for Win32
+cmake -G "Visual Studio 17 2022" -A Win32 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+```
 
-NOTE:
-- By default VS2019 and higher target "x64"
-- By default VS2017 and lower target "Win32"
+Note: VS2019 and higher target "x64" by default. VS2017 and lower target "Win32" by default
 
 Check the [official CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators) for further information on Visual Studio generators.
-
-When generating the project files, the absolute path to a Vulkan-Headers
-install directory must be provided. This can be done by setting the
-`VULKAN_HEADERS_INSTALL_DIR` environment variable or by setting the
-`VULKAN_HEADERS_INSTALL_DIR` CMake variable with the `-D` CMake option. In
-either case, the variable should point to the installation directory of a
-Vulkan-Headers repository built with the install target.
-
-When generating the project files, the absolute path to a glslang install
-directory must be provided. This can be done by setting the
-`GLSLANG_INSTALL_DIR` environment variable or by setting the
-`GLSLANG_INSTALL_DIR` CMake variable with the `-D` CMake option. In either
-case, the variable should point to the installation directory of a glslang
-repository built with the install target.
 
 The above steps create a Windows solution file named
 `Vulkan-ValidationLayers.sln` in the build directory.
@@ -462,77 +239,13 @@ The above steps create a Windows solution file named
 At this point, you can build the solution from the command line or open the
 generated solution with Visual Studio.
 
-#### Build the Solution From the Command Line
+If you want to build the Solution From the Command Line
 
-While still in the build directory:
-
-    cmake --build .
-
-to build the Debug configuration (the default), or:
-
-    cmake --build . --config Release
-
-to make a Release build.
-
-#### Build the Solution With Visual Studio
-
-Launch Visual Studio and open the "Vulkan-ValidationLayers.sln" solution file
-in the build folder. You may select "Debug" or "Release" from the Solution
-Configurations drop-down list. Start a build by selecting the Build->Build
-Solution menu item.
-
-#### Windows Install Target
-
-The CMake project also generates an "install" target that you can use to copy
-the primary build artifacts to a specific location using a "bin, include, lib"
-style directory structure. This may be useful for collecting the artifacts and
-providing them to another project that is dependent on them.
-
-The default location is `$CMAKE_BINARY_DIR\install`, but can be changed with
-the `CMAKE_INSTALL_PREFIX` variable when first generating the project build
-files with CMake.
-
-You can build the install target from the command line with:
-
-    cmake --build . --config Release --target install
-
-or build the `INSTALL` target from the Visual Studio solution explorer.
-
-#### Using a Loader Built from a Repository
-
-If you do need to build and use your own loader, build the Vulkan-Loader
-repository with the install target and modify your CMake invocation to add the
-location of the loader's install directory:
-
-    cmake -A x64 -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DVULKAN_LOADER_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-                 -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-                 ..
-
-### Windows Tests and Demos
-
-After making any changes to the repository, you should perform some quick
-sanity tests, especially the included layer validation tests (vk_layer_validation_tests).
-In addition, running sample applications such as the
-[vkcube demo](https://www.github.com/KhronosGroup/Vulkan-Tools.git)
-with validation enabled is advised.
-
-### Windows Notes
-
-#### Using The Vulkan Loader Library in this Repository on Windows
-
-Vulkan programs must be able to find and use the Vulkan loader
-(`vulkan-1.dll`) library as well as any other libraries the program requires.
-One convenient way to do this is to copy the required libraries into the same
-directory as the program. If you provided a loader repository location via the
-`VULKAN_LOADER_INSTALL_DIR` variable, the projects in this solution copy the
-Vulkan loader library and the "googletest" libraries to the
-`build\tests\Debug` or the `build\tests\Release` directory, which is where the
-test executables are found, depending on what configuration you built. (The
-layer validation tests use the "googletest" testing framework.)
+```batch
+cmake --build . --config Debug
+# Or
+cmake --build . --config Release
+```
 
 ## Building On Linux
 
@@ -546,99 +259,13 @@ repository to other Linux distributions.
 
 [CMake 3.10.2](https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz) is recommended.
 
-#### Required Package List
-
-    sudo apt-get install git build-essential libx11-xcb-dev \
+```bash
+sudo apt-get install git build-essential libx11-xcb-dev \
         libxkbcommon-dev libwayland-dev libxrandr-dev \
-        libegl1-mesa-dev
+        libegl1-mesa-dev python3-distutils
+```
 
-##### Required package for Ubuntu 18.04 users
-
-For python2 users
-
-    sudo apt install python-distutils
-
-or for python3 users
-
-	sudo apt install python3-distutils
-
-### Linux Build
-
-The general approach is to run CMake to generate make files. Then either run
-CMake with the `--build` option or `make` to build from the command line.
-
-#### Linux Quick Start
-
-    cd Vulkan-ValidationLayers
-    mkdir build
-    cd build
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-          ..
-    make
-
-See below for the details.
-
-#### Use CMake to Create the Make Files
-
-Change your current directory to the top of the cloned repository directory,
-create a build directory and generate the make files.
-
-    cd Vulkan-ValidationLayers
-    mkdir build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug \
-          -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-          -DCMAKE_INSTALL_PREFIX=install ..
-
-> Note: The `..` parameter tells `cmake` the location of the top of the
-> repository. If you place your `build` directory someplace else, you'll need
-> to specify the location of the repository top differently.
-
-Use `-DCMAKE_BUILD_TYPE` to specify a Debug or Release build.
-
-When generating the project files, the absolute path to a Vulkan-Headers
-install directory must be provided. This can be done by setting the
-`VULKAN_HEADERS_INSTALL_DIR` environment variable or by setting the
-`VULKAN_HEADERS_INSTALL_DIR` CMake variable with the `-D` CMake option. In
-either case, the variable should point to the installation directory of a
-Vulkan-Headers repository built with the install target.
-
-When generating the project files, the absolute path to a glslang install
-directory must be provided. This can be done by setting the
-`GLSLANG_INSTALL_DIR` environment variable or by setting the
-`GLSLANG_INSTALL_DIR` CMake variable with the `-D` CMake option. In either
-case, the variable should point to the installation directory of a glslang
-repository built with the install target.
-
-> Note: For Linux, the default value for `CMAKE_INSTALL_PREFIX` is
-> `/usr/local`, which would be used if you do not specify
-> `CMAKE_INSTALL_PREFIX`. In this case, you may need to use `sudo` to install
-> to system directories later when you run `make install`.
-
-#### Build the Project
-
-You can just run `make` to begin the build.
-
-To speed up the build on a multi-core machine, use the `-j` option for `make`
-to specify the number of cores to use for the build. For example:
-
-    make -j4
-
-You can also use
-
-    cmake --build .
-
-### Linux Notes
-
-#### WSI Support Build Options
+### WSI Support Build Options
 
 By default, the repository components are built with support for the
 Vulkan-defined WSI display servers: Xcb, Xlib, and Wayland. It is recommended
@@ -647,57 +274,7 @@ maximize their usability across Linux platforms. If it is necessary to build
 these modules without support for one of the display servers, the appropriate
 CMake option of the form `BUILD_WSI_xxx_SUPPORT` can be set to `OFF`.
 
-#### Linux Install to System Directories
-
-Installing the files resulting from your build to the systems directories is
-optional since environment variables can usually be used instead to locate the
-binaries. There are also risks with interfering with binaries installed by
-packages. If you are certain that you would like to install your binaries to
-system directories, you can proceed with these instructions.
-
-Assuming that you've built the code as described above and the current
-directory is still `build`, you can execute:
-
-    sudo make install
-
-This command installs files to `/usr/local` if no `CMAKE_INSTALL_PREFIX` is
-specified when creating the build files with CMake:
-
-- `/usr/local/lib`:  Vulkan layers shared objects
-- `/usr/local/share/vulkan/explicit_layer.d`:  Layer JSON files
-
-You may need to run `ldconfig` in order to refresh the system loader search
-cache on some Linux systems.
-
-You can further customize the installation location by setting additional
-CMake variables to override their defaults. For example, if you would like to
-install to `/tmp/build` instead of `/usr/local`, on your CMake command line
-specify:
-
-    -DCMAKE_INSTALL_PREFIX=/tmp/build
-
-Then run `make install` as before. The install step places the files in
-`/tmp/build`. This may be useful for collecting the artifacts and providing
-them to another project that is dependent on them.
-
-See the CMake documentation for more details on using these variables to
-further customize your installation.
-
-Also see the `LoaderAndLayerInterface` document in the `loader` folder of the
-Vulkan-Loader repository for more information about loader and layer
-operation.
-
-#### Linux Uninstall
-
-To uninstall the files from the system directories, you can execute:
-
-    sudo make uninstall
-
-#### Linux Tests
-
-Build and run the `vk_layer_validation_tests`, in the tests subdirectory.
-
-#### Linux 32-bit support
+### Linux 32-bit support
 
 Usage of this repository's contents in 32-bit Linux environments is not
 officially supported. However, since this repository is supported on 32-bit
@@ -706,12 +283,11 @@ Windows, these modules should generally work on 32-bit Linux.
 Here are some notes for building 32-bit targets on a 64-bit Ubuntu "reference"
 platform:
 
-If not already installed, install the following 32-bit development libraries:
-
-`gcc-multilib g++-multilib libx11-dev:i386`
-
-This list may vary depending on your distribution and which windowing systems
-you are building for.
+```bash
+# 32-bit libs
+# your PKG_CONFIG configuration may be different, depending on your distribution
+sudo apt-get install gcc-multilib g++-multilib libx11-dev:i386
+```
 
 Set up your environment for building 32-bit targets:
 
@@ -722,23 +298,7 @@ export CXXFLAGS=-m32
 export PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu
 ```
 
-Again, your PKG_CONFIG configuration may be different, depending on your distribution.
-
-Finally, rebuild the repository using `cmake` and `make`, as explained above.
-
-#### Using the new layers
-
-```bash
-export VK_LAYER_PATH=<path to your repository root>/build/layers
-```
-
-You can run the `vkcube` or `vulkaninfo` applications from the Vulkan-Tools
-repository to see which driver, loader and layers are being used.
-
 ## Building On Android
-
-Install the required tools for Linux and Windows covered above, then add the
-following.
 
 ### Android Build Requirements
 
@@ -866,31 +426,6 @@ for VS2015:
     update_external_sources_android.bat
     ndk-build
 
-### Android Tests and Demos
-
-After making any changes to the repository you should perform some quick
-sanity tests, including the layer validation tests and the vkcube
-demo with validation enabled.
-
-#### Run Layer Validation Tests
-
-Use the following steps to build, install, and run the layer validation tests
-for Android:
-
-    cd build-android
-    ./build_all.sh
-    adb install -r bin/VulkanLayerValidationTests.apk
-    adb shell am start com.example.VulkanLayerValidationTests/android.app.NativeActivity
-
-Alternatively, you can use the test_APK script to install and run the layer
-validation tests:
-
-    test_APK.sh -s <serial number> -p <plaform name> -f <gtest_filter>
-
-To view to logging while running in a separate terminal run
-
-    adb logcat -c && adb logcat *:S VulkanLayerValidationTests
-
 ## Building on MacOS
 
 ### MacOS Build Requirements
@@ -917,15 +452,7 @@ export PATH=/usr/local/bin:$PATH
 
       brew install python python3 git
 
-### Clone the Repository
-
-Clone the Vulkan-ValidationLayers repository:
-
-    git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
-
-### MacOS build
-
-#### CMake Generators
+### CMake Generators
 
 This repository uses CMake to generate build or project files that are then
 used to build the repository. The CMake generators explicitly supported in
@@ -934,90 +461,91 @@ this repository are:
 - Unix Makefiles
 - Xcode
 
-#### Building with the Unix Makefiles Generator
-
-This generator is the default generator, so all that is needed for a debug
-build is:
-
-    mkdir build
-    cd build
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-          -DCMAKE_BUILD_TYPE=Debug ..
-    make
-
-To speed up the build on a multi-core machine, use the `-j` option for `make`
-to specify the number of cores to use for the build. For example:
-
-    make -j4
-
-#### Building with the Xcode Generator
+### Building with the Xcode Generator
 
 To create and open an Xcode project:
 
-    mkdir build-xcode
-    cd build-xcode
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DGLSLANG_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_HEADERS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DSPIRV_TOOLS_INSTALL_DIR=absolute_path_to_install_dir \
-          -DROBIN_HOOD_HASHING_INSTALL_DIR=absolute_path_to_install_dir \
-          -GXcode ..
-    open VULKAN.xcodeproj
+```bash
+cmake -G Xcode -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+open VULKAN.xcodeproj
+```
 
 Within Xcode, you can select Debug or Release builds in the Build Settings of the project.
 
-#### Using the new layers on MacOS
+## Installed Files
 
-```
-export VK_LAYER_PATH=<path to your repository root>/build/layers
-```
+The `install` target installs the following files under the directory
+indicated by *install_dir*:
 
-You can run the `vulkaninfo` applications from the Vulkan-Tools repository to
-see which driver, loader and layers are being used.
+- *install_dir*`/lib` : The Vulkan validation layer libraries
+- *install_dir*`/share/vulkan/explicit_layer.d` : The Vulkan validation layer
+  JSON files (Linux and MacOS)
 
-### MacOS Tests
+The `uninstall` target can be used to remove the above files from the install
+directory.
 
-After making any changes to the repository, you should build and run the included
-vk_layer_validation_tests located in the tests subdirectory.
+### Windows Install Target
 
-These test require a manual path to an ICD to run properly on MacOS.
+The CMake project also generates an "install" target that you can use to copy
+the primary build artifacts to a specific location using a "bin, include, lib"
+style directory structure. This may be useful for collecting the artifacts and
+providing them to another project that is dependent on them.
 
-You can use:
+The default location is `$CMAKE_BINARY_DIR\install`, but can be changed with
+the `CMAKE_INSTALL_PREFIX` variable when first generating the project build
+files with CMake.
 
-- MoltenVK ICD
-- Mock ICD
+You can build the install target from the command line with:
 
-#### Using MoltenVK ICD
+    cmake --build . --config Release --target install
 
-Clone and build the [MoltenVK](https://github.com/KhronosGroup/MoltenVK) repository.
+or build the `INSTALL` target from the Visual Studio solution explorer.
 
-You will have to direct the loader from Vulkan-Loader to the MoltenVK ICD:
+### Linux Install Target
 
-```bash
-export VK_ICD_FILENAMES=<path to MoltenVK repository>/Package/Latest/MoltenVK/macOS/MoltenVK_icd.json
-```
+Installing the files resulting from your build to the systems directories is
+optional since environment variables can usually be used instead to locate the
+binaries. There are also risks with interfering with binaries installed by
+packages. If you are certain that you would like to install your binaries to
+system directories, you can proceed with these instructions.
 
-#### Using Mock ICD
+Assuming that you've built the code as described above and the current
+directory is still `build`, you can execute:
 
-Clone and build the [Vulkan-Tools](https://github.com/KhronosGroup/Vulkan-Tools) repository.
+    sudo make install
 
-You will have to direct the loader from Vulkan-Loader to the Mock ICD:
+This command installs files to `/usr/local` if no `CMAKE_INSTALL_PREFIX` is
+specified when creating the build files with CMake:
 
-```bash
-export VK_ICD_FILENAMES=<path to Vulkan-Tools repository>/build/icd/VkICD_mock_icd.json
-```
+- `/usr/local/lib`:  Vulkan layers shared objects
+- `/usr/local/share/vulkan/explicit_layer.d`:  Layer JSON files
 
-#### Running the Tests
+You may need to run `ldconfig` in order to refresh the system loader search
+cache on some Linux systems.
 
-In a terminal, change to the build/tests directory and run the vk_layer_validation_tests.
+You can further customize the installation location by setting additional
+CMake variables to override their defaults. For example, if you would like to
+install to `/tmp/build` instead of `/usr/local`, on your CMake command line
+specify:
 
-Further testing and sanity checking can be achieved by running the vkcube and
-vulkaninfo applications in the
-[Vulkan-Tools](https://github.com/KhronosGroup/Vulkan-Tools)
-repository.
+    -DCMAKE_INSTALL_PREFIX=/tmp/build
 
-Note that MoltenVK is still adding Vulkan features and some tests may fail.
+Then run `make install` as before. The install step places the files in
+`/tmp/build`. This may be useful for collecting the artifacts and providing
+them to another project that is dependent on them.
+
+See the CMake documentation for more details on using these variables to
+further customize your installation.
+
+Also see the `LoaderAndLayerInterface` document in the `loader` folder of the
+Vulkan-Loader repository for more information about loader and layer
+operation.
+
+> Note: For Linux, the default value for `CMAKE_INSTALL_PREFIX` is
+> `/usr/local`, which would be used if you do not specify
+> `CMAKE_INSTALL_PREFIX`. In this case, you may need to use `sudo` to install
+> to system directories later when you run `make install`.
+
+To uninstall the files from the system directories, you can execute:
+
+    sudo make uninstall

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@
 The source code for The Vulkan-ValidationLayer components is sponsored by Khronos and LunarG.
 * [Khronos Vulkan-ValidationLayers](https://github.com/KhronosGroup/Vulkan-ValidationLayers)
 
-
-### **The Vulkan Ecosystem Needs Your Help**
+## **The Vulkan Ecosystem Needs Your Help**
 
 The Vulkan validation layers make up a significant part of the Vulkan ecosystem.
 While there are often active and organized development efforts underway to improve their coverage,
@@ -17,39 +16,34 @@ There are a couple of methods to identify areas of need:
 * Examine the [issues list](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues)
 in this repository and look for issues that are of interest
 * Examine the Validation Layer 'Coverage - html' page at [the Vulkan SDK
-documentation page](https://vulkan.lunarg.com/doc/sdk/) -- it lists all published Vulkan VUIDs and their status.
-* Run the `vk_validation_stats.py` script (in the scripts directory) with the `-todo`
-command line argument to see a list of as-yet unimplemented validation checks.
-
-Having selected a validation check to work on, it is often efficient to implement a block of related checks
-at once. Refer to the validation database output from `vk_validation_stats.py` (available in text, html,
-or csv format) to identify related checks that may be implemented simultaneously.
+documentation page](https://vulkan.lunarg.com/doc/sdk/latest/windows/validation_error_database.html) -- it lists all published Vulkan VUIDs and their status.
+* Run `scripts/vk_validation_stats.py` with `-todo` to see a list of as-yet unimplemented validation checks.
+  * ```bash
+    # Get summary report
+    python3 scripts/vk_validation_stats.py external/Vulkan-Headers/registry/validusage.json -summary
+    # Some VUIDs are handled in `spirv-val` and need to pass in the repo to check against
+    python3 scripts/vk_validation_stats.py external/Vulkan-Headers/registry/validusage.json -spirvtools ~/path/to/SPIRV-Tools/ -summary
+    # Print out all the information to an HTML page (also has text and csv support)
+    python3 scripts/vk_validation_stats.py external/Vulkan-Headers/registry/validusage.json -spirvtools ~/path/to/SPIRV-Tools/ -html vuid.html
+    # -todo filters out only VUID that are unimplemented
+    python3 scripts/vk_validation_stats.py external/Vulkan-Headers/registry/validusage.json -spirvtools ~/path/to/SPIRV-Tools/ -todo -html todo.html
+    ```
 
 Of course, if you have your own work in mind, please open an issue to describe it and assign it to yourself.
 Finally, please feel free to contact any of the developers that are actively contributing should you
 wish to coordinate further.
-Please see the [section about Validation Layers](#special-considerations-for-validation-layers)
-later on this page.
-
-Repository Issue labels:
-
-* _Bug_:          These issues refer to invalid or broken functionality and are the highest priority.
-* _Incomplete_:   These issues refer to missing validation checks that users have encountered during application
-development that would have been directly useful, and are high priority.
-* _Enhancement_:  These issues refer to ideas for extending or improving the validation layers.
-* _Triaged_:      These issues have been assessed and/or reviewed
 
 It is the maintainers goal for all issues to be assigned or triaged within one business day of their submission. If you choose
 to work on an issue that is assigned, simply coordinate with the current assignee.
 
-### **How to Submit Fixes**
+## **How to Submit Fixes**
 
 * **Ensure that the bug was not already reported or fixed** by searching on GitHub under Issues
   and Pull Requests.
 * Use the existing GitHub forking and pull request process.
   This will involve [forking the repository](https://help.github.com/articles/fork-a-repo/),
   creating a branch with your commits, and then [submitting a pull request](https://help.github.com/articles/using-pull-requests/).
-* Please read and adhere to the style and process [guidelines ](#coding-conventions-and-formatting) enumerated below. Some highlights:
+* Please read and adhere to the style and process guidelines enumerated below. Some highlights:
   - Source code must follow the repo coding style guidelines, including a pass through a clang-format utility
   - Implemented VUID checks must be accompanied by relevant tests
   - Validation source code should be in a separate commit from the tests, unless there are interdependencies. The repo should compile and
@@ -59,7 +53,7 @@ to work on an issue that is assigned, simply coordinate with the current assigne
   passes the Google/LunarG internal CI processes. Once the Pull Request has been approved and is passing internal CI, a repository maintainer
   will merge the PR.
 
-#### **Coding Conventions and Formatting**
+### **Coding Conventions and Formatting**
 * Use the **[Google style guide](https://google.github.io/styleguide/cppguide.html)** for source code with the following exceptions:
     * The column limit is 132 (as opposed to the default value 80). The clang-format tool will handle this. See below.
     * The indent is 4 spaces instead of the default 2 spaces. Access modifier (e.g. `public:`) is indented 2 spaces instead of the
@@ -68,6 +62,8 @@ to work on an issue that is assigned, simply coordinate with the current assigne
     * If you can justify a reason for violating a rule in the guidelines, then you are free to do so. Be prepared to defend your
 decision during code review. This should be used responsibly. An example of a bad reason is "I don't like that rule." An example of
 a good reason is "This violates the style guide, but it improves type safety."
+
+> New code should target the above Google style guide, avoid copying/pasting incorrectly formatted code.
 
 * Run **clang-format** on your changes to maintain consistent formatting
     * There are `.clang-format` files present in the repository to define clang-format settings
@@ -100,13 +96,13 @@ that to be accepted into the repository, the pull request must [pass all tests](
 -- the continuous integration features will assist in enforcing this requirement.
 
 #### **Testing Your Changes**
-* Run the included layer validation tests (vk_layer_validation_tests) in the repository before and after each of your commits to check for any regressions.
+* Run the included layer validation tests (`vk_layer_validation_tests`) in the repository before and after each of your commits to check for any regressions.
 
 * Write additional layer validation tests that explicitly exercise your changes.
 
 * Feel free to subject your code changes to other tests as well!
 
-* Take a look at the [overview for creating tests](docs/creating_tests.md).
+* [How to setup tests to run](./tests) and [overview for creating tests](docs/creating_tests.md).
 
 #### **GitHub Cloud CI Testing**
 Pull Requests to GitHub are tested in the cloud on Linux and Windows VMs. The Linux VMs use [Github Actions](https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions) with the sequence of commands driven by the [ci_build.yml](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/.github/workflows/ci_build.yml) file. The Windows VMs use [AppVeyor](https://ci.appveyor.com/project/Khronoswebmaster/vulkan-validationlayers/branch/master) with the sequence of commands driven by the [.appveyor.yml](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/.appveyor.yml) file.
@@ -114,14 +110,6 @@ Pull Requests to GitHub are tested in the cloud on Linux and Windows VMs. The Li
 The Linux testing includes iterating on all of the validation layer tests over multiple [different device](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/master/tests/device_profiles) profiles using the [devsim layer](https://github.com/LunarG/VulkanTools/tree/master/layersvt) in combination with the [mock icd](https://github.com/KhronosGroup/Vulkan-Tools/tree/master/icd). This is a fast way to simulate testing across different devices. Any new tests must pass across all device profiles.
 
 #### **Special Considerations for Validation Layers**
-* **Validation Tests:**  If you are submitting a change that adds a new validation check, you should also construct a "negative" test function.
-The negative test function purposely violates the validation rule that the new validation check is looking for.
-The test should cause your new validation check to identify the violation and issue a validation error report.
-And finally, the test should check that the validation error report is generated and consider the test as "passing"
-if the report is received.  Otherwise, the test should indicate "failure".
-This new test should be added to the validation layer test program in the `tests` directory and contributed
-at the same time as the new validation check itself. There are many existing validation tests in this directory that can be
-used as a starting point.
 * **Validation Checks:**  Validation checks are carried out by the Khronos Validation layer. The CoreChecks validation object
 contains checks that require significant amounts of application state to carry out. In contrast, the stateless validation object contains
 checks that require (mostly) no state at all. Please inquire if you are unsure of the location for your contribution. The other
@@ -131,15 +119,9 @@ output all of the applicable Vulkan Objects and related values. Also, ensure tha
 fix the problem, they should do so to better assist the user. Note that Vulkan object handles must be output via the `FormatHandle()`
 function, and that all object handles visible in a message should also be included in the callback data.  If more than a single object is
 output, the LogObjectList structure should be used.
-* **Validation Statistics:** The `vk_validation_stats.py` script (in the scripts directory) inspects the layer and test source files
-and reports a variety of statistics on validation completeness and correctness. Before submitting a change you should run this
-script with the consistency check (`-c`) argument to ensure that your changes have not introduced any inconsistencies in the code.
 * **Generated Source Code:** The `layers/generated` directory contains source code that is created by several
 generator scripts in the `scripts` directory. All changes to these scripts _must_ be submitted with the
-corresponding generated output to keep the repository self-consistent. This requirement is enforced by
-the continuous integration testing. Regenerate source files after modifying any of the generator
-scripts and before building and testing your changes. More details can be found in
-[BUILD.md](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/BUILD.md#generated-source-code).
+corresponding generated output to keep the repository self-consistent. [Here for more information](docs/generated_code.md).
 
 #### Coding Conventions for [CMake](http://cmake.org) files
 

--- a/README.md
+++ b/README.md
@@ -19,25 +19,20 @@ a Vulkan driver. Applications have full control and responsibility for correct o
 how Vulkan is used can result in a crash. This project provides Vulkan validation layers that can be enabled
 to assist development by enabling developers to verify their applications correct use of the Vulkan API.
 
-The following components are available in this repository:
-- [*Validation Layers*](layers/)
-- [*Tests*](tests/)
+This repository contains both the [*Validation Layers*](layers/) source as well as [*Tests*](tests/) for them.
 
 ## Contact Information
 * [Mark Lobodzinski](mailto:mark@lunarg.com)
 * [Nate Cesario](mailto:nathaniel@lunarg.com)
+* Can also be found on the [Khronos Slack](https://khr.io/slack)
 
-## Information for Developing or Contributing:
-
-Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file in this repository for more details.
-Please see the [GOVERNANCE.md](GOVERNANCE.md) file in this repository for repository management details.
-
-## How to Build and Run
-
-[BUILD.md](BUILD.md)
-Includes directions for building all components as well as running validation tests.
-
-Information on how to enable the various Validation layers is in [LAYER_CONFIGURATION.md](LAYER_CONFIGURATION.md).
+## Info
+* [BUILD.md](BUILD.md) - Instructions for building the Validation Layers
+* [LAYER_CONFIGURATION.md](LAYER_CONFIGURATION.md) - Instructions for configuring the Validation Layers at runtime.
+* [CONTRIBUTING.md](CONTRIBUTING.md) - Information needed to make a contribution.
+    * [./docs](./docs/) - Details of the Validation Layer source code. **For those wanting to make contributions**
+    * [./tests](./tests) - Information about testing the Validation Layers.
+    * [GOVERNANCE.md](GOVERNANCE.md) - Repository management details.
 
 ## Version Tagging Scheme
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Validation Layers Source Documentation
+
+This directory contains more detailed information about how each part of the Validation Layers work.
+
+- [VK_LAYER_KHRONOS_validation overview](./khronos_validation_layer.md)
+    - [Core Validation Checks](./core_checks.md)
+    - [Best Practices Validation](./best_practices.md)
+    - [Shader Debug Printf](./debug_printf.md)
+    - [Fine Grained Locking](./fine_grained_locking.md)
+        - [Fine Grained Locking - Usage](./fine_grained_locking_usage.md)
+    - [Generated Code](./generated_code.md)
+    - [GPU-Assisted Validation](./gpu_validation.md)
+    - [Handle Wrapping](./handle_wrapping.md)
+    - [Object Lifetimes](./object_lifetimes.md)
+    - [VK_KHR_portability_subset](./portability_validation.md)
+    - [Shader Validation](./shader_validation.md)
+    - [Stateless Parameter Validation](./stateless_validation.md)
+    - [Synchronization Validation Design Documentation](./synchronization.md)
+        - [Synchronization Validation Usage](./synchronization_usage.md)
+    - [Thread Safety Validation](./thread_safety.md)
+- [Creating Tests](./creating_tests.md)

--- a/docs/core_checks.md
+++ b/docs/core_checks.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2021 LunarG, Inc. -->
+<!-- Copyright 2015-2022 LunarG, Inc. -->
 
 [![Khronos Vulkan][1]][2]
 
@@ -42,21 +42,6 @@ for work. Specifically the layer validates that:
 
 Errors will be printed if validation checks are not correctly met and warnings if improper (but not illegal) use of
 memory is detected.  Validation also dumps all memory references and bindings for each operation.
-
-## Shader validation functionality
-
-Additional checks apply to the VS->FS and FS->CB interfaces with the pipeline.  These checks include:
-
-- validating that all variables which are part of a shader interface are  decorated with either `spv::DecLocation` or `spv::DecBuiltin` (that is, only the SSO rendezvous-by-location model is supported)
-- emitting a warning if a location is declared only in the producing stage (useless work is being done)
-- emitting an error if a location is declared only in the consuming stage (garbage will be read).
-
-A special error checking case invoked when the FS stage writes a built-in corresponding to the legacy `gl_FragColor`.  In this case, an error is emitted if
-
-- the FS also writes any user-defined output
-- the CB has any attachment with a `UINT` or `SINT` type.
-
-These extra checks are to ensure that the legacy broadcast of `gl_FragColor` to all bound color attachments is well-defined.
 
 ## Swapchain validation functionality
 

--- a/docs/generated_code.md
+++ b/docs/generated_code.md
@@ -1,0 +1,34 @@
+# Generated Code
+
+There is a lot of code generated in `layers/generated/`. This is done to prevent errors forgetting to add support for new
+values when the Vulkan Headers or SPIR-V Grammer is updated.
+
+How to generate the code:
+
+```bash
+python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
+```
+
+When making change to the `scripts/` folder, make sure to run `generate_source.py` and check in both the changes to
+`scripts/` and `layers/generated/` in any PR.
+
+## Cmake helper
+
+A helper CMake target `VulkanVL_generated_source` is also provided to simplify
+the invocation of `scripts/generate_source.py` from the build directory:
+
+```bash
+cmake --build . --target VulkanVL_generated_source
+```
+
+## How it works
+
+`generate_source.py` sets up the environment and then calls into `lvl_genvk.py` where each file is generated at a time. Many of the generation scripts will generate both the `.cpp` source and `.h` header
+
+The Vulkan code is generated from the [vk.xml](https://github.com/KhronosGroup/Vulkan-Headers/blob/main/registry/vk.xml) and uses the python helper functions in the `Vulkan-Headers/registry` folder.
+
+The SPIR-V code is generated from the [SPIR-V Grammer](https://github.com/KhronosGroup/SPIRV-Headers/blob/master/include/spirv/unified1/spirv.core.grammar.json)
+
+## Tips
+
+If only dealing with a single file, comment out all the other file names in `scripts/generate_source.py` to speed up testing iterations.

--- a/docs/khronos_validation_layer.md
+++ b/docs/khronos_validation_layer.md
@@ -14,18 +14,6 @@ Any errors in Vulkan usage can result in unexpected behavior or even a crash.  T
 can be used to to assist developers in isolating incorrect usage, and in verifying that applications
 correctly use the API.
 
-
-The `VK_LAYER_KHRONOS_validation` layer supports the following validation coverage areas:
-
-- [Core validation](core_checks.md)
-- [GPU-Assisted validation](gpu_validation.md)
-- [Thread safety validation](thread_safety.md)
-- [Synchronization validation](synchronization_usage.md)
-- [Best practices validation](best_practices.md)
-- [Debug Printf functionality](debug_printf.md)
-- [Handle wrapping functionality](handle_wrapping.md)
-- [Fine grained locking functionality](fine_grained_locking_usage.md)
-
 **Note:**
 
 * Most *Khronos Validation layer* features can be used simultaneously. However, this could result in noticeable performance degradation. The best practice is to run *Core validation*, *GPU-Assisted validation*, *Synchronization Validation* and *Best practices validation* features individually.

--- a/docs/shader_validation.md
+++ b/docs/shader_validation.md
@@ -1,0 +1,32 @@
+# Shader Validation
+
+Shader validation is run at `vkCreateShaderModule` and `vkCreate*Pipelines` time. It makes sure both the `SPIR-V` is valid
+as well as the `VkPipeline` object interface with the shader. Note, this is all done on the CPU and different than
+[GPU-Assisted Validation](gpu_validation.md).
+
+## Standalone VUs with spirv-val
+
+There are many [VUID labeled](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#spirvenv-module-validation-standalone) as `VUID-StandaloneSpirv-*` and all the
+[Built-In Variables](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-builtin-variables)
+VUIDs that can be validated on a single shader module and require no runtime information.
+
+All of these validations are passed off to `spirv-val` in [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/).
+
+## spirv-opt
+
+There are a few special places where `spirv-opt` is run to reduce recreating work already done in `SPIRV-Tools`.
+
+## Different sections
+
+The code is currently split up into the following main sections
+
+- `layers/shader_instruction.cpp`
+    - This contains information about each SPIR-V instruction.
+- `layers/shader_module.cpp`
+    - This contains information about the `VkShaderModule` object
+- `layers/shader_validation.cpp`
+    - This takes the following above and does the actual validation. All errors are produced here.
+    - `layers/generated/spirv_validation_helper.cpp`
+        - This is generated file provides a way to generate checks for things found in the `vk.xml` related to SPIR-V
+- `layers/generated/spirv_grammar_helper.cpp`
+    - This is a general util file that is [generated](generated_code.md) from the SPIR-V grammar

--- a/docs/stateless_validation.md
+++ b/docs/stateless_validation.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2021 LunarG, Inc. -->
+<!-- Copyright 2015-2022 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -15,3 +15,6 @@ This layer performs the following tasks:
 - null pointer conditions
 - stateless valid usage checks
 - checks requiring only static state such as properties or limits
+
+The Stateless Validation is run before [Core Validation Checks](core_checks.md). If there is a
+validation error found in Stateless Validation, it will return and not call Core Validation nor call down the layer chain.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,130 @@
+# Validation Layers Tests
+
+The Validation Layers use [Google Test (gtest)](https://github.com/google/googletest) for testing the
+Validation Layers. This helps make sure all new changes are correct and prevent regressions.
+
+The following is information how to setup and run the tests. There is seperate documentation for [creating tests](../docs/creating_tests.md).
+
+## Building the tests
+
+Make sure `-DBUILD_TESTS` was passed into the CMake command when generating the project
+
+## Different Categories of tests
+
+The tests are grouped into different categories. Some of the main test categories are:
+
+- `VkLayerTest` - General tests that expect the Validation Layers to trigger an error
+    - Also known as "negative tests"
+- `VkPositiveLayerTest` - Tests that make sure Validation isn't accidentally triggering an error
+- `VkBestPracticesLayerTest` - Tests the [best practice layer](../docs/best_practices.md)
+- `VkGpuAssistedLayerTest` - Test [GPU-Assisted Validation](../docs/gpu_validation.md)
+- `VkPortabilitySubsetTest` - Test [VK_KHR_portability_subset validation](../docs/portability_validation.md)
+
+## Running Test on Linux
+
+**IMPORTANT** Make sure you have the correct `VK_LAYER_PATH` set on Linux
+
+```bash
+export VK_LAYER_PATH=/path/to/Vulkan-ValidationLayers/build/layers/
+```
+
+To run the tests
+
+```bash
+cd build
+
+# Run all the test
+./tests/vk_layer_validation_tests
+
+# Run with certain VkPhysicalDevice
+# see --help for more options
+./tests/vk_layer_validation_tests --device-index 1
+
+# Run a single test
+./tests/vk_layer_validation_tests --gtest_filter=VkLayerTest.BufferExtents
+
+# Run a multiple tests with a patter
+./tests/vk_layer_validation_tests --gtest_filter=*Buffer*
+```
+
+## Running Test on Android
+
+```bash
+cd build-android
+
+# Optional
+adb uninstall com.example.VulkanLayerValidationTests
+
+adb install -r bin/VulkanLayerValidationTests.apk
+
+# Runs all test
+adb shell am start com.example.VulkanLayerValidationTests/android.app.NativeActivity
+
+# Run test with gtest_filter
+adb shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.VulkanLayerValidationTests/android.app.NativeActivity --es args --gtest_filter="*AndroidHardwareBuffer*"
+```
+
+Alternatively, you can use the test_APK script to install and run the layer
+validation tests:
+
+```bash
+test_APK.sh -s <serial number> -p <plaform name> -f <gtest_filter>
+```
+
+To view to logging while running in a separate terminal run
+
+```bash
+adb logcat -c && adb logcat *:S VulkanLayerValidationTests
+```
+
+Or the files can be pulled off the device with
+
+```bash
+adb shell cat /sdcard/Android/data/com.example.VulkanLayerValidationTests/files/out.txt
+adb shell cat /sdcard/Android/data/com.example.VulkanLayerValidationTests/files/err.txt
+```
+
+## Running Test on MacOS
+
+Clone and build the [MoltenVK](https://github.com/KhronosGroup/MoltenVK) repository.
+
+You will have to direct the loader from Vulkan-Loader to the MoltenVK ICD:
+
+```bash
+export VK_ICD_FILENAMES=<path to MoltenVK repository>/Package/Latest/MoltenVK/macOS/MoltenVK_icd.json
+```
+
+## Running Tests on DevSim and MockICD
+
+To allow a much higher coverage of testing the Validation Layers a test writer can use the Device Simulation layer. [More details here](https://www.lunarg.com/new-vulkan-dev-sim-layer/), but the main idea is the layer intercepts the Physical Device queries allowing testing of much more device properties. The Mock ICD is a "null driver" that is used to handle the Vulkan calls as the Validation Layers mostly only care about input "input" of the driver. If your tests relies on the "output" of the driver (such that a driver/implementation is correctly doing what it should do with valid input), then it might be worth looking into the [Vulkan CTS instead](https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/vulkan_cts.md).
+
+Both the Device Simulation Layer and MockICD can be found in the Vulkan SDK, otherwise, they will need to be cloned from [VulkanTools](https://github.com/LunarG/VulkanTools/blob/master/layersvt/VkLayer_device_simulation.json.in) and [Vulkan-Tools](https://github.com/KhronosGroup/Vulkan-Tools/tree/master/icd) respectfully. Currently, you will need to build the MockICD from source (found in Vulkan SDK or in a local copy somewhere)
+
+Here is an example of setting up and running the Device Simulation layer with MockICD on a Linux environment
+```bash
+export VULKAN_SDK=/path/to/vulkansdk
+export VVL=/path/to/Vulkan-ValidationLayers
+
+# Add built Vulkan Validation Layers... remember it was Rule #1
+export VK_LAYER_PATH=$VVL/build/layers/
+
+# This step can be skipped if the Vulkan SDK is properly installed
+# Add path for device simulation layer
+export VK_LAYER_PATH=$VK_LAYER_PATH:$VULKAN_SDK/etc/vulkan/explicit_layer.d/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VULKAN_SDK/lib/
+
+# Set MockICD to be driver
+export VK_ICD_FILENAMES=/path/to/Vulkan-Tools/build/icd/VkICD_mock_icd.json
+
+# Set device simulation profile to a valid json file
+# There are a set of profiles used in CI in the device_profiles folder
+export VK_DEVSIM_FILENAME=$VVL/tests/device_profiles/mobile_chip.json
+
+# Needed or else the code `IsPlatform(kMockICD)` will not work
+# Also allows profiles to use extensions exposed in .json profile file
+# More details - https://github.com/LunarG/VulkanTools/issues/985
+export VK_DEVSIM_MODIFY_EXTENSION_LIST=1
+
+# Running tests just need the extra --devsim added
+$VVL/build/tests/vk_layer_validation_tests --devsim --gtest_filter=TestName
+```


### PR DESCRIPTION
In effort to make it easier for new developers to get up and running with the code

Highlights:
- Reduce `BUILD.md` to just what it takes to build
- Created `tests/README.md` to hold information about running the tests
- Added a `docs/generated_code.md` and `docs/shader_validation.md`