### PR TITLE
layers: Attempt (again) to solve semaphore race conditions

### DIFF
--- a/layers/queue_state.h
+++ b/layers/queue_state.h
@@ -122,11 +122,9 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     }
 
     struct SemOp {
-        SemOp() : op_type(kNone), queue(nullptr), seq(0), payload(0) {}
         SemOp(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload)
             : op_type(ot), queue(q), seq(queue_seq), payload(timeline_payload) {}
-        // NOTE: c++11 doesn't allow aggregate initialization and default member
-        // initializers in the same struct. This limitation is removed in c++14
+
         OpType op_type;
         QUEUE_STATE *queue;
         uint64_t seq;
@@ -136,18 +134,32 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
 
         bool IsWait() const { return op_type == kWait; }
         bool IsSignal() const { return op_type == kSignal; }
+        bool IsAcquire() const { return op_type == kBinaryAcquire; }
 
         // NOTE: Present semaphores are waited on by the implementation, not queue operations. We do not yet
         // have a good way to figure out when this wait completes, so we must assume they are safe to re-use
         bool CanBeSignaled() const { return op_type == kNone || op_type == kWait; }
         bool CanBeWaited() const {  return op_type == kSignal || op_type == kBinaryAcquire; }
+
+        void Notify() const;
     };
 
-    struct SemOpEntry : public SemOp {
-        SemOpEntry(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload)
-            : SemOp(ot, q, queue_seq, timeline_payload), completed(), waiter(completed.get_future()) {}
+    struct TimePoint {
+        TimePoint(SemOp &op) : signal_op(), completed(), waiter(completed.get_future()) {
+            if (op.op_type == kWait) {
+                wait_ops.emplace(op);
+            } else {
+                signal_op.emplace(op);
+            }
+        }
+        layer_data::optional<SemOp> signal_op;
+        std::set<SemOp> wait_ops;
         std::promise<void> completed;
         std::shared_future<void> waiter;
+
+        bool HasSignaler() const { return signal_op.has_value(); }
+        bool HasWaiters() const { return !wait_ops.empty(); }
+        void Notify() const;
     };
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -200,7 +212,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
 
     // Enqueue a semaphore operation. For binary semaphores, the payload value is generated and
     // returned, so that every semaphore operation has a unique value.
-    bool EnqueueSignal(QUEUE_STATE *queue, uint64_t queue_seq, uint64_t &payload);
+    void EnqueueSignal(QUEUE_STATE *queue, uint64_t queue_seq, uint64_t &payload);
     void EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64_t &payload);
 
     // Binary only special cases enqueue functions
@@ -217,18 +229,14 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     // Remove completed operations and signal any waiters. This should only be called by QUEUE_STATE
     void Retire(QUEUE_STATE *current_queue, uint64_t payload);
 
-    // For vkSignalSemaphores()
-    void RetireTimeline(uint64_t payload);
-
     // look for most recent / highest payload operation that matches
     layer_data::optional<SemOp> LastOp(const std::function<bool(const SemOp &, bool is_pending)> &filter = nullptr) const;
 
     bool CanBeSignaled() const;
     bool CanBeWaited() const;
-    VkQueue AnotherQueueWaitsBinary(VkQueue queue) const;
     bool HasPendingOps() const {
         auto guard = ReadLock();
-        return !operations_.empty();
+        return !timeline_.empty();
     }
 
     void Import(VkExternalSemaphoreHandleTypeFlagBits handle_type, VkSemaphoreImportFlags flags);
@@ -250,9 +258,9 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     uint64_t next_payload_;
 
     // Set of pending operations ordered by payload.
-    // Timeline operations can be added in any order and multiple operations
+    // Timeline operations can be added in any order and multiple wait operations
     // can use the same payload value.
-    std::multimap<uint64_t, SemOpEntry> operations_;
+    std::map<uint64_t, TimePoint> timeline_;
     mutable ReadWriteLock lock_;
     ValidationStateTracker &dev_data_;
 };
