### PR TITLE
cmake: Update min to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16...3.19)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(Vulkan-ValidationLayers LANGUAGES CXX C)

--- a/scripts/cmake_test_min.py
+++ b/scripts/cmake_test_min.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021 Valve Corporation
-# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021-2022 Valve Corporation
+# Copyright (c) 2021-2022 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ def get_cmake_min_version():
         if m is not None:
             return m.group(1)
         else:
-            return '3.10.2'
+            return '3.16.3'
 
 
 curr_platform = platform.system().lower()


### PR DESCRIPTION
[CMake 3.16 is shipped with Ubuntu 20.04 LTS](https://packages.ubuntu.com/search?suite=focal&searchon=names&keywords=cmake)