### PR TITLE
Account for `VkSurfaceFullScreenExclusiveInfoEXT` when validating swapchain creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build-android/third_party
 .DS_Store
 .editorconfig
 scripts/.vs
+.vs/

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -18139,7 +18139,7 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
     }
 #endif
     const auto surface_caps2 = surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                              physical_device_state->PhysDev(), full_screen_info_copy_addr);
+                                                              physical_device_state->PhysDev(), full_screen_info_copy_addr, this);
 
     bool skip = false;
     VkSurfaceTransformFlagBitsKHR current_transform = surface_caps2.surfaceCapabilities.currentTransform;
@@ -18187,8 +18187,9 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
                               surface_caps2.surfaceCapabilities.maxImageExtent)) {
         safe_VkSurfaceCapabilities2KHR cached_capabilities{};
         if (surface_state) {
-            cached_capabilities = surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                                 physical_device_state->PhysDev(), full_screen_info_copy_addr);
+            cached_capabilities =
+                surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
+                                               physical_device_state->PhysDev(), full_screen_info_copy_addr, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             cached_capabilities = physical_device_state->surfaceless_query_state.capabilities;
         }
@@ -18313,7 +18314,7 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
         layer_data::span<const safe_VkSurfaceFormat2KHR> formats{};
         if (surface_state) {
             formats = surface_state->GetFormats(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                physical_device_state->PhysDev(), full_screen_info_copy_addr);
+                                                physical_device_state->PhysDev(), full_screen_info_copy_addr, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             formats = physical_device_state->surfaceless_query_state.formats;
         }
@@ -18353,7 +18354,7 @@ bool CoreChecks::ValidateCreateSwapchain(const char *func_name, VkSwapchainCreat
 
     std::vector<VkPresentModeKHR> present_modes{};
     if (surface_state) {
-        present_modes = surface_state->GetPresentModes(physical_device);
+        present_modes = surface_state->GetPresentModes(physical_device, this);
     } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
         present_modes = physical_device_state->surfaceless_query_state.present_modes;
     }
@@ -18827,7 +18828,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const AcquireVersion 
         safe_VkSurfaceCapabilities2KHR caps{};
         if (swapchain_data->surface) {
             caps = swapchain_data->surface->GetCapabilities(IsExtEnabled(device_extensions.vk_khr_get_surface_capabilities2),
-                                                            physical_device);
+                                                            physical_device, nullptr, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             caps = physical_device_state->surfaceless_query_state.capabilities;
         }

--- a/layers/device_state.h
+++ b/layers/device_state.h
@@ -115,9 +115,9 @@ class QUEUE_FAMILY_PERF_COUNTERS {
 
 class SURFACELESS_QUERY_STATE {
   public:
-    std::vector<VkSurfaceFormatKHR> formats;
+    std::vector<safe_VkSurfaceFormat2KHR> formats;
     std::vector<VkPresentModeKHR> present_modes;
-    VkSurfaceCapabilitiesKHR capabilities;
+    safe_VkSurfaceCapabilities2KHR capabilities;
 };
 
 class PHYSICAL_DEVICE_STATE : public BASE_NODE {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "vulkan/vulkan.h"
 #include "vk_layer_settings_ext.h"
@@ -4105,6 +4106,15 @@ class ValidationObject {
             LogObjectList single_object(src_object);
             return LogMsgLocked(report_data, kInformationBit, single_object, vuid_text, str);
         };
+
+        void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
+                              std::string_view entrypoint, VkResult err) const {
+            const std::string_view err_string = string_VkResult(err);
+            std::string vuid = "INTERNAL-ERROR-";
+            vuid += entrypoint;
+            LogError(obj_list, vuid, "In %s: %s() failed with result = %s.", failure_location.data(), entrypoint.data(),
+                                       err_string.data());
+        }
 
         // Handle Wrapping Data
         // Reverse map display handles

--- a/layers/image_state.cpp
+++ b/layers/image_state.cpp
@@ -709,49 +709,107 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice ph
     }
     std::vector<VkPresentModeKHR> result;
     uint32_t count = 0;
-    DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, surface(), &count, nullptr);
+    VkResult err = DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, surface(), &count, nullptr);
+    if (!(err == VK_SUCCESS || err == VK_INCOMPLETE)) {
+        return result;
+    }
     result.resize(count);
-    DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, surface(), &count, result.data());
+    err = DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, surface(), &count, result.data());
+    assert(err == VK_SUCCESS);
+    if (err != VK_SUCCESS) {
+        result.resize(0);
+        return result;
+    }
     return result;
 }
 
