### PR TITLE
Clang tidy performance

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -3889,7 +3889,7 @@ void BestPractices::ValidateBoundDescriptorSets(bp_state::CommandBuffer& cb_stat
     auto lvl_bind_point = ConvertToLvlBindPoint(bind_point);
     auto& state = cb_state.lastBound[lvl_bind_point];
 
-    for (auto descriptor_set : state.per_set) {
+    for (const auto& descriptor_set : state.per_set) {
         if (!descriptor_set.bound_descriptor_set) continue;
         for (const auto& binding : *descriptor_set.bound_descriptor_set) {
             // For bindless scenarios, we should not attempt to track descriptor set state.

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -1902,7 +1902,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     }
 
     if (!enabled_features.fragment_density_map_offset_features.fragmentDensityMapOffset) {
-        uint32_t ceiling_width = static_cast<uint32_t>(ceil(
+        uint32_t ceiling_width = static_cast<uint32_t>(ceilf(
             static_cast<float>(device_limits->maxFramebufferWidth) /
             std::max(static_cast<float>(phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width), 1.0f)));
         if ((pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) && (pCreateInfo->extent.width > ceiling_width)) {
@@ -1916,7 +1916,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                              phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width, ceiling_width);
         }
 
-        uint32_t ceiling_height = static_cast<uint32_t>(ceil(
+        uint32_t ceiling_height = static_cast<uint32_t>(ceilf(
             static_cast<float>(device_limits->maxFramebufferHeight) /
             std::max(static_cast<float>(phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.height), 1.0f)));
         if ((pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) && (pCreateInfo->extent.height > ceiling_height)) {

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -48,7 +48,7 @@ using LayoutRange = image_layout_map::ImageSubresourceLayoutMap::RangeType;
 using LayoutEntry = image_layout_map::ImageSubresourceLayoutMap::LayoutEntry;
 
 // All VUID from copy_bufferimage_to_imagebuffer_common.txt
-static const char *GetBufferImageCopyCommandVUID(std::string id, bool image_to_buffer, bool copy2) {
+static const char *GetBufferImageCopyCommandVUID(const std::string &id, bool image_to_buffer, bool copy2) {
     // clang-format off
     static const std::map<std::string, std::array<const char *, 4>> copy_imagebuffer_vuid = {
         {"00193", {

--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -369,7 +369,7 @@ ImageSubresourceLayoutMap *CMD_BUFFER_STATE::GetImageSubresourceLayoutMap(const 
     return layout_map.get();
 }
 
-static bool SetQueryState(QueryObject object, QueryState value, QueryMap *localQueryToStateMap) {
+static bool SetQueryState(const QueryObject &object, QueryState value, QueryMap *localQueryToStateMap) {
     (*localQueryToStateMap)[object] = value;
     return false;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8336,10 +8336,8 @@ static bool UniqueImageViews(const VkRenderingInfo* pRenderingInfo, VkImageView 
     return unique_views;
 }
 
-bool CoreChecks::ValidateRenderingInfoAttachment(const std::shared_ptr<const IMAGE_VIEW_STATE> image_view,
-                                                 const char *attachment,
-                                                 const VkRenderingInfo *pRenderingInfo,
-                                                 const char *func_name) const {
+bool CoreChecks::ValidateRenderingInfoAttachment(const std::shared_ptr<const IMAGE_VIEW_STATE> &image_view, const char *attachment,
+                                                 const VkRenderingInfo *pRenderingInfo, const char *func_name) const {
     bool skip = false;
 
     // Upcasting to handle overflow
@@ -11925,7 +11923,7 @@ static QueryState GetLocalQueryState(const QueryMap *localQueryToStateMap, VkQue
     return QUERYSTATE_UNKNOWN;
 }
 
-bool CoreChecks::VerifyQueryIsReset(CMD_BUFFER_STATE &cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+bool CoreChecks::VerifyQueryIsReset(CMD_BUFFER_STATE &cb_state, const QueryObject &query_obj, const CMD_TYPE cmd_type,
                                     VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
     bool skip = false;
     auto state_data = cb_state.dev_data;
@@ -11960,7 +11958,7 @@ bool CoreChecks::VerifyQueryIsReset(CMD_BUFFER_STATE &cb_state, QueryObject quer
     return skip;
 }
 
-bool CoreChecks::ValidatePerformanceQuery(CMD_BUFFER_STATE &cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+bool CoreChecks::ValidatePerformanceQuery(CMD_BUFFER_STATE &cb_state, const QueryObject &query_obj, const CMD_TYPE cmd_type,
                                           VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
     auto state_data = cb_state.dev_data;
     auto query_pool_state = state_data->Get<QUERY_POOL_STATE>(query_obj.pool);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3890,7 +3890,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
                           "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07405"},
                          {VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT, "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07406",
                           "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07407"}}};
-                    for (auto check_info : check_infos) {
+                    for (const auto &check_info : check_infos) {
                         if ((pipeline->GetPipelineCreateFlags() & check_info.bit)) {
                             if (!(lib->GetPipelineCreateFlags() & check_info.bit)) {
                                 LogObjectList objs(device);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -362,9 +362,9 @@ class CoreChecks : public ValidationStateTracker {
     static bool ValidateCopyQueryPoolResults(CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
                                              uint32_t queryCount, uint32_t perfPass, VkQueryResultFlags flags,
                                              QueryMap* localQueryToStateMap);
-    static bool VerifyQueryIsReset(CMD_BUFFER_STATE& cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+    static bool VerifyQueryIsReset(CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, const CMD_TYPE cmd_type,
                                    VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
-    static bool ValidatePerformanceQuery(CMD_BUFFER_STATE& cb_state, QueryObject query_obj, const CMD_TYPE cmd_type,
+    static bool ValidatePerformanceQuery(CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, const CMD_TYPE cmd_type,
                                          VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
     bool ValidateBeginQuery(const CMD_BUFFER_STATE* cb_state, const QueryObject& query_obj, VkFlags flags, uint32_t index,
                             CMD_TYPE cmd, const ValidateBeginQueryVuids* vuids) const;
@@ -1219,8 +1219,8 @@ class CoreChecks : public ValidationStateTracker {
                                              const VkCopyDescriptorSet* pDescriptorCopies) const override;
     bool PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer,
                                            const VkCommandBufferBeginInfo* pBeginInfo) const override;
-    bool ValidateRenderingInfoAttachment(const std::shared_ptr<const IMAGE_VIEW_STATE> image_view, const char* attachment, const VkRenderingInfo* pRenderingInfo,
-                                         const char* func_name) const;
+    bool ValidateRenderingInfoAttachment(const std::shared_ptr<const IMAGE_VIEW_STATE>& image_view, const char* attachment,
+                                         const VkRenderingInfo* pRenderingInfo, const char* func_name) const;
     bool ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo, CMD_TYPE cmd_type) const;
     bool PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
                                              const VkRenderingInfoKHR* pRenderingInfo) const override;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -333,7 +333,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
             std::vector<std::string> format_strings = { "%ul", "%lu", "%lx" };
             size_t ul_pos = 0;
             bool print_hex = true;
-            for (auto ul_string : format_strings) {
+            for (const auto &ul_string : format_strings) {
                 ul_pos = substring.string.find(ul_string);
                 if (ul_pos != std::string::npos) {
                     if (ul_string == "%lu") print_hex = false;

--- a/layers/debug_printf.cpp
+++ b/layers/debug_printf.cpp
@@ -163,7 +163,7 @@ vartype vartype_lookup(char intype) {
     }
 }
 
-std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string format_string) {
+std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string &format_string) {
     const char types[] = {'d', 'i', 'o', 'u', 'x', 'X', 'a', 'A', 'e', 'E', 'f', 'F', 'g', 'G', 'v', '\0'};
     std::vector<DPFSubstring> parsed_strings;
     size_t pos = 0;
@@ -263,7 +263,7 @@ std::string DebugPrintf::FindFormatString(std::vector<uint32_t> pgm, uint32_t st
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
 
-void snprintf_with_malloc(std::stringstream &shader_message, DPFSubstring substring, size_t needed, void *values) {
+void snprintf_with_malloc(std::stringstream &shader_message, const DPFSubstring &substring, size_t needed, void *values) {
     char *buffer = static_cast<char *>(malloc((needed + 1) * sizeof(char)));  // Add 1 for terminator
     if (substring.longval) {
         snprintf(buffer, needed, substring.string.c_str(), substring.longval);

--- a/layers/debug_printf.h
+++ b/layers/debug_printf.h
@@ -88,7 +88,7 @@ class DebugPrintf : public GpuAssistedBase {
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
-    std::vector<DPFSubstring> ParseFormatString(std::string format_string);
+    std::vector<DPFSubstring> ParseFormatString(const std::string& format_string);
     std::string FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo &buffer_info,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer);

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -1065,7 +1065,7 @@ void ReadOpSource(const SHADER_MODULE_STATE &module_state, const uint32_t report
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 #if defined(__GNUC__) && GCC_VERSION < 40900
-bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::string &filename) {
+bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
     // # line <linenumber> "<filename>" or
     // #line <linenumber> "<filename>"
     std::vector<std::string> tokens;
@@ -1090,7 +1090,7 @@ bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::str
     return true;
 }
 #else
-bool GetLineAndFilename(const std::string string, uint32_t *linenumber, std::string &filename) {
+bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
     static const std::regex line_regex(  // matches #line directives
         "^"                              // beginning of line
         "\\s*"                           // optional whitespace

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -1256,7 +1256,7 @@ void GpuAssisted::SetBindingState(uint32_t *data, uint32_t index, const cvdescri
 // For the given command buffer, map its debug data buffers and update the status of any update after bind descriptors
 void GpuAssisted::UpdateInstrumentationBuffer(gpuav_state::CommandBuffer *cb_node) {
     uint32_t *data;
-    for (auto buffer_info : cb_node->di_input_buffer_list) {
+    for (const auto &buffer_info : cb_node->di_input_buffer_list) {
         if (buffer_info.update_at_submit.size() > 0) {
             VkResult result =
                 vmaMapMemory(vmaAllocator, buffer_info.allocation, reinterpret_cast<void **>(&data));

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -965,7 +965,8 @@ void GpuAssisted::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
 }
 
 // Generate the part of the message describing the violation.
-bool GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, std::string &vuid_msg, GpuAssistedBufferInfo buf_info, GpuAssisted *gpu_assisted) {
+bool GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, std::string &vuid_msg,
+                               const GpuAssistedBufferInfo &buf_info, GpuAssisted *gpu_assisted) {
     using namespace spvtools;
     std::ostringstream strm;
     bool return_code = true;
@@ -1735,7 +1736,7 @@ VkPipeline GpuAssisted::GetValidationPipeline(VkRenderPass render_pass) {
     return pipeline;
 }
 
-void GpuAssisted::AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBlock output_block,
+void GpuAssisted::AllocatePreDrawValidationResources(const GpuAssistedDeviceMemoryBlock &output_block,
                                                      GpuAssistedPreDrawResources &resources, const VkRenderPass render_pass,
                                                      VkPipeline *pPipeline, const GpuAssistedCmdIndirectState *indirect_state) {
     VkResult result;
@@ -1825,7 +1826,7 @@ void GpuAssisted::AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBloc
     }
     DispatchUpdateDescriptorSets(device, buffer_count, desc_writes, 0, NULL);
 }
-void GpuAssisted::AllocatePreDispatchValidationResources(GpuAssistedDeviceMemoryBlock output_block,
+void GpuAssisted::AllocatePreDispatchValidationResources(const GpuAssistedDeviceMemoryBlock &output_block,
                                                          GpuAssistedPreDispatchResources &resources,
                                                          const GpuAssistedCmdIndirectState *indirect_state) {
     VkResult result;

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -275,10 +275,10 @@ class GpuAssisted : public GpuAssistedBase {
     void PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress) override;
     void AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point, CMD_TYPE cmd,
                                      const GpuAssistedCmdIndirectState* indirect_state = nullptr);
-    void AllocatePreDrawValidationResources(GpuAssistedDeviceMemoryBlock output_block, GpuAssistedPreDrawResources& resources,
-                                            const VkRenderPass render_pass, VkPipeline* pPipeline,
-                                            const GpuAssistedCmdIndirectState* indirect_state);
-    void AllocatePreDispatchValidationResources(GpuAssistedDeviceMemoryBlock output_block,
+    void AllocatePreDrawValidationResources(const GpuAssistedDeviceMemoryBlock& output_block,
+                                            GpuAssistedPreDrawResources& resources, const VkRenderPass render_pass,
+                                            VkPipeline* pPipeline, const GpuAssistedCmdIndirectState* indirect_state);
+    void AllocatePreDispatchValidationResources(const GpuAssistedDeviceMemoryBlock& output_block,
                                                 GpuAssistedPreDispatchResources& resources,
                                                 const GpuAssistedCmdIndirectState* indirect_state);
     void PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -186,7 +186,7 @@ std::string GetNextToken(std::string *token_list, const std::string &delimiter, 
 }
 
 // Given a string representation of a list of enable enum values, call the appropriate setter function
-void SetLocalEnableSetting(std::string list_of_enables, std::string delimiter, CHECK_ENABLED &enables) {
+void SetLocalEnableSetting(std::string list_of_enables, const std::string &delimiter, CHECK_ENABLED &enables) {
     size_t pos = 0;
     std::string token;
     while (list_of_enables.length() != 0) {
@@ -211,7 +211,7 @@ void SetLocalEnableSetting(std::string list_of_enables, std::string delimiter, C
 }
 
 // Given a string representation of a list of disable enum values, call the appropriate setter function
-void SetLocalDisableSetting(std::string list_of_disables, std::string delimiter, CHECK_DISABLED &disables) {
+void SetLocalDisableSetting(std::string list_of_disables, const std::string &delimiter, CHECK_DISABLED &disables) {
     size_t pos = 0;
     std::string token;
     while (list_of_disables.length() != 0) {
@@ -240,7 +240,7 @@ uint32_t TokenToUint(std::string &token) {
     return int_id;
 }
 
-void CreateFilterMessageIdList(std::string raw_id_list, std::string delimiter, std::vector<uint32_t> &filter_list) {
+void CreateFilterMessageIdList(std::string raw_id_list, const std::string &delimiter, std::vector<uint32_t> &filter_list) {
     size_t pos = 0;
     std::string token;
     while (raw_id_list.length() != 0) {
@@ -258,7 +258,7 @@ void CreateFilterMessageIdList(std::string raw_id_list, std::string delimiter, s
     }
 }
 
-void SetCustomStypeInfo(std::string raw_id_list, std::string delimiter) {
+void SetCustomStypeInfo(std::string raw_id_list, const std::string &delimiter) {
     size_t pos = 0;
     std::string token;
     // List format is a list of integer pairs

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -712,7 +712,7 @@ void ObjectLifetimes::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapch
     RecordDestroyObject(swapchain, kVulkanObjectTypeSwapchainKHR);
 
     auto snapshot = swapchainImageMap.snapshot(
-        [swapchain](std::shared_ptr<ObjTrackState> pNode) { return pNode->parent_object == HandleToUint64(swapchain); });
+        [swapchain](const std::shared_ptr<ObjTrackState> &pNode) { return pNode->parent_object == HandleToUint64(swapchain); });
     for (const auto &itr : snapshot) {
         swapchainImageMap.erase(itr.first);
     }
@@ -794,7 +794,7 @@ bool ObjectLifetimes::PreCallValidateDestroyCommandPool(VkDevice device, VkComma
                            "VUID-vkDestroyCommandPool-commandPool-parent");
 
     auto snapshot = object_map[kVulkanObjectTypeCommandBuffer].snapshot(
-        [commandPool](std::shared_ptr<ObjTrackState> pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
+        [commandPool](const std::shared_ptr<ObjTrackState> &pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
     for (const auto &itr : snapshot) {
         auto node = itr.second;
         skip |= ValidateCommandBuffer(commandPool, reinterpret_cast<VkCommandBuffer>(itr.first));
@@ -809,7 +809,7 @@ bool ObjectLifetimes::PreCallValidateDestroyCommandPool(VkDevice device, VkComma
 void ObjectLifetimes::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                                       const VkAllocationCallbacks *pAllocator) {
     auto snapshot = object_map[kVulkanObjectTypeCommandBuffer].snapshot(
-        [commandPool](std::shared_ptr<ObjTrackState> pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
+        [commandPool](const std::shared_ptr<ObjTrackState> &pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
     // A CommandPool's cmd buffers are implicitly deleted when pool is deleted. Remove this pool's cmdBuffers from cmd buffer map.
     for (const auto &itr : snapshot) {
         RecordDestroyObject(reinterpret_cast<VkCommandBuffer>(itr.first), kVulkanObjectTypeCommandBuffer);

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -100,7 +100,7 @@ bool StatelessValidation::validate_instance_extensions(const VkInstanceCreateInf
     return skip;
 }
 
-bool StatelessValidation::SupportedByPdev(const VkPhysicalDevice physical_device, const std::string ext_name) const {
+bool StatelessValidation::SupportedByPdev(const VkPhysicalDevice physical_device, const std::string &ext_name) const {
     if (instance_extensions.vk_khr_get_physical_device_properties2) {
         // Struct is legal IF it's supported
         const auto &dev_exts_enumerated = device_extensions_enumerated.find(physical_device);
@@ -6521,7 +6521,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBu
     return skip;
 }
 
-bool StatelessValidation::ValidateDebugUtilsObjectNameInfoEXT(std::string api_name, VkDevice device,
+bool StatelessValidation::ValidateDebugUtilsObjectNameInfoEXT(const std::string &api_name, VkDevice device,
                                                               const VkDebugUtilsObjectNameInfoEXT *pNameInfo) const {
     bool skip = false;
     if ((pNameInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) && (pNameInfo->objectHandle == HandleToUint64(VK_NULL_HANDLE))) {

--- a/layers/pipeline_layout_state.cpp
+++ b/layers/pipeline_layout_state.cpp
@@ -73,8 +73,8 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
     return true;
 }
 
-static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId pcr_id,
-                                             const PipelineLayoutSetLayoutsId set_layouts_id) {
+static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId &pcr_id,
+                                             const PipelineLayoutSetLayoutsId &set_layouts_id) {
     return pipeline_layout_compat_dict.look_up(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));
 }
 

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -268,7 +268,7 @@ std::shared_ptr<VertexInputState> PIPELINE_STATE::CreateVertexInputState(const P
 // static
 std::shared_ptr<PreRasterState> PIPELINE_STATE::CreatePreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &state,
                                                                      const safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                     std::shared_ptr<const RENDER_PASS_STATE> rp) {
+                                                                     const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {  // Pre-raster graphics library
         return std::make_shared<PreRasterState>(p, state, create_info, rp);
@@ -293,7 +293,7 @@ std::shared_ptr<PreRasterState> PIPELINE_STATE::CreatePreRasterState(const PIPEL
 // static
 std::shared_ptr<FragmentShaderState> PIPELINE_STATE::CreateFragmentShaderState(
     const PIPELINE_STATE &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, std::shared_ptr<const RENDER_PASS_STATE> rp) {
+    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT) {  // Fragment shader graphics library
         return std::make_shared<FragmentShaderState>(p, state, create_info, rp);
@@ -320,7 +320,7 @@ std::shared_ptr<FragmentShaderState> PIPELINE_STATE::CreateFragmentShaderState(
 // create_info.
 std::shared_ptr<FragmentOutputState> PIPELINE_STATE::CreateFragmentOutputState(
     const PIPELINE_STATE &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, std::shared_ptr<const RENDER_PASS_STATE> rp) {
+    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT) {  // Fragment output graphics library
         return std::make_shared<FragmentOutputState>(p, create_info, rp);

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -492,17 +492,17 @@ class PIPELINE_STATE : public BASE_NODE {
                                                                     const safe_VkGraphicsPipelineCreateInfo &create_info);
     static std::shared_ptr<PreRasterState> CreatePreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &state,
                                                                 const safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                std::shared_ptr<const RENDER_PASS_STATE> rp);
+                                                                const std::shared_ptr<const RENDER_PASS_STATE> &rp);
     static std::shared_ptr<FragmentShaderState> CreateFragmentShaderState(const PIPELINE_STATE &p,
                                                                           const ValidationStateTracker &state,
                                                                           const VkGraphicsPipelineCreateInfo &create_info,
                                                                           const safe_VkGraphicsPipelineCreateInfo &safe_create_info,
-                                                                          std::shared_ptr<const RENDER_PASS_STATE> rp);
+                                                                          const std::shared_ptr<const RENDER_PASS_STATE> &rp);
     static std::shared_ptr<FragmentOutputState> CreateFragmentOutputState(const PIPELINE_STATE &p,
                                                                           const ValidationStateTracker &state,
                                                                           const VkGraphicsPipelineCreateInfo &create_info,
                                                                           const safe_VkGraphicsPipelineCreateInfo &safe_create_info,
-                                                                          std::shared_ptr<const RENDER_PASS_STATE> rp);
+                                                                          const std::shared_ptr<const RENDER_PASS_STATE> &rp);
 
     // Merged layouts
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> merged_graphics_layout;

--- a/layers/queue_state.cpp
+++ b/layers/queue_state.cpp
@@ -354,7 +354,7 @@ void SEMAPHORE_STATE::EnqueueAcquire() {
     operations_.emplace(payload, SemOpEntry(kBinaryAcquire, nullptr, 0, payload));
 }
 
-layer_data::optional<SemOp> SEMAPHORE_STATE::LastOp(std::function<bool(const SemOp &)> filter) const {
+layer_data::optional<SemOp> SEMAPHORE_STATE::LastOp(const std::function<bool(const SemOp &)> &filter) const {
     auto guard = ReadLock();
     layer_data::optional<SemOp> result;
 

--- a/layers/queue_state.h
+++ b/layers/queue_state.h
@@ -220,7 +220,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     void RetireTimeline(uint64_t payload);
 
     // look for most recent / highest payload operation that matches
-    layer_data::optional<SemOp> LastOp(std::function<bool(const SemOp &)> filter = nullptr) const;
+    layer_data::optional<SemOp> LastOp(const std::function<bool(const SemOp &)> &filter = nullptr) const;
 
     bool CanBeSignaled() const;
     bool CanBeWaited() const;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -1526,7 +1526,7 @@ layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLo
     if (store_pointer_ids.empty()) {
         return location_list;
     }
-    for (auto output : outputs) {
+    for (const auto& output : outputs) {
         auto store_it = store_pointer_ids.find(output.second.id);
         if (store_it != store_pointer_ids.end()) {
             location_list.insert(output.first.first);

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1142,7 +1142,7 @@ bool CoreChecks::ValidateShaderStageMaxResources(const SHADER_MODULE_STATE &modu
     // input from CreatePipeline and CreatePipelineLayout level
     const auto &layout_state = pipeline->PipelineLayoutState();
     if (layout_state) {
-        for (auto set_layout : layout_state->set_layouts) {
+        for (const auto &set_layout : layout_state->set_layouts) {
             if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) != 0) {
                 continue;
             }
@@ -3044,7 +3044,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
     skip |= ValidatePushConstantUsage(*pipeline, module_state, pStage, vuid_layout_mismatch);
 
     // Validate descriptor use
-    for (auto use : stage_state.descriptor_uses) {
+    for (const auto &use : stage_state.descriptor_uses) {
         // Verify given pipelineLayout has requested setLayout with requested binding
         // const auto& layout_state = (stage_state.stage_flag == VK_SHADER_STAGE_VERTEX_BIT) ?
         // pipeline->PreRasterPipelineLayoutState() : pipeline->FragmentShaderPipelineLayoutState();
@@ -3091,7 +3091,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
         if (rp_state && !rp_state->UsesDynamicRendering()) {
             auto rpci = rp_state->createInfo.ptr();
             auto subpass = pipeline->Subpass();
-            for (auto use : input_attachment_uses) {
+            for (const auto &use : input_attachment_uses) {
                 auto input_attachments = rpci->pSubpasses[subpass].pInputAttachments;
                 auto index = (input_attachments && use.first < rpci->pSubpasses[subpass].inputAttachmentCount)
                     ? input_attachments[use.first].attachment

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -525,7 +525,7 @@ class StatelessValidation : public ValidationObject {
     // Forward declarations
     bool CheckPromotedApiAgainstVulkanVersion(VkInstance instance, const char *api_name, const uint32_t promoted_version) const;
     bool CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice pdev, const char *api_name, const uint32_t promoted_version) const;
-    bool SupportedByPdev(const VkPhysicalDevice physical_device, const std::string ext_name) const;
+    bool SupportedByPdev(const VkPhysicalDevice physical_device, const std::string &ext_name) const;
 
     bool ValidatePnextStructContents(const char *api_name, const ParameterName &parameter_name, const VkBaseOutStructure *header,
                                      const char *pnext_vuid, bool is_physdev_api = false, bool is_const_param = true) const;
@@ -1019,7 +1019,7 @@ class StatelessValidation : public ValidationObject {
 
         VkBool32 attachment_feedback_loop_layout = false;
         const auto *attachment_feedback_loop_layout_features =
-                LvlFindInChain<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(device_createinfo_pnext);
+            LvlFindInChain<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(device_createinfo_pnext);
         if (attachment_feedback_loop_layout_features)
             attachment_feedback_loop_layout = attachment_feedback_loop_layout_features->attachmentFeedbackLoopLayout;
 
@@ -1319,7 +1319,8 @@ class StatelessValidation : public ValidationObject {
             // Need to check first so layer doesn't segfault from out of bound array access
             // src subpass bound check
             if ((dependency.srcSubpass != VK_SUBPASS_EXTERNAL) && (dependency.srcSubpass >= pCreateInfo->subpassCount)) {
-                vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-srcSubpass-02526" : "VUID-VkRenderPassCreateInfo-pDependencies-06866";
+                vuid =
+                    use_rp2 ? "VUID-VkRenderPassCreateInfo2-srcSubpass-02526" : "VUID-VkRenderPassCreateInfo-pDependencies-06866";
                 skip |= LogError(device, vuid,
                                  "%s: pCreateInfo->pDependencies[%u].srcSubpass index (%u) has to be less than subpassCount (%u)",
                                  func_name, i, dependency.srcSubpass, pCreateInfo->subpassCount);
@@ -1327,7 +1328,8 @@ class StatelessValidation : public ValidationObject {
 
             // dst subpass bound check
             if ((dependency.dstSubpass != VK_SUBPASS_EXTERNAL) && (dependency.dstSubpass >= pCreateInfo->subpassCount)) {
-                vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-dstSubpass-02527" : "VUID-VkRenderPassCreateInfo-pDependencies-06867";
+                vuid =
+                    use_rp2 ? "VUID-VkRenderPassCreateInfo2-dstSubpass-02527" : "VUID-VkRenderPassCreateInfo-pDependencies-06867";
                 skip |= LogError(device, vuid,
                                  "%s: pCreateInfo->pDependencies[%u].dstSubpass index (%u) has to be less than subpassCount (%u)",
                                  func_name, i, dependency.dstSubpass, pCreateInfo->subpassCount);
@@ -1468,7 +1470,7 @@ class StatelessValidation : public ValidationObject {
                                                     VkPipelineLayout *pPipelineLayout) const;
 
     bool ValidatePipelineShaderStageCreateInfo(const char *func_name, const char *msg,
-                                                const VkPipelineShaderStageCreateInfo *pCreateInfo) const;
+                                               const VkPipelineShaderStageCreateInfo *pCreateInfo) const;
     bool manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) const;
@@ -1496,7 +1498,7 @@ class StatelessValidation : public ValidationObject {
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
     bool ExportMetalObjectsPNextUtil(VkExportMetalObjectTypeFlagBitsEXT bit, const char *vuid, const char *api_call,
-                                         const char *sType, const void *pNext) const;
+                                     const char *sType, const void *pNext) const;
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
     bool validate_WriteDescriptorSet(const char *vkCallingFunction, const uint32_t descriptorWriteCount,
@@ -1701,7 +1703,7 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                                     const VkBuffer *pBuffers, const VkDeviceSize *pOffsets) const;
 
-    bool ValidateDebugUtilsObjectNameInfoEXT(std::string api_name, VkDevice device,
+    bool ValidateDebugUtilsObjectNameInfoEXT(const std::string &api_name, VkDevice device,
                                              const VkDebugUtilsObjectNameInfoEXT *pNameInfo) const;
     bool manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) const;
 

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -1020,9 +1020,9 @@ struct ApplyTrackbackStackAction {
 // Returns the position past the last resolved range -- the entry covering the remainder of entry->first not included in the
 // range [first, last)
 template <typename BarrierAction>
-static void ResolveMapToEntry(ResourceAccessRangeMap *dest, ResourceAccessRangeMap::iterator entry,
-                              ResourceAccessRangeMap::const_iterator first, ResourceAccessRangeMap::const_iterator last,
-                              BarrierAction &barrier_action) {
+static void ResolveMapToEntry(ResourceAccessRangeMap *dest, const ResourceAccessRangeMap::iterator &entry,
+                              const ResourceAccessRangeMap::const_iterator &first,
+                              const ResourceAccessRangeMap::const_iterator &last, BarrierAction &barrier_action) {
     auto at = entry;
     for (auto pos = first; pos != last; ++pos) {
         // Every member of the input iterator range must fit within the remaining portion of entry
@@ -1741,14 +1741,14 @@ void UpdateMemoryAccessState(ResourceAccessRangeMap *accesses, const Action &act
 }
 struct UpdateMemoryAccessStateFunctor {
     using Iterator = ResourceAccessRangeMap::iterator;
-    Iterator Infill(ResourceAccessRangeMap *accesses, Iterator pos, ResourceAccessRange range) const {
+    Iterator Infill(ResourceAccessRangeMap *accesses, const Iterator &pos, const ResourceAccessRange &range) const {
         // this is only called on gaps, and never returns a gap.
         ResourceAccessState default_state;
         context.ResolvePreviousAccess(type, range, accesses, &default_state);
         return accesses->lower_bound(range);
     }
 
-    Iterator operator()(ResourceAccessRangeMap *accesses, Iterator pos) const {
+    Iterator operator()(ResourceAccessRangeMap *accesses, const Iterator &pos) const {
         auto &access_state = pos->second;
         access_state.Update(usage, ordering_rule, tag);
         return pos;
@@ -3964,7 +3964,7 @@ QueueBatchContext::BatchSet SyncValidator::GetQueueLastBatchSnapshot(Predicate &
 
 QueueBatchContext::BatchSet SyncValidator::GetQueueBatchSnapshot() {
     QueueBatchContext::BatchSet snapshot = GetQueueLastBatchSnapshot();
-    auto append = [&snapshot](const std::shared_ptr<QueueBatchContext> batch) {
+    auto append = [&snapshot](const std::shared_ptr<QueueBatchContext> &batch) {
         if (batch && !layer_data::Contains(snapshot, batch)) {
             snapshot.emplace(batch);
         }

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -146,7 +146,7 @@ VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const string &option, layer_data::un
 
     while (option_list.length() != 0) {
         // Find length of option string
-        std::size_t option_length = option_list.find(",");
+        std::size_t option_length = option_list.find(',');
         if (option_length == option_list.npos) {
             option_length = option_list.size();
         }
@@ -162,12 +162,12 @@ VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const string &option, layer_data::un
         // Remove first option from option_list
         option_list.erase(0, option_length);
         // Remove possible comma separator
-        std::size_t char_position = option_list.find(",");
+        std::size_t char_position = option_list.find(',');
         if (char_position == 0) {
             option_list.erase(char_position, 1);
         }
         // Remove possible space
-        char_position = option_list.find(" ");
+        char_position = option_list.find(' ');
         if (char_position == 0) {
             option_list.erase(char_position, 1);
         }

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -139,7 +139,7 @@ VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *option, const char *layer_na
 }
 
 // Map option strings to flag enum values
-VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(string option, layer_data::unordered_map<string, VkFlags> const &enum_data,
+VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const string &option, layer_data::unordered_map<string, VkFlags> const &enum_data,
                                             uint32_t option_default) {
     VkDebugReportFlagsEXT flags = option_default;
     string option_list = layer_config.GetOption(option.c_str());

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -99,7 +99,8 @@ VK_LAYER_EXPORT const char *GetLayerEnvVar(const char *option);
 VK_LAYER_EXPORT const SettingsFileInfo *GetLayerSettingsFileInfo();
 
 VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *option, const char *layer_name);
-VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(std::string option, layer_data::unordered_map<std::string, VkFlags> const &enum_data,
+VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const std::string &option,
+                                            layer_data::unordered_map<std::string, VkFlags> const &enum_data,
                                             uint32_t option_default);
 
 VK_LAYER_EXPORT void setLayerOption(const char *option, const char *val);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -554,7 +554,7 @@ void NegHeightViewportTests(VkDeviceObj *m_device, VkCommandBufferObj *m_command
     }
 }
 
-void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *create_info, std::string code) {
+void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *create_info, const std::string &code) {
     if (code.length()) {
         test.Monitor().SetDesiredFailureMsg(kErrorBit | kWarningBit, code);
     }
@@ -566,7 +566,7 @@ void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *create_info
     }
 }
 
-void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *create_info, std::string code) {
+void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *create_info, const std::string &code) {
     if (code.length()) {
         test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     }
@@ -576,7 +576,7 @@ void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *create_info, 
     }
 }
 
-void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *create_info, std::string code) {
+void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *create_info, const std::string &code) {
     if (code.length()) {
         test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     }
@@ -596,7 +596,7 @@ void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *creat
     }
 }
 
-void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *create_info, std::string code) {
+void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *create_info, const std::string &code) {
     if (code.length()) {
         test.Monitor().SetDesiredFailureMsg(kErrorBit, code);
     }
@@ -683,8 +683,7 @@ bool CheckTimelineSemaphoreSupportAndInitState(VkRenderFramework *renderFramewor
 
 bool CheckSynchronization2SupportAndInitState(VkRenderFramework *framework) {
     PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(framework->instance(),
-                                                                     "vkGetPhysicalDeviceFeatures2");
+        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(framework->instance(), "vkGetPhysicalDeviceFeatures2");
 
     {
         auto sync2_features = lvl_init_struct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
@@ -1235,7 +1234,7 @@ void SetImageLayout(VkDeviceObj *device, VkImageAspectFlags aspect, VkImage imag
     VkCommandBufferObj cmd_buf(device, &pool);
 
     cmd_buf.begin();
-    VkImageMemoryBarrier layout_barrier{ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+    VkImageMemoryBarrier layout_barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                         nullptr,
                                         0,
                                         VK_ACCESS_MEMORY_READ_BIT,
@@ -1244,22 +1243,20 @@ void SetImageLayout(VkDeviceObj *device, VkImageAspectFlags aspect, VkImage imag
                                         VK_QUEUE_FAMILY_IGNORED,
                                         VK_QUEUE_FAMILY_IGNORED,
                                         image,
-                                        {aspect, 0, 1, 0, 1} };
+                                        {aspect, 0, 1, 0, 1}};
 
     cmd_buf.PipelineBarrier(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 1,
-        &layout_barrier);
+                            &layout_barrier);
     cmd_buf.end();
 
     cmd_buf.QueueCommandBuffer();
 }
 
-std::unique_ptr<VkImageObj> VkArmBestPracticesLayerTest::CreateImage(VkFormat format, const uint32_t width,
-                                                                     const uint32_t height,
+std::unique_ptr<VkImageObj> VkArmBestPracticesLayerTest::CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
                                                                      VkImageUsageFlags attachment_usage) {
     auto img = std::unique_ptr<VkImageObj>(new VkImageObj(m_device));
     img->Init(width, height, 1, format,
-              VK_IMAGE_USAGE_SAMPLED_BIT | attachment_usage |
-              VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+              VK_IMAGE_USAGE_SAMPLED_BIT | attachment_usage | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
               VK_IMAGE_TILING_OPTIMAL);
     return img;
 }
@@ -2325,7 +2322,7 @@ BarrierQueueFamilyBase::QueueFamilyObjs *BarrierQueueFamilyBase::GetQueueFamilyI
     return qf;
 }
 
-void BarrierQueueFamilyTestHelper::operator()(std::string img_err, std::string buf_err, uint32_t src, uint32_t dst,
+void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const std::string &buf_err, uint32_t src, uint32_t dst,
                                               uint32_t queue_family_index, Modifier mod) {
     auto &monitor = context_->layer_test->Monitor();
     const bool has_img_err = img_err.size() > 0;
@@ -2367,7 +2364,7 @@ void BarrierQueueFamilyTestHelper::operator()(std::string img_err, std::string b
     context_->Reset();
 };
 
-void Barrier2QueueFamilyTestHelper::operator()(std::string img_err, std::string buf_err, uint32_t src, uint32_t dst,
+void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const std::string &buf_err, uint32_t src, uint32_t dst,
                                                uint32_t queue_family_index, Modifier mod) {
     auto &monitor = context_->layer_test->Monitor();
     bool positive = true;

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -787,7 +787,7 @@ class BarrierQueueFamilyTestHelper : public BarrierQueueFamilyBase {
     // Init with queue families non-null for CONCURRENT sharing mode (which requires them)
     void Init(std::vector<uint32_t> *families, bool image_memory = true, bool buffer_memory = true);
 
-    void operator()(std::string img_err, std::string buf_err = "", uint32_t src = VK_QUEUE_FAMILY_IGNORED,
+    void operator()(const std::string &img_err, const std::string &buf_err = "", uint32_t src = VK_QUEUE_FAMILY_IGNORED,
                     uint32_t dst = VK_QUEUE_FAMILY_IGNORED, uint32_t queue_family_index = kInvalidQueueFamily,
                     Modifier mod = Modifier::NONE);
 
@@ -806,7 +806,7 @@ class Barrier2QueueFamilyTestHelper : public BarrierQueueFamilyBase {
     // Init with queue families non-null for CONCURRENT sharing mode (which requires them)
     void Init(std::vector<uint32_t> *families, bool image_memory = true, bool buffer_memory = true);
 
-    void operator()(std::string img_err, std::string buf_err = "", uint32_t src = VK_QUEUE_FAMILY_IGNORED,
+    void operator()(const std::string &img_err, const std::string &buf_err = "", uint32_t src = VK_QUEUE_FAMILY_IGNORED,
                     uint32_t dst = VK_QUEUE_FAMILY_IGNORED, uint32_t queue_family_index = kInvalidQueueFamily,
                     Modifier mod = Modifier::NONE);
 
@@ -891,15 +891,15 @@ void AllocateDisjointMemory(VkDeviceObj *device, PFN_vkGetImageMemoryRequirement
 
 void NegHeightViewportTests(VkDeviceObj *m_device, VkCommandBufferObj *m_commandBuffer, ErrorMonitor *m_errorMonitor);
 
-void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *pCreateInfo, std::string code = "");
+void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *pCreateInfo, const std::string &code = "");
 
-void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, std::string code = "");
+void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, const std::string &code = "");
 
-void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, std::string code = "");
+void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, const std::string &code = "");
 
 void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCreateInfo, const std::vector<std::string> &codes);
 
-void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreateInfo, std::string code = "");
+void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreateInfo, const std::string &code = "");
 
 bool InitFrameworkForRayTracingTest(VkRenderFramework *framework, bool is_khr, VkPhysicalDeviceFeatures2KHR *features2 = nullptr,
                                     VkValidationFeaturesEXT *enabled_features = nullptr, bool mockicd_valid = false);

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -9701,7 +9701,7 @@ TEST_F(VkLayerTest, SamplerImageViewFormatUnsupportedFilter) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    for (auto test_struct : tests) {
+    for (const auto &test_struct : tests) {
         if (test_struct.format == VK_FORMAT_UNDEFINED) {
             printf("%s Could not find a testable format for filter %d.  Skipping test for said filter.\n", kSkipPrefix,
                    test_struct.filter);

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -65,7 +65,7 @@ void ErrorMonitor::Reset() {
     MonitorReset();
 }
 
-void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const string msg) { SetDesiredFailureMsg(msgFlags, msg.c_str()); }
+void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const string &msg) { SetDesiredFailureMsg(msgFlags, msg.c_str()); }
 
 void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msgFlags, const char *const msgString) {
     if (NeedCheckSuccess()) {
@@ -2277,7 +2277,7 @@ void VkPipelineObj::AddColorAttachment(uint32_t binding, const VkPipelineColorBl
 
 void VkPipelineObj::SetDepthStencil(const VkPipelineDepthStencilStateCreateInfo *ds_state) { m_ds_state = ds_state; }
 
-void VkPipelineObj::SetViewport(const vector<VkViewport> viewports) {
+void VkPipelineObj::SetViewport(const vector<VkViewport> &viewports) {
     m_viewports = viewports;
     // If we explicitly set a null viewport, pass it through to create info
     // but preserve viewportCount because it musn't change
@@ -2286,7 +2286,7 @@ void VkPipelineObj::SetViewport(const vector<VkViewport> viewports) {
     }
 }
 
-void VkPipelineObj::SetScissor(const vector<VkRect2D> scissors) {
+void VkPipelineObj::SetScissor(const vector<VkRect2D> &scissors) {
     m_scissors = scissors;
     // If we explicitly set a null scissor, pass it through to create info
     // but preserve scissorCount because it musn't change

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -103,7 +103,7 @@ class ErrorMonitor {
     void Reset();
 
     // ErrorMonitor will look for an error message containing the specified string(s)
-    void SetDesiredFailureMsg(const VkFlags msgFlags, const std::string msg);
+    void SetDesiredFailureMsg(const VkFlags msgFlags, const std::string &msg);
     void SetDesiredFailureMsg(const VkFlags msgFlags, const char *const msgString);
 
     // ErrorMonitor will look for an error message containing the specified string(s)
@@ -852,8 +852,8 @@ class VkPipelineObj : public vk_testing::Pipeline {
     void SetInputAssembly(const VkPipelineInputAssemblyStateCreateInfo *ia_state);
     void SetRasterization(const VkPipelineRasterizationStateCreateInfo *rs_state);
     void SetTessellation(const VkPipelineTessellationStateCreateInfo *te_state);
-    void SetViewport(const std::vector<VkViewport> viewports);
-    void SetScissor(const std::vector<VkRect2D> scissors);
+    void SetViewport(const std::vector<VkViewport> &viewports);
+    void SetScissor(const std::vector<VkRect2D> &scissors);
     void SetLineState(const VkPipelineRasterizationLineStateCreateInfoEXT *line_state);
 
     void InitGraphicsPipelineCreateInfo(VkGraphicsPipelineCreateInfo *gp_ci);

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -2397,7 +2397,7 @@ struct CreateRenderPassHelper {
         }
     }
 
-    void AddSubpassDescription(const std::vector<VkAttachmentReference>& input, const std::vector<VkAttachmentReference> color) {
+    void AddSubpassDescription(const std::vector<VkAttachmentReference>& input, const std::vector<VkAttachmentReference>& color) {
         subpass_description_store.emplace_back(input, color);
     }
 


### PR DESCRIPTION
Various clang-tidy performance fixes:
- [performance-unneccessary-value-param](https://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-value-param.html)
- [performance-for-range-copy.](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-for-range-copy.html)
- [performance-faster-string-find](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-faster-string-find.html)
- [performance-type-promotion-in-math-fn](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-type-promotion-in-math-fn.html)