### PR TITLE
build: Add Fuchsia build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -15,10 +15,6 @@
 
 import("//build_overrides/vulkan_validation_layers.gni")
 
-# Fuchsia has non-upstream changes to the vulkan layers, so we don't want
-# to build it from upstream sources.
-assert(!is_fuchsia)
-
 vulkan_undefine_configs = []
 if (is_win) {
   vulkan_undefine_configs += [ "//build/config/win:unicode" ]
@@ -47,6 +43,19 @@ action("vulkan_clean_old_validation_layer_objects") {
   ]
 }
 
+config("generated_layers_config") {
+  cflags = [
+    "-Wno-conversion",
+    "-Wno-deprecated-copy",
+    "-Wno-extra-semi",
+    "-Wno-implicit-fallthrough",
+    "-Wno-missing-field-initializers",
+    "-Wno-newline-eof",
+    "-Wno-sign-compare",
+    "-Wno-unused-const-variable",
+  ]
+}
+
 config("vulkan_internal_config") {
   defines = [
     "VULKAN_NON_CMAKE_BUILD",
@@ -67,6 +76,12 @@ config("vulkan_internal_config") {
       "FALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\"",
     ]
   }
+
+  # Suppress warnings the vulkan code doesn't comply with.
+  if (is_fuchsia) {
+    configs = [ "//build/config:Wno-unused-but-set-variable" ]
+  }
+  cflags += [ "-Wno-extra-semi" ]
 }
 
 # The validation layers
@@ -77,6 +92,7 @@ config("vulkan_layer_config") {
     "layers",
     "layers/generated",
   ]
