### PR TITLE
build: Do not include vk_sdk_platform.h

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -272,7 +272,6 @@ source_set("vulkan_layer_utils") {
   ]
   sources = [
     "$vulkan_headers_dir/include/vulkan/vk_layer.h",
-    "$vulkan_headers_dir/include/vulkan/vk_sdk_platform.h",
     "$vulkan_headers_dir/include/vulkan/vulkan.h",
     "layers/android_ndk_types.h",
     "layers/cast_utils.h",

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -34,7 +34,6 @@
 #include <vulkan/vk_layer.h>
 // sdk_platform header redefines NOMINMAX
 #undef NOMINMAX
-#include <vulkan/vk_sdk_platform.h>
 #include "vk_layer_utils.h"
 
 #if defined(_WIN32)

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -40,9 +40,6 @@
 #include <winsock2.h>
 #endif
 
-// sdk_platform header redefines NOMINMAX
-#undef NOMINMAX
-#include <vulkan/vk_sdk_platform.h>
 #include <vulkan/vulkan.h>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
None of the macros it defines are being used.