### PR TITLE
build: Fix disabling BUILD_WERROR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,9 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "(GNU|Clang)")
                         -fno-builtin-memcmp)
 
     # Treat warnings as errors for versions of GCC and c++11-compliant Clang versions that are shipped on Ubuntu 18.04 or older.
-    if(BUILD_WERROR OR
+    if(BUILD_WERROR AND (
       (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 7.3.0) OR
-      (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0))
+      (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0.0)))
         add_compile_options(-Werror)
     endif()
 


### PR DESCRIPTION
After commit 3bfe7b52a55c568d19a5d5cf53dc830aad895a2d, BUILD_WERROR=OFF doesn't do anything if the clang version is new enough. That change doesn't seem intentional and prevents building on extremely new clang versions with new warnings added.