### PR TITLE
test: Increase gtest discovery timeout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,7 +117,7 @@ add_executable(vk_layer_validation_tests
 if (CMAKE_CROSSCOMPILING)
     gtest_add_tests(TARGET vk_layer_validation_tests)
 else()
-    gtest_discover_tests(vk_layer_validation_tests)
+    gtest_discover_tests(vk_layer_validation_tests DISCOVERY_TIMEOUT 100)
 endif()
 
 add_dependencies(vk_layer_validation_tests VkLayer_khronos_validation VkLayer_khronos_validation-json)


### PR DESCRIPTION
The short default timeout of 1 second caused CI runs to fail when the call to gtest_discover_tests would error. Setting it to 100 makes the timeout be one hundred seconds, giving ample time for the command to run.