-void SURFACE_STATE::SetFormats(VkPhysicalDevice phys_dev, std::vector<VkSurfaceFormatKHR> &&fmts) {
+void SURFACE_STATE::SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts) {
     auto guard = Lock();
     assert(phys_dev);
     formats_[phys_dev] = std::move(fmts);
 }
 
-std::vector<VkSurfaceFormatKHR> SURFACE_STATE::GetFormats(VkPhysicalDevice phys_dev) const {
+layer_data::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_surface_capabilities2,
+                                                                           VkPhysicalDevice phys_dev,
+                                                                           const void *surface_info2_pnext /*= nullptr*/) const {
     auto guard = Lock();
     assert(phys_dev);
-    auto iter = formats_.find(phys_dev);
-    if (iter != formats_.end()) {
-        return iter->second;
+    auto search = formats_.find(phys_dev);
+    if (search != formats_.end()) {
+        layer_data::span<const safe_VkSurfaceFormat2KHR>(search->second);
     }
-    std::vector<VkSurfaceFormatKHR> result;
-    uint32_t count = 0;
-    DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, surface(), &count, nullptr);
-    result.resize(count);
-    DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, surface(), &count, result.data());
-    formats_[phys_dev] = result;
-    return result;
+
+    std::vector<safe_VkSurfaceFormat2KHR> result;
+    if (get_surface_capabilities2) {
+        uint32_t count = 0;
+        const auto surface_info2 = GetSurfaceInfo2(surface_info2_pnext);
+        VkResult err = DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, nullptr);
+        if (!(err == VK_SUCCESS || err == VK_INCOMPLETE)) {
+            return result;
+        }
+        std::vector<VkSurfaceFormat2KHR> formats2(count);
+        err = DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, formats2.data());
+        assert(err == VK_SUCCESS);
+        if (err != VK_SUCCESS) {
+            result.resize(0);
+        } else {
+            result.resize(count);
+            for (uint32_t surface_format_index = 0; surface_format_index < count; ++surface_format_index) {
+                result.emplace_back(safe_VkSurfaceFormat2KHR(&formats2[surface_format_index]));
+            }
+        }
+
+    } else {
+        std::vector<VkSurfaceFormatKHR> formats;
+        uint32_t count = 0;
+        VkResult err = DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, surface(), &count, nullptr);
+        if (!(err == VK_SUCCESS || err == VK_INCOMPLETE)) {
+            return result;
+        }
+        formats.resize(count);
+        err = DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, surface(), &count, formats.data());
+        assert(err == VK_SUCCESS);
+        if (err == VK_SUCCESS) {
+            result.reserve(count);
+            auto format2 = LvlInitStruct<VkSurfaceFormat2KHR>();
+            for (const auto &format : formats) {
+                format2.surfaceFormat = format;
+                result.emplace_back(safe_VkSurfaceFormat2KHR(&format2));
+            }
+        }
+    }
+    formats_[phys_dev] = std::move(result);
+    return layer_data::span<const safe_VkSurfaceFormat2KHR>(formats_[phys_dev]);
 }
 
-void SURFACE_STATE::SetCapabilities(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR &caps) {
+void SURFACE_STATE::SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps) {
     auto guard = Lock();
     assert(phys_dev);
     capabilities_[phys_dev] = caps;
 }
 
-VkSurfaceCapabilitiesKHR SURFACE_STATE::GetCapabilities(VkPhysicalDevice phys_dev) const {
+safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
+                                                              const void *surface_info2_pnext /*= nullptr*/) const {
     auto guard = Lock();
     assert(phys_dev);
     auto iter = capabilities_.find(phys_dev);
     if (iter != capabilities_.end()) {
         return iter->second;
     }
-    VkSurfaceCapabilitiesKHR result{};
-    DispatchGetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev, surface(), &result);
-    capabilities_[phys_dev] = result;
-    return result;
+    auto surface_caps2 = LvlInitStruct<VkSurfaceCapabilities2KHR>();
+    if (get_surface_capabilities2) {
+        const auto surface_info2 = GetSurfaceInfo2(surface_info2_pnext);
+        const VkResult err = DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info2, &surface_caps2);
+        assert(err == VK_SUCCESS);
+        UNUSED(err);
+    } else {
+        VkSurfaceCapabilitiesKHR caps{};
+        const VkResult err = DispatchGetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev, surface(), &caps);
+        assert(err == VK_SUCCESS);
+        UNUSED(err);
+        surface_caps2.surfaceCapabilities = caps;
+    }
+    safe_VkSurfaceCapabilities2KHR safe_surface_caps2(&surface_caps2);
+    capabilities_[phys_dev] = safe_surface_caps2;
+    return safe_surface_caps2;
 }

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -352,6 +352,12 @@ class SURFACE_STATE : public BASE_NODE {
     }
 
     VkSurfaceKHR surface() const { return handle_.Cast<VkSurfaceKHR>(); }
