### PR TITLE
tests: Rework require_success to REQUIRE_SUCCESS

### DIFF
--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -134,4 +134,24 @@ static inline void test_error_callback(const char *expr, const char *file, unsig
     ADD_FAILURE_AT(file, line) << "Assertion: `" << expr << "'";
 }
 
+// Wrap FAIL:
+//  * DRY for common messages
+//  * for test stability reasons sometimes cleanup code is required *prior* to the return hidden in FAIL
+//  * result_arg_ *can* (should) have side-effect, but is referenced exactly once
+//  * label_ must be converitble to bool, and *should* *not* have side-effects
+//  * clean_ *can* (should) have side-effects
+//    * "{}" or ";" are valid clean_ values for noop
+#define REQUIRE_SUCCESS(result_arg_, label_, clean_)                    \
+    {                                                                   \
+        const VkResult result_ = (result_arg_);                         \
+        if (result_ != VK_SUCCESS) {                                    \
+            { clean_; }                                                 \
+            if (bool(label_)) {                                         \
+                FAIL() << string_VkResult(result_) << ": " << (label_); \
+            } else {                                                    \
+                FAIL() << string_VkResult(result_);                     \
+            }                                                           \
+        }                                                               \
+    }
+
 #endif  // TEST_COMMON_H


### PR DESCRIPTION
So to handle the timeout in my acquire/present testing, initially had a lamba doing the timeout check, but didn't actually "FAIL" correctly (i.e. return from the test).

This refactors that logic into a macro which will, and incorporates cleanup support.  Relocated to tests_common as REQUIRE_SUCCESS is likely useful anywhere we're failing on timeout, as it includes that cleanup capability.