### PR TITLE
cmake: Remove BUILD_WSI_*

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -310,9 +310,6 @@ on/off options currently supported by this repository:
 | BUILD_TESTS | All | `OFF` | Controls whether or not the validation layer tests are built. |
 | INSTALL_TESTS | All | `OFF` | Controls whether or not the validation layer tests are installed. This option is only available when `BUILD_TESTS` is `ON` |
 | BUILD_WERROR | All | `ON` | Controls whether or not to treat compiler warnings as errors. |
-| BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the components with XCB support. |
-| BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the components with Xlib support. |
-| BUILD_WSI_WAYLAND_SUPPORT | Linux | `ON` | Build the components with Wayland support. |
 
 ### CCACHE
 
@@ -541,7 +538,7 @@ repository to other Linux distributions.
 
     sudo apt-get install git build-essential libx11-xcb-dev \
         libxkbcommon-dev libwayland-dev libxrandr-dev \
-        libegl1-mesa-dev
+        libegl1-mesa-dev pkg-config
 
 ##### Required package for Ubuntu 18.04 users
 
@@ -628,16 +625,6 @@ You can also use
     cmake --build .
 
 ### Linux Notes
-
-#### WSI Support Build Options
-
-By default, the repository components are built with support for the
-Vulkan-defined WSI display servers: Xcb, Xlib, and Wayland. It is recommended
-to build the repository components with support for these display servers to
-maximize their usability across Linux platforms. If it is necessary to build
-these modules without support for one of the display servers, the appropriate
-CMake option of the form `BUILD_WSI_xxx_SUPPORT` can be set to `OFF`.
-
 #### Linux Install to System Directories
 
 Installing the files resulting from your build to the systems directories is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,28 +135,19 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(LAYERS_HELPER_FOLDER "Helper Targets")
 
 set(LINUX OFF) # NOTE: Variable as of 3.25
-if (UNIX AND NOT APPLE) # Options for Linux only
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(LINUX ON)
-
-    option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
-    option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
-    option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
 
     find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
 
-    if(BUILD_WSI_XCB_SUPPORT)
-        pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
-        add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
-    endif()
-
-    if(BUILD_WSI_XLIB_SUPPORT)
-        pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
-        add_definitions(-DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT)
-    endif()
-
-    if(BUILD_WSI_WAYLAND_SUPPORT)
-        add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
-    endif()
+    pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
+    pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
+    
+    add_definitions(
+        -DVK_USE_PLATFORM_XCB_KHR # XCB
+        -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT # X11
+        -DVK_USE_PLATFORM_WAYLAND_KHR # Wayland
+    )
 endif()
 
 option(BUILD_WERROR "Treat compiler warnings as errors" ON)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,18 +156,14 @@ target_link_libraries(vk_layer_validation_tests PRIVATE
     SPIRV-Tools-opt
     GTest::gtest
     GTest::gtest_main
+    ${CMAKE_DL_LIBS}
 )
 
-if (NOT WIN32)
-    target_link_libraries(vk_layer_validation_tests PRIVATE ${CMAKE_DL_LIBS})
-
-    if(BUILD_WSI_XCB_SUPPORT)
-        target_link_libraries(vk_layer_validation_tests PRIVATE PkgConfig::XCB)
-    endif()
-
-    if (BUILD_WSI_XLIB_SUPPORT)
-        target_link_libraries(vk_layer_validation_tests PRIVATE PkgConfig::X11)
-    endif()
+if (LINUX)
+    target_link_libraries(vk_layer_validation_tests PRIVATE
+        PkgConfig::XCB
+        PkgConfig::X11
+    )
 endif()
 
 if(INSTALL_TESTS)


### PR DESCRIPTION
When building for linux, we should always support all 3 of the WSI interfaces. That's currently what we do for all SDK releases.

Micro-optimizing the WSI libraries will only cause issues.