### PR TITLE
cmake: Fix incorrect install location

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -306,7 +306,7 @@ set(INTERMEDIATE_FILE "${CMAKE_CURRENT_BINARY_DIR}/json/validation.json")
 set(OUTPUT_FILE_FINAL_NAME "VkLayer_khronos_validation.json")
 set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
 if (WIN32)
-    set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+    set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_BINDIR}) # WIN32/MINGW expect the dll in the `bin` dir, this matches our WIN32 SDK process
 endif()
 
 if (WIN32)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -305,6 +305,9 @@ set(INPUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/json/VkLayer_khronos_validation.json
 set(INTERMEDIATE_FILE "${CMAKE_CURRENT_BINARY_DIR}/json/validation.json")
 set(OUTPUT_FILE_FINAL_NAME "VkLayer_khronos_validation.json")
 set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+if (WIN32)
+    set(LAYER_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if (WIN32)
     set(JSON_LIBRARY_PATH ".\\\\VkLayer_khronos_validation.dll")


### PR DESCRIPTION
After looking into this for a while. CMake doesn't have a standard location for `MODULE` libraries. Because there is no standard for plugin type libraries.

As a result just match our SDK creation process. This doesn't change UNIX platforms, it only matches our WIN32 SDK installation.

closes #4805

Example install ouput

```
# WIN32
-- Installing: D:/a/.../install/bin/VkLayer_khronos_validation.json
-- Installing: D:/a/.../install/bin/VkLayer_khronos_validation.dll
```