### PR TITLE
cmake: Cleanup CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,14 @@ elseif(MSVC)
     add_compile_options("/w34057")
     # Warn about signed/unsigned mismatch.
     add_compile_options("/w34245")
+
+    # Allow usage of unsafe CRT functions and minimize what Windows.h leaks
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -DWIN32_LEAN_AND_MEAN)
+    if(MINGW)
+        add_definitions(-D_WIN32_WINNT=0x0600) # Must be declared before including Windows.h
+    endif()
+
+    add_compile_options($<$<BOOL:${MSVC_IDE}>:/MP>) # Speed up Visual Studio builds
 endif()
 
 option(INSTALL_TESTS "Install tests" OFF)
@@ -255,12 +263,6 @@ if (VVL_ENABLE_ASAN)
     target_compile_options(VkLayer_utils PRIVATE -fsanitize=address)
     # NOTE: Use target_link_options when cmake 3.13 is available on CI
     target_link_libraries(VkLayer_utils PRIVATE "-fsanitize=address")
-endif()
-if(WIN32)
-    target_compile_definitions(VkLayer_utils PUBLIC _CRT_SECURE_NO_WARNINGS NOMINMAX)
-    if(MINGW)
-        target_compile_definitions(VkLayer_utils PUBLIC "_WIN32_WINNT=0x0600")
-    endif()
 endif()
 set_target_properties(VkLayer_utils PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(VkLayer_utils

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -16,7 +16,7 @@
 # ~~~
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
+    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX)
 elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR -DVK_USE_PLATFORM_ANDROID_KHX)
 elseif(APPLE)
@@ -63,14 +63,10 @@ if(BUILD_LAYER_SUPPORT_FILES)
 endif()
 
 if(MSVC)
-    # Applies to all configurations
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
     add_compile_options("/bigobj")
     add_compile_options("/we4189")
     add_compile_options("/we5038")
-    # Allow Windows to use multiprocessor compilation
-    add_compile_options(/MP)
     # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is
     # that constructor initializers are now fixed to clear the struct members.
     add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
@@ -78,10 +74,8 @@ else()
     if(MINGW)
         add_compile_options("-Wa,-mbig-obj")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
+    add_compile_options(-Wpointer-arith -Wno-unused-function -Wno-sign-compare)
 endif()
-
 
 if(ANNOTATED_SPEC_LINK)
     message("-- ANNOTATED_SPEC_LINK is ${ANNOTATED_SPEC_LINK}")
@@ -261,8 +255,7 @@ if (VVL_ENABLE_ASAN)
 endif()
 
 if(WIN32)
