### PR TITLE
tests: Clean up checking for depth stencil format

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -39,6 +39,7 @@ VkFormat FindSupportedDepthOnlyFormat(VkPhysicalDevice phy) {
             return ds_formats[i];
         }
     }
+    assert(false);  // Vulkan drivers are guaranteed to have at least one supported format
     return VK_FORMAT_UNDEFINED;
 }
 
@@ -65,6 +66,7 @@ VkFormat FindSupportedDepthStencilFormat(VkPhysicalDevice phy) {
             return ds_formats[i];
         }
     }
+    assert(false);  // Vulkan drivers are guaranteed to have at least one supported format
     return VK_FORMAT_UNDEFINED;
 }
 
@@ -814,7 +816,6 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
     VkImageView *depth_attachment = nullptr;
     if (failcase_needs_depth) {
         m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-        ASSERT_TRUE(m_depth_stencil_fmt != VK_FORMAT_UNDEFINED);
 
         m_depthStencil->Init(m_device, static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), m_depth_stencil_fmt,
                              VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -392,10 +392,6 @@ TEST_F(VkPositiveLayerTest, SecondaryCommandBufferImageLayoutTransitions) {
     VkResult err;
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s Couldn't find depth stencil format.\n", kSkipPrefix);
-        return;
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     // Allocate a secondary and primary cmd buffer
     VkCommandBufferAllocateInfo command_buffer_allocate_info = LvlInitStruct<VkCommandBufferAllocateInfo>();

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -820,10 +820,6 @@ TEST_F(VkPositiveLayerTest, BarrierLayoutToImageUsage) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkImageMemoryBarrier img_barrier = LvlInitStruct<VkImageMemoryBarrier>();
@@ -950,11 +946,6 @@ TEST_F(VkPositiveLayerTest, ClearDepthStencilWithValidRange) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
-
     VkImageObj image(m_device);
     image.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(image.create_info().arrayLayers == 1);

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -788,8 +788,6 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
     }
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
-
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
@@ -1559,10 +1557,6 @@ TEST_F(VkPositiveLayerTest, SubpassWithReadOnlyLayoutWithoutDependency) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     // A renderpass with one color attachment.
     VkAttachmentDescription attachment = {0,
@@ -7031,7 +7025,6 @@ TEST_F(VkPositiveLayerTest, DynamicColorWriteNoColorAttachments) {
     ASSERT_NE(vkCmdSetColorWriteEnableEXT, nullptr);
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -138,10 +138,6 @@ TEST_F(VkPositiveLayerTest, RenderPassCreateAttachmentLayoutWithLoadOpThenReadOn
         "layout, and a second subpass then uses a valid *READ_ONLY* layout.");
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentReference attach[2] = {};
     attach[0].attachment = 0;
@@ -286,10 +282,6 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginStencilLoadOp) {
     VkResult result = VK_SUCCESS;
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     VkImageFormatProperties formatProps;
     vk::GetPhysicalDeviceImageFormatProperties(gpu(), depth_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0,
@@ -446,10 +438,6 @@ TEST_F(VkPositiveLayerTest, RenderPassBeginDepthStencilLayoutTransitionFromUndef
 
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     VkImageFormatProperties format_props;
     vk::GetPhysicalDeviceImageFormatProperties(gpu(), depth_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, 0, &format_props);

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -641,7 +641,6 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
         return;
     }
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
 
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     InitRenderTarget(m_depthStencil->BindInfo());

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -990,11 +990,6 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
     }
 
     auto format = FindSupportedDepthStencilFormat(gpu());
-    if (!format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
-
     VkImageObj image(m_device);
     // Initialize image with transfer source usage
     image.Init(128, 128, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -5200,11 +5195,6 @@ TEST_F(VkLayerTest, ClearDepthStencilWithBadAspect) {
     const bool separate_stencil_usage_supported = IsExtensionsEnabled(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
 
     const auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -5294,11 +5284,6 @@ TEST_F(VkLayerTest, ClearDepthStencilWithBadRange) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
-
     VkImageObj image(m_device);
     image.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(image.create_info().arrayLayers == 1);
@@ -5427,10 +5412,6 @@ TEST_F(VkLayerTest, ClearDepthStencilImageErrors) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkClearDepthStencilValue clear_value = {0};
     VkImageCreateInfo image_create_info = VkImageObj::create_info();
@@ -5478,10 +5459,6 @@ TEST_F(VkLayerTest, ClearDepthRangeUnrestricted) {
 
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    if (m_depth_stencil_fmt == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     int depth_attachment_index = 1;
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt,
@@ -5580,10 +5557,6 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, (vkGetPhysicalDeviceFeatures2KHR) ? &features2 : nullptr));
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     // Add a token self-dependency for this test to avoid unexpected errors
     m_addRenderPassSelfDependency = true;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -6076,10 +6049,6 @@ TEST_F(VkLayerTest, Sync2InvalidBarriers) {
     }
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     // Add a token self-dependency for this test to avoid unexpected errors
     m_addRenderPassSelfDependency = true;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -7108,10 +7077,6 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     }
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     // Create src & dst images to use for copy operations
     VkImageObj src_image(m_device);
     VkImageObj dst_image(m_device);
@@ -8005,10 +7970,6 @@ TEST_F(VkLayerTest, CreateImageViewNoSeparateStencilUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     const auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     // without VK_EXT_separate_stencil_usage explicitly enabled
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -8067,10 +8028,6 @@ TEST_F(VkLayerTest, CreateImageViewStencilUsageCreateInfo) {
     }
 
     const auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -8385,10 +8342,6 @@ TEST_F(VkLayerTest, CreateImageViewFormatMismatchUnrelated) {
     }
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s Couldn't find depth stencil image format.\n", kSkipPrefix);
-        return;
-    }
 
     VkFormatProperties formatProps;
 
@@ -10067,10 +10020,6 @@ TEST_F(VkLayerTest, DepthStencilImageViewWithColorAspectBitError) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s Couldn't find depth stencil format.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageObj image_bad(m_device);
     VkImageObj image_good(m_device);
@@ -12811,10 +12760,6 @@ TEST_F(VkLayerTest, CreateImageViewIncompatibleDepthFormat) {
 
     const VkFormat depthOnlyFormat = FindSupportedDepthOnlyFormat(gpu());
     const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    if ((depthOnlyFormat == VK_FORMAT_UNDEFINED) || (depthStencilFormat == VK_FORMAT_UNDEFINED)) {
-        printf("%s requires a depth only and depth/stencil format.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageCreateInfo imageInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                    nullptr,
@@ -15462,10 +15407,6 @@ TEST_F(VkLayerTest, CreateColorImageWithDepthAspect) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     auto format = FindSupportedDepthStencilFormat(gpu());
-    if (!format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageObj color_image(m_device);
     color_image.Init(64, 64, 1, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
@@ -16205,8 +16146,8 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
     }
 
     // Depth format, Stencil aspect
-    const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-    if (depth_format != VK_FORMAT_UNDEFINED) {
+    {
+        const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
         VkImageObj image(m_device);
         if (create_compressed_image(depth_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2EXT-format-04462");
@@ -16220,7 +16161,6 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
             m_errorMonitor->VerifyFound();
         }
     }
-
     // Stencil format, Depth aspect
     const VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
     if (stencil_format != VK_FORMAT_UNDEFINED) {
@@ -16239,8 +16179,8 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
     }
 
     // AspectMask should be a bitset
-    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-    if (stencil_format != VK_FORMAT_UNDEFINED) {
+    {
+        const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
         VkImageObj image(m_device);
         if (create_compressed_image(depth_stencil_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2EXT-aspectMask-00997");

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -3876,10 +3876,6 @@ TEST_F(VkLayerTest, CopyImageFormatSizeMismatch) {
 TEST_F(VkLayerTest, CopyImageDepthStencilFormatMismatch) {
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s Couldn't depth stencil image format.\n", kSkipPrefix);
-        return;
-    }
 
     VkFormatProperties properties;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D32_SFLOAT, &properties);
@@ -4042,10 +4038,6 @@ TEST_F(VkLayerTest, CopyImageAspectMismatch) {
     }
 
     auto ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (!ds_format) {
-        printf("%s Couldn't find depth stencil format.\n", kSkipPrefix);
-        return;
-    }
 
     // Add Transfer support for all used formats
     VkFormatProperties formatProps;
@@ -4998,10 +4990,6 @@ TEST_F(VkLayerTest, DepthStencilImageCopyNoGraphicsQueueFlags) {
     } else {
         // Create Depth image
         const VkFormat ds_format = FindSupportedDepthOnlyFormat(gpu());
-        if (ds_format == VK_FORMAT_UNDEFINED) {
-            printf("%s No only Depth format found. Skipped.\n", kSkipPrefix);
-            return;
-        }
 
         VkImageObj ds_image(m_device);
         ds_image.Init(64, 64, 1, ds_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
@@ -10219,10 +10207,6 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingDepthStenci
 
     VkImageObj image(m_device);
     auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_stencil_format) {
-        printf("%s Couldn't depth stencil image format.\n", kSkipPrefix);
-        return;
-    }
     image.Init(32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(depth_stencil_format, VK_IMAGE_ASPECT_DEPTH_BIT|VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -10422,10 +10406,6 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewRa
 
     VkImageObj depthStencilImage(m_device);
     auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_stencil_format) {
-        printf("%s Couldn't depth stencil image format.\n", kSkipPrefix);
-        return;
-    }
     depthStencilImage.Init(32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL,
                            0);
     VkImageView depthStencilImageView =
@@ -10570,10 +10550,6 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewAt
 
     VkImageObj depthStencilImage(m_device);
     auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_stencil_format) {
-        printf("%s Couldn't depth stencil image format.\n", kSkipPrefix);
-        return;
-    }
     depthStencilImage.Init(32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL,
                            0);
     VkImageView depthStencilImageView =
@@ -11281,9 +11257,8 @@ TEST_F(VkLayerTest, TestCommandBufferInheritanceWithInvalidDepthFormat) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     auto stencil_format = FindSupportedStencilOnlyFormat(gpu());
-    if (!stencil_format) {
-        printf("%s Couldn't stencil image format.\n", kSkipPrefix);
-        return;
+    if (stencil_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
     auto inheritance_rendering_info = LvlInitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -350,10 +350,6 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReadOnlyButCleared) {
     }
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentDescription description = {0,
                                            ds_format,
@@ -493,8 +489,11 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     auto depth_format = FindSupportedDepthOnlyFormat(gpu());
-    auto stencil_format = FindSupportedStencilOnlyFormat(gpu());
     auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    if (stencil_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Couldn't find a stencil only image format";
+    }
 
     if (separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
@@ -700,10 +699,6 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     std::vector<VkAttachmentDescription> attachments = {
         // input attachments
@@ -955,10 +950,6 @@ TEST_F(VkLayerTest, InvalidRenderPassCreateRenderPassShaderResolveQCOM) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     std::vector<VkAttachmentDescription> attachments = {
         // input attachments
@@ -2595,10 +2586,6 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
     }
 
     const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (depth_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     image_create_info.flags = 0;  // image will not have needed flag
     image_create_info.format = depth_format;
@@ -2908,10 +2895,6 @@ TEST_F(VkLayerTest, InvalidRenderPassEndFragmentDensityMapOffsetQCOM) {
     }
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     std::vector<VkAttachmentDescription2> attachments = {
         // FDM attachments
@@ -6248,10 +6231,8 @@ TEST_F(VkLayerTest, DSAspectBitsErrors) {
         ASSERT_NO_FATAL_FAILURE(InitState());
     }
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    if (!depth_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-    } else {
+    {
+        auto depth_format = FindSupportedDepthStencilFormat(gpu());
         OneOffDescriptorSet descriptor_set(m_device,
                                            {
                                                {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
@@ -9139,10 +9120,6 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-    if (depth_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth only format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
     VkDepthStencilObj depth_image(m_device);
     depth_image.Init(m_device, 64, 64, depth_format,
                   VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
@@ -9672,10 +9649,6 @@ TEST_F(VkLayerTest, FramebufferDepthStencilResolveAttachmentTests) {
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
     VkFormat attachmentFormat = FindSupportedDepthStencilFormat(gpu());
-    if (attachmentFormat == VK_FORMAT_UNDEFINED) {
-        printf("%s Did not find a supported depth stencil format; skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentDescription2KHR attachmentDescriptions[2] = {};
     // Depth/stencil attachment
@@ -9796,12 +9769,10 @@ TEST_F(VkLayerTest, DepthStencilResolveMode) {
     assert(vkCreateRenderPass2KHR != nullptr);
 
     VkFormat depthFormat = FindSupportedDepthOnlyFormat(gpu());
-    VkFormat stencilFormat = FindSupportedStencilOnlyFormat(gpu());
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    if ((depthFormat == VK_FORMAT_UNDEFINED) || (stencilFormat == VK_FORMAT_UNDEFINED) ||
-        (depthStencilFormat == VK_FORMAT_UNDEFINED)) {
-        printf("%s Did not find a supported depth stencil formats; skipped.\n", kSkipPrefix);
-        return;
+    VkFormat stencilFormat = FindSupportedStencilOnlyFormat(gpu());
+    if (stencilFormat == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
     VkPhysicalDeviceDepthStencilResolveProperties ds_resolve_props = LvlInitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
@@ -10579,10 +10550,6 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentDescription2KHR attachmentDescriptions[2] = {};
     // Depth/stencil attachment
@@ -12102,10 +12069,6 @@ TEST_F(VkLayerTest, SamplingFromReadOnlyDepthStencilAttachment) {
     const uint32_t width = 32;
     const uint32_t height = 32;
     const VkFormat format = FindSupportedDepthStencilFormat(gpu());
-    if (format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentReference attach_ref = {};
     attach_ref.attachment = 0;
@@ -12315,8 +12278,7 @@ TEST_F(VkLayerTest, CreateRenderPassWithInvalidStencilLoadOp) {
 
     const VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
     auto vkCreateRenderPass2KHR =
@@ -12708,10 +12670,6 @@ TEST_F(VkLayerTest, InvalidRenderPassAttachmentUndefinedLayout) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkSubpassDescription subpass = {};
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -970,7 +970,6 @@ TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachments) {
     pipe2.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info2);
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(depthStencilFormat != 0);
 
     bool testStencil = false;
     VkFormat stencilFormat = VK_FORMAT_UNDEFINED;
@@ -1148,7 +1147,6 @@ TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachmentSamples) {
     pipe1.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info1);
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(depthStencilFormat != 0);
 
     auto ds_state = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
 
@@ -1344,7 +1342,6 @@ TEST_F(VkLayerTest, DynamicRenderingWithMismatchingMixedAttachmentSamples) {
     pipe1.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info1);
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(depthStencilFormat != 0);
     auto ds_state = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
 
     VkPipelineObj pipe2(m_device);
@@ -1700,7 +1697,6 @@ TEST_F(VkLayerTest, TestDynamicRenderingPipelineMissingFlags) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(depthStencilFormat != 0);
 
     VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
@@ -1896,10 +1892,6 @@ TEST_F(VkLayerTest, TestRenderingInfoMismatchedSamples) {
     color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
 
     const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-    if (depth_format == VK_FORMAT_UNDEFINED) {
-        printf("%s requires a depth only format, skipping.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageObj depth_image(m_device);
     depth_image.Init(64, 64, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
@@ -2214,8 +2206,7 @@ TEST_F(VkLayerTest, BeginRenderingInvalidDepthAttachmentFormat) {
 
     VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
-        printf("%s requires a stencil only format format.\n", kSkipPrefix);
-        return;
+        GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
     VkImageObj image(m_device);
@@ -2493,10 +2484,6 @@ TEST_F(VkLayerTest, BeginRenderingInvalidStencilAttachmentFormat) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-    if (depth_format == VK_FORMAT_UNDEFINED) {
-        printf("%s requires a stencil only format format.\n", kSkipPrefix);
-        return;
-    }
 
     VkImageObj image(m_device);
     image.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
@@ -2540,10 +2527,6 @@ TEST_F(VkLayerTest, TestInheritanceRenderingInfoStencilAttachmentFormat) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-    if (depth_format == VK_FORMAT_UNDEFINED) {
-        printf("%s requires a stencil only format format.\n", kSkipPrefix);
-        return;
-    }
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
@@ -2730,24 +2713,22 @@ TEST_F(VkLayerTest, DynamicRenderingAreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format != VK_FORMAT_UNDEFINED) {
-        VkImageObj depthImage(m_device);
-        depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-        VkImageView depthImageView = depthImage.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
+    VkImageObj depthImage(m_device);
+    depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    VkImageView depthImageView = depthImage.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
 
-        VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
-        depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        depth_attachment.imageView = depthImageView;
+    VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+    depth_attachment.imageView = depthImageView;
 
-        begin_rendering_info.colorAttachmentCount = 0;
-        begin_rendering_info.pDepthAttachment = &depth_attachment;
-        begin_rendering_info.renderArea.offset.y = 0;
-        begin_rendering_info.renderArea.extent.height = 64;
+    begin_rendering_info.colorAttachmentCount = 0;
+    begin_rendering_info.pDepthAttachment = &depth_attachment;
+    begin_rendering_info.renderArea.offset.y = 0;
+    begin_rendering_info.renderArea.extent.height = 64;
 
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06076");
-        m_commandBuffer->BeginRendering(begin_rendering_info);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06076");
+    m_commandBuffer->BeginRendering(begin_rendering_info);
+    m_errorMonitor->VerifyFound();
 
     m_commandBuffer->end();
 }
@@ -2828,24 +2809,22 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
     m_errorMonitor->VerifyFound();
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format != VK_FORMAT_UNDEFINED) {
-        VkImageObj depthImage(m_device);
-        depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-        VkImageView depthImageView = depthImage.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
+    VkImageObj depthImage(m_device);
+    depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    VkImageView depthImageView = depthImage.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
 
-        VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
-        depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        depth_attachment.imageView = depthImageView;
+    VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+    depth_attachment.imageView = depthImageView;
 
-        begin_rendering_info.colorAttachmentCount = 0;
-        begin_rendering_info.pDepthAttachment = &depth_attachment;
-        begin_rendering_info.renderArea.offset.y = 0;
-        begin_rendering_info.renderArea.extent.height = 64;
+    begin_rendering_info.colorAttachmentCount = 0;
+    begin_rendering_info.pDepthAttachment = &depth_attachment;
+    begin_rendering_info.renderArea.offset.y = 0;
+    begin_rendering_info.renderArea.extent.height = 64;
 
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
-        m_commandBuffer->BeginRendering(begin_rendering_info);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
+    m_commandBuffer->BeginRendering(begin_rendering_info);
+    m_errorMonitor->VerifyFound();
 
     m_commandBuffer->end();
 }
@@ -4216,11 +4195,6 @@ TEST_F(VkLayerTest, InvalidRenderingColorAttachmentFormat) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkFormat format = FindSupportedDepthStencilFormat(gpu());
-    if (format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
-
     auto pipeline_rendering_info = LvlInitStruct<VkPipelineRenderingCreateInfoKHR>();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &format;
@@ -5212,10 +5186,6 @@ TEST_F(VkLayerTest, TestRenderingInfoDepthAttachment) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found, skipping test..\n", kSkipPrefix);
-        return;
-    }
 
     auto depth_stencil_resolve_properties = LvlInitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&depth_stencil_resolve_properties);
@@ -5868,10 +5838,6 @@ TEST_F(VkLayerTest, DynamicNullDepthStencilExecuteCommands) {
     VkCommandBufferObj secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-
-    if (depth_stencil_format == VK_FORMAT_UNDEFINED) {
-        GTEST_SKIP() << "No found depth stencil format";
-    }
 
     auto cbiri = LvlInitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
     // format is defined, although no image view provided in dynamic rendering

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -952,10 +952,6 @@ TEST_F(VkLayerTest, ImagelessFramebufferDepthStencilResolveAttachmentTests) {
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
     VkFormat attachmentFormat = FindSupportedDepthStencilFormat(gpu());
-    if (attachmentFormat == VK_FORMAT_UNDEFINED) {
-        printf("%s Did not find a supported depth stencil format; skipped.\n", kSkipPrefix);
-        return;
-    }
 
     VkAttachmentDescription2KHR attachmentDescriptions[2] = {};
     // Depth/stencil attachment

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -2907,7 +2907,6 @@ TEST_F(VkLayerTest, CreateGraphicsPipelineWithBadBasePointer) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
 
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
 
@@ -2997,10 +2996,6 @@ TEST_F(VkLayerTest, SetDepthRangeUnrestricted) {
 
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    if (m_depth_stencil_fmt == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
 
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -6676,10 +6671,6 @@ TEST_F(VkLayerTest, FramebufferMixedSamples) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (ds_format == VK_FORMAT_UNDEFINED) {
-        printf("%s No Depth + Stencil format found rest of tests skipped.\n", kSkipPrefix);
-        return;
-    }
 
     struct TestCase {
         VkSampleCountFlagBits color_samples;

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -261,7 +261,6 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -305,7 +304,6 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     auto vertex_stride = portability_properties.minVertexInputBindingStrideAlignment - 1;
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -347,7 +345,6 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -445,7 +442,6 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -491,7 +487,6 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    ASSERT_TRUE(m_depth_stencil_fmt != 0);
     m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1780,10 +1780,6 @@ TEST_F(VkSyncValTest, SyncCmdClear) {
 
     // CmdClearDepthStencilImage
     format = FindSupportedDepthStencilFormat(gpu());
-    if (!format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     VkImageObj image_ds_a(m_device), image_ds_b(m_device);
     image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
     image_ds_a.Init(image_ci);
@@ -1881,9 +1877,6 @@ TEST_F(VkSyncValTest, SyncCmdDrawDepthStencil) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto format_ds = FindSupportedDepthStencilFormat(gpu());
-    if (!format_ds) {
-        GTEST_SKIP() << "No Depth + Stencil format found. Skipped.";
-    }
 
     // Vulkan doesn't support copying between different depth stencil formats, so the formats have to change.
     auto format_dp = format_ds;
@@ -2126,10 +2119,6 @@ TEST_F(VkSyncValTest, SyncRenderPassWithWrongDepthStencilInitialLayout) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    if (!ds_format) {
-        printf("%s No Depth + Stencil format found. Skipped.\n", kSkipPrefix);
-        return;
-    }
     VkImageUsageFlags usage_color = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     VkImageUsageFlags usage_ds = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     VkImageObj image_color(m_device), image_color2(m_device);


### PR DESCRIPTION
Reduces unnecessary checks in test code. Also, there were many spots that were not already checking for `FindSupportedDepthOnlyFormat` or `FindSupportedDepthStencilFormat` currently anyway