### PR TITLE
 corechecks: Improve timeline semaphore VUID checks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5328,7 +5328,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "%s (%s) is a timeline semaphore, but VkSubmitInfo does "
                                  "not include an instance of VkTimelineSemaphoreSubmitInfo",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str());
-                continue;
+                break;
             } else if (submit.waitSemaphoreCount != timeline_semaphore_submit_info->waitSemaphoreValueCount) {
                 skip |= LogError(semaphore, "VUID-VkSubmitInfo-pNext-03240",
                                  "%s (%s) is a timeline semaphore, it contains an "
@@ -5336,7 +5336,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "waitSemaphoreCount (%u)",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str(),
                                  timeline_semaphore_submit_info->waitSemaphoreValueCount, submit.waitSemaphoreCount);
-                continue;
+                break;
             }
             value = timeline_semaphore_submit_info->pWaitSemaphoreValues[i];
         }
@@ -5357,7 +5357,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "%s (%s) is a timeline semaphore, but VkSubmitInfo"
                                  "does not include an instance of VkTimelineSemaphoreSubmitInfo",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str());
-                continue;
+                break;
             } else if (submit.signalSemaphoreCount != timeline_semaphore_submit_info->signalSemaphoreValueCount) {
                 skip |= LogError(semaphore, "VUID-VkSubmitInfo-pNext-03241",
                                  "%s (%s) is a timeline semaphore, it contains an "
@@ -5365,7 +5365,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "signalSemaphoreCount (%u)",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str(),
                                  timeline_semaphore_submit_info->signalSemaphoreValueCount, submit.signalSemaphoreCount);
-                continue;
+                break;
             }
             value = timeline_semaphore_submit_info->pSignalSemaphoreValues[i];
         }
@@ -5434,7 +5434,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "%s (%s) is a timeline semaphore, but VkSubmitInfo does "
                                  "not include an instance of VkTimelineSemaphoreSubmitInfo",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str());
-                continue;
+                break;
             } else if (submit.waitSemaphoreCount != timeline_semaphore_submit_info->waitSemaphoreValueCount) {
                 skip |= LogError(semaphore, "VUID-VkBindSparseInfo-pNext-03247",
                                  "%s (%s) is a timeline semaphore, it contains an "
@@ -5442,7 +5442,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "waitSemaphoreCount (%u)",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str(),
                                  timeline_semaphore_submit_info->waitSemaphoreValueCount, submit.waitSemaphoreCount);
-                continue;
+                break;
             }
             value = timeline_semaphore_submit_info->pWaitSemaphoreValues[i];
         }
@@ -5463,7 +5463,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "%s (%s) is a timeline semaphore, but VkSubmitInfo"
                                  "does not include an instance of VkTimelineSemaphoreSubmitInfo",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str());
