### PR TITLE
layers: Improve shader descriptor error message

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -3041,28 +3041,28 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE *pipeline, con
             LogObjectList objlist(module_state.vk_shader_module());
             objlist.add(pipeline->PipelineLayoutState()->layout());
             skip |= LogError(objlist, vuid_layout_mismatch,
-                             "Shader uses descriptor slot %u.%u (expected `%s`) but not declared in pipeline layout", use.first.set,
-                             use.first.binding, string_descriptorTypes(descriptor_types).c_str());
+                             "Set %u Binding %u in shader uses descriptor slot (expected `%s`) but not declared in pipeline layout",
+                             use.first.set, use.first.binding, string_descriptorTypes(descriptor_types).c_str());
         } else if (~binding->stageFlags & pStage->stage) {
             LogObjectList objlist(module_state.vk_shader_module());
             objlist.add(pipeline->PipelineLayoutState()->layout());
             skip |= LogError(objlist, vuid_layout_mismatch,
-                             "Shader uses descriptor slot %u.%u but descriptor not accessible from stage %s", use.first.set,
-                             use.first.binding, string_VkShaderStageFlagBits(pStage->stage));
+                             "Set %u Binding %u in shader uses descriptor slot but descriptor not accessible from stage %s",
+                             use.first.set, use.first.binding, string_VkShaderStageFlagBits(pStage->stage));
         } else if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_MUTABLE_EXT) &&
                    (descriptor_types.find(binding->descriptorType) == descriptor_types.end())) {
             LogObjectList objlist(module_state.vk_shader_module());
             objlist.add(pipeline->PipelineLayoutState()->layout());
             skip |= LogError(objlist, vuid_layout_mismatch,
-                             "Type mismatch on descriptor slot %u.%u (expected `%s`) but descriptor of type %s", use.first.set,
-                             use.first.binding, string_descriptorTypes(descriptor_types).c_str(),
-                             string_VkDescriptorType(binding->descriptorType));
+                             "Set %u Binding %u type mismatch on descriptor slot, uses type %s but expected %s", use.first.set,
+                             use.first.binding, string_VkDescriptorType(binding->descriptorType),
+                             string_descriptorTypes(descriptor_types).c_str());
         } else if (binding->descriptorCount < required_descriptor_count) {
             LogObjectList objlist(module_state.vk_shader_module());
             objlist.add(pipeline->PipelineLayoutState()->layout());
             skip |= LogError(objlist, vuid_layout_mismatch,
-                             "Shader expects at least %u descriptors for binding %u.%u but only %u provided",
-                             required_descriptor_count, use.first.set, use.first.binding, binding->descriptorCount);
+                             "Set %u Binding %u in shader expects at least %u descriptors, but only %u provided", use.first.set,
+                             use.first.binding, required_descriptor_count, binding->descriptorCount);
         }
     }
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4461,7 +4461,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckShaderDescriptorTypeMismatch) {
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&descriptor_set.layout_});
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Type mismatch on descriptor slot 0.0 ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-00756");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -4495,7 +4495,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckShaderDescriptorNotAccessible) {
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&ds.layout_});
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Shader uses descriptor slot 0.0 ");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-00756");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -6381,7 +6381,7 @@ TEST_F(VkLayerTest, CreateComputePipelineMissingDescriptor) {
     pipe.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT));
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {});
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Shader uses descriptor slot 0.0");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-00703");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -6404,8 +6404,7 @@ TEST_F(VkLayerTest, CreateComputePipelineDescriptorTypeMismatch) {
         helper.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT));
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     };
-    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                             "but descriptor of type VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER");
+    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-00703");
 }
 
 TEST_F(VkLayerTest, MultiplePushDescriptorSets) {


### PR DESCRIPTION
The error message `Shader uses descriptor slot 1.0` is not helpful for most people, explicitly say `Set 1 Binding 0` now