### PR TITLE
build: Remove Android dependency on Vulkan-Tools

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -131,7 +131,6 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(SRC_DIR)/libs \
-                    $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Tools/common \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
@@ -179,7 +178,6 @@ LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(SRC_DIR)/libs \
-                    $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Tools/common \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/robin-hood-hashing/src/include
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc

--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -19,12 +19,6 @@
             "commit": "v1.3.234"
         },
         {
-            "name": "Vulkan-Tools",
-            "url": "https://github.com/KhronosGroup/Vulkan-Tools.git",
-            "sub_dir": "Vulkan-Tools",
-            "commit": "v1.3.234"
-        },
-        {
             "name": "SPIRV-Tools",
             "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "sub_dir": "shaderc/third_party/spirv-tools",

--- a/build-android/update_external_sources_android.bat
+++ b/build-android/update_external_sources_android.bat
@@ -2,9 +2,9 @@
 REM Update source for glslang, spirv-tools, and shaderc
 
 REM
-REM Copyright 2016 The Android Open Source Project
-REM Copyright (C) 2015 Valve Corporation
-REM Copyright 2018 LunarG, Inc.
+REM Copyright (c) 2016 The Android Open Source Project
+REM Copyright (c) 2015-2022 Valve Corporation
+REM Copyright (c) 2018-2022 LunarG, Inc.
 REM
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ if %ERRORLEVEL% equ 1 (
 
 if %errorCode% neq 0 (goto:error)
 
-echo Creating and/or updating glslang, spirv-tools, spirv-headers, shaderc, vulkan-headers, vulkan-tools in %BASE_DIR%
+echo Creating and/or updating glslang, spirv-tools, spirv-headers, shaderc, vulkan-headers in %BASE_DIR%
 
 set build-shaderc=1
 

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -27,11 +27,7 @@
 #ifndef VKLAYERTEST_H
 #define VKLAYERTEST_H
 
-#ifdef ANDROID
-#include "vulkan_wrapper.h"
-#else
 #include <vulkan/vulkan.h>
-#endif
 
 #include "layers/vk_lunarg_device_profile_api_layer.h"
 #include "vk_layer_settings_ext.h"


### PR DESCRIPTION
@juan-lunarg asked why the Android build needs Vulkan-Tools and I couldn't find a good reason!