+    VkPhysicalDeviceSurfaceInfo2KHR GetSurfaceInfo2(const void *surface_info2_pnext = nullptr) const {
+        auto surface_info2 = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        surface_info2.pNext = surface_info2_pnext;
+        surface_info2.surface = surface();
+        return surface_info2;
+    }
 
     void Destroy() override;
 
@@ -365,11 +371,13 @@ class SURFACE_STATE : public BASE_NODE {
     void SetPresentModes(VkPhysicalDevice phys_dev, std::vector<VkPresentModeKHR> &&modes);
     std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev) const;
 
-    void SetFormats(VkPhysicalDevice phys_dev, std::vector<VkSurfaceFormatKHR> &&fmts);
-    std::vector<VkSurfaceFormatKHR> GetFormats(VkPhysicalDevice phys_dev) const;
+    void SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts);
+    layer_data::span<const safe_VkSurfaceFormat2KHR> GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
+                                                                const void *surface_info2_pnext = nullptr) const;
 
-    void SetCapabilities(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR &caps);
-    VkSurfaceCapabilitiesKHR GetCapabilities(VkPhysicalDevice phys_dev) const;
+    void SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps);
+    safe_VkSurfaceCapabilities2KHR GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
+                                                   const void *surface_info2_pnext = nullptr) const;
 
     SWAPCHAIN_NODE *swapchain{nullptr};
 
@@ -378,6 +386,6 @@ class SURFACE_STATE : public BASE_NODE {
     mutable std::mutex lock_;
     mutable layer_data::unordered_map<GpuQueue, bool> gpu_queue_support_;
     mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>> present_modes_;
-    mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
-    mutable layer_data::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
+    mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<safe_VkSurfaceFormat2KHR>> formats_;
+    mutable layer_data::unordered_map<VkPhysicalDevice, safe_VkSurfaceCapabilities2KHR> capabilities_;
 };

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -338,6 +338,8 @@ struct hash<GpuQueue> {
 };
 }  // namespace std
 
+class ValidationObject;
+
 // State for VkSurfaceKHR objects.
 // Parent -> child relationships in the object usage tree:
 //    SURFACE_STATE -> nothing
@@ -369,15 +371,16 @@ class SURFACE_STATE : public BASE_NODE {
     bool GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const;
 
     void SetPresentModes(VkPhysicalDevice phys_dev, std::vector<VkPresentModeKHR> &&modes);
-    std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev) const;
+    std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev, const ValidationObject *validation_obj) const;
 
     void SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts);
     layer_data::span<const safe_VkSurfaceFormat2KHR> GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                                const void *surface_info2_pnext = nullptr) const;
+                                                                const void *surface_info2_pnext,
+                                                                const ValidationObject *validation_obj) const;
 
     void SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps);
     safe_VkSurfaceCapabilities2KHR GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                   const void *surface_info2_pnext = nullptr) const;
+                                                   const void *surface_info2_pnext, const ValidationObject *validation_obj) const;
 
     SWAPCHAIN_NODE *swapchain{nullptr};
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3959,7 +3959,9 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesK
                                                                                    VkResult result) {
     if (VK_SUCCESS != result) return;
     auto surface_state = Get<SURFACE_STATE>(surface);
-    surface_state->SetCapabilities(physicalDevice, *pSurfaceCapabilities);
+    auto caps2 = LvlInitStruct<VkSurfaceCapabilities2KHR>();
+    caps2.surfaceCapabilities = *pSurfaceCapabilities;
+    surface_state->SetCapabilities(physicalDevice, safe_VkSurfaceCapabilities2KHR(&caps2));
 }
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(
@@ -3969,12 +3971,12 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
 
     if (pSurfaceInfo->surface) {
         auto surface_state = Get<SURFACE_STATE>(pSurfaceInfo->surface);
-        surface_state->SetCapabilities(physicalDevice, pSurfaceCapabilities->surfaceCapabilities);
+        surface_state->SetCapabilities(physicalDevice, safe_VkSurfaceCapabilities2KHR(pSurfaceCapabilities));
     } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query) &&
                lvl_find_in_chain<VkSurfaceProtectedCapabilitiesKHR>(pSurfaceCapabilities->pNext)) {
         auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
         assert(pd_state);
-        pd_state->surfaceless_query_state.capabilities = pSurfaceCapabilities->surfaceCapabilities;
+        pd_state->surfaceless_query_state.capabilities = safe_VkSurfaceCapabilities2KHR(pSurfaceCapabilities);
     }
 }
 
