### PR TITLE
layers: Remove unused ValidateViConsistency

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -670,7 +670,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE* pipeline) const;
-    bool ValidateViConsistency(safe_VkPipelineVertexInputStateCreateInfo const* vi) const;
     bool ValidateViAgainstVsInputs(safe_VkPipelineVertexInputStateCreateInfo const* vi, const SHADER_MODULE_STATE& module_state,
                                    const Instruction& entrypoint) const;
     bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -59,7 +59,6 @@ static const char DECORATE_UNUSED *kVUID_Core_DrawState_QueueForwardProgress = "
 static const char DECORATE_UNUSED *kVUID_Core_DrawState_InvalidImageView = "UNASSIGNED-CoreValidation-DrawState-InvalidImageView";
 
 static const char DECORATE_UNUSED *kVUID_Core_Shader_InconsistentSpirv = "UNASSIGNED-CoreValidation-Shader-InconsistentSpirv";
-static const char DECORATE_UNUSED *kVUID_Core_Shader_InconsistentVi = "UNASSIGNED-CoreValidation-Shader-InconsistentVi";
 static const char DECORATE_UNUSED *kVUID_Core_Shader_InputAttachmentTypeMismatch = "UNASSIGNED-CoreValidation-Shader-InputAttachmentTypeMismatch";
 static const char DECORATE_UNUSED *kVUID_Core_Shader_InputNotProduced = "UNASSIGNED-CoreValidation-Shader-InputNotProduced";
 static const char DECORATE_UNUSED *kVUID_Core_Shader_InterfaceTypeMismatch = "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch";


### PR DESCRIPTION
I realized that `ValidateViConsistency` is not being checked because there is already 

> VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616
>
> All elements of pVertexBindingDescriptions must describe distinct binding numbers

That is validating this

Also while at it, took the `vkCmdSetVertexInputEXT` logic and made it consistent and improved the error message