### PR TITLE
Move GPU-AV input buffer allocation and initialization to CmdBindDescriptorSets

### DIFF
--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1270,6 +1270,109 @@ void GpuAssisted::UpdateInstrumentationBuffer(gpuav_state::CommandBuffer *cb_nod
             }
         }
     }
+    for (auto buffer_info : cb_node->di_input_buffer_list) {
+        VkResult result = vmaMapMemory(vmaAllocator, buffer_info.allocation, reinterpret_cast<void **>(&data));
+        if (result == VK_SUCCESS) {
+            // Descriptor indexing needs the number of descriptors at each binding.
+            if (descriptor_indexing) {
+                uint32_t number_of_sets = static_cast<uint32_t>(buffer_info.per_set.size());
+                // Pointer to a sets array that points into the sizes array
+                uint32_t *sets_to_sizes = data + 1;
+                // Pointer to the sizes array that contains the array size of the descriptor at each binding
+                uint32_t *sizes = sets_to_sizes + number_of_sets;
+                // Pointer to another sets array that points into the bindings array that points into the written array
+                uint32_t *sets_to_bindings = sizes + buffer_info.binding_count;
+                // Pointer to the bindings array that points at the start of the writes in the writes array for each binding
+                uint32_t *bindings_to_written = sets_to_bindings + number_of_sets;
+                // Index of the next entry in the written array to be updated
+                uint32_t written_index = 1 + (number_of_sets * 2) + (buffer_info.binding_count * 2);
+                uint32_t bind_counter = number_of_sets + 1;
+                // Index of the start of the sets_to_bindings array
+                data[0] = number_of_sets + buffer_info.binding_count + 1;
+
+                for (const auto &s : buffer_info.per_set) {
+                    auto desc = s.bound_descriptor_set;
+                    if (desc && (desc->GetBindingCount() > 0)) {
+                        auto layout = desc->GetLayout();
+                        // For each set, fill in index of its bindings sizes in the sizes array
+                        *sets_to_sizes++ = bind_counter;
+                        // For each set, fill in the index of its bindings in the bindings_to_written array
+                        *sets_to_bindings++ = bind_counter + number_of_sets + buffer_info.binding_count;
+                        for (auto &binding : *desc) {
+                            // For each binding, fill in its size in the sizes array
+                            // Shader instrumentation is tracking inline uniform blocks as scalers. Don't try to validate inline
+                            // uniform blocks
+                            if (VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT == binding->type) {
+                                sizes[binding->binding] = 1;
+                            } else {
+                                sizes[binding->binding] = binding->count;
+                            }
+                            // Fill in the starting index for this binding in the written array in the bindings_to_written array
+                            bindings_to_written[binding->binding] = written_index;
+
+                            // Shader instrumentation is tracking inline uniform blocks as scalers. Don't try to validate inline
+                            // uniform blocks
+                            if (VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT == binding->type) {
+                                data[written_index++] = UINT_MAX;
+                                continue;
+                            }
+
+                            SetBindingState(data, written_index, binding.get());
+                            written_index += binding->count;
+                        }
+                        auto last = desc->GetLayout()->GetMaxBinding();
+                        bindings_to_written += last + 1;
+                        bind_counter += last + 1;
+                        sizes += last + 1;
+                    } else {
+                        *sets_to_sizes++ = 0;
+                        *sets_to_bindings++ = 0;
+                    }
+                }
+            } else {
+                // If no descriptor indexing, we don't need number of descriptors at each binding, so
+                // no sets_to_sizes or sizes arrays, just sets_to_bindings, bindings_to_written and written_index
+                uint32_t number_of_sets = static_cast<uint32_t>(buffer_info.per_set.size());
+                // Pointer to sets array that points into the bindings array that points into the written array
+                uint32_t *sets_to_bindings = data + 1;
+                // Pointer to the bindings array that points at the start of the writes in the writes array for each binding
+                uint32_t *bindings_to_written = sets_to_bindings + number_of_sets;
+                // Index of the next entry in the written array to be updated
+                uint32_t written_index = 1 + number_of_sets + buffer_info.binding_count;
+                uint32_t bind_counter = number_of_sets + 1;
+                data[0] = 1;
+
+                for (const auto &s : buffer_info.per_set) {
+                    auto desc = s.bound_descriptor_set;
+                    if (desc && (desc->GetBindingCount() > 0)) {
+                        auto layout = desc->GetLayout();
+                        *sets_to_bindings++ = bind_counter;
+                        for (auto &binding : *desc) {
+                            // Fill in the starting index for this binding in the written array in the bindings_to_written array
+                            bindings_to_written[binding->binding] = written_index;
+
+                            // Shader instrumentation is tracking inline uniform blocks as scalers. Don't try to validate inline
+                            // uniform blocks
+                            if (VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT == binding->type) {
+                                data[written_index++] = UINT_MAX;
+                                continue;
+                            }
+
+                            // note that VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT is part of descriptor indexing
+                            SetBindingState(data, written_index, binding.get());
+                            written_index += binding->count;
+                        }
+                        auto last = desc->GetLayout()->GetMaxBinding();
+                        bindings_to_written += last + 1;
+                        bind_counter += last + 1;
+                    } else {
+                        *sets_to_bindings++ = 0;
+                    }
+                }
+            }
+        }
+        vmaUnmapMemory(vmaAllocator, buffer_info.allocation);
+    }
 }
 
 void GpuAssisted::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
