### PR TITLE
Add several RTX VUIDs, Update `buffer` <-> `device address` mapping

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -107,7 +107,8 @@ Note that currently, VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT validation is n
 ### Buffer device address checking
 The vkGetBufferDeviceAddressEXT routine can be used to get a GPU address that a shader can use to directly address a particular buffer.
 GPU-Assisted Validation code keeps track of all such addresses, along with the size of the associated buffer, and creates an input buffer listing all such address/size pairs
-Shader code is instrumented to validate buffer_reference addresses and report any reads or writes that do no fall within the listed address/size regions._
+Shader code is instrumented to validate buffer_reference addresses and report any reads or writes that do no fall within the listed address/size regions.
+Note: The mapping between a `VkBuffer` and a GPU address is not necessarily one to one. For instance, if multiple `VkBuffer` are bound to the same memory region, they can have the same GPU address.
 
 ## GPU-Assisted Validation Limitations
 

--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -35,6 +35,7 @@
 #include "device_state.h"
 #include "descriptor_sets.h"
 #include "qfo_transfer.h"
+#include "vk_layer_data.h"
 
 struct SUBPASS_INFO;
 class FRAMEBUFFER_STATE;
@@ -356,6 +357,12 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     void AddChild(std::shared_ptr<StateObject> &child_node) {
         auto base = std::static_pointer_cast<BASE_NODE>(child_node);
         AddChild(base);
+    }
+    template <typename StateObject>
+    void AddChildren(layer_data::span<std::shared_ptr<StateObject>> &child_nodes) {
+        for (auto &child_node : child_nodes) {
+            AddChild(child_node);
+        }
     }
 
     void RemoveChild(std::shared_ptr<BASE_NODE> &base_node);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -1140,6 +1140,15 @@ class CoreChecks : public ValidationStateTracker {
                                        VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                        VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                        uint32_t width, uint32_t height, uint32_t depth) const override;
+    bool ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuffer, const char* rt_func_name,
+                                              const char* vuid_single_device_memory, const char* vuid_binding_table_flag,
+                                              const VkStridedDeviceAddressRegionKHR& binding_table,
+                                              const char* binding_table_name) const;
+    bool ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer commandBuffer,
+                                 const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                 const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                 const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                 const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable) const;
     bool PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
                                         const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -20,9 +20,6 @@
  */
 #pragma once
 
-#ifndef RANGE_VECTOR_H_
-#define RANGE_VECTOR_H_
-
 #include <algorithm>
 #include <cassert>
 #include <limits>
@@ -168,6 +165,9 @@ struct split_op_keep_upper {
 };
 
 enum class value_precedence { prefer_source, prefer_dest };
+
+template <typename Iterator, typename Map, typename Range>
+Iterator split(Iterator in, Map &map, const Range &range);
 
 // The range based sparse map implemented on the ImplMap
 template <typename Key, typename T, typename RangeKey = range<Key>, typename ImplMap = std::map<RangeKey, T>>
@@ -377,7 +377,7 @@ class range_map {
                     // for the range
                     pos = split_impl(pos, bounds.end, split_op_keep_both());
                 }
-                // advance to the upper haf of the split which will be upper_bound  or to next which will both be out of bounds
+                // advance to the upper half of the split which will be upper_bound  or to next which will both be out of bounds
                 ++pos;
                 RANGE_ASSERT(!bounds.includes(pos->first.begin));
             }
@@ -387,12 +387,13 @@ class range_map {
         return range<ImplIterator>(lower, pos);
     }
 
