### PR TITLE
scripts: Address python tarfile exploit

### DIFF
--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2021 Valve Corporation
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021-2022 Valve Corporation
+# Copyright (c) 2021-2022 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,11 +68,30 @@ class URLRequest:
 
     def close(self): self.conn_.close()
 
+# Addresses CVE-2007-4559 security bug around malicious tar files
+# https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4715
+def _safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+    def is_within_directory(directory, target):
+        abs_directory = os.path.abspath(directory)
+        abs_target = os.path.abspath(target)
+
+        prefix = os.path.commonprefix([abs_directory, abs_target])
+
+        return prefix == abs_directory
+
+    for member in tar.getmembers():
+        member_path = os.path.join(path, member.name)
+        if not is_within_directory(path, member_path):
+            raise Exception("Attempted Path Traversal in Tar File")
+
+    tar.extractall(path, members, numeric_owner=numeric_owner)
+
 # Currently only gzip tar and zip files are supported
 def expand_archive(path):
     if path.endswith('tar.gz') or path.endswith('tgz'):
         import tarfile
-        with tarfile.open(path, 'r:gz') as tar: tar.extractall()
+        with tarfile.open(path, 'r:gz') as tar:
+            _safe_extract(tar = tar)
     elif path.endswith('.zip'):
         import zipfile
         with zipfile.ZipFile(path, 'r') as archive: archive.extractall('.')


### PR DESCRIPTION
Basically just a cleaned up version of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4715 since the bot can't sign a CLA