@@ -3983,14 +3985,16 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
                                                                                     VkSurfaceCapabilities2EXT *pSurfaceCapabilities,
                                                                                     VkResult result) {
     auto surface_state = Get<SURFACE_STATE>(surface);
-    VkSurfaceCapabilitiesKHR caps{
+    const VkSurfaceCapabilitiesKHR caps{
         pSurfaceCapabilities->minImageCount,           pSurfaceCapabilities->maxImageCount,
         pSurfaceCapabilities->currentExtent,           pSurfaceCapabilities->minImageExtent,
         pSurfaceCapabilities->maxImageExtent,          pSurfaceCapabilities->maxImageArrayLayers,
         pSurfaceCapabilities->supportedTransforms,     pSurfaceCapabilities->currentTransform,
         pSurfaceCapabilities->supportedCompositeAlpha, pSurfaceCapabilities->supportedUsageFlags,
     };
-    surface_state->SetCapabilities(physicalDevice, caps);
+    auto caps2 = LvlInitStruct<VkSurfaceCapabilities2KHR>();
+    caps2.surfaceCapabilities = caps;
+    surface_state->SetCapabilities(physicalDevice, safe_VkSurfaceCapabilities2KHR(&caps2));
 }
 
 void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice,
@@ -4029,15 +4033,17 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(Vk
     if ((VK_SUCCESS != result) && (VK_INCOMPLETE != result)) return;
 
     if (pSurfaceFormats) {
+        std::vector<safe_VkSurfaceFormat2KHR> formats2(*pSurfaceFormatCount);
+        for (uint32_t surface_format_index = 0; surface_format_index < *pSurfaceFormatCount; surface_format_index++) {
+            formats2[surface_format_index].surfaceFormat = pSurfaceFormats[surface_format_index];
+        }
         if (surface) {
             auto surface_state = Get<SURFACE_STATE>(surface);
-            surface_state->SetFormats(physicalDevice,
-                                      std::vector<VkSurfaceFormatKHR>(pSurfaceFormats, pSurfaceFormats + *pSurfaceFormatCount));
+            surface_state->SetFormats(physicalDevice, std::move(formats2));
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
             assert(pd_state);
-            pd_state->surfaceless_query_state.formats =
-                std::vector<VkSurfaceFormatKHR>(pSurfaceFormats, pSurfaceFormats + *pSurfaceFormatCount);
+            pd_state->surfaceless_query_state.formats = std::move(formats2);
         }
     }
 }
@@ -4050,17 +4056,22 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(V
     if ((VK_SUCCESS != result) && (VK_INCOMPLETE != result)) return;
 
     if (pSurfaceFormats) {
-        std::vector<VkSurfaceFormatKHR> fmts(*pSurfaceFormatCount);
-        for (uint32_t i = 0; i < *pSurfaceFormatCount; i++) {
-            fmts[i] = pSurfaceFormats[i].surfaceFormat;
-        }
         if (pSurfaceInfo->surface) {
             auto surface_state = Get<SURFACE_STATE>(pSurfaceInfo->surface);
-            surface_state->SetFormats(physicalDevice, std::move(fmts));
+            std::vector<safe_VkSurfaceFormat2KHR> formats2(*pSurfaceFormatCount);
+            for (uint32_t surface_format_index = 0; surface_format_index < *pSurfaceFormatCount; surface_format_index++) {
+                formats2[surface_format_index].initialize(&pSurfaceFormats[surface_format_index]);
+            }
+            surface_state->SetFormats(physicalDevice, std::move(formats2));
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
             assert(pd_state);
-            pd_state->surfaceless_query_state.formats = std::move(fmts);
+            pd_state->surfaceless_query_state.formats.clear();
+            pd_state->surfaceless_query_state.formats.reserve(*pSurfaceFormatCount);
+            for (uint32_t surface_format_index = 0; surface_format_index < *pSurfaceFormatCount; ++surface_format_index) {
+                pd_state->surfaceless_query_state.formats.emplace_back(
+                    safe_VkSurfaceFormat2KHR(&pSurfaceFormats[surface_format_index]));
+            }
         }
     }
 }

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -102,6 +102,11 @@ struct LogObjectList {
         add(object);
     }
 
+    template <typename... HANDLE_T>
+    LogObjectList(HANDLE_T... objects) {
+        (..., add(objects));
+    }
+
     LogObjectList(){};
 };
 

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -692,9 +692,9 @@ static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg
                                 const std::string &vuid_text, char *err_msg) {
     std::string str_plus_spec_text(err_msg ? err_msg : "Allocation failure");
 
-    // Append the spec error text to the error message, unless it's an UNASSIGNED or UNDEFINED vuid
+    // Append the spec error text to the error message, unless it is treated as special
     if ((vuid_text.find("UNASSIGNED-") == std::string::npos) && (vuid_text.find(kVUIDUndefined) == std::string::npos) &&
-        (vuid_text.rfind("SYNC-", 0) == std::string::npos)) {
+        (vuid_text.rfind("SYNC-", 0) == std::string::npos) && (vuid_text.find("INTERNAL-ERROR-") == std::string::npos)) {
         // Linear search makes no assumptions about the layout of the string table. This is not fast, but it does not need to be at
         // this point in the error reporting path
         uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -42,6 +42,9 @@
 #define STRINGIFY_HELPER(s) #s
 
 #ifdef __cplusplus
+template <typename... Types>
+void UNUSED(Types...) {}
+
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};
     return d3;

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -41,9 +41,16 @@
 #define STRINGIFY(s) STRINGIFY_HELPER(s)
 #define STRINGIFY_HELPER(s) #s
 
+// For MSVC
+#if !defined(__PRETTY_FUNCTION__)
+#if defined(__FUNCSIG__)
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#else
+#define __PRETTY_FUNCTION__ __FILE__ ":" STRINGIFY(__LINE__)
+#endif
+#endif
+
 #ifdef __cplusplus
-template <typename... Types>
-void UNUSED(Types...) {}
 
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -326,6 +326,21 @@ static inline VkDeviceSize SafeDivision(VkDeviceSize dividend, VkDeviceSize divi
     return result;
 }
 
+// Find whether or not an element is in list
+// Two definitions, to be able to do the following calls:
+// IsIn(1, {1, 2, 3});
+// std::array arr {1, 2, 3};
+// IsIn(1, arr);
+template <typename T, typename RANGE>
+bool IsValueIn(const T &v, const RANGE &range) {
+    return std::find(std::begin(range), std::end(range), v) != std::end(range);
+}
+
+template <typename T>
+bool IsValueIn(const T &v, const std::initializer_list<T> &list) {
+    return IsValueIn<T, decltype(list)>(v, list);
+}
+
 extern "C" {
 #endif
 

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -220,6 +220,7 @@ class LayerChassisOutputGenerator(OutputGenerator):
 #include <string.h>
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "vulkan/vulkan.h"
 #include "vk_layer_settings_ext.h"
@@ -589,6 +590,15 @@ class ValidationObject {
             LogObjectList single_object(src_object);
             return LogMsgLocked(report_data, kInformationBit, single_object, vuid_text, str);
         };
+
+        void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
+                              std::string_view entrypoint, VkResult err) const {
+            const std::string_view err_string = string_VkResult(err);
+            std::string vuid = "INTERNAL-ERROR-";
+            vuid += entrypoint;
+            LogError(obj_list, vuid, "In %s: %s() failed with result = %s.", failure_location.data(), entrypoint.data(),
+                                       err_string.data());
+        }
 
         // Handle Wrapping Data
         // Reverse map display handles

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -2197,7 +2197,7 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
     }
     InitSwapchainInfo();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    if (!InitSwapchain()) {
+    if (!InitSwapchain(m_surface)) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4594

The main thing about the fix is an update to `SURFACE_STATE` to use `VkSurfaceFormat2KHR`, `VkSurfaceCapabilities2KHR` and `VkPhysicalDeviceSurfaceInfo2KHR`. It now relies on `DispatchGetPhysicalDeviceSurfaceFormats2KHR` and `DispatchGetPhysicalDeviceSurfaceCapabilities2KHR` when `vk_khr_get_surface_capabilities2` is enabled. Otherwise it fall backs to the original functions.

I am still not sure about 3 things:
1) I do a deep copy of the `pCreateInfo->pnext` part that concerns full screen info ([code here](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4703/files#r1021863471)), is it needed?