@@ -1352,7 +1455,8 @@ void GpuAssisted::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuf
             result = vmaMapMemory(vmaAllocator, allocation, reinterpret_cast<void **>(&data_ptr));
             memset(data_ptr, 0, static_cast<size_t>(buffer_info.size));
             vmaUnmapMemory(vmaAllocator, allocation);
-            cb_node->di_input_buffer_list.emplace_back(buffer, allocation, state.per_set);
+            cb_node->di_input_buffer_list.emplace_back(buffer, allocation, binding_count, state.per_set);
+            cb_node->current_input_buffer = buffer;
         }
 
     }
@@ -2165,7 +2269,9 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
             }
             vmaUnmapMemory(vmaAllocator, di_input_block.allocation);
 
+            di_input_desc_buffer_info.range = VK_WHOLE_SIZE; 
             di_input_desc_buffer_info.range = (words_needed * 4);
+            di_input_desc_buffer_info.buffer = cb_node->current_input_buffer;
             di_input_desc_buffer_info.buffer = di_input_block.buffer;
             di_input_desc_buffer_info.offset = 0;
 

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -61,7 +61,6 @@ struct GpuAssistedPreDispatchResources {
 
 struct GpuAssistedBufferInfo {
     GpuAssistedDeviceMemoryBlock output_mem_block;
-    GpuAssistedDeviceMemoryBlock di_input_mem_block;   // Descriptor Indexing input
     GpuAssistedDeviceMemoryBlock bda_input_mem_block;  // Buffer Device Address input
     GpuAssistedPreDrawResources pre_draw_resources;
     GpuAssistedPreDispatchResources pre_dispatch_resources;
@@ -69,12 +68,11 @@ struct GpuAssistedBufferInfo {
     VkDescriptorPool desc_pool;
     VkPipelineBindPoint pipeline_bind_point;
     CMD_TYPE cmd_type;
-    GpuAssistedBufferInfo(GpuAssistedDeviceMemoryBlock output_mem_block, GpuAssistedDeviceMemoryBlock di_input_mem_block,
+    GpuAssistedBufferInfo(GpuAssistedDeviceMemoryBlock output_mem_block,
                           GpuAssistedDeviceMemoryBlock bda_input_mem_block, GpuAssistedPreDrawResources pre_draw_resources,
                           GpuAssistedPreDispatchResources pre_dispatch_resources, VkDescriptorSet desc_set,
                           VkDescriptorPool desc_pool, VkPipelineBindPoint pipeline_bind_point, CMD_TYPE cmd_type)
         : output_mem_block(output_mem_block),
-          di_input_mem_block(di_input_mem_block),
           bda_input_mem_block(bda_input_mem_block),
           pre_draw_resources(pre_draw_resources),
           pre_dispatch_resources(pre_dispatch_resources),

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -31,16 +31,6 @@ struct GpuAssistedDeviceMemoryBlock {
     layer_data::unordered_map<uint32_t, const cvdescriptorset::DescriptorBinding*> update_at_submit;
 };
 
-struct GpuAssistedDeviceInputMemoryBlock {
-    VkBuffer buffer;
-    VmaAllocation allocation;
-    uint32_t binding_count;
-    const std::vector<LAST_BOUND_STATE::PER_SET, std::allocator<LAST_BOUND_STATE::PER_SET>> per_set;
-    GpuAssistedDeviceInputMemoryBlock(VkBuffer buffer, VmaAllocation allocation, uint32_t binding_count,
-        const std::vector<LAST_BOUND_STATE::PER_SET, std::allocator<LAST_BOUND_STATE::PER_SET>> per_set)
-        : buffer(buffer), allocation(allocation), binding_count(binding_count), per_set(per_set){};
-};
-
 struct GpuAssistedPreDrawResources {
     VkDescriptorPool desc_pool = VK_NULL_HANDLE;
     VkDescriptorSet desc_set = VK_NULL_HANDLE;
@@ -160,7 +150,7 @@ namespace gpuav_state {
 class CommandBuffer : public gpu_utils_state::CommandBuffer {
   public:
     std::vector<GpuAssistedBufferInfo> per_draw_buffer_list;
-    std::vector<GpuAssistedDeviceInputMemoryBlock> di_input_buffer_list;
+    std::vector<GpuAssistedDeviceMemoryBlock> di_input_buffer_list;
     std::vector<GpuAssistedAccelerationStructureBuildValidationBufferInfo> as_validation_buffers;
     VkBuffer current_input_buffer = VK_NULL_HANDLE;
 

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -203,6 +203,10 @@ class GpuAssisted : public GpuAssistedBase {
     void SetBindingState(uint32_t* data, uint32_t index, const cvdescriptorset::DescriptorBinding* binding);
     void UpdateInstrumentationBuffer(gpuav_state::CommandBuffer* cb_node);
     const GpuVuid& GetGpuVuid(CMD_TYPE cmd_type) const;
+    void PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+                                            VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
+                                            const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
+                                            const uint32_t* pDynamicOffsets) override;
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;
     void PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits,
                                       VkFence fence) override;

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -34,10 +34,11 @@ struct GpuAssistedDeviceMemoryBlock {
 struct GpuAssistedDeviceInputMemoryBlock {
     VkBuffer buffer;
     VmaAllocation allocation;
+    uint32_t binding_count;
     const std::vector<LAST_BOUND_STATE::PER_SET, std::allocator<LAST_BOUND_STATE::PER_SET>> per_set;
-    GpuAssistedDeviceInputMemoryBlock(VkBuffer buffer, VmaAllocation allocation,
+    GpuAssistedDeviceInputMemoryBlock(VkBuffer buffer, VmaAllocation allocation, uint32_t binding_count,
         const std::vector<LAST_BOUND_STATE::PER_SET, std::allocator<LAST_BOUND_STATE::PER_SET>> per_set)
-        : buffer(buffer), allocation(allocation), per_set(per_set){};
+        : buffer(buffer), allocation(allocation), binding_count(binding_count), per_set(per_set){};
 };
 
 struct GpuAssistedPreDrawResources {
@@ -163,6 +164,7 @@ class CommandBuffer : public gpu_utils_state::CommandBuffer {
     std::vector<GpuAssistedBufferInfo> per_draw_buffer_list;
     std::vector<GpuAssistedDeviceInputMemoryBlock> di_input_buffer_list;
     std::vector<GpuAssistedAccelerationStructureBuildValidationBufferInfo> as_validation_buffers;
+    VkBuffer current_input_buffer = VK_NULL_HANDLE;
 
     CommandBuffer(GpuAssisted* ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
                   const COMMAND_POOL_STATE* pool);


### PR DESCRIPTION
Improves GPU-AV performance and memory use running apps with large descriptor sets