### PR TITLE
cmake: Cleanup layers/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,6 @@ if(WIN32)
         target_compile_definitions(VkLayer_utils PUBLIC "_WIN32_WINNT=0x0600")
     endif()
 endif()
-install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 set_target_properties(VkLayer_utils PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(VkLayer_utils
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/layers

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -69,39 +69,8 @@ if(BUILD_LAYER_SUPPORT_FILES)
         generated/vk_extension_helper.h
         generated/vk_typemap_helper.h)
     install(FILES ${LAYER_UTIL_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan)
+    install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
-
-set(TARGET_NAMES
-    VkLayer_khronos_validation)
-
-# System-specific macro to create a library target.
-macro(AddVkLayer target LAYER_COMPILE_DEFINITIONS)
-    add_library(VkLayer_${target} SHARED ${ARGN})
-    set_target_properties(VkLayer_${target} PROPERTIES CXX_STANDARD ${VVL_CPP_STANDARD})
-    target_compile_definitions(VkLayer_${target} PUBLIC ${LAYER_COMPILE_DEFINITIONS})
-    target_link_libraries(VkLayer_${target} PRIVATE VkLayer_utils)
-
-    if (VVL_ENABLE_ASAN)
-        target_compile_options(VkLayer_${target} PRIVATE -fsanitize=address)
-        # NOTE: Use target_link_options when cmake 3.13 is available on CI
-        target_link_libraries(VkLayer_${target} PRIVATE "-fsanitize=address")
-    endif()
-
-    if(WIN32)
-        target_sources(VkLayer_${target} PRIVATE VkLayer_${target}.def)
-        target_compile_definitions(VkLayer_${target} PUBLIC NOMINMAX)
-    elseif(APPLE)
-        set_target_properties(VkLayer_${target}
-                              PROPERTIES LINK_FLAGS
-                                         "-Wl"
-                                         INSTALL_RPATH
-                                         "@loader_path/")
-    else(LINUX)
-        set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_${target}.map,-Bsymbolic,--exclude-libs,ALL")
-    endif()
-
-    install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endmacro()
 
 if(MSVC)
     # Applies to all configurations
@@ -273,7 +242,9 @@ if(INSTRUMENT_OPTICK)
 endif()
 
 if(BUILD_LAYERS)
-    AddVkLayer(khronos_validation "${KHRONOS_LAYER_COMPILE_DEFINITIONS}"
+    add_library(VkLayer_khronos_validation SHARED)
+
+    target_sources(VkLayer_khronos_validation PRIVATE
         ${CHASSIS_LIBRARY_FILES}
         ${CORE_VALIDATION_LIBRARY_FILES}
         ${OBJECT_LIFETIMES_LIBRARY_FILES}
@@ -284,7 +255,38 @@ if(BUILD_LAYERS)
         ${GPU_ASSISTED_LIBRARY_FILES}
         ${DEBUG_PRINTF_LIBRARY_FILES}
         ${SYNC_VALIDATION_LIBRARY_FILES}
-        ${OPTICK_SOURCE_FILES})
+        ${OPTICK_SOURCE_FILES}
+    )
+
+    set_target_properties(VkLayer_khronos_validation PROPERTIES
+        CXX_STANDARD ${VVL_CPP_STANDARD}
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+    
+    target_compile_definitions(VkLayer_khronos_validation PUBLIC ${KHRONOS_LAYER_COMPILE_DEFINITIONS})
+    target_link_libraries(VkLayer_khronos_validation PRIVATE VkLayer_utils)
+
+    if (VVL_ENABLE_ASAN)
+        target_compile_options(VkLayer_khronos_validation PRIVATE -fsanitize=address)
+        # NOTE: Use target_link_options when cmake 3.13 is available on CI
+        target_link_libraries(VkLayer_khronos_validation PRIVATE "-fsanitize=address")
+    endif()
+
+    if(WIN32)
+        target_sources(VkLayer_khronos_validation PRIVATE VkLayer_khronos_validation.def)
+        target_compile_definitions(VkLayer_khronos_validation PUBLIC NOMINMAX)
+    elseif(APPLE)
+        set_target_properties(VkLayer_khronos_validation
+                                PROPERTIES LINK_FLAGS
+                                            "-Wl"
+                                            INSTALL_RPATH
+                                            "@loader_path/")
+    else(LINUX)
+        set_target_properties(VkLayer_khronos_validation PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_khronos_validation.map,-Bsymbolic,--exclude-libs,ALL")
+    endif()
+
+    install(TARGETS VkLayer_khronos_validation DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     # Force generation of the PDB file for Release builds.
     # Note that CMake reduces inlining optimization levels for RelWithDebInfo builds.
@@ -307,7 +309,6 @@ if(BUILD_LAYERS)
     target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
     target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_TARGET} SPIRV-Tools-opt)
 
-
     # The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
     # because the json format uses backslash escapes
     file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)
@@ -320,50 +321,36 @@ if(BUILD_LAYERS)
     # compile time, instead of configure time Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and
     # TARGET_FILE_DIR, specifically)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\" @ONLY)")
-    foreach(TARGET_NAME ${TARGET_NAMES})
-        set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in" -DVK_VERSION=${VulkanHeaders_VERSION})
-        # If this json file is not a metalayer, get the needed properties from that target
-        if(TARGET ${TARGET_NAME})
-            set(CONFIG_DEFINES
-                ${CONFIG_DEFINES}
-                -DOUTPUT_FILE="$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json"
-                -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>")
-            # If this json file is a metalayer, make the output path match core validation, and there is no layer binary file
-        else()
-            set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_khronos_validation>/${TARGET_NAME}.json")
-        endif()
-        add_custom_target(${TARGET_NAME}-json ALL
-                          COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
-        if (MSVC_IDE)
-            set_target_properties(${TARGET_NAME}-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
-        endif()
-    endforeach()
+    
+    set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/VkLayer_khronos_validation.json.in" -DVK_VERSION=${VulkanHeaders_VERSION})
+
+    set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_khronos_validation>/VkLayer_khronos_validation.json")
+
+    set(CONFIG_DEFINES ${CONFIG_DEFINES} -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:VkLayer_khronos_validation>")
+
+    add_custom_target(VkLayer_khronos_validation-json ALL
+                        COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+
+    set_target_properties(VkLayer_khronos_validation-json PROPERTIES FOLDER ${LAYERS_HELPER_FOLDER})
 
     # For UNIX-based systems, `library_path` should not contain a relative path (indicated by "./") before installing to system
     # directories, so we do not include it in the staging-json files which are used for installation
     if(UNIX)
-        foreach(TARGET_NAME ${TARGET_NAMES})
-            set(INSTALL_DEFINES
-                -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
-                -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json"
-                -DVK_VERSION=${VulkanHeaders_VERSION})
-            # If this json file is not a metalayer, get the needed properties from that target
-            if(TARGET ${TARGET_NAME})
-                set(INSTALL_DEFINES ${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY="$<TARGET_FILE_NAME:${TARGET_NAME}>")
-            endif()
-            add_custom_target(${TARGET_NAME}-staging-json ALL
-                              COMMAND ${CMAKE_COMMAND} ${INSTALL_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
-        endforeach()
+        set(INSTALL_DEFINES
+            -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/VkLayer_khronos_validation.json.in"
+            -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/staging-json/VkLayer_khronos_validation.json"
+            -DVK_VERSION=${VulkanHeaders_VERSION})
+
+        set(INSTALL_DEFINES ${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY="$<TARGET_FILE_NAME:VkLayer_khronos_validation>")
+
+        add_custom_target(VkLayer_khronos_validation-staging-json ALL
+                            COMMAND ${CMAKE_COMMAND} ${INSTALL_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
     endif()
 
     # Install the layer json files
-    foreach(TARGET_NAME ${TARGET_NAMES})
-        if(WIN32)
-            install(FILES $<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json
-                    DESTINATION ${CMAKE_INSTALL_LIBDIR})
-        elseif(UNIX)
-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/${TARGET_NAME}.json
-                    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d)
-        endif()
-    endforeach()
+    if(WIN32)
+        install(FILES $<TARGET_FILE_DIR:VkLayer_khronos_validation>/VkLayer_khronos_validation.json DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    elseif(UNIX)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/staging-json/VkLayer_khronos_validation.json DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/explicit_layer.d)
+    endif()
 endif()


### PR DESCRIPTION
- Remove pointless macro AddVkLayer that makes reading/debugging
much more difficult.
- Remove TARGET_NAMES since it also makes reading/debugging much
more difficult
- Move VkLayers_Utils to appropriate location