### PR TITLE
layers: Fix null DSLs

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1143,6 +1143,10 @@ bool CoreChecks::ValidateShaderStageMaxResources(const SHADER_MODULE_STATE &modu
     const auto &layout_state = pipeline->PipelineLayoutState();
     if (layout_state) {
         for (const auto &set_layout : layout_state->set_layouts) {
+            if (!set_layout) {
+                continue;
+            }
+
             if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) != 0) {
                 continue;
             }


### PR DESCRIPTION
Fix a crash in
dEQP-VK.pipeline.pipeline_library.graphics_library.misc.other .null_descriptor_set_in_monolithic_pipeline
when independent sets/null DSLs are used in.