### PR TITLE
corechecks: Add VUID 03881 checking

### DIFF
--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -952,7 +952,6 @@ static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
          {Key(Struct::VkSemaphoreSignalInfo), "VUID-VkSemaphoreSignalInfo-value-03258"},
          {Key(Struct::VkBindSparseInfo), "VUID-VkBindSparseInfo-pSignalSemaphores-03249"},
          {Key(Struct::VkSubmitInfo), "VUID-VkSubmitInfo-pSignalSemaphores-03242"},
-         {Key(Struct::VkSubmitInfo2), "VUID-VkSubmitInfo2-semaphore-03881"},
          {Key(Struct::VkSubmitInfo2), "VUID-VkSubmitInfo2-semaphore-03882"},
      }},
     {SubmitError::kSemAlreadySignalled,


### PR DESCRIPTION
This specifies that within a single queue submission, any waits on a timeline semaphore must use a lower value than any signals for that same semaphore. This is only a required for vkQueueSubmit2(), but it could also apply to vkQueueSubmit() and vkQueueBindSparse(), if we wanted to make an UNASSIGNED check for it.
