### PR TITLE
Move pool destroy in GPU-AV to after state tracker call

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -117,7 +117,6 @@ void CMD_BUFFER_STATE::RemoveChild(std::shared_ptr<BASE_NODE> &child_node) {
 // Reset the command buffer state
 //  Maintain the createInfo and set state to CB_NEW, but clear all other state
 void CMD_BUFFER_STATE::Reset() {
-    assert(!InUse());
     // Reset CB state (note that createInfo is not cleared)
     memset(&beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
     memset(&inheritanceInfo, 0, sizeof(VkCommandBufferInheritanceInfo));

--- a/layers/gpu_utils.cpp
+++ b/layers/gpu_utils.cpp
@@ -365,6 +365,9 @@ void GpuAssistedBase::PreCallRecordDestroyDevice(VkDevice device, const VkAlloca
     }
     ValidationStateTracker::PreCallRecordDestroyDevice(device, pAllocator);
     // State Tracker can end up making vma calls through callbacks - don't destroy allocator until ST is done
+    if (output_buffer_pool) {
+        vmaDestroyPool(vmaAllocator, output_buffer_pool);
+    }
     if (vmaAllocator) {
         vmaDestroyAllocator(vmaAllocator);
     }

--- a/layers/gpu_utils.h
+++ b/layers/gpu_utils.h
@@ -222,6 +222,7 @@ class GpuAssistedBase : public ValidationStateTracker {
     VkDescriptorSetLayout dummy_desc_layout = VK_NULL_HANDLE;
     uint32_t desc_set_bind_index = 0;
     VmaAllocator vmaAllocator = {};
+    VmaPool output_buffer_pool = VK_NULL_HANDLE;
     std::unique_ptr<UtilDescriptorSetManager> desc_set_manager;
     vl_concurrent_unordered_map<uint32_t, GpuAssistedShaderTracker> shader_map;
     std::vector<VkDescriptorSetLayoutBinding> bindings_;

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -210,9 +210,6 @@ void GpuAssisted::PreCallRecordDestroyDevice(VkDevice device, const VkAllocation
     acceleration_structure_validation_state.Destroy(device, vmaAllocator);
     pre_draw_validation_state.Destroy(device);
     pre_dispatch_validation_state.Destroy(device);
-    if (output_buffer_pool) {
-        vmaDestroyPool(vmaAllocator, output_buffer_pool);
-    }
     GpuAssistedBase::PreCallRecordDestroyDevice(device, pAllocator);
 }
 

--- a/layers/gpu_validation.h
+++ b/layers/gpu_validation.h
@@ -300,7 +300,6 @@ class GpuAssisted : public GpuAssistedBase {
     bool buffer_oob_enabled;
     bool validate_draw_indirect;
     bool validate_dispatch_indirect;
-    VmaPool output_buffer_pool = VK_NULL_HANDLE;
     GpuAssistedAccelerationStructureBuildValidationState acceleration_structure_validation_state;
     GpuAssistedPreDrawValidationState pre_draw_validation_state;
     GpuAssistedPreDispatchValidationState pre_dispatch_validation_state;


### PR DESCRIPTION
Also remove an assert that an app leaking in flight command buffers can reach and trigger
Fixes a crash playing back a game trace with GPU-AV