-                continue;
+                break;
             } else if (submit.signalSemaphoreCount != timeline_semaphore_submit_info->signalSemaphoreValueCount) {
                 skip |= LogError(semaphore, "VUID-VkBindSparseInfo-pNext-03248",
                                  "%s (%s) is a timeline semaphore, it contains an "
@@ -5471,7 +5471,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
                                  "signalSemaphoreCount (%u)",
                                  loc.Message().c_str(), report_data->FormatHandle(semaphore).c_str(),
                                  timeline_semaphore_submit_info->signalSemaphoreValueCount, submit.signalSemaphoreCount);
-                continue;
+                break;
             }
             value = timeline_semaphore_submit_info->pSignalSemaphoreValues[i];
         }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5129,8 +5129,8 @@ struct SemaphoreSubmitState {
                                         core->report_data->FormatHandle(semaphore).c_str());
             } else if (CannotWait(semaphore_state)) {
                 auto error = IsExtEnabled(core->device_extensions.vk_khr_timeline_semaphore)
-                                    ? SubmitError::kTimelineCannotBeSignalled
-                                    : SubmitError::kBinaryCannotBeSignalled;
+                                    ? SubmitError::kBinaryCannotBeSignalled
+                                    : SubmitError::kOldBinaryCannotBeSignalled;
                 const auto &vuid = GetQueueSubmitVUID(loc, error);
                 LogObjectList objlist(semaphore);
                 objlist.add(queue);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5120,9 +5120,7 @@ struct SemaphoreSubmitState {
         if ((semaphore_state.Scope() == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
             VkQueue other_queue = AnotherQueueWaits(semaphore_state, queue);
             if (other_queue) {
-                const char *vuid = loc.function == core_error::Func::vkQueueSubmit
-                                        ? "VUID-vkQueueSubmit-pWaitSemaphores-00068"
-                                        : "VUID-vkQueueSubmit2-semaphore-03871";
+                const auto &vuid = GetQueueSubmitVUID(loc, SubmitError::kOtherQueueWaiting);
                 LogObjectList objlist(semaphore);
                 objlist.add(queue);
                 objlist.add(other_queue);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -248,12 +248,9 @@ class CoreChecks : public ValidationStateTracker {
                                uint32_t count, const uint32_t* indices) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence, const char* inflight_vuid, const char* retired_vuid,
                                 const char* func_name) const;
-    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, VkQueue queue, const VkSubmitInfo* submit,
-                                     const Location& loc) const;
-    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, VkQueue queue, const VkSubmitInfo2KHR* submit,
-                                     const Location& loc) const;
-    bool ValidateMaxTimelineSemaphoreValueDifference(const Location& loc, const SEMAPHORE_STATE& semaphore_state,
-                                                     uint64_t value) const;
+    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo& submit, const Location& loc) const;
+    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo2KHR& submit, const Location& loc) const;
+    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkBindSparseInfo& submit, const Location& loc) const;
     bool ValidateStatus(const CMD_BUFFER_STATE* pNode, CBDynamicStatus status, const char* fail_msg, const char* msg_code) const;
     bool ValidateDrawStateFlags(const CMD_BUFFER_STATE* pCB, const PIPELINE_STATE* pPipe, const char* msg_code) const;
     bool LogInvalidAttachmentMessage(const char* type1_string, const RENDER_PASS_STATE* rp1_state, const char* type2_string,

--- a/layers/queue_state.cpp
+++ b/layers/queue_state.cpp
@@ -354,15 +354,18 @@ void SEMAPHORE_STATE::EnqueueAcquire() {
     operations_.emplace(payload, SemOpEntry(kBinaryAcquire, nullptr, 0, payload));
 }
 
-layer_data::optional<SemOp> SEMAPHORE_STATE::LastOp(const std::function<bool(const SemOp &)> &filter) const {
+layer_data::optional<SemOp> SEMAPHORE_STATE::LastOp(const std::function<bool(const SemOp &, bool)> &filter) const {
     auto guard = ReadLock();
     layer_data::optional<SemOp> result;
 
     for (auto pos = operations_.rbegin(); pos != operations_.rend(); ++pos) {
-        if (!filter || filter(pos->second)) {
+        if (!filter || filter(pos->second, true)) {
             result.emplace(pos->second);
             break;
         }
+    }
+    if (!result && (!filter || filter(completed_, false))) {
+        result.emplace(completed_);
     }
     return result;
 }

--- a/layers/queue_state.h
+++ b/layers/queue_state.h
@@ -180,7 +180,8 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
 #endif  // VK_USE_PLATFORM_METAL_EXT
           type(type_create_info ? type_create_info->semaphoreType : VK_SEMAPHORE_TYPE_BINARY),
           exportHandleTypes(GetExportHandleTypes(pCreateInfo)),
-          completed_{kNone, nullptr, 0, type_create_info ? type_create_info->initialValue : 0},
+          completed_{type == VK_SEMAPHORE_TYPE_TIMELINE ? kSignal : kNone, nullptr, 0,
+                     type_create_info ? type_create_info->initialValue : 0},
           next_payload_(completed_.payload + 1),
           dev_data_(dev) {
     }
@@ -220,7 +221,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     void RetireTimeline(uint64_t payload);
 
     // look for most recent / highest payload operation that matches
-    layer_data::optional<SemOp> LastOp(const std::function<bool(const SemOp &)> &filter = nullptr) const;
+    layer_data::optional<SemOp> LastOp(const std::function<bool(const SemOp &, bool is_pending)> &filter = nullptr) const;
 
     bool CanBeSignaled() const;
     bool CanBeWaited() const;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -1832,6 +1832,8 @@ void ValidationStateTracker::PreCallRecordSignalSemaphoreKHR(VkDevice device, co
 
 void ValidationStateTracker::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
                                                               VkResult result) {
+    if (result != VK_SUCCESS) return;
+
     auto semaphore_state = Get<SEMAPHORE_STATE>(pSignalInfo->semaphore);
     if (semaphore_state) {
         semaphore_state->Retire(nullptr, pSignalInfo->value);

--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -964,6 +964,7 @@ static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
      {
          {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-00069"},
          {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-semaphore-03872"},
+         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pWaitSemaphores-03245"},
      }},
     {SubmitError::kTimelineCannotBeSignalled,
      {

--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -960,16 +960,17 @@ static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
          {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pSignalSemaphores-01115"},
          {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-semaphore-03868"},
      }},
-    {SubmitError::kBinaryCannotBeSignalled,
+    {SubmitError::kOldBinaryCannotBeSignalled,
      {
          {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-00069"},
          {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-semaphore-03872"},
-         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pWaitSemaphores-03245"},
+         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pWaitSemaphores-01117"},
      }},
-    {SubmitError::kTimelineCannotBeSignalled,
+    {SubmitError::kBinaryCannotBeSignalled,
      {
          {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-03238"},
          {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-semaphore-03873"},
+         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pWaitSemaphores-03245"},
      }},
     {SubmitError::kTimelineSemMaxDiff,
      {

--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -1028,6 +1028,12 @@ static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
          {Key(Func::vkCmdResetEvent), "VUID-vkCmdResetEvent-stageMask-01153"},
          {Key(Func::vkCmdResetEvent2), "VUID-vkCmdResetEvent2-stageMask-03830"},
      }},
+    {SubmitError::kOtherQueueWaiting,
+     {
+         {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pWaitSemaphores-00068"},
+         {Key(Func::vkQueueBindSparse), "VUID-vkQueueBindSparse-pWaitSemaphores-01116"},
+         {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-semaphore-03871"},
+     }},
 };
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {

--- a/layers/sync_vuid_maps.h
+++ b/layers/sync_vuid_maps.h
@@ -105,6 +105,7 @@ enum class SubmitError {
     kCmdWrongQueueFamily,
     kSecondaryCmdInSubmit,
     kHostStageMask,
+    kOtherQueueWaiting,
 };
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error);

--- a/layers/sync_vuid_maps.h
+++ b/layers/sync_vuid_maps.h
@@ -93,8 +93,8 @@ const SubresourceRangeErrorCodes &GetSubResourceVUIDs(const Location &loc);
 enum class SubmitError {
     kTimelineSemSmallValue,
     kSemAlreadySignalled,
-    kBinaryCannotBeSignalled,
-    kTimelineCannotBeSignalled,
+    kOldBinaryCannotBeSignalled, // timeline semaphores not supported
+    kBinaryCannotBeSignalled, // timeline semaphores supported
     kTimelineSemMaxDiff,
     kProtectedFeatureDisabled,
     kBadUnprotectedSubmit,


### PR DESCRIPTION
Restructure timeline semaphore checking so that it is easier to be aware of of timeline values within a single submission.
Redo vkQueueBindSparse() to use the common semaphore submission checking code.
