### PR TITLE
cmake: Fix incorrect else() argument warning

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -271,7 +271,7 @@ if(WIN32)
     target_compile_definitions(VkLayer_khronos_validation PUBLIC NOMINMAX)
 elseif(APPLE)
     set_target_properties(VkLayer_khronos_validation PROPERTIES SUFFIX ".dylib")
-else(LINUX)
+else()
     set_target_properties(VkLayer_khronos_validation PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_khronos_validation.map,-Bsymbolic,--exclude-libs,ALL")
 endif()
 


### PR DESCRIPTION
CMake requires the same argument in if(), else(), endif() sequences.

"elseif(LINUX)" may have been intended here, but simply removing the LINUX from the else() retains current behavior and is arguably clearer than replacing it with "APPLE" to match the else with the if.