-    ImplIterator impl_erase_range(const key_type &bounds, ImplIterator lower) {
+    template <typename TouchOp>
+    ImplIterator impl_erase_range(const key_type &bounds, ImplIterator lower, const TouchOp &touch_mapped_value) {
         // Logic assumes we are starting at a valid lower bound
         RANGE_ASSERT(!at_impl_end(lower));
         RANGE_ASSERT(lower == lower_bound_impl(bounds));
 
-        // Trim/infil the beginning if needed
+        // Trim/infill the beginning if needed
         auto current = lower;
         const auto first_begin = current->first.begin;
         if (bounds.begin > first_begin) {
@@ -411,12 +412,27 @@ class range_map {
 
         // Loop over completely contained entries and erase them
         while (!at_impl_end(current) && (current->first.end <= bounds.end)) {
-            current = impl_erase(current);
+            if (touch_mapped_value(current->second)) {
+                current = impl_erase(current);
+            } else {
+                ++current;
+            }
         }
 
         if (!at_impl_end(current) && current->first.includes(bounds.end)) {
             // last entry extends past the end of the bounds range, snip to only erase the bounded section
-            current = split_impl(current, bounds.end, split_op_keep_upper());
+            current = split_impl(current, bounds.end, split_op_keep_both());
+            // test if lower_bound (eventually) computed in split_impl is not empty.
+            // If it is not empty, then it contains values inside the bounds range,
+            // they need to be touched
+            if ((current->first & bounds).non_empty()) {
+                if (touch_mapped_value(current->second)) {
+                    current = impl_erase(current);
+                } else {
+                    // make current point to upper bound
+                    ++current;
+                }
+            }
         }
 
         RANGE_ASSERT(current == upper_bound_impl(bounds));
@@ -538,15 +554,24 @@ class range_map {
 
     iterator erase(iterator first, iterator last) { return erase(range<iterator>(first, last)); }
 
-    iterator erase_range(const key_type &bounds) {
+    // Before trying to erase a range, function touch_mapped_value is called on the mapped value.
+    // touch_mapped_value is allowed to have it's parameter type to be non const reference.
+    // If it returns true, regular erase will occur.
+    // Else, range is kept.
+    template <typename TouchOp>
+    iterator erase_range_or_touch(const key_type &bounds, const TouchOp &touch_mapped_value) {
         auto lower = lower_bound_impl(bounds);
 
         if (at_impl_end(lower) || !bounds.intersects(lower->first)) {
             // There is nothing in this range lower bound is above bound
             return iterator(lower);
         }
-        auto next = impl_erase_range(bounds, lower);
+        auto next = impl_erase_range(bounds, lower, touch_mapped_value);
         return iterator(next);
+    }
+
+    iterator erase_range(const key_type &bounds) {
+        return erase_range_or_touch(bounds, [](const auto &) { return true; });
     }
 
     void clear() { impl_map_.clear(); }
@@ -597,7 +622,7 @@ class range_map {
         // we don't have to check upper if just check that lower doesn't intersect (which it would if lower != upper)
         auto lower = lower_bound_impl(key);
         if (at_impl_end(lower) || !lower->first.intersects(key)) {
-            // range is not even paritally overlapped, and lower is strictly > than key
+            // range is not even partially overlapped, and lower is strictly > than key
             auto impl_insert = impl_map_.emplace_hint(lower, value);
             // auto impl_insert = impl_map_.emplace(value);
             iterator wrap_it(impl_insert);
@@ -634,6 +659,45 @@ class range_map {
         return iterator(impl_insert);
     }
 
+    // Try to insert value. If insertion failed, recursively split union of retrieved stored range with inserted range.
+    // Split at intersection of stored range and inserted range.
+    // Range intersection is merged using merge_op.
+    // Ranges before and after this intersection are recursively inserted.
+    // merge_pos should have this signature: (mapped_type& current_value, const mapped_type& new_value) -> void
+    template <typename MergeOp>
+    iterator split_and_merge_insert(const value_type &value, const MergeOp &merge_op) {
+        if (!value.first.non_empty()) {
+            return end();
+        }
+
+        if (auto [it, was_inserted] = insert(value); !was_inserted) {
+            // insert failed, so at least one stored range intersects with new range
+            const RangeKey it_range = it->first;
+            const auto &[inserted_range, insert_mapped_value] = value;
+            const RangeKey intersection = it_range & inserted_range;
+            // if intersection is empty or invalid, insertion should have succeeded
+            assert(intersection.non_empty());
+
+            const iterator split_point_it = sparse_container::split(it, *this, intersection);
+            // given it->first and instersection do intersect, split should have succeeded
+            RANGE_ASSERT(split_point_it != end());
+            // merge values at inserted range and retrieved range intersection
+            merge_op(split_point_it->second, insert_mapped_value);
+
+            // Recursively insert ranges before and after intersection
+            const RangeKey range_after_intersection(intersection.end, std::max(it_range.end, inserted_range.end));
+            const RangeKey range_before_intersection(std::min(it_range.begin, inserted_range.begin), intersection.begin);
+            split_and_merge_insert({range_after_intersection, insert_mapped_value}, merge_op);
+            if (range_before_intersection.non_empty()) {
+                return split_and_merge_insert({range_before_intersection, insert_mapped_value}, merge_op);
+            } else {
+                return split_point_it;
+            }
+        } else {
+            return it;
+        }
+    }
+
     template <typename SplitOp>
     iterator split(const iterator whole_it, const index_type &index, const SplitOp &split_op) {
         auto split_it = split_impl(whole_it.pos_, index, split_op);
@@ -650,7 +714,7 @@ class range_map {
         if (!at_impl_end(lower_impl)) {
             // If we're at end (and the hint is good, there's nothing to erase
             RANGE_ASSERT(lower == lower_bound(value.first));
-            insert_hint = impl_erase_range(value.first, lower_impl);
+            insert_hint = impl_erase_range(value.first, lower_impl, [](const auto &) { return true; });
         }
         auto inserted = impl_insert(insert_hint, std::forward<Value>(value));
         return iterator(inserted);
@@ -1533,7 +1597,7 @@ const MappedType &evaluate(const CachedLowerBound &clb, const MappedType &defaul
     return default_value;
 }
 
-// Split a range into pieces bound by the interection of the interator's range and the supplied range
+// Split a range into pieces bound by the intersection of the iterator's range and the supplied range
 template <typename Iterator, typename Map, typename Range>
 Iterator split(Iterator in, Map &map, const Range &range) {
     assert(in != map.end());  // Not designed for use with invalid iterators...
@@ -1864,5 +1928,3 @@ void consolidate(RangeMap &map) {
 }
 
 }  // namespace sparse_container
-
-#endif

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -762,8 +762,9 @@ template <typename T>
 class span {
   public:
     using pointer = T *;
+    using const_pointer = T const *;
     using iterator = pointer;
-    using const_iterator = T const *;
+    using const_iterator = const_pointer;
 
     span() = default;
     span(pointer start, size_t n) : data_(start), count_(n) {}
@@ -788,8 +789,10 @@ class span {
     const T &back() const { return *(data_ + (count_ - 1)); }
 
     size_t size() const { return count_; }
+    bool empty() const { return count_ == 0; }
 
     pointer data() { return data_; }
+    const_pointer data() const { return data_; }
 
   private:
     pointer data_ = {};

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -311,6 +311,7 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     DeviceMemory(const Device &dev, const VkMemoryAllocateInfo &info) { init(dev, info); }
     ~DeviceMemory() noexcept;
     void destroy() noexcept;
+    DeviceMemory &operator=(DeviceMemory &&) = default;
 
     // vkAllocateMemory()
     void init(const Device &dev, const VkMemoryAllocateInfo &info);
@@ -445,7 +446,12 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     }
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, NoMemT) { init_no_mem(dev, info); }
     explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
-
+    Buffer &operator=(Buffer &&rhs) {
+        NonDispHandle::operator=(std::move(rhs));
+        create_info_ = std::move(rhs.create_info_);
+        internal_mem_ = std::move(rhs.internal_mem_);
+        return *this;
+    }
     ~Buffer() noexcept;
     void destroy() noexcept;
 
@@ -712,6 +718,7 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
 
 class AccelerationStructureKHR : public internal::NonDispHandle<VkAccelerationStructureKHR> {
   public:
+    explicit AccelerationStructureKHR(){};
     explicit AccelerationStructureKHR(const Device &dev, const VkAccelerationStructureCreateInfoKHR &info,
                                       bool init_memory = true) {
         init(dev, info, init_memory);


### PR DESCRIPTION
Objectives:
=
- Add VUIDs listed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4556
- Still some TODOs to properly handle new `GetBuffersByAddress` calls introduced by rebasing on master
- Fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4714

Summary:
=
Aside adding some VUIDS, how the mapping between `VkBuffer` and `VkDeviceAddress` has been updated. This mapping is not 1:1, multiple `VkBuffer` can return the same starting `VkDeviceAddress`. It can happen if for instance 2 `VkBuffer`s are bound to the same memory region. See 118ec423c61f9c0afc28e6be9f717a081743dc8b for how the mapping has been updated.

Tests:
`BuffersAndBufferDeviceAddressesMapping`: Test how that adding and removing elements in the buffer <-> address map is correctly handled.
`ValidateCmdTraceRaysKHR`: Added new test cases

Where reviewers are especially needed:
=

- I need to make sure update to the aforementioned mapping were done where needed, especially I am not sure updates made to `RecordDeviceAccelerationStructureBuildInfo` and how it now stores multiple buffers instead of one are correctly propagated to code portions that consume that data.
