### PR TITLE
layers: Ensure shader stage validation for GPL 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build-android/third_party
 .DS_Store
 .editorconfig
 scripts/.vs
+.*.sw[op]

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -258,10 +258,11 @@ static layer_data::unordered_set<uint32_t> GetFSOutputLocations(const PIPELINE_S
     return result;
 }
 
-static VkPrimitiveTopology GetTopologyAtRasterizer(const PIPELINE_STATE::StageStateVec &stage_states,
-                                                   const safe_VkPipelineInputAssemblyStateCreateInfo *assembly_state) {
-    VkPrimitiveTopology result = assembly_state ? assembly_state->topology : static_cast<VkPrimitiveTopology>(0);
-    for (const auto &stage : stage_states) {
+static VkPrimitiveTopology GetTopologyAtRasterizer(const PIPELINE_STATE &pipeline) {
+    auto result = (pipeline.vertex_input_state && pipeline.vertex_input_state->input_assembly_state)
+                      ? pipeline.vertex_input_state->input_assembly_state->topology
+                      : VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
+    for (const auto &stage : pipeline.stage_state) {
         if (!stage.entrypoint) {
             continue;
         }
@@ -536,7 +537,7 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       active_slots(GetActiveSlots(stage_state)),
       max_active_slot(GetMaxActiveSlot(active_slots)),
       active_shaders(GetActiveShaders(stage_state)),
-      topology_at_rasterizer(GetTopologyAtRasterizer(stage_state, create_info.graphics.pInputAssemblyState)),
+      topology_at_rasterizer(GetTopologyAtRasterizer(*this)),
       uses_shader_module_id(UsesShaderModuleId(stage_state)),
       descriptor_buffer_mode((create_info.graphics.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
       uses_pipeline_robustness(UsesPipelineRobustness(PNext(), stage_state)),
@@ -607,7 +608,6 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       stage_state(GetStageStates(*state_data, *this, csm_states)),
       active_slots(GetActiveSlots(stage_state)),
       active_shaders(GetActiveShaders(stage_state)),
-      topology_at_rasterizer{},
       uses_shader_module_id(UsesShaderModuleId(stage_state)),
       descriptor_buffer_mode((create_info.compute.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
       uses_pipeline_robustness(UsesPipelineRobustness(PNext(), stage_state)),
@@ -623,7 +623,6 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       stage_state(GetStageStates(*state_data, *this, csm_states)),
       active_slots(GetActiveSlots(stage_state)),
       active_shaders(GetActiveShaders(stage_state)),
-      topology_at_rasterizer{},
       uses_shader_module_id(UsesShaderModuleId(stage_state)),
       descriptor_buffer_mode((create_info.raytracing.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
       uses_pipeline_robustness(UsesPipelineRobustness(PNext(), stage_state)),
@@ -641,7 +640,6 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       stage_state(GetStageStates(*state_data, *this, csm_states)),
       active_slots(GetActiveSlots(stage_state)),
       active_shaders(GetActiveShaders(stage_state)),
-      topology_at_rasterizer{},
       uses_shader_module_id(UsesShaderModuleId(stage_state)),
       descriptor_buffer_mode((create_info.graphics.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
       uses_pipeline_robustness(UsesPipelineRobustness(PNext(), stage_state)),

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -213,7 +213,7 @@ class PIPELINE_STATE : public BASE_NODE {
 
     // Flag of which shader stages are active for this pipeline
     const uint32_t active_shaders = 0;
-    const VkPrimitiveTopology topology_at_rasterizer;
+    const VkPrimitiveTopology topology_at_rasterizer = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
     const bool uses_shader_module_id;
     const bool descriptor_buffer_mode = false;
     const bool uses_pipeline_robustness;
@@ -274,7 +274,7 @@ class PIPELINE_STATE : public BASE_NODE {
         }
     }
 
-    bool IsGraphicsLibrary() const { return graphics_lib_type != static_cast<VkGraphicsPipelineLibraryFlagsEXT>(0); }
+    bool IsGraphicsLibrary() const { return !HasFullState(); }
     bool HasFullState() const { return vertex_input_state && pre_raster_state && fragment_shader_state && fragment_output_state; }
 
     template <VkGraphicsPipelineLibraryFlagBitsEXT type_flag>

--- a/tests/positive/graphics_library.cpp
+++ b/tests/positive/graphics_library.cpp
@@ -360,7 +360,7 @@ TEST_F(VkPositiveGraphicsLibraryLayerTest, DrawWithNullDSLs) {
     {
         const char vs_src[] = R"glsl(
             #version 450
-            layout(set=2, binding=0) uniform foo { float x; } bar;
+            layout(set=0, binding=0) uniform foo { float x; } bar;
             void main() {
             gl_Position = vec4(bar.x);
             }

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -574,6 +574,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
         frag_out.pipeline_,
     };
     vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    ASSERT_TRUE(pipe);
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
@@ -721,6 +722,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
         };
 
         vk_testing::GraphicsPipelineFromLibraries pipe2(*m_device, libraries_i64);
+        ASSERT_TRUE(pipe2);
 
         m_commandBuffer->begin(&begin_info);
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -889,6 +891,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
         frag_out.pipeline_,
     };
     vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    ASSERT_TRUE(pipe);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -1045,6 +1048,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragmentIndependentSets) {
         frag_out.pipeline_,
     };
     vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    ASSERT_TRUE(pipe);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -2314,6 +2314,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
         frag_out.pipeline_,
     };
     vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    ASSERT_TRUE(pipe);
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
     m_commandBuffer->begin(&begin_info);
@@ -2519,6 +2520,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
         frag_out.pipeline_,
     };
     vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    ASSERT_TRUE(pipe);
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
     m_commandBuffer->begin(&begin_info);

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -439,6 +439,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidCreateStateGPL) {
         pipe.InitPreRasterLibInfo(1, &stage_ci);
         pipe.InitState();
 
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06846");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06607");
         pipe.CreateGraphicsPipeline();
@@ -929,7 +930,7 @@ TEST_F(VkGraphicsLibraryLayerTest, ImmutableSamplersIncompatibleDSL) {
     {
         const char vs_src[] = R"glsl(
             #version 450
-            layout(set=2, binding=0) uniform foo { float x; } bar;
+            layout(set=0, binding=0) uniform foo { float x; } bar;
             void main() {
             gl_Position = vec4(bar.x);
             }

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -15549,6 +15549,7 @@ TEST_F(VkLayerTest, ShaderModuleIdentifier) {
     stage_ci.pNext = nullptr;
     // No shader module ci and no shader module id ci in pNext and invalid module
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06845");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-parameter");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
@@ -15648,6 +15649,7 @@ TEST_F(VkLayerTest, ShaderModuleIdentifierFeatures) {
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06846");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-parameter");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -1231,10 +1231,11 @@ struct GraphicsPipelineFromLibraries {
             auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
             pipe.init(dev, exe_pipe_ci);
         }
-        assert(pipe.initialized());
+        pipe.initialized();
     }
 
     operator VkPipeline() const { return pipe.handle(); }
+    operator bool() const { return pipe.initialized(); }
 };
 
 }  // namespace vk_testing


### PR DESCRIPTION
Fixes the IsGraphicsLibrary and a shader module identifier check that
prevented all shader stage validation from happening when GPL was in
use.

Closes #4811.