### PR TITLE
tests: Workaround PresentId driver bugs

### DIFF
--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -1890,7 +1890,10 @@ TEST_F(VkLayerTest, PresentIdWait) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required, skipping test.";
     }
 
-    ASSERT_TRUE(InitSwapchain());
+    if (!InitSwapchain()) {
+        GTEST_SKIP() << "Cannot create swapchain, skipping test";
+    }
+
     VkSurfaceKHR surface2;
     VkSwapchainKHR swapchain2;
     InitSurface(surface2);
@@ -1993,7 +1996,9 @@ TEST_F(VkLayerTest, PresentIdWaitFeatures) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required, skipping test.";
     }
 
-    ASSERT_TRUE(InitSwapchain());
+    if (!InitSwapchain()) {
+        GTEST_SKIP() << "Cannot create swapchain, skipping test";
+    }
 
     auto vkWaitForPresentKHR = (PFN_vkWaitForPresentKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR");
     assert(vkWaitForPresentKHR != nullptr);


### PR DESCRIPTION
Currently NVIDIA's driver support for "VK_KHR_present_wait" for "VK_KHR_present_id" is broken. 

<details>
<summary>I verified this by running the relevant CTS tests.</summary>

```
juan@pop-os:~/projects/VK-GL-CTS$ export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
juan@pop-os:~/projects/VK-GL-CTS$ ./build/external/vulkancts/modules/vulkan/deqp-vk --deqp-case=dEQP-VK.wsi.x*.present_id_wait.*
Writing test log into TestResults.qpa
dEQP Core git-acb25bf242c31cef2d82d4ebdb8d8d2f67af0ef6 (0xacb25bf2) starting..
  target implementation = 'Default'

Test case 'dEQP-VK.wsi.xlib.present_id_wait.id.zero'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.id.increasing'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.id.interleaved'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.single_no_timeout'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.past_no_timeout'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.no_frames'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.no_frame_id'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.future_frame'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xlib.present_id_wait.wait.two_swapchains'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.id.zero'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.id.increasing'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.id.interleaved'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.single_no_timeout'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.past_no_timeout'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.no_frames'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.no_frame_id'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.future_frame'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

Test case 'dEQP-VK.wsi.xcb.present_id_wait.wait.two_swapchains'..
  Fail (vk.createSwapchainKHR(device, pCreateInfo, pAllocator, &object): VK_ERROR_INITIALIZATION_FAILED at vkRefUtilImpl.inl:385)

DONE!

Test run totals:
  Passed:        0/18 (0.0%)
  Failed:        18/18 (100.0%)
  Not supported: 0/18 (0.0%)
  Warnings:      0/18 (0.0%)
  Waived:        0/18 (0.0%)
```
</details>

This change works around the issue by skipping the test if the Swapchain cannot be created.

Other swapchain tests already employ similar behavior so it's consistent.