+  cflags = [ "-Wno-extra-semi" ]
 }
 
 core_validation_sources = [
@@ -223,11 +239,12 @@ if (!is_android) {
   action("vulkan_gen_json_files") {
     script = "build-gn/generate_vulkan_layers_json.py"
 
-    # Make sure that the cleanup of old layer JSON files happens before the new ones are generated.
-    deps = [
-      ":vulkan_clean_old_validation_layer_objects",
-      "$vulkan_headers_dir:vulkan_headers",
-    ]
+    deps = [ "$vulkan_headers_dir:vulkan_headers" ]
+    if (!is_fuchsia) {
+      # Make sure that the cleanup of old layer JSON files happens before the new ones are generated.
+      deps += [ ":vulkan_clean_old_validation_layer_objects" ]
+    }
+
     json_names = [ "VkLayer_khronos_validation.json" ]
     sources = [ "$vulkan_headers_dir/include/vulkan/vulkan_core.h" ]
     outputs = []
@@ -242,6 +259,8 @@ if (!is_android) {
       _platform = "Windows"
     } else if (is_mac) {
       _platform = "Darwin"
+    } else if (is_fuchsia) {
+      _platform = "Fuchsia"
     } else {
       _platform = "Other"
     }
@@ -252,6 +271,9 @@ if (!is_android) {
              rebase_path("layers/json", root_build_dir),
              rebase_path(vulkan_data_dir, root_build_dir),
            ] + rebase_path(sources, root_build_dir)
+    if (is_fuchsia) {
+      args += [ "--no-path-prefix" ]
+    }
 
     # The layer JSON files are part of the necessary data deps.
     data = outputs
@@ -303,10 +325,13 @@ source_set("vulkan_layer_utils") {
     ":vulkan_internal_config",
     ":vulkan_memory_allocator_config",
   ]
-  configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
   public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
+
   configs -= vulkan_undefine_configs
+  if (!is_fuchsia) {
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+  }
 }
 
 config("vulkan_core_validation_config") {
@@ -331,20 +356,36 @@ config("vulkan_stateless_validation_config") {
   }
 }
 
+if (is_fuchsia) {
+  library_type = "loadable_module"
+} else {
+  library_type = "shared_library"
+}
+
 foreach(layer_info, layers) {
   name = layer_info[0]
-  shared_library("VkLayer_$name") {
+  target(library_type, "VkLayer_$name") {
     defines = []
-    configs -= [ "//build/config/compiler:chromium_code" ]
-    configs += [ "//build/config/compiler:no_chromium_code" ]
-    configs += [ "//build/config/compiler:rtti" ]
+    ldflags = []
+    if (is_fuchsia) {
+      configs -= [ "//build/config:thread_safety_annotations" ]
+      ldflags += [ "-static-libstdc++" ]
+      configs += [ "//build/config:rtti" ]
+    } else {
+      configs -= [ "//build/config/compiler:chromium_code" ]
+      configs += [ "//build/config/compiler:no_chromium_code" ]
+      configs += [ "//build/config/compiler:rtti" ]
+    }
     configs -= vulkan_undefine_configs
+    configs += [ ":generated_layers_config" ]
     public_configs = [ ":vulkan_layer_config" ]
-    deps = [
-      # Make sure the cleanup of old layers happen before the new ones are compiled.
-      ":vulkan_clean_old_validation_layer_objects",
-      ":vulkan_layer_utils",
-    ]
+    deps = [ ":vulkan_layer_utils" ]
+    if (!is_fuchsia) {
+      deps += [
+        # Make sure the cleanup of old layers happen before the new ones are compiled.
+        ":vulkan_clean_old_validation_layer_objects",
+      ]
+    }
     if (layer_info[2] != "") {
       deps += layer_info[2]
     }
@@ -353,10 +394,10 @@ foreach(layer_info, layers) {
       defines += [ "NOMINMAX" ]
       sources += [ "layers/VkLayer_$name.def" ]
     }
-    if (is_linux || is_android) {
-      ldflags = [ "-Wl,-Bsymbolic,--exclude-libs,ALL" ]
+    if (is_linux || is_android || is_fuchsia) {
+      ldflags += [ "-Wl,-Bsymbolic,--exclude-libs,ALL" ]
     }
-    if (ozone_platform_x11) {
+    if (defined(ozone_platform_x11) && ozone_platform_x11) {
       defines += [ "VK_USE_PLATFORM_XLIB_KHR" ]
     }
     if (is_android) {
@@ -371,9 +412,18 @@ foreach(layer_info, layers) {
 }
 
 group("vulkan_validation_layers") {
+  public_deps = []
   data_deps = []
   foreach(layer_info, layers) {
     name = layer_info[0]
-    data_deps += [ ":VkLayer_$name" ]
+    if (is_fuchsia) {
+      public_deps += [ ":VkLayer_$name" ]
+    } else {
+      data_deps += [ ":VkLayer_$name" ]
+    }
   }
+}
+
+group("tests") {
+  # TODO(fxbug.dev/13288)
 }

--- a/build-gn/generate_vulkan_layers_json.py
+++ b/build-gn/generate_vulkan_layers_json.py
@@ -35,9 +35,10 @@ def glob_slash(dirname):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--icd', action='store_true')
+    parser.add_argument('--no-path-prefix', action='store_true')
     parser.add_argument('--platform', type=str, default=platform.system(),
         help='Target platform to build validation layers for: '
-             'Linux|Darwin|Windows|...')
+             'Linux|Darwin|Windows|Fuchsia|...')
     parser.add_argument('source_dir')
     parser.add_argument('target_dir')
     parser.add_argument('version_header', help='path to vulkan_core.h')
@@ -98,10 +99,14 @@ def main():
         return 1
 
     # Set json file prefix and suffix for generating files, default to Linux.
-    relative_path_prefix = '../lib'
+    if args.no_path_prefix:
+        relative_path_prefix = ''
+    elif args.platform == 'Windows':
+        relative_path_prefix = r'..\\'  # json-escaped, hence two backslashes.
+    else:
+        relative_path_prefix = '../lib'
     file_type_suffix = '.so'
     if args.platform == 'Windows':
-        relative_path_prefix = r'..\\'  # json-escaped, hence two backslashes.
         file_type_suffix = '.dll'
     elif args.platform == 'Darwin':
         file_type_suffix = '.dylib'

--- a/build-gn/layers-fuchsia.gni
+++ b/build-gn/layers-fuchsia.gni
@@ -1,0 +1,67 @@
+# Copyright (C) 2022 The Fuchsia Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This scope makes it easy to incorporate the Vulkan validation layers into a
+# package that is part of the Fuchsia system build.
+#
+# To use it, import this gni file and add the entries of the
+# 'vulkan_validation_layers' scope to the package's 'loadable_modules',
+# 'resources', and 'public_deps' parameters.
+#
+# Example BUILD.gn file:
+#
+# import("//src/graphics/lib/vulkan/layers.gni")
+#
+# package("my_funky_vulkan_using_program") {
+#   loadable_modules = [
+#     ...
+#     ] + vulkan_validation_layers.loadable_modules
+#
+#   resources = [
+#     ...
+#     ] + vulkan_validation_layers.resources
+#
+#   public_deps = [
+#     ...
+#     ] + vulkan_validation_layers.public_deps
+# }
+#
+# This will end up placing the validation libraries within the package's "lib/"
+# directory, where they can be loaded like normal libraries, and place the layer
+# configuration data in the package's "data/vulkan/explicit_layer.d" directory which
+# is mapped to "/config/vulkan/explicit_layer.d"
+
+import("//build_overrides/vulkan_validation_layers.gni")
+
+vulkan_data_dir = "$root_out_dir/$vulkan_data_subdir"
+
+vulkan_validation_layers = {
+  loadable_modules = [
+    {
+      name = "VkLayer_khronos_validation.so"
+    },
+  ]
+
+  resources = [
+    {
+      path = rebase_path("$vulkan_data_dir/VkLayer_khronos_validation.json")
+      dest = "vulkan/explicit_layer.d/VkLayer_khronos_validation.json"
+    },
+  ]
+
+  public_deps = [
+    "//third_party/Vulkan-ValidationLayers:vulkan_gen_json_files",
+    "//third_party/Vulkan-ValidationLayers:vulkan_validation_layers",
+  ]
+}


### PR DESCRIPTION
This change lets us build the validation layers for the Fuchsia operating system. The layers are normally packaged with the Fuchsia SDK, so this repo must be checked out as part of the Fuchsia source tree [0] to build the layers.

[0]: https://fuchsia.dev/fuchsia-src/get-started/learn/build/source-tree?hl=en