### PR TITLE
layers: Fix image nullptr crash

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -4773,6 +4773,9 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const CMD_BUFFE
     for (const auto &layout_map_entry : pCB->image_layout_map) {
         const auto *image_state = layout_map_entry.first;
         const auto &subres_map = layout_map_entry.second;
+        if (!subres_map) {
+            continue;
+        }
         const auto &layout_map = subres_map->GetLayoutMap();
         // Validate the initial_uses for each subresource referenced
         if (layout_map.empty()) continue;
@@ -4846,6 +4849,9 @@ void CoreChecks::UpdateCmdBufImageLayouts(CMD_BUFFER_STATE *pCB) {
     for (const auto &layout_map_entry : pCB->image_layout_map) {
         const auto *image_state = layout_map_entry.first;
         const auto &subres_map = layout_map_entry.second;
+        if (!subres_map) {
+            continue;
+        }
         auto guard = image_state->layout_range_map->WriteLock();
         sparse_container::splice(*image_state->layout_range_map, subres_map->GetLayoutMap(), GlobalLayoutUpdater());
     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12832,9 +12832,11 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                         }
 
                         // Verify that image memory is valid
-                        auto image_data = Get<IMAGE_STATE>(ivci.image);
-                        skip |= ValidateMemoryIsBoundToImage(image_data.get(), "vkCreateFramebuffer()",
-                                                             kVUID_Core_Bound_Resource_FreedMemoryAccess);
+                        const auto &image_data = Get<IMAGE_STATE>(ivci.image);
+                        if (image_data) {
+                            skip |= ValidateMemoryIsBoundToImage(image_data.get(), "vkCreateFramebuffer()",
+                                                                 kVUID_Core_Bound_Resource_FreedMemoryAccess);
+                        }
 
                         // Verify that view only has a single mip level
                         if (subresource_range.levelCount != 1) {
@@ -13051,8 +13053,8 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                                 string_VkComponentSwizzle(ivci.components.b), string_VkComponentSwizzle(ivci.components.a));
                         }
                         if ((ivci.viewType == VK_IMAGE_VIEW_TYPE_2D) || (ivci.viewType == VK_IMAGE_VIEW_TYPE_2D)) {
-                            auto image_state = Get<IMAGE_STATE>(ivci.image);
-                            if (image_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
+                            const auto &image_state = Get<IMAGE_STATE>(ivci.image);
+                            if (image_state && image_state->createInfo.imageType == VK_IMAGE_TYPE_3D) {
                                 if (FormatIsDepthOrStencil(ivci.format)) {
                                     LogObjectList objlist(device);
                                     objlist.add(ivci.image);


### PR DESCRIPTION
This crash happened when `vkQueuePresentKHR ` returned `VK_SUBOPTIMAL_KHR`, not sure if I can write a test for this