-    target_sources(VkLayer_khronos_validation PRIVATE VkLayer_khronos_validation.def)
-    target_compile_definitions(VkLayer_khronos_validation PUBLIC NOMINMAX)
+    set_target_properties(VkLayer_khronos_validation PROPERTIES LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def")
 elseif(APPLE)
     set_target_properties(VkLayer_khronos_validation PROPERTIES SUFFIX ".dylib")
 else()
@@ -278,7 +271,6 @@ if(MSVC)
 endif()
 
 # Khronos validation additional dependencies
-target_include_directories(VkLayer_khronos_validation PRIVATE ${GLSLANG_INCLUDE_DIR})
 if(INSTRUMENT_OPTICK)
     target_include_directories(VkLayer_khronos_validation PRIVATE ${OPTICK_SOURCE_DIR})
 endif()
@@ -287,8 +279,11 @@ if (USE_ROBIN_HOOD_HASHING)
     # This warning produces what look like false positives in robin_hood.h with Visual Studio 2015
     target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.1>>:/wd4996>")
 endif()
-target_include_directories(VkLayer_khronos_validation PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
-target_link_libraries(VkLayer_khronos_validation PRIVATE ${SPIRV_TOOLS_TARGET} SPIRV-Tools-opt)
+target_link_libraries(VkLayer_khronos_validation PRIVATE
+    ${SPIRV_TOOLS_TARGET}
+    SPIRV-Tools-opt
+    SPIRV-Headers::SPIRV-Headers
+)
 
 # There are 2 primary deliverables for the validation layers.
 # - The actual library VkLayer_khronos_validation.(dll|so|dylib)

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -32,8 +32,6 @@
 #include <sys/stat.h>
 
 #include <vulkan/vk_layer.h>
-// sdk_platform header redefines NOMINMAX
-#undef NOMINMAX
 #include "vk_layer_utils.h"
 
 #if defined(_WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,37 +30,23 @@ if(ANNOTATED_SPEC_LINK)
 endif()
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
+    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    # If MSVC, allow Windows to use multiprocessor compilation
-    if(MSVC)
-        add_compile_options(/MP)
-    endif()
 elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
-elseif(LINUX)
-else()
-    message(FATAL_ERROR "Unsupported Platform!")
 endif()
 
-if(WIN32)
-    file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/tests)
+if(MSVC_IDE)
+    file(COPY vk_layer_validation_tests.vcxproj.user DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-
+if(MSVC)
     # If MSVC, disable some signed/unsigned mismatch warnings.
-    if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
-    endif()
-
+    add_compile_options(/wd4267)
 endif()
-
-set(LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
 
 set(COMMON_CPP
     vklayertests_instanceless.cpp
@@ -103,14 +89,14 @@ set(COMMON_CPP
     vktestbinding.cpp
     vktestframework.cpp)
 
-set_source_files_properties(${PROJECT_BINARY_DIR}/vk_safe_struct.cpp PROPERTIES GENERATED TRUE)
 add_executable(vk_layer_validation_tests
-               layer_validation_tests.cpp
-               ../layers/generated/vk_format_utils.cpp
-               ../layers/convert_to_renderpass2.cpp
-               ../layers/generated/vk_safe_struct.cpp
-               ../layers/generated/lvt_function_pointers.cpp
-               ${COMMON_CPP})
+    layer_validation_tests.cpp
+    ../layers/generated/vk_format_utils.cpp
+    ../layers/convert_to_renderpass2.cpp
+    ../layers/generated/vk_safe_struct.cpp
+    ../layers/generated/lvt_function_pointers.cpp
+    ${COMMON_CPP}
+)
 
 # gtest_discover_tests has problem with cross-compiling, but it is faster and more robust
 if (CMAKE_CROSSCOMPILING)
@@ -144,8 +130,6 @@ if (NOT MSVC)
     target_compile_options(vk_layer_validation_tests PRIVATE "-Wno-sign-compare")
 endif()
 
-target_include_directories(vk_layer_validation_tests PRIVATE ${SPIRV_HEADERS_INCLUDE_DIR})
-
 target_link_libraries(vk_layer_validation_tests PRIVATE
     VkLayer_utils
     glslang::glslang
@@ -158,6 +142,7 @@ target_link_libraries(vk_layer_validation_tests PRIVATE
     glslang::SPVRemapper
     ${SPIRV_TOOLS_TARGET}
     SPIRV-Tools-opt
+    SPIRV-Headers::SPIRV-Headers
     GTest::gtest
     GTest::gtest_main
 )

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -23,8 +23,6 @@ add_library(VkLayer_device_profile_api MODULE
 target_link_libraries(VkLayer_device_profile_api PRIVATE VkLayer_utils)
 
 if (WIN32)
-    target_compile_definitions(VkLayer_device_profile_api PRIVATE _CRT_SECURE_NO_WARNINGS)
-
     # Need to use this instead of target_link_options() for older versions of CMake.
     set_target_properties(VkLayer_device_profile_api PROPERTIES
         LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_device_profile_api.def"

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -37,9 +37,6 @@
 #include <string.h>
 
 #ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
- Set common WIN32 defines in 1 location
- Only set /MP for visual studio builds, not needed for Ninja
- Don't use CMAKE_CXX_FLAGS/CMAKE_C_FLAGS (Not modern)
- Use linker option /DEF clearly instead of adding source file
- Use targets instead of old variable names
- vk_sdk_platform.h no longer defines NOMINMAX
- Only vcxproj.user only needed for Visual Studio builds
- Remove usage of USE_MATH_DEFINES
- Remove libglm variable (does nothing)