@@ -313,12 +321,12 @@ class QUEUE_STATE : public BASE_NODE {
     // Tell the queue and then wait for it to finish updating its state.
     // UINT64_MAX means to finish all submissions.
     void NotifyAndWait(uint64_t until_seq = UINT64_MAX);
+    std::shared_future<void> Wait(uint64_t until_seq = UINT64_MAX);
 
     const uint32_t queueFamilyIndex;
     const VkDeviceQueueCreateFlags flags;
     const VkQueueFamilyProperties queueFamilyProperties;
 
-    std::shared_future<void> Wait(uint64_t until_seq = UINT64_MAX);
   private:
     using LockGuard = std::unique_lock<std::mutex>;
     void ThreadFunc();

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -14223,51 +14223,6 @@ TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
     vk::DestroyPipeline(m_device->handle(), library, nullptr);
 }
 
-TEST_F(VkLayerTest, TestMultipleQueuesWaitingOnSemaphore) {
-    TEST_DESCRIPTION("Test submitting two command buffers that wait on the same semaphore to different queues.");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-
-    if (m_device->graphics_queues().size() < 2) {
-        GTEST_SKIP() << "2 graphics queues are needed";
-    }
-
-    auto sem_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-
-    vk_testing::Semaphore semaphore;
-    semaphore.init(*m_device, sem_info);
-
-    VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-
-    auto signal_submit_info = LvlInitStruct<VkSubmitInfo>();
-    signal_submit_info.signalSemaphoreCount = 1;
-    signal_submit_info.pSignalSemaphores = &semaphore.handle();
-
-    auto wait_submit_info = LvlInitStruct<VkSubmitInfo>();
-    wait_submit_info.waitSemaphoreCount = 1;
-    wait_submit_info.pWaitSemaphores = &semaphore.handle();
-    wait_submit_info.pWaitDstStageMask = &stageFlags;
-
-    auto wait_and_signal_submit_info = LvlInitStruct<VkSubmitInfo>();
-    wait_and_signal_submit_info.signalSemaphoreCount = 1;
-    wait_and_signal_submit_info.pSignalSemaphores = &semaphore.handle();
-    wait_and_signal_submit_info.waitSemaphoreCount = 1;
-    wait_and_signal_submit_info.pWaitSemaphores = &semaphore.handle();
-    wait_and_signal_submit_info.pWaitDstStageMask = &stageFlags;
-
-    VkQueue other = m_device->graphics_queues()[1]->handle();
-
-    vk::QueueSubmit(m_device->m_queue, 1, &signal_submit_info, VK_NULL_HANDLE);
-    vk::QueueSubmit(m_device->m_queue, 1, &wait_and_signal_submit_info, VK_NULL_HANDLE);
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit-pWaitSemaphores-00068");
-    vk::QueueSubmit(other, 1, &wait_submit_info, VK_NULL_HANDLE);
-    m_errorMonitor->VerifyFound();
-
-    // Need to ensure semaphore is not in use before the test ends and it gets destroyed
-    vk::QueueWaitIdle(m_device->m_queue);
-}
-
 TEST_F(VkLayerTest, IncompatibleRenderPass) {
     TEST_DESCRIPTION("Validate if attachments in render pass and descriptor set use the same image subresources");
 


### PR DESCRIPTION
Store signal and wait operation(s) in a single std::map entry. For timeline semaphores, there can only ever be 1 signal operation for each value. For binary semaphores, each signal operation must have exactly 1 wait. Storing the signals and waits together makes it easier to keep track of these conditions. (Reminder: for binary semaphores, timeline-like values are assigned to every signal/wait signal pair by SEMAPHORE_STATE itself)

Stop assuming that completion of any signal operation implies anything about operations with lower timeline values. Instead, only retire the exact timeline value for each semaphore when its queue submission (or host signal operation) completes. The retire should trigger a chain reaction through all of the queues causing prior operations to retire in the correct order